### PR TITLE
Remove all use of deprecated coordinate transform constructors

### DIFF
--- a/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -65,8 +65,11 @@ Performs raster layer calculations.
       BandError,
     };
 
+
     QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
-                         const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries );
+                         const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows,
+                         const QVector<QgsRasterCalculatorEntry> &rasterEntries,
+                         const QgsCoordinateTransformContext &transformContext );
 %Docstring
 QgsRasterCalculator constructor.
 
@@ -77,10 +80,18 @@ QgsRasterCalculator constructor.
 :param nOutputColumns: number of columns in output raster
 :param nOutputRows: number of rows in output raster
 :param rasterEntries: list of referenced raster layers
+:param transformContext: coordinate transformation context
+
+.. deprecated:: since QGIS 3.8, use the version with transformContext instead
+
+.. versionadded:: 3.8
 %End
 
     QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
-                         const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries );
+                         const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs,
+                         int nOutputColumns, int nOutputRows,
+                         const QVector<QgsRasterCalculatorEntry> &rasterEntries,
+                         const QgsCoordinateTransformContext &transformContext );
 %Docstring
 QgsRasterCalculator constructor.
 
@@ -92,6 +103,45 @@ QgsRasterCalculator constructor.
 :param nOutputColumns: number of columns in output raster
 :param nOutputRows: number of rows in output raster
 :param rasterEntries: list of referenced raster layers
+:param transformContext: coordinate transformation context
+
+.. deprecated:: since QGIS 3.8, use the version with transformContext instead
+
+.. versionadded:: 3.8
+%End
+
+
+ QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
+                                           const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated/;
+%Docstring
+QgsRasterCalculator constructor.
+
+:param formulaString: formula for raster calculation
+:param outputFile: output file path
+:param outputFormat: output file format
+:param outputExtent: output extent. CRS for output is taken from first entry in rasterEntries.
+:param nOutputColumns: number of columns in output raster
+:param nOutputRows: number of rows in output raster
+:param rasterEntries: list of referenced raster layers
+
+.. deprecated:: since QGIS 3.8, use the version with transformContext instead
+%End
+
+ QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
+                                           const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) /Deprecated/;
+%Docstring
+QgsRasterCalculator constructor.
+
+:param formulaString: formula for raster calculation
+:param outputFile: output file path
+:param outputFormat: output file format
+:param outputExtent: output extent, CRS is specified by outputCrs parameter
+:param outputCrs: destination CRS for output raster
+:param nOutputColumns: number of columns in output raster
+:param nOutputRows: number of rows in output raster
+:param rasterEntries: list of referenced raster layers
+
+.. deprecated:: since QGIS 3.8, use the version with transformContext instead
 
 .. versionadded:: 2.10
 %End

--- a/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -82,8 +82,6 @@ QgsRasterCalculator constructor.
 :param rasterEntries: list of referenced raster layers
 :param transformContext: coordinate transformation context
 
-.. deprecated:: since QGIS 3.8, use the version with transformContext instead
-
 .. versionadded:: 3.8
 %End
 
@@ -104,8 +102,6 @@ QgsRasterCalculator constructor.
 :param nOutputRows: number of rows in output raster
 :param rasterEntries: list of referenced raster layers
 :param transformContext: coordinate transformation context
-
-.. deprecated:: since QGIS 3.8, use the version with transformContext instead
 
 .. versionadded:: 3.8
 %End

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -556,7 +556,7 @@ Responsible for reading native mesh data
 #include "qgsmeshdataprovider.h"
 %End
   public:
-    QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 %Docstring
 Ctor
 %End

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -78,16 +78,26 @@ is the MDAL connection string. QGIS must be built with MDAL support to allow thi
     struct LayerOptions
     {
 
-      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
+ explicit LayerOptions( ) /Deprecated/;
 %Docstring
 Constructor for LayerOptions.
+
+.. deprecated:: Use version with transformContext argument instead
+%End
+
+
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext );
+%Docstring
+Constructor for LayerOptions.
+
+.. versionadded:: 3.10
 %End
 
       QgsCoordinateTransformContext transformContext;
     };
 
-    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
-                           const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
+ explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+        const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() ) /Deprecated/;
 %Docstring
 Constructor - creates a mesh layer
 
@@ -100,7 +110,29 @@ data.
 :param baseName: The name used to represent the layer in the legend
 :param providerLib: The name of the data provider, e.g., "mesh_memory", "mdal"
 :param options: general mesh layer options
+
+.. deprecated:: Use version with layer options as a first argument instead
 %End
+
+    explicit QgsMeshLayer( const QgsMeshLayer::LayerOptions &options, const QString &path = QString(),
+                           const QString &baseName = QString(), const QString &providerLib = "mesh_memory" );
+%Docstring
+Constructor - creates a mesh layer
+
+The QgsMeshLayer is constructed by instantiating a data provider.  The provider
+interprets the supplied path (url) of the data source to connect to and access the
+data.
+
+:param options: general mesh layer options
+:param path: The path or url of the parameter.  Typically this encodes
+             parameters used by the data provider as url query items.
+:param baseName: The name used to represent the layer in the legend
+:param providerLib: The name of the data provider, e.g., "mesh_memory", "mdal"
+
+.. versionadded:: 3.10
+%End
+
+
     ~QgsMeshLayer();
 
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -78,26 +78,20 @@ is the MDAL connection string. QGIS must be built with MDAL support to allow thi
     struct LayerOptions
     {
 
- explicit LayerOptions( ) /Deprecated/;
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext( ) );
 %Docstring
-Constructor for LayerOptions.
+Constructor for LayerOptions with optional ``transformContext``.
 
-.. deprecated:: Use version with transformContext argument instead
-%End
+.. note::
 
-
-      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext );
-%Docstring
-Constructor for LayerOptions.
-
-.. versionadded:: 3.10
+   transformContext argument was added in QGIS 3.10
 %End
 
       QgsCoordinateTransformContext transformContext;
     };
 
- explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
-        const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() ) /Deprecated/;
+    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+                           const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
 %Docstring
 Constructor - creates a mesh layer
 
@@ -110,28 +104,7 @@ data.
 :param baseName: The name used to represent the layer in the legend
 :param providerLib: The name of the data provider, e.g., "mesh_memory", "mdal"
 :param options: general mesh layer options
-
-.. deprecated:: Use version with layer options as a first argument instead
 %End
-
-    explicit QgsMeshLayer( const QgsMeshLayer::LayerOptions &options, const QString &path = QString(),
-                           const QString &baseName = QString(), const QString &providerLib = "mesh_memory" );
-%Docstring
-Constructor - creates a mesh layer
-
-The QgsMeshLayer is constructed by instantiating a data provider.  The provider
-interprets the supplied path (url) of the data source to connect to and access the
-data.
-
-:param options: general mesh layer options
-:param path: The path or url of the parameter.  Typically this encodes
-             parameters used by the data provider as url query items.
-:param baseName: The name used to represent the layer in the legend
-:param providerLib: The name of the data provider, e.g., "mesh_memory", "mdal"
-
-.. versionadded:: 3.10
-%End
-
 
     ~QgsMeshLayer();
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -201,6 +201,7 @@ Interpolates the value on the given point from given dataset.
   public slots:
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
+
 %Docstring
 Sets the coordinate transform context to ``transformContext``.
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -84,13 +84,13 @@ Constructor for LayerOptions with optional ``transformContext``.
 
 .. note::
 
-   transformContext argument was added in QGIS 3.10
+   transformContext argument was added in QGIS 3.8
 %End
 
       QgsCoordinateTransformContext transformContext;
     };
 
-    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = QStringLiteral( "mesh_memory" ),
                            const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
 %Docstring
 Constructor - creates a mesh layer

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -202,9 +202,9 @@ Interpolates the value on the given point from given dataset.
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Triggered when the coordinate transform context has changed ``transformContext``
+Sets the coordinate transform context to ``transformContext``.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.8
 %End
 
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -77,7 +77,13 @@ is the MDAL connection string. QGIS must be built with MDAL support to allow thi
 
     struct LayerOptions
     {
-      int unused;  //!< @todo remove me once there are actual members here (breaks SIP <4.19)
+
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
+%Docstring
+Constructor for LayerOptions.
+%End
+
+      QgsCoordinateTransformContext transformContext;
     };
 
     explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
@@ -186,6 +192,16 @@ Interpolates the value on the given point from given dataset.
 
 .. versionadded:: 3.4
 %End
+
+  public slots:
+
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
+%Docstring
+Triggered when the coordinate transform context has changed ``transformContext``
+
+.. versionadded:: 3.10
+%End
+
 
   signals:
 

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -183,7 +183,7 @@ Combines the extent of several map ``layers``. If specified, the target ``crs``
 will be used to transform the layer's extent to the desired output reference system
 using the specified ``context``.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.8
 %End
 
  static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Deprecated/;
@@ -191,7 +191,7 @@ using the specified ``context``.
 Combines the extent of several map ``layers``. If specified, the target ``crs``
 will be used to transform the layer's extent to the desired output reference system.
 
-.. deprecated:: Use version with transformContext argument instead
+.. deprecated:: Use version with QgsProcessingContext argument instead
 %End
 
     static QVariant generateIteratingDestination( const QVariant &input, const QVariant &id, QgsProcessingContext &context );

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -177,11 +177,11 @@ temporary layer store.
 %End
 
 
-    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext );
+    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, QgsProcessingContext &context );
 %Docstring
 Combines the extent of several map ``layers``. If specified, the target ``crs``
 will be used to transform the layer's extent to the desired output reference system
-using the specified ``transformContext``.
+using the specified ``context``.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -176,10 +176,22 @@ temporary layer store.
    available in Python bindings as createFeatureSink()
 %End
 
-    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+
+    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext );
+%Docstring
+Combines the extent of several map ``layers``. If specified, the target ``crs``
+will be used to transform the layer's extent to the desired output reference system
+using the specified ``transformContext``.
+
+.. versionadded:: 3.10
+%End
+
+ static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) /Deprecated/;
 %Docstring
 Combines the extent of several map ``layers``. If specified, the target ``crs``
 will be used to transform the layer's extent to the desired output reference system.
+
+.. deprecated:: Use version with transformContext argument instead
 %End
 
     static QVariant generateIteratingDestination( const QVariant &input, const QVariant &id, QgsProcessingContext &context );

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -50,7 +50,6 @@ transforms coordinates from the layer's coordinate system to the map canvas.
 Default constructor, creates an invalid QgsCoordinateTransform.
 %End
 
-
     explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source,
                                      const QgsCoordinateReferenceSystem &destination,
                                      const QgsCoordinateTransformContext &context );

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -58,7 +58,7 @@ Abstract base class for spatial data provider implementations.
 
     struct ProviderOptions
     {
-      QgsCoordinateTransformContext coordinateTransformContext;
+      QgsCoordinateTransformContext transformContext;
     };
 
     QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
@@ -387,24 +387,23 @@ Returns ``True`` if metadata was successfully written to the data provider.
 .. versionadded:: 3.0
 %End
 
-    QgsCoordinateTransformContext coordinateTransformContext() const;
+    QgsCoordinateTransformContext transformContext() const;
 %Docstring
 Returns data provider coordinate transform context
 
-.. seealso:: :py:func:`setCoordinateTranformContext`
-
-.. seealso:: :py:func:`coordinateTransformContextChanged`
+.. seealso:: :py:func:`setTranformContext`
 
 .. versionadded:: 3.10
 %End
 
-    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Sets data coordinate transform context to ``coordinateTransformContext``
+Sets data coordinate transform context to ``transformContext``
 
-.. seealso:: :py:func:`coordinateTransformContext`
+The default implementation is a simple setter, subclasses may override to perform
+additional actions required by a change of coordinate tranform context.
 
-.. seealso:: :py:func:`coordinateTransformContextChanged`
+.. seealso:: :py:func:`transformContext`
 
 .. versionadded:: 3.10
 %End
@@ -442,17 +441,6 @@ Emitted when the datasource issues a notification.
 .. seealso:: :py:func:`setListening`
 
 .. versionadded:: 3.0
-%End
-
-    void coordinateTransformContextChanged( const QgsCoordinateTransformContext &coordinateTransformContext );
-%Docstring
-Emitted when the data provider coordinate transform context has changed
-
-.. seealso:: :py:func:`coordinateTransformContext`
-
-.. seealso:: :py:func:`setCoordinateTranformContext`
-
-.. versionadded:: 3.10
 %End
 
 

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -58,7 +58,7 @@ Abstract base class for spatial data provider implementations.
 
     struct ProviderOptions
     {
-      int unused; //!< @todo remove me once there are actual members here (breaks SIP <4.19)
+      QgsCoordinateTransformContext coordinateTransformContext;
     };
 
     QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -61,7 +61,7 @@ Abstract base class for spatial data provider implementations.
       QgsCoordinateTransformContext coordinateTransformContext;
     };
 
-    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
 %Docstring
 Create a new dataprovider with the specified in the ``uri``.
 
@@ -387,24 +387,24 @@ Returns ``True`` if metadata was successfully written to the data provider.
 .. versionadded:: 3.0
 %End
 
-    QgsDataProvider::ProviderOptions options() const;
+    QgsCoordinateTransformContext coordinateTransformContext() const;
 %Docstring
-Returns data provider options
+Returns data provider coordinate transform context
 
-.. seealso:: :py:func:`setOptions`
+.. seealso:: :py:func:`setCoordinateTranformContext`
 
-.. seealso:: :py:func:`optionsChanged`
+.. seealso:: :py:func:`coordinateTransformContextChanged`
 
 .. versionadded:: 3.10
 %End
 
-    void setOptions( const QgsDataProvider::ProviderOptions &options );
+    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
 %Docstring
-Sets data provider options to ``options``
+Sets data coordinate transform context to ``coordinateTransformContext``
 
-.. seealso:: :py:func:`options`
+.. seealso:: :py:func:`coordinateTransformContext`
 
-.. seealso:: :py:func:`optionsChanged`
+.. seealso:: :py:func:`coordinateTransformContextChanged`
 
 .. versionadded:: 3.10
 %End
@@ -444,13 +444,13 @@ Emitted when the datasource issues a notification.
 .. versionadded:: 3.0
 %End
 
-    void optionsChanged( const QgsDataProvider::ProviderOptions &options );
+    void coordinateTransformContextChanged( const QgsCoordinateTransformContext &coordinateTransformContext );
 %Docstring
-Emitted when the data provider options has changed
+Emitted when the data provider coordinate transform context has changed
 
-.. seealso:: :py:func:`setOptions`
+.. seealso:: :py:func:`coordinateTransformContext`
 
-.. seealso:: :py:func:`options`
+.. seealso:: :py:func:`setCoordinateTranformContext`
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -75,7 +75,6 @@ If the provider isn't capable of returning its projection then an invalid
 QgsCoordinateReferenceSystem will be returned.
 %End
 
-
     virtual void setDataSourceUri( const QString &uri );
 %Docstring
 Set the data source specification. This may be a path or database

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -61,12 +61,14 @@ Abstract base class for spatial data provider implementations.
       QgsCoordinateTransformContext coordinateTransformContext;
     };
 
-    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() ):
 %Docstring
 Create a new dataprovider with the specified in the ``uri``.
 
 Additional creation options are specified within the ``options`` value.
 %End
+      mDataSourceURI( uri ),
+      mOptions( options );
 
     virtual QgsCoordinateReferenceSystem crs() const = 0;
 %Docstring
@@ -388,6 +390,28 @@ Returns ``True`` if metadata was successfully written to the data provider.
 .. versionadded:: 3.0
 %End
 
+    QgsDataProvider::ProviderOptions options() const;
+%Docstring
+Returns data provider options
+
+.. seealso:: :py:func:`setOptions`
+
+.. seealso:: :py:func:`optionsChanged`
+
+.. versionadded:: 3.10
+%End
+
+    void setOptions( const QgsDataProvider::ProviderOptions &options );
+%Docstring
+Sets data provider options to ``options``
+
+.. seealso:: :py:func:`options`
+
+.. seealso:: :py:func:`optionsChanged`
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void fullExtentCalculated();
@@ -421,6 +445,17 @@ Emitted when the datasource issues a notification.
 .. seealso:: :py:func:`setListening`
 
 .. versionadded:: 3.0
+%End
+
+    void optionsChanged( const QgsDataProvider::ProviderOptions &options );
+%Docstring
+Emitted when the data provider options has changed
+
+.. seealso:: :py:func:`setOptions`
+
+.. seealso:: :py:func:`options`
+
+.. versionadded:: 3.10
 %End
 
 

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -61,14 +61,12 @@ Abstract base class for spatial data provider implementations.
       QgsCoordinateTransformContext coordinateTransformContext;
     };
 
-    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() ):
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 %Docstring
 Create a new dataprovider with the specified in the ``uri``.
 
 Additional creation options are specified within the ``options`` value.
 %End
-      mDataSourceURI( uri ),
-      mOptions( options );
 
     virtual QgsCoordinateReferenceSystem crs() const = 0;
 %Docstring

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -387,26 +387,7 @@ Returns ``True`` if metadata was successfully written to the data provider.
 .. versionadded:: 3.0
 %End
 
-    QgsCoordinateTransformContext transformContext() const;
-%Docstring
-Returns data provider coordinate transform context
 
-.. seealso:: :py:func:`setTransformContext`
-
-.. versionadded:: 3.10
-%End
-
-    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
-%Docstring
-Sets data coordinate transform context to ``transformContext``
-
-The default implementation is a simple setter, subclasses may override to perform
-additional actions required by a change of coordinate transform context.
-
-.. seealso:: :py:func:`transformContext`
-
-.. versionadded:: 3.10
-%End
 
   signals:
 

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -391,7 +391,7 @@ Returns ``True`` if metadata was successfully written to the data provider.
 %Docstring
 Returns data provider coordinate transform context
 
-.. seealso:: :py:func:`setTranformContext`
+.. seealso:: :py:func:`setTransformContext`
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -401,7 +401,7 @@ Returns data provider coordinate transform context
 Sets data coordinate transform context to ``transformContext``
 
 The default implementation is a simple setter, subclasses may override to perform
-additional actions required by a change of coordinate tranform context.
+additional actions required by a change of coordinate transform context.
 
 .. seealso:: :py:func:`transformContext`
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1341,11 +1341,18 @@ Set whether provider notification is connected to triggerRepaint
 
     void setRefreshOnNofifyMessage( const QString &message );
 %Docstring
-Set the notification message that triggers repaine
+Set the notification message that triggers repaint
 If refresh on notification is enabled, the notification will triggerRepaint only
 if the notification message is equal to:param message:
 
 .. versionadded:: 3.0
+%End
+
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) = 0;
+%Docstring
+Triggered when the coordinate transform context has changed ``transformContext``
+
+.. versionadded:: 3.10
 %End
 
   signals:
@@ -1481,6 +1488,7 @@ Emitted whenever the layer's data source has been changed.
 
 .. versionadded:: 3.5
 %End
+
 
   protected:
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -622,7 +622,7 @@ Sets layer's spatial reference system
 Returns the layer data provider coordinate transform context
 or a default transform context if the layer does not have a valid data provider.
 
-.. versionadded:: 3.10
+.. versionadded:: 3.8
 %End
 
 
@@ -1359,9 +1359,9 @@ if the notification message is equal to:param message:
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) = 0;
 %Docstring
-Triggered when the coordinate transform context has changed ``transformContext``
+Sets the coordinate transform context to ``transformContext``
 
-.. versionadded:: 3.10
+.. versionadded:: 3.8
 %End
 
   signals:

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -617,6 +617,15 @@ Returns the layer's spatial reference system.
 Sets layer's spatial reference system
 %End
 
+    QgsCoordinateTransformContext transformContext( ) const;
+%Docstring
+Returns the layer data provider coordinate transform context
+or a default transform context if the layer does not have a valid data provider.
+
+.. versionadded:: 3.10
+%End
+
+
     static QString formatLayerName( const QString &name );
 %Docstring
 A convenience function to capitalize and format a layer ``name``.

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -117,7 +117,7 @@ It's usually the QgsProject where the function with the context is made and won'
 %Docstring
 Returns data provider coordinate transform context
 
-.. seealso:: :py:func:`setTranformContext`
+.. seealso:: :py:func:`setTransformContext`
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -113,20 +113,20 @@ It's usually the QgsProject where the function with the context is made and won'
 .. versionadded:: 3.4
 %End
 
-    QgsCoordinateTransformContext coordinateTransformContext() const;
+    QgsCoordinateTransformContext transformContext() const;
 %Docstring
 Returns data provider coordinate transform context
 
-.. seealso:: :py:func:`setCoordinateTranformContext`
+.. seealso:: :py:func:`setTranformContext`
 
 .. versionadded:: 3.10
 %End
 
-    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Sets data coordinate transform context to ``coordinateTransformContext``
+Sets data coordinate transform context to ``transformContext``
 
-.. seealso:: :py:func:`coordinateTransformContext`
+.. seealso:: :py:func:`transformContext`
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -113,6 +113,24 @@ It's usually the QgsProject where the function with the context is made and won'
 .. versionadded:: 3.4
 %End
 
+    QgsCoordinateTransformContext coordinateTransformContext() const;
+%Docstring
+Returns data provider coordinate transform context
+
+.. seealso:: :py:func:`setCoordinateTranformContext`
+
+.. versionadded:: 3.10
+%End
+
+    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+%Docstring
+Sets data coordinate transform context to ``coordinateTransformContext``
+
+.. seealso:: :py:func:`coordinateTransformContext`
+
+.. versionadded:: 3.10
+%End
+
       public:
 };
 

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -68,7 +68,7 @@ of feature and attribute information from a spatial datasource.
       UnknownCount,
     };
 
-    QgsVectorDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsVectorDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
 %Docstring
 Constructor for a vector data provider.
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -365,8 +365,6 @@ data.
 :param baseName: The name used to represent the layer in the legend
 :param providerLib: The name of the data provider, e.g., "memory", "postgres"
 :param options: layer load options
-
-.. deprecated:: Use version with options as mandatory argument instead
 %End
 
     ~QgsVectorLayer();

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -326,7 +326,9 @@ TODO QGIS3: Remove virtual from non-inherited methods (like isModified)
     struct LayerOptions
     {
 
-      explicit LayerOptions( bool loadDefaultStyle = true, bool readExtentFromXml = false );
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             bool readExtentFromXml = false,
+                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() );
 %Docstring
 Constructor for LayerOptions.
 %End
@@ -334,6 +336,8 @@ Constructor for LayerOptions.
       bool loadDefaultStyle;
 
       bool readExtentFromXml;
+
+      QgsCoordinateTransformContext coordinateTransformContext;
 
     };
 
@@ -2260,6 +2264,7 @@ Configuration and logic to apply automatically on any edit happening on this lay
 
 
 
+
   public slots:
 
     void select( QgsFeatureId featureId );
@@ -2328,6 +2333,14 @@ rollBack().
 .. seealso:: :py:func:`commitChanges`
 
 .. seealso:: :py:func:`rollBack`
+%End
+
+
+    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+%Docstring
+Change coordinate transform context to ``coordinateTransformContext``
+
+.. versionadded:: 3.10
 %End
 
   signals:

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -326,18 +326,16 @@ TODO QGIS3: Remove virtual from non-inherited methods (like isModified)
     struct LayerOptions
     {
 
- explicit LayerOptions( bool loadDefaultStyle = true,
-          bool readExtentFromXml = false );
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             bool readExtentFromXml = false );
 %Docstring
 Constructor for LayerOptions.
-
-.. deprecated:: Use version with transformContext argument instead
 %End
 
-          explicit LayerOptions( const QgsCoordinateTransformContext & transformContext,
-                                 bool loadDefaultStyle = true,
-                                 bool readExtentFromXml = false
-                               );
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext,
+                             bool loadDefaultStyle = true,
+                             bool readExtentFromXml = false
+                           );
 %Docstring
 Constructor for LayerOptions.
 
@@ -353,8 +351,8 @@ Constructor for LayerOptions.
     };
 
 
- explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
-        const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() ) /Deprecated/;
+    explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
+                             const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() );
 %Docstring
 Constructor - creates a vector layer
 
@@ -370,26 +368,6 @@ data.
 
 .. deprecated:: Use version with options as mandatory argument instead
 %End
-
-
-    explicit QgsVectorLayer( const QgsVectorLayer::LayerOptions &options, const QString &path = QString(), const QString &baseName = QString(),
-                             const QString &providerLib = "ogr" );
-%Docstring
-Constructor - creates a vector layer
-
-The QgsVectorLayer is constructed by instantiating a data provider.  The provider
-interprets the supplied path (url) of the data source to connect to and access the
-data.
-
-:param options: layer load options
-:param path: The path or url of the parameter.  Typically this encodes
-             parameters used by the data provider as url query items.
-:param baseName: The name used to represent the layer in the legend
-:param providerLib: The name of the data provider, e.g., "memory", "postgres"
-
-.. versionadded:: 3.10
-%End
-
 
     ~QgsVectorLayer();
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2346,9 +2346,9 @@ rollBack().
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Triggered when the coordinate transform context has changed ``transformContext``
+Sets the coordinate transform context to ``transformContext``
 
-.. versionadded:: 3.10
+.. versionadded:: 3.8
 %End
 
   signals:

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -326,11 +326,22 @@ TODO QGIS3: Remove virtual from non-inherited methods (like isModified)
     struct LayerOptions
     {
 
-      explicit LayerOptions( bool loadDefaultStyle = true,
-                             bool readExtentFromXml = false,
-                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
+ explicit LayerOptions( bool loadDefaultStyle = true,
+          bool readExtentFromXml = false );
 %Docstring
 Constructor for LayerOptions.
+
+.. deprecated:: Use version with transformContext argument instead
+%End
+
+          explicit LayerOptions( const QgsCoordinateTransformContext & transformContext,
+                                 bool loadDefaultStyle = true,
+                                 bool readExtentFromXml = false
+                               );
+%Docstring
+Constructor for LayerOptions.
+
+.. versionadded:: 3.10
 %End
 
       bool loadDefaultStyle;
@@ -341,8 +352,8 @@ Constructor for LayerOptions.
 
     };
 
-    explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
-                             const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() );
+ explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
+        const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() ) /Deprecated/;
 %Docstring
 Constructor - creates a vector layer
 
@@ -355,6 +366,27 @@ data.
 :param baseName: The name used to represent the layer in the legend
 :param providerLib: The name of the data provider, e.g., "memory", "postgres"
 :param options: layer load options
+
+.. deprecated:: Use version with options as mandatory argument instead
+%End
+
+
+    explicit QgsVectorLayer( const QgsVectorLayer::LayerOptions &options, const QString &path = QString(), const QString &baseName = QString(),
+                             const QString &providerLib = "ogr" );
+%Docstring
+Constructor - creates a vector layer
+
+The QgsVectorLayer is constructed by instantiating a data provider.  The provider
+interprets the supplied path (url) of the data source to connect to and access the
+data.
+
+:param options: layer load options
+:param path: The path or url of the parameter.  Typically this encodes
+             parameters used by the data provider as url query items.
+:param baseName: The name used to represent the layer in the legend
+:param providerLib: The name of the data provider, e.g., "memory", "postgres"
+
+.. versionadded:: 3.10
 %End
 
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -352,6 +352,7 @@ Constructor for LayerOptions.
 
     };
 
+
  explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
         const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() ) /Deprecated/;
 %Docstring

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -328,7 +328,7 @@ TODO QGIS3: Remove virtual from non-inherited methods (like isModified)
 
       explicit LayerOptions( bool loadDefaultStyle = true,
                              bool readExtentFromXml = false,
-                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() );
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
 %Docstring
 Constructor for LayerOptions.
 %End
@@ -337,7 +337,7 @@ Constructor for LayerOptions.
 
       bool readExtentFromXml;
 
-      QgsCoordinateTransformContext coordinateTransformContext;
+      QgsCoordinateTransformContext transformContext;
 
     };
 
@@ -2335,10 +2335,9 @@ rollBack().
 .. seealso:: :py:func:`rollBack`
 %End
 
-
-    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Change coordinate transform context to ``coordinateTransformContext``
+Triggered when the coordinate transform context has changed ``transformContext``
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -82,7 +82,7 @@ Base class for raster data providers.
 
     QgsRasterDataProvider();
 
-    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
 %Docstring
 Constructor for QgsRasterDataProvider.
 

--- a/python/core/auto_generated/raster/qgsrasterfilewriter.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewriter.sip.in
@@ -81,8 +81,9 @@ Ownership of the returned provider is passed to the caller.
 .. versionadded:: 3.0
 %End
 
-    WriterError writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
-                             const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 );
+
+ WriterError writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
+        const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = 0 ) /Deprecated/;
 %Docstring
 Write raster file
 
@@ -92,7 +93,28 @@ Write raster file
 :param outputExtent: extent to output
 :param crs: crs to reproject to
 :param feedback: optional feedback object for progress reports
+
+.. deprecated:: since QGIS 3.8, use version with transformContext instead
 %End
+
+    WriterError writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
+                             const QgsCoordinateReferenceSystem &crs,
+                             const QgsCoordinateTransformContext &transformContext,
+                             QgsRasterBlockFeedback *feedback = 0 );
+%Docstring
+Write raster file
+
+:param pipe: raster pipe
+:param nCols: number of output columns
+:param nRows: number of output rows (or -1 to automatically calculate row number to have square pixels)
+:param outputExtent: extent to output
+:param crs: crs to reproject to
+:param transformContext: coordinate transform context
+:param feedback: optional feedback object for progress reports
+
+.. versionadded:: 3.8
+%End
+
 
     QString outputUrl() const;
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
@@ -28,15 +28,34 @@ QGIS interface.
 %End
   public:
 
-    QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe /Transfer/,
-                             int columns, int rows,
-                             const QgsRectangle &outputExtent,
-                             const QgsCoordinateReferenceSystem &crs );
+ QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe /Transfer/,
+        int columns, int rows,
+        const QgsRectangle &outputExtent,
+        const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
 %Docstring
 Constructor for QgsRasterFileWriterTask. Takes a source ``writer``,
 ``columns``, ``rows``, ``outputExtent`` and destination ``crs``.
 Ownership of the ``pipe`` is transferred to the writer task, and will
 be deleted when the task completes.
+
+.. deprecated:: since QGIS 3.8, use version with transformContext instead
+%End
+
+
+    QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe /Transfer/,
+                             int columns, int rows,
+                             const QgsRectangle &outputExtent,
+                             const QgsCoordinateReferenceSystem &crs,
+                             const QgsCoordinateTransformContext &transformContext
+                           );
+%Docstring
+Constructor for QgsRasterFileWriterTask. Takes a source ``writer``,
+``columns``, ``rows``, ``outputExtent``, destination ``crs`` and
+coordinate ``transformContext`` .
+Ownership of the ``pipe`` is transferred to the writer task, and will
+be deleted when the task completes.
+
+.. deprecated:: since QGIS 3.8, use version with transformContext instead
 %End
 
     virtual void cancel();

--- a/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterfilewritertask.sip.in
@@ -54,8 +54,6 @@ Constructor for QgsRasterFileWriterTask. Takes a source ``writer``,
 coordinate ``transformContext`` .
 Ownership of the ``pipe`` is transferred to the writer task, and will
 be deleted when the task completes.
-
-.. deprecated:: since QGIS 3.8, use version with transformContext instead
 %End
 
     virtual void cancel();

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -104,20 +104,11 @@ Constructor. Provider is not set.
     struct LayerOptions
     {
 
- explicit LayerOptions( bool loadDefaultStyle = true ) /Deprecated/;
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
 %Docstring
 Constructor for LayerOptions.
-
-.. deprecated:: Use version with transformContext argument instead
 %End
-
-      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext, bool loadDefaultStyle = true );
-%Docstring
-Constructor for LayerOptions.
-
-.. versionadded:: 3.10
-%End
-
 
       bool loadDefaultStyle;
 

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -386,9 +386,9 @@ Writes the symbology of the layer into the document provided in SLD 1.0.0 format
 
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Triggered when the coordinate transform context has changed ``transformContext``
+Sets the coordinate transform context to ``transformContext``
 
-.. versionadded:: 3.10
+.. versionadded:: 3.8
 %End
 
   protected:

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -104,11 +104,20 @@ Constructor. Provider is not set.
     struct LayerOptions
     {
 
-      explicit LayerOptions( bool loadDefaultStyle = true,
-                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
+ explicit LayerOptions( bool loadDefaultStyle = true ) /Deprecated/;
 %Docstring
 Constructor for LayerOptions.
+
+.. deprecated:: Use version with transformContext argument instead
 %End
+
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext, bool loadDefaultStyle = true );
+%Docstring
+Constructor for LayerOptions.
+
+.. versionadded:: 3.10
+%End
+
 
       bool loadDefaultStyle;
 

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -104,12 +104,16 @@ Constructor. Provider is not set.
     struct LayerOptions
     {
 
-      explicit LayerOptions( bool loadDefaultStyle = true );
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() );
 %Docstring
 Constructor for LayerOptions.
 %End
 
       bool loadDefaultStyle;
+
+      QgsCoordinateTransformContext coordinateTransformContext;
+
     };
 
     explicit QgsRasterLayer( const QString &uri,
@@ -379,6 +383,13 @@ Writes the symbology of the layer into the document provided in SLD 1.0.0 format
 
   public slots:
     void showStatusMessage( const QString &message );
+
+    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+%Docstring
+Change coordinate transform context to ``coordinateTransformContext``
+
+.. versionadded:: 3.10
+%End
 
   protected:
     virtual bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories );

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -105,14 +105,14 @@ Constructor. Provider is not set.
     {
 
       explicit LayerOptions( bool loadDefaultStyle = true,
-                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() );
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() );
 %Docstring
 Constructor for LayerOptions.
 %End
 
       bool loadDefaultStyle;
 
-      QgsCoordinateTransformContext coordinateTransformContext;
+      QgsCoordinateTransformContext transformContext;
 
     };
 
@@ -384,9 +384,9 @@ Writes the symbology of the layer into the document provided in SLD 1.0.0 format
   public slots:
     void showStatusMessage( const QString &message );
 
-    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 %Docstring
-Change coordinate transform context to ``coordinateTransformContext``
+Triggered when the coordinate transform context has changed ``transformContext``
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/raster/qgsrasterprojector.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterprojector.sip.in
@@ -46,10 +46,20 @@ which are used to calculate affine transformation matrices.
     virtual Qgis::DataType dataType( int bandNo ) const;
 
 
-    void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
-                 int srcDatumTransform = -1, int destDatumTransform = -1 );
+ void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
+                                   int srcDatumTransform = -1, int destDatumTransform = -1 ) /Deprecated/;
 %Docstring
 Sets the source and destination CRS
+
+.. deprecated:: since QGIS 3.8, use transformContext version instead
+%End
+
+    void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
+                 QgsCoordinateTransformContext transformContext );
+%Docstring
+Sets source CRS to ``srcCRS`` and destination CRS to ``destCRS`` and the transformation context to ``transformContext``
+
+.. versionadded:: 3.8
 %End
 
     QgsCoordinateReferenceSystem sourceCrs() const;

--- a/python/core/auto_generated/raster/qgsrasterviewport.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterviewport.sip.in
@@ -31,6 +31,8 @@ struct QgsRasterViewPort
 
   int mSrcDatumTransform;
   int mDestDatumTransform;
+
+  QgsCoordinateTransformContext mTransformContext;
 };
 
 /************************************************************************

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -489,9 +489,9 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
                     elif layer.type() == QgsMapLayerType.VectorLayer:
                         self.loadVectorLayer(layerName, layer, external=None, feedback=feedback)
 
-        self.postInputs()
+        self.postInputs(context)
 
-    def postInputs(self):
+    def postInputs(self, context):
         """
         After layer imports, we need to update some internal parameters
         """
@@ -500,7 +500,7 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
 
         # Build GRASS region
         if self.region.isEmpty():
-            self.region = QgsProcessingUtils.combineLayerExtents(self.inputLayers)
+            self.region = QgsProcessingUtils.combineLayerExtents(self.inputLayers, context)
         command = 'g.region n={} s={} e={} w={}'.format(
             self.region.yMaximum(), self.region.yMinimum(),
             self.region.xMaximum(), self.region.xMinimum()

--- a/python/plugins/processing/algs/grass7/ext/r_blend_combine.py
+++ b/python/plugins/processing/algs/grass7/ext/r_blend_combine.py
@@ -33,7 +33,7 @@ def processInputs(alg, parameters, context, feedback):
     # Use v.in.ogr
     for name in ['first', 'second']:
         alg.loadRasterLayerFromParameter(name, parameters, context, False, None)
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processOutputs(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/r_blend_rgb.py
+++ b/python/plugins/processing/algs/grass7/ext/r_blend_rgb.py
@@ -37,7 +37,7 @@ def processInputs(alg, parameters, context, feedback):
     # Use v.in.ogr
     for name in ['first', 'second']:
         alg.loadRasterLayerFromParameter(name, parameters, context, False, None)
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processCommand(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/r_category.py
+++ b/python/plugins/processing/algs/grass7/ext/r_category.py
@@ -52,7 +52,7 @@ def processInputs(alg, parameters, context, feedback):
                                          parameters, context,
                                          False, None)
     alg.loadRasterLayerFromParameter('map', parameters, context)
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processCommand(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/r_colors.py
+++ b/python/plugins/processing/algs/grass7/ext/r_colors.py
@@ -54,7 +54,7 @@ def processInputs(alg, parameters, context, feedback):
     if raster:
         alg.loadRasterLayerFromParameter('raster', parameters, context, False, None)
 
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processCommand(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/r_colors_stddev.py
+++ b/python/plugins/processing/algs/grass7/ext/r_colors_stddev.py
@@ -35,7 +35,7 @@ def processInputs(alg, parameters, context, feedback):
 
     # We need to import all the bands and color tables of the input raster
     alg.loadRasterLayerFromParameter('map', parameters, context, False, None)
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processCommand(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/r_null.py
+++ b/python/plugins/processing/algs/grass7/ext/r_null.py
@@ -42,7 +42,7 @@ def processInputs(alg, parameters, context, feedback):
 
     # We need to import without r.external
     alg.loadRasterLayerFromParameter('map', parameters, context, False)
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processCommand(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/r_rgb.py
+++ b/python/plugins/processing/algs/grass7/ext/r_rgb.py
@@ -32,7 +32,7 @@ def processInputs(alg, parameters, context, feedback):
 
     # We need to import all the bands and color tables of the input raster
     alg.loadRasterLayerFromParameter('input', parameters, context, False, None)
-    alg.postInputs()
+    alg.postInputs(context)
 
 
 def processCommand(alg, parameters, context, feedback):

--- a/python/plugins/processing/algs/grass7/ext/v_sample.py
+++ b/python/plugins/processing/algs/grass7/ext/v_sample.py
@@ -34,4 +34,4 @@ def processInputs(alg, parameters, context, feedback):
     # and we can use r.external for the raster
     alg.loadVectorLayerFromParameter('input', parameters, context, feedback, False)
     alg.loadRasterLayerFromParameter('raster', parameters, context, True)
-    alg.postInputs()
+    alg.postInputs(context)

--- a/python/plugins/processing/algs/grass7/ext/v_to_3d.py
+++ b/python/plugins/processing/algs/grass7/ext/v_to_3d.py
@@ -42,4 +42,4 @@ def processInputs(alg, parameters, context, feedback):
 
     # We need to import the vector layer with v.in.ogr
     alg.loadVectorLayerFromParameter('input', parameters, context, feedback, False)
-    alg.postInputs()
+    alg.postInputs(context)

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -184,7 +184,8 @@ class RasterCalculator(QgisAlgorithm):
                                    crs,
                                    width,
                                    height,
-                                   entries)
+                                   entries,
+                                   context.transformContext())
 
         res = calc.processCalculation(feedback)
         if res == QgsRasterCalculator.ParserError:

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -127,7 +127,7 @@ class RasterCalculator(QgisAlgorithm):
                 bbox = transform.transformBoundingBox(bbox)
 
         if bbox.isNull() and layers:
-            bbox = QgsProcessingUtils.combineLayerExtents(layers, crs)
+            bbox = QgsProcessingUtils.combineLayerExtents(layers, crs, context)
 
         cellsize = self.parameterAsDouble(parameters, self.CELLSIZE, context)
         if cellsize == 0 and not layers:

--- a/src/3d/terrain/qgsdemterraingenerator.cpp
+++ b/src/3d/terrain/qgsdemterraingenerator.cpp
@@ -27,7 +27,7 @@ QgsDemTerrainGenerator::~QgsDemTerrainGenerator()
 void QgsDemTerrainGenerator::setLayer( QgsRasterLayer *layer )
 {
   mLayer = QgsMapLayerRef( layer );
-  updateGenerator();
+  updateGenerator( mTransformContext );
 }
 
 QgsRasterLayer *QgsDemTerrainGenerator::layer() const
@@ -39,7 +39,7 @@ void QgsDemTerrainGenerator::setCrs( const QgsCoordinateReferenceSystem &crs, co
 {
   mCrs = crs;
   mTransformContext = context;
-  updateGenerator();
+  updateGenerator( context );
 }
 
 QgsTerrainGenerator *QgsDemTerrainGenerator::clone() const
@@ -49,7 +49,7 @@ QgsTerrainGenerator *QgsDemTerrainGenerator::clone() const
   cloned->mLayer = mLayer;
   cloned->mResolution = mResolution;
   cloned->mSkirtHeight = mSkirtHeight;
-  cloned->updateGenerator();
+  cloned->updateGenerator( mTransformContext );
   return cloned;
 }
 
@@ -93,7 +93,7 @@ void QgsDemTerrainGenerator::readXml( const QDomElement &elem )
 void QgsDemTerrainGenerator::resolveReferences( const QgsProject &project )
 {
   mLayer = QgsMapLayerRef( project.mapLayer( mLayer.layerId ) );
-  updateGenerator();
+  updateGenerator( project.transformContext() );
 }
 
 QgsChunkLoader *QgsDemTerrainGenerator::createChunkLoader( QgsChunkNode *node ) const
@@ -101,7 +101,7 @@ QgsChunkLoader *QgsDemTerrainGenerator::createChunkLoader( QgsChunkNode *node ) 
   return new QgsDemTerrainTileLoader( mTerrain, node );
 }
 
-void QgsDemTerrainGenerator::updateGenerator()
+void QgsDemTerrainGenerator::updateGenerator( const QgsCoordinateTransformContext &transformContext )
 {
   QgsRasterLayer *dem = layer();
   if ( dem )
@@ -112,7 +112,7 @@ void QgsDemTerrainGenerator::updateGenerator()
 
     mTerrainTilingScheme = QgsTilingScheme( te, mCrs );
     delete mHeightMapGenerator;
-    mHeightMapGenerator = new QgsDemHeightMapGenerator( dem, mTerrainTilingScheme, mResolution );
+    mHeightMapGenerator = new QgsDemHeightMapGenerator( dem, mTerrainTilingScheme, mResolution, transformContext );
   }
   else
   {

--- a/src/3d/terrain/qgsdemterraingenerator.cpp
+++ b/src/3d/terrain/qgsdemterraingenerator.cpp
@@ -27,7 +27,7 @@ QgsDemTerrainGenerator::~QgsDemTerrainGenerator()
 void QgsDemTerrainGenerator::setLayer( QgsRasterLayer *layer )
 {
   mLayer = QgsMapLayerRef( layer );
-  updateGenerator( mTransformContext );
+  updateGenerator();
 }
 
 QgsRasterLayer *QgsDemTerrainGenerator::layer() const
@@ -39,7 +39,7 @@ void QgsDemTerrainGenerator::setCrs( const QgsCoordinateReferenceSystem &crs, co
 {
   mCrs = crs;
   mTransformContext = context;
-  updateGenerator( context );
+  updateGenerator();
 }
 
 QgsTerrainGenerator *QgsDemTerrainGenerator::clone() const
@@ -49,7 +49,7 @@ QgsTerrainGenerator *QgsDemTerrainGenerator::clone() const
   cloned->mLayer = mLayer;
   cloned->mResolution = mResolution;
   cloned->mSkirtHeight = mSkirtHeight;
-  cloned->updateGenerator( mTransformContext );
+  cloned->updateGenerator();
   return cloned;
 }
 
@@ -93,7 +93,7 @@ void QgsDemTerrainGenerator::readXml( const QDomElement &elem )
 void QgsDemTerrainGenerator::resolveReferences( const QgsProject &project )
 {
   mLayer = QgsMapLayerRef( project.mapLayer( mLayer.layerId ) );
-  updateGenerator( project.transformContext() );
+  updateGenerator();
 }
 
 QgsChunkLoader *QgsDemTerrainGenerator::createChunkLoader( QgsChunkNode *node ) const
@@ -101,7 +101,7 @@ QgsChunkLoader *QgsDemTerrainGenerator::createChunkLoader( QgsChunkNode *node ) 
   return new QgsDemTerrainTileLoader( mTerrain, node );
 }
 
-void QgsDemTerrainGenerator::updateGenerator( const QgsCoordinateTransformContext &transformContext )
+void QgsDemTerrainGenerator::updateGenerator()
 {
   QgsRasterLayer *dem = layer();
   if ( dem )
@@ -112,7 +112,7 @@ void QgsDemTerrainGenerator::updateGenerator( const QgsCoordinateTransformContex
 
     mTerrainTilingScheme = QgsTilingScheme( te, mCrs );
     delete mHeightMapGenerator;
-    mHeightMapGenerator = new QgsDemHeightMapGenerator( dem, mTerrainTilingScheme, mResolution, transformContext );
+    mHeightMapGenerator = new QgsDemHeightMapGenerator( dem, mTerrainTilingScheme, mResolution, mTransformContext );
   }
   else
   {

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -72,7 +72,7 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
     QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override SIP_FACTORY;
 
   private:
-    void updateGenerator();
+    void updateGenerator( const QgsCoordinateTransformContext &transformContext );
 
     QgsDemHeightMapGenerator *mHeightMapGenerator = nullptr;
 

--- a/src/3d/terrain/qgsdemterraingenerator.h
+++ b/src/3d/terrain/qgsdemterraingenerator.h
@@ -72,7 +72,7 @@ class _3D_EXPORT QgsDemTerrainGenerator : public QgsTerrainGenerator
     QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override SIP_FACTORY;
 
   private:
-    void updateGenerator( const QgsCoordinateTransformContext &transformContext );
+    void updateGenerator();
 
     QgsDemHeightMapGenerator *mHeightMapGenerator = nullptr;
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -148,13 +148,13 @@ void QgsDemTerrainTileLoader::onHeightMapReady( int jobId, const QByteArray &hei
 #include <QFutureWatcher>
 #include "qgsterraindownloader.h"
 
-QgsDemHeightMapGenerator::QgsDemHeightMapGenerator( QgsRasterLayer *dtm, const QgsTilingScheme &tilingScheme, int resolution )
+QgsDemHeightMapGenerator::QgsDemHeightMapGenerator( QgsRasterLayer *dtm, const QgsTilingScheme &tilingScheme, int resolution, const QgsCoordinateTransformContext &transformContext )
   : mDtm( dtm )
   , mClonedProvider( dtm ? ( QgsRasterDataProvider * )dtm->dataProvider()->clone() : nullptr )
   , mTilingScheme( tilingScheme )
   , mResolution( resolution )
   , mLastJobId( 0 )
-  , mDownloader( dtm ? nullptr : new QgsTerrainDownloader )
+  , mDownloader( dtm ? nullptr : new QgsTerrainDownloader( transformContext ) )
 {
 }
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -176,7 +176,7 @@ static QByteArray _readDtmData( QgsRasterDataProvider *provider, const QgsRectan
   if ( provider->crs() != destCrs )
   {
     projector.reset( new QgsRasterProjector );
-    projector->setCrs( provider->crs(), destCrs );
+    projector->setCrs( provider->crs(), destCrs, provider->transformContext() );
     projector->setInput( provider );
     input = projector.get();
   }

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -37,6 +37,7 @@
 
 class QgsRasterDataProvider;
 class QgsRasterLayer;
+class QgsCoordinateTransformContext;
 
 /**
  * \ingroup 3d
@@ -80,7 +81,7 @@ class QgsDemHeightMapGenerator : public QObject
      * Constructs height map generator based on a raster layer with elevation model,
      * terrain's tiling scheme and height map resolution (number of height values on each side of tile)
      */
-    QgsDemHeightMapGenerator( QgsRasterLayer *dtm, const QgsTilingScheme &tilingScheme, int resolution );
+    QgsDemHeightMapGenerator( QgsRasterLayer *dtm, const QgsTilingScheme &tilingScheme, int resolution, const QgsCoordinateTransformContext &transformContext );
     ~QgsDemHeightMapGenerator() override;
 
     //! asynchronous terrain read for a tile (array of floats)

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -113,5 +113,5 @@ void QgsOnlineTerrainGenerator::updateGenerator()
     mTerrainTilingScheme = QgsTilingScheme( mExtent, mCrs );
   }
 
-  mHeightMapGenerator.reset( new QgsDemHeightMapGenerator( nullptr, mTerrainTilingScheme, mResolution ) );
+  mHeightMapGenerator.reset( new QgsDemHeightMapGenerator( nullptr, mTerrainTilingScheme, mResolution, mTransformContext ) );
 }

--- a/src/3d/terrain/qgsterraindownloader.cpp
+++ b/src/3d/terrain/qgsterraindownloader.cpp
@@ -21,16 +21,14 @@
 #include "qgsgdalutils.h"
 
 
-QgsTerrainDownloader::QgsTerrainDownloader()
+QgsTerrainDownloader::QgsTerrainDownloader( const QgsCoordinateTransformContext &transformContext )
 {
   setDataSource( defaultDataSource() );
 
   // the whole world is projected to a square:
   // X going from 180 W to 180 E
   // Y going from ~85 N to ~85 S  (=atan(sinh(pi)) ... to get a square)
-  Q_NOWARN_DEPRECATED_PUSH
-  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( "EPSG:3857" ) );
-  Q_NOWARN_DEPRECATED_POP
+  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), transformContext );
   QgsPointXY topLeftLonLat( -180, 180.0 / M_PI * std::atan( std::sinh( M_PI ) ) );
   QgsPointXY bottomRightLonLat( 180, 180.0 / M_PI * std::atan( std::sinh( -M_PI ) ) );
   QgsPointXY topLeft = ct.transform( topLeftLonLat );

--- a/src/3d/terrain/qgsterraindownloader.h
+++ b/src/3d/terrain/qgsterraindownloader.h
@@ -44,7 +44,13 @@ class _3D_EXPORT QgsTerrainDownloader
 {
 
   public:
+
+    /**
+     * Constructs a QgsTerrainDownloader object
+     * \param transformContext coordinate transform context
+     */
     QgsTerrainDownloader( const QgsCoordinateTransformContext  &transformContext );
+
     ~QgsTerrainDownloader();
 
     //! Definition of data source for terrain tiles (assuming "terrarium" data encoding with usual XYZ tiling scheme)

--- a/src/3d/terrain/qgsterraindownloader.h
+++ b/src/3d/terrain/qgsterraindownloader.h
@@ -27,6 +27,7 @@
 class QgsRectangle;
 class QgsCoordinateReferenceSystem;
 class QgsRasterLayer;
+class QgsCoordinateTransformContext;
 
 /**
  * \ingroup 3d
@@ -43,7 +44,7 @@ class _3D_EXPORT QgsTerrainDownloader
 {
 
   public:
-    QgsTerrainDownloader();
+    QgsTerrainDownloader( const QgsCoordinateTransformContext  &transformContext );
     ~QgsTerrainDownloader();
 
     //! Definition of data source for terrain tiles (assuming "terrarium" data encoding with usual XYZ tiling scheme)

--- a/src/analysis/processing/qgsalgorithmrasterlogicalop.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlogicalop.cpp
@@ -103,7 +103,7 @@ bool QgsRasterBooleanLogicAlgorithmBase::prepareAlgorithm( const QVariantMap &pa
       {
         input.projector = qgis::make_unique< QgsRasterProjector >();
         input.projector->setInput( input.sourceDataProvider.get() );
-        input.projector->setCrs( layer->crs(), mCrs );
+        input.projector->setCrs( layer->crs(), mCrs, context.transformContext() );
         input.interface = input.projector.get();
       }
       mInputs.emplace_back( std::move( input ) );

--- a/src/analysis/processing/qgsalgorithmrasterzonalstats.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterzonalstats.cpp
@@ -140,7 +140,7 @@ bool QgsRasterLayerZonalStatsAlgorithm::prepareAlgorithm( const QVariantMap &par
       {
         mProjector = qgis::make_unique< QgsRasterProjector >();
         mProjector->setInput( mZonesDataProvider.get() );
-        mProjector->setCrs( zonesLayer->crs(), layer->crs() );
+        mProjector->setCrs( zonesLayer->crs(), layer->crs(), context.transformContext() );
         mZonesInterface = mProjector.get();
       }
       break;
@@ -158,7 +158,7 @@ bool QgsRasterLayerZonalStatsAlgorithm::prepareAlgorithm( const QVariantMap &par
       {
         mProjector = qgis::make_unique< QgsRasterProjector >();
         mProjector->setInput( mSourceDataProvider.get() );
-        mProjector->setCrs( layer->crs(), zonesLayer->crs() );
+        mProjector->setCrs( layer->crs(), zonesLayer->crs(), context.transformContext() );
         mSourceInterface = mProjector.get();
       }
       break;

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -36,6 +36,36 @@
 #include "qgsgdalutils.h"
 #endif
 
+QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat, const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries, const QgsCoordinateTransformContext &transformContext )
+  : mFormulaString( formulaString )
+  , mOutputFile( outputFile )
+  , mOutputFormat( outputFormat )
+  , mOutputRectangle( outputExtent )
+  , mNumOutputColumns( nOutputColumns )
+  , mNumOutputRows( nOutputRows )
+  , mRasterEntries( rasterEntries )
+  , mTransformContext( transformContext )
+{
+
+}
+
+QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
+    const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows,
+    const QVector<QgsRasterCalculatorEntry> &rasterEntries, const QgsCoordinateTransformContext &transformContext )
+  : mFormulaString( formulaString )
+  , mOutputFile( outputFile )
+  , mOutputFormat( outputFormat )
+  , mOutputRectangle( outputExtent )
+  , mOutputCrs( outputCrs )
+  , mNumOutputColumns( nOutputColumns )
+  , mNumOutputRows( nOutputRows )
+  , mRasterEntries( rasterEntries )
+  , mTransformContext( transformContext )
+{
+
+}
+
+// Deprecated!
 QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
     const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries )
   : mFormulaString( formulaString )
@@ -48,8 +78,11 @@ QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QS
 {
   //default to first layer's crs
   mOutputCrs = mRasterEntries.at( 0 ).raster->crs();
+  mTransformContext = QgsProject::instance()->transformContext();
 }
 
+
+// Deprecated!
 QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
     const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries )
   : mFormulaString( formulaString )
@@ -61,6 +94,7 @@ QgsRasterCalculator::QgsRasterCalculator( const QString &formulaString, const QS
   , mNumOutputRows( nOutputRows )
   , mRasterEntries( rasterEntries )
 {
+  mTransformContext = QgsProject::instance()->transformContext();
 }
 
 QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback *feedback )
@@ -176,7 +210,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
         if ( uniqueRasterEntries[layerRef.first].raster->crs() != mOutputCrs )
         {
           QgsRasterProjector proj;
-          proj.setCrs( ref.raster->crs(), mOutputCrs, ref.raster->dataProvider()->transformContext() );
+          proj.setCrs( ref.raster->crs(), mOutputCrs, mTransformContext );
           proj.setInput( ref.raster->dataProvider() );
           proj.setPrecision( QgsRasterProjector::Exact );
           layerRef.second.reset( proj.block( ref.bandNumber, rect, mNumOutputColumns, 1 ) );

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -176,7 +176,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
         if ( uniqueRasterEntries[layerRef.first].raster->crs() != mOutputCrs )
         {
           QgsRasterProjector proj;
-          proj.setCrs( ref.raster->crs(), mOutputCrs );
+          proj.setCrs( ref.raster->crs(), mOutputCrs, ref.raster->dataProvider()->transformContext() );
           proj.setInput( ref.raster->dataProvider() );
           proj.setPrecision( QgsRasterProjector::Exact );
           layerRef.second.reset( proj.block( ref.bandNumber, rect, mNumOutputColumns, 1 ) );
@@ -227,7 +227,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
       if ( it->raster->crs() != mOutputCrs )
       {
         QgsRasterProjector proj;
-        proj.setCrs( it->raster->crs(), mOutputCrs );
+        proj.setCrs( it->raster->crs(), mOutputCrs, it->raster->dataProvider()->transformContext() );
         proj.setInput( it->raster->dataProvider() );
         proj.setPrecision( QgsRasterProjector::Exact );
 
@@ -516,7 +516,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
       if ( ref.layer->crs() != mOutputCrs )
       {
         QgsRasterProjector proj;
-        proj.setCrs( ref.layer->crs(), mOutputCrs );
+        proj.setCrs( ref.layer->crs(), mOutputCrs, ref.layer->dataProvider()->transformContext() );
         proj.setInput( ref.layer->dataProvider() );
         proj.setPrecision( QgsRasterProjector::Exact );
         block.reset( proj.block( ref.band, rect, mNumOutputColumns, 1 ) );

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -261,7 +261,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
       if ( it->raster->crs() != mOutputCrs )
       {
         QgsRasterProjector proj;
-        proj.setCrs( it->raster->crs(), mOutputCrs, it->raster->dataProvider()->transformContext() );
+        proj.setCrs( it->raster->crs(), mOutputCrs, it->raster->transformContext() );
         proj.setInput( it->raster->dataProvider() );
         proj.setPrecision( QgsRasterProjector::Exact );
 
@@ -550,7 +550,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
       if ( ref.layer->crs() != mOutputCrs )
       {
         QgsRasterProjector proj;
-        proj.setCrs( ref.layer->crs(), mOutputCrs, ref.layer->dataProvider()->transformContext() );
+        proj.setCrs( ref.layer->crs(), mOutputCrs, ref.layer->transformContext() );
         proj.setInput( ref.layer->dataProvider() );
         proj.setPrecision( QgsRasterProjector::Exact );
         block.reset( proj.block( ref.band, rect, mNumOutputColumns, 1 ) );

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -99,8 +99,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
      * \param nOutputColumns number of columns in output raster
      * \param nOutputRows number of rows in output raster
      * \param rasterEntries list of referenced raster layers
-      * \param transformContext coordinate transformation context
-     * \deprecated since QGIS 3.8, use the version with transformContext instead
+     * \param transformContext coordinate transformation context
      * \since QGIS 3.8
      */
     QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
@@ -119,7 +118,6 @@ class ANALYSIS_EXPORT QgsRasterCalculator
      * \param nOutputRows number of rows in output raster
      * \param rasterEntries list of referenced raster layers
      * \param transformContext coordinate transformation context
-     * \deprecated since QGIS 3.8, use the version with transformContext instead
      * \since QGIS 3.8
      */
     QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -89,6 +89,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
       BandError = 6, //!< Invalid band number for input
     };
 
+
     /**
      * QgsRasterCalculator constructor.
      * \param formulaString formula for raster calculation
@@ -98,9 +99,14 @@ class ANALYSIS_EXPORT QgsRasterCalculator
      * \param nOutputColumns number of columns in output raster
      * \param nOutputRows number of rows in output raster
      * \param rasterEntries list of referenced raster layers
+      * \param transformContext coordinate transformation context
+     * \deprecated since QGIS 3.8, use the version with transformContext instead
+     * \since QGIS 3.8
      */
     QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
-                         const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries );
+                         const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows,
+                         const QVector<QgsRasterCalculatorEntry> &rasterEntries,
+                         const QgsCoordinateTransformContext &transformContext );
 
     /**
      * QgsRasterCalculator constructor.
@@ -112,10 +118,46 @@ class ANALYSIS_EXPORT QgsRasterCalculator
      * \param nOutputColumns number of columns in output raster
      * \param nOutputRows number of rows in output raster
      * \param rasterEntries list of referenced raster layers
-     * \since QGIS 2.10
+     * \param transformContext coordinate transformation context
+     * \deprecated since QGIS 3.8, use the version with transformContext instead
+     * \since QGIS 3.8
      */
     QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
-                         const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries );
+                         const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs,
+                         int nOutputColumns, int nOutputRows,
+                         const QVector<QgsRasterCalculatorEntry> &rasterEntries,
+                         const QgsCoordinateTransformContext &transformContext );
+
+
+    /**
+    * QgsRasterCalculator constructor.
+    * \param formulaString formula for raster calculation
+    * \param outputFile output file path
+    * \param outputFormat output file format
+    * \param outputExtent output extent. CRS for output is taken from first entry in rasterEntries.
+    * \param nOutputColumns number of columns in output raster
+    * \param nOutputRows number of rows in output raster
+    * \param rasterEntries list of referenced raster layers
+    * \deprecated since QGIS 3.8, use the version with transformContext instead
+    */
+    Q_DECL_DEPRECATED QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
+                                           const QgsRectangle &outputExtent, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) SIP_DEPRECATED;
+
+    /**
+     * QgsRasterCalculator constructor.
+     * \param formulaString formula for raster calculation
+     * \param outputFile output file path
+     * \param outputFormat output file format
+     * \param outputExtent output extent, CRS is specified by outputCrs parameter
+     * \param outputCrs destination CRS for output raster
+     * \param nOutputColumns number of columns in output raster
+     * \param nOutputRows number of rows in output raster
+     * \param rasterEntries list of referenced raster layers
+     * \deprecated since QGIS 3.8, use the version with transformContext instead
+     * \since QGIS 2.10
+     */
+    Q_DECL_DEPRECATED QgsRasterCalculator( const QString &formulaString, const QString &outputFile, const QString &outputFormat,
+                                           const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &outputCrs, int nOutputColumns, int nOutputRows, const QVector<QgsRasterCalculatorEntry> &rasterEntries ) SIP_DEPRECATED;
 
     /**
      * Starts the calculation and writes a new raster.
@@ -172,6 +214,8 @@ class ANALYSIS_EXPORT QgsRasterCalculator
 
     /***/
     QVector<QgsRasterCalculatorEntry> mRasterEntries;
+
+    QgsCoordinateTransformContext mTransformContext;
 };
 
 #endif // QGSRASTERCALCULATOR_H

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -364,7 +364,7 @@ void QgsLayerItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
         case QgsMapLayerType::VectorLayer:
         {
           const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-          std::unique_ptr<QgsVectorLayer> layer( new QgsVectorLayer( options, layerItem->uri(), layerItem->name(), layerItem->providerKey() ) );
+          std::unique_ptr<QgsVectorLayer> layer( new QgsVectorLayer( layerItem->uri(), layerItem->name(), layerItem->providerKey(), options ) );
           if ( layer && layer->isValid() )
           {
             QgisApp::instance()->saveAsFile( layer.get(), false, false );

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -363,7 +363,8 @@ void QgsLayerItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
       {
         case QgsMapLayerType::VectorLayer:
         {
-          std::unique_ptr<QgsVectorLayer> layer( new QgsVectorLayer( layerItem->uri(), layerItem->name(), layerItem->providerKey() ) );
+          const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+          std::unique_ptr<QgsVectorLayer> layer( new QgsVectorLayer( options, layerItem->uri(), layerItem->name(), layerItem->providerKey() ) );
           if ( layer && layer->isValid() )
           {
             QgisApp::instance()->saveAsFile( layer.get(), false, false );

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -148,9 +148,9 @@ void QgsDwgImportDialog::pbLoadDatabase_clicked()
 
   bool lblVisible = false;
 
-  QgsVectorLayer::LayerOptions options;
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   options.loadDefaultStyle = false;
-  std::unique_ptr<QgsVectorLayer> d( new QgsVectorLayer( QStringLiteral( "%1|layername=drawing" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ), options ) );
+  std::unique_ptr<QgsVectorLayer> d( new QgsVectorLayer( options, QStringLiteral( "%1|layername=drawing" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ) ) );
   if ( d && d->isValid() )
   {
     int idxPath = d->fields().lookupField( QStringLiteral( "path" ) );
@@ -185,7 +185,7 @@ void QgsDwgImportDialog::pbLoadDatabase_clicked()
 
   lblMessage->setVisible( lblVisible );
 
-  std::unique_ptr<QgsVectorLayer> l( new QgsVectorLayer( QStringLiteral( "%1|layername=layers" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ), options ) );
+  std::unique_ptr<QgsVectorLayer> l( new QgsVectorLayer( options, QStringLiteral( "%1|layername=layers" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ) ) );
   if ( l && l->isValid() )
   {
     int idxName = l->fields().lookupField( QStringLiteral( "name" ) );
@@ -263,9 +263,9 @@ void QgsDwgImportDialog::pbImportDrawing_clicked()
 
 QgsVectorLayer *QgsDwgImportDialog::layer( QgsLayerTreeGroup *layerGroup, const QString &layerFilter, const QString &table )
 {
-  QgsVectorLayer::LayerOptions options;
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   options.loadDefaultStyle = false;
-  QgsVectorLayer *l = new QgsVectorLayer( QStringLiteral( "%1|layername=%2" ).arg( mDatabaseFileWidget->filePath(), table ), table, QStringLiteral( "ogr" ), options );
+  QgsVectorLayer *l = new QgsVectorLayer( options, QStringLiteral( "%1|layername=%2" ).arg( mDatabaseFileWidget->filePath(), table ), table, QStringLiteral( "ogr" ) );
   l->setSubsetString( QStringLiteral( "%1space=0 AND block=-1" ).arg( layerFilter ) );
 
   if ( l->featureCount() == 0 )

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -150,7 +150,7 @@ void QgsDwgImportDialog::pbLoadDatabase_clicked()
 
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   options.loadDefaultStyle = false;
-  std::unique_ptr<QgsVectorLayer> d( new QgsVectorLayer( options, QStringLiteral( "%1|layername=drawing" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ) ) );
+  std::unique_ptr<QgsVectorLayer> d( new QgsVectorLayer( QStringLiteral( "%1|layername=drawing" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ), options ) );
   if ( d && d->isValid() )
   {
     int idxPath = d->fields().lookupField( QStringLiteral( "path" ) );
@@ -185,7 +185,7 @@ void QgsDwgImportDialog::pbLoadDatabase_clicked()
 
   lblMessage->setVisible( lblVisible );
 
-  std::unique_ptr<QgsVectorLayer> l( new QgsVectorLayer( options, QStringLiteral( "%1|layername=layers" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ) ) );
+  std::unique_ptr<QgsVectorLayer> l( new QgsVectorLayer( QStringLiteral( "%1|layername=layers" ).arg( mDatabaseFileWidget->filePath() ), QStringLiteral( "layers" ), QStringLiteral( "ogr" ), options ) );
   if ( l && l->isValid() )
   {
     int idxName = l->fields().lookupField( QStringLiteral( "name" ) );
@@ -265,7 +265,7 @@ QgsVectorLayer *QgsDwgImportDialog::layer( QgsLayerTreeGroup *layerGroup, const 
 {
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   options.loadDefaultStyle = false;
-  QgsVectorLayer *l = new QgsVectorLayer( options, QStringLiteral( "%1|layername=%2" ).arg( mDatabaseFileWidget->filePath(), table ), table, QStringLiteral( "ogr" ) );
+  QgsVectorLayer *l = new QgsVectorLayer( QStringLiteral( "%1|layername=%2" ).arg( mDatabaseFileWidget->filePath(), table ), table, QStringLiteral( "ogr" ), options );
   l->setSubsetString( QStringLiteral( "%1space=0 AND block=-1" ).arg( layerFilter ) );
 
   if ( l->featureCount() == 0 )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7554,7 +7554,7 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
   QString outputFormat = d.outputFormat();
 
   QgsRasterFileWriterTask *writerTask = new QgsRasterFileWriterTask( fileWriter, pipe.release(), d.nColumns(), d.nRows(),
-      d.outputRectangle(), QgsProject::instance()->transformContext(), d.outputCrs() );
+      d.outputRectangle(), d.outputCrs(), QgsProject::instance()->transformContext() );
 
   // when writer is successful:
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4685,7 +4685,7 @@ bool QgisApp::addVectorLayersPrivate( const QStringList &layerQStringList, const
     const bool isRemoteUrl { scheme.startsWith( QStringLiteral( "http" ) ) || scheme == QStringLiteral( "ftp" ) };
 
     // create the layer
-    QgsVectorLayer::LayerOptions options;
+    QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
     if ( isVsiCurl || isRemoteUrl )
     {
@@ -5226,7 +5226,7 @@ QList<QgsMapLayer *> QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
 
     QgsDebugMsg( "Creating new vector layer using " + composedURI );
     QString name = fileName + " " + def.layerName;
-    QgsVectorLayer::LayerOptions options;
+    QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
     QgsVectorLayer *layer = new QgsVectorLayer( composedURI, name, QStringLiteral( "ogr" ), options );
     if ( layer && layer->isValid() )
@@ -5289,7 +5289,7 @@ void QgisApp::addDatabaseLayers( QStringList const &layerPathList, QString const
     // create the layer
     QgsDataSourceUri uri( layerPath );
 
-    QgsVectorLayer::LayerOptions options;
+    QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
     QgsVectorLayer *layer = new QgsVectorLayer( uri.uri( false ), uri.table(), providerKey, options );
     Q_CHECK_PTR( layer );
@@ -11044,7 +11044,7 @@ QgsVectorLayer *QgisApp::addVectorLayerPrivate( const QString &vectorLayerPath, 
   }
 
   // create the layer
-  QgsVectorLayer::LayerOptions options;
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   // Default style is loaded later in this method
   options.loadDefaultStyle = false;
   QgsVectorLayer *layer = new QgsVectorLayer( vectorLayerPath, baseName, providerKey, options );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4615,7 +4615,7 @@ static void setupVectorLayer( const QString &vectorLayerPath,
     QString composedURI( uriParts.value( QStringLiteral( "path" ) ).toString() );
     composedURI += "|layername=" + rawLayerName;
 
-    auto newLayer = qgis::make_unique<QgsVectorLayer>( options, composedURI, layer->name(), QStringLiteral( "ogr" ) );
+    auto newLayer = qgis::make_unique<QgsVectorLayer>( composedURI, layer->name(), QStringLiteral( "ogr" ), options );
     if ( newLayer && newLayer->isValid() )
     {
       delete layer;
@@ -4693,7 +4693,7 @@ bool QgisApp::addVectorLayersPrivate( const QStringList &layerQStringList, const
       QApplication::setOverrideCursor( Qt::WaitCursor );
       qApp->processEvents();
     }
-    QgsVectorLayer *layer = new QgsVectorLayer( options, src, baseName, QStringLiteral( "ogr" ) );
+    QgsVectorLayer *layer = new QgsVectorLayer( src, baseName, QStringLiteral( "ogr" ), options );
     Q_CHECK_PTR( layer );
     if ( isVsiCurl || isRemoteUrl )
     {
@@ -5228,7 +5228,7 @@ QList<QgsMapLayer *> QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
     QString name = fileName + " " + def.layerName;
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
-    QgsVectorLayer *layer = new QgsVectorLayer( options, composedURI, name, QStringLiteral( "ogr" ) );
+    QgsVectorLayer *layer = new QgsVectorLayer( composedURI, name, QStringLiteral( "ogr" ), options );
     if ( layer && layer->isValid() )
     {
       result << layer;
@@ -5291,7 +5291,7 @@ void QgisApp::addDatabaseLayers( QStringList const &layerPathList, QString const
 
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
-    QgsVectorLayer *layer = new QgsVectorLayer( options, uri.uri( false ), uri.table(), providerKey );
+    QgsVectorLayer *layer = new QgsVectorLayer( uri.uri( false ), uri.table(), providerKey, options );
     Q_CHECK_PTR( layer );
 
     if ( ! layer )
@@ -5368,7 +5368,7 @@ void QgisApp::replaceSelectedVectorLayer( const QString &oldId, const QString &u
     return;
   QgsVectorLayer *oldLayer = static_cast<QgsVectorLayer *>( old );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *newLayer = new QgsVectorLayer( options, uri, layerName, provider );
+  QgsVectorLayer *newLayer = new QgsVectorLayer( uri, layerName, provider, options );
   if ( !newLayer || !newLayer->isValid() )
     return;
 
@@ -9803,7 +9803,7 @@ void QgisApp::layerSubsetString()
     {
       QgsVirtualLayerDefinition def = QgsVirtualLayerDefinitionUtils::fromJoinedLayer( vlayer );
       const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      QgsVectorLayer *newLayer = new QgsVectorLayer( options, def.toString(), vlayer->name() + " (virtual)", QStringLiteral( "virtual" ) );
+      QgsVectorLayer *newLayer = new QgsVectorLayer( def.toString(), vlayer->name() + " (virtual)", QStringLiteral( "virtual" ), options );
       if ( newLayer->isValid() )
       {
         duplicateVectorStyle( vlayer, newLayer );
@@ -11049,7 +11049,7 @@ QgsVectorLayer *QgisApp::addVectorLayerPrivate( const QString &vectorLayerPath, 
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   // Default style is loaded later in this method
   options.loadDefaultStyle = false;
-  QgsVectorLayer *layer = new QgsVectorLayer( options, vectorLayerPath, baseName, providerKey );
+  QgsVectorLayer *layer = new QgsVectorLayer( vectorLayerPath, baseName, providerKey, options );
 
   if ( authok && layer && layer->isValid() )
   {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7532,7 +7532,7 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
       QgsDebugMsg( QStringLiteral( "Cannot get pipe projector" ) );
       return QString();
     }
-    projector->setCrs( rasterLayer->crs(), d.outputCrs(), rasterLayer->dataProvider()->transformContext() );
+    projector->setCrs( rasterLayer->crs(), d.outputCrs(), QgsProject::instance()->transformContext() );
   }
 
   if ( !pipe->last() )
@@ -7554,7 +7554,7 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
   QString outputFormat = d.outputFormat();
 
   QgsRasterFileWriterTask *writerTask = new QgsRasterFileWriterTask( fileWriter, pipe.release(), d.nColumns(), d.nRows(),
-      d.outputRectangle(), d.outputCrs() );
+      d.outputRectangle(), QgsProject::instance()->transformContext(), d.outputCrs() );
 
   // when writer is successful:
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7505,7 +7505,7 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
     if ( d.outputCrs() != rasterLayer->crs() )
     {
       QgsRasterProjector *projector = new QgsRasterProjector;
-      projector->setCrs( rasterLayer->crs(), d.outputCrs() );
+      projector->setCrs( rasterLayer->crs(), d.outputCrs(), rasterLayer->dataProvider()->transformContext() );
       if ( !pipe->insert( 2, projector ) )
       {
         QgsDebugMsg( QStringLiteral( "Cannot set pipe projector" ) );
@@ -7524,7 +7524,7 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
       QgsDebugMsg( QStringLiteral( "Cannot get pipe projector" ) );
       return QString();
     }
-    projector->setCrs( rasterLayer->crs(), d.outputCrs() );
+    projector->setCrs( rasterLayer->crs(), d.outputCrs(), rasterLayer->dataProvider()->transformContext() );
   }
 
   if ( !pipe->last() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5768,7 +5768,15 @@ void QgisApp::showRasterCalculator()
   if ( d.exec() == QDialog::Accepted )
   {
     //invoke analysis library
-    QgsRasterCalculator rc( d.formulaString(), d.outputFile(), d.outputFormat(), d.outputRectangle(), d.outputCrs(), d.numberOfColumns(), d.numberOfRows(), QgsRasterCalculatorEntry::rasterEntries() );
+    QgsRasterCalculator rc( d.formulaString(),
+                            d.outputFile(),
+                            d.outputFormat(),
+                            d.outputRectangle(),
+                            d.outputCrs(),
+                            d.numberOfColumns(),
+                            d.numberOfRows(),
+                            QgsRasterCalculatorEntry::rasterEntries(),
+                            QgsProject::instance()->transformContext() );
 
     QProgressDialog p( tr( "Calculating raster expression…" ), tr( "Abort" ), 0, 0 );
     p.setWindowModality( Qt::WindowModal );
@@ -7505,7 +7513,7 @@ QString QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer, const bool defau
     if ( d.outputCrs() != rasterLayer->crs() )
     {
       QgsRasterProjector *projector = new QgsRasterProjector;
-      projector->setCrs( rasterLayer->crs(), d.outputCrs(), rasterLayer->dataProvider()->transformContext() );
+      projector->setCrs( rasterLayer->crs(), d.outputCrs(), QgsProject::instance()->transformContext() );
       if ( !pipe->insert( 2, projector ) )
       {
         QgsDebugMsg( QStringLiteral( "Cannot set pipe projector" ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4615,7 +4615,7 @@ static void setupVectorLayer( const QString &vectorLayerPath,
     QString composedURI( uriParts.value( QStringLiteral( "path" ) ).toString() );
     composedURI += "|layername=" + rawLayerName;
 
-    auto newLayer = qgis::make_unique<QgsVectorLayer>( composedURI, layer->name(), QStringLiteral( "ogr" ), options );
+    auto newLayer = qgis::make_unique<QgsVectorLayer>( options, composedURI, layer->name(), QStringLiteral( "ogr" ) );
     if ( newLayer && newLayer->isValid() )
     {
       delete layer;
@@ -4693,7 +4693,7 @@ bool QgisApp::addVectorLayersPrivate( const QStringList &layerQStringList, const
       QApplication::setOverrideCursor( Qt::WaitCursor );
       qApp->processEvents();
     }
-    QgsVectorLayer *layer = new QgsVectorLayer( src, baseName, QStringLiteral( "ogr" ), options );
+    QgsVectorLayer *layer = new QgsVectorLayer( options, src, baseName, QStringLiteral( "ogr" ) );
     Q_CHECK_PTR( layer );
     if ( isVsiCurl || isRemoteUrl )
     {
@@ -5228,7 +5228,7 @@ QList<QgsMapLayer *> QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
     QString name = fileName + " " + def.layerName;
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
-    QgsVectorLayer *layer = new QgsVectorLayer( composedURI, name, QStringLiteral( "ogr" ), options );
+    QgsVectorLayer *layer = new QgsVectorLayer( options, composedURI, name, QStringLiteral( "ogr" ) );
     if ( layer && layer->isValid() )
     {
       result << layer;
@@ -5291,7 +5291,7 @@ void QgisApp::addDatabaseLayers( QStringList const &layerPathList, QString const
 
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
-    QgsVectorLayer *layer = new QgsVectorLayer( uri.uri( false ), uri.table(), providerKey, options );
+    QgsVectorLayer *layer = new QgsVectorLayer( options, uri.uri( false ), uri.table(), providerKey );
     Q_CHECK_PTR( layer );
 
     if ( ! layer )
@@ -5367,7 +5367,8 @@ void QgisApp::replaceSelectedVectorLayer( const QString &oldId, const QString &u
   if ( !old )
     return;
   QgsVectorLayer *oldLayer = static_cast<QgsVectorLayer *>( old );
-  QgsVectorLayer *newLayer = new QgsVectorLayer( uri, layerName, provider );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *newLayer = new QgsVectorLayer( options, uri, layerName, provider );
   if ( !newLayer || !newLayer->isValid() )
     return;
 
@@ -9801,7 +9802,8 @@ void QgisApp::layerSubsetString()
                                 QMessageBox::Yes | QMessageBox::No ) == QMessageBox::Yes )
     {
       QgsVirtualLayerDefinition def = QgsVirtualLayerDefinitionUtils::fromJoinedLayer( vlayer );
-      QgsVectorLayer *newLayer = new QgsVectorLayer( def.toString(), vlayer->name() + " (virtual)", QStringLiteral( "virtual" ) );
+      const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+      QgsVectorLayer *newLayer = new QgsVectorLayer( options, def.toString(), vlayer->name() + " (virtual)", QStringLiteral( "virtual" ) );
       if ( newLayer->isValid() )
       {
         duplicateVectorStyle( vlayer, newLayer );
@@ -11047,7 +11049,7 @@ QgsVectorLayer *QgisApp::addVectorLayerPrivate( const QString &vectorLayerPath, 
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
   // Default style is loaded later in this method
   options.loadDefaultStyle = false;
-  QgsVectorLayer *layer = new QgsVectorLayer( vectorLayerPath, baseName, providerKey, options );
+  QgsVectorLayer *layer = new QgsVectorLayer( options, vectorLayerPath, baseName, providerKey );
 
   if ( authok && layer && layer->isValid() )
   {

--- a/src/app/qgsappscreenshots.cpp
+++ b/src/app/qgsappscreenshots.cpp
@@ -42,9 +42,10 @@ QgsAppScreenShots::QgsAppScreenShots( const QString &saveDirectory )
   : mSaveDirectory( saveDirectory )
 {
   QString layerDef = QStringLiteral( "Point?crs=epsg:4326&field=pk:integer&field=my_text:string&field=fk_polygon:integer&field=my_double:double&key=pk" );
-  mLineLayer = new QgsVectorLayer( layerDef, QStringLiteral( "Line Layer" ), QStringLiteral( "memory" ) );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  mLineLayer = new QgsVectorLayer( options, layerDef, QStringLiteral( "Line Layer" ), QStringLiteral( "memory" ) );
   layerDef = QStringLiteral( "Polygon?crs=epsg:2056&field=pk:integer&field=my_text:string&field=my_integer:integer&field=height:double&key=pk" );
-  mPolygonLayer = new QgsVectorLayer( layerDef, QStringLiteral( "Polygon Layer" ), QStringLiteral( "memory" ) );
+  mPolygonLayer = new QgsVectorLayer( options, layerDef, QStringLiteral( "Polygon Layer" ), QStringLiteral( "memory" ) );
 
   QString dataPath( TEST_DATA_DIR ); //defined in CmakeLists.txt
   mRasterLayer = new QgsRasterLayer( dataPath + "/raster/with_color_table.tif", QStringLiteral( "raster" ), QStringLiteral( "gdal" ) );

--- a/src/app/qgsappscreenshots.cpp
+++ b/src/app/qgsappscreenshots.cpp
@@ -43,9 +43,9 @@ QgsAppScreenShots::QgsAppScreenShots( const QString &saveDirectory )
 {
   QString layerDef = QStringLiteral( "Point?crs=epsg:4326&field=pk:integer&field=my_text:string&field=fk_polygon:integer&field=my_double:double&key=pk" );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  mLineLayer = new QgsVectorLayer( options, layerDef, QStringLiteral( "Line Layer" ), QStringLiteral( "memory" ) );
+  mLineLayer = new QgsVectorLayer( layerDef, QStringLiteral( "Line Layer" ), QStringLiteral( "memory" ), options );
   layerDef = QStringLiteral( "Polygon?crs=epsg:2056&field=pk:integer&field=my_text:string&field=my_integer:integer&field=height:double&key=pk" );
-  mPolygonLayer = new QgsVectorLayer( options, layerDef, QStringLiteral( "Polygon Layer" ), QStringLiteral( "memory" ) );
+  mPolygonLayer = new QgsVectorLayer( layerDef, QStringLiteral( "Polygon Layer" ), QStringLiteral( "memory" ), options );
 
   QString dataPath( TEST_DATA_DIR ); //defined in CmakeLists.txt
   mRasterLayer = new QgsRasterLayer( dataPath + "/raster/with_color_table.tif", QStringLiteral( "raster" ), QStringLiteral( "gdal" ) );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -454,7 +454,8 @@ bool QgsNewSpatialiteLayerDialog::apply()
     }
   }
 
-  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "dbname='%1' table='%2'%3 sql=" )
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *layer = new QgsVectorLayer( options, QStringLiteral( "dbname='%1' table='%2'%3 sql=" )
       .arg( mDatabaseComboBox->currentText(),
             leLayerName->text(),
             mGeometryTypeBox->currentIndex() != 0 ? QStringLiteral( "(%1)" ).arg( leGeometryColumn->text() ) : QString() ),

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -455,11 +455,11 @@ bool QgsNewSpatialiteLayerDialog::apply()
   }
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *layer = new QgsVectorLayer( options, QStringLiteral( "dbname='%1' table='%2'%3 sql=" )
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "dbname='%1' table='%2'%3 sql=" )
       .arg( mDatabaseComboBox->currentText(),
             leLayerName->text(),
             mGeometryTypeBox->currentIndex() != 0 ? QStringLiteral( "(%1)" ).arg( leGeometryColumn->text() ) : QString() ),
-      leLayerName->text(), QStringLiteral( "spatialite" ) );
+      leLayerName->text(), QStringLiteral( "spatialite" ), options );
   if ( layer->isValid() )
   {
     // Reload connections to refresh browser panel

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -212,7 +212,8 @@ void QgsStatusBarCoordinatesWidget::contributors()
   }
   QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/contributors.json" );
   QFileInfo fileInfo = QFileInfo( fileName );
-  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *layer = new QgsVectorLayer( options, fileInfo.absoluteFilePath(),
       tr( "QGIS Contributors" ), QStringLiteral( "ogr" ) );
   // Register this layer with the layers registry
   QgsProject::instance()->addMapLayer( layer );
@@ -228,7 +229,8 @@ void QgsStatusBarCoordinatesWidget::world()
   }
   QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.shp" );
   QFileInfo fileInfo = QFileInfo( fileName );
-  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *layer = new QgsVectorLayer( options, fileInfo.absoluteFilePath(),
       tr( "World Map" ), QStringLiteral( "ogr" ) );
   // Register this layer with the layers registry
   QgsProject::instance()->addMapLayer( layer );
@@ -242,7 +244,8 @@ void QgsStatusBarCoordinatesWidget::hackfests()
   }
   QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/qgis-hackfests.json" );
   QFileInfo fileInfo = QFileInfo( fileName );
-  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *layer = new QgsVectorLayer( options, fileInfo.absoluteFilePath(),
       tr( "QGIS Hackfests" ), QStringLiteral( "ogr" ) );
   // Register this layer with the layers registry
   QgsProject::instance()->addMapLayer( layer );

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -213,8 +213,8 @@ void QgsStatusBarCoordinatesWidget::contributors()
   QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/contributors.json" );
   QFileInfo fileInfo = QFileInfo( fileName );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *layer = new QgsVectorLayer( options, fileInfo.absoluteFilePath(),
-      tr( "QGIS Contributors" ), QStringLiteral( "ogr" ) );
+  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+      tr( "QGIS Contributors" ), QStringLiteral( "ogr" ), options );
   // Register this layer with the layers registry
   QgsProject::instance()->addMapLayer( layer );
   layer->setAutoRefreshInterval( 500 );
@@ -230,8 +230,8 @@ void QgsStatusBarCoordinatesWidget::world()
   QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.shp" );
   QFileInfo fileInfo = QFileInfo( fileName );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *layer = new QgsVectorLayer( options, fileInfo.absoluteFilePath(),
-      tr( "World Map" ), QStringLiteral( "ogr" ) );
+  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+      tr( "World Map" ), QStringLiteral( "ogr" ), options );
   // Register this layer with the layers registry
   QgsProject::instance()->addMapLayer( layer );
 }
@@ -245,8 +245,8 @@ void QgsStatusBarCoordinatesWidget::hackfests()
   QString fileName = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/qgis-hackfests.json" );
   QFileInfo fileInfo = QFileInfo( fileName );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *layer = new QgsVectorLayer( options, fileInfo.absoluteFilePath(),
-      tr( "QGIS Hackfests" ), QStringLiteral( "ogr" ) );
+  QgsVectorLayer *layer = new QgsVectorLayer( fileInfo.absoluteFilePath(),
+      tr( "QGIS Hackfests" ), QStringLiteral( "ogr" ), options );
   // Register this layer with the layers registry
   QgsProject::instance()->addMapLayer( layer );
   layer->setAutoRefreshInterval( 500 );

--- a/src/core/layout/qgslayoutitemmapoverview.cpp
+++ b/src/core/layout/qgslayoutitemmapoverview.cpp
@@ -33,7 +33,7 @@
 
 QgsLayoutItemMapOverview::QgsLayoutItemMapOverview( const QString &name, QgsLayoutItemMap *map )
   : QgsLayoutItemMapItem( name, map )
-  , mExtentLayer( qgis::make_unique< QgsVectorLayer >( QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ), QStringLiteral( "Polygon?crs=EPSG:4326" ), QStringLiteral( "overview" ), QStringLiteral( "memory" ) ) )
+  , mExtentLayer( qgis::make_unique< QgsVectorLayer >( QStringLiteral( "Polygon?crs=EPSG:4326" ), QStringLiteral( "overview" ), QStringLiteral( "memory" ), QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ) ) )
 {
   createDefaultFrameSymbol();
 }

--- a/src/core/layout/qgslayoutitemmapoverview.cpp
+++ b/src/core/layout/qgslayoutitemmapoverview.cpp
@@ -33,7 +33,7 @@
 
 QgsLayoutItemMapOverview::QgsLayoutItemMapOverview( const QString &name, QgsLayoutItemMap *map )
   : QgsLayoutItemMapItem( name, map )
-  , mExtentLayer( qgis::make_unique< QgsVectorLayer >( QStringLiteral( "Polygon?crs=EPSG:4326" ), QStringLiteral( "overview" ), QStringLiteral( "memory" ) ) )
+  , mExtentLayer( qgis::make_unique< QgsVectorLayer >( QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ), QStringLiteral( "Polygon?crs=EPSG:4326" ), QStringLiteral( "overview" ), QStringLiteral( "memory" ) ) )
 {
   createDefaultFrameSymbol();
 }

--- a/src/core/layout/qgslayoutitemmapoverview.cpp
+++ b/src/core/layout/qgslayoutitemmapoverview.cpp
@@ -33,7 +33,7 @@
 
 QgsLayoutItemMapOverview::QgsLayoutItemMapOverview( const QString &name, QgsLayoutItemMap *map )
   : QgsLayoutItemMapItem( name, map )
-  , mExtentLayer( qgis::make_unique< QgsVectorLayer >( QStringLiteral( "Polygon?crs=EPSG:4326" ), QStringLiteral( "overview" ), QStringLiteral( "memory" ), QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ) ) )
+  , mExtentLayer( qgis::make_unique< QgsVectorLayer >( QStringLiteral( "Polygon?crs=EPSG:4326" ), QStringLiteral( "overview" ), QStringLiteral( "memory" ), QgsVectorLayer::LayerOptions( map && map->layout() && map->layout()->project() ? map->layout()->project()->transformContext() : QgsCoordinateTransformContext() ) ) )
 {
   createDefaultFrameSymbol();
 }

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -551,7 +551,7 @@ class CORE_EXPORT QgsMeshDataProvider: public QgsDataProvider, public QgsMeshDat
 
   public:
     //! Ctor
-    QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
   signals:
     //! Emitted when some new dataset groups have been added

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -34,23 +34,34 @@
 #include "qgsstyle.h"
 #include "qgstriangularmesh.h"
 
+
+
 QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QString &baseName,
                             const QString &providerKey,
-                            const LayerOptions & )
+                            const LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::MeshLayer, baseName, meshLayerPath )
+  , mOptions( options )
 {
   setProviderType( providerKey );
   // if we’re given a provider type, try to create and bind one to this layer
   if ( !meshLayerPath.isEmpty() && !providerKey.isEmpty() )
   {
-    QgsDataProvider::ProviderOptions providerOptions;
+    QgsDataProvider::ProviderOptions providerOptions { options.transformContext };
     setDataProvider( providerKey, providerOptions );
   }
 
   setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
   setDefaultRendererSettings();
 } // QgsMeshLayer ctor
+
+QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
+                            const QString &baseName,
+                            const QString &providerKey,
+                            const LayerOptions &options )
+  : QgsMeshLayer( options, meshLayerPath, baseName, providerKey )
+{
+}
 
 void QgsMeshLayer::setDefaultRendererSettings()
 {
@@ -85,7 +96,7 @@ const QgsMeshDataProvider *QgsMeshLayer::dataProvider() const
 
 QgsMeshLayer *QgsMeshLayer::clone() const
 {
-  QgsMeshLayer *layer = new QgsMeshLayer( source(), name(), mProviderKey );
+  QgsMeshLayer *layer = new QgsMeshLayer( mOptions, source(), name(), mProviderKey );
   QgsMapLayer::clone( layer );
   return layer;
 }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -202,6 +202,12 @@ QgsMeshDatasetValue QgsMeshLayer::datasetValue( const QgsMeshDatasetIndex &index
   return value;
 }
 
+void QgsMeshLayer::setTransformContext( const QgsCoordinateTransformContext &transformContext )
+{
+  if ( mDataProvider )
+    mDataProvider->setTransformContext( transformContext );
+}
+
 void QgsMeshLayer::fillNativeMesh()
 {
   Q_ASSERT( !mNativeMesh );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -39,7 +39,7 @@
 QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QString &baseName,
                             const QString &providerKey,
-                            const LayerOptions &options )
+                            const QgsMeshLayer::LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::MeshLayer, baseName, meshLayerPath )
   , mOptions( options )
 {
@@ -55,13 +55,6 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
   setDefaultRendererSettings();
 } // QgsMeshLayer ctor
 
-QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
-                            const QString &baseName,
-                            const QString &providerKey,
-                            const LayerOptions &options )
-  : QgsMeshLayer( options, meshLayerPath, baseName, providerKey )
-{
-}
 
 void QgsMeshLayer::setDefaultRendererSettings()
 {
@@ -96,7 +89,7 @@ const QgsMeshDataProvider *QgsMeshLayer::dataProvider() const
 
 QgsMeshLayer *QgsMeshLayer::clone() const
 {
-  QgsMeshLayer *layer = new QgsMeshLayer( mOptions, source(), name(), mProviderKey );
+  QgsMeshLayer *layer = new QgsMeshLayer( source(), name(), mProviderKey, mOptions );
   QgsMapLayer::clone( layer );
   return layer;
 }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -41,7 +41,6 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QString &providerKey,
                             const QgsMeshLayer::LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::MeshLayer, baseName, meshLayerPath )
-  , mOptions( options )
 {
   setProviderType( providerKey );
   // if we’re given a provider type, try to create and bind one to this layer
@@ -89,7 +88,12 @@ const QgsMeshDataProvider *QgsMeshLayer::dataProvider() const
 
 QgsMeshLayer *QgsMeshLayer::clone() const
 {
-  QgsMeshLayer *layer = new QgsMeshLayer( source(), name(), mProviderKey, mOptions );
+  QgsMeshLayer::LayerOptions options;
+  if ( mDataProvider )
+  {
+    options.transformContext = mDataProvider->transformContext();
+  }
+  QgsMeshLayer *layer = new QgsMeshLayer( source(), name(), mProviderKey,  options );
   QgsMapLayer::clone( layer );
   return layer;
 }

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -100,7 +100,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
       /**
        * Constructor for LayerOptions with optional \a transformContext.
-       * \note transformContext argument was added in QGIS 3.10
+       * \note transformContext argument was added in QGIS 3.8
        */
       explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext( ) )
         : transformContext( transformContext )
@@ -122,7 +122,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
      * \param options general mesh layer options
      */
-    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = QStringLiteral( "mesh_memory" ),
                            const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
 
     ~QgsMeshLayer() override;

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -100,12 +100,23 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
       /**
        * Constructor for LayerOptions.
+       * \deprecated Use version with transformContext argument instead
+       *
        */
-      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
+      Q_DECL_DEPRECATED explicit LayerOptions( ) SIP_DEPRECATED
+    : transformContext( QgsCoordinateTransformContext() )
+      {}
+
+
+      /**
+       * Constructor for LayerOptions.
+       * \since QGIS 3.10
+       */
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext )
         : transformContext( transformContext )
       {}
 
-      QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
+      QgsCoordinateTransformContext transformContext;
     };
 
     /**
@@ -120,9 +131,29 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      * \param baseName The name used to represent the layer in the legend
      * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
      * \param options general mesh layer options
+     * \deprecated Use version with layer options as a first argument instead
      */
-    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
-                           const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
+    Q_DECL_DEPRECATED explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+        const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() ) SIP_DEPRECATED;
+
+    /**
+     * Constructor - creates a mesh layer
+     *
+     * The QgsMeshLayer is constructed by instantiating a data provider.  The provider
+     * interprets the supplied path (url) of the data source to connect to and access the
+     * data.
+     *
+     * \param options general mesh layer options
+     * \param path  The path or url of the parameter.  Typically this encodes
+     *               parameters used by the data provider as url query items.
+     * \param baseName The name used to represent the layer in the legend
+     * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
+     * \since QGIS 3.10
+     */
+    explicit QgsMeshLayer( const QgsMeshLayer::LayerOptions &options, const QString &path = QString(),
+                           const QString &baseName = QString(), const QString &providerLib = "mesh_memory" );
+
+
     ~QgsMeshLayer() override;
 
     //! QgsMeshLayer cannot be copied.
@@ -303,6 +334,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
 
     //! Time format configuration
     QgsMeshTimeSettings mTimeSettings;
+
+    //! Layer options
+    QgsMeshLayer::LayerOptions mOptions;
 };
 
 #endif //QGSMESHLAYER_H

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -231,9 +231,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
   public slots:
 
     /**
-     * Triggered when the coordinate transform context has changed \a transformContext
+     * Sets the coordinate transform context to \a transformContext.
      *
-     * \since QGIS 3.10
+     * \since QGIS 3.8
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 
@@ -306,8 +306,6 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     //! Time format configuration
     QgsMeshTimeSettings mTimeSettings;
 
-    //! Layer options
-    QgsMeshLayer::LayerOptions mOptions;
 };
 
 #endif //QGSMESHLAYER_H

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -97,7 +97,15 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      */
     struct LayerOptions
     {
-      int unused;  //!< @todo remove me once there are actual members here (breaks SIP <4.19)
+
+      /**
+       * Constructor for LayerOptions.
+       */
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
+        : transformContext( transformContext )
+      {}
+
+      QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
     };
 
     /**
@@ -217,6 +225,16 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       * \since QGIS 3.4
       */
     QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
+
+  public slots:
+
+    /**
+     * Triggered when the coordinate transform context has changed \a transformContext
+     *
+     * \since QGIS 3.10
+     */
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
+
 
   signals:
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -99,20 +99,10 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     {
 
       /**
-       * Constructor for LayerOptions.
-       * \deprecated Use version with transformContext argument instead
-       *
+       * Constructor for LayerOptions with optional \a transformContext.
+       * \note transformContext argument was added in QGIS 3.10
        */
-      Q_DECL_DEPRECATED explicit LayerOptions( ) SIP_DEPRECATED
-    : transformContext( QgsCoordinateTransformContext() )
-      {}
-
-
-      /**
-       * Constructor for LayerOptions.
-       * \since QGIS 3.10
-       */
-      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext )
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext( ) )
         : transformContext( transformContext )
       {}
 
@@ -131,28 +121,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      * \param baseName The name used to represent the layer in the legend
      * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
      * \param options general mesh layer options
-     * \deprecated Use version with layer options as a first argument instead
      */
-    Q_DECL_DEPRECATED explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
-        const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() ) SIP_DEPRECATED;
-
-    /**
-     * Constructor - creates a mesh layer
-     *
-     * The QgsMeshLayer is constructed by instantiating a data provider.  The provider
-     * interprets the supplied path (url) of the data source to connect to and access the
-     * data.
-     *
-     * \param options general mesh layer options
-     * \param path  The path or url of the parameter.  Typically this encodes
-     *               parameters used by the data provider as url query items.
-     * \param baseName The name used to represent the layer in the legend
-     * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
-     * \since QGIS 3.10
-     */
-    explicit QgsMeshLayer( const QgsMeshLayer::LayerOptions &options, const QString &path = QString(),
-                           const QString &baseName = QString(), const QString &providerLib = "mesh_memory" );
-
+    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+                           const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
 
     ~QgsMeshLayer() override;
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -235,7 +235,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      *
      * \since QGIS 3.8
      */
-    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
+    void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 
 
   signals:

--- a/src/core/mesh/qgsmeshmemorydataprovider.h
+++ b/src/core/mesh/qgsmeshmemorydataprovider.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsMeshMemoryDataProvider: public QgsMeshDataProvider
      *    );
      * \endcode
      */
-    QgsMeshMemoryDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsMeshMemoryDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     bool isValid() const override;
     QString name() const override;
@@ -160,7 +160,7 @@ class CORE_EXPORT QgsMeshMemoryDataProvider: public QgsMeshDataProvider
     //! Returns the memory provider description
     static QString providerDescription();
     //! Provider factory
-    static QgsMeshMemoryDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    static QgsMeshMemoryDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
   private:
     void calculateMinMaxForDatasetGroup( QgsMeshMemoryDatasetGroup &grp ) const;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -239,7 +239,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
   {
     QgsVectorLayer::LayerOptions options { transformContext };
     options.loadDefaultStyle = false;
-    std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( options, string, name, QStringLiteral( "ogr" ) );
+    std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( string, name, QStringLiteral( "ogr" ), options );
     if ( layer->isValid() )
     {
       return layer.release();
@@ -611,7 +611,7 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
       // use destination string as layer name (eg "postgis:..." )
       if ( !layerName.isEmpty() )
         uri += QStringLiteral( "|layername=%1" ).arg( layerName );
-      std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( layerOptions, uri, destination, providerKey );
+      std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( uri, destination, providerKey, layerOptions );
       // update destination to layer ID
       destination = layer->id();
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -627,7 +627,7 @@ void QgsProcessingUtils::createFeatureSinkPython( QgsFeatureSink **sink, QString
 }
 
 
-QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext )
+QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, QgsProcessingContext &context )
 {
   QgsRectangle extent;
   for ( const QgsMapLayer *layer : layers )
@@ -638,7 +638,7 @@ QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *>
     if ( crs.isValid() )
     {
       //transform layer extent to target CRS
-      QgsCoordinateTransform ct( layer->crs(), crs, transformContext );
+      QgsCoordinateTransform ct( layer->crs(), crs, context.transformContext() );
       try
       {
         QgsRectangle reprojExtent = ct.transformBoundingBox( layer->extent() );
@@ -662,7 +662,8 @@ QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *>
 // Deprecated
 QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs )
 {
-  return QgsProcessingUtils::combineLayerExtents( layers, crs, QgsCoordinateTransformContext( ) );
+  QgsProcessingContext context;
+  return QgsProcessingUtils::combineLayerExtents( layers, crs, context );
 }
 
 QVariant QgsProcessingUtils::generateIteratingDestination( const QVariant &input, const QVariant &id, QgsProcessingContext &context )

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -638,9 +638,7 @@ QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *>
     if ( crs.isValid() )
     {
       //transform layer extent to target CRS
-      Q_NOWARN_DEPRECATED_PUSH
-      QgsCoordinateTransform ct( layer->crs(), crs );
-      Q_NOWARN_DEPRECATED_POP
+      QgsCoordinateTransform ct( layer->crs(), crs, QgsProject::instance()->transformContext() );
       try
       {
         QgsRectangle reprojExtent = ct.transformBoundingBox( layer->extent() );

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -627,7 +627,7 @@ void QgsProcessingUtils::createFeatureSinkPython( QgsFeatureSink **sink, QString
 }
 
 
-QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs )
+QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext )
 {
   QgsRectangle extent;
   for ( const QgsMapLayer *layer : layers )
@@ -638,7 +638,7 @@ QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *>
     if ( crs.isValid() )
     {
       //transform layer extent to target CRS
-      QgsCoordinateTransform ct( layer->crs(), crs, QgsProject::instance()->transformContext() );
+      QgsCoordinateTransform ct( layer->crs(), crs, transformContext );
       try
       {
         QgsRectangle reprojExtent = ct.transformBoundingBox( layer->extent() );
@@ -657,6 +657,12 @@ QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *>
 
   }
   return extent;
+}
+
+// Deprecated
+QgsRectangle QgsProcessingUtils::combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs )
+{
+  return QgsProcessingUtils::combineLayerExtents( layers, crs, QgsCoordinateTransformContext( ) );
 }
 
 QVariant QgsProcessingUtils::generateIteratingDestination( const QVariant &input, const QVariant &id, QgsProcessingContext &context )

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -312,11 +312,25 @@ class CORE_EXPORT QgsProcessingUtils
 
     /**
      * Interprets a string as a map layer. The method will attempt to
+     * load a layer matching the passed \a string using the given coordinate
+     * \a transformContext.
+     * E.g. if the string is a file path,
+     * then the layer at this file path will be loaded.
+     * The caller takes responsibility for deleting the returned map layer.
+     *
+     * \since QGIS 3.8
+     */
+    static QgsMapLayer *loadMapLayerFromString( const QString &string, const QgsCoordinateTransformContext &transformContext, LayerHint typeHint = UnknownType );
+
+    /**
+     * Interprets a string as a map layer. The method will attempt to
      * load a layer matching the passed \a string. E.g. if the string is a file path,
      * then the layer at this file path will be loaded.
      * The caller takes responsibility for deleting the returned map layer.
+     *
+     * \deprecated use mapLayerFromString() that takes QgsCoordinateTransformContext as an argument instead
      */
-    static QgsMapLayer *loadMapLayerFromString( const QString &string, QgsProcessingUtils::LayerHint typeHint = QgsProcessingUtils::LayerHint::UnknownType );
+    Q_DECL_DEPRECATED static QgsMapLayer *loadMapLayerFromString( const QString &string, LayerHint typeHint = UnknownType ) SIP_DEPRECATED ;
 
     static void parseDestinationString( QString &destination, QString &providerKey, QString &uri, QString &layerName, QString &format, QMap<QString, QVariant> &options, bool &useWriter, QString &extension );
 

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -218,14 +218,14 @@ class CORE_EXPORT QgsProcessingUtils
      * Combines the extent of several map \a layers. If specified, the target \a crs
      * will be used to transform the layer's extent to the desired output reference system
      * using the specified \a context.
-     * \since QGIS 3.10
+     * \since QGIS 3.8
      */
     static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, QgsProcessingContext &context );
 
     /**
      * Combines the extent of several map \a layers. If specified, the target \a crs
      * will be used to transform the layer's extent to the desired output reference system.
-     * \deprecated Use version with transformContext argument instead
+     * \deprecated Use version with QgsProcessingContext argument instead
      */
     Q_DECL_DEPRECATED static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) SIP_DEPRECATED;
 

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -213,11 +213,21 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static void createFeatureSinkPython( QgsFeatureSink **sink SIP_OUT SIP_TRANSFERBACK, QString &destination SIP_INOUT, QgsProcessingContext &context, const QgsFields &fields, QgsWkbTypes::Type geometryType, const QgsCoordinateReferenceSystem &crs, const QVariantMap &createOptions = QVariantMap() ) SIP_THROW( QgsProcessingException ) SIP_PYNAME( createFeatureSink );
 
+
+    /**
+     * Combines the extent of several map \a layers. If specified, the target \a crs
+     * will be used to transform the layer's extent to the desired output reference system
+     * using the specified \a transformContext.
+     * \since QGIS 3.10
+     */
+    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext );
+
     /**
      * Combines the extent of several map \a layers. If specified, the target \a crs
      * will be used to transform the layer's extent to the desired output reference system.
+     * \deprecated Use version with transformContext argument instead
      */
-    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() );
+    Q_DECL_DEPRECATED static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem() ) SIP_DEPRECATED;
 
     /**
      * Converts an \a input parameter value for use in source iterating mode, where one individual sink

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -330,7 +330,7 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * \since QGIS 3.8
      */
-    static QgsMapLayer *loadMapLayerFromString( const QString &string, const QgsCoordinateTransformContext &transformContext, LayerHint typeHint = UnknownType );
+    static QgsMapLayer *loadMapLayerFromString( const QString &string, const QgsCoordinateTransformContext &transformContext, LayerHint typeHint = LayerHint::UnknownType );
 
     /**
      * Interprets a string as a map layer. The method will attempt to
@@ -340,7 +340,7 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * \deprecated use mapLayerFromString() that takes QgsCoordinateTransformContext as an argument instead
      */
-    Q_DECL_DEPRECATED static QgsMapLayer *loadMapLayerFromString( const QString &string, LayerHint typeHint = UnknownType ) SIP_DEPRECATED ;
+    Q_DECL_DEPRECATED static QgsMapLayer *loadMapLayerFromString( const QString &string, LayerHint typeHint = LayerHint::UnknownType ) SIP_DEPRECATED ;
 
     static void parseDestinationString( QString &destination, QString &providerKey, QString &uri, QString &layerName, QString &format, QMap<QString, QVariant> &options, bool &useWriter, QString &extension );
 

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -217,10 +217,10 @@ class CORE_EXPORT QgsProcessingUtils
     /**
      * Combines the extent of several map \a layers. If specified, the target \a crs
      * will be used to transform the layer's extent to the desired output reference system
-     * using the specified \a transformContext.
+     * using the specified \a context.
      * \since QGIS 3.10
      */
-    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext );
+    static QgsRectangle combineLayerExtents( const QList<QgsMapLayer *> &layers, const QgsCoordinateReferenceSystem &crs, QgsProcessingContext &context );
 
     /**
      * Combines the extent of several map \a layers. If specified, the target \a crs

--- a/src/core/providers/memory/qgsmemoryprovider.h
+++ b/src/core/providers/memory/qgsmemoryprovider.h
@@ -31,7 +31,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsMemoryProvider( const QString &uri, const QgsVectorDataProvider::ProviderOptions &options );
+    explicit QgsMemoryProvider( const QString &uri, const QgsVectorDataProvider::ProviderOptions &coordinateTransformContext );
 
     ~QgsMemoryProvider() override;
 
@@ -44,7 +44,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
      * Creates a new memory provider, with provider properties embedded within the given \a uri and \a options
      * argument.
      */
-    static QgsMemoryProvider *createProvider( const QString &uri, const QgsVectorDataProvider::ProviderOptions &options );
+    static QgsMemoryProvider *createProvider( const QString &uri, const QgsVectorDataProvider::ProviderOptions &coordinateTransformContext );
 
     /* Implementation of functions from QgsVectorDataProvider */
 

--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -74,5 +74,5 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
   }
 
   QString uri = geomType + '?' + parts.join( '&' );
-  return new QgsVectorLayer( QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ), uri, name, QStringLiteral( "memory" ) );
+  return new QgsVectorLayer( uri, name, QStringLiteral( "memory" ), QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ) );
 }

--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -74,6 +74,5 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
   }
 
   QString uri = geomType + '?' + parts.join( '&' );
-
-  return new QgsVectorLayer( uri, name, QStringLiteral( "memory" ) );
+  return new QgsVectorLayer( QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ), uri, name, QStringLiteral( "memory" ) );
 }

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -61,7 +61,9 @@ const QVector<QgsPalLayerSettings::Property> palHiddenProperties
 //
 
 QgsAuxiliaryLayer::QgsAuxiliaryLayer( const QString &pkField, const QString &filename, const QString &table, QgsVectorLayer *vlayer )
-  : QgsVectorLayer( QString( "%1|layername=%2" ).arg( filename, table ), QString( "%1_auxiliarystorage" ).arg( table ), "ogr" )
+  : QgsVectorLayer( QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext( ) ),
+                    QString( "%1|layername=%2" ).arg( filename, table ),
+                    QString( "%1_auxiliarystorage" ).arg( table ), "ogr" )
   , mFileName( filename )
   , mTable( table )
   , mLayer( vlayer )

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -61,9 +61,8 @@ const QVector<QgsPalLayerSettings::Property> palHiddenProperties
 //
 
 QgsAuxiliaryLayer::QgsAuxiliaryLayer( const QString &pkField, const QString &filename, const QString &table, QgsVectorLayer *vlayer )
-  : QgsVectorLayer( QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext( ) ),
-                    QString( "%1|layername=%2" ).arg( filename, table ),
-                    QString( "%1_auxiliarystorage" ).arg( table ), "ogr" )
+  : QgsVectorLayer( QStringLiteral( "%1|layername=%2" ).arg( filename, table ),
+                    QStringLiteral( "%1_auxiliarystorage" ).arg( table ), QStringLiteral( "ogr" ) )
   , mFileName( filename )
   , mTable( table )
   , mLayer( vlayer )

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -52,20 +52,6 @@ QgsCoordinateTransform::QgsCoordinateTransform()
   d = new QgsCoordinateTransformPrivate();
 }
 
-QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
-{
-  d = new QgsCoordinateTransformPrivate( source, destination, QgsCoordinateTransformContext() );
-
-  if ( !d->checkValidity() )
-    return;
-
-  if ( !setFromCache( d->mSourceCRS, d->mDestCRS, d->mSourceDatumTransform, d->mDestinationDatumTransform ) )
-  {
-    d->initialize();
-    addToCache();
-  }
-}
-
 QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, const QgsCoordinateTransformContext &context )
 {
   mContext = context;

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -65,19 +65,6 @@ class CORE_EXPORT QgsCoordinateTransform
     QgsCoordinateTransform();
 
     /**
-     * Constructs a QgsCoordinateTransform using QgsCoordinateReferenceSystem objects.
-     * \param source source CRS, typically of the layer's coordinate system
-     * \param destination CRS, typically of the map canvas coordinate system
-     * correctly handle the user's datum transform setup. Instead the constructor
-     * variant which accepts a QgsCoordinateTransformContext or QgsProject
-     * argument should be used instead. It is highly likely that this constructor
-     * will be removed in future QGIS versions.
-     * \note Not available in Python bindings.
-     * \deprecated Use of this constructor is strongly discouraged, as it will not
-     */
-    Q_DECL_DEPRECATED explicit QgsCoordinateTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) SIP_SKIP;
-
-    /**
      * Constructs a QgsCoordinateTransform to transform from the \a source
      * to \a destination coordinate reference system.
      *

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsCoordinateTransformContext
      */
     QgsCoordinateTransformContext();
 
-    ~QgsCoordinateTransformContext();
+    ~QgsCoordinateTransformContext() ;
 
     /**
      * Copy constructor

--- a/src/core/qgsdataprovider.cpp
+++ b/src/core/qgsdataprovider.cpp
@@ -46,3 +46,14 @@ bool QgsDataProvider::renderInPreview( const PreviewContext &context )
 {
   return context.lastRenderingTimeMs <= context.maxRenderingTimeMs;
 }
+
+QgsDataProvider::ProviderOptions QgsDataProvider::options() const
+{
+  return mOptions;
+}
+
+void QgsDataProvider::setOptions( const QgsDataProvider::ProviderOptions &options )
+{
+  mOptions = options;
+  emit optionsChanged( options );
+}

--- a/src/core/qgsdataprovider.cpp
+++ b/src/core/qgsdataprovider.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QMutexLocker>
 #include "qgsdataprovider.h"
 
 QString QgsDataProvider::SUBLAYER_SEPARATOR = QString( "!!::!!" );
@@ -53,13 +54,14 @@ bool QgsDataProvider::renderInPreview( const PreviewContext &context )
   return context.lastRenderingTimeMs <= context.maxRenderingTimeMs;
 }
 
-QgsCoordinateTransformContext QgsDataProvider::coordinateTransformContext() const
+QgsCoordinateTransformContext QgsDataProvider::transformContext() const
 {
-  return mOptions.coordinateTransformContext;
+  QMutexLocker locker( &mOptionsMutex );
+  return mOptions.transformContext;
 }
 
-void QgsDataProvider::setCoordinateTransformContext( const QgsCoordinateTransformContext &value )
+void QgsDataProvider::setTransformContext( const QgsCoordinateTransformContext &value )
 {
-  mOptions.coordinateTransformContext = value;
-  emit coordinateTransformContextChanged( value );
+  QMutexLocker locker( &mOptionsMutex );
+  mOptions.transformContext = value;
 }

--- a/src/core/qgsdataprovider.cpp
+++ b/src/core/qgsdataprovider.cpp
@@ -17,9 +17,9 @@
 
 QString QgsDataProvider::SUBLAYER_SEPARATOR = QString( "!!::!!" );
 
-QgsDataProvider::QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options )
+QgsDataProvider::QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions )
   : mDataSourceURI( uri ),
-    mOptions( options )
+    mOptions( providerOptions )
 {
 }
 
@@ -53,13 +53,13 @@ bool QgsDataProvider::renderInPreview( const PreviewContext &context )
   return context.lastRenderingTimeMs <= context.maxRenderingTimeMs;
 }
 
-QgsDataProvider::ProviderOptions QgsDataProvider::options() const
+QgsCoordinateTransformContext QgsDataProvider::coordinateTransformContext() const
 {
-  return mOptions;
+  return mOptions.coordinateTransformContext;
 }
 
-void QgsDataProvider::setOptions( const QgsDataProvider::ProviderOptions &options )
+void QgsDataProvider::setCoordinateTransformContext( const QgsCoordinateTransformContext &value )
 {
-  mOptions = options;
-  emit optionsChanged( options );
+  mOptions.coordinateTransformContext = value;
+  emit coordinateTransformContextChanged( value );
 }

--- a/src/core/qgsdataprovider.cpp
+++ b/src/core/qgsdataprovider.cpp
@@ -17,6 +17,12 @@
 
 QString QgsDataProvider::SUBLAYER_SEPARATOR = QString( "!!::!!" );
 
+QgsDataProvider::QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options )
+  : mDataSourceURI( uri ),
+    mOptions( options )
+{
+}
+
 void QgsDataProvider::setProviderProperty( QgsDataProvider::ProviderProperty property, const QVariant &value )
 {
   mProviderProperties.insert( property, value );

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -527,9 +527,10 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * \see setTransformContext()
      *
-     * \since QGIS 3.10
+     * \since QGIS 3.8
+     * \note not available in Python bindings
      */
-    QgsCoordinateTransformContext transformContext() const;
+    QgsCoordinateTransformContext transformContext() const SIP_SKIP;
 
     /**
      * Sets data coordinate transform context to \a transformContext
@@ -539,9 +540,10 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * \see transformContext()
      *
-     * \since QGIS 3.10
+     * \since QGIS 3.8
+     * \note not available in Python bindings
      */
-    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) SIP_SKIP;
 
   signals:
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -106,7 +106,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * Additional creation options are specified within the \a options value.
      */
-    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
 
     /**
      * Returns the coordinate system for the data source.
@@ -522,24 +522,24 @@ class CORE_EXPORT QgsDataProvider : public QObject
     virtual bool writeLayerMetadata( const QgsLayerMetadata &metadata ) { Q_UNUSED( metadata ); return false; }
 
     /**
-     * Returns data provider options
+     * Returns data provider coordinate transform context
      *
-     * \see setOptions()
-     * \see optionsChanged()
+     * \see setCoordinateTranformContext()
+     * \see coordinateTransformContextChanged()
      *
      * \since QGIS 3.10
      */
-    QgsDataProvider::ProviderOptions options() const;
+    QgsCoordinateTransformContext coordinateTransformContext() const;
 
     /**
-     * Sets data provider options to \a options
+     * Sets data coordinate transform context to \a coordinateTransformContext
      *
-     * \see options()
-     * \see optionsChanged()
+     * \see coordinateTransformContext()
+     * \see coordinateTransformContextChanged()
      *
      * \since QGIS 3.10
      */
-    void setOptions( const QgsDataProvider::ProviderOptions &options );
+    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
 
   signals:
 
@@ -575,14 +575,14 @@ class CORE_EXPORT QgsDataProvider : public QObject
     void notify( const QString &msg );
 
     /**
-     * Emitted when the data provider options has changed
+     * Emitted when the data provider coordinate transform context has changed
      *
-     * \see setOptions()
-     * \see options()
+     * \see coordinateTransformContext()
+     * \see setCoordinateTranformContext()
      *
      * \since QGIS 3.10
      */
-    void optionsChanged( const QgsDataProvider::ProviderOptions &options );
+    void coordinateTransformContextChanged( const QgsCoordinateTransformContext &coordinateTransformContext );
 
 
   protected:

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -24,6 +24,7 @@
 
 //#include "qgsdataitem.h"
 #include "qgsdatasourceuri.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgslayermetadata.h"
 #include "qgserror.h"
 
@@ -94,7 +95,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     struct ProviderOptions
     {
-      int unused; //!< @todo remove me once there are actual members here (breaks SIP <4.19)
+      QgsCoordinateTransformContext coordinateTransformContext;
     };
 
     /**

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -93,7 +93,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
     /**
      * Setting options for creating vector data providers.
      *
-     * \note coordinateTransformContext was added in QGIS 3.10
+     * \note coordinateTransformContext was added in QGIS 3.8
      *
      * \since QGIS 3.2
      */

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -115,7 +115,6 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     virtual QgsCoordinateReferenceSystem crs() const = 0;
 
-
     /**
      * Set the data source specification. This may be a path or database
      * connection string

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -91,6 +91,9 @@ class CORE_EXPORT QgsDataProvider : public QObject
 
     /**
      * Setting options for creating vector data providers.
+     *
+     * \note coordinateTransformContext was added in QGIS 3.10
+     *
      * \since QGIS 3.2
      */
     struct ProviderOptions
@@ -103,10 +106,10 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * Additional creation options are specified within the \a options value.
      */
-    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() )
-      : mDataSourceURI( uri )
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() ):
+      mDataSourceURI( uri ),
+      mOptions( options )
     {
-      Q_UNUSED( options );
     }
 
     /**
@@ -523,6 +526,26 @@ class CORE_EXPORT QgsDataProvider : public QObject
     */
     virtual bool writeLayerMetadata( const QgsLayerMetadata &metadata ) { Q_UNUSED( metadata ); return false; }
 
+    /**
+     * Returns data provider options
+     *
+     * \see setOptions()
+     * \see optionsChanged()
+     *
+     * \since QGIS 3.10
+     */
+    QgsDataProvider::ProviderOptions options() const;
+
+    /**
+     * Sets data provider options to \a options
+     *
+     * \see options()
+     * \see optionsChanged()
+     *
+     * \since QGIS 3.10
+     */
+    void setOptions( const QgsDataProvider::ProviderOptions &options );
+
   signals:
 
     /**
@@ -556,6 +579,16 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     void notify( const QString &msg );
 
+    /**
+     * Emitted when the data provider options has changed
+     *
+     * \see setOptions()
+     * \see options()
+     *
+     * \since QGIS 3.10
+     */
+    void optionsChanged( const QgsDataProvider::ProviderOptions &options );
+
 
   protected:
 
@@ -582,6 +615,9 @@ class CORE_EXPORT QgsDataProvider : public QObject
     QString mDataSourceURI;
 
     QMap< int, QVariant > mProviderProperties;
+
+    QgsDataProvider::ProviderOptions mOptions;
+
 };
 
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -106,11 +106,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * Additional creation options are specified within the \a options value.
      */
-    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() ):
-      mDataSourceURI( uri ),
-      mOptions( options )
-    {
-    }
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 
     /**
      * Returns the coordinate system for the data source.

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QMutex>
 
 //#include "qgsdataitem.h"
 #include "qgsdatasourceuri.h"
@@ -98,7 +99,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     struct ProviderOptions
     {
-      QgsCoordinateTransformContext coordinateTransformContext;
+      QgsCoordinateTransformContext transformContext;
     };
 
     /**
@@ -524,22 +525,23 @@ class CORE_EXPORT QgsDataProvider : public QObject
     /**
      * Returns data provider coordinate transform context
      *
-     * \see setCoordinateTranformContext()
-     * \see coordinateTransformContextChanged()
+     * \see setTranformContext()
      *
      * \since QGIS 3.10
      */
-    QgsCoordinateTransformContext coordinateTransformContext() const;
+    QgsCoordinateTransformContext transformContext() const;
 
     /**
-     * Sets data coordinate transform context to \a coordinateTransformContext
+     * Sets data coordinate transform context to \a transformContext
      *
-     * \see coordinateTransformContext()
-     * \see coordinateTransformContextChanged()
+     * The default implementation is a simple setter, subclasses may override to perform
+     * additional actions required by a change of coordinate tranform context.
+     *
+     * \see transformContext()
      *
      * \since QGIS 3.10
      */
-    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 
   signals:
 
@@ -574,16 +576,6 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     void notify( const QString &msg );
 
-    /**
-     * Emitted when the data provider coordinate transform context has changed
-     *
-     * \see coordinateTransformContext()
-     * \see setCoordinateTranformContext()
-     *
-     * \since QGIS 3.10
-     */
-    void coordinateTransformContextChanged( const QgsCoordinateTransformContext &coordinateTransformContext );
-
 
   protected:
 
@@ -612,6 +604,11 @@ class CORE_EXPORT QgsDataProvider : public QObject
     QMap< int, QVariant > mProviderProperties;
 
     QgsDataProvider::ProviderOptions mOptions;
+
+    /**
+     * Protects options from being accessed concurrently
+     */
+    mutable QMutex mOptionsMutex;
 
 };
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -526,9 +526,8 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * Returns data provider coordinate transform context
      *
      * \see setTransformContext()
-     *
-     * \since QGIS 3.8
      * \note not available in Python bindings
+     * \since QGIS 3.8
      */
     QgsCoordinateTransformContext transformContext() const SIP_SKIP;
 
@@ -539,9 +538,8 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * additional actions required by a change of coordinate transform context.
      *
      * \see transformContext()
-     *
-     * \since QGIS 3.8
      * \note not available in Python bindings
+     * \since QGIS 3.8
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) SIP_SKIP;
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -525,7 +525,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
     /**
      * Returns data provider coordinate transform context
      *
-     * \see setTranformContext()
+     * \see setTransformContext()
      *
      * \since QGIS 3.10
      */

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -535,7 +535,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * Sets data coordinate transform context to \a transformContext
      *
      * The default implementation is a simple setter, subclasses may override to perform
-     * additional actions required by a change of coordinate tranform context.
+     * additional actions required by a change of coordinate transform context.
      *
      * \see transformContext()
      *

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -265,7 +265,8 @@ QList<QgsMapLayer *> QgsLayerDefinition::loadLayerDefinitionLayers( QDomDocument
 
     if ( type == QLatin1String( "vector" ) )
     {
-      layer = new QgsVectorLayer;
+      const QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
+      layer = new QgsVectorLayer( options );
     }
     else if ( type == QLatin1String( "raster" ) )
     {

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -265,8 +265,7 @@ QList<QgsMapLayer *> QgsLayerDefinition::loadLayerDefinitionLayers( QDomDocument
 
     if ( type == QLatin1String( "vector" ) )
     {
-      const QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
-      layer = new QgsVectorLayer( options );
+      layer = new QgsVectorLayer( );
     }
     else if ( type == QLatin1String( "raster" ) )
     {

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -782,6 +782,11 @@ void QgsMapLayer::setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSign
     emit crsChanged();
 }
 
+QgsCoordinateTransformContext QgsMapLayer::transformContext() const
+{
+  return dataProvider() ? dataProvider()->transformContext() : QgsCoordinateTransformContext();
+}
+
 QString QgsMapLayer::formatLayerName( const QString &name )
 {
   QString layerName( name );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -615,7 +615,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /**
      * Returns the layer data provider coordinate transform context
      * or a default transform context if the layer does not have a valid data provider.
-    \since QGIS 3.10
+    \since QGIS 3.8
      */
     QgsCoordinateTransformContext transformContext( ) const;
 
@@ -1209,9 +1209,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setRefreshOnNofifyMessage( const QString &message ) { mRefreshOnNofifyMessage = message; }
 
     /**
-     * Triggered when the coordinate transform context has changed \a transformContext
+     * Sets the coordinate transform context to \a transformContext
      *
-     * \since QGIS 3.10
+     * \since QGIS 3.8
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) = 0;
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1192,13 +1192,20 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setRefreshOnNotifyEnabled( bool enabled );
 
     /**
-     * Set the notification message that triggers repaine
+     * Set the notification message that triggers repaint
      * If refresh on notification is enabled, the notification will triggerRepaint only
      * if the notification message is equal to \param message
      *
      * \since QGIS 3.0
      */
     void setRefreshOnNofifyMessage( const QString &message ) { mRefreshOnNofifyMessage = message; }
+
+    /**
+     * Triggered when the coordinate transform context has changed \a transformContext
+     *
+     * \since QGIS 3.10
+     */
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) = 0;
 
   signals:
 
@@ -1309,6 +1316,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \since QGIS 3.5
      */
     void dataSourceChanged();
+
 
   private slots:
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -613,6 +613,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSignal = true );
 
     /**
+     * Returns the layer data provider coordinate transform context
+     * or a default transform context if the layer does not have a valid data provider.
+    \since QGIS 3.10
+     */
+    QgsCoordinateTransformContext transformContext( ) const;
+
+
+    /**
      * A convenience function to capitalize and format a layer \a name.
      *
      * \since QGIS 3.0

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -615,7 +615,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /**
      * Returns the layer data provider coordinate transform context
      * or a default transform context if the layer does not have a valid data provider.
-    \since QGIS 3.8
+    * \since QGIS 3.8
      */
     QgsCoordinateTransformContext transformContext( ) const;
 

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -95,7 +95,7 @@ QgsVectorLayer *QgsMimeDataUtils::Uri::vectorLayer( bool &owner, QString &error 
   }
   owner = true;
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  return new QgsVectorLayer( options, uri, name, providerKey );
+  return new QgsVectorLayer( uri, name, providerKey, options );
 }
 
 QgsRasterLayer *QgsMimeDataUtils::Uri::rasterLayer( bool &owner, QString &error ) const

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -94,7 +94,8 @@ QgsVectorLayer *QgsMimeDataUtils::Uri::vectorLayer( bool &owner, QString &error 
     return vectorLayer;
   }
   owner = true;
-  return new QgsVectorLayer( uri, name, providerKey );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  return new QgsVectorLayer( options, uri, name, providerKey );
 }
 
 QgsRasterLayer *QgsMimeDataUtils::Uri::rasterLayer( bool &owner, QString &error ) const

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -236,7 +236,7 @@ void QgsOfflineEditing::synchronize()
     QString remoteName = layer->name();
     remoteName.remove( QRegExp( " \\(offline\\)$" ) );
     const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-    QgsVectorLayer *remoteLayer = new QgsVectorLayer( options, remoteSource, remoteName, remoteProvider );
+    QgsVectorLayer *remoteLayer = new QgsVectorLayer( remoteSource, remoteName, remoteProvider, options );
     if ( remoteLayer->isValid() )
     {
       // Rebuild WFS cache to get feature id<->GML fid mapping
@@ -634,8 +634,8 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
                                  .arg( offlineDbPath,
                                        tableName, layer->isSpatial() ? "(Geometry)" : "" );
       QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      newLayer = new QgsVectorLayer( options, connectionString,
-                                     layer->name() + " (offline)", QStringLiteral( "spatialite" ) );
+      newLayer = new QgsVectorLayer( connectionString,
+                                     layer->name() + " (offline)", QStringLiteral( "spatialite" ), options );
       break;
     }
     case GPKG:
@@ -731,7 +731,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
 
       QString uri = QStringLiteral( "%1|layername=%2" ).arg( offlineDbPath,  tableName );
       QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
-      newLayer = new QgsVectorLayer( layerOptions, uri, layer->name() + " (offline)", QStringLiteral( "ogr" ) );
+      newLayer = new QgsVectorLayer( uri, layer->name() + " (offline)", QStringLiteral( "ogr" ), layerOptions );
       break;
     }
   }

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -235,8 +235,8 @@ void QgsOfflineEditing::synchronize()
     QString remoteProvider = layer->customProperty( CUSTOM_PROPERTY_REMOTE_PROVIDER, "" ).toString();
     QString remoteName = layer->name();
     remoteName.remove( QRegExp( " \\(offline\\)$" ) );
-
-    QgsVectorLayer *remoteLayer = new QgsVectorLayer( remoteSource, remoteName, remoteProvider );
+    const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+    QgsVectorLayer *remoteLayer = new QgsVectorLayer( options, remoteSource, remoteName, remoteProvider );
     if ( remoteLayer->isValid() )
     {
       // Rebuild WFS cache to get feature id<->GML fid mapping
@@ -633,7 +633,8 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       QString connectionString = QStringLiteral( "dbname='%1' table='%2'%3 sql=" )
                                  .arg( offlineDbPath,
                                        tableName, layer->isSpatial() ? "(Geometry)" : "" );
-      newLayer = new QgsVectorLayer( connectionString,
+      QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+      newLayer = new QgsVectorLayer( options, connectionString,
                                      layer->name() + " (offline)", QStringLiteral( "spatialite" ) );
       break;
     }
@@ -729,7 +730,8 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       hDS.reset();
 
       QString uri = QStringLiteral( "%1|layername=%2" ).arg( offlineDbPath,  tableName );
-      newLayer = new QgsVectorLayer( uri, layer->name() + " (offline)", QStringLiteral( "ogr" ) );
+      QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
+      newLayer = new QgsVectorLayer( layerOptions, uri, layer->name() + " (offline)", QStringLiteral( "ogr" ) );
       break;
     }
   }

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -74,7 +74,7 @@ class QgsPluginLayerDataProvider : public QgsDataProvider
     Q_OBJECT
 
   public:
-    QgsPluginLayerDataProvider( const QString &layerType, const QgsDataProvider::ProviderOptions &options );
+    QgsPluginLayerDataProvider( const QString &layerType, const QgsDataProvider::ProviderOptions &providerOptions );
     void setExtent( const QgsRectangle &extent ) { mExtent = extent; }
     QgsCoordinateReferenceSystem crs() const override;
     QString name() const override;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -923,6 +923,8 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
       QgsReadWriteContext context;
       context.setPathResolver( pathResolver() );
       context.setProjectTranslator( this );
+      context.setCoordinateTransformContext( transformContext() );
+
       if ( !addLayer( element, brokenNodes, context ) )
       {
         returnStatus = false;
@@ -1646,6 +1648,7 @@ bool QgsProject::readLayer( const QDomNode &layerNode )
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
   context.setProjectTranslator( this );
+  context.setCoordinateTransformContext( transformContext() );
   QList<QDomNode> brokenNodes;
   if ( addLayer( layerNode.toElement(), brokenNodes, context ) )
   {
@@ -1693,6 +1696,7 @@ bool QgsProject::write()
     }
 
     QgsReadWriteContext context;
+    context.setCoordinateTransformContext( transformContext() );
     if ( !storage->writeProject( mFile.fileName(), &tmpZipFile, context ) )
     {
       QString err = tr( "Unable to save project to storage %1" ).arg( mFile.fileName() );
@@ -1749,6 +1753,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
 
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
+  context.setCoordinateTransformContext( transformContext() );
 
   QDomImplementation DomImplementation;
   DomImplementation.setInvalidDataPolicy( QDomImplementation::DropInvalidChars );
@@ -2304,6 +2309,7 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
   if ( !useAbsolutePaths )
     embeddedContext.setPathResolver( QgsPathResolver( projectFilePath ) );
   embeddedContext.setProjectTranslator( this );
+  embeddedContext.setCoordinateTransformContext( transformContext() );
 
   QDomElement projectLayersElem = sProjectDocument.documentElement().firstChildElement( QStringLiteral( "projectlayers" ) );
   if ( projectLayersElem.isNull() )
@@ -2361,6 +2367,7 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
   context.setProjectTranslator( this );
+  context.setCoordinateTransformContext( transformContext() );
 
   QgsLayerTreeGroup *root = new QgsLayerTreeGroup;
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -963,7 +963,6 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   if ( type == QLatin1String( "vector" ) )
   {
     mapLayer = qgis::make_unique<QgsVectorLayer>();
-
     // apply specific settings to vector layer
     if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mapLayer.get() ) )
     {

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -935,7 +935,7 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
       QgsReadWriteContext context;
       context.setPathResolver( pathResolver() );
       context.setProjectTranslator( this );
-      context.setCoordinateTransformContext( transformContext() );
+      context.setTransformContext( transformContext() );
 
       if ( !addLayer( element, brokenNodes, context ) )
       {
@@ -1660,7 +1660,7 @@ bool QgsProject::readLayer( const QDomNode &layerNode )
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
   context.setProjectTranslator( this );
-  context.setCoordinateTransformContext( transformContext() );
+  context.setTransformContext( transformContext() );
   QList<QDomNode> brokenNodes;
   if ( addLayer( layerNode.toElement(), brokenNodes, context ) )
   {
@@ -1708,7 +1708,7 @@ bool QgsProject::write()
     }
 
     QgsReadWriteContext context;
-    context.setCoordinateTransformContext( transformContext() );
+    context.setTransformContext( transformContext() );
     if ( !storage->writeProject( mFile.fileName(), &tmpZipFile, context ) )
     {
       QString err = tr( "Unable to save project to storage %1" ).arg( mFile.fileName() );
@@ -1765,7 +1765,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
 
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
-  context.setCoordinateTransformContext( transformContext() );
+  context.setTransformContext( transformContext() );
 
   QDomImplementation DomImplementation;
   DomImplementation.setInvalidDataPolicy( QDomImplementation::DropInvalidChars );
@@ -2321,7 +2321,7 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
   if ( !useAbsolutePaths )
     embeddedContext.setPathResolver( QgsPathResolver( projectFilePath ) );
   embeddedContext.setProjectTranslator( this );
-  embeddedContext.setCoordinateTransformContext( transformContext() );
+  embeddedContext.setTransformContext( transformContext() );
 
   QDomElement projectLayersElem = sProjectDocument.documentElement().firstChildElement( QStringLiteral( "projectlayers" ) );
   if ( projectLayersElem.isNull() )
@@ -2379,7 +2379,7 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
   context.setProjectTranslator( this );
-  context.setCoordinateTransformContext( transformContext() );
+  context.setTransformContext( transformContext() );
 
   QgsLayerTreeGroup *root = new QgsLayerTreeGroup;
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2786,11 +2786,18 @@ QList<QgsMapLayer *> QgsProject::addMapLayers(
   bool addToLegend,
   bool takeOwnership )
 {
-  const QList<QgsMapLayer *> myResultList = mLayerStore->addMapLayers( layers, takeOwnership );
+  const QList<QgsMapLayer *> myResultList { mLayerStore->addMapLayers( layers, takeOwnership ) };
   if ( !myResultList.isEmpty() )
   {
+    // Update transform context
+    for ( auto &l : myResultList )
+    {
+      l->setTransformContext( transformContext() );
+    }
     if ( addToLegend )
+    {
       emit legendLayersAdded( myResultList );
+    }
   }
 
   if ( mAuxiliaryStorage )

--- a/src/core/qgsprojectfiletransform.cpp
+++ b/src/core/qgsprojectfiletransform.cpp
@@ -340,9 +340,9 @@ void QgsProjectFileTransform::transform0110to1000()
       QString providerKey = providerNode.toElement().text();
 
       //create the layer to get the provider for int->fieldName conversion
-      QgsVectorLayer::LayerOptions options;
+      QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
       options.loadDefaultStyle = false;
-      QgsVectorLayer *layer = new QgsVectorLayer( dataSource, QString(), providerKey, options );
+      QgsVectorLayer *layer = new QgsVectorLayer( options, dataSource, QString(), providerKey );
       if ( !layer->isValid() )
       {
         delete layer;

--- a/src/core/qgsprojectfiletransform.cpp
+++ b/src/core/qgsprojectfiletransform.cpp
@@ -342,7 +342,7 @@ void QgsProjectFileTransform::transform0110to1000()
       //create the layer to get the provider for int->fieldName conversion
       QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
       options.loadDefaultStyle = false;
-      QgsVectorLayer *layer = new QgsVectorLayer( options, dataSource, QString(), providerKey );
+      QgsVectorLayer *layer = new QgsVectorLayer( dataSource, QString(), providerKey, options );
       if ( !layer->isValid() )
       {
         delete layer;

--- a/src/core/qgsreadwritecontext.cpp
+++ b/src/core/qgsreadwritecontext.cpp
@@ -56,10 +56,21 @@ void QgsReadWriteContext::leaveCategory()
     mCategories.pop_back();
 }
 
+QgsCoordinateTransformContext QgsReadWriteContext::coordinateTransformContext() const
+{
+  return mCoordinateTransformContext;
+}
+
+void QgsReadWriteContext::setCoordinateTransformContext( const QgsCoordinateTransformContext &value )
+{
+  mCoordinateTransformContext = value;
+}
+
 void QgsReadWriteContext::setProjectTranslator( QgsProjectTranslator *projectTranslator )
 {
   mProjectTranslator = projectTranslator;
 }
+
 
 QList<QgsReadWriteContext::ReadWriteMessage > QgsReadWriteContext::takeMessages()
 {

--- a/src/core/qgsreadwritecontext.cpp
+++ b/src/core/qgsreadwritecontext.cpp
@@ -56,14 +56,14 @@ void QgsReadWriteContext::leaveCategory()
     mCategories.pop_back();
 }
 
-QgsCoordinateTransformContext QgsReadWriteContext::coordinateTransformContext() const
+QgsCoordinateTransformContext QgsReadWriteContext::transformContext() const
 {
   return mCoordinateTransformContext;
 }
 
-void QgsReadWriteContext::setCoordinateTransformContext( const QgsCoordinateTransformContext &value )
+void QgsReadWriteContext::setTransformContext( const QgsCoordinateTransformContext &transformContext )
 {
-  mCoordinateTransformContext = value;
+  mCoordinateTransformContext = transformContext;
 }
 
 void QgsReadWriteContext::setProjectTranslator( QgsProjectTranslator *projectTranslator )

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -118,20 +118,20 @@ class CORE_EXPORT QgsReadWriteContext
     /**
      * Returns data provider coordinate transform context
      *
-     * \see setCoordinateTranformContext()
+     * \see setTranformContext()
      *
      * \since QGIS 3.10
      */
-    QgsCoordinateTransformContext coordinateTransformContext() const;
+    QgsCoordinateTransformContext transformContext() const;
 
     /**
-     * Sets data coordinate transform context to \a coordinateTransformContext
+     * Sets data coordinate transform context to \a transformContext
      *
-     * \see coordinateTransformContext()
+     * \see transformContext()
      *
      * \since QGIS 3.10
      */
-    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    void setTransformContext( const QgsCoordinateTransformContext &transformContext );
 
   private:
 

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -21,6 +21,7 @@
 #include "qgspathresolver.h"
 #include "qgis.h"
 #include "qgsprojecttranslator.h"
+#include "qgscoordinatetransformcontext.h"
 
 class QgsReadWriteContextCategoryPopper;
 
@@ -114,6 +115,24 @@ class CORE_EXPORT QgsReadWriteContext
      */
     void setProjectTranslator( QgsProjectTranslator *projectTranslator );
 
+    /**
+     * Returns data provider coordinate transform context
+     *
+     * \see setCoordinateTranformContext()
+     *
+     * \since QGIS 3.10
+     */
+    QgsCoordinateTransformContext coordinateTransformContext() const;
+
+    /**
+     * Sets data coordinate transform context to \a coordinateTransformContext
+     *
+     * \see coordinateTransformContext()
+     *
+     * \since QGIS 3.10
+     */
+    void setCoordinateTransformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+
   private:
 
     class DefaultTranslator : public QgsProjectTranslator
@@ -132,6 +151,7 @@ class CORE_EXPORT QgsReadWriteContext
     QgsProjectTranslator *mProjectTranslator = nullptr;
     friend class QgsReadWriteContextCategoryPopper;
     DefaultTranslator mDefaultTranslator;
+    QgsCoordinateTransformContext mCoordinateTransformContext = QgsCoordinateTransformContext();
 };
 
 

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -118,7 +118,7 @@ class CORE_EXPORT QgsReadWriteContext
     /**
      * Returns data provider coordinate transform context
      *
-     * \see setTranformContext()
+     * \see setTransformContext()
      *
      * \since QGIS 3.10
      */

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -122,7 +122,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      *
      * Additional creation options are specified within the \a options value.
      */
-    QgsVectorDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsVectorDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
 
     /**
      * Returns feature source object that can be used for querying provider's data. The returned feature source

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2440,9 +2440,7 @@ QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
   QgsCoordinateTransform ct;
   if ( destCRS.isValid() && layer )
   {
-    Q_NOWARN_DEPRECATED_PUSH
-    ct = QgsCoordinateTransform( layer->crs(), destCRS );
-    Q_NOWARN_DEPRECATED_POP
+    ct = QgsCoordinateTransform( layer->crs(), destCRS, layer->transformContext() );
   }
 
   QgsVectorFileWriter::WriterError error = writeAsVectorFormat( layer, fileName, fileEncoding, ct, driverName, onlySelected,

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -142,7 +142,7 @@ typedef bool deleteStyleById_t(
 QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
                                 const QString &baseName,
                                 const QString &providerKey,
-                                const LayerOptions &options )
+                                const QgsVectorLayer::LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::VectorLayer, baseName, vectorLayerPath )
   , mAuxiliaryLayer( nullptr )
   , mAuxiliaryLayerKey( QString() )
@@ -208,7 +208,7 @@ QgsVectorLayer::~QgsVectorLayer()
 
 QgsVectorLayer *QgsVectorLayer::clone() const
 {
-  QgsVectorLayer *layer = new QgsVectorLayer( mOptions, source(), name(), mProviderKey );
+  QgsVectorLayer *layer = new QgsVectorLayer( source(), name(), mProviderKey, mOptions );
   QgsMapLayer::clone( layer );
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -163,7 +163,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   // if we're given a provider type, try to create and bind one to this layer
   if ( !vectorLayerPath.isEmpty() && !mProviderKey.isEmpty() )
   {
-    QgsDataProvider::ProviderOptions providerOptions;
+    QgsDataProvider::ProviderOptions providerOptions { options.coordinateTransformContext };
     setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, options.loadDefaultStyle );
   }
 
@@ -1372,6 +1372,12 @@ bool QgsVectorLayer::startEditing()
   return true;
 }
 
+void QgsVectorLayer::changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext )
+{
+  if ( mDataProvider )
+    mDataProvider->setCoordinateTransformContext( coordinateTransformContext );
+}
+
 bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &context )
 {
   QgsDebugMsgLevel( QStringLiteral( "Datasource in QgsVectorLayer::readXml: %1" ).arg( mDataSource.toLocal8Bit().data() ), 3 );
@@ -1404,7 +1410,7 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     mProviderKey = QStringLiteral( "ogr" );
   }
 
-  QgsDataProvider::ProviderOptions options;
+  QgsDataProvider::ProviderOptions options; // {  };
   if ( !setDataProvider( mProviderKey, options ) )
   {
     QgsDebugMsg( QStringLiteral( "Could not set data provider for layer %1" ).arg( publicSource() ) );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -139,7 +139,6 @@ typedef bool deleteStyleById_t(
 );
 
 
-
 QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
                                 const QString &baseName,
                                 const QString &providerKey,
@@ -148,6 +147,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   , mAuxiliaryLayer( nullptr )
   , mAuxiliaryLayerKey( QString() )
   , mReadExtentFromXml( options.readExtentFromXml )
+  , mOptions( options )
 {
   setProviderType( providerKey );
 
@@ -208,7 +208,7 @@ QgsVectorLayer::~QgsVectorLayer()
 
 QgsVectorLayer *QgsVectorLayer::clone() const
 {
-  QgsVectorLayer *layer = new QgsVectorLayer( source(), name(), mProviderKey );
+  QgsVectorLayer *layer = new QgsVectorLayer( mOptions, source(), name(), mProviderKey );
   QgsMapLayer::clone( layer );
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1414,7 +1414,7 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     mProviderKey = QStringLiteral( "ogr" );
   }
 
-  QgsDataProvider::ProviderOptions options; // {  };
+  QgsDataProvider::ProviderOptions options { context.transformContext() };
   if ( !setDataProvider( mProviderKey, options ) )
   {
     QgsDebugMsg( QStringLiteral( "Could not set data provider for layer %1" ).arg( publicSource() ) );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -147,7 +147,6 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   , mAuxiliaryLayer( nullptr )
   , mAuxiliaryLayerKey( QString() )
   , mReadExtentFromXml( options.readExtentFromXml )
-  , mOptions( options )
 {
   setProviderType( providerKey );
 
@@ -208,7 +207,12 @@ QgsVectorLayer::~QgsVectorLayer()
 
 QgsVectorLayer *QgsVectorLayer::clone() const
 {
-  QgsVectorLayer *layer = new QgsVectorLayer( source(), name(), mProviderKey, mOptions );
+  QgsVectorLayer::LayerOptions options;
+  if ( mDataProvider )
+  {
+    options.transformContext = mDataProvider->transformContext();
+  }
+  QgsVectorLayer *layer = new QgsVectorLayer( source(), name(), mProviderKey, options );
   QgsMapLayer::clone( layer );
 
   QList<QgsVectorLayerJoinInfo> joins = vectorJoins();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -139,6 +139,7 @@ typedef bool deleteStyleById_t(
 );
 
 
+
 QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
                                 const QString &baseName,
                                 const QString &providerKey,
@@ -148,7 +149,6 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   , mAuxiliaryLayerKey( QString() )
   , mReadExtentFromXml( options.readExtentFromXml )
 {
-
   setProviderType( providerKey );
 
   mGeometryOptions = qgis::make_unique<QgsGeometryOptions>();
@@ -179,8 +179,8 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   mSimplifyMethod.setThreshold( settings.value( QStringLiteral( "qgis/simplifyDrawingTol" ), mSimplifyMethod.threshold() ).toFloat() );
   mSimplifyMethod.setForceLocalOptimization( settings.value( QStringLiteral( "qgis/simplifyLocal" ), mSimplifyMethod.forceLocalOptimization() ).toBool() );
   mSimplifyMethod.setMaximumScale( settings.value( QStringLiteral( "qgis/simplifyMaxScale" ), mSimplifyMethod.maximumScale() ).toFloat() );
-} // QgsVectorLayer ctor
 
+} // QgsVectorLayer ctor
 
 
 QgsVectorLayer::~QgsVectorLayer()

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -163,7 +163,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   // if we're given a provider type, try to create and bind one to this layer
   if ( !vectorLayerPath.isEmpty() && !mProviderKey.isEmpty() )
   {
-    QgsDataProvider::ProviderOptions providerOptions { options.coordinateTransformContext };
+    QgsDataProvider::ProviderOptions providerOptions { options.transformContext };
     setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, options.loadDefaultStyle );
   }
 
@@ -1372,10 +1372,10 @@ bool QgsVectorLayer::startEditing()
   return true;
 }
 
-void QgsVectorLayer::changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext )
+void QgsVectorLayer::setTransformContext( const QgsCoordinateTransformContext &transformContext )
 {
   if ( mDataProvider )
-    mDataProvider->setCoordinateTransformContext( coordinateTransformContext );
+    mDataProvider->setTransformContext( transformContext );
 }
 
 bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &context )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -401,9 +401,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
       /**
        * Constructor for LayerOptions.
        */
-      explicit LayerOptions( bool loadDefaultStyle = true, bool readExtentFromXml = false )
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             bool readExtentFromXml = false,
+                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() )
         : loadDefaultStyle( loadDefaultStyle )
         , readExtentFromXml( readExtentFromXml )
+        , coordinateTransformContext( coordinateTransformContext )
       {}
 
       //! Set to TRUE if the default layer style should be loaded
@@ -414,6 +417,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        * project file). If FALSE, the extent will be determined by the provider on layer load.
        */
       bool readExtentFromXml = false;
+
+      /**
+       * Coordinate transform context
+       * \since QGIS 3.10
+       */
+      QgsCoordinateTransformContext coordinateTransformContext = QgsCoordinateTransformContext();
 
     };
 
@@ -2070,6 +2079,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void setAllowCommit( bool allowCommit ) SIP_SKIP;
 
+
   public slots:
 
     /**
@@ -2138,6 +2148,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \see rollBack()
      */
     bool startEditing();
+
+
+    /**
+     * Change coordinate transform context to \a coordinateTransformContext
+     *
+     * \since QGIS 3.10
+     */
+    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
 
   signals:
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -400,11 +400,23 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
       /**
        * Constructor for LayerOptions.
+       * \deprecated Use version with transformContext argument instead
        */
-      explicit LayerOptions( bool loadDefaultStyle = true,
-                             bool readExtentFromXml = false,
-                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
+      Q_DECL_DEPRECATED explicit LayerOptions( bool loadDefaultStyle = true,
+          bool readExtentFromXml = false )
         : loadDefaultStyle( loadDefaultStyle )
+        , readExtentFromXml( readExtentFromXml ) SIP_DEPRECATED
+          {}
+
+          /**
+           * Constructor for LayerOptions.
+           * \since QGIS 3.10
+           */
+          explicit LayerOptions( const QgsCoordinateTransformContext & transformContext,
+                                 bool loadDefaultStyle = true,
+                                 bool readExtentFromXml = false
+                               )
+            : loadDefaultStyle( loadDefaultStyle )
         , readExtentFromXml( readExtentFromXml )
         , transformContext( transformContext )
       {}
@@ -438,9 +450,28 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param baseName The name used to represent the layer in the legend
      * \param providerLib  The name of the data provider, e.g., "memory", "postgres"
      * \param options layer load options
+     * \deprecated Use version with options as mandatory argument instead
      */
-    explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
-                             const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() );
+    Q_DECL_DEPRECATED explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
+        const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() ) SIP_DEPRECATED;
+
+
+    /**
+     * Constructor - creates a vector layer
+     *
+     * The QgsVectorLayer is constructed by instantiating a data provider.  The provider
+     * interprets the supplied path (url) of the data source to connect to and access the
+     * data.
+     *
+     * \param options layer load options
+     * \param path  The path or url of the parameter.  Typically this encodes
+     *               parameters used by the data provider as url query items.
+     * \param baseName The name used to represent the layer in the legend
+     * \param providerLib  The name of the data provider, e.g., "memory", "postgres"
+     * \since QGIS 3.10
+     */
+    explicit QgsVectorLayer( const QgsVectorLayer::LayerOptions &options, const QString &path = QString(), const QString &baseName = QString(),
+                             const QString &providerLib = "ogr" );
 
 
     ~QgsVectorLayer() override;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -400,23 +400,22 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
       /**
        * Constructor for LayerOptions.
-       * \deprecated Use version with transformContext argument instead
        */
-      Q_DECL_DEPRECATED explicit LayerOptions( bool loadDefaultStyle = true,
-          bool readExtentFromXml = false )
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             bool readExtentFromXml = false )
         : loadDefaultStyle( loadDefaultStyle )
-        , readExtentFromXml( readExtentFromXml ) SIP_DEPRECATED
-          {}
+        , readExtentFromXml( readExtentFromXml )
+      {}
 
-          /**
-           * Constructor for LayerOptions.
-           * \since QGIS 3.10
-           */
-          explicit LayerOptions( const QgsCoordinateTransformContext & transformContext,
-                                 bool loadDefaultStyle = true,
-                                 bool readExtentFromXml = false
-                               )
-            : loadDefaultStyle( loadDefaultStyle )
+      /**
+       * Constructor for LayerOptions.
+       * \since QGIS 3.10
+       */
+      explicit LayerOptions( const QgsCoordinateTransformContext &transformContext,
+                             bool loadDefaultStyle = true,
+                             bool readExtentFromXml = false
+                           )
+        : loadDefaultStyle( loadDefaultStyle )
         , readExtentFromXml( readExtentFromXml )
         , transformContext( transformContext )
       {}
@@ -453,27 +452,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param options layer load options
      * \deprecated Use version with options as mandatory argument instead
      */
-    Q_DECL_DEPRECATED explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
-        const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() ) SIP_DEPRECATED;
-
-
-    /**
-     * Constructor - creates a vector layer
-     *
-     * The QgsVectorLayer is constructed by instantiating a data provider.  The provider
-     * interprets the supplied path (url) of the data source to connect to and access the
-     * data.
-     *
-     * \param options layer load options
-     * \param path  The path or url of the parameter.  Typically this encodes
-     *               parameters used by the data provider as url query items.
-     * \param baseName The name used to represent the layer in the legend
-     * \param providerLib  The name of the data provider, e.g., "memory", "postgres"
-     * \since QGIS 3.10
-     */
-    explicit QgsVectorLayer( const QgsVectorLayer::LayerOptions &options, const QString &path = QString(), const QString &baseName = QString(),
-                             const QString &providerLib = "ogr" );
-
+    explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
+                             const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() );
 
     ~QgsVectorLayer() override;
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -403,10 +403,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        */
       explicit LayerOptions( bool loadDefaultStyle = true,
                              bool readExtentFromXml = false,
-                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() )
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
         : loadDefaultStyle( loadDefaultStyle )
         , readExtentFromXml( readExtentFromXml )
-        , coordinateTransformContext( coordinateTransformContext )
+        , transformContext( transformContext )
       {}
 
       //! Set to TRUE if the default layer style should be loaded
@@ -422,7 +422,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        * Coordinate transform context
        * \since QGIS 3.10
        */
-      QgsCoordinateTransformContext coordinateTransformContext = QgsCoordinateTransformContext();
+      QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
 
     };
 
@@ -2149,13 +2149,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     bool startEditing();
 
-
     /**
-     * Change coordinate transform context to \a coordinateTransformContext
+     * Triggered when the coordinate transform context has changed \a transformContext
      *
      * \since QGIS 3.10
      */
-    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 
   signals:
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -450,7 +450,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param baseName The name used to represent the layer in the legend
      * \param providerLib  The name of the data provider, e.g., "memory", "postgres"
      * \param options layer load options
-     * \deprecated Use version with options as mandatory argument instead
      */
     explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),
                              const QString &providerLib = "ogr", const QgsVectorLayer::LayerOptions &options = QgsVectorLayer::LayerOptions() );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2161,9 +2161,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     bool startEditing();
 
     /**
-     * Triggered when the coordinate transform context has changed \a transformContext
+     * Sets the coordinate transform context to \a transformContext
      *
-     * \since QGIS 3.10
+     * \since QGIS 3.8
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 
@@ -2592,8 +2592,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     std::unique_ptr<QgsGeometryOptions> mGeometryOptions;
 
     bool mAllowCommit = true;
-
-    QgsVectorLayer::LayerOptions mOptions;
 
     friend class QgsVectorLayerFeatureSource;
 };

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -438,6 +438,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     };
 
+
     /**
      * Constructor - creates a vector layer
      *
@@ -2612,6 +2613,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     std::unique_ptr<QgsGeometryOptions> mGeometryOptions;
 
     bool mAllowCommit = true;
+
+    QgsVectorLayer::LayerOptions mOptions;
 
     friend class QgsVectorLayerFeatureSource;
 };

--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -351,9 +351,7 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
   // Create our transform
   if ( destCRS.isValid() )
   {
-    Q_NOWARN_DEPRECATED_PUSH
-    ct = QgsCoordinateTransform( layer->crs(), destCRS );
-    Q_NOWARN_DEPRECATED_POP
+    ct = QgsCoordinateTransform( layer->crs(), destCRS, layer->transformContext() );
   }
 
   // Check for failure

--- a/src/core/qgsvirtuallayertask.cpp
+++ b/src/core/qgsvirtuallayertask.cpp
@@ -24,7 +24,7 @@ QgsVirtualLayerTask::QgsVirtualLayerTask( const QgsVirtualLayerDefinition &defin
 {
   mDefinition.setLazy( true );
   QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
-  mLayer = qgis::make_unique<QgsVectorLayer>( options, mDefinition.toString(), QStringLiteral( "layer" ), QLatin1Literal( "virtual" ) );
+  mLayer = qgis::make_unique<QgsVectorLayer>( mDefinition.toString(), QStringLiteral( "layer" ), QLatin1Literal( "virtual" ), options );
 }
 
 bool QgsVirtualLayerTask::run()

--- a/src/core/qgsvirtuallayertask.cpp
+++ b/src/core/qgsvirtuallayertask.cpp
@@ -23,7 +23,8 @@ QgsVirtualLayerTask::QgsVirtualLayerTask( const QgsVirtualLayerDefinition &defin
   : mDefinition( definition )
 {
   mDefinition.setLazy( true );
-  mLayer = qgis::make_unique<QgsVectorLayer>( mDefinition.toString(), "layer", "virtual" );
+  QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
+  mLayer = qgis::make_unique<QgsVectorLayer>( options, mDefinition.toString(), QStringLiteral( "layer" ), QLatin1Literal( "virtual" ) );
 }
 
 bool QgsVirtualLayerTask::run()

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -114,7 +114,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      *
      * The \a options argument specifies generic provider options.
      */
-    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions = QgsDataProvider::ProviderOptions() );
 
     QgsRasterInterface *clone() const override = 0;
 

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -231,9 +231,7 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
       QgsRasterProjector *projector = pipe->projector();
       if ( projector && projector->destinationCrs() != projector->sourceCrs() )
       {
-        Q_NOWARN_DEPRECATED_PUSH
-        QgsCoordinateTransform ct( projector->destinationCrs(), projector->sourceCrs() );
-        Q_NOWARN_DEPRECATED_POP
+        QgsCoordinateTransform ct( projector->destinationCrs(), projector->sourceCrs(), srcProvider->transformContext() );
         srcExtent = ct.transformBoundingBox( outputExtent );
       }
       if ( !srcProvider->extent().contains( srcExtent ) )

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -68,8 +68,17 @@ QgsRasterFileWriter::QgsRasterFileWriter()
 
 }
 
+
+// Deprecated!
 QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
     const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback )
+{
+  return writeRaster( pipe, nCols, nRows, outputExtent, crs, ( pipe && pipe->provider() ) ? pipe->provider()->transformContext() : QgsCoordinateTransformContext(), feedback );
+}
+
+QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
+    const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext,
+    QgsRasterBlockFeedback *feedback )
 {
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
 
@@ -142,13 +151,13 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeRaster( const QgsRast
   }
   else
   {
-    WriterError e = writeDataRaster( pipe, &iter, nCols, nRows, outputExtent, crs, feedback );
+    WriterError e = writeDataRaster( pipe, &iter, nCols, nRows, outputExtent, crs, transformContext, feedback );
     return e;
   }
 }
 
 QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const QgsRasterPipe *pipe, QgsRasterIterator *iter, int nCols, int nRows, const QgsRectangle &outputExtent,
-    const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback )
+    const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext, QgsRasterBlockFeedback *feedback )
 {
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   if ( !iter )
@@ -231,7 +240,7 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
       QgsRasterProjector *projector = pipe->projector();
       if ( projector && projector->destinationCrs() != projector->sourceCrs() )
       {
-        QgsCoordinateTransform ct( projector->destinationCrs(), projector->sourceCrs(), srcProvider->transformContext() );
+        QgsCoordinateTransform ct( projector->destinationCrs(), projector->sourceCrs(), transformContext );
         srcExtent = ct.transformBoundingBox( outputExtent );
       }
       if ( !srcProvider->extent().contains( srcExtent ) )
@@ -496,10 +505,10 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeImageRaster( QgsRaste
   iter->setMaximumTileWidth( mMaxTileWidth );
   iter->setMaximumTileHeight( mMaxTileHeight );
 
-  void *redData = qgsMalloc( mMaxTileWidth * mMaxTileHeight );
-  void *greenData = qgsMalloc( mMaxTileWidth * mMaxTileHeight );
-  void *blueData = qgsMalloc( mMaxTileWidth * mMaxTileHeight );
-  void *alphaData = qgsMalloc( mMaxTileWidth * mMaxTileHeight );
+  void *redData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
+  void *greenData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
+  void *blueData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
+  void *alphaData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
   int iterLeft = 0, iterTop = 0, iterCols = 0, iterRows = 0;
   int fileIndex = 0;
 

--- a/src/core/raster/qgsrasterfilewriter.h
+++ b/src/core/raster/qgsrasterfilewriter.h
@@ -17,6 +17,7 @@
 
 #include "qgis_core.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include <QDomDocument>
 #include <QDomElement>
 #include <QString>
@@ -93,6 +94,7 @@ class CORE_EXPORT QgsRasterFileWriter
         const QgsCoordinateReferenceSystem &crs,
         int nBands ) SIP_FACTORY;
 
+
     /**
      * Write raster file
         \param pipe raster pipe
@@ -101,9 +103,27 @@ class CORE_EXPORT QgsRasterFileWriter
         \param outputExtent extent to output
         \param crs crs to reproject to
         \param feedback optional feedback object for progress reports
+        \deprecated since QGIS 3.8, use version with transformContext instead
+    */
+    Q_DECL_DEPRECATED WriterError writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
+        const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = nullptr ) SIP_DEPRECATED;
+
+    /**
+     * Write raster file
+        \param pipe raster pipe
+        \param nCols number of output columns
+        \param nRows number of output rows (or -1 to automatically calculate row number to have square pixels)
+        \param outputExtent extent to output
+        \param crs crs to reproject to
+        \param transformContext coordinate transform context
+        \param feedback optional feedback object for progress reports
+        \since QGIS 3.8
     */
     WriterError writeRaster( const QgsRasterPipe *pipe, int nCols, int nRows, const QgsRectangle &outputExtent,
-                             const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = nullptr );
+                             const QgsCoordinateReferenceSystem &crs,
+                             const QgsCoordinateTransformContext &transformContext,
+                             QgsRasterBlockFeedback *feedback = nullptr );
+
 
     /**
      * Returns the output URL for the raster.
@@ -210,7 +230,8 @@ class CORE_EXPORT QgsRasterFileWriter
   private:
     QgsRasterFileWriter(); //forbidden
     WriterError writeDataRaster( const QgsRasterPipe *pipe, QgsRasterIterator *iter, int nCols, int nRows, const QgsRectangle &outputExtent,
-                                 const QgsCoordinateReferenceSystem &crs, QgsRasterBlockFeedback *feedback = nullptr );
+                                 const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &transformContext,
+                                 QgsRasterBlockFeedback *feedback = nullptr );
 
     // Helper method used by previous one
     WriterError writeDataRaster( const QgsRasterPipe *pipe,
@@ -282,8 +303,8 @@ class CORE_EXPORT QgsRasterFileWriter
 
     //! False: Write one file, TRUE: create a directory and add the files numbered
     bool mTiledMode = false;
-    double mMaxTileWidth = 500;
-    double mMaxTileHeight = 500;
+    int mMaxTileWidth = 500;
+    int mMaxTileHeight = 500;
 
     QList< int > mPyramidsList;
     QString mPyramidsResampling = QStringLiteral( "AVERAGE" );

--- a/src/core/raster/qgsrasterfilewritertask.cpp
+++ b/src/core/raster/qgsrasterfilewritertask.cpp
@@ -17,11 +17,20 @@
 
 #include "qgsrasterfilewritertask.h"
 #include "qgsrasterinterface.h"
+#include "qgsrasterdataprovider.h"
 
-QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe,
-    int columns, int rows,
+// Deprecated!
+QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe, int columns, int rows,
+    const QgsRectangle &outputExtent, const QgsCoordinateReferenceSystem &crs )
+  : QgsRasterFileWriterTask( writer, pipe, columns, rows, outputExtent, crs,
+                             ( pipe && pipe->provider() ) ? pipe->provider()->transformContext() : QgsCoordinateTransformContext() )
+{
+}
+
+QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe, int columns, int rows,
     const QgsRectangle &outputExtent,
-    const QgsCoordinateReferenceSystem &crs )
+    const QgsCoordinateReferenceSystem &crs,
+    const QgsCoordinateTransformContext &transformContext )
   : QgsTask( tr( "Saving %1" ).arg( writer.outputUrl() ), QgsTask::CanCancel )
   , mWriter( writer )
   , mRows( rows )
@@ -30,7 +39,9 @@ QgsRasterFileWriterTask::QgsRasterFileWriterTask( const QgsRasterFileWriter &wri
   , mCrs( crs )
   , mPipe( pipe )
   , mFeedback( new QgsRasterBlockFeedback() )
-{}
+  , mTransformContext( transformContext )
+{
+}
 
 void QgsRasterFileWriterTask::cancel()
 {
@@ -45,7 +56,7 @@ bool QgsRasterFileWriterTask::run()
 
   connect( mFeedback.get(), &QgsRasterBlockFeedback::progressChanged, this, &QgsRasterFileWriterTask::setProgress );
 
-  mError = mWriter.writeRaster( mPipe.get(), mColumns, mRows, mExtent, mCrs, mFeedback.get() );
+  mError = mWriter.writeRaster( mPipe.get(), mColumns, mRows, mExtent, mCrs, mTransformContext, mFeedback.get() );
 
   return mError == QgsRasterFileWriter::NoError;
 }

--- a/src/core/raster/qgsrasterfilewritertask.h
+++ b/src/core/raster/qgsrasterfilewritertask.h
@@ -21,6 +21,7 @@
 #include "qgis_core.h"
 #include "qgstaskmanager.h"
 #include "qgsrasterfilewriter.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgsrasterinterface.h"
 #include "qgsrasterpipe.h"
 
@@ -45,11 +46,28 @@ class CORE_EXPORT QgsRasterFileWriterTask : public QgsTask
      * \a columns, \a rows, \a outputExtent and destination \a crs.
      * Ownership of the \a pipe is transferred to the writer task, and will
      * be deleted when the task completes.
+     * \deprecated since QGIS 3.8, use version with transformContext instead
+     */
+    Q_DECL_DEPRECATED QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe SIP_TRANSFER,
+        int columns, int rows,
+        const QgsRectangle &outputExtent,
+        const QgsCoordinateReferenceSystem &crs ) SIP_DEPRECATED;
+
+
+    /**
+     * Constructor for QgsRasterFileWriterTask. Takes a source \a writer,
+     * \a columns, \a rows, \a outputExtent, destination \a crs and
+     * coordinate \a transformContext .
+     * Ownership of the \a pipe is transferred to the writer task, and will
+     * be deleted when the task completes.
+     * \deprecated since QGIS 3.8, use version with transformContext instead
      */
     QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe SIP_TRANSFER,
                              int columns, int rows,
                              const QgsRectangle &outputExtent,
-                             const QgsCoordinateReferenceSystem &crs );
+                             const QgsCoordinateReferenceSystem &crs,
+                             const QgsCoordinateTransformContext &transformContext
+                           );
 
     void cancel() override;
 
@@ -86,6 +104,8 @@ class CORE_EXPORT QgsRasterFileWriterTask : public QgsTask
     std::unique_ptr< QgsRasterBlockFeedback > mFeedback;
 
     QgsRasterFileWriter::WriterError mError = QgsRasterFileWriter::NoError;
+
+    QgsCoordinateTransformContext mTransformContext;
 
 };
 

--- a/src/core/raster/qgsrasterfilewritertask.h
+++ b/src/core/raster/qgsrasterfilewritertask.h
@@ -60,7 +60,6 @@ class CORE_EXPORT QgsRasterFileWriterTask : public QgsTask
      * coordinate \a transformContext .
      * Ownership of the \a pipe is transferred to the writer task, and will
      * be deleted when the task completes.
-     * \deprecated since QGIS 3.8, use version with transformContext instead
      */
     QgsRasterFileWriterTask( const QgsRasterFileWriter &writer, QgsRasterPipe *pipe SIP_TRANSFER,
                              int columns, int rows,

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -137,7 +137,12 @@ QgsRasterLayer::~QgsRasterLayer()
 
 QgsRasterLayer *QgsRasterLayer::clone() const
 {
-  QgsRasterLayer *layer = new QgsRasterLayer( source(), name(), mProviderKey );
+  QgsRasterLayer::LayerOptions options;
+  if ( mDataProvider )
+  {
+    options.transformContext = mDataProvider->transformContext();
+  }
+  QgsRasterLayer *layer = new QgsRasterLayer( source(), name(), mProviderKey, options );
   QgsMapLayer::clone( layer );
 
   // do not clone data provider which is the first element in pipe

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1510,6 +1510,12 @@ void QgsRasterLayer::showStatusMessage( QString const &message )
   emit statusChanged( message );
 }
 
+void QgsRasterLayer::changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext )
+{
+  if ( mDataProvider )
+    mDataProvider->setCoordinateTransformContext( coordinateTransformContext );
+}
+
 QStringList QgsRasterLayer::subLayers() const
 {
   return mDataProvider->subLayers();
@@ -1746,7 +1752,7 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     // <<< BACKWARD COMPATIBILITY < 1.9
   }
 
-  QgsDataProvider::ProviderOptions providerOptions;
+  QgsDataProvider::ProviderOptions providerOptions { context.coordinateTransformContext() };
   setDataProvider( mProviderKey, providerOptions );
 
   if ( ! mDataProvider )

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1752,7 +1752,7 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     // <<< BACKWARD COMPATIBILITY < 1.9
   }
 
-  QgsDataProvider::ProviderOptions providerOptions { context.coordinateTransformContext() };
+  QgsDataProvider::ProviderOptions providerOptions { context.transformContext() };
   setDataProvider( mProviderKey, providerOptions );
 
   if ( ! mDataProvider )

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1510,10 +1510,10 @@ void QgsRasterLayer::showStatusMessage( QString const &message )
   emit statusChanged( message );
 }
 
-void QgsRasterLayer::changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext )
+void QgsRasterLayer::setTransformContext( const QgsCoordinateTransformContext &transformContext )
 {
   if ( mDataProvider )
-    mDataProvider->setCoordinateTransformContext( coordinateTransformContext );
+    mDataProvider->setTransformContext( transformContext );
 }
 
 QStringList QgsRasterLayer::subLayers() const

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -272,7 +272,7 @@ void QgsRasterLayer::draw( QPainter *theQPainter,
   // params in QgsRasterProjector
   if ( projector )
   {
-    projector->setCrs( rasterViewPort->mSrcCRS, rasterViewPort->mDestCRS, rasterViewPort->mSrcDatumTransform, rasterViewPort->mDestDatumTransform );
+    projector->setCrs( rasterViewPort->mSrcCRS, rasterViewPort->mDestCRS, rasterViewPort->mTransformContext );
   }
 
   // Drawer to pipe?

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -121,7 +121,7 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   setProviderType( providerKey );
 
-  QgsDataProvider::ProviderOptions providerOptions;
+  QgsDataProvider::ProviderOptions providerOptions { options.transformContext };
 
   setDataSource( uri, baseName, providerKey, providerOptions, options.loadDefaultStyle );
 

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -174,12 +174,21 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
       /**
        * Constructor for LayerOptions.
        */
-      explicit LayerOptions( bool loadDefaultStyle = true )
+      explicit LayerOptions( bool loadDefaultStyle = true,
+                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() )
         : loadDefaultStyle( loadDefaultStyle )
+        , coordinateTransformContext( coordinateTransformContext )
       {}
 
       //! Sets to TRUE if the default layer style should be loaded
       bool loadDefaultStyle = true;
+
+      /**
+       * Coordinate transform context
+       * \since QGIS 3.10
+       */
+      QgsCoordinateTransformContext coordinateTransformContext = QgsCoordinateTransformContext();
+
     };
 
     /**
@@ -428,6 +437,13 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
   public slots:
     void showStatusMessage( const QString &message );
+
+    /**
+     * Change coordinate transform context to \a coordinateTransformContext
+     *
+     * \since QGIS 3.10
+     */
+    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
 
   protected:
     bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories ) override;

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -175,9 +175,9 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
        * Constructor for LayerOptions.
        */
       explicit LayerOptions( bool loadDefaultStyle = true,
-                             const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() )
+                             const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext() )
         : loadDefaultStyle( loadDefaultStyle )
-        , coordinateTransformContext( coordinateTransformContext )
+        , transformContext( transformContext )
       {}
 
       //! Sets to TRUE if the default layer style should be loaded
@@ -187,7 +187,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
        * Coordinate transform context
        * \since QGIS 3.10
        */
-      QgsCoordinateTransformContext coordinateTransformContext = QgsCoordinateTransformContext();
+      QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
 
     };
 
@@ -439,11 +439,11 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     void showStatusMessage( const QString &message );
 
     /**
-     * Change coordinate transform context to \a coordinateTransformContext
+     * Triggered when the coordinate transform context has changed \a transformContext
      *
      * \since QGIS 3.10
      */
-    void changeCoordinateTranformContext( const QgsCoordinateTransformContext &coordinateTransformContext );
+    virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 
   protected:
     bool readSymbology( const QDomNode &node, QString &errorMessage, QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories = QgsMapLayer::AllStyleCategories ) override;

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -185,7 +185,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
       /**
        * Coordinate transform context
-       * \since QGIS 3.10
+       * \since QGIS 3.8
        */
       QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
 
@@ -439,9 +439,9 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     void showStatusMessage( const QString &message );
 
     /**
-     * Triggered when the coordinate transform context has changed \a transformContext
+     * Sets the coordinate transform context to \a transformContext
      *
-     * \since QGIS 3.10
+     * \since QGIS 3.8
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -163,6 +163,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
     mRasterViewPort->mDestCRS = rendererContext.coordinateTransform().destinationCrs();
     mRasterViewPort->mSrcDatumTransform = rendererContext.coordinateTransform().sourceDatumTransformId();
     mRasterViewPort->mDestDatumTransform = rendererContext.coordinateTransform().destinationDatumTransformId();
+    mRasterViewPort->mTransformContext = rendererContext.transformContext();
   }
   else
   {
@@ -263,7 +264,7 @@ bool QgsRasterLayerRenderer::render()
   // params in QgsRasterProjector
   if ( projector )
   {
-    projector->setCrs( mRasterViewPort->mSrcCRS, mRasterViewPort->mDestCRS, mRasterViewPort->mSrcDatumTransform, mRasterViewPort->mDestDatumTransform );
+    projector->setCrs( mRasterViewPort->mSrcCRS, mRasterViewPort->mDestCRS, mRasterViewPort->mTransformContext );
   }
 
   // Drawer to pipe?

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -59,7 +59,6 @@ Qgis::DataType QgsRasterProjector::dataType( int bandNo ) const
 
 /// @cond PRIVATE
 
-
 void QgsRasterProjector::setCrs( const QgsCoordinateReferenceSystem &srcCRS,
                                  const QgsCoordinateReferenceSystem &destCRS,
                                  int srcDatumTransform,
@@ -192,8 +191,8 @@ ProjectorData::ProjectorData( const QgsRectangle &extent, int width, int height,
     }
   }
   QgsDebugMsgLevel( QStringLiteral( "CPMatrix size: mCPRows = %1 mCPCols = %2" ).arg( mCPRows ).arg( mCPCols ), 4 );
-  mDestRowsPerMatrixRow = static_cast< float >( mDestRows ) / ( mCPRows - 1 );
-  mDestColsPerMatrixCol = static_cast< float >( mDestCols ) / ( mCPCols - 1 );
+  mDestRowsPerMatrixRow = static_cast< double >( mDestRows ) / ( mCPRows - 1 );
+  mDestColsPerMatrixCol = static_cast< double >( mDestCols ) / ( mCPCols - 1 );
 
   QgsDebugMsgLevel( QStringLiteral( "CPMatrix:" ), 5 );
   QgsDebugMsgLevel( cpToString(), 5 );

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -758,7 +758,6 @@ QgsRasterBlock *QgsRasterProjector::block( int bandNo, QgsRectangle  const &exte
   if ( feedback && feedback->isCanceled() )
     return new QgsRasterBlock();
 
-  // TODO: check if the last condition always apply to context
   if ( ! mSrcCRS.isValid() || ! mDestCRS.isValid() || mSrcCRS == mDestCRS )
   {
     QgsDebugMsgLevel( QStringLiteral( "No projection necessary" ), 4 );

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -69,9 +69,19 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
 
     Qgis::DataType dataType( int bandNo ) const override;
 
-    //! Sets the source and destination CRS
+    /**
+     * Sets the source and destination CRS
+     * \deprecated since QGIS 3.8, use transformContext version instead
+     */
+    Q_DECL_DEPRECATED void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
+                                   int srcDatumTransform = -1, int destDatumTransform = -1 ) SIP_DEPRECATED;
+
+    /**
+     * Sets source CRS to \a srcCRS and destination CRS to \a destCRS and the transformation context to \a transformContext
+     * \since QGIS 3.8
+     */
     void setCrs( const QgsCoordinateReferenceSystem &srcCRS, const QgsCoordinateReferenceSystem &destCRS,
-                 int srcDatumTransform = -1, int destDatumTransform = -1 );
+                 QgsCoordinateTransformContext transformContext );
 
     //! Returns the source CRS
     QgsCoordinateReferenceSystem sourceCrs() const { return mSrcCRS; }
@@ -111,6 +121,9 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
 
     //! Requested precision
     Precision mPrecision = Approximate;
+
+    //! Transform context
+    QgsCoordinateTransformContext mTransformContext;
 
 };
 

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -122,9 +122,6 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     //! Requested precision
     Precision mPrecision = Approximate;
 
-    //! Transform context
-    QgsCoordinateTransformContext mTransformContext;
-
 };
 
 

--- a/src/core/raster/qgsrasterviewport.h
+++ b/src/core/raster/qgsrasterviewport.h
@@ -19,6 +19,7 @@
 
 #include "qgspointxy.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgscoordinatetransformcontext.h"
 #include "qgsrectangle.h"
 
 /**
@@ -68,6 +69,11 @@ struct CORE_EXPORT QgsRasterViewPort
 
   int mSrcDatumTransform;
   int mDestDatumTransform;
+
+  /**
+   * Coordinate transform context
+   */
+  QgsCoordinateTransformContext mTransformContext;
 };
 
 #endif //QGSRASTERVIEWPORT_H

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -52,7 +52,6 @@ class QgsMapLayerConfigWidgetFactory;
 class QgsMessageBar;
 class QgsPluginManagerInterface;
 class QgsRasterLayer;
-class QgsSnappingUtils;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
 class QgsOptionsWidgetFactory;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -734,7 +734,7 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value )
     {
       Q_NOWARN_DEPRECATED_PUSH
       emit attributeChanged( eww->field().name(), value );
-      Q_NOWARN_DEPRECATED_PUSH
+      Q_NOWARN_DEPRECATED_POP
       emit widgetValueChanged( eww->field().name(), value, !mIsSettingFeature );
 
       signalEmitted = true;
@@ -773,7 +773,7 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value )
   {
     Q_NOWARN_DEPRECATED_PUSH
     emit attributeChanged( eww->field().name(), value );
-    Q_NOWARN_DEPRECATED_PUSH
+    Q_NOWARN_DEPRECATED_POP
     emit widgetValueChanged( eww->field().name(), value, !mIsSettingFeature );
   }
 }

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -202,7 +202,8 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     case QgsMapLayerType::MeshLayer:
     {
       QgsDebugMsg( QStringLiteral( "creating mesh layer" ) );
-      mLayer = qgis::make_unique < QgsMeshLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
+      const QgsMeshLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+      mLayer = qgis::make_unique < QgsMeshLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey(), options );
       break;
     }
 
@@ -210,7 +211,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     {
       QgsDebugMsg( QStringLiteral( "creating vector layer" ) );
       const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      mLayer = qgis::make_unique < QgsVectorLayer>( options, layerItem->uri(), layerItem->name(), layerItem->providerKey() );
+      mLayer = qgis::make_unique < QgsVectorLayer>( layerItem->uri(), layerItem->name(), layerItem->providerKey(), options );
       break;
     }
 

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -209,7 +209,8 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     case QgsMapLayerType::VectorLayer:
     {
       QgsDebugMsg( QStringLiteral( "creating vector layer" ) );
-      mLayer = qgis::make_unique < QgsVectorLayer>( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
+      const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+      mLayer = qgis::make_unique < QgsVectorLayer>( options, layerItem->uri(), layerItem->name(), layerItem->providerKey() );
       break;
     }
 

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -493,7 +493,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
   QString uri( QStringLiteral( "%1|layername=%2" ).arg( fileName, tableName ) );
   QString userVisiblelayerName( layerIdentifier.isEmpty() ? tableName : layerIdentifier );
   QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
-  std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique< QgsVectorLayer >( layerOptions, uri, userVisiblelayerName, QStringLiteral( "ogr" ) );
+  std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique< QgsVectorLayer >( uri, userVisiblelayerName, QStringLiteral( "ogr" ), layerOptions );
   if ( layer->isValid() )
   {
     if ( mAddToProject )

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -492,7 +492,8 @@ bool QgsNewGeoPackageLayerDialog::apply()
 
   QString uri( QStringLiteral( "%1|layername=%2" ).arg( fileName, tableName ) );
   QString userVisiblelayerName( layerIdentifier.isEmpty() ? tableName : layerIdentifier );
-  std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique< QgsVectorLayer >( uri, userVisiblelayerName, QStringLiteral( "ogr" ) );
+  QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
+  std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique< QgsVectorLayer >( layerOptions, uri, userVisiblelayerName, QStringLiteral( "ogr" ) );
   if ( layer->isValid() )
   {
     if ( mAddToProject )

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -63,8 +63,7 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
   mAreaCanvas->setDestinationCrs( srs );
 
   QString layerPath = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.shp" );
-  const QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
-  mLayers << new QgsVectorLayer( options, layerPath );
+  mLayers << new QgsVectorLayer( layerPath );
   mAreaCanvas->setLayers( mLayers );
   mAreaCanvas->setMapTool( new QgsMapToolPan( mAreaCanvas ) );
   mAreaCanvas->setPreviewJobsEnabled( true );

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -63,7 +63,8 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
   mAreaCanvas->setDestinationCrs( srs );
 
   QString layerPath = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.shp" );
-  mLayers << new QgsVectorLayer( layerPath );
+  const QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
+  mLayers << new QgsVectorLayer( options, layerPath );
   mAreaCanvas->setLayers( mLayers );
   mAreaCanvas->setMapTool( new QgsMapToolPan( mAreaCanvas ) );
   mAreaCanvas->setPreviewJobsEnabled( true );

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -936,7 +936,7 @@ bool QgsRasterLayerSaveAsDialog::outputLayerExists() const
 
   std::unique_ptr< QgsRasterLayer > rastLayer( new QgsRasterLayer( uri, "", QStringLiteral( "gdal" ) ) );
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr< QgsVectorLayer > vectLayer( new QgsVectorLayer( options, uri, "", QStringLiteral( "ogr" ) ) );
+  std::unique_ptr< QgsVectorLayer > vectLayer = qgis::make_unique<QgsVectorLayer>( uri, QString(), QStringLiteral( "ogr" ),  options );
   return ( rastLayer->isValid() || vectLayer->isValid() );
 }
 

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -935,7 +935,8 @@ bool QgsRasterLayerSaveAsDialog::outputLayerExists() const
   }
 
   std::unique_ptr< QgsRasterLayer > rastLayer( new QgsRasterLayer( uri, "", QStringLiteral( "gdal" ) ) );
-  std::unique_ptr< QgsVectorLayer > vectLayer( new QgsVectorLayer( uri, "", QStringLiteral( "ogr" ) ) );
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  std::unique_ptr< QgsVectorLayer > vectLayer( new QgsVectorLayer( options, uri, "", QStringLiteral( "ogr" ) ) );
   return ( rastLayer->isValid() || vectLayer->isValid() );
 }
 

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -105,7 +105,7 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
 
   // prepare layer and model to preview legend
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  mPreviewLayer = new QgsVectorLayer( options, QStringLiteral( "Point?crs=EPSG:4326" ), QStringLiteral( "Preview" ), QStringLiteral( "memory" ) );
+  mPreviewLayer = new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:4326" ), QStringLiteral( "Preview" ), QStringLiteral( "memory" ), options );
   mPreviewTree = new QgsLayerTree;
   mPreviewLayerNode = mPreviewTree->addLayer( mPreviewLayer );  // node owned by the tree
   mPreviewModel = new QgsLayerTreeModel( mPreviewTree );
@@ -188,7 +188,10 @@ void QgsDataDefinedSizeLegendWidget::changeSymbol()
 
   QString crsAuthId = mMapCanvas ? mMapCanvas->mapSettings().destinationCrs().authid() : QString();
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr<QgsVectorLayer> layer = qgis::make_unique<QgsVectorLayer>( options, "Point?crs=" + crsAuthId, QStringLiteral( "tmp" ), QStringLiteral( "memory" ) ) ;
+  std::unique_ptr<QgsVectorLayer> layer = qgis::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=%1" ).arg( crsAuthId ),
+                                          QStringLiteral( "tmp" ),
+                                          QStringLiteral( "memory" ),
+                                          options ) ;
 
   QgsSymbolSelectorDialog d( newSymbol.get(), QgsStyle::defaultStyle(), layer.get(), this );
   d.setContext( context );

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -104,7 +104,8 @@ QgsDataDefinedSizeLegendWidget::QgsDataDefinedSizeLegendWidget( const QgsDataDef
   connect( mSizeClassesModel, &QStandardItemModel::dataChanged, this, &QgsDataDefinedSizeLegendWidget::onSizeClassesChanged );
 
   // prepare layer and model to preview legend
-  mPreviewLayer = new QgsVectorLayer( QStringLiteral( "Point?crs=EPSG:4326" ), QStringLiteral( "Preview" ), QStringLiteral( "memory" ) );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  mPreviewLayer = new QgsVectorLayer( options, QStringLiteral( "Point?crs=EPSG:4326" ), QStringLiteral( "Preview" ), QStringLiteral( "memory" ) );
   mPreviewTree = new QgsLayerTree;
   mPreviewLayerNode = mPreviewTree->addLayer( mPreviewLayer );  // node owned by the tree
   mPreviewModel = new QgsLayerTreeModel( mPreviewTree );
@@ -186,7 +187,8 @@ void QgsDataDefinedSizeLegendWidget::changeSymbol()
   context.setExpressionContext( &ec );
 
   QString crsAuthId = mMapCanvas ? mMapCanvas->mapSettings().destinationCrs().authid() : QString();
-  std::unique_ptr<QgsVectorLayer> layer( new QgsVectorLayer( "Point?crs=" + crsAuthId, QStringLiteral( "tmp" ), QStringLiteral( "memory" ) ) );
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  std::unique_ptr<QgsVectorLayer> layer = qgis::make_unique<QgsVectorLayer>( options, "Point?crs=" + crsAuthId, QStringLiteral( "tmp" ), QStringLiteral( "memory" ) ) ;
 
   QgsSymbolSelectorDialog d( newSymbol.get(), QgsStyle::defaultStyle(), layer.get(), this );
   d.setContext( context );

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -274,7 +274,7 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
   }
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *layer = new QgsVectorLayer( options, file, QFileInfo( file ).baseName(), QStringLiteral( "ogr" ) );
+  QgsVectorLayer *layer = new QgsVectorLayer( file, QFileInfo( file ).baseName(), QStringLiteral( "ogr" ), options );
   if ( !layer->isValid() )
   {
     delete layer;

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -272,7 +272,9 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
   {
     return false;
   }
-  QgsVectorLayer *layer = new QgsVectorLayer( file, QFileInfo( file ).baseName(), QStringLiteral( "ogr" ) );
+
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *layer = new QgsVectorLayer( options, file, QFileInfo( file ).baseName(), QStringLiteral( "ogr" ) );
   if ( !layer->isValid() )
   {
     delete layer;

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -322,8 +322,8 @@ void QgsGeometryCheckerSetupTab::runChecks()
         createErrors.append( errMsg );
         continue;
       }
-
-      QgsVectorLayer *newlayer = new QgsVectorLayer( outputPath, QFileInfo( outputPath ).completeBaseName(), QStringLiteral( "ogr" ) );
+      const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+      QgsVectorLayer *newlayer = new QgsVectorLayer( options, outputPath, QFileInfo( outputPath ).completeBaseName(), QStringLiteral( "ogr" ) );
       if ( selectedOnly )
       {
         QgsFeature feature;

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -323,7 +323,7 @@ void QgsGeometryCheckerSetupTab::runChecks()
         continue;
       }
       const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      QgsVectorLayer *newlayer = new QgsVectorLayer( options, outputPath, QFileInfo( outputPath ).completeBaseName(), QStringLiteral( "ogr" ) );
+      QgsVectorLayer *newlayer = new QgsVectorLayer( outputPath, QFileInfo( outputPath ).completeBaseName(), QStringLiteral( "ogr" ), options );
       if ( selectedOnly )
       {
         QgsFeature feature;

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -117,7 +117,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   if ( mSharedData->mExtent.isEmpty() )
   {
     mSharedData->mExtent = originalExtent;
-    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, coordinateTransformContext() ).transformBoundingBox( mSharedData->mExtent );
+    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, transformContext() ).transformBoundingBox( mSharedData->mExtent );
   }
 
   QString objectIdFieldName;

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -117,7 +117,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   if ( mSharedData->mExtent.isEmpty() )
   {
     mSharedData->mExtent = originalExtent;
-    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, transformContext() ).transformBoundingBox( mSharedData->mExtent );
+    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, options.transformContext ).transformBoundingBox( mSharedData->mExtent );
   }
 
   QString objectIdFieldName;

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -117,9 +117,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   if ( mSharedData->mExtent.isEmpty() )
   {
     mSharedData->mExtent = originalExtent;
-    Q_NOWARN_DEPRECATED_PUSH
-    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS ).transformBoundingBox( mSharedData->mExtent );
-    Q_NOWARN_DEPRECATED_POP
+    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, options.coordinateTransformContext ).transformBoundingBox( mSharedData->mExtent );
   }
 
   QString objectIdFieldName;

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -117,7 +117,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   if ( mSharedData->mExtent.isEmpty() )
   {
     mSharedData->mExtent = originalExtent;
-    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, options.coordinateTransformContext ).transformBoundingBox( mSharedData->mExtent );
+    mSharedData->mExtent = QgsCoordinateTransform( extentCrs, mSharedData->mSourceCRS, coordinateTransformContext() ).transformBoundingBox( mSharedData->mExtent );
   }
 
   QString objectIdFieldName;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -36,7 +36,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
 
   public:
 
-    QgsAfsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsAfsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     /* Inherited from QgsVectorDataProvider */
     QgsAbstractFeatureSource *featureSource() const override;

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -54,7 +54,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     Q_OBJECT
 
   public:
-    QgsAmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsAmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     /* Inherited from QgsDataProvider */
     bool isValid() const override { return mValid; }

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -310,9 +310,7 @@ void QgsArcGisServiceSourceSelect::addButtonClicked()
   {
     try
     {
-      Q_NOWARN_DEPRECATED_PUSH
-      extent = QgsCoordinateTransform( canvasCrs, pCrs ).transform( extent );
-      Q_NOWARN_DEPRECATED_POP
+      extent = QgsCoordinateTransform( canvasCrs, pCrs, QgsProject::instance()->transformContext() ).transform( extent );
       QgsDebugMsg( QStringLiteral( "canvas transform: Canvas CRS=%1, Provider CRS=%2, BBOX=%3" )
                    .arg( canvasCrs.authid(), pCrs.authid(), extent.asWktCoordinates() ) );
     }

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -25,6 +25,7 @@
 #include "qgssettings.h"
 #include "qgsmessageoutput.h"
 #include "qgsapplication.h"
+#include "qgsproject.h"
 
 #ifdef HAVE_GUI
 #include "qgsdb2newconnection.h"
@@ -339,7 +340,8 @@ bool QgsDb2ConnectionItem::handleDrop( const QMimeData *data, const QString &toS
 
     QgsDebugMsg( QStringLiteral( "uri: %1; name: %2; key: %3" ).arg( u.uri, u.name, u.providerKey ) );
     // open the source layer
-    QgsVectorLayer *srcLayer = new QgsVectorLayer( u.uri, u.name, u.providerKey );
+    const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+    QgsVectorLayer *srcLayer = new QgsVectorLayer( options, u.uri, u.name, u.providerKey );
 
     if ( srcLayer->isValid() )
     {

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -341,7 +341,7 @@ bool QgsDb2ConnectionItem::handleDrop( const QMimeData *data, const QString &toS
     QgsDebugMsg( QStringLiteral( "uri: %1; name: %2; key: %3" ).arg( u.uri, u.name, u.providerKey ) );
     // open the source layer
     const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-    QgsVectorLayer *srcLayer = new QgsVectorLayer( options, u.uri, u.name, u.providerKey );
+    QgsVectorLayer *srcLayer = new QgsVectorLayer( u.uri, u.name, u.providerKey, options );
 
     if ( srcLayer->isValid() )
     {

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1289,11 +1289,8 @@ QgsVectorLayerExporter::ExportError QgsDb2Provider::createEmptyLayer( const QStr
     const QgsCoordinateReferenceSystem &srs,
     bool overwrite,
     QMap<int, int> *oldToNewAttrIdxMap,
-    QString *errorMessage,
-    const QMap<QString, QVariant> *options )
+    QString *errorMessage )
 {
-  Q_UNUSED( options );
-
   // populate members from the uri structure
   QgsDataSourceUri dsUri( uri );
 
@@ -1772,12 +1769,11 @@ QGISEXTERN QgsVectorLayerExporter::ExportError createEmptyLayer(
   const QgsCoordinateReferenceSystem &srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
-  QString *errorMessage,
-  const QMap<QString, QVariant> *options )
+  QString *errorMessage )
 {
   return QgsDb2Provider::createEmptyLayer(
            uri, fields, wkbType, srs, overwrite,
-           oldToNewAttrIdxMap, errorMessage, options
+           oldToNewAttrIdxMap, errorMessage
          );
 }
 

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -100,8 +100,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
       const QgsCoordinateReferenceSystem &srs,
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
-      QString *errorMessage = nullptr,
-      const QMap<QString, QVariant> *coordinateTransformContext = nullptr
+      QString *errorMessage = nullptr
     );
 
     //! Convert a QgsField to work with DB2

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -35,7 +35,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsDb2Provider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsDb2Provider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     ~QgsDb2Provider() override;
 
@@ -101,7 +101,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,
-      const QMap<QString, QVariant> *options = nullptr
+      const QMap<QString, QVariant> *coordinateTransformContext = nullptr
     );
 
     //! Convert a QgsField to work with DB2

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -30,6 +30,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
+#include "qgsproject.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -593,7 +594,8 @@ void QgsDb2SourceSelect::setSql( const QModelIndex &index )
   QModelIndex idx = mProxyModel.mapToSource( index );
   QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsDb2TableModel::DbtmTable ) )->text();
 
-  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer >( mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata ), tableName, QStringLiteral( "DB2" ) );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer >( options,  mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata ), tableName, QStringLiteral( "DB2" ) );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -595,7 +595,7 @@ void QgsDb2SourceSelect::setSql( const QModelIndex &index )
   QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsDb2TableModel::DbtmTable ) )->text();
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer >( options,  mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata ), tableName, QStringLiteral( "DB2" ) );
+  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer >( mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata ), tableName, QStringLiteral( "DB2" ), options );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -75,7 +75,7 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
       GeomAsWkt
     };
 
-    explicit QgsDelimitedTextProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsDelimitedTextProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
     ~QgsDelimitedTextProvider() override;
 
     /* Implementation of functions from QgsVectorDataProvider */

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -70,7 +70,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
      * \param   newDataset  handle of newly created dataset.
      *
      */
-    QgsGdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, bool update = false, GDALDatasetH newDataset = nullptr );
+    QgsGdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, bool update = false, GDALDatasetH newDataset = nullptr );
 
     //! Create invalid provider with error
     QgsGdalProvider( const QString &uri, const QgsError &error );

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -43,7 +43,7 @@ class QgsGPXProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsGPXProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsGPXProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
     ~QgsGPXProvider() override;
 
     /* Functions inherited from QgsVectorDataProvider */

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -44,7 +44,7 @@ class QgsMdalProvider : public QgsMeshDataProvider
      * \param uri file name
      * \param options generic provider options
      */
-    QgsMdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsMdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
     ~QgsMdalProvider() override;
 
     bool isValid() const override;

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -501,7 +501,7 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
 
     // open the source layer
     const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-    QgsVectorLayer *srcLayer = new QgsVectorLayer( options, u.uri, u.name, u.providerKey );
+    QgsVectorLayer *srcLayer = new QgsVectorLayer( u.uri, u.name, u.providerKey, options );
 
     if ( srcLayer->isValid() )
     {

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -29,6 +29,7 @@
 #include "qgsmessageoutput.h"
 #include "qgsmssqlconnection.h"
 #include "qgsapplication.h"
+#include "qgsproject.h"
 
 #ifdef HAVE_GUI
 #include "qgsmssqlsourceselect.h"
@@ -499,7 +500,8 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData *data, const QString &t
     }
 
     // open the source layer
-    QgsVectorLayer *srcLayer = new QgsVectorLayer( u.uri, u.name, u.providerKey );
+    const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+    QgsVectorLayer *srcLayer = new QgsVectorLayer( options, u.uri, u.name, u.providerKey );
 
     if ( srcLayer->isValid() )
     {

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -50,7 +50,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsMssqlProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsMssqlProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     ~QgsMssqlProvider() override;
 
@@ -134,7 +134,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,
-      const QMap<QString, QVariant> *options = nullptr
+      const QMap<QString, QVariant> *coordinateTransformContext = nullptr
     );
 
     QgsCoordinateReferenceSystem crs() const override;

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -678,7 +678,7 @@ void QgsMssqlSourceSelect::setSql( const QModelIndex &index )
   const QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsMssqlTableModel::DbtmTable ) )->text();
   const bool disableInvalidGeometryHandling = QgsMssqlConnection::isInvalidGeometryHandlingDisabled( cmbConnections->currentText() );
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer>( options, mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling ), tableName, QStringLiteral( "mssql" ) );
+  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer>( mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling ), tableName, QStringLiteral( "mssql" ), options );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -29,6 +29,7 @@
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
 #include "qgsmssqlconnection.h"
+#include "qgsproject.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -676,8 +677,8 @@ void QgsMssqlSourceSelect::setSql( const QModelIndex &index )
   QModelIndex idx = mProxyModel.mapToSource( index );
   const QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), QgsMssqlTableModel::DbtmTable ) )->text();
   const bool disableInvalidGeometryHandling = QgsMssqlConnection::isInvalidGeometryHandlingDisabled( cmbConnections->currentText() );
-
-  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer>( mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling ), tableName, QStringLiteral( "mssql" ) );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  std::unique_ptr< QgsVectorLayer > vlayer = qgis::make_unique< QgsVectorLayer>( options, mTableModel.layerURI( idx, mConnInfo, mUseEstimatedMetadata, disableInvalidGeometryHandling ), tableName, QStringLiteral( "mssql" ) );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -105,7 +105,8 @@ QList<QgsOgrDbLayerInfo *> QgsOgrLayerItem::subLayers( const QString &path, cons
   QList<QgsOgrDbLayerInfo *> children;
 
   // Vector layers
-  QgsVectorLayer layer( path, QStringLiteral( "ogr_tmp" ), QStringLiteral( "ogr" ) );
+  const QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
+  QgsVectorLayer layer( layerOptions, path, QStringLiteral( "ogr_tmp" ), QStringLiteral( "ogr" ) );
   if ( ! layer.isValid( ) )
   {
     QgsDebugMsgLevel( QStringLiteral( "Layer is not a valid %1 Vector layer %2" ).arg( path ), 3 );

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -106,7 +106,7 @@ QList<QgsOgrDbLayerInfo *> QgsOgrLayerItem::subLayers( const QString &path, cons
 
   // Vector layers
   const QgsVectorLayer::LayerOptions layerOptions { QgsProject::instance()->transformContext() };
-  QgsVectorLayer layer( layerOptions, path, QStringLiteral( "ogr_tmp" ), QStringLiteral( "ogr" ) );
+  QgsVectorLayer layer( path, QStringLiteral( "ogr_tmp" ), QStringLiteral( "ogr" ), layerOptions );
   if ( ! layer.isValid( ) )
   {
     QgsDebugMsgLevel( QStringLiteral( "Layer is not a valid %1 Vector layer %2" ).arg( path ), 3 );

--- a/src/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/providers/ogr/qgsogrdbsourceselect.cpp
@@ -371,7 +371,7 @@ void QgsOgrDbSourceSelect::setSql( const QModelIndex &index )
   QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), 0 ) )->text();
 
   QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  std::unique_ptr<QgsVectorLayer> vlayer = qgis::make_unique<QgsVectorLayer>( options, layerURI( idx ), tableName, QStringLiteral( "ogr" ) );
+  std::unique_ptr<QgsVectorLayer> vlayer = qgis::make_unique<QgsVectorLayer>( layerURI( idx ), tableName, QStringLiteral( "ogr" ), options );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/providers/ogr/qgsogrdbsourceselect.cpp
@@ -21,6 +21,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsquerybuilder.h"
 #include "qgssettings.h"
+#include "qgsproject.h"
 
 #include <QMessageBox>
 
@@ -369,7 +370,8 @@ void QgsOgrDbSourceSelect::setSql( const QModelIndex &index )
   QModelIndex idx = mProxyModel.mapToSource( index );
   QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), 0 ) )->text();
 
-  std::unique_ptr<QgsVectorLayer> vlayer( new QgsVectorLayer( layerURI( idx ), tableName, QStringLiteral( "ogr" ) ) );
+  QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  std::unique_ptr<QgsVectorLayer> vlayer = qgis::make_unique<QgsVectorLayer>( options, layerURI( idx ), tableName, QStringLiteral( "ogr" ) );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -72,7 +72,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,
-      const QMap<QString, QVariant> *options = nullptr
+      const QMap<QString, QVariant> *coordinateTransformContext = nullptr
     );
 
     /**
@@ -81,7 +81,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
      * \param options generic data provider options
      */
     explicit QgsOgrProvider( QString const &uri,
-                             const QgsDataProvider::ProviderOptions &options );
+                             const QgsDataProvider::ProviderOptions &providerOptions );
 
     ~QgsOgrProvider() override;
 

--- a/src/providers/ows/qgsowsprovider.h
+++ b/src/providers/ows/qgsowsprovider.h
@@ -47,7 +47,7 @@ class QgsOwsProvider : public QgsDataProvider
      * \param options generic data provider options
      *
      */
-    explicit QgsOwsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsOwsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     /* Pure virtuals */
 

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -633,7 +633,7 @@ void QgsPgSourceSelect::setSql( const QModelIndex &index )
   }
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *vlayer = new QgsVectorLayer( options, uri, tableName, QStringLiteral( "postgres" ) );
+  QgsVectorLayer *vlayer = new QgsVectorLayer( uri, tableName, QStringLiteral( "postgres" ), options );
   if ( !vlayer->isValid() )
   {
     delete vlayer;

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -29,6 +29,7 @@ email                : sherman at mrcc.com
 #include "qgscolumntypethread.h"
 #include "qgssettings.h"
 #include "qgsproxyprogresstask.h"
+#include "qgsproject.h"
 
 #include <QFileDialog>
 #include <QInputDialog>
@@ -631,7 +632,8 @@ void QgsPgSourceSelect::setSql( const QModelIndex &index )
     return;
   }
 
-  QgsVectorLayer *vlayer = new QgsVectorLayer( uri, tableName, QStringLiteral( "postgres" ) );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *vlayer = new QgsVectorLayer( options, uri, tableName, QStringLiteral( "postgres" ) );
   if ( !vlayer->isValid() )
   {
     delete vlayer;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -79,7 +79,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,
-      const QMap<QString, QVariant> *options = nullptr
+      const QMap<QString, QVariant> *coordinateTransformContext = nullptr
     );
 
     /**
@@ -89,7 +89,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      * and query the table.
      * \param options generic data provider options
      */
-    explicit QgsPostgresProvider( QString const &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsPostgresProvider( QString const &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
 
     ~QgsPostgresProvider() override;
@@ -285,7 +285,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     void setEditorWidgets();
 
     //! Convert a QgsField to work with PG
-    static bool convertField( QgsField &field, const QMap<QString, QVariant> *options = nullptr );
+    static bool convertField( QgsField &field, const QMap<QString, QVariant> *coordinateTransformContext = nullptr );
 
     /**
      * Parses the enum_range of an attribute and inserts the possible values into a stringlist

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -66,7 +66,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,
-      const QMap<QString, QVariant> *options = nullptr
+      const QMap<QString, QVariant> *coordinateTransformContext = nullptr
     );
 
     /**
@@ -74,7 +74,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
      * \param uri uniform resource locator (URI) for a dataset
      * \param options generic data provider options
      */
-    explicit QgsSpatiaLiteProvider( QString const &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsSpatiaLiteProvider( QString const &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
     ~ QgsSpatiaLiteProvider() override;
 

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -26,6 +26,7 @@ email                : a.furieri@lqt.it
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
 #include "qgsproviderregistry.h"
+#include "qgsproject.h"
 
 #include <QInputDialog>
 #include <QMessageBox>
@@ -522,7 +523,8 @@ void QgsSpatiaLiteSourceSelect::setSql( const QModelIndex &index )
   QModelIndex idx = mProxyModel.mapToSource( index );
   QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), 0 ) )->text();
 
-  QgsVectorLayer *vlayer = new QgsVectorLayer( layerURI( idx ), tableName, QStringLiteral( "spatialite" ) );
+  const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+  QgsVectorLayer *vlayer = new QgsVectorLayer( options, layerURI( idx ), tableName, QStringLiteral( "spatialite" ) );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -524,7 +524,7 @@ void QgsSpatiaLiteSourceSelect::setSql( const QModelIndex &index )
   QString tableName = mTableModel.itemFromIndex( idx.sibling( idx.row(), 0 ) )->text();
 
   const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-  QgsVectorLayer *vlayer = new QgsVectorLayer( options, layerURI( idx ), tableName, QStringLiteral( "spatialite" ) );
+  QgsVectorLayer *vlayer = new QgsVectorLayer( layerURI( idx ), tableName, QStringLiteral( "spatialite" ), options );
 
   if ( !vlayer->isValid() )
   {

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -35,7 +35,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
      * \param uri uniform resource locator (URI) for a dataset
      * \param options generic data provider options
      */
-    explicit QgsVirtualLayerProvider( QString const &uri, const ProviderOptions &options );
+    explicit QgsVirtualLayerProvider( QString const &uri, const ProviderOptions &coordinateTransformContext );
 
     QgsAbstractFeatureSource *featureSource() const override;
     QString storageType() const override;

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -207,7 +207,7 @@ void QgsVirtualLayerSourceSelect::testQuery()
   if ( ! def.toString().isEmpty() )
   {
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-    std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( options, def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ) ) );
+    std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ), options ) );
     if ( vl->isValid() )
     {
       QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -206,7 +206,8 @@ void QgsVirtualLayerSourceSelect::testQuery()
   //       according to the validity of the active layer definition
   if ( ! def.toString().isEmpty() )
   {
-    std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ) ) );
+    QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+    std::unique_ptr<QgsVectorLayer> vl( new QgsVectorLayer( options, def.toString(), QStringLiteral( "test" ), QStringLiteral( "virtual" ) ) );
     if ( vl->isValid() )
     {
       QMessageBox::information( nullptr, tr( "Virtual layer test" ), tr( "No error" ) );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1069,7 +1069,7 @@ bool QgsWcsProvider::calculateExtent() const
       //QgsDebugMsg( "qgisSrsSource: " + qgisSrsSource.toWkt() );
       //QgsDebugMsg( "qgisSrsDest: " + qgisSrsDest.toWkt() );
 
-      mCoordinateTransform = QgsCoordinateTransform( qgisSrsSource, qgisSrsDest, coordinateTransformContext() );
+      mCoordinateTransform = QgsCoordinateTransform( qgisSrsSource, qgisSrsDest, transformContext() );
     }
 
     QgsDebugMsg( "mCoverageSummary.wgs84BoundingBox= " + mCoverageSummary.wgs84BoundingBox.toString() );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1069,9 +1069,7 @@ bool QgsWcsProvider::calculateExtent() const
       //QgsDebugMsg( "qgisSrsSource: " + qgisSrsSource.toWkt() );
       //QgsDebugMsg( "qgisSrsDest: " + qgisSrsDest.toWkt() );
 
-      Q_NOWARN_DEPRECATED_PUSH
-      mCoordinateTransform = QgsCoordinateTransform( qgisSrsSource, qgisSrsDest );
-      Q_NOWARN_DEPRECATED_POP
+      mCoordinateTransform = QgsCoordinateTransform( qgisSrsSource, qgisSrsDest, options().coordinateTransformContext );
     }
 
     QgsDebugMsg( "mCoverageSummary.wgs84BoundingBox= " + mCoverageSummary.wgs84BoundingBox.toString() );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1069,7 +1069,7 @@ bool QgsWcsProvider::calculateExtent() const
       //QgsDebugMsg( "qgisSrsSource: " + qgisSrsSource.toWkt() );
       //QgsDebugMsg( "qgisSrsDest: " + qgisSrsDest.toWkt() );
 
-      mCoordinateTransform = QgsCoordinateTransform( qgisSrsSource, qgisSrsDest, options().coordinateTransformContext );
+      mCoordinateTransform = QgsCoordinateTransform( qgisSrsSource, qgisSrsDest, coordinateTransformContext() );
     }
 
     QgsDebugMsg( "mCoverageSummary.wgs84BoundingBox= " + mCoverageSummary.wgs84BoundingBox.toString() );

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -116,7 +116,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
      *                otherwise we contact the host directly.
      * \param options generic data provider options
      */
-    explicit QgsWcsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    explicit QgsWcsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
 
     ~QgsWcsProvider() override;

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -485,7 +485,7 @@ void QgsWfsCapabilities::capabilitiesReplyFinished()
           // into the CRS, and then back to WGS84, works (check that we are in the validity area)
           QgsCoordinateReferenceSystem crsWGS84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "CRS:84" ) );
 
-          QgsCoordinateTransform ct( crsWGS84, crs, mOptions.coordinateTransformContext );
+          QgsCoordinateTransform ct( crsWGS84, crs, mOptions.transformContext );
 
           QgsPointXY ptMin( featureType.bbox.xMinimum(), featureType.bbox.yMinimum() );
           QgsPointXY ptMinBack( ct.transform( ct.transform( ptMin, QgsCoordinateTransform::ForwardTransform ), QgsCoordinateTransform::ReverseTransform ) );

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -27,8 +27,9 @@
 #include <QDomDocument>
 #include <QStringList>
 
-QgsWfsCapabilities::QgsWfsCapabilities( const QString &uri )
-  : QgsWfsRequest( QgsWFSDataSourceURI( uri ) )
+QgsWfsCapabilities::QgsWfsCapabilities( const QString &uri, const QgsDataProvider::ProviderOptions &options )
+  : QgsWfsRequest( QgsWFSDataSourceURI( uri ) ),
+    mOptions( options )
 {
   // Using Qt::DirectConnection since the download might be running on a different thread.
   // In this case, the request was sent from the main thread and is executed with the main
@@ -484,9 +485,7 @@ void QgsWfsCapabilities::capabilitiesReplyFinished()
           // into the CRS, and then back to WGS84, works (check that we are in the validity area)
           QgsCoordinateReferenceSystem crsWGS84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "CRS:84" ) );
 
-          Q_NOWARN_DEPRECATED_PUSH
-          QgsCoordinateTransform ct( crsWGS84, crs );
-          Q_NOWARN_DEPRECATED_POP
+          QgsCoordinateTransform ct( crsWGS84, crs, mOptions.coordinateTransformContext );
 
           QgsPointXY ptMin( featureType.bbox.xMinimum(), featureType.bbox.yMinimum() );
           QgsPointXY ptMinBack( ct.transform( ct.transform( ptMin, QgsCoordinateTransform::ForwardTransform ), QgsCoordinateTransform::ReverseTransform ) );

--- a/src/providers/wfs/qgswfscapabilities.h
+++ b/src/providers/wfs/qgswfscapabilities.h
@@ -20,13 +20,14 @@
 
 #include "qgsrectangle.h"
 #include "qgswfsrequest.h"
+#include "qgsdataprovider.h"
 
 //! Manages the GetCapabilities request
 class QgsWfsCapabilities : public QgsWfsRequest
 {
     Q_OBJECT
   public:
-    explicit QgsWfsCapabilities( const QString &uri );
+    explicit QgsWfsCapabilities( const QString &uri, const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 
     //! start network connection to get capabilities
     bool requestCapabilities( bool synchronous, bool forceRefresh );
@@ -125,6 +126,8 @@ class QgsWfsCapabilities : public QgsWfsRequest
 
   private:
     Capabilities mCaps;
+
+    QgsDataProvider::ProviderOptions mOptions;
 
     //! Takes <Operations> element and updates the capabilities
     void parseSupportedOperations( const QDomElement &operationsElem,

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1819,10 +1819,7 @@ bool QgsWFSProvider::getCapabilities()
         if ( mShared->mCaps.featureTypes[i].bboxSRSIsWGS84 )
         {
           QgsCoordinateReferenceSystem src = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "CRS:84" ) );
-          Q_NOWARN_DEPRECATED_PUSH
-          QgsCoordinateTransform ct( src, mShared->mSourceCRS );
-          Q_NOWARN_DEPRECATED_POP
-
+          QgsCoordinateTransform ct( src, mShared->mSourceCRS, options().coordinateTransformContext );
           QgsDebugMsgLevel( "latlon ext:" + r.toString(), 4 );
           QgsDebugMsgLevel( "src:" + src.authid(), 4 );
           QgsDebugMsgLevel( "dst:" + mShared->mSourceCRS.authid(), 4 );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1819,7 +1819,7 @@ bool QgsWFSProvider::getCapabilities()
         if ( mShared->mCaps.featureTypes[i].bboxSRSIsWGS84 )
         {
           QgsCoordinateReferenceSystem src = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "CRS:84" ) );
-          QgsCoordinateTransform ct( src, mShared->mSourceCRS, options().coordinateTransformContext );
+          QgsCoordinateTransform ct( src, mShared->mSourceCRS, coordinateTransformContext() );
           QgsDebugMsgLevel( "latlon ext:" + r.toString(), 4 );
           QgsDebugMsgLevel( "src:" + src.authid(), 4 );
           QgsDebugMsgLevel( "dst:" + mShared->mSourceCRS.authid(), 4 );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1819,7 +1819,7 @@ bool QgsWFSProvider::getCapabilities()
         if ( mShared->mCaps.featureTypes[i].bboxSRSIsWGS84 )
         {
           QgsCoordinateReferenceSystem src = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "CRS:84" ) );
-          QgsCoordinateTransform ct( src, mShared->mSourceCRS, coordinateTransformContext() );
+          QgsCoordinateTransform ct( src, mShared->mSourceCRS, transformContext() );
           QgsDebugMsgLevel( "latlon ext:" + r.toString(), 4 );
           QgsDebugMsgLevel( "src:" + src.authid(), 4 );
           QgsDebugMsgLevel( "dst:" + mShared->mSourceCRS.authid(), 4 );

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -63,7 +63,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
     Q_OBJECT
   public:
 
-    explicit QgsWFSProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, const QgsWfsCapabilities::Capabilities &caps = QgsWfsCapabilities::Capabilities() );
+    explicit QgsWFSProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, const QgsWfsCapabilities::Capabilities &caps = QgsWfsCapabilities::Capabilities() );
     ~QgsWFSProvider() override;
 
     /* Inherited from QgsVectorDataProvider */

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -160,6 +160,12 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 // ----------------------
 
 
+QgsWmsCapabilities::QgsWmsCapabilities( const QgsDataProvider::ProviderOptions &options ):
+  mOptions( options )
+{
+
+}
+
 bool QgsWmsCapabilities::parseResponse( const QByteArray &response, QgsWmsParserSettings settings )
 {
   mParserSettings = settings;
@@ -828,12 +834,8 @@ void QgsWmsCapabilities::parseLayer( QDomElement const &e, QgsWmsLayerProperty &
           try
           {
             QgsCoordinateReferenceSystem src = QgsCoordinateReferenceSystem::fromOgcWmsCrs( e1.attribute( QStringLiteral( "SRS" ) ) );
-
             QgsCoordinateReferenceSystem dst = QgsCoordinateReferenceSystem::fromOgcWmsCrs( DEFAULT_LATLON_CRS );
-
-            Q_NOWARN_DEPRECATED_PUSH
-            QgsCoordinateTransform ct( src, dst );
-            Q_NOWARN_DEPRECATED_POP
+            QgsCoordinateTransform ct( src, dst, mOptions.coordinateTransformContext );
             layerProperty.ex_GeographicBoundingBox = ct.transformBoundingBox( layerProperty.ex_GeographicBoundingBox );
           }
           catch ( QgsCsException &cse )

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -160,8 +160,8 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 // ----------------------
 
 
-QgsWmsCapabilities::QgsWmsCapabilities( const QgsDataProvider::ProviderOptions &options ):
-  mOptions( options )
+QgsWmsCapabilities::QgsWmsCapabilities( const QgsCoordinateTransformContext &coordinateTransformContext ):
+  mCoordinateTransformContext( coordinateTransformContext )
 {
 
 }
@@ -835,7 +835,7 @@ void QgsWmsCapabilities::parseLayer( QDomElement const &e, QgsWmsLayerProperty &
           {
             QgsCoordinateReferenceSystem src = QgsCoordinateReferenceSystem::fromOgcWmsCrs( e1.attribute( QStringLiteral( "SRS" ) ) );
             QgsCoordinateReferenceSystem dst = QgsCoordinateReferenceSystem::fromOgcWmsCrs( DEFAULT_LATLON_CRS );
-            QgsCoordinateTransform ct( src, dst, mOptions.coordinateTransformContext );
+            QgsCoordinateTransform ct( src, dst, mCoordinateTransformContext );
             layerProperty.ex_GeographicBoundingBox = ct.transformBoundingBox( layerProperty.ex_GeographicBoundingBox );
           }
           catch ( QgsCsException &cse )

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -630,9 +630,9 @@ class QgsWmsCapabilities
   public:
 
     /**
-     * Constructs a QgsWmsCapabilities object with the given \a options
+     * Constructs a QgsWmsCapabilities object with the given \a coordinateTransformContext
      */
-    QgsWmsCapabilities( const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
+    QgsWmsCapabilities( const QgsCoordinateTransformContext &coordinateTransformContext = QgsCoordinateTransformContext() );
 
     bool isValid() const { return mValid; }
 
@@ -767,7 +767,7 @@ class QgsWmsCapabilities
 
   private:
 
-    QgsDataProvider::ProviderOptions mOptions;
+    QgsCoordinateTransformContext mCoordinateTransformContext;
 
     friend class QgsWmsProvider;
 };

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -26,6 +26,8 @@
 #include "qgsrectangle.h"
 #include "qgsrasteriterator.h"
 #include "qgsapplication.h"
+#include "qgsdataprovider.h"
+
 
 class QNetworkReply;
 
@@ -626,7 +628,11 @@ class QgsWmsSettings
 class QgsWmsCapabilities
 {
   public:
-    QgsWmsCapabilities() = default;
+
+    /**
+     * Constructs a QgsWmsCapabilities object with the given \a options
+     */
+    QgsWmsCapabilities( const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 
     bool isValid() const { return mValid; }
 
@@ -758,6 +764,10 @@ class QgsWmsCapabilities
 
     //temporarily caches invert axis setting for each crs
     QHash<QString, bool> mCrsInvertAxis;
+
+  private:
+
+    QgsDataProvider::ProviderOptions mOptions;
 
     friend class QgsWmsProvider;
 };

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1193,7 +1193,7 @@ bool QgsWmsProvider::retrieveServerCapabilities( bool forceRefresh )
       return false;
     }
 
-    QgsWmsCapabilities caps;
+    QgsWmsCapabilities caps( options() );
     if ( !caps.parseResponse( downloadCaps.response(), mSettings.parserSettings() ) )
     {
       mErrorFormat = caps.lastErrorFormat();
@@ -1217,9 +1217,8 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri )
   QgsDataSourceUri parsedUri;
   parsedUri.setEncodedUri( uri );
 
-  Q_NOWARN_DEPRECATED_PUSH
-  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( mSettings.mCrsId ) );
-  Q_NOWARN_DEPRECATED_POP
+  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( mSettings.mCrsId ),
+                             options().coordinateTransformContext );
 
   // the whole world is projected to a square:
   // X going from 180 W to 180 E

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1193,7 +1193,7 @@ bool QgsWmsProvider::retrieveServerCapabilities( bool forceRefresh )
       return false;
     }
 
-    QgsWmsCapabilities caps( coordinateTransformContext() );
+    QgsWmsCapabilities caps( transformContext() );
     if ( !caps.parseResponse( downloadCaps.response(), mSettings.parserSettings() ) )
     {
       mErrorFormat = caps.lastErrorFormat();
@@ -1218,7 +1218,7 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri )
   parsedUri.setEncodedUri( uri );
 
   QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( mSettings.mCrsId ),
-                             coordinateTransformContext() );
+                             transformContext() );
 
   // the whole world is projected to a square:
   // X going from 180 W to 180 E
@@ -1365,7 +1365,7 @@ bool QgsWmsProvider::extentForNonTiledLayer( const QString &layerName, const QSt
   if ( !wgs.isValid() || !dst.isValid() )
     return false;
 
-  QgsCoordinateTransform xform( wgs, dst, coordinateTransformContext() );
+  QgsCoordinateTransform xform( wgs, dst, transformContext() );
 
   QgsDebugMsg( QStringLiteral( "transforming layer extent %1" ).arg( extent.toString( true ) ) );
   try
@@ -1596,7 +1596,7 @@ bool QgsWmsProvider::calculateExtent() const
         {
           QgsCoordinateReferenceSystem qgisSrsSource = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mTileLayer->boundingBoxes[i].crs );
 
-          QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest, coordinateTransformContext() );
+          QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest, transformContext() );
 
           QgsDebugMsg( QStringLiteral( "ct: %1 => %2" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ) );
 
@@ -2950,7 +2950,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           QgsCoordinateTransform coordinateTransform;
           if ( featuresCrs.isValid() && featuresCrs != crs() )
           {
-            coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), coordinateTransformContext() );
+            coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), transformContext() );
           }
           QgsFeatureStore featureStore( fields, crs() );
           QMap<QString, QVariant> params;
@@ -3026,7 +3026,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
             if ( featuresCrs.isValid() && featuresCrs != crs() )
             {
-              coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), coordinateTransformContext() );
+              coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), transformContext() );
             }
           }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1365,9 +1365,7 @@ bool QgsWmsProvider::extentForNonTiledLayer( const QString &layerName, const QSt
   if ( !wgs.isValid() || !dst.isValid() )
     return false;
 
-  Q_NOWARN_DEPRECATED_PUSH
-  QgsCoordinateTransform xform( wgs, dst );
-  Q_NOWARN_DEPRECATED_POP
+  QgsCoordinateTransform xform( wgs, dst, options().coordinateTransformContext );
 
   QgsDebugMsg( QStringLiteral( "transforming layer extent %1" ).arg( extent.toString( true ) ) );
   try
@@ -1598,9 +1596,7 @@ bool QgsWmsProvider::calculateExtent() const
         {
           QgsCoordinateReferenceSystem qgisSrsSource = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mTileLayer->boundingBoxes[i].crs );
 
-          Q_NOWARN_DEPRECATED_PUSH
-          QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest );
-          Q_NOWARN_DEPRECATED_POP
+          QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest, options().coordinateTransformContext );
 
           QgsDebugMsg( QStringLiteral( "ct: %1 => %2" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ) );
 
@@ -2954,9 +2950,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           QgsCoordinateTransform coordinateTransform;
           if ( featuresCrs.isValid() && featuresCrs != crs() )
           {
-            Q_NOWARN_DEPRECATED_PUSH
-            coordinateTransform = QgsCoordinateTransform( featuresCrs, crs() );
-            Q_NOWARN_DEPRECATED_POP
+            coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), options().coordinateTransformContext );
           }
           QgsFeatureStore featureStore( fields, crs() );
           QMap<QString, QVariant> params;
@@ -3032,9 +3026,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
             if ( featuresCrs.isValid() && featuresCrs != crs() )
             {
-              Q_NOWARN_DEPRECATED_PUSH
-              coordinateTransform = QgsCoordinateTransform( featuresCrs, crs() );
-              Q_NOWARN_DEPRECATED_POP
+              coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), options().coordinateTransformContext );
             }
           }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1193,7 +1193,7 @@ bool QgsWmsProvider::retrieveServerCapabilities( bool forceRefresh )
       return false;
     }
 
-    QgsWmsCapabilities caps( options() );
+    QgsWmsCapabilities caps( coordinateTransformContext() );
     if ( !caps.parseResponse( downloadCaps.response(), mSettings.parserSettings() ) )
     {
       mErrorFormat = caps.lastErrorFormat();
@@ -1218,7 +1218,7 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri )
   parsedUri.setEncodedUri( uri );
 
   QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( mSettings.mCrsId ),
-                             options().coordinateTransformContext );
+                             coordinateTransformContext() );
 
   // the whole world is projected to a square:
   // X going from 180 W to 180 E
@@ -1365,7 +1365,7 @@ bool QgsWmsProvider::extentForNonTiledLayer( const QString &layerName, const QSt
   if ( !wgs.isValid() || !dst.isValid() )
     return false;
 
-  QgsCoordinateTransform xform( wgs, dst, options().coordinateTransformContext );
+  QgsCoordinateTransform xform( wgs, dst, coordinateTransformContext() );
 
   QgsDebugMsg( QStringLiteral( "transforming layer extent %1" ).arg( extent.toString( true ) ) );
   try
@@ -1596,7 +1596,7 @@ bool QgsWmsProvider::calculateExtent() const
         {
           QgsCoordinateReferenceSystem qgisSrsSource = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mTileLayer->boundingBoxes[i].crs );
 
-          QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest, options().coordinateTransformContext );
+          QgsCoordinateTransform ct( qgisSrsSource, qgisSrsDest, coordinateTransformContext() );
 
           QgsDebugMsg( QStringLiteral( "ct: %1 => %2" ).arg( mTileLayer->boundingBoxes.at( i ).crs, mImageCrs ) );
 
@@ -2950,7 +2950,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
           QgsCoordinateTransform coordinateTransform;
           if ( featuresCrs.isValid() && featuresCrs != crs() )
           {
-            coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), options().coordinateTransformContext );
+            coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), coordinateTransformContext() );
           }
           QgsFeatureStore featureStore( fields, crs() );
           QMap<QString, QVariant> params;
@@ -3026,7 +3026,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
             if ( featuresCrs.isValid() && featuresCrs != crs() )
             {
-              coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), options().coordinateTransformContext );
+              coordinateTransform = QgsCoordinateTransform( featuresCrs, crs(), coordinateTransformContext() );
             }
           }
 

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -123,7 +123,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
      * \param capabilities Optionally existing parsed capabilities for the given URI
      *
      */
-    QgsWmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, const QgsWmsCapabilities *capabilities = nullptr );
+    QgsWmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions, const QgsWmsCapabilities *capabilities = nullptr );
 
 
     ~QgsWmsProvider() override;

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -480,7 +480,7 @@ void QgsWMSSourceSelect::btnConnect_clicked()
     return;
   }
 
-  QgsWmsCapabilities caps( QgsDataProvider::ProviderOptions { QgsProject::instance()->transformContext() } );
+  QgsWmsCapabilities caps { QgsProject::instance()->transformContext()  };
   if ( !caps.parseResponse( capDownload.response(), wmsSettings.parserSettings() ) )
   {
     QMessageBox msgBox( QMessageBox::Warning, tr( "WMS Provider" ),

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -480,7 +480,7 @@ void QgsWMSSourceSelect::btnConnect_clicked()
     return;
   }
 
-  QgsWmsCapabilities caps;
+  QgsWmsCapabilities caps( QgsDataProvider::ProviderOptions { QgsProject::instance()->transformContext() } );
   if ( !caps.parseResponse( capDownload.response(), wmsSettings.parserSettings() ) )
   {
     QMessageBox msgBox( QMessageBox::Warning, tr( "WMS Provider" ),

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -199,14 +199,14 @@ namespace QgsWcs
     if ( responseCRS != rLayer->crs() )
     {
       QgsRasterProjector *projector = new QgsRasterProjector;
-      projector->setCrs( rLayer->crs(), responseCRS, rLayer->dataProvider()->transformContext() );
+      projector->setCrs( rLayer->crs(), responseCRS, rLayer->transformContext() );
       if ( !pipe.insert( 2, projector ) )
       {
         throw QgsRequestNotWellFormedException( QStringLiteral( "Cannot set pipe projector" ) );
       }
     }
 
-    QgsRasterFileWriter::WriterError err = fileWriter.writeRaster( &pipe, width, height, rect, responseCRS, rLayer->dataProvider()->transformContext() );
+    QgsRasterFileWriter::WriterError err = fileWriter.writeRaster( &pipe, width, height, rect, responseCRS, rLayer->transformContext() );
     if ( err != QgsRasterFileWriter::NoError )
     {
       throw QgsRequestNotWellFormedException( QStringLiteral( "Cannot write raster error code: %1" ).arg( err ) );

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -199,7 +199,7 @@ namespace QgsWcs
     if ( responseCRS != rLayer->crs() )
     {
       QgsRasterProjector *projector = new QgsRasterProjector;
-      projector->setCrs( rLayer->crs(), responseCRS );
+      projector->setCrs( rLayer->crs(), responseCRS, rLayer->dataProvider()->transformContext() );
       if ( !pipe.insert( 2, projector ) )
       {
         throw QgsRequestNotWellFormedException( QStringLiteral( "Cannot set pipe projector" ) );

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -206,7 +206,7 @@ namespace QgsWcs
       }
     }
 
-    QgsRasterFileWriter::WriterError err = fileWriter.writeRaster( &pipe, width, height, rect, responseCRS );
+    QgsRasterFileWriter::WriterError err = fileWriter.writeRaster( &pipe, width, height, rect, responseCRS, rLayer->dataProvider()->transformContext() );
     if ( err != QgsRasterFileWriter::NoError )
     {
       throw QgsRequestNotWellFormedException( QStringLiteral( "Cannot write raster error code: %1" ).arg( err ) );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2553,7 +2553,7 @@ namespace QgsWms
 
       // create vector layer
       const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      std::unique_ptr<QgsVectorLayer> layer = qgis::make_unique<QgsVectorLayer>( options, url, param.mName, QLatin1Literal( "memory" ) );
+      std::unique_ptr<QgsVectorLayer> layer = qgis::make_unique<QgsVectorLayer>( url, param.mName, QLatin1Literal( "memory" ), options );
       if ( !layer->isValid() )
       {
         continue;

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2552,8 +2552,8 @@ namespace QgsWms
       }
 
       // create vector layer
-      std::unique_ptr<QgsVectorLayer> layer;
-      layer.reset( new QgsVectorLayer( url, param.mName, "memory" ) );
+      const QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
+      std::unique_ptr<QgsVectorLayer> layer = qgis::make_unique<QgsVectorLayer>( options, url, param.mName, QLatin1Literal( "memory" ) );
       if ( !layer->isValid() )
       {
         continue;

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6237,7 +6237,7 @@ void TestQgsProcessing::checkParamValues()
 void TestQgsProcessing::combineLayerExtent()
 {
   QgsProcessingContext context;
-  QgsRectangle ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>(), context );
+  QgsRectangle ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>(), QgsCoordinateReferenceSystem(), context );
   QVERIFY( ext.isNull() );
 
   QString testDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
@@ -6249,13 +6249,13 @@ void TestQgsProcessing::combineLayerExtent()
   QFileInfo fi2( raster2 );
   std::unique_ptr< QgsRasterLayer > r2( new QgsRasterLayer( fi2.filePath(), "R2" ) );
 
-  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get(), context );
+  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get(), QgsCoordinateReferenceSystem(), context );
   QGSCOMPARENEAR( ext.xMinimum(), 1535375.000000, 10 );
   QGSCOMPARENEAR( ext.xMaximum(), 1535475, 10 );
   QGSCOMPARENEAR( ext.yMinimum(), 5083255, 10 );
   QGSCOMPARENEAR( ext.yMaximum(), 5083355, 10 );
 
-  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get(), context );
+  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get(), QgsCoordinateReferenceSystem(), context );
   QGSCOMPARENEAR( ext.xMinimum(), 781662, 10 );
   QGSCOMPARENEAR( ext.xMaximum(), 1535475, 10 );
   QGSCOMPARENEAR( ext.yMinimum(), 3339523, 10 );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -44,6 +44,7 @@
 #include "qgsprintlayout.h"
 #include "qgslayoutmanager.h"
 #include "qgslayoutitemlabel.h"
+#include "qgscoordinatetransformcontext.h"
 
 class DummyAlgorithm : public QgsProcessingAlgorithm
 {
@@ -1032,7 +1033,7 @@ void TestQgsProcessing::mapLayers()
   QString vector = testDataDir + "points.shp";
 
   // test loadMapLayerFromString with raster
-  QgsMapLayer *l = QgsProcessingUtils::loadMapLayerFromString( raster );
+  QgsMapLayer *l = QgsProcessingUtils::loadMapLayerFromString( raster, QgsCoordinateTransformContext() );
   QVERIFY( l->isValid() );
   QCOMPARE( l->type(), QgsMapLayerType::RasterLayer );
   QCOMPARE( l->name(), QStringLiteral( "landsat" ) );
@@ -1040,17 +1041,17 @@ void TestQgsProcessing::mapLayers()
   delete l;
 
   //test with vector
-  l = QgsProcessingUtils::loadMapLayerFromString( vector );
+  l = QgsProcessingUtils::loadMapLayerFromString( vector, QgsCoordinateTransformContext() );
   QVERIFY( l->isValid() );
   QCOMPARE( l->type(), QgsMapLayerType::VectorLayer );
   QCOMPARE( l->name(), QStringLiteral( "points" ) );
   delete l;
 
-  l = QgsProcessingUtils::loadMapLayerFromString( QString() );
+  l = QgsProcessingUtils::loadMapLayerFromString( QString(), QgsCoordinateTransformContext() );
   QVERIFY( !l );
-  l = QgsProcessingUtils::loadMapLayerFromString( QStringLiteral( "so much room for activities!" ) );
+  l = QgsProcessingUtils::loadMapLayerFromString( QStringLiteral( "so much room for activities!" ), QgsCoordinateTransformContext() );
   QVERIFY( !l );
-  l = QgsProcessingUtils::loadMapLayerFromString( testDataDir + "multipoint.shp" );
+  l = QgsProcessingUtils::loadMapLayerFromString( testDataDir + "multipoint.shp", QgsCoordinateTransformContext() );
   QVERIFY( l->isValid() );
   QCOMPARE( l->type(), QgsMapLayerType::VectorLayer );
   QCOMPARE( l->name(), QStringLiteral( "multipoint" ) );
@@ -1058,15 +1059,15 @@ void TestQgsProcessing::mapLayers()
 
   // Test layers from a string with parameters
   QString osmFilePath = testDataDir + "openstreetmap/testdata.xml";
-  std::unique_ptr< QgsVectorLayer > osm( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath ) ) );
+  std::unique_ptr< QgsVectorLayer > osm( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath, QgsCoordinateTransformContext() ) ) );
   QVERIFY( osm->isValid() );
   QCOMPARE( osm->geometryType(), QgsWkbTypes::PointGeometry );
 
-  osm.reset( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3" ) ) );
+  osm.reset( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3", QgsCoordinateTransformContext() ) ) );
   QVERIFY( osm->isValid() );
   QCOMPARE( osm->geometryType(), QgsWkbTypes::PolygonGeometry );
 
-  osm.reset( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3|subset=\"building\" is not null" ) ) );
+  osm.reset( qobject_cast< QgsVectorLayer *>( QgsProcessingUtils::loadMapLayerFromString( osmFilePath + "|layerid=3|subset=\"building\" is not null", QgsCoordinateTransformContext() ) ) );
   QVERIFY( osm->isValid() );
   QCOMPARE( osm->geometryType(), QgsWkbTypes::PolygonGeometry );
   QCOMPARE( osm->subsetString(), QStringLiteral( "\"building\" is not null" ) );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6236,7 +6236,8 @@ void TestQgsProcessing::checkParamValues()
 
 void TestQgsProcessing::combineLayerExtent()
 {
-  QgsRectangle ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() );
+  QgsProcessingContext context;
+  QgsRectangle ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>(), context );
   QVERIFY( ext.isNull() );
 
   QString testDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
@@ -6248,20 +6249,20 @@ void TestQgsProcessing::combineLayerExtent()
   QFileInfo fi2( raster2 );
   std::unique_ptr< QgsRasterLayer > r2( new QgsRasterLayer( fi2.filePath(), "R2" ) );
 
-  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() );
+  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get(), context );
   QGSCOMPARENEAR( ext.xMinimum(), 1535375.000000, 10 );
   QGSCOMPARENEAR( ext.xMaximum(), 1535475, 10 );
   QGSCOMPARENEAR( ext.yMinimum(), 5083255, 10 );
   QGSCOMPARENEAR( ext.yMaximum(), 5083355, 10 );
 
-  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get() );
+  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get(), context );
   QGSCOMPARENEAR( ext.xMinimum(), 781662, 10 );
   QGSCOMPARENEAR( ext.xMaximum(), 1535475, 10 );
   QGSCOMPARENEAR( ext.yMinimum(), 3339523, 10 );
   QGSCOMPARENEAR( ext.yMaximum(), 5083355, 10 );
 
   // with reprojection
-  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get(), QgsCoordinateReferenceSystem::fromEpsgId( 3785 ) );
+  ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get(), QgsCoordinateReferenceSystem::fromEpsgId( 3785 ), context );
   QGSCOMPARENEAR( ext.xMinimum(), 1995320, 10 );
   QGSCOMPARENEAR( ext.xMaximum(), 2008833, 10 );
   QGSCOMPARENEAR( ext.yMinimum(), 3523084, 10 );

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -466,7 +466,8 @@ void TestQgsRasterCalculator::calcWithLayers()
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + 2" ),
                           tmpName,
                           QStringLiteral( "GTiff" ),
-                          extent, crs, 2, 3, entries );
+                          extent, crs, 2, 3, entries,
+                          QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 0 );
 
   //open output file and check results
@@ -487,7 +488,8 @@ void TestQgsRasterCalculator::calcWithLayers()
   QgsRasterCalculator rc2( QStringLiteral( "\"landsat@1\" + \"landsat@2\"" ),
                            tmpName,
                            QStringLiteral( "GTiff" ),
-                           extent, crs, 2, 3, entries );
+                           extent, crs, 2, 3, entries,
+                           QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc2.processCalculation() ), 0 );
 
   //open output file and check results
@@ -532,7 +534,8 @@ void TestQgsRasterCalculator::calcWithReprojectedLayers()
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@1\" + \"landsat_4326@2\"" ),
                           tmpName,
                           QStringLiteral( "GTiff" ),
-                          extent, crs, 2, 3, entries );
+                          extent, crs, 2, 3, entries,
+                          QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 0 );
 
   //open output file and check results
@@ -627,7 +630,8 @@ void TestQgsRasterCalculator::errors( )
   QgsRasterCalculator rc( QStringLiteral( "\"landsat@0\"" ),
                           tmpName,
                           QStringLiteral( "GTiff" ),
-                          extent, crs, 2, 3, entries );
+                          extent, crs, 2, 3, entries,
+                          QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 6 );
   QCOMPARE( rc.lastError(), QStringLiteral( "Band number 0 is not valid for entry landsat@0" ) );
 
@@ -637,7 +641,8 @@ void TestQgsRasterCalculator::errors( )
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ),
                             tmpName,
                             QStringLiteral( "GTiff" ),
-                            extent, crs, 2, 3, entries );
+                            extent, crs, 2, 3, entries,
+                            QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 6 );
   QCOMPARE( rc.lastError(), QStringLiteral( "Band number 10 is not valid for entry landsat@0" ) );
 
@@ -650,7 +655,8 @@ void TestQgsRasterCalculator::errors( )
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ),
                             tmpName,
                             QStringLiteral( "GTiff" ),
-                            extent, crs, 2, 3, entries );
+                            extent, crs, 2, 3, entries,
+                            QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 2 );
   QCOMPARE( rc.lastError(), QStringLiteral( "No raster layer for entry landsat@0" ) );
 
@@ -662,7 +668,8 @@ void TestQgsRasterCalculator::errors( )
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ),
                             tmpName,
                             QStringLiteral( "xxxxx" ),
-                            extent, crs, 2, 3, entries );
+                            extent, crs, 2, 3, entries,
+                            QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 1 );
   QCOMPARE( rc.lastError(), QStringLiteral( "Could not obtain driver for xxxxx" ) );
 
@@ -670,7 +677,8 @@ void TestQgsRasterCalculator::errors( )
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ),
                             QStringLiteral( "/goodluckwritinghere/blah/blah.tif" ),
                             QStringLiteral( "GTiff" ),
-                            extent, crs, 2, 3, entries );
+                            extent, crs, 2, 3, entries,
+                            QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 1 );
   QCOMPARE( rc.lastError(), QStringLiteral( "Could not create output /goodluckwritinghere/blah/blah.tif" ) );
 
@@ -680,7 +688,8 @@ void TestQgsRasterCalculator::errors( )
   rc = QgsRasterCalculator( QStringLiteral( "\"landsat@0\"" ),
                             tmpName,
                             QStringLiteral( "GTiff" ),
-                            extent, crs, 2, 3, entries );
+                            extent, crs, 2, 3, entries,
+                            QgsProject::instance()->transformContext() );
   QCOMPARE( static_cast< int >( rc.processCalculation( &feedback ) ), 3 );
   QVERIFY( rc.lastError().isEmpty() );
 }
@@ -743,7 +752,8 @@ void TestQgsRasterCalculator::calcFormulasWithReprojectedLayers()
     QgsRasterCalculator rc( formula,
                             tmpName,
                             QStringLiteral( "GTiff" ),
-                            extent, crs, 2, 3, entries );
+                            extent, crs, 2, 3, entries,
+                            QgsProject::instance()->transformContext() );
     QCOMPARE( static_cast< int >( rc.processCalculation() ), 0 );
     //open output file and check results
     QgsRasterLayer *result = new QgsRasterLayer( tmpName, QStringLiteral( "result" ) );

--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -159,7 +159,7 @@ bool TestQgsRasterFileWriter::writeTest( const QString &rasterName )
 
   // Reprojection not really done
   QgsRasterProjector *projector = new QgsRasterProjector;
-  projector->setCrs( provider->crs(), provider->crs() );
+  projector->setCrs( provider->crs(), provider->crs(), provider->transformContext() );
   if ( !pipe->insert( 2, projector ) )
   {
     logError( QStringLiteral( "Cannot set pipe projector" ) );

--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -168,7 +168,7 @@ bool TestQgsRasterFileWriter::writeTest( const QString &rasterName )
   }
   qDebug() << "projector set";
 
-  fileWriter.writeRaster( pipe, provider->xSize(), provider->ySize(), provider->extent(), provider->crs() );
+  fileWriter.writeRaster( pipe, provider->xSize(), provider->ySize(), provider->extent(), provider->crs(), provider->transformContext() );
 
   delete pipe;
 
@@ -302,7 +302,7 @@ void TestQgsRasterFileWriter::testVrtCreation()
   QgsRasterPipe pipe;
   pipe.set( srcRasterLayer->dataProvider()->clone() );
   // Let's do it !
-  QgsRasterFileWriter::WriterError res = rasterFileWriter->writeRaster( &pipe, srcRasterLayer->width(), srcRasterLayer->height(), srcRasterLayer->extent(), crs );
+  QgsRasterFileWriter::WriterError res = rasterFileWriter->writeRaster( &pipe, srcRasterLayer->width(), srcRasterLayer->height(), srcRasterLayer->extent(), crs,  srcRasterLayer->transformContext() );
   QCOMPARE( res, QgsRasterFileWriter::NoError );
 
   // Now let's compare the georef of the original raster with the georef of the generated vrt file

--- a/tests/src/core/testqgsvectordataprovider.cpp
+++ b/tests/src/core/testqgsvectordataprovider.cpp
@@ -65,12 +65,12 @@ void TestQgsVectorDataProvider::initTestCase()
   QString layerLinesUrl = QStringLiteral( TEST_DATA_DIR ) + "/lines.shp";
 
   // load layers
-
-  vlayerPoints = new QgsVectorLayer( layerPointsUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ) );
+  const QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
+  vlayerPoints = new QgsVectorLayer( options, layerPointsUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ) );
   QVERIFY( vlayerPoints );
   QVERIFY( vlayerPoints->isValid() );
 
-  vlayerLines = new QgsVectorLayer( layerLinesUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ) );
+  vlayerLines = new QgsVectorLayer( options, layerLinesUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ) );
   QVERIFY( vlayerLines );
   QVERIFY( vlayerLines->isValid() );
 }

--- a/tests/src/core/testqgsvectordataprovider.cpp
+++ b/tests/src/core/testqgsvectordataprovider.cpp
@@ -66,11 +66,11 @@ void TestQgsVectorDataProvider::initTestCase()
 
   // load layers
   const QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
-  vlayerPoints = new QgsVectorLayer( options, layerPointsUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ) );
+  vlayerPoints = new QgsVectorLayer( layerPointsUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ), options );
   QVERIFY( vlayerPoints );
   QVERIFY( vlayerPoints->isValid() );
 
-  vlayerLines = new QgsVectorLayer( options, layerLinesUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ) );
+  vlayerLines = new QgsVectorLayer( layerLinesUrl, QStringLiteral( "testlayer" ), QStringLiteral( "ogr" ), options );
   QVERIFY( vlayerLines );
   QVERIFY( vlayerLines->isValid() );
 }

--- a/tests/src/core/testziplayer.cpp
+++ b/tests/src/core/testziplayer.cpp
@@ -111,7 +111,7 @@ QgsMapLayer *TestZipLayer::getLayer( const QString &myPath, const QString &myNam
   if ( myProviderKey == QLatin1String( "ogr" ) )
   {
     QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
-    myLayer = new QgsVectorLayer( options, myPath, fullName, QStringLiteral( "ogr" ) );
+    myLayer = new QgsVectorLayer( myPath, fullName, QStringLiteral( "ogr" ), options );
   }
   else if ( myProviderKey == QLatin1String( "gdal" ) )
   {

--- a/tests/src/core/testziplayer.cpp
+++ b/tests/src/core/testziplayer.cpp
@@ -110,7 +110,8 @@ QgsMapLayer *TestZipLayer::getLayer( const QString &myPath, const QString &myNam
 
   if ( myProviderKey == QLatin1String( "ogr" ) )
   {
-    myLayer = new QgsVectorLayer( myPath, fullName, QStringLiteral( "ogr" ) );
+    QgsVectorLayer::LayerOptions options { QgsCoordinateTransformContext() };
+    myLayer = new QgsVectorLayer( options, myPath, fullName, QStringLiteral( "ogr" ) );
   }
   else if ( myProviderKey == QLatin1String( "gdal" ) )
   {

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -19,6 +19,7 @@ import os
 import qgis  # NOQA
 
 from qgis.core import (QgsProject,
+                       QgsCoordinateTransformContext,
                        QgsProjectDirtyBlocker,
                        QgsApplication,
                        QgsUnitTypes,
@@ -1189,6 +1190,16 @@ class TestQgsProject(unittest.TestCase):
         p.deleteLater()
         del p
         self.assertEqual(len(spy), 0)
+
+    def testTransformContextSignalIsEmitted(self):
+        """Test that when a project transform context changes a transformContextChanged signal is emitted"""
+
+        p = QgsProject()
+        spy = QSignalSpy(p.transformContextChanged)
+        ctx = QgsCoordinateTransformContext()
+        ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+        p.setTransformContext(ctx)
+        self.assertEqual(len(spy), 1)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsrasterfilewritertask.py
+++ b/tests/src/python/test_qgsrasterfilewritertask.py
@@ -17,6 +17,7 @@ import os
 
 from qgis.core import (
     QgsApplication,
+    QgsCoordinateTransformContext,
     QgsRasterLayer,
     QgsRasterPipe,
     QgsRasterFileWriter,
@@ -57,7 +58,7 @@ class TestQgsRasterFileWriterTask(unittest.TestCase):
         tmp = create_temp_filename('success.tif')
         writer = QgsRasterFileWriter(tmp)
 
-        task = QgsRasterFileWriterTask(writer, pipe, 100, 100, raster_layer.extent(), raster_layer.crs())
+        task = QgsRasterFileWriterTask(writer, pipe, 100, 100, raster_layer.extent(), raster_layer.crs(), QgsCoordinateTransformContext())
 
         task.writeComplete.connect(self.onSuccess)
         task.errorOccurred.connect(self.onFail)
@@ -82,7 +83,7 @@ class TestQgsRasterFileWriterTask(unittest.TestCase):
         tmp = create_temp_filename('remove_layer.tif')
         writer = QgsRasterFileWriter(tmp)
 
-        task = QgsRasterFileWriterTask(writer, pipe, 100, 100, raster_layer.extent(), raster_layer.crs())
+        task = QgsRasterFileWriterTask(writer, pipe, 100, 100, raster_layer.extent(), raster_layer.crs(), QgsCoordinateTransformContext())
 
         task.writeComplete.connect(self.onSuccess)
         task.errorOccurred.connect(self.onFail)

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -47,7 +47,10 @@ from qgis.core import (QgsRaster,
                        QgsSingleBandPseudoColorRenderer,
                        QgsLimitedRandomColorRamp,
                        QgsGradientColorRamp,
-                       QgsHueSaturationFilter)
+                       QgsHueSaturationFilter,
+                       QgsCoordinateTransformContext,
+                       QgsCoordinateReferenceSystem
+                       )
 from utilities import unitTestDataPath
 from qgis.testing import start_app, unittest
 from qgis.testing.mocked import get_iface
@@ -1030,6 +1033,62 @@ class TestQgsRasterLayer(unittest.TestCase):
         return dom, root, errorMessage
 
 
+class TestQgsRasterLayerTransformContext(unittest.TestCase):
+
+    def setUp(self):
+        """Prepare tc"""
+        super(TestQgsRasterLayerTransformContext, self).setUp()
+        self.ctx = QgsCoordinateTransformContext()
+        self.ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+        self.rpath = os.path.join(unitTestDataPath(), 'landsat.tif')
+
+    def testTransformContextIsSetInCtor(self):
+        """Test transform context can be set from ctor"""
+
+        rl = QgsRasterLayer(self.rpath, 'raster')
+        self.assertFalse(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        options = QgsRasterLayer.LayerOptions(transformContext=self.ctx)
+        rl = QgsRasterLayer(self.rpath, 'raster', 'gdal', options)
+        self.assertTrue(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+    def testTransformContextInheritsFromProject(self):
+        """Test that when a layer is added to a project it inherits its context"""
+
+        rl = QgsRasterLayer(self.rpath, 'raster')
+        self.assertFalse(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p = QgsProject()
+        self.assertFalse(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        p.setTransformContext(self.ctx)
+        self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p.addMapLayers([rl])
+        self.assertTrue(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+    def testTransformContextIsSyncedFromProject(self):
+        """Test that when a layer is synced when project context changes"""
+
+        rl = QgsRasterLayer(self.rpath, 'raster')
+        self.assertFalse(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p = QgsProject()
+        self.assertFalse(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        p.setTransformContext(self.ctx)
+        self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p.addMapLayers([rl])
+        self.assertTrue(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        # Now change the project context
+        tc2 = QgsCoordinateTransformContext()
+        p.setTransformContext(tc2)
+        self.assertFalse(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        self.assertFalse(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        p.setTransformContext(self.ctx)
+        self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        self.assertTrue(rl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+
 if __name__ == '__main__':
     unittest.main()
-rule

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -57,7 +57,6 @@ from qgis.core import (QgsWkbTypes,
                        QgsTextFormat,
                        QgsVectorLayerSelectedFeatureSource,
                        QgsExpression,
-                       QgsCoordinateTransformContext,
                        NULL)
 from qgis.gui import (QgsAttributeTableModel,
                       QgsGui
@@ -3167,19 +3166,6 @@ class TestQgsVectorLayerSourceDeletedFeaturesInBuffer(unittest.TestCase, Feature
         """
         pass
 
-
-class TestQgsVectorLayerTransformContext(unittest.TestCase):
-
-    def testTransformContext(self):
-        vl = QgsVectorLayer(
-            'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
-            'test', 'memory')
-        ctx = QgsCoordinateTransformContext()
-        ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
-        vl.dataProvider().setTransformContext(ctx)
-        self.assertTrue(vl.isValid())
-        self.assertEqual(vl.transformContext(), vl.dataProvider().transformContext())
-        self.assertEqual(list(vl.transformContext().sourceDestinationDatumTransforms().keys())[0], ('EPSG:4326', 'EPSG:3857'))
 
 # TODO:
 # - fetch rect: feat with changed geometry: 1. in rect, 2. out of rect

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -57,6 +57,7 @@ from qgis.core import (QgsWkbTypes,
                        QgsTextFormat,
                        QgsVectorLayerSelectedFeatureSource,
                        QgsExpression,
+                       QgsCoordinateTransformContext,
                        NULL)
 from qgis.gui import (QgsAttributeTableModel,
                       QgsGui
@@ -3165,6 +3166,20 @@ class TestQgsVectorLayerSourceDeletedFeaturesInBuffer(unittest.TestCase, Feature
         """ Skip max values test - as noted in the docs this is unreliable when features are in the buffer
         """
         pass
+
+
+class TestQgsVectorLayerTransformContext(unittest.TestCase):
+
+    def testTransformContext(self):
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
+            'test', 'memory')
+        ctx = QgsCoordinateTransformContext()
+        ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+        vl.dataProvider().setTransformContext(ctx)
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.transformContext(), vl.dataProvider().transformContext())
+        self.assertEqual(list(vl.transformContext().sourceDestinationDatumTransforms().keys())[0], ('EPSG:4326', 'EPSG:3857'))
 
 # TODO:
 # - fetch rect: feat with changed geometry: 1. in rect, 2. out of rect

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -22,6 +22,7 @@ from qgis.PyQt.QtXml import QDomDocument
 
 from qgis.core import (QgsWkbTypes,
                        QgsAction,
+                       QgsCoordinateTransformContext,
                        QgsDataProvider,
                        QgsDefaultValue,
                        QgsEditorWidgetSetup,
@@ -3165,6 +3166,70 @@ class TestQgsVectorLayerSourceDeletedFeaturesInBuffer(unittest.TestCase, Feature
         """ Skip max values test - as noted in the docs this is unreliable when features are in the buffer
         """
         pass
+
+
+class TestQgsVectorLayerTransformContext(unittest.TestCase):
+
+    def setUp(self):
+        """Prepare tc"""
+        super(TestQgsVectorLayerTransformContext, self).setUp()
+        self.ctx = QgsCoordinateTransformContext()
+        self.ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+
+    def testTransformContextIsSetInCtor(self):
+        """Test transform context can be set from ctor"""
+
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
+            'test', 'memory')
+        self.assertFalse(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        options = QgsVectorLayer.LayerOptions(self.ctx)
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
+            'test', 'memory', options)
+        self.assertTrue(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+    def testTransformContextInheritsFromProject(self):
+        """Test that when a layer is added to a project it inherits its context"""
+
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
+            'test', 'memory')
+        self.assertFalse(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p = QgsProject()
+        self.assertFalse(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        p.setTransformContext(self.ctx)
+        self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p.addMapLayers([vl])
+        self.assertTrue(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+    def testTransformContextIsSyncedFromProject(self):
+        """Test that when a layer is synced when project context changes"""
+
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
+            'test', 'memory')
+        self.assertFalse(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p = QgsProject()
+        self.assertFalse(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        p.setTransformContext(self.ctx)
+        self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        p.addMapLayers([vl])
+        self.assertTrue(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+
+        # Now change the project context
+        tc2 = QgsCoordinateTransformContext()
+        p.setTransformContext(tc2)
+        self.assertFalse(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        self.assertFalse(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        p.setTransformContext(self.ctx)
+        self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
+        self.assertTrue(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
 
 
 # TODO:


### PR DESCRIPTION
... and ensure all coordinate transforms correctly utilise the project's coordinate transform context.

Sponsored by ICSM