### PR TITLE
[processing] Monkey patch stable external Processing API into qgis.processing

### DIFF
--- a/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
+++ b/python/plugins/MetaSearch/dialogs/newconnectiondialog.py
@@ -27,7 +27,6 @@
 #
 ###############################################################################
 
-import warnings
 from qgis.core import QgsSettings
 from qgis.PyQt.QtWidgets import QDialog, QMessageBox
 

--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -24,11 +24,6 @@
 #
 ###############################################################################
 
-# avoid PendingDeprecationWarning from qgis.PyQt.uic
-import warnings
-warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
-warnings.filterwarnings("ignore", category=DeprecationWarning)
-
 from gettext import gettext, ngettext
 import logging
 import os

--- a/python/plugins/processing/__init__.py
+++ b/python/plugins/processing/__init__.py
@@ -39,8 +39,6 @@ qgis.processing.runAndLoadResults = runAndLoadResults
 qgis.processing.createAlgorithmDialog = createAlgorithmDialog
 qgis.processing.execAlgorithmDialog = execAlgorithmDialog
 qgis.processing.createContext = createContext
-qgis.processing.isWindows = isWindows
-qgis.processing.isMac = isMac
 
 
 def classFactory(iface):

--- a/python/plugins/processing/__init__.py
+++ b/python/plugins/processing/__init__.py
@@ -31,6 +31,17 @@ from processing.tools.vector import *               # NOQA
 from processing.tools.raster import *               # NOQA
 from processing.tools.system import *               # NOQA
 
+# monkey patch Python specific Processing API into stable qgis.processing module
+import qgis.processing
+qgis.processing.algorithmHelp = algorithmHelp
+qgis.processing.run = run
+qgis.processing.runAndLoadResults = runAndLoadResults
+qgis.processing.createAlgorithmDialog = createAlgorithmDialog
+qgis.processing.execAlgorithmDialog = execAlgorithmDialog
+qgis.processing.createContext = createContext
+qgis.processing.isWindows = isWindows
+qgis.processing.isMac = isMac
+
 
 def classFactory(iface):
     from processing.ProcessingPlugin import ProcessingPlugin

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -64,7 +64,11 @@ from qgis.core import (Qgis,
                        QgsVectorLayer,
                        QgsProviderRegistry)
 from qgis.utils import iface
-from osgeo import ogr
+
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from osgeo import ogr
 
 from processing.core.ProcessingConfig import ProcessingConfig
 

--- a/python/plugins/processing/algs/help/__init__.py
+++ b/python/plugins/processing/algs/help/__init__.py
@@ -43,7 +43,7 @@ def loadShortHelp():
             with codecs.open(filename, encoding='utf-8') as stream:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=DeprecationWarning)
-                    for k, v in yaml.load(stream).items():
+                    for k, v in yaml.load(stream, Loader=yaml.SafeLoader).items():
                         if v is None:
                             continue
                         h[k] = QCoreApplication.translate("{}Algorithm".format(f[:-5].upper()), v)

--- a/python/plugins/processing/algs/qgis/Datasources2Vrt.py
+++ b/python/plugins/processing/algs/qgis/Datasources2Vrt.py
@@ -28,7 +28,10 @@ __revision__ = '$Format:%H$'
 import codecs
 import xml.sax.saxutils
 
-from osgeo import ogr
+import warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from osgeo import ogr
 from qgis.core import (QgsProcessingFeedback,
                        QgsProcessingParameterMultipleLayers,
                        QgsProcessingParameterBoolean,

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -273,6 +273,16 @@ class BasicWidgetWrapper(WidgetWrapper):
 
 class BooleanWidgetWrapper(WidgetWrapper):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("BooleanWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
     def createLabel(self):
         if self.dialogType == DIALOG_STANDARD:
             return None
@@ -312,6 +322,16 @@ class BooleanWidgetWrapper(WidgetWrapper):
 
 
 class CrsWidgetWrapper(WidgetWrapper):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("CrsWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     def createWidget(self):
         if self.dialogType == DIALOG_MODELER:
@@ -458,6 +478,16 @@ class ExtentWidgetWrapper(WidgetWrapper):
 
 class PointWidgetWrapper(WidgetWrapper):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("PointWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
             return PointSelectionPanel(self.dialog, self.parameterDefinition().defaultValue())
@@ -505,6 +535,16 @@ class PointWidgetWrapper(WidgetWrapper):
 
 
 class FileWidgetWrapper(WidgetWrapper):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("FileWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
@@ -571,6 +611,16 @@ class FileWidgetWrapper(WidgetWrapper):
 
 
 class FixedTableWidgetWrapper(WidgetWrapper):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("FixedTableWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
@@ -768,6 +818,16 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
 
 class NumberWidgetWrapper(WidgetWrapper):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("NumberWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
             widget = NumberInputPanel(self.parameterDefinition())
@@ -798,6 +858,16 @@ class NumberWidgetWrapper(WidgetWrapper):
 
 
 class DistanceWidgetWrapper(WidgetWrapper):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("DistanceWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
@@ -834,6 +904,16 @@ class DistanceWidgetWrapper(WidgetWrapper):
 
 
 class RangeWidgetWrapper(WidgetWrapper):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("RangeWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     def createWidget(self):
         widget = RangePanel(self.parameterDefinition())
@@ -1032,6 +1112,16 @@ class MeshWidgetWrapper(MapLayerWidgetWrapper):
 
 class EnumWidgetWrapper(WidgetWrapper):
     NOT_SELECTED = '[Not selected]'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("EnumWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     def createWidget(self, useCheckBoxes=False, columns=1):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
@@ -1271,6 +1361,16 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
 
 class StringWidgetWrapper(WidgetWrapper):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("StringWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
     def createWidget(self):
         if self.dialogType == DIALOG_STANDARD:
             if self.parameterDefinition().multiLine():
@@ -1367,6 +1467,14 @@ class StringWidgetWrapper(WidgetWrapper):
 class ExpressionWidgetWrapper(WidgetWrapper):
 
     def __init__(self, param, dialog, row=0, col=0, **kwargs):
+        """
+        .. deprecated:: 3.4
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("StringWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
         super().__init__(param, dialog, row, col, **kwargs)
         self.context = dataobjects.createContext()
 
@@ -1881,28 +1989,37 @@ class WidgetWrapperFactory:
     def create_wrapper_from_class(param, dialog, row=0, col=0):
         wrapper = None
         if param.type() == 'boolean':
+            # deprecated, moved to c++
             wrapper = BooleanWidgetWrapper
         elif param.type() == 'crs':
+            # deprecated, moved to c++
             wrapper = CrsWidgetWrapper
         elif param.type() == 'extent':
             wrapper = ExtentWidgetWrapper
         elif param.type() == 'point':
+            # deprecated, moved to c++
             wrapper = PointWidgetWrapper
         elif param.type() == 'file':
+            # deprecated, moved to c++
             wrapper = FileWidgetWrapper
         elif param.type() == 'multilayer':
             wrapper = MultipleLayerWidgetWrapper
         elif param.type() == 'number':
+            # deprecated, moved to c++
             wrapper = NumberWidgetWrapper
         elif param.type() == 'distance':
+            # deprecated, moved to c++
             wrapper = DistanceWidgetWrapper
         elif param.type() == 'raster':
             wrapper = RasterWidgetWrapper
         elif param.type() == 'enum':
+            # deprecated, moved to c++
             wrapper = EnumWidgetWrapper
         elif param.type() == 'string':
+            # deprecated, moved to c++
             wrapper = StringWidgetWrapper
         elif param.type() == 'expression':
+            # deprecated, moved to c++
             wrapper = ExpressionWidgetWrapper
         elif param.type() == 'vector':
             wrapper = VectorLayerWidgetWrapper
@@ -1915,8 +2032,10 @@ class WidgetWrapperFactory:
         elif param.type() == 'layer':
             wrapper = MapLayerWidgetWrapper
         elif param.type() == 'range':
+            # deprecated, moved to c++
             wrapper = RangeWidgetWrapper
         elif param.type() == 'matrix':
+            # deprecated, moved to c++
             wrapper = FixedTableWidgetWrapper
         elif param.type() == 'mesh':
             wrapper = MeshWidgetWrapper

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1902,7 +1902,7 @@ class BandWidgetWrapper(WidgetWrapper):
 
                 for v in value:
                     for i, opt in enumerate(options):
-                        match = re.search('(?:\A|[^0-9]){}(?:\Z|[^0-9]|)'.format(v), opt)
+                        match = re.search('(?:\\A|[^0-9]){}(?:\\Z|[^0-9]|)'.format(v), opt)
                         if match:
                             selected.append(i)
 
@@ -1917,7 +1917,7 @@ class BandWidgetWrapper(WidgetWrapper):
             if self.parameterDefinition().allowMultiple():
                 bands = []
                 for i in self.widget.selectedoptions:
-                    match = re.search('(?:\A|[^0-9])([0-9]+)(?:\Z|[^0-9]|)', self.widget.options[i])
+                    match = re.search('(?:\\A|[^0-9])([0-9]+)(?:\\Z|[^0-9]|)', self.widget.options[i])
                     if match:
                         bands.append(match.group(1))
                 return bands

--- a/python/plugins/processing/script/ScriptTemplate.py
+++ b/python/plugins/processing/script/ScriptTemplate.py
@@ -18,7 +18,7 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingAlgorithm,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFeatureSink)
-import processing
+from qgis import processing
 
 
 class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):

--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -72,7 +72,7 @@ class AlgorithmsTest(object):
         This is the main test function. All others will be executed based on the definitions in testdata/algorithm_tests.yaml
         """
         with open(os.path.join(processingTestDataPath(), self.test_definition_file()), 'r') as stream:
-            algorithm_tests = yaml.load(stream)
+            algorithm_tests = yaml.load(stream, Loader=yaml.SafeLoader)
 
         if 'tests' in algorithm_tests and algorithm_tests['tests'] is not None:
             for idx, algtest in enumerate(algorithm_tests['tests']):

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -105,8 +105,15 @@ def createExpressionContext():
 
 
 def load(fileName, name=None, crs=None, style=None, isRaster=False):
-    """Loads a layer/table into the current project, given its file.
     """
+    Loads a layer/table into the current project, given its file.
+
+    .. deprecated:: 3.0
+    Do not use, will be removed in QGIS 4.0
+    """
+
+    from warnings import warn
+    warn("processing.load is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
 
     if fileName is None:
         return

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -28,16 +28,12 @@ __revision__ = '$Format:%H$'
 import os
 import re
 
-from qgis.core import (QgsVectorFileWriter,
-                       QgsMapLayer,
-                       QgsDataProvider,
+from qgis.core import (QgsDataProvider,
                        QgsRasterLayer,
                        QgsWkbTypes,
                        QgsVectorLayer,
                        QgsProject,
-                       QgsCoordinateReferenceSystem,
                        QgsSettings,
-                       QgsProcessingUtils,
                        QgsProcessingContext,
                        QgsFeatureRequest,
                        QgsExpressionContext,
@@ -48,9 +44,6 @@ from qgis.PyQt.QtCore import QCoreApplication
 from qgis.utils import iface
 
 from processing.core.ProcessingConfig import ProcessingConfig
-from processing.algs.gdal.GdalUtils import GdalUtils
-from processing.tools.system import (getTempFilename,
-                                     removeInvalidChars)
 
 ALL_TYPES = [-1]
 
@@ -66,6 +59,12 @@ TYPE_TABLE = 5
 def createContext(feedback=None):
     """
     Creates a default processing context
+
+    :param feedback: Optional existing QgsProcessingFeedback object, or None to use a default feedback object
+    :type feedback: Optional[QgsProcessingFeedback]
+
+    :returns: New QgsProcessingContext object
+    :rtype: QgsProcessingContext
     """
     context = QgsProcessingContext()
     context.setProject(QgsProject.instance())
@@ -132,7 +131,8 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
             if prjSetting:
                 settings.setValue('/Projections/defaultBehavior', prjSetting)
             raise RuntimeError(QCoreApplication.translate('dataobject',
-                                                          'Could not load layer: {0}\nCheck the processing framework log to look for errors.').format(fileName))
+                                                          'Could not load layer: {0}\nCheck the processing framework log to look for errors.').format(
+                fileName))
     else:
         qgslayer = QgsVectorLayer(fileName, name, 'ogr')
         if qgslayer.isValid():
@@ -155,7 +155,6 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
 
 
 def getRasterSublayer(path, param):
-
     layer = QgsRasterLayer(path)
 
     try:

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -24,10 +24,6 @@ __copyright__ = '(C) 2013, Victor Olaya'
 # This will get replaced with a git SHA1 when you do a git archive
 
 __revision__ = '$Format:%H$'
-
-import os
-import configparser
-
 from qgis.core import (QgsApplication,
                        QgsProcessingAlgorithm,
                        QgsProcessingParameterEnum,
@@ -43,8 +39,13 @@ from qgis.utils import iface
 
 
 def algorithmHelp(id):
-    """Prints algorithm parameters with their types. Also
-    provides information about options if any.
+    """
+    Prints algorithm parameters with their types. Also
+    provides information about parameters and outputs,
+    and their acceptable values.
+
+    :param id: An algorithm's ID
+    :type id: str
     """
     alg = QgsApplication.processingRegistry().algorithmById(id)
     if alg is not None:
@@ -100,6 +101,9 @@ def run(algOrName, parameters, onFinish=None, feedback=None, context=None, is_ch
     :param context: Processing context object
     :param is_child_algorithm: Set to True if this algorithm is being run as part of a larger algorithm,
     i.e. it is a sub-part of an algorithm which calls other Processing algorithms.
+
+    :returns algorithm results as a dictionary, or None if execution failed
+    :rtype: Union[dict, None]
     """
     if onFinish or not is_child_algorithm:
         return Processing.runAlgorithm(algOrName, parameters, onFinish, feedback, context)
@@ -114,8 +118,17 @@ def run(algOrName, parameters, onFinish=None, feedback=None, context=None, is_ch
 
 
 def runAndLoadResults(algOrName, parameters, feedback=None, context=None):
-    """Executes given algorithm and load its results into QGIS project
+    """
+    Executes given algorithm and load its results into the current QGIS project
     when possible.
+
+    :param algOrName: Either an instance of an algorithm, or an algorithm's ID
+    :param parameters: Algorithm parameters dictionary
+    :param feedback: Processing feedback object
+    :param context: Processing context object
+
+    :returns algorithm results as a dictionary, or None if execution failed
+    :rtype: Union[dict, None]
     """
     if isinstance(algOrName, QgsProcessingAlgorithm):
         alg = algOrName
@@ -127,7 +140,8 @@ def runAndLoadResults(algOrName, parameters, feedback=None, context=None):
         if not param.name() in parameters:
             continue
 
-        if isinstance(param, (QgsProcessingParameterFeatureSink, QgsProcessingParameterVectorDestination, QgsProcessingParameterRasterDestination)):
+        if isinstance(param, (QgsProcessingParameterFeatureSink, QgsProcessingParameterVectorDestination,
+                              QgsProcessingParameterRasterDestination)):
             p = parameters[param.name()]
             if not isinstance(p, QgsProcessingOutputLayerDefinition):
                 parameters[param.name()] = QgsProcessingOutputLayerDefinition(p, QgsProject.instance())
@@ -135,13 +149,21 @@ def runAndLoadResults(algOrName, parameters, feedback=None, context=None):
                 p.destinationProject = QgsProject.instance()
                 parameters[param.name()] = p
 
-    return Processing.runAlgorithm(alg, parameters=parameters, onFinish=handleAlgorithmResults, feedback=feedback, context=context)
+    return Processing.runAlgorithm(alg, parameters=parameters, onFinish=handleAlgorithmResults, feedback=feedback,
+                                   context=context)
 
 
 def createAlgorithmDialog(algOrName, parameters={}):
-    """Creates and returns an algorithm dialog for the specified algorithm, prepopulated
+    """
+    Creates and returns an algorithm dialog for the specified algorithm, prepopulated
     with a given set of parameters. It is the caller's responsibility to execute
     and delete this dialog.
+
+    :param algOrName: Either an instance of an algorithm, or an algorithm's ID
+    :param parameters: Initial algorithm parameters dictionary
+
+    :returns algorithm results as a dictionary, or None if execution failed
+    :rtype: Union[dict, None]
     """
     if isinstance(algOrName, QgsProcessingAlgorithm):
         alg = algOrName.create()
@@ -162,10 +184,15 @@ def createAlgorithmDialog(algOrName, parameters={}):
 
 
 def execAlgorithmDialog(algOrName, parameters={}):
-    """Executes an algorithm dialog for the specified algorithm, prepopulated
+    """
+    Executes an algorithm dialog for the specified algorithm, prepopulated
     with a given set of parameters.
 
-    Returns the algorithm's results.
+    :param algOrName: Either an instance of an algorithm, or an algorithm's ID
+    :param parameters: Initial algorithm parameters dictionary
+
+    :returns algorithm results as a dictionary, or None if execution failed
+    :rtype: Union[dict, None]
     """
     dlg = createAlgorithmDialog(algOrName, parameters)
     if dlg is None:

--- a/python/plugins/processing/tools/system.py
+++ b/python/plugins/processing/tools/system.py
@@ -118,6 +118,14 @@ def tempHelpFolder():
 
 
 def escapeAndJoin(strList):
+    """
+    .. deprecated:: 3.0
+    Do not use, will be removed in QGIS 4.0
+    """
+
+    from warnings import warn
+    warn("processing.escapeAndJoin is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
     joined = ''
     for s in strList:
         if s[0] != '-' and ' ' in s:

--- a/python/processing/__init__.py
+++ b/python/processing/__init__.py
@@ -1,20 +1,25 @@
-# -*- coding: utf-8 -*-
+# -#- coding: utf-8 -#-
+
+###########################################################################
+#    __init__.py
+#    ---------------------
+#    Date                 : November 2018
+#    Copyright            : (C) 2018 by Nathan Woodrow
+#    Email                : woodrow dot nathan at gmail dot com
+###########################################################################
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+###########################################################################
 
 """
-***************************************************************************
-    __init__.py
-    ---------------------
-    Date                 : November 2018
-    Copyright            : (C) 2018 by Nathan Woodrow
-    Email                : woodrow dot nathan at gmail dot com
-***************************************************************************
-*                                                                         *
-*   This program is free software; you can redistribute it and/or modify  *
-*   it under the terms of the GNU General Public License as published by  *
-*   the Free Software Foundation; either version 2 of the License, or     *
-*   (at your option) any later version.                                   *
-*                                                                         *
-***************************************************************************
+QGIS Processing Python additions.
+
+This module contains stable API adding additional Python specific functionality
+to the core QGIS c++ Processing classes.
 """
 
 __author__ = 'Nathan Woodrow'


### PR DESCRIPTION
Instead of encouraging use of the internal Processing modules
(e.g. from processing.tools.general import run , import processing, ...)
instead expose all Python specific STABLE processing additions
to the qgis.processing module.

Instead, scripts and plugins should now use

from qgis.processing import run, algorithmHelp,...

This makes a clear distinction between internal Processing python
modules (i.e., everything else!) and the parts of Processing
which are stable and designed to be used by plugins and scripts.

TODO: QGIS 4.0 -- move the internal Processing plugin modules
to __processing, to clearer indicate that this is all internal
stuff.