### PR TITLE
Filter input using spacial tree (pyqtree)

### DIFF
--- a/python/plugins/processing/algs/qgis/voronoi.py
+++ b/python/plugins/processing/algs/qgis/voronoi.py
@@ -185,7 +185,7 @@ class Context(object):
         if (self.debug):
             # fix_print_with_import
             print("line(%d) %gx+%gy=%g, bisecting %d %d" % (
-            edge.edgenum, edge.a, edge.b, edge.c, edge.reg[0].sitenum, edge.reg[1].sitenum))
+                edge.edgenum, edge.a, edge.b, edge.c, edge.reg[0].sitenum, edge.reg[1].sitenum))
         elif (self.triangulate):
             if (self.plot):
                 self.line(edge.reg[0].x, edge.reg[0].y, edge.reg[1].x, edge.reg[1].y)
@@ -392,10 +392,10 @@ class Site(object):
             return True
         else:
             return False
-    
+
     def __getitem__(self, item):
         return [self.x, self.y][item]
-    
+
     def distance(self, other):
         dx = self.x - other.x
         dy = self.y - other.y
@@ -601,8 +601,8 @@ class Halfedge(object):
             e = e2
 
         rightOfSite = xint >= e.reg[1].x
-        if ((rightOfSite and he.pm == Edge.LE) or
-                (not rightOfSite and he.pm == Edge.RE)):
+        if ((rightOfSite and he.pm == Edge.LE)
+                or (not rightOfSite and he.pm == Edge.RE)):
             return None
 
         # create a new site at the point of intersection - this is a new
@@ -613,7 +613,7 @@ class Halfedge(object):
 # ------------------------------------------------------------------
 class EdgeList(object):
 
-    __slots__ = ("hash", "rightend", "leftend", "xmin",  "deltax", "hashsize")
+    __slots__ = ("hash", "rightend", "leftend", "xmin", "deltax", "hashsize")
 
     def __init__(self, xmin, xmax, nsites):
         if xmin > xmax:

--- a/python/plugins/processing/algs/qgis/voronoi.py
+++ b/python/plugins/processing/algs/qgis/voronoi.py
@@ -392,7 +392,10 @@ class Site(object):
             return True
         else:
             return False
-
+    
+    def __getitem__(self, item):
+        return [self.x, self.y][item]
+    
     def distance(self, other):
         dx = self.x - other.x
         dy = self.y - other.y
@@ -904,7 +907,7 @@ if __name__ == "__main__":
 
         if filtering and threshold > 0:
 
-            # filter input using spacial tree
+            # filter input using spatial tree
 
             # import at runtime only if needed
             from qgis.core import (QgsSpatialIndex,


### PR DESCRIPTION
Delaunay triangulation often suffer from over sampled / irregular non grid sampled data.
The idea behind this patch is to filter input using a naive first point found wins strategy in a spacial tree.

IMPORTANT this implementation depends on pyqtree [Home Page](http://github.com/karimbahgat/Pyqtree)

Advantages
- smart controlled under sampling
- massive speedup of over sampled data
- prevent duplicate points
- prevent step effect
- provide better triangulation quality

Documentation
Add
-f threshold
option where threshold is minimum distance between points when filtering

Note: this PR replace #9632 done in 2.6 branch.
