### PR TITLE
 Port QgsCoordinateTransform to proj 6 API

### DIFF
--- a/python/core/auto_generated/qgsprojutils.sip.in
+++ b/python/core/auto_generated/qgsprojutils.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsProjUtils
 {
 %Docstring
@@ -27,6 +28,7 @@ Utility functions for working with the proj library.
 %Docstring
 Returns the proj library major version number.
 %End
+
 };
 
 /************************************************************************

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -38,14 +38,12 @@
 #include <sqlite3.h>
 
 //proj4 includes
-extern "C"
-{
-#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#endif
+#if PROJ_VERSION_MAJOR>=6
+#include "qgsprojutils.h"
+#include <proj.h>
+#else
 #include <proj_api.h>
-}
-
+#endif
 
 QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
@@ -446,15 +444,19 @@ void QgsCustomProjectionDialog::updateListFromCurrentItem()
 void QgsCustomProjectionDialog::pbnCalculate_clicked()
 {
   // We must check the prj def is valid!
+#if PROJ_VERSION_MAJOR>=6
+  PJ_CONTEXT *pContext = QgsProjContext::get();
+  const QString projDef = teParameters->toPlainText();
+  QgsDebugMsg( QStringLiteral( "Proj: %1" ).arg( projDef ) );
+#else
   projCtx pContext = pj_ctx_alloc();
   projPJ proj = pj_init_plus_ctx( pContext, teParameters->toPlainText().toLocal8Bit().data() );
-
   QgsDebugMsg( QStringLiteral( "Proj: %1" ).arg( teParameters->toPlainText() ) );
 
   if ( !proj )
   {
     QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "This proj4 projection definition is not valid." ) );
+                              tr( "This proj projection definition is not valid." ) );
     projectedX->clear();
     projectedY->clear();
     pj_free( proj );
@@ -462,22 +464,31 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
     return;
 
   }
+#endif
   // Get the WGS84 coordinates
   bool okN, okE;
-  double northing = northWGS84->text().toDouble( &okN ) * DEG_TO_RAD;
-  double easting = eastWGS84->text().toDouble( &okE )  * DEG_TO_RAD;
+  double northing = northWGS84->text().toDouble( &okN );
+  double easting = eastWGS84->text().toDouble( &okE );
+
+#if PROJ_VERSION_MAJOR<6
+  northing *= DEG_TO_RAD;
+  easting * = DEG_TO_RAD;
+#endif
 
   if ( !okN || !okE )
   {
     QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "Northing and Easthing must be in decimal form." ) );
+                              tr( "Northing and Easting must be in decimal form." ) );
     projectedX->clear();
     projectedY->clear();
+#if PROJ_VERSION_MAJOR<6
     pj_free( proj );
     pj_ctx_free( pContext );
+#endif
     return;
   }
 
+#if PROJ_VERSION_MAJOR < 6
   projPJ wgs84Proj = pj_init_plus_ctx( pContext, GEOPROJ4.toLocal8Bit().data() ); //defined in qgis.h
 
   if ( !wgs84Proj )
@@ -490,28 +501,53 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
     pj_ctx_free( pContext );
     return;
   }
+#endif
 
+#if PROJ_VERSION_MAJOR>=6
+  QgsProjUtils::proj_pj_unique_ptr res( proj_create_crs_to_crs( pContext, "EPSG:4326", projDef.toUtf8(), nullptr ) );
+  if ( !res )
+  {
+    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
+                              tr( "This proj projection definition is not valid." ) );
+    projectedX->clear();
+    projectedY->clear();
+    return;
+  }
+
+  proj_trans_generic( res.get(), PJ_FWD,
+                      &easting, sizeof( double ), 1,
+                      &northing, sizeof( double ), 1,
+                      nullptr, sizeof( double ), 0,
+                      nullptr, sizeof( double ), 0 );
+  int projResult = proj_errno( res.get() );
+#else
   double z = 0.0;
-
   int projResult = pj_transform( wgs84Proj, proj, 1, 0, &easting, &northing, &z );
+#endif
   if ( projResult != 0 )
   {
     projectedX->setText( tr( "Error" ) );
     projectedY->setText( tr( "Error" ) );
+#if PROJ_VERSION_MAJOR>=6
+    QgsDebugMsg( proj_errno_string( projResult ) );
+#else
     QgsDebugMsg( pj_strerrno( projResult ) );
+#endif
   }
   else
   {
     QString tmp;
 
-    int precision = 4;
+    int precision = 7;
 
+#if PROJ_VERSION_MAJOR<6
     if ( pj_is_latlong( proj ) )
     {
       northing *= RAD_TO_DEG;
       easting *= RAD_TO_DEG;
       precision = 7;
     }
+#endif
 
     tmp = QLocale().toString( northing, 'f', precision );
     projectedX->setText( tmp );
@@ -519,9 +555,11 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
     projectedY->setText( tmp );
   }
 
+#if PROJ_VERSION_MAJOR<6
   pj_free( proj );
   pj_free( wgs84Proj );
   pj_ctx_free( pContext );
+#endif
 }
 
 void QgsCustomProjectionDialog::showHelp()

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -538,16 +538,23 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
   {
     QString tmp;
 
-    int precision = 7;
+    int precision = 4;
+    bool isLatLong = false;
 
-#if PROJ_VERSION_MAJOR<6
-    if ( pj_is_latlong( proj ) )
+#if PROJ_VERSION_MAJOR>= 6
+    isLatLong = QgsProjUtils::usesAngularUnit( projDef );
+#else
+    isLatLong = pj_is_latlong( proj );
+    if ( isLatLong )
     {
       northing *= RAD_TO_DEG;
       easting *= RAD_TO_DEG;
-      precision = 7;
     }
 #endif
+    if ( isLatLong )
+    {
+      precision = 7;
+    }
 
     tmp = QLocale().toString( northing, 'f', precision );
     projectedX->setText( tmp );

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -98,7 +98,7 @@ void QgsCustomProjectionDialog::populateList()
     Q_ASSERT( result == SQLITE_OK );
   }
   QString sql = QStringLiteral( "select srs_id,description,parameters from tbl_srs" );
-  QgsDebugMsg( QStringLiteral( "Query to populate existing list:%1" ).arg( sql ) );
+  QgsDebugMsgLevel( QStringLiteral( "Query to populate existing list:%1" ).arg( sql ), 4 );
   preparedStatement = database.prepare( sql, result );
   if ( result == SQLITE_OK )
   {
@@ -143,7 +143,7 @@ bool  QgsCustomProjectionDialog::deleteCrs( const QString &id )
   sqlite3_database_unique_ptr database;
 
   QString sql = "delete from tbl_srs where srs_id=" + QgsSqliteUtils::quotedString( id );
-  QgsDebugMsg( sql );
+  QgsDebugMsgLevel( sql, 4 );
   //check the db is available
   int result = database.open( QgsApplication::qgisUserDatabaseFilePath() );
   if ( result != SQLITE_OK )
@@ -199,7 +199,7 @@ void  QgsCustomProjectionDialog::insertProjection( const QString &projectionAcro
     {
       if ( srsPreparedStatement.step() == SQLITE_ROW )
       {
-        QgsDebugMsg( QStringLiteral( "Trying to insert projection" ) );
+        QgsDebugMsgLevel( QStringLiteral( "Trying to insert projection" ), 4 );
         // We have the result from system srs.db. Now insert into user db.
         sql = "insert into tbl_projection(acronym,name,notes,parameters) values ("
               + QgsSqliteUtils::quotedString( srsPreparedStatement.columnAsText( 0 ) )
@@ -228,7 +228,7 @@ bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem parameters
   int returnId;
   QString projectionAcronym = parameters.projectionAcronym();
   QString ellipsoidAcronym = parameters.ellipsoidAcronym();
-  QgsDebugMsg( QStringLiteral( "Saving a CRS:%1, %2, %3" ).arg( name, parameters.toProj4() ).arg( newEntry ) );
+  QgsDebugMsgLevel( QStringLiteral( "Saving a CRS:%1, %2, %3" ).arg( name, parameters.toProj4() ).arg( newEntry ), 4 );
   if ( newEntry )
   {
     returnId = parameters.saveAsUserCrs( name );
@@ -247,7 +247,7 @@ bool QgsCustomProjectionDialog::saveCrs( QgsCoordinateReferenceSystem parameters
           + ",is_geo=0" // <--shamelessly hard coded for now
           + " where srs_id=" + QgsSqliteUtils::quotedString( id )
           ;
-    QgsDebugMsg( sql );
+    QgsDebugMsgLevel( sql, 4 );
     sqlite3_database_unique_ptr database;
     //check if the db is available
     int result = database.open( QgsApplication::qgisUserDatabaseFilePath() );
@@ -374,7 +374,7 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
     mCustomCRSparameters[i] = teParameters->toPlainText();
   }
 
-  QgsDebugMsg( QStringLiteral( "We save the modified CRS." ) );
+  QgsDebugMsgLevel( QStringLiteral( "We save the modified CRS." ), 4 );
 
   //Check if all CRS are valid:
   QgsCoordinateReferenceSystem CRS;
@@ -410,7 +410,7 @@ void QgsCustomProjectionDialog::buttonBox_accepted()
       QgsDebugMsg( QStringLiteral( "Error when saving CRS '%1'" ).arg( mCustomCRSnames[i] ) );
     }
   }
-  QgsDebugMsg( QStringLiteral( "We remove the deleted CRS." ) );
+  QgsDebugMsgLevel( QStringLiteral( "We remove the deleted CRS." ), 4 );
   for ( int i = 0; i < mDeletedCRSs.size(); ++i )
   {
     saveSuccess &= deleteCrs( mDeletedCRSs[i] );
@@ -447,11 +447,11 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
 #if PROJ_VERSION_MAJOR>=6
   PJ_CONTEXT *pContext = QgsProjContext::get();
   const QString projDef = teParameters->toPlainText();
-  QgsDebugMsg( QStringLiteral( "Proj: %1" ).arg( projDef ) );
+  QgsDebugMsgLevel( QStringLiteral( "Proj: %1" ).arg( projDef ), 3 );
 #else
   projCtx pContext = pj_ctx_alloc();
   projPJ proj = pj_init_plus_ctx( pContext, teParameters->toPlainText().toLocal8Bit().data() );
-  QgsDebugMsg( QStringLiteral( "Proj: %1" ).arg( teParameters->toPlainText() ) );
+  QgsDebugMsgLevel( QStringLiteral( "Proj: %1" ).arg( teParameters->toPlainText() ), 3 );
 
   if ( !proj )
   {

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -472,7 +472,7 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
 
 #if PROJ_VERSION_MAJOR<6
   northing *= DEG_TO_RAD;
-  easting * = DEG_TO_RAD;
+  easting *= DEG_TO_RAD;
 #endif
 
   if ( !okN || !okE )

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -648,8 +648,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   int projResult = 0;
 #if PROJ_VERSION_MAJOR>=6
-  const bool sourceAxisOrderSwapped = d->mSourceAxisOrderSwapped;
-  const bool destinationAxisOrderSwapped = d->mDestAxisOrderSwapped;
+  const bool sourceAxisOrderSwapped =  direction == ForwardTransform ? d->mSourceAxisOrderSwapped : d->mDestAxisOrderSwapped;
 
   proj_trans_generic( projData, direction == ForwardTransform ? PJ_FWD : PJ_INV,
                       !sourceAxisOrderSwapped ? x : y, sizeof( double ), numPoints,
@@ -657,7 +656,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
                       z, sizeof( double ), numPoints,
                       nullptr, sizeof( double ), 0 );
   projResult = proj_errno( projData );
-  if ( projResult == 0 && destinationAxisOrderSwapped )
+  // ewww - this logic is gross. We should drop support for PROJ 6.0 as quickly as possible and dump this code (in favour of built in methods used for >=6.1 builds)
+  if ( projResult == 0 && ( d->mSourceAxisOrderSwapped != d->mDestAxisOrderSwapped ) )
   {
     size_t size = sizeof( double ) * numPoints;
     void *tmp = malloc( size );

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -691,8 +691,8 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     QString dir = ( direction == ForwardTransform ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
 
 #if PROJ_VERSION_MAJOR>=6
-    PJ *src = proj_get_source_crs( QgsProjContext::get(), projData );
-    PJ *dest = proj_get_source_crs( QgsProjContext::get(), projData );
+    QgsProjUtils::proj_pj_unique_ptr src( proj_get_source_crs( QgsProjContext::get(), projData ) );
+    QgsProjUtils::proj_pj_unique_ptr dest( proj_get_source_crs( QgsProjContext::get(), projData ) );
     QString msg = QObject::tr( "%1 of\n"
                                "%2"
                                "PROJ: %3\n"
@@ -701,8 +701,6 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
                         points,
                         proj_as_proj_string( QgsProjContext::get(), projData, PJ_PROJ_5, nullptr ),
                         QString::fromUtf8( proj_errno_string( projResult ) ) );
-    proj_destroy( src );
-    proj_destroy( dest );
 #else
     char *srcdef = pj_get_def( sourceProj, 0 );
     char *dstdef = pj_get_def( destProj, 0 );

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -32,13 +32,13 @@
 #include <QStringList>
 #include <QVector>
 
-extern "C"
-{
-#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#endif
+#if PROJ_VERSION_MAJOR>=6
+#include <proj.h>
+#include "qgsprojutils.h"
+#else
 #include <proj_api.h>
-}
+#endif
+
 #include <sqlite3.h>
 
 // if defined shows all information about transform to stdout
@@ -625,21 +625,36 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
   // if the source/destination projection is lat/long, convert the points to radians
   // prior to transforming
-  QPair<projPJ, projPJ> projData = d->threadLocalProjData();
+  ProjData projData = d->threadLocalProjData();
+#if PROJ_VERSION_MAJOR<6
+  bool sourceIsLatLong = false;
+  bool destIsLatLong = false;
+
   projPJ sourceProj = projData.first;
   projPJ destProj = projData.second;
+  sourceIsLatLong = pj_is_latlong( sourceProj );
+  destIsLatLong = pj_is_latlong( destProj );
 
-  if ( ( pj_is_latlong( destProj ) && ( direction == ReverseTransform ) )
-       || ( pj_is_latlong( sourceProj ) && ( direction == ForwardTransform ) ) )
+  if ( ( destIsLatLong && ( direction == ReverseTransform ) )
+       || ( sourceIsLatLong && ( direction == ForwardTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {
       x[i] *= DEG_TO_RAD;
       y[i] *= DEG_TO_RAD;
     }
-
   }
-  int projResult;
+#endif
+
+  int projResult = 0;
+#if PROJ_VERSION_MAJOR>=6
+  proj_trans_generic( projData, direction == ForwardTransform ? PJ_FWD : PJ_INV,
+                      x, sizeof( double ), numPoints,
+                      y, sizeof( double ), numPoints,
+                      z, sizeof( double ), numPoints,
+                      nullptr, sizeof( double ), 0 );
+  projResult = proj_errno( projData );
+#else
   if ( direction == ReverseTransform )
   {
     projResult = pj_transform( destProj, sourceProj, numPoints, 0, x, y, z );
@@ -650,6 +665,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     Q_ASSERT( destProj );
     projResult = pj_transform( sourceProj, destProj, numPoints, 0, x, y, z );
   }
+#endif
 
   if ( projResult != 0 )
   {
@@ -664,12 +680,30 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
       }
       else
       {
+#if PROJ_VERSION_MAJOR>=6
+        points += QStringLiteral( "(%1, %2)\n" ).arg( x[i], 0, 'f' ).arg( y[i], 0, 'f' );
+#else
         points += QStringLiteral( "(%1, %2)\n" ).arg( x[i] * RAD_TO_DEG, 0, 'f' ).arg( y[i] * RAD_TO_DEG, 0, 'f' );
+#endif
       }
     }
 
     QString dir = ( direction == ForwardTransform ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
 
+#if PROJ_VERSION_MAJOR>=6
+    PJ *src = proj_get_source_crs( QgsProjContext::get(), projData );
+    PJ *dest = proj_get_source_crs( QgsProjContext::get(), projData );
+    QString msg = QObject::tr( "%1 of\n"
+                               "%2"
+                               "PROJ: %3\n"
+                               "Error: %4" )
+                  .arg( dir,
+                        points,
+                        proj_as_proj_string( QgsProjContext::get(), projData, PJ_PROJ_5, nullptr ),
+                        QString::fromUtf8( proj_errno_string( projResult ) ) );
+    proj_destroy( src );
+    proj_destroy( dest );
+#else
     char *srcdef = pj_get_def( sourceProj, 0 );
     char *dstdef = pj_get_def( destProj, 0 );
 
@@ -684,6 +718,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
     pj_dalloc( srcdef );
     pj_dalloc( dstdef );
+#endif
 
     QgsDebugMsg( "Projection failed emitting invalid transform signal: " + msg );
     QgsDebugMsg( QStringLiteral( "throwing exception" ) );
@@ -691,10 +726,11 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     throw QgsCsException( msg );
   }
 
+#if PROJ_VERSION_MAJOR<6
   // if the result is lat/long, convert the results from radians back
   // to degrees
-  if ( ( pj_is_latlong( destProj ) && ( direction == ForwardTransform ) )
-       || ( pj_is_latlong( sourceProj ) && ( direction == ReverseTransform ) ) )
+  if ( ( destIsLatLong && ( direction == ForwardTransform ) )
+       || ( sourceIsLatLong && ( direction == ReverseTransform ) ) )
   {
     for ( int i = 0; i < numPoints; ++i )
     {
@@ -702,6 +738,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
       y[i] *= RAD_TO_DEG;
     }
   }
+#endif
 #ifdef COORDINATE_TRANSFORM_VERBOSE
   QgsDebugMsg( QStringLiteral( "[[[[[[ Projected %1, %2 to %3, %4 ]]]]]]" )
                .arg( xorg, 0, 'g', 15 ).arg( yorg, 0, 'g', 15 )

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -267,7 +267,7 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
   locker.changeMode( QgsReadWriteLocker::Write );
 
 #if PROJ_VERSION_MAJOR>=6
-  ProjData res = proj_create_crs_to_crs( context, mSourceProjString.toUtf8(), mDestProjString.toUtf8(), nullptr );
+  ProjData res = proj_create_crs_to_crs( context, mSourceProjString.toUtf8().constData(), mDestProjString.toUtf8().constData(), nullptr );
   mProjProjections.insert( reinterpret_cast< uintptr_t>( context ), res );
 #else
 #ifdef USE_THREAD_LOCAL

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -20,19 +20,20 @@
 #include "qgsapplication.h"
 #include "qgsreadwritelocker.h"
 
-extern "C"
-{
-#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
-#endif
+#if PROJ_VERSION_MAJOR>=6
+#include "qgsprojutils.h"
+#include <proj.h>
+#else
 #include <proj_api.h>
-}
+#endif
+
 #include <sqlite3.h>
 
 #include <QStringList>
 
 /// @cond PRIVATE
 
+#if PROJ_VERSION_MAJOR<6
 #ifdef USE_THREAD_LOCAL
 thread_local QgsProjContextStore QgsCoordinateTransformPrivate::mProjContext;
 #else
@@ -48,6 +49,8 @@ QgsProjContextStore::~QgsProjContextStore()
 {
   pj_ctx_free( context );
 }
+
+#endif
 
 QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate()
 {
@@ -163,17 +166,22 @@ bool QgsCoordinateTransformPrivate::initialize()
   }
 
   // create proj projections for current thread
-  QPair<projPJ, projPJ> res = threadLocalProjData();
+  ProjData res = threadLocalProjData();
 
 #ifdef COORDINATE_TRANSFORM_VERBOSE
   QgsDebugMsg( "From proj : " + mSourceCRS.toProj4() );
   QgsDebugMsg( "To proj   : " + mDestCRS.toProj4() );
 #endif
 
+#if PROJ_VERSION_MAJOR>=6
+  if ( !res )
+    mIsValid = false;
+#else
   if ( !res.first || !res.second )
   {
     mIsValid = false;
   }
+#endif
 
 #ifdef COORDINATE_TRANSFORM_VERBOSE
   if ( mIsValid )
@@ -224,10 +232,14 @@ void QgsCoordinateTransformPrivate::calculateTransforms( const QgsCoordinateTran
   mDestinationDatumTransform = transforms.destinationTransformId;
 }
 
-QPair<projPJ, projPJ> QgsCoordinateTransformPrivate::threadLocalProjData()
+ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
 {
   QgsReadWriteLocker locker( mProjLock, QgsReadWriteLocker::Read );
 
+#if PROJ_VERSION_MAJOR>=6
+  PJ_CONTEXT *context = QgsProjContext::get();
+  QMap < uintptr_t, ProjData >::const_iterator it = mProjProjections.constFind( reinterpret_cast< uintptr_t>( context ) );
+#else
 #ifdef USE_THREAD_LOCAL
   QMap < uintptr_t, QPair< projPJ, projPJ > >::const_iterator it = mProjProjections.constFind( reinterpret_cast< uintptr_t>( mProjContext.get() ) );
 #else
@@ -243,16 +255,21 @@ QPair<projPJ, projPJ> QgsCoordinateTransformPrivate::threadLocalProjData()
   }
   QMap < uintptr_t, QPair< projPJ, projPJ > >::const_iterator it = mProjProjections.constFind( reinterpret_cast< uintptr_t>( pContext ) );
 #endif
+#endif
 
   if ( it != mProjProjections.constEnd() )
   {
-    QPair<projPJ, projPJ> res = it.value();
+    ProjData res = it.value();
     return res;
   }
 
   // proj projections don't exist yet, so we need to create
   locker.changeMode( QgsReadWriteLocker::Write );
 
+#if PROJ_VERSION_MAJOR>=6
+  ProjData res = proj_create_crs_to_crs( context, mSourceProjString.toUtf8(), mDestProjString.toUtf8(), nullptr );
+  mProjProjections.insert( reinterpret_cast< uintptr_t>( context ), res );
+#else
 #ifdef USE_THREAD_LOCAL
   QPair<projPJ, projPJ> res = qMakePair( pj_init_plus_ctx( mProjContext.get(), mSourceProjString.toUtf8() ),
                                          pj_init_plus_ctx( mProjContext.get(), mDestProjString.toUtf8() ) );
@@ -261,6 +278,7 @@ QPair<projPJ, projPJ> QgsCoordinateTransformPrivate::threadLocalProjData()
   QPair<projPJ, projPJ> res = qMakePair( pj_init_plus_ctx( pContext, mSourceProjString.toUtf8() ),
                                          pj_init_plus_ctx( pContext, mDestProjString.toUtf8() ) );
   mProjProjections.insert( reinterpret_cast< uintptr_t>( pContext ), res );
+#endif
 #endif
   return res;
 }
@@ -331,11 +349,15 @@ void QgsCoordinateTransformPrivate::setFinder()
 void QgsCoordinateTransformPrivate::freeProj()
 {
   QgsReadWriteLocker locker( mProjLock, QgsReadWriteLocker::Write );
-  QMap < uintptr_t, QPair< projPJ, projPJ > >::const_iterator it = mProjProjections.constBegin();
+  QMap < uintptr_t, ProjData >::const_iterator it = mProjProjections.constBegin();
   for ( ; it != mProjProjections.constEnd(); ++it )
   {
+#if PROJ_VERSION_MAJOR>=6
+    proj_destroy( it.value() );
+#else
     pj_free( it.value().first );
     pj_free( it.value().second );
+#endif
   }
   mProjProjections.clear();
 }

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -84,6 +84,8 @@ QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate( const QgsCoordinat
   , mDestCRS( other.mDestCRS )
   , mSourceDatumTransform( other.mSourceDatumTransform )
   , mDestinationDatumTransform( other.mDestinationDatumTransform )
+  , mSourceAxisOrderSwapped( other.mSourceAxisOrderSwapped )
+  , mDestAxisOrderSwapped( other.mDestAxisOrderSwapped )
 {
   //must reinitialize to setup mSourceProjection and mDestinationProjection
   initialize();
@@ -167,6 +169,16 @@ bool QgsCoordinateTransformPrivate::initialize()
 
   // create proj projections for current thread
   ProjData res = threadLocalProjData();
+
+#if PROJ_VERSION_MAJOR>=6
+  PJ_CONTEXT *context = QgsProjContext::get();
+  QgsProjUtils::proj_pj_unique_ptr sourceCrs( proj_get_source_crs( context, res ) );
+  if ( sourceCrs )
+    mSourceAxisOrderSwapped = QgsProjUtils::axisOrderIsSwapped( sourceCrs.get() );
+  QgsProjUtils::proj_pj_unique_ptr destCrs( proj_get_target_crs( context, res ) );
+  if ( destCrs )
+    mDestAxisOrderSwapped = QgsProjUtils::axisOrderIsSwapped( destCrs.get() );
+#endif
 
 #ifdef COORDINATE_TRANSFORM_VERBOSE
   QgsDebugMsg( "From proj : " + mSourceCRS.toProj4() );

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -126,6 +126,9 @@ class QgsCoordinateTransformPrivate : public QSharedData
     int mSourceDatumTransform = -1;
     int mDestinationDatumTransform = -1;
 
+    bool mSourceAxisOrderSwapped = false;
+    bool mDestAxisOrderSwapped = false;
+
 #if PROJ_VERSION_MAJOR<6
 
     /**

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -34,6 +34,7 @@
 #include <QSharedData>
 
 #if PROJ_VERSION_MAJOR<6
+typedef void *projPJ;
 #ifndef USE_THREAD_LOCAL
 #include <QThreadStorage>
 #endif
@@ -48,7 +49,7 @@ typedef PJ *ProjData;
 #include "qgscoordinatetransformcontext.h"
 
 #if PROJ_VERSION_MAJOR<6
-typedef void *projPJ;
+
 typedef void *projCtx;
 
 /**

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -33,13 +33,21 @@
 
 #include <QSharedData>
 
+#if PROJ_VERSION_MAJOR<6
 #ifndef USE_THREAD_LOCAL
 #include <QThreadStorage>
+#endif
+typedef QPair< projPJ, projPJ > ProjData;
+#else
+struct PJconsts;
+typedef struct PJconsts PJ;
+typedef PJ *ProjData;
 #endif
 
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransformcontext.h"
 
+#if PROJ_VERSION_MAJOR<6
 typedef void *projPJ;
 typedef void *projCtx;
 
@@ -60,6 +68,8 @@ class QgsProjContextStore
   private:
     projCtx context;
 };
+
+#endif
 
 class QgsCoordinateTransformPrivate : public QSharedData
 {
@@ -89,7 +99,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
 
     void calculateTransforms( const QgsCoordinateTransformContext &context );
 
-    QPair< projPJ, projPJ > threadLocalProjData();
+    ProjData threadLocalProjData();
 
     /**
      * Flag to indicate whether the transform is valid (ie has a valid
@@ -115,6 +125,8 @@ class QgsCoordinateTransformPrivate : public QSharedData
     int mSourceDatumTransform = -1;
     int mDestinationDatumTransform = -1;
 
+#if PROJ_VERSION_MAJOR<6
+
     /**
      * Thread local proj context storage. A new proj context will be created
      * for every thread.
@@ -124,9 +136,11 @@ class QgsCoordinateTransformPrivate : public QSharedData
 #else
     static QThreadStorage< QgsProjContextStore * > mProjContext;
 #endif
+#endif
+
 
     QReadWriteLock mProjLock;
-    QMap < uintptr_t, QPair< projPJ, projPJ > > mProjProjections;
+    QMap < uintptr_t, ProjData > mProjProjections;
 
   private:
 

--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -359,17 +359,18 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
         PROJ_STRING_LIST codesIt = codes;
         while ( char *code = *codesIt )
         {
-          if ( PJ *ellipsoid = proj_create_from_database( context, authority, code, PJ_CATEGORY_ELLIPSOID, 0, nullptr ) )
+          QgsProjUtils::proj_pj_unique_ptr ellipsoid( proj_create_from_database( context, authority, code, PJ_CATEGORY_ELLIPSOID, 0, nullptr ) );
+          if ( ellipsoid.get() )
           {
             EllipsoidDefinition def;
-            QString name = QString( proj_get_name( ellipsoid ) );
+            QString name = QString( proj_get_name( ellipsoid.get() ) );
             def.acronym = QStringLiteral( "%1:%2" ).arg( authority, code );
             name.replace( '_', ' ' );
             def.description = QStringLiteral( "%1 (%2:%3)" ).arg( name, authority, code );
 
             double semiMajor, semiMinor, invFlattening;
             int semiMinorComputed = 0;
-            if ( proj_ellipsoid_get_parameters( context, ellipsoid, &semiMajor, &semiMinor, &semiMinorComputed, &invFlattening ) )
+            if ( proj_ellipsoid_get_parameters( context, ellipsoid.get(), &semiMajor, &semiMinor, &semiMinorComputed, &invFlattening ) )
             {
               def.parameters.semiMajor = semiMajor;
               def.parameters.semiMinor = semiMinor;
@@ -385,8 +386,6 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
             {
               def.parameters.valid = false;
             }
-
-            proj_destroy( ellipsoid );
 
             defs << def;
             sEllipsoidCache.insert( def.acronym, def.parameters );

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -119,17 +119,17 @@ bool QgsProjUtils::axisOrderIsSwapped( const PJ *crs )
     return false;
 
   PJ_CONTEXT *context = QgsProjContext::get();
-  QgsProjUtils::proj_pj_unique_ptr pjCrs( proj_crs_get_coordinate_system( context, crs ) );
-  if ( !pjCrs )
+  QgsProjUtils::proj_pj_unique_ptr pjCs( proj_crs_get_coordinate_system( context, crs ) );
+  if ( !pjCs )
     return false;
 
-  const int axisCount = proj_cs_get_axis_count( context, pjCrs.get() );
+  const int axisCount = proj_cs_get_axis_count( context, pjCs.get() );
   if ( axisCount > 0 )
   {
     const char *outDirection = nullptr;
     // Read only first axis, see if it is degrees / north
 
-    proj_cs_get_axis_info( context, pjCrs.get(), 0,
+    proj_cs_get_axis_info( context, pjCs.get(), 0,
                            nullptr,
                            nullptr,
                            &outDirection,

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -112,4 +112,36 @@ bool QgsProjUtils::usesAngularUnit( const QString &projDef )
   return false;
 }
 
+bool QgsProjUtils::axisOrderIsSwapped( const PJ *crs )
+{
+  //ported from https://github.com/pramsey/postgis/blob/7ecf6839c57a838e2c8540001a3cd35b78a730db/liblwgeom/lwgeom_transform.c#L299
+  if ( !crs )
+    return false;
+
+  PJ_CONTEXT *context = QgsProjContext::get();
+  QgsProjUtils::proj_pj_unique_ptr pjCrs( proj_crs_get_coordinate_system( context, crs ) );
+  if ( !pjCrs )
+    return false;
+
+  const int axisCount = proj_cs_get_axis_count( context, pjCrs.get() );
+  if ( axisCount > 0 )
+  {
+    const char *outDirection = nullptr;
+    // Read only first axis, see if it is degrees / north
+
+    proj_cs_get_axis_info( context, pjCrs.get(), 0,
+                           nullptr,
+                           nullptr,
+                           &outDirection,
+                           nullptr,
+                           nullptr,
+                           nullptr,
+                           nullptr
+                         );
+    return QString( outDirection ).compare( QLatin1String( "north" ), Qt::CaseInsensitive ) == 0;
+  }
+  return false;
+}
+
 #endif
+

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -65,3 +65,10 @@ PJ_CONTEXT *QgsProjContext::get()
   return pContext;
 #endif
 }
+
+#if PROJ_VERSION_MAJOR>=6
+void QgsProjUtils::ProjPJDeleter::operator()( PJ *object )
+{
+  proj_destroy( object );
+}
+#endif

--- a/src/core/qgsprojutils.h
+++ b/src/core/qgsprojutils.h
@@ -79,7 +79,13 @@ class CORE_EXPORT QgsProjUtils
      */
     static bool usesAngularUnit( const QString &projDef );
 
+    //TODO - remove when proj 6.1 is minimum supported version, and replace with proj_normalize_for_visualization
 
+    /**
+     * Returns true if the given proj coordinate system uses requires y/x coordinate
+     * order instead of x/y.
+     */
+    static bool axisOrderIsSwapped( const PJ *crs );
 
 #endif
 #endif

--- a/src/core/qgsprojutils.h
+++ b/src/core/qgsprojutils.h
@@ -21,9 +21,17 @@
 
 #include "qgis_core.h"
 #include "qgsconfig.h"
+#include <memory>
 
 #if !defined(USE_THREAD_LOCAL) || defined(Q_OS_WIN)
 #include <QThreadStorage>
+#endif
+
+#if PROJ_VERSION_MAJOR>=6
+#ifndef SIP_RUN
+struct PJconsts;
+typedef struct PJconsts PJ;
+#endif
 #endif
 
 /**
@@ -43,6 +51,30 @@ class CORE_EXPORT QgsProjUtils
     {
       return PROJ_VERSION_MAJOR;
     }
+
+#ifndef SIP_RUN
+#if PROJ_VERSION_MAJOR >= 6
+
+    /**
+     * Destroys Proj PJ objects.
+     */
+    struct ProjPJDeleter
+    {
+
+      /**
+       * Destroys an PJ \a object, using the correct proj calls.
+       */
+      void CORE_EXPORT operator()( PJ *object );
+
+    };
+
+    /**
+     * Scoped Proj PJ object.
+     */
+    using proj_pj_unique_ptr = std::unique_ptr< PJ, ProjPJDeleter >;
+
+#endif
+#endif
 };
 
 #ifndef SIP_RUN

--- a/src/core/qgsprojutils.h
+++ b/src/core/qgsprojutils.h
@@ -73,6 +73,14 @@ class CORE_EXPORT QgsProjUtils
      */
     using proj_pj_unique_ptr = std::unique_ptr< PJ, ProjPJDeleter >;
 
+    /**
+     * Returns true if the given proj coordinate system uses angular units. \a projDef must be
+     * a proj string defining a CRS object.
+     */
+    static bool usesAngularUnit( const QString &projDef );
+
+
+
 #endif
 #endif
 };

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -260,6 +260,7 @@ void TestQgsCoordinateTransform::transform_data()
   QTest::addColumn<QgsCoordinateReferenceSystem>( "destCrs" );
   QTest::addColumn<double>( "x" );
   QTest::addColumn<double>( "y" );
+  QTest::addColumn<int>( "direction" );
   QTest::addColumn<double>( "outX" );
   QTest::addColumn<double>( "outY" );
   QTest::addColumn<double>( "precision" );
@@ -267,11 +268,19 @@ void TestQgsCoordinateTransform::transform_data()
   QTest::newRow( "To geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
-      << 2545059.0 << 2393190.0 << 145.512750 << -37.961375 << 0.000001;
+      << 2545059.0 << 2393190.0 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 145.512750 << -37.961375 << 0.000001;
   QTest::newRow( "From geographic" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
-      << 145.512750 <<  -37.961375 << 2545059.0 << 2393190.0 << 0.1;
+      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 2545059.0 << 2393190.0 << 0.1;
+  QTest::newRow( "To geographic (reverse)" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 2545059.0 << 2393190.0 << 0.1;
+  QTest::newRow( "From geographic (reverse)" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
+      << 2545058.9675128171 << 2393190.0509782173 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 145.512750 << -37.961375 << 0.000001;
 }
 
 void TestQgsCoordinateTransform::transform()
@@ -280,6 +289,7 @@ void TestQgsCoordinateTransform::transform()
   QFETCH( QgsCoordinateReferenceSystem, destCrs );
   QFETCH( double, x );
   QFETCH( double, y );
+  QFETCH( int, direction );
   QFETCH( double, outX );
   QFETCH( double, outY );
   QFETCH( double, precision );
@@ -287,7 +297,7 @@ void TestQgsCoordinateTransform::transform()
   double z = 0;
   QgsCoordinateTransform ct( sourceCrs, destCrs, QgsProject::instance() );
 
-  ct.transformInPlace( x, y, z );
+  ct.transformInPlace( x, y, z, static_cast<  QgsCoordinateTransform::TransformDirection >( direction ) );
   QGSCOMPARENEAR( x, outX, precision );
   QGSCOMPARENEAR( y, outY, precision );
 }

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -273,6 +273,10 @@ void TestQgsCoordinateTransform::transform_data()
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 2545059.0 << 2393190.0 << 0.1;
+  QTest::newRow( "From geographic to geographic" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4164 )
+      << 145.512750 <<  -37.961375 << static_cast< int >( QgsCoordinateTransform::ForwardTransform ) << 145.510966 <<  -37.961741 << 0.0001;
   QTest::newRow( "To geographic (reverse)" )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
@@ -281,6 +285,11 @@ void TestQgsCoordinateTransform::transform_data()
       << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
       << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
       << 2545058.9675128171 << 2393190.0509782173 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) << 145.512750 << -37.961375 << 0.000001;
+  QTest::newRow( "From geographic to geographic reverse" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4164 )
+      << 145.510966 <<  -37.961741 << static_cast< int >( QgsCoordinateTransform::ReverseTransform ) <<  145.512750 <<  -37.961375 << 0.0001;
+
 }
 
 void TestQgsCoordinateTransform::transform()

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -38,6 +38,8 @@ class TestQgsCoordinateTransform: public QObject
     void contextShared();
     void scaleFactor();
     void scaleFactor_data();
+    void transform_data();
+    void transform();
 
   private:
 
@@ -250,6 +252,44 @@ void TestQgsCoordinateTransform::scaleFactor_data()
       << QgsCoordinateReferenceSystem::fromEpsgId( 2056 )
       << QgsRectangle( 2550000, 1200000, 2550100, 1200100 )
       << 1.0;
+}
+
+void TestQgsCoordinateTransform::transform_data()
+{
+  QTest::addColumn<QgsCoordinateReferenceSystem>( "sourceCrs" );
+  QTest::addColumn<QgsCoordinateReferenceSystem>( "destCrs" );
+  QTest::addColumn<double>( "x" );
+  QTest::addColumn<double>( "y" );
+  QTest::addColumn<double>( "outX" );
+  QTest::addColumn<double>( "outY" );
+  QTest::addColumn<double>( "precision" );
+
+  QTest::newRow( "To geographic" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << 2545059.0 << 2393190.0 << 145.512750 << -37.961375 << 0.000001;
+  QTest::newRow( "From geographic" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 3111 )
+      << 145.512750 <<  -37.961375 << 2545059.0 << 2393190.0 << 0.1;
+}
+
+void TestQgsCoordinateTransform::transform()
+{
+  QFETCH( QgsCoordinateReferenceSystem, sourceCrs );
+  QFETCH( QgsCoordinateReferenceSystem, destCrs );
+  QFETCH( double, x );
+  QFETCH( double, y );
+  QFETCH( double, outX );
+  QFETCH( double, outY );
+  QFETCH( double, precision );
+
+  double z = 0;
+  QgsCoordinateTransform ct( sourceCrs, destCrs, QgsProject::instance() );
+
+  ct.transformInPlace( x, y, z );
+  QGSCOMPARENEAR( x, outX, precision );
+  QGSCOMPARENEAR( y, outY, precision );
 }
 
 void TestQgsCoordinateTransform::transformBoundingBox()

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -70,11 +70,13 @@ void TestQgsProjUtils::threadSafeContext()
 
 void TestQgsProjUtils::usesAngularUnits()
 {
+#if PROJ_VERSION_MAJOR>=6
   QVERIFY( !QgsProjUtils::usesAngularUnit( QString() ) );
   QVERIFY( !QgsProjUtils::usesAngularUnit( QString( "" ) ) );
   QVERIFY( !QgsProjUtils::usesAngularUnit( QStringLiteral( "x" ) ) );
   QVERIFY( QgsProjUtils::usesAngularUnit( QStringLiteral( "+proj=longlat +ellps=WGS60 +no_defs" ) ) );
   QVERIFY( !QgsProjUtils::usesAngularUnit( QStringLiteral( "+proj=tmerc +lat_0=0 +lon_0=147 +k_0=0.9996 +x_0=500000 +y_0=10000000 +ellps=GRS80 +units=m +no_defs" ) ) );
+#endif
 }
 
 QGSTEST_MAIN( TestQgsProjUtils )

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -18,6 +18,10 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 
+#if PROJ_VERSION_MAJOR>=6
+#include <proj.h>
+#endif
+
 //header for class being tested
 #include "qgsprojutils.h"
 #include <QtConcurrent>
@@ -30,6 +34,7 @@ class TestQgsProjUtils: public QObject
     void cleanupTestCase();
     void threadSafeContext();
     void usesAngularUnits();
+    void axisOrderIsSwapped();
 
 };
 
@@ -76,6 +81,19 @@ void TestQgsProjUtils::usesAngularUnits()
   QVERIFY( !QgsProjUtils::usesAngularUnit( QStringLiteral( "x" ) ) );
   QVERIFY( QgsProjUtils::usesAngularUnit( QStringLiteral( "+proj=longlat +ellps=WGS60 +no_defs" ) ) );
   QVERIFY( !QgsProjUtils::usesAngularUnit( QStringLiteral( "+proj=tmerc +lat_0=0 +lon_0=147 +k_0=0.9996 +x_0=500000 +y_0=10000000 +ellps=GRS80 +units=m +no_defs" ) ) );
+#endif
+}
+
+void TestQgsProjUtils::axisOrderIsSwapped()
+{
+#if PROJ_VERSION_MAJOR>=6
+  PJ_CONTEXT *context = QgsProjContext::get();
+  QVERIFY( !QgsProjUtils::axisOrderIsSwapped( nullptr ) );
+
+  QgsProjUtils::proj_pj_unique_ptr crs( proj_create( context, "urn:ogc:def:crs:EPSG::3111" ) );
+  QVERIFY( !QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
+  crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::4326" ) );
+  QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
 #endif
 }
 

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -29,6 +29,7 @@ class TestQgsProjUtils: public QObject
     void initTestCase();
     void cleanupTestCase();
     void threadSafeContext();
+    void usesAngularUnits();
 
 };
 
@@ -65,6 +66,15 @@ void TestQgsProjUtils::threadSafeContext()
   QVector< int > list;
   list.resize( 100 );
   QtConcurrent::blockingMap( list, ProjContextWrapper() );
+}
+
+void TestQgsProjUtils::usesAngularUnits()
+{
+  QVERIFY( !QgsProjUtils::usesAngularUnit( QString() ) );
+  QVERIFY( !QgsProjUtils::usesAngularUnit( QString( "" ) ) );
+  QVERIFY( !QgsProjUtils::usesAngularUnit( QStringLiteral( "x" ) ) );
+  QVERIFY( QgsProjUtils::usesAngularUnit( QStringLiteral( "+proj=longlat +ellps=WGS60 +no_defs" ) ) );
+  QVERIFY( !QgsProjUtils::usesAngularUnit( QStringLiteral( "+proj=tmerc +lat_0=0 +lon_0=147 +k_0=0.9996 +x_0=500000 +y_0=10000000 +ellps=GRS80 +units=m +no_defs" ) ) );
 }
 
 QGSTEST_MAIN( TestQgsProjUtils )


### PR DESCRIPTION
Ports the internals of QgsCoordinateTransform to the proj6 API, where available.

Sponsored by ICSM

Still todo: crs db.