### PR TITLE
[quick] Fix validity condition in QgsQuickFeatureLayerPair

### DIFF
--- a/src/quickgui/qgsquickfeaturelayerpair.cpp
+++ b/src/quickgui/qgsquickfeaturelayerpair.cpp
@@ -66,8 +66,5 @@ bool QgsQuickFeatureLayerPair::hasValidGeometry() const
   if ( mFeature.geometry().type() != mLayer->geometryType() )
     return false;
 
-  if ( QgsWkbTypes::hasZ( mLayer->wkbType() ) != QgsWkbTypes::hasZ( mFeature.geometry().wkbType() ) )
-    return false;
-
   return true;
 }


### PR DESCRIPTION
The extra condition enforcing that feature's geometry needs to have Z coordinate if also its parent layer has Z coordinates was not doing good job and surprisingly marking also valid geometries as invalid if layer type was PointZ but the geometry had undefined Z value. This caused issues in IdentifyKit not picking up some features.
