### PR TITLE
[processing] Refine check for usable layers

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -368,12 +368,12 @@ bool QgsProcessingUtils::canUseLayer( const QgsMeshLayer *layer )
 bool QgsProcessingUtils::canUseLayer( const QgsRasterLayer *layer )
 {
   // only gdal file-based layers
-  return layer && layer->providerType() == QStringLiteral( "gdal" );
+  return layer && layer->isValid();
 }
 
 bool QgsProcessingUtils::canUseLayer( const QgsVectorLayer *layer, const QList<int> &sourceTypes )
 {
-  return layer &&
+  return layer && layer->isValid() &&
          ( sourceTypes.isEmpty()
            || ( sourceTypes.contains( QgsProcessing::TypeVectorPoint ) && layer->geometryType() == QgsWkbTypes::PointGeometry )
            || ( sourceTypes.contains( QgsProcessing::TypeVectorLine ) && layer->geometryType() == QgsWkbTypes::LineGeometry )


### PR DESCRIPTION
- allow WMS layers and other non-GDAL raster layers. This will work
fine for native algorithms, likely not work for other providers. They
will need to be adapted to throw errors when incompatible raster
layer providers are used

- invalid layers are not permitted (e.g. those with missing data
sources)

@3nids this fixes your script