### PR TITLE
Fix grass7 v.voronoi again

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.voronoi.skeleton.txt
+++ b/python/plugins/processing/algs/grass7/description/v.voronoi.skeleton.txt
@@ -1,0 +1,11 @@
+v.voronoi.skeleton
+Creates a Voronoi diagram (or compute the center line or the skeleton) from an input vector layer containing polygons.
+Vector (v.*)
+QgsProcessingParameterFeatureSource|input|Input polygons layer|2|None|False
+QgsProcessingParameterNumber|smoothness|Factor for output smoothness|QgsProcessingParameterNumber.Double|0.25|True|None|None
+QgsProcessingParameterNumber|thin|Maximum dangle length of skeletons (-1 will extract the center line)|QgsProcessingParameterNumber.Double|-1.0|True|-1.0|None
+*QgsProcessingParameterBoolean|-a|Create Voronoi diagram for input areas|False
+*QgsProcessingParameterBoolean|-s|Extract skeletons for input areas|False
+*QgsProcessingParameterBoolean|-l|Output tessellation as a graph (lines), not areas|False
+*QgsProcessingParameterBoolean|-t|Do not create attribute table|False
+QgsProcessingParameterVectorDestination|output|Voronoi

--- a/python/plugins/processing/algs/grass7/description/v.voronoi.txt
+++ b/python/plugins/processing/algs/grass7/description/v.voronoi.txt
@@ -3,9 +3,6 @@ Creates a Voronoi diagram from an input vector layer containing points.
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input points layer|0|None|False
 QgsProcessingParameterNumber|smoothness|Factor for output smoothness|QgsProcessingParameterNumber.Double|0.25|True|None|None
-QgsProcessingParameterNumber|thin|Maximum dangle length of skeletons (-1 will extract the center line)|QgsProcessingParameterNumber.Double|-1.0|True|-1.0|None
-*QgsProcessingParameterBoolean|-a|Create Voronoi diagram for input areas|False
-*QgsProcessingParameterBoolean|-s|Extract skeletons for input areas|False
 *QgsProcessingParameterBoolean|-l|Output tessellation as a graph (lines), not areas|False
 *QgsProcessingParameterBoolean|-t|Do not create attribute table|False
 QgsProcessingParameterVectorDestination|output|Voronoi


### PR DESCRIPTION
## Description

The GRASS7 module as it is now only accepts points as inputs... BUT... the tool can also:

*) compute the voronoi diagram of polygons
*) compute the center line or skeleton of polygons (input polygons must be generalized to give good results, but this is another matter)

As in processing we cannot (I think) specify more than one type of vector inputs (other than using -1 for all types, but in this case lines do not apply) then the tool was split in two, as we did in 2.*.

This needs to be backported to both 3.6 and 3.4

fixes https://issues.qgis.org/issues/21662


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
