### PR TITLE
Fix crash as json

### DIFF
--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -402,22 +402,25 @@ QString QgsCurvePolygon::asJson( int precision ) const
   // GeoJSON does not support curves
   QString json = QStringLiteral( "{\"type\": \"Polygon\", \"coordinates\": [" );
 
-  std::unique_ptr< QgsLineString > exteriorLineString( exteriorRing()->curveToLine() );
-  QgsPointSequence exteriorPts;
-  exteriorLineString->points( exteriorPts );
-  json += QgsGeometryUtils::pointsToJSON( exteriorPts, precision ) + QLatin1String( ", " );
+  if ( exteriorRing() )
+  {
+    std::unique_ptr< QgsLineString > exteriorLineString( exteriorRing()->curveToLine() );
+    QgsPointSequence exteriorPts;
+    exteriorLineString->points( exteriorPts );
+    json += QgsGeometryUtils::pointsToJSON( exteriorPts, precision ) + QLatin1String( ", " );
 
-  std::unique_ptr< QgsLineString > interiorLineString;
-  for ( int i = 0, n = numInteriorRings(); i < n; ++i )
-  {
-    interiorLineString.reset( interiorRing( i )->curveToLine() );
-    QgsPointSequence interiorPts;
-    interiorLineString->points( interiorPts );
-    json += QgsGeometryUtils::pointsToJSON( interiorPts, precision ) + QLatin1String( ", " );
-  }
-  if ( json.endsWith( QLatin1String( ", " ) ) )
-  {
-    json.chop( 2 ); // Remove last ", "
+    std::unique_ptr< QgsLineString > interiorLineString;
+    for ( int i = 0, n = numInteriorRings(); i < n; ++i )
+    {
+      interiorLineString.reset( interiorRing( i )->curveToLine() );
+      QgsPointSequence interiorPts;
+      interiorLineString->points( interiorPts );
+      json += QgsGeometryUtils::pointsToJSON( interiorPts, precision ) + QLatin1String( ", " );
+    }
+    if ( json.endsWith( QLatin1String( ", " ) ) )
+    {
+      json.chop( 2 ); // Remove last ", "
+    }
   }
   json += QLatin1String( "] }" );
   return json;

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -158,6 +158,8 @@ class TestQgsGeometry : public QObject
 
     void convertGeometryCollectionToSubclass();
 
+    void emptyJson();
+
   private:
     //! A helper method to do a render check to see if the geometry op is as expected
     bool renderCheck( const QString &testName, const QString &comment = QString(), int mismatchCount = 0 );
@@ -17467,6 +17469,37 @@ void TestQgsGeometry::convertGeometryCollectionToSubclass()
   // trying to convert a geometry that is not a geometry collection
   QgsGeometry wrong = QgsGeometry::fromWkt( QStringLiteral( "Point(1 2)" ) );
   QVERIFY( !wrong.convertGeometryCollectionToSubclass( QgsWkbTypes::PolygonGeometry ) );
+}
+
+void TestQgsGeometry::emptyJson()
+{
+  QString expected;
+// TODO: harmonize Json output. Should be ... [] }
+  expected = QStringLiteral( "{\"type\": \"LineString\", \"coordinates\": [ ]}" );
+  QCOMPARE( QgsCircularString().asJson(), expected );
+  QCOMPARE( QgsCompoundCurve().asJson(), expected );
+  QCOMPARE( QgsLineString().asJson(), expected );
+
+  expected = QStringLiteral( "{\"type\": \"GeometryCollection\", \"geometries\": [] }" );
+  QCOMPARE( QgsGeometryCollection().asJson(), expected );
+
+  expected = QStringLiteral( "{\"type\": \"MultiLineString\", \"coordinates\": [] }" );
+  QCOMPARE( QgsMultiCurve().asJson(), expected );
+  QCOMPARE( QgsMultiLineString().asJson(), expected );
+
+  expected = QStringLiteral( "{\"type\": \"MultiPoint\", \"coordinates\": [ ] }" );
+  QCOMPARE( QgsMultiPoint().asJson(), expected );
+
+  expected = QStringLiteral( "{\"type\": \"MultiPolygon\", \"coordinates\": [] }" );
+  QCOMPARE( QgsMultiSurface().asJson(), expected );
+
+  expected = QStringLiteral( "{\"type\": \"Point\", \"coordinates\": [0, 0]}" ); // should be []
+  QCOMPARE( QgsPoint().asJson(), expected );
+
+  expected = QStringLiteral( "{\"type\": \"Polygon\", \"coordinates\": [] }" );
+  QCOMPARE( QgsCurvePolygon().asJson(), expected );
+  QCOMPARE( QgsPolygon().asJson(), expected );
+  QCOMPARE( QgsTriangle().asJson(), expected );
 }
 
 QGSTEST_MAIN( TestQgsGeometry )


### PR DESCRIPTION
## Description
Qgis crashes with one of this command (example in python console):

```
>>> QgsPolygon().asJson()
>>> QgsTriangle().asJson()
>>> QgsCurvePolygon().asJson()
```
 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
