### PR TITLE
Include missing include of <functional>

### DIFF
--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -33,6 +33,8 @@
 #include <QStringList>
 #include <QVariant>
 
+#include <functional>
+
 class QNetworkReply;
 class QgsNetworkAccessManager;
 class QgsFields;


### PR DESCRIPTION
## Description

PR adds an include statement to the `arcgisrest` provider that I needed to build QGIS with GCC7 and MSVC14. According to [GCC7 porting documentation](https://www.gnu.org/software/gcc/gcc-7/porting_to.html), the `std::function` had previously been implicitly included when including unrelated components which should help explain why this wasn't caught before on CIs. We're also building on OSX using Clang 4.0, which did not need this change to compile but also wasn't negatively affected by it.

@elpaso offered to review my PR in conda-forge/qgis-feedstock#47, and I'm happy to get feedback generally. I've read through the contributing docs but apologies in advance if I've missed anything.

Thank you all for the incredible work on QGIS!

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
