### PR TITLE
Fix QgsProxyProgressTask can get stuck if it's finalized before the task starts

### DIFF
--- a/.ci/travis/linux/scripts/test_blacklist.txt
+++ b/.ci/travis/linux/scripts/test_blacklist.txt
@@ -18,8 +18,6 @@ qgis_openstreetmaptest
 qgis_wcsprovidertest
 PyQgsWFSProviderGUI
 qgis_ziplayertest
-qgis_fieldcalculatortest
-qgis_attributetabletest
 
 # Flaky, see https://dash.orfeo-toolbox.org/testDetails.php?test=63061783&build=297405
 PyQgsSpatialiteProvider

--- a/src/core/qgsproxyprogresstask.h
+++ b/src/core/qgsproxyprogresstask.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsProxyProgressTask : public QgsTask
 
     QWaitCondition mNotFinishedWaitCondition;
     QMutex mNotFinishedMutex;
+    bool mAlreadyFinished = false;
     bool mResult = true;
 
 };


### PR DESCRIPTION
Fixes a number of issues where tasks get "stuck" in the manager, and also should fix the long-standing timeout issues with the attribute table tests!