### PR TITLE
[processing] Include version information at start of log

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -92,6 +92,13 @@ report the output from executing an external command or subprocess.
 .. seealso:: :py:func:`pushCommandInfo`
 %End
 
+    void pushVersionInfo();
+%Docstring
+Pushes a summary of the QGIS (and underlying library) version information to the log.
+
+.. versionadded:: 3.4.7
+%End
+
 };
 
 

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -205,6 +205,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     break
 
             self.clearProgress()
+            self.feedback.pushVersionInfo()
             self.setProgressText(QCoreApplication.translate('AlgorithmDialog', 'Processing algorithm…'))
 
             self.setInfo(

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -16,6 +16,63 @@
  ***************************************************************************/
 
 #include "qgsprocessingfeedback.h"
+#include "qgsgeos.h"
+#include <ogr_api.h>
+#include <gdal_version.h>
+#if PROJ_VERSION_MAJOR > 4
+#include <proj.h>
+#else
+#include <proj_api.h>
+#endif
+
+void QgsProcessingFeedback::setProgressText( const QString & )
+{
+}
+
+void QgsProcessingFeedback::reportError( const QString &error, bool )
+{
+  QgsMessageLog::logMessage( error, tr( "Processing" ), Qgis::Critical );
+}
+
+void QgsProcessingFeedback::pushInfo( const QString &info )
+{
+  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+}
+
+void QgsProcessingFeedback::pushCommandInfo( const QString &info )
+{
+  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+}
+
+void QgsProcessingFeedback::pushDebugInfo( const QString &info )
+{
+  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+}
+
+void QgsProcessingFeedback::pushConsoleInfo( const QString &info )
+{
+  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+}
+
+void QgsProcessingFeedback::pushVersionInfo()
+{
+  pushDebugInfo( tr( "QGIS version: %1" ).arg( Qgis::QGIS_VERSION ) );
+  if ( QString( Qgis::QGIS_DEV_VERSION ) != QLatin1String( "exported" ) )
+  {
+    pushDebugInfo( tr( "QGIS code revision: %1" ).arg( Qgis::QGIS_DEV_VERSION ) );
+  }
+  pushDebugInfo( tr( "Qt version: %1" ).arg( qVersion() ) );
+  pushDebugInfo( tr( "GDAL version: %1" ).arg( GDALVersionInfo( "RELEASE_NAME" ) ) );
+  pushDebugInfo( tr( "GEOS version: %1" ).arg( GEOSversion() ) );
+
+#if PROJ_VERSION_MAJOR > 4
+  PJ_INFO info = proj_info();
+  pushDebugInfo( tr( "PROJ version: %1.%2.%3" ).arg( PROJ_VERSION_MAJOR ).arg( PROJ_VERSION_MINOR ).arg( PROJ_VERSION_PATCH );
+#else
+  pushDebugInfo( tr( "PROJ version: %1" ).arg( PJ_VERSION ) );
+#endif
+}
+
 
 QgsProcessingMultiStepFeedback::QgsProcessingMultiStepFeedback( int childAlgorithmCount, QgsProcessingFeedback *feedback )
   : mChildSteps( childAlgorithmCount )
@@ -67,5 +124,4 @@ void QgsProcessingMultiStepFeedback::updateOverallProgress( double progress )
   double currentAlgorithmProgress = progress / mChildSteps;
   mFeedback->setProgress( baseProgress + currentAlgorithmProgress );
 }
-
 

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -44,14 +44,14 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * 4 of 5 layers".
      * \see setProgress()
      */
-    virtual void setProgressText( const QString &text ) { Q_UNUSED( text ); }
+    virtual void setProgressText( const QString &text );
 
     /**
      * Reports that the algorithm encountered an \a error while executing.
      *
      * If \a fatalError is TRUE then the error prevented the algorithm from executing.
      */
-    virtual void reportError( const QString &error, bool fatalError = false ) { Q_UNUSED( fatalError ); QgsMessageLog::logMessage( error, tr( "Processing" ), Qgis::Critical ); }
+    virtual void reportError( const QString &error, bool fatalError = false );
 
     /**
      * Pushes a general informational message from the algorithm. This can
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \see pushDebugInfo()
      * \see pushConsoleInfo()
      */
-    virtual void pushInfo( const QString &info ) { QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info ); }
+    virtual void pushInfo( const QString &info );
 
     /**
      * Pushes an informational message containing a command from the algorithm.
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \see pushDebugInfo()
      * \see pushConsoleInfo()
      */
-    virtual void pushCommandInfo( const QString &info ) { QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info ); }
+    virtual void pushCommandInfo( const QString &info );
 
     /**
      * Pushes an informational message containing debugging helpers from
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \see pushCommandInfo()
      * \see pushConsoleInfo()
      */
-    virtual void pushDebugInfo( const QString &info ) { QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info ); }
+    virtual void pushDebugInfo( const QString &info );
 
     /**
      * Pushes a console feedback message from the algorithm. This is used to
@@ -89,7 +89,13 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \see pushDebugInfo()
      * \see pushCommandInfo()
      */
-    virtual void pushConsoleInfo( const QString &info ) { QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info ); }
+    virtual void pushConsoleInfo( const QString &info );
+
+    /**
+     * Pushes a summary of the QGIS (and underlying library) version information to the log.
+     * \since QGIS 3.4.7
+     */
+    void pushVersionInfo();
 
 };
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -375,7 +375,7 @@ void QgsProcessingAlgorithmDialogBase::pushCommandInfo( const QString &command )
 
 void QgsProcessingAlgorithmDialogBase::pushDebugInfo( const QString &message )
 {
-  txtLog->append( QStringLiteral( "<span style=\"color:blue\">%1</span>" ).arg( formatStringForLog( message.toHtmlEscaped() ) ) );
+  txtLog->append( QStringLiteral( "<span style=\"color:#777\">%1</span>" ).arg( formatStringForLog( message.toHtmlEscaped() ) ) );
   scrollToBottomOfLog();
   processEvents();
 }


### PR DESCRIPTION
Start the log text with QGIS/Qt/GEOS/GDAL version information strings.
This is helpful for debugging and accountability.