### PR TITLE
Fixes compilation warning

### DIFF
--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -67,7 +67,7 @@ void QgsProcessingFeedback::pushVersionInfo()
 
 #if PROJ_VERSION_MAJOR > 4
   PJ_INFO info = proj_info();
-  pushDebugInfo( tr( "PROJ version: %1.%2.%3" ).arg( PROJ_VERSION_MAJOR ).arg( PROJ_VERSION_MINOR ).arg( PROJ_VERSION_PATCH ) );
+  pushDebugInfo( tr( "PROJ version: %1" ).arg( info.release ) );
 #else
   pushDebugInfo( tr( "PROJ version: %1" ).arg( PJ_VERSION ) );
 #endif


### PR DESCRIPTION
## Description

Fixes the warning:

```
[465/5017] Building CXX object src/core/CMakeFiles/qgis_core.dir/processing/qgsprocessingfeedback.cpp.o
../src/core/processing/qgsprocessingfeedback.cpp: In member function ‘void QgsProcessingFeedback::pushVersionInfo()’:
../src/core/processing/qgsprocessingfeedback.cpp:69:11: warning: variable ‘info’ set but not used [-Wunused-but-set-variable]
   PJ_INFO info = proj_info();
           ^~~~
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
