### PR TITLE
[vertex tool] fixes some editor-tool synchronization issues

### DIFF
--- a/src/app/vertextool/qgslockedfeature.cpp
+++ b/src/app/vertextool/qgslockedfeature.cpp
@@ -42,15 +42,6 @@ QgsLockedFeature::QgsLockedFeature( QgsFeatureId featureId,
   // signal changing of current layer
   connect( QgisApp::instance()->layerTreeView(), &QgsLayerTreeView::currentLayerChanged, this, &QgsLockedFeature::currentLayerChanged );
 
-  // feature was deleted
-  connect( mLayer, &QgsVectorLayer::featureDeleted, this, &QgsLockedFeature::featureDeleted );
-
-  // rolling back
-  connect( mLayer, &QgsVectorLayer::beforeRollBack, this, &QgsLockedFeature::beforeRollBack );
-
-  // geometry was changed
-  connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsLockedFeature::geometryChanged );
-
   replaceVertexMap();
 }
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1304,8 +1304,13 @@ void QgsVertexTool::onCachedGeometryChanged( QgsFeatureId fid, const QgsGeometry
   // re-run validation for the feature
   validateGeometry( layer, fid );
 
-  if ( mVertexEditor && mLockedFeature && mLockedFeature->featureId() == fid && mLockedFeature->layer() == layer )
-    mVertexEditor->updateEditor( mLockedFeature.get() );
+  if ( mLockedFeature && mLockedFeature->featureId() == fid && mLockedFeature->layer() == layer )
+  {
+    mLockedFeature->geometryChanged( fid, geom );
+    if ( mVertexEditor )
+      mVertexEditor->updateEditor( mLockedFeature.get() );
+    updateLockedFeatureVertices();
+  }
 }
 
 void QgsVertexTool::onCachedGeometryDeleted( QgsFeatureId fid )
@@ -1318,6 +1323,12 @@ void QgsVertexTool::onCachedGeometryDeleted( QgsFeatureId fid )
 
   // refresh highlighted vertices - some may have been deleted
   setHighlightedVertices( mSelectedVertices );
+
+  if ( mLockedFeature && mLockedFeature->featureId() == fid && mLockedFeature->layer() == layer )
+  {
+    mLockedFeature->featureDeleted( fid );
+    updateLockedFeatureVertices();
+  }
 }
 
 void QgsVertexTool::updateVertexEditor( QgsVectorLayer *layer, QgsFeatureId fid )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2022,6 +2022,7 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
     }
   }
 
+  updateLockedFeatureVertices();
   if ( mVertexEditor )
     mVertexEditor->updateEditor( mLockedFeature.get() );
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1412,6 +1412,7 @@ void QgsVertexTool::cleanupVertexEditor()
 {
   mLockedFeature.reset();
   mVertexEditor.reset();
+  updateLockedFeatureVertices();
 }
 
 void QgsVertexTool::cleanupLockedFeature()


### PR DESCRIPTION
mainly due to the fact that geometry changed slot was called on locked feature after the one on the tool.

@bstroebl are you able to test this PR or can only test on nightly builds?