### PR TITLE
[Backport release-3_4] deleteShapeFile(): delete also ".cpg", ".sbn", ".sbx", ".idm", ".ind" files

### DIFF
--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -528,7 +528,7 @@ Adds a ``feature`` to the currently opened data source, using the style from a s
 
     static bool deleteShapeFile( const QString &fileName );
 %Docstring
-Delete a shapefile (and its accompanying shx / dbf / prf)
+Delete a shapefile (and its accompanying shx / dbf / prj / qix / qpj / cpg / sbn / sbx / idm / ind)
 
 :param fileName: /path/to/file.shp
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2831,7 +2831,7 @@ bool QgsVectorFileWriter::deleteShapeFile( const QString &fileName )
   QDir dir = fi.dir();
 
   QStringList filter;
-  const char *suffixes[] = { ".shp", ".shx", ".dbf", ".prj", ".qix", ".qpj" };
+  const char *suffixes[] = { ".shp", ".shx", ".dbf", ".prj", ".qix", ".qpj", ".cpg", ".sbn", ".sbx", ".idm", ".ind" };
   for ( std::size_t i = 0; i < sizeof( suffixes ) / sizeof( *suffixes ); i++ )
   {
     filter << fi.completeBaseName() + suffixes[i];

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -718,7 +718,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     ~QgsVectorFileWriter() override;
 
     /**
-     * Delete a shapefile (and its accompanying shx / dbf / prf)
+     * Delete a shapefile (and its accompanying shx / dbf / prj / qix / qpj / cpg / sbn / sbx / idm / ind)
      * \param fileName /path/to/file.shp
      * \returns bool true if the file was deleted successfully
      */


### PR DESCRIPTION
Backport #9660.

Make QgsVectorFileWriter::deleteShapeFile() delete ".cpg" (and ".sbn", ".sbx", ".idm", ".ind") files along with ".shp", ".shx", ".dbf", ".prj", ".qix", ".qpj" ones.