### PR TITLE
[server] Move specialised funtions in correponding service cpp files

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreelayer.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreelayer.sip.in
@@ -78,6 +78,10 @@ Sets the layer's name.
 .. versionadded:: 3.0
 %End
 
+    void setUseLayerName( bool use = true );
+
+    bool useLayerName() const;
+
     static QgsLayerTreeLayer *readXml( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
 %Docstring
 Read layer node from XML. Returns new instance.
@@ -125,6 +129,7 @@ Emitted when a previously available layer got unloaded (from layer registry).
 
   protected:
     void attachToLayer();
+
 
 
   private:

--- a/python/core/auto_generated/layertree/qgslayertreelayer.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreelayer.sip.in
@@ -79,8 +79,19 @@ Sets the layer's name.
 %End
 
     void setUseLayerName( bool use = true );
+%Docstring
+Uses the layer's name if ``use`` is true, or the name manually set if
+false.
+
+.. versionadded:: 3.8
+%End
 
     bool useLayerName() const;
+%Docstring
+Returns whether the layer's name is used, or the name manually set.
+
+.. versionadded:: 3.8
+%End
 
     static QgsLayerTreeLayer *readXml( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
 %Docstring

--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -76,12 +76,12 @@ void QgsLayerTreeLayer::attachToLayer()
 
 QString QgsLayerTreeLayer::name() const
 {
-  return mRef ? mRef->name() : mLayerName;
+  return ( mRef && mUseLayerName ) ? mRef->name() : mLayerName;
 }
 
 void QgsLayerTreeLayer::setName( const QString &n )
 {
-  if ( mRef )
+  if ( mRef && mUseLayerName )
   {
     if ( mRef->name() == n )
       return;
@@ -173,6 +173,15 @@ void QgsLayerTreeLayer::layerWillBeDeleted()
 
 }
 
+void QgsLayerTreeLayer::setUseLayerName( const bool use )
+{
+  mUseLayerName = use;
+}
+
+bool QgsLayerTreeLayer::useLayerName() const
+{
+  return mUseLayerName;
+}
 
 void QgsLayerTreeLayer::layerNameChanged()
 {

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -90,8 +90,17 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
      */
     void setName( const QString &n ) override;
 
+    /**
+     * Uses the layer's name if \a use is true, or the name manually set if
+     * false.
+     * \since QGIS 3.8
+     */
     void setUseLayerName( bool use = true );
 
+    /**
+     * Returns whether the layer's name is used, or the name manually set.
+     * \since QGIS 3.8
+     */
     bool useLayerName() const;
 
     /**

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -90,6 +90,10 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
      */
     void setName( const QString &n ) override;
 
+    void setUseLayerName( bool use = true );
+
+    bool useLayerName() const;
+
     /**
      * Read layer node from XML. Returns new instance.
      * Does not resolve textual references to layers. Call resolveReferences() afterwards to do it.
@@ -133,8 +137,11 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
 
     //! Weak reference to the layer (or just it's ID if the reference is not resolved yet)
     QgsMapLayerRef mRef;
-    //! Layer name - only used if layer does not exist
+    //! Layer name - only used if layer does not exist or if mUseLayerName is false
     QString mLayerName;
+
+    //!
+    bool mUseLayerName = true;
 
   private slots:
 

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -228,5 +228,18 @@ namespace QgsWms
 
     return tree.release();
   }
+
+  QgsLayerTreeModelLegendNode *legendNode( const QgsLayerTreeModel &model, const QString &rule )
+  {
+    for ( QgsLayerTreeLayer *layer : model->rootGroup()->findLayers() )
+    {
+      for ( QgsLayerTreeModelLegendNode *node : model->layerLegendNodes( layer ) )
+      {
+        if ( node->data( Qt::DisplayRole ).toString().compare( rule ) == 0 )
+          return node;
+      }
+    }
+    return nullptr;
+  }
 } // namespace QgsWms
 

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -34,6 +34,9 @@ namespace QgsWms
     // get parameters from query
     QgsWmsParameters parameters( QUrlQuery( request.url() ) );
 
+    // check parameters validity
+    checkParameters( parameters );
+
     // init render context
     QgsWmsRenderContext context( project, serverIface );
     context.setFlag( QgsWmsRenderContext::UseScaleDenominator );
@@ -98,6 +101,27 @@ namespace QgsWms
     else
     {
       throw QgsException( QStringLiteral( "Failed to compute GetLegendGraphics image" ) );
+    }
+  }
+
+  void checkParameters( const QgsWmsParameters &parameters )
+  {
+    if ( parameters.allLayersNickname().isEmpty() )
+    {
+      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+                                    parameters[QgsWmsParameter::LAYERS] );
+    }
+
+    if ( parameters.format() == QgsWmsParameters::Format::NONE )
+    {
+      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+                                    parameters[QgsWmsParameter::FORMAT] );
+    }
+
+    if ( ! parameters.bbox().isEmpty() && !parameters.rule().isEmpty() )
+    {
+      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+                                    QStringLiteral( "BBOX parameter cannot be combined with RULE." ) );
     }
   }
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -96,8 +96,6 @@ namespace QgsWms
     std::unique_ptr<QgsLayerTreeModel> model( legendModel( context, *tree.get() ) );
 
     // rendering
-    QgsRenderer renderer( context );
-
     std::unique_ptr<QImage> result;
     if ( !parameters.rule().isEmpty() )
     {

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -127,13 +127,33 @@ namespace QgsWms
       throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
                                     QStringLiteral( "BBOX parameter cannot be combined with RULE." ) );
     }
+
+    if ( ! parameters.bbox().isEmpty() && parameters.bboxAsRectangle().isEmpty() )
+    {
+      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+                                    parameters[QgsWmsParameter::BBOX] );
+    }
   }
 
   QgsLayerTreeModel *legendModel( const QgsWmsRenderContext &context, QgsLayerTree &tree )
   {
     const QgsWmsParameters parameters = context.parameters();
-
     std::unique_ptr<QgsLayerTreeModel> model( new QgsLayerTreeModel( &tree ) );
+
+    if ( context.scaleDenominator() > 0 )
+    {
+      model->setLegendFilterByScale( context.scaleDenominator() );
+    }
+
+    // content based legend
+    if ( ! parameters.bbox().isEmpty() )
+    {
+      QgsRenderer renderer( context );
+      const QgsRenderer::HitTest symbols = renderer.symbols();
+
+      // TODO
+    }
+
     return model.release();
   }
 

--- a/src/server/services/wms/qgswmsgetlegendgraphics.h
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.h
@@ -37,4 +37,6 @@ namespace QgsWms
   QgsLayerTreeModel *legendModel( const QgsWmsRenderContext &context, QgsLayerTree &tree );
 
   QgsLayerTree *layerTree( const QgsWmsRenderContext &context );
+
+  QgsLayerTreeModelLegendNode *legendNode( const QgsLayerTreeModel &model, const QString &rule );
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetlegendgraphics.h
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.h
@@ -18,6 +18,9 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include "qgslayertreemodel.h"
+
+#include "qgswmsrendercontext.h"
 
 namespace QgsWms
 {
@@ -30,8 +33,8 @@ namespace QgsWms
                                QgsServerResponse &response );
 
   void checkParameters( const QgsWmsParameters &parameters );
+
+  QgsLayerTreeModel *legendModel( const QgsWmsRenderContext &context, QgsLayerTree &tree );
+
+  QgsLayerTree *layerTree( const QgsWmsRenderContext &context );
 } // namespace QgsWms
-
-
-
-

--- a/src/server/services/wms/qgswmsgetlegendgraphics.h
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.h
@@ -38,5 +38,5 @@ namespace QgsWms
 
   QgsLayerTree *layerTree( const QgsWmsRenderContext &context );
 
-  QgsLayerTreeModelLegendNode *legendNode( const QgsLayerTreeModel &model, const QString &rule );
+  QgsLayerTreeModelLegendNode *legendNode( const QString &rule, QgsLayerTreeModel &model );
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetlegendgraphics.h
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.h
@@ -29,6 +29,7 @@ namespace QgsWms
                                const QString &version, const QgsServerRequest &request,
                                QgsServerResponse &response );
 
+  void checkParameters( const QgsWmsParameters &parameters );
 } // namespace QgsWms
 
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -129,15 +129,6 @@ namespace QgsWms
 
   QImage *QgsRenderer::getLegendGraphics()
   {
-    // check parameters
-    if ( mWmsParameters.allLayersNickname().isEmpty() )
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
-                                    mWmsParameters[QgsWmsParameter::LAYERS] );
-
-    if ( mWmsParameters.format() == QgsWmsParameters::Format::NONE )
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
-                                    mWmsParameters[QgsWmsParameter::FORMAT] );
-
     // get layers
     std::unique_ptr<QgsLayerRestorer> restorer;
     restorer.reset( new QgsLayerRestorer( mContext.layers() ) );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -734,11 +734,7 @@ namespace QgsWms
   QImage *QgsRenderer::getMap( QgsMapSettings &mapSettings, HitTest *hitTest )
   {
     // check size
-    if ( !checkMaximumWidthHeight() )
-    {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
-                                    QStringLiteral( "The requested map size is too large" ) );
-    }
+    checkMaximumWidthHeight();
 
     // init layer restorer before doing anything
     std::unique_ptr<QgsLayerRestorer> restorer;
@@ -1859,7 +1855,7 @@ namespace QgsWms
     }
   }
 
-  bool QgsRenderer::checkMaximumWidthHeight() const
+  void QgsRenderer::checkMaximumWidthHeight() const
   {
     //test if maxWidth / maxHeight are set in the project or as an env variable
     //and WIDTH / HEIGHT parameter is in the range allowed range
@@ -1881,7 +1877,8 @@ namespace QgsWms
     int width = this->width();
     if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
     {
-      return false;
+      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+                                    QStringLiteral( "The requested map width is too large" ) );
     }
 
     //HEIGHT
@@ -1902,7 +1899,8 @@ namespace QgsWms
     int height = this->height();
     if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
     {
-      return false;
+      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+                                    QStringLiteral( "The requested map height is too large" ) );
     }
 
 
@@ -1929,9 +1927,10 @@ namespace QgsWms
          || height <= 0
          || std::numeric_limits<int>::max() / static_cast<uint>( bytes_per_line ) < static_cast<uint>( height )
          || std::numeric_limits<int>::max() / sizeof( uchar * ) < static_cast<uint>( height ) )
-      return false;
-
-    return true;
+    {
+      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+                                    QStringLiteral( "The requested map size is too large" ) );
+    }
   }
 
   void QgsRenderer::convertFeatureInfoToSia2045( QDomDocument &doc ) const

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -218,7 +218,7 @@ namespace QgsWms
       /**
        * Checks WIDTH/HEIGHT values against MaxWidth and MaxHeight
         \returns true if width/height values are okay*/
-      bool checkMaximumWidthHeight() const;
+      void checkMaximumWidthHeight() const;
 
       //! Converts a feature info xml document to SIA2045 norm
       void convertFeatureInfoToSia2045( QDomDocument &doc ) const;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -77,15 +77,30 @@ namespace QgsWms
       ~QgsRenderer();
 
       /**
-       * Returns the map legend as an image (or NULLPTR in case of error). The caller takes ownership
-      of the image object*/
+       * Returns the map legend as an image (or NULLPTR in case of error). The
+       * caller takes ownership of the image object.
+       * \param model The layer tree model to use for building the legend
+       * \returns the legend as an image
+       * \since QGIS 3.8
+       */
       QImage *getLegendGraphics( QgsLayerTreeModel &model );
 
+      /**
+       * Returns the map legend as an image (or NULLPTR in case of error). The
+       * caller takes ownership of the image object.
+       * \param nodeModel The node model to use for building the legend
+       * \returns the legend as an image
+       * \since QGIS 3.8
+       */
       QImage *getLegendGraphics( QgsLayerTreeModelLegendNode &nodeModel );
 
       typedef QSet<QString> SymbolSet;
       typedef QHash<QgsVectorLayer *, SymbolSet> HitTest;
 
+      /**
+       * Returns the hit test according to the current context.
+       * \since QGIS 3.8
+       */
       HitTest symbols();
 
       /**

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -83,6 +83,8 @@ namespace QgsWms
       typedef QSet<QString> SymbolSet;
       typedef QHash<QgsVectorLayer *, SymbolSet> HitTest;
 
+      HitTest symbols();
+
       /**
        * Returns the map as an image (or NULLPTR in case of error). The caller takes ownership
       of the image object). If an instance to existing hit test structure is passed, instead of rendering

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -24,6 +24,7 @@
 #include "qgswmsparameters.h"
 #include "qgswmsrendercontext.h"
 #include "qgsfeaturefilter.h"
+#include "qgslayertreemodellegendnode.h"
 #include <QDomDocument>
 #include <QMap>
 #include <QString>
@@ -79,6 +80,10 @@ namespace QgsWms
        * Returns the map legend as an image (or NULLPTR in case of error). The caller takes ownership
       of the image object*/
       QImage *getLegendGraphics();
+
+      QImage *getLegendGraphics( QgsLayerTreeModel &model );
+
+      QImage *getLegendGraphics( QgsLayerTreeModelLegendNode &node );
 
       typedef QSet<QString> SymbolSet;
       typedef QHash<QgsVectorLayer *, SymbolSet> HitTest;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -79,11 +79,9 @@ namespace QgsWms
       /**
        * Returns the map legend as an image (or NULLPTR in case of error). The caller takes ownership
       of the image object*/
-      QImage *getLegendGraphics();
-
       QImage *getLegendGraphics( QgsLayerTreeModel &model );
 
-      QImage *getLegendGraphics( QgsLayerTreeModelLegendNode &node );
+      QImage *getLegendGraphics( QgsLayerTreeModelLegendNode &nodeModel );
 
       typedef QSet<QString> SymbolSet;
       typedef QHash<QgsVectorLayer *, SymbolSet> HitTest;
@@ -150,9 +148,6 @@ namespace QgsWms
 
       // Scale image with WIDTH/HEIGHT if necessary
       QImage *scaleImage( const QImage *image ) const;
-
-      // Build a layer tree model for legend
-      QgsLayerTreeModel *buildLegendTreeModel( const QList<QgsMapLayer *> &layers, double scaleDenominator, QgsLayerTree &rootGroup );
 
       /**
        * Creates a QImage from the HEIGHT and WIDTH parameters

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -104,15 +104,11 @@ namespace QgsWms
       HitTest symbols();
 
       /**
-       * Returns the map as an image (or NULLPTR in case of error). The caller takes ownership
-      of the image object). If an instance to existing hit test structure is passed, instead of rendering
-      it will fill the structure with symbols that would be used for rendering */
-      QImage *getMap( HitTest *hitTest = nullptr );
-
-      /**
-       * Identical to getMap( HitTest* hitTest ) and updates the map settings actually used.
-        \since QGIS 3.0 */
-      QImage *getMap( QgsMapSettings &mapSettings, HitTest *hitTest = nullptr );
+       * Returns the map as an image (or NULLPTR in case of error). The caller
+       * takes ownership of the image object).
+       * \since QGIS 3.8
+       */
+      QImage *getMap();
 
       /**
        * Returns the map as DXF data
@@ -141,7 +137,7 @@ namespace QgsWms
       QList<QgsMapLayer *> externalLayers( const QList<QgsWmsParametersExternalLayer> &params );
 
       // Rendering step for layers
-      QPainter *layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest = nullptr ) const;
+      QPainter *layersRendering( const QgsMapSettings &mapSettings, QImage &image ) const;
 
       // Rendering step for annotations
       void annotationsRendering( QPainter *painter ) const;

--- a/tests/src/python/test_qgsserver_wms_getmap_size_project.py
+++ b/tests/src/python/test_qgsserver_wms_getmap_size_project.py
@@ -45,7 +45,7 @@ class TestQgsServerWMSGetMapSizeProject(QgsServerTestBase):
         os.environ['QGIS_SERVER_WMS_MAX_HEIGHT'] = '6000'
         super(TestQgsServerWMSGetMapSizeProject, self).setUp()
         self.project = os.path.join(self.testdata_path, "test_project_with_size.qgs")
-        self.expected_too_big = self.strip_version_xmlns(b'<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">\n <ServiceException code="InvalidParameterValue">The requested map size is too large</ServiceException>\n</ServiceExceptionReport>\n')
+        self.expected_too_big = self.strip_version_xmlns(b'<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">\n <ServiceException code="InvalidParameterValue">The requested map height is too large</ServiceException>\n</ServiceExceptionReport>\n')
 
     def test_wms_getmap_invalid_size_project(self):
         # test the 6000 limit from server is overridden by the more conservative 5000 in the project

--- a/tests/src/python/test_qgsserver_wms_getmap_size_server.py
+++ b/tests/src/python/test_qgsserver_wms_getmap_size_server.py
@@ -43,7 +43,7 @@ class TestQgsServerWMSGetMapSizeServer(QgsServerTestBase):
         os.environ['QGIS_SERVER_WMS_MAX_HEIGHT'] = '3000'
         super(TestQgsServerWMSGetMapSizeServer, self).setUp()
         self.project = os.path.join(self.testdata_path, "test_project_with_size.qgs")
-        self.expected_too_big = self.strip_version_xmlns(b'<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">\n <ServiceException code="InvalidParameterValue">The requested map size is too large</ServiceException>\n</ServiceExceptionReport>\n')
+        self.expected_too_big = self.strip_version_xmlns(b'<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">\n <ServiceException code="InvalidParameterValue">The requested map height is too large</ServiceException>\n</ServiceExceptionReport>\n')
 
     def test_wms_getmap_invalid_size_server(self):
         # test the 3000 limit from server is overriding the less conservative 5000 in the project


### PR DESCRIPTION
## Description

The underlying idea is to simplify the WMS renderer by separating responsibilities. For example, every function/method dedicated to the `GetLegendGraphics` request should be moved in `qgswmsgetlegendgraphics.cpp` instead of being within the renderer itself.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
