### PR TITLE
remove forcing Night Mapping theme

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3283,17 +3283,6 @@ void QgisApp::setTheme( const QString &themeName )
   */
 
   QString theme = themeName;
-#ifdef Q_OS_MAC
-#if QT_VERSION < QT_VERSION_CHECK( 5, 12, 0 )
-  if ( theme == QStringLiteral( "default" ) &&
-       QgsGui::instance()->nativePlatformInterface()->hasDarkTheme() )
-  {
-    QString darkTheme = QStringLiteral( "Night Mapping" );
-    if ( QgsApplication::uiThemes().contains( darkTheme ) )
-      theme = darkTheme;
-  }
-#endif
-#endif
 
   mStyleSheetBuilder->buildStyleSheet( mStyleSheetBuilder->defaultOptions() );
   QgsApplication::setUITheme( theme );


### PR DESCRIPTION
This hack was introduced when Qt had poor support of Mac Dark Theme so that the combination of the default QGIS theme and Dark Theme on the OS was forcing to use QGIS Night Mapping theme.
Since Qt 5.12, it does look good and it's the last Qt LTS version.

