### PR TITLE
Fix grammer errors in GEOWKT string

### DIFF
--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -53,14 +53,14 @@ const QString GEOWKT =
   "GEOGCS[\"WGS 84\", "
   "  DATUM[\"WGS_1984\", "
   "    SPHEROID[\"WGS 84\",6378137,298.257223563, "
-  "      AUTHORITY[\"EPSG\",7030]], "
+  "      AUTHORITY[\"EPSG\",\"7030\"]], "
   "    TOWGS84[0,0,0,0,0,0,0], "
-  "    AUTHORITY[\"EPSG\",6326]], "
-  "  PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",8901]], "
-  "  UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",9108]], "
+  "    AUTHORITY[\"EPSG\",\"6326\"]], "
+  "  PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]], "
+  "  UNIT[\"DMSH\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9108\"]], "
   "  AXIS[\"Lat\",NORTH], "
   "  AXIS[\"Long\",EAST], "
-  "  AUTHORITY[\"EPSG\",4326]]";
+  "  AUTHORITY[\"EPSG\",\"4326\"]]";
 
 const QString PROJECT_SCALES =
   "1:1000000,1:500000,1:250000,1:100000,1:50000,1:25000,"


### PR DESCRIPTION
OSRImportFromWkt is fine with the current one, but proj_create_from_wkt isn't happy with having the numeric code values.