### PR TITLE
[Backport release-3_6] of SRCHEIGHT/SRCWIDTH for GetLegendGraphic request

### DIFF
--- a/python/core/auto_generated/qgslegendsettings.sip.in
+++ b/python/core/auto_generated/qgslegendsettings.sip.in
@@ -200,7 +200,7 @@ Returns the factor of map units per pixel for symbols with size given in map uni
 
 .. seealso:: :py:func:`setMapUnitsPerPixel`
 
-.. versionadded:: 3.8
+.. versionadded:: 3.4
 %End
 
     void setMapUnitsPerPixel( double mapUnitsPerPixel );
@@ -209,7 +209,7 @@ Sets the mmPerMapUnit calculated by ``mapUnitsPerPixel`` mostly taken from the m
 
 .. seealso:: :py:func:`mapUnitsPerPixel`
 
-.. versionadded:: 3.8
+.. versionadded:: 3.4
 %End
 
     int dpi() const;

--- a/src/core/qgslegendsettings.h
+++ b/src/core/qgslegendsettings.h
@@ -181,14 +181,14 @@ class CORE_EXPORT QgsLegendSettings
     /**
      * Returns the factor of map units per pixel for symbols with size given in map units calculated by dpi and mmPerMapUnit
      * \see setMapUnitsPerPixel()
-     * \since QGIS 3.8
+     * \since QGIS 3.4
      */
     double mapUnitsPerPixel() const;
 
     /**
      * Sets the mmPerMapUnit calculated by \a mapUnitsPerPixel mostly taken from the map settings.
      * \see mapUnitsPerPixel()
-     * \since QGIS 3.8
+     * \since QGIS 3.4
      */
     void setMapUnitsPerPixel( double mapUnitsPerPixel );
 

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -359,6 +359,16 @@ namespace QgsWms
                                   QVariant( 0 ) );
     save( pWidth );
 
+    const QgsWmsParameter pSrcHeight( QgsWmsParameter::SRCHEIGHT,
+                                      QVariant::Int,
+                                      QVariant( 0 ) );
+    save( pSrcHeight );
+
+    const QgsWmsParameter pSrcWidth( QgsWmsParameter::SRCWIDTH,
+                                     QVariant::Int,
+                                     QVariant( 0 ) );
+    save( pSrcWidth );
+
     const QgsWmsParameter pBbox( QgsWmsParameter::BBOX );
     save( pBbox );
 
@@ -676,6 +686,26 @@ namespace QgsWms
   int QgsWmsParameters::widthAsInt() const
   {
     return mWmsParameters[ QgsWmsParameter::WIDTH ].toInt();
+  }
+
+  QString QgsWmsParameters::srcHeight() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCHEIGHT ].toString();
+  }
+
+  QString QgsWmsParameters::srcWidth() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCWIDTH ].toString();
+  }
+
+  int QgsWmsParameters::srcHeightAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCHEIGHT ].toInt();
+  }
+
+  int QgsWmsParameters::srcWidthAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCWIDTH ].toInt();
   }
 
   QString QgsWmsParameters::dpi() const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -372,7 +372,7 @@ namespace QgsWms
       /**
        * Returns SRCWIDTH parameter or an empty string if not defined.
        * \returns srcWidth parameter
-       * \since QGIS 3.8
+       * \since QGIS 3.4
        */
       QString srcWidth() const;
 
@@ -382,14 +382,14 @@ namespace QgsWms
        * converted.
        * \returns srcWidth parameter
        * \throws QgsBadRequestException
-       * \since QGIS 3.8
+       * \since QGIS 3.4
        */
       int srcWidthAsInt() const;
 
       /**
        * Returns SRCHEIGHT parameter or an empty string if not defined.
        * \returns srcHeight parameter
-       * \since QGIS 3.8
+       * \since QGIS 3.4
        */
       QString srcHeight() const;
 
@@ -399,7 +399,7 @@ namespace QgsWms
        * converted.
        * \returns srcHeight parameter
        * \throws QgsBadRequestException
-       * \since QGIS 3.8
+       * \since QGIS 3.4
        */
       int srcHeightAsInt() const;
 

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -167,7 +167,9 @@ namespace QgsWms
         WITH_GEOMETRY,
         WITH_MAPTIP,
         WMTVER,
-        ATLAS_PK
+        ATLAS_PK,
+        SRCWIDTH,
+        SRCHEIGHT
       };
       Q_ENUM( Name )
 
@@ -366,6 +368,40 @@ namespace QgsWms
        * \throws QgsBadRequestException
        */
       int heightAsInt() const;
+
+      /**
+       * Returns SRCWIDTH parameter or an empty string if not defined.
+       * \returns srcWidth parameter
+       * \since QGIS 3.8
+       */
+      QString srcWidth() const;
+
+      /**
+       * Returns SRCWIDTH parameter as an int or its default value if not
+       * defined. An exception is raised if SRCWIDTH is defined and cannot be
+       * converted.
+       * \returns srcWidth parameter
+       * \throws QgsBadRequestException
+       * \since QGIS 3.8
+       */
+      int srcWidthAsInt() const;
+
+      /**
+       * Returns SRCHEIGHT parameter or an empty string if not defined.
+       * \returns srcHeight parameter
+       * \since QGIS 3.8
+       */
+      QString srcHeight() const;
+
+      /**
+       * Returns SRCHEIGHT parameter as an int or its default value if not
+       * defined. An exception is raised if SRCHEIGHT is defined and cannot be
+       * converted.
+       * \returns srcHeight parameter
+       * \throws QgsBadRequestException
+       * \since QGIS 3.8
+       */
+      int srcHeightAsInt() const;
 
       /**
        * Returns VERSION parameter if defined or its default value.

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -187,7 +187,7 @@ namespace QgsWms
     if ( !mWmsParameters.bbox().isEmpty() )
     {
       QgsMapSettings mapSettings;
-      image.reset( createImage( mWmsParameters.widthAsInt(), mWmsParameters.heightAsInt(), false ) );
+      image.reset( createImage( width(), height(), false ) );
       configureMapSettings( image.get(), mapSettings );
       legendSettings.setMapScale( mapSettings.scale() );
       legendSettings.setMapUnitsPerPixel( mapSettings.mapUnitsPerPixel() );
@@ -1151,10 +1151,10 @@ namespace QgsWms
   QImage *QgsRenderer::createImage( int width, int height, bool useBbox ) const
   {
     if ( width < 0 )
-      width = mWmsParameters.widthAsInt();
+      width = this->width();
 
     if ( height < 0 )
-      height = mWmsParameters.heightAsInt();
+      height = this->height();
 
     //Adapt width / height if the aspect ratio does not correspond with the BBOX.
     //Required by WMS spec. 1.3.
@@ -2055,14 +2055,14 @@ namespace QgsWms
   {
     //test if maxWidth / maxHeight set and WIDTH / HEIGHT parameter is in the range
     int wmsMaxWidth = QgsServerProjectUtils::wmsMaxWidth( *mProject );
-    int width = mWmsParameters.widthAsInt();
+    int width = this->width();
     if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
     {
       return false;
     }
 
     int wmsMaxHeight = QgsServerProjectUtils::wmsMaxHeight( *mProject );
-    int height = mWmsParameters.heightAsInt();
+    int height = this->height();
     if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
     {
       return false;
@@ -3277,8 +3277,8 @@ namespace QgsWms
     // WIDTH / HEIGHT parameters. If not, the image has to be scaled (required
     // by WMS spec)
     QImage *scaledImage = nullptr;
-    int width = mWmsParameters.widthAsInt();
-    int height = mWmsParameters.heightAsInt();
+    int width = this->width();
+    int height = this->height();
     if ( width != image->width() || height != image->height() )
     {
       scaledImage = new QImage( image->scaled( width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) );
@@ -3515,5 +3515,22 @@ namespace QgsWms
     return result;
   }
 
+  int QgsRenderer::height() const
+  {
+    if ( ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
+           mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) == 0 ) &&
+         mWmsParameters.srcHeightAsInt() > 0 )
+      return mWmsParameters.srcHeightAsInt();
+    return mWmsParameters.heightAsInt();
+  }
+
+  int QgsRenderer::width() const
+  {
+    if ( ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
+           mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) == 0 ) &&
+         mWmsParameters.srcWidthAsInt() > 0 )
+      return mWmsParameters.srcWidthAsInt();
+    return mWmsParameters.widthAsInt();
+  }
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -294,14 +294,14 @@ namespace QgsWms
       /**
        * Returns QgsWmsParameter SRCWIDTH if it's a GetLegendGraphics request and otherwise HEIGHT parameter
        * \returns height parameter
-       * \since QGIS 3.4.7
+       * \since QGIS 3.4
        */
       int height() const;
 
       /**
        * Returns QgsWmsParameter SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
        * \returns width parameter
-       * \since QGIS 3.4.7
+       * \since QGIS 3.4
        */
       int width() const;
 

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -294,14 +294,14 @@ namespace QgsWms
       /**
        * Returns QgsWmsParameter SRCWIDTH if it's a GetLegendGraphics request and otherwise HEIGHT parameter
        * \returns height parameter
-       * \since QGIS 3.8
+       * \since QGIS 3.4.7
        */
       int height() const;
 
       /**
        * Returns QgsWmsParameter SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
        * \returns width parameter
-       * \since QGIS 3.8
+       * \since QGIS 3.4.7
        */
       int width() const;
 

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -291,7 +291,19 @@ namespace QgsWms
 
       void handlePrintErrors( const QgsLayout *layout ) const;
 
-    private:
+      /**
+       * Returns QgsWmsParameter SRCWIDTH if it's a GetLegendGraphics request and otherwise HEIGHT parameter
+       * \returns height parameter
+       * \since QGIS 3.8
+       */
+      int height() const;
+
+      /**
+       * Returns QgsWmsParameter SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
+       * \returns width parameter
+       * \since QGIS 3.8
+       */
+      int width() const;
 
       const QgsWmsParameters &mWmsParameters;
 

--- a/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
@@ -468,6 +468,42 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "LAYER": "Country,Hello,db_point",
             "LAYERTITLE": "FALSE",
             "FORMAT": "image/png",
+            "SRCHEIGHT": "500",
+            "SRCWIDTH": "500",
+            "BBOX": "-151.7,-38.9,51.0,78.0",
+            "CRS": "EPSG:4326"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetLegendGraphic_BBox")
+
+    def test_wms_GetLegendGraphic_BBox2(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetLegendGraphic",
+            "LAYER": "Country,Hello,db_point",
+            "LAYERTITLE": "FALSE",
+            "FORMAT": "image/png",
+            "SRCHEIGHT": "500",
+            "SRCWIDTH": "500",
+            "BBOX": "-76.08,-6.4,-19.38,38.04",
+            "SRS": "EPSG:4326"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetLegendGraphic_BBox2")
+
+    def test_wms_GetLegendGraphic_BBox_Fallback(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetLegendGraphic",
+            "LAYER": "Country,Hello,db_point",
+            "LAYERTITLE": "FALSE",
+            "FORMAT": "image/png",
             "HEIGHT": "500",
             "WIDTH": "500",
             "BBOX": "-151.7,-38.9,51.0,78.0",
@@ -477,7 +513,7 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetLegendGraphic_BBox")
 
-    def test_wms_GetLegendGraphic_BBox2(self):
+    def test_wms_GetLegendGraphic_BBox2_Fallback(self):
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": urllib.parse.quote(self.projectPath),
             "SERVICE": "WMS",
@@ -503,8 +539,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "QGIS%20Server%20Hello%20World",
             "FORMAT": "image/png",
-            "HEIGHT": "840",
-            "WIDTH": "1226",
+            "SRCHEIGHT": "840",
+            "SRCWIDTH": "1226",
             "BBOX": "10.38450,-49.6370,73.8183,42.9461",
             "SRS": "EPSG:4326",
             "SCALE": "15466642"
@@ -525,8 +561,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "QGIS%20Server%20-%20Grouped%20Layer",
             "FORMAT": "image/png",
-            "HEIGHT": "840",
-            "WIDTH": "1226",
+            "SRCHEIGHT": "840",
+            "SRCWIDTH": "1226",
             "BBOX": "609152,5808188,625492,5814318",
             "SRS": "EPSG:25832",
             "SCALE": "38976"
@@ -544,8 +580,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "All_grouped_layers",
             "FORMAT": "image/png",
-            "HEIGHT": "840",
-            "WIDTH": "1226",
+            "SRCHEIGHT": "840",
+            "SRCWIDTH": "1226",
             "BBOX": "609152,5808188,625492,5814318",
             "SRS": "EPSG:25832",
             "SCALE": "38976"
@@ -563,8 +599,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "-608.4,-1002.6,698.2,1019.0",
             "CRS": "EPSG:4326"
         }.items())])
@@ -579,8 +615,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "-1261.7,-2013.5,1351.5,2029.9",
             "CRS": "EPSG:4326"
         }.items())])
@@ -596,8 +632,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "31.8,-12.0,58.0,28.4",
             "CRS": "EPSG:4326"
         }.items())])
@@ -613,8 +649,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "25.3,-22.1,64.5,38.5",
             "CRS": "EPSG:4326"
         }.items())])
@@ -630,8 +666,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "44.8,8.0,45.0,8.4",
             "CRS": "EPSG:4326"
         }.items())])
@@ -646,8 +682,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "43.6,6.2,46.2,10.2",
             "CRS": "EPSG:4326"
         }.items())])


### PR DESCRIPTION
It takes these values as map size in case of GetLegendGraphics Request and still HEIGHT and WIDTH if not a GetLegendGraphics Request.

Backport of #9545