### PR TITLE
Fix "\since" comment because of backporting

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -264,14 +264,14 @@ namespace QgsWms
       /**
        * Returns QgsWmsParameter SRCWIDTH if it's a GetLegendGraphics request and otherwise HEIGHT parameter
        * \returns height parameter
-       * \since QGIS 3.8
+       * \since QGIS 3.4.7
        */
       int height() const;
 
       /**
        * Returns QgsWmsParameter SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
        * \returns width parameter
-       * \since QGIS 3.8
+       * \since QGIS 3.4.7
        */
       int width() const;
 


### PR DESCRIPTION
Because of porting this #9545 back to 3.4 with #9726