### PR TITLE
Qgis as a namespace

### DIFF
--- a/external/libdxfrw/CMakeLists.txt
+++ b/external/libdxfrw/CMakeLists.txt
@@ -5,7 +5,8 @@ INCLUDE_DIRECTORIES(
         ${CMAKE_BINARY_DIR}/src/core
         ${CMAKE_BINARY_DIR}/src/core/geometry
 
-	${Qt5Core_INCLUDE_DIRS}
+        ${Qt5Core_INCLUDE_DIRS}
+        ${Qt5Gui_INCLUDE_DIRS}
 )
 
 ADD_LIBRARY(libdxfrw STATIC

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 %ModuleHeaderCode
 #include <qgis.h>
 %End
@@ -19,68 +20,60 @@ int QgisEvent = QEvent::User + 1;
 %End
 
 
-class Qgis
+namespace Qgis
 {
-%Docstring
-The Qgis class provides global constants for use throughout the application.
-%End
-
-%TypeHeaderCode
-#include "qgis.h"
-%End
-  public:
-    static const QString QGIS_VERSION;
-    static const int QGIS_VERSION_INT;
-    static const QString QGIS_RELEASE_NAME;
-    static const char *QGIS_DEV_VERSION;
+  const QString QGIS_VERSION;
+  const int QGIS_VERSION_INT;
+  const QString QGIS_RELEASE_NAME;
+  const QString QGIS_DEV_VERSION;
 
 
-    enum MessageLevel
-    {
-      Info,
-      Warning,
-      Critical,
-      Success,
-      None
-    };
+  enum MessageLevel
+  {
+    Info,
+    Warning,
+    Critical,
+    Success,
+    None
+  };
 
-    enum DataType
-    {
-      UnknownDataType,
-      Byte,
-      UInt16,
-      Int16,
-      UInt32,
-      Int32,
-      Float32,
-      Float64,
-      CInt16,
-      CInt32,
-      CFloat32,
-      CFloat64,
-      ARGB32,
-      ARGB32_Premultiplied
-    };
+  enum DataType
+  {
+    UnknownDataType,
+    Byte,
+    UInt16,
+    Int16,
+    UInt32,
+    Int32,
+    Float32,
+    Float64,
+    CInt16,
+    CInt32,
+    CFloat32,
+    CFloat64,
+    ARGB32,
+    ARGB32_Premultiplied
+  };
 
-    static const double DEFAULT_SEARCH_RADIUS_MM;
+  const double DEFAULT_SEARCH_RADIUS_MM;
 
-    static const float DEFAULT_MAPTOPIXEL_THRESHOLD;
+  const float DEFAULT_MAPTOPIXEL_THRESHOLD;
 
-    static const QColor DEFAULT_HIGHLIGHT_COLOR;
+  const QColor DEFAULT_HIGHLIGHT_COLOR;
 
-    static const double DEFAULT_HIGHLIGHT_BUFFER_MM;
+  const double DEFAULT_HIGHLIGHT_BUFFER_MM;
 
-    static const double DEFAULT_HIGHLIGHT_MIN_WIDTH_MM;
+  const double DEFAULT_HIGHLIGHT_MIN_WIDTH_MM;
 
-    static const double SCALE_PRECISION;
+  const double SCALE_PRECISION;
 
-    static const double DEFAULT_Z_COORDINATE;
+  const double DEFAULT_Z_COORDINATE;
 
-    static const double UI_SCALE_FACTOR;
+  const double UI_SCALE_FACTOR;
 
-    static const double DEFAULT_SNAP_TOLERANCE;
+  const double DEFAULT_SNAP_TOLERANCE;
 
-    static const QgsTolerance::UnitType DEFAULT_SNAP_UNITS;
+  const QgsTolerance::UnitType DEFAULT_SNAP_UNITS;
 };
 
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -19,6 +19,7 @@
 #ifndef QGSVERSION
 #include "qgsversion.h"
 #endif
+
 #include <QCoreApplication>
 #include <QColor>
 #include <QDate>
@@ -30,22 +31,6 @@
 #include "qgswkbtypes.h"
 
 #include <ogr_api.h>
-
-// Version constants
-//
-
-// Version string
-const QString Qgis::QGIS_VERSION( QStringLiteral( VERSION ) );
-
-// development version
-const char *Qgis::QGIS_DEV_VERSION = QGSVERSION;
-
-// Version number used for comparing versions using the
-// "Check QGIS Version" function
-const int Qgis::QGIS_VERSION_INT = VERSION_INT;
-
-// Release name
-const QString Qgis::QGIS_RELEASE_NAME( QStringLiteral( RELEASE_NAME ) );
 
 const QString GEOPROJ4 = QStringLiteral( "+proj=longlat +datum=WGS84 +no_defs" );
 
@@ -69,30 +54,6 @@ const QString PROJECT_SCALES =
 const QString GEO_EPSG_CRS_AUTHID = QStringLiteral( "EPSG:4326" );
 
 const QString GEO_NONE = QStringLiteral( "NONE" );
-
-const double Qgis::DEFAULT_SEARCH_RADIUS_MM = 2.;
-
-const float Qgis::DEFAULT_MAPTOPIXEL_THRESHOLD = 1.0f;
-
-const QColor Qgis::DEFAULT_HIGHLIGHT_COLOR = QColor( 255, 0, 0, 128 );
-
-const double Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM = 0.5;
-
-const double Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM = 1.0;
-
-const double Qgis::SCALE_PRECISION = 0.9999999999;
-
-const double Qgis::DEFAULT_Z_COORDINATE = 0.0;
-
-const double Qgis::DEFAULT_SNAP_TOLERANCE = 12.0;
-
-const QgsTolerance::UnitType Qgis::DEFAULT_SNAP_UNITS = QgsTolerance::Pixels;
-
-#ifdef Q_OS_WIN
-const double Qgis::UI_SCALE_FACTOR = 1.5;
-#else
-const double Qgis::UI_SCALE_FACTOR = 1;
-#endif
 
 double qgsPermissiveToDouble( QString string, bool &ok )
 {

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -19,6 +19,7 @@
 #define QGIS_H
 
 #include <QMetaEnum>
+#include <QColor>
 #include <cfloat>
 #include <memory>
 #include <cmath>
@@ -26,6 +27,11 @@
 #include "qgstolerance.h"
 #include "qgis_core.h"
 #include "qgis_sip.h"
+
+#ifndef QGSVERSION
+#include "qgsversion.h"
+#endif
+#include "qgsconfig.h"
 
 #ifdef SIP_RUN
 % ModuleHeaderCode
@@ -42,113 +48,116 @@ int QgisEvent = QEvent::User + 1;
  * \ingroup core
  * The Qgis class provides global constants for use throughout the application.
  */
-class CORE_EXPORT Qgis
+namespace Qgis
 {
-  public:
-    // Version constants
-    //
-    //! Version string
-    static const QString QGIS_VERSION;
-    //! Version number used for comparing versions using the "Check QGIS Version" function
-    static const int QGIS_VERSION_INT;
-    //! Release name
-    static const QString QGIS_RELEASE_NAME;
-    //! The development version
-    static const char *QGIS_DEV_VERSION;
+  // Version constants
+  //
+  //! Version string
+  const QString QGIS_VERSION = QStringLiteral( VERSION );
+  //! Version number used for comparing versions using the "Check QGIS Version" function
+  const int QGIS_VERSION_INT = VERSION_INT;
+  //! Release name
+  const QString QGIS_RELEASE_NAME = QStringLiteral( RELEASE_NAME );
+  //! The development version
+  const QString QGIS_DEV_VERSION = QStringLiteral( QGSVERSION );
 
-    // Enumerations
-    //
+  // Enumerations
+  //
 
-    /**
-     * \brief Level for messages
-     * This will be used both for message log and message bar in application.
-     */
-    enum MessageLevel
-    {
-      Info = 0,
-      Warning = 1,
-      Critical = 2,
-      Success = 3,
-      None = 4
-    };
+  /**
+   * \brief Level for messages
+   * This will be used both for message log and message bar in application.
+   */
+  enum MessageLevel
+  {
+    Info = 0,
+    Warning = 1,
+    Critical = 2,
+    Success = 3,
+    None = 4
+  };
 
-    /**
-     * Raster data types.
-     *  This is modified and extended copy of GDALDataType.
-     */
-    enum DataType
-    {
-      UnknownDataType = 0, //!< Unknown or unspecified type
-      Byte = 1, //!< Eight bit unsigned integer (quint8)
-      UInt16 = 2, //!< Sixteen bit unsigned integer (quint16)
-      Int16 = 3, //!< Sixteen bit signed integer (qint16)
-      UInt32 = 4, //!< Thirty two bit unsigned integer (quint32)
-      Int32 = 5, //!< Thirty two bit signed integer (qint32)
-      Float32 = 6, //!< Thirty two bit floating point (float)
-      Float64 = 7, //!< Sixty four bit floating point (double)
-      CInt16 = 8, //!< Complex Int16
-      CInt32 = 9, //!< Complex Int32
-      CFloat32 = 10, //!< Complex Float32
-      CFloat64 = 11, //!< Complex Float64
-      ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
-      ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
-    };
+  /**
+   * Raster data types.
+   *  This is modified and extended copy of GDALDataType.
+   */
+  enum DataType
+  {
+    UnknownDataType = 0, //!< Unknown or unspecified type
+    Byte = 1, //!< Eight bit unsigned integer (quint8)
+    UInt16 = 2, //!< Sixteen bit unsigned integer (quint16)
+    Int16 = 3, //!< Sixteen bit signed integer (qint16)
+    UInt32 = 4, //!< Thirty two bit unsigned integer (quint32)
+    Int32 = 5, //!< Thirty two bit signed integer (qint32)
+    Float32 = 6, //!< Thirty two bit floating point (float)
+    Float64 = 7, //!< Sixty four bit floating point (double)
+    CInt16 = 8, //!< Complex Int16
+    CInt32 = 9, //!< Complex Int32
+    CFloat32 = 10, //!< Complex Float32
+    CFloat64 = 11, //!< Complex Float64
+    ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
+    ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
+  };
 
-    /**
-     * Identify search radius in mm
-     *  \since QGIS 2.3 */
-    static const double DEFAULT_SEARCH_RADIUS_MM;
+  /**
+   * Identify search radius in mm
+   *  \since QGIS 2.3 */
+  const double DEFAULT_SEARCH_RADIUS_MM = 2.0;
 
-    //! Default threshold between map coordinates and device coordinates for map2pixel simplification
-    static const float DEFAULT_MAPTOPIXEL_THRESHOLD;
+  //! Default threshold between map coordinates and device coordinates for map2pixel simplification
+  const float DEFAULT_MAPTOPIXEL_THRESHOLD = 1.0f;
 
-    /**
-     * Default highlight color.  The transparency is expected to only be applied to polygon
-     *  fill. Lines and outlines are rendered opaque.
-     *  \since QGIS 2.3 */
-    static const QColor DEFAULT_HIGHLIGHT_COLOR;
+  /**
+   * Default highlight color.  The transparency is expected to only be applied to polygon
+   *  fill. Lines and outlines are rendered opaque.
+   *  \since QGIS 2.3 */
+  const QColor DEFAULT_HIGHLIGHT_COLOR = QColor( 255, 0, 0, 128 );
 
-    /**
-     * Default highlight buffer in mm.
-     *  \since QGIS 2.3 */
-    static const double DEFAULT_HIGHLIGHT_BUFFER_MM;
+  /**
+   * Default highlight buffer in mm.
+   *  \since QGIS 2.3 */
+  const double DEFAULT_HIGHLIGHT_BUFFER_MM = 0.5;
 
-    /**
-     * Default highlight line/stroke minimum width in mm.
-     *  \since QGIS 2.3 */
-    static const double DEFAULT_HIGHLIGHT_MIN_WIDTH_MM;
+  /**
+   * Default highlight line/stroke minimum width in mm.
+   *  \since QGIS 2.3 */
+  const double DEFAULT_HIGHLIGHT_MIN_WIDTH_MM = 1.0;
 
-    /**
-     * Fudge factor used to compare two scales. The code is often going from scale to scale
-     *  denominator. So it looses precision and, when a limit is inclusive, can lead to errors.
-     *  To avoid that, use this factor instead of using <= or >=.
-     * \since QGIS 2.15*/
-    static const double SCALE_PRECISION;
+  /**
+   * Fudge factor used to compare two scales. The code is often going from scale to scale
+   *  denominator. So it looses precision and, when a limit is inclusive, can lead to errors.
+   *  To avoid that, use this factor instead of using <= or >=.
+   * \since QGIS 2.15*/
+  const double SCALE_PRECISION = 0.9999999999;
 
-    /**
-     * Default Z coordinate value for 2.5d geometry
-     *  This value have to be assigned to the Z coordinate for the new 2.5d geometry vertex.
-     *  \since QGIS 3.0 */
-    static const double DEFAULT_Z_COORDINATE;
+  /**
+   * Default Z coordinate value for 2.5d geometry
+   *  This value have to be assigned to the Z coordinate for the new 2.5d geometry vertex.
+   *  \since QGIS 3.0 */
+  const double DEFAULT_Z_COORDINATE = 0.0;
 
-    /**
-     * UI scaling factor. This should be applied to all widget sizes obtained from font metrics,
-     * to account for differences in the default font sizes across different platforms.
-     *  \since QGIS 3.0
-    */
-    static const double UI_SCALE_FACTOR;
+  /**
+   * UI scaling factor. This should be applied to all widget sizes obtained from font metrics,
+   * to account for differences in the default font sizes across different platforms.
+   *  \since QGIS 3.0
+  */
+#ifdef Q_OS_WIN
+  const double UI_SCALE_FACTOR = 1.5 SIP_SKIP;
+#else
+  const double UI_SCALE_FACTOR = 1;
+#endif
 
-    /**
-     * Default snapping distance tolerance.
-     *  \since QGIS 3.0
-    */
-    static const double DEFAULT_SNAP_TOLERANCE;
+  /**
+   * Default snapping distance tolerance.
+   *  \since QGIS 3.0
+  */
+  const double DEFAULT_SNAP_TOLERANCE = 12.0;
 
-    /**
-     * Default snapping distance units.
-     *  \since QGIS 3.0
-    */
-    static const QgsTolerance::UnitType DEFAULT_SNAP_UNITS;
+  /**
+   * Default snapping distance units.
+   *  \since QGIS 3.0
+  */
+  const QgsTolerance::UnitType DEFAULT_SNAP_UNITS = QgsTolerance::Pixels;
 };
 
 // hack to workaround warnings when casting void pointers


### PR DESCRIPTION
following discussion in #9437 

making Qgis a namespace instead of a class.
We could define general enums in there (like map layer type, or message level which is already there) AND use forward declarations.

I could not have the value defined in the source file and using `extern`. This goes a bit beyond my understanding of compilation and I am not sure about the implications.

some reference: https://stackoverflow.com/questions/42080571/c-referencing-extern-const-within-a-namespace
