### PR TITLE
[processing] Add method to specify additional expression context variables for a parameter

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -459,7 +459,46 @@ the dynamic parameter.
 .. seealso:: :py:func:`setDynamicPropertyDefinition`
 %End
 
+    QStringList additionalExpressionContextVariables() const;
+%Docstring
+Returns a list of additional expression context variables which are available for use when evaluating
+this parameter.
+
+The additional variables will be added to the variables exposed from the usual expression
+context available to the parameter. They can be used to expose variables which are ONLY available
+to this parameter.
+
+The returned list should contain the variable names only, without the usual "@" prefix.
+
+.. seealso:: :py:func:`setAdditionalExpressionContextVariables`
+
+.. versionadded:: 3.8
+%End
+
+    void setAdditionalExpressionContextVariables( const QStringList &variables );
+%Docstring
+Sets a list of additional expression context ``variables`` which are available for use when evaluating
+this parameter.
+
+The additional variables will be added to the variables exposed from the usual expression
+context available to the parameter. They can be used to expose variables which are ONLY available
+to this parameter.
+
+The ``variables`` list should contain the variable names only, without the usual "@" prefix.
+
+.. note::
+
+   Specifying variables via this method is for metadata purposes only. It is the algorithm's responsibility
+   to correctly set the value of these additional variables in all expression context used when evaluating the parameter,
+   in whichever way is appropriate for that particular variable.
+
+.. seealso:: :py:func:`additionalExpressionContextVariables`
+
+.. versionadded:: 3.8
+%End
+
   protected:
+
 
 
 

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -450,6 +450,15 @@ variable.
 .. seealso:: :py:func:`isHighlightedFunction`
 %End
 
+    QStringList highlightedVariables() const;
+%Docstring
+Returns the current list of variables highlighted within the context.
+
+.. seealso:: :py:func:`setHighlightedVariables`
+
+.. versionadded:: 3.8
+%End
+
     void setHighlightedVariables( const QStringList &variableNames );
 %Docstring
 Sets the list of variable names within the context intended to be highlighted to the user. This

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -515,6 +515,40 @@ class CORE_EXPORT QgsProcessingParameterDefinition
      */
     void setDynamicLayerParameterName( const QString &name ) { mDynamicLayerParameterName = name; }
 
+    /**
+     * Returns a list of additional expression context variables which are available for use when evaluating
+     * this parameter.
+     *
+     * The additional variables will be added to the variables exposed from the usual expression
+     * context available to the parameter. They can be used to expose variables which are ONLY available
+     * to this parameter.
+     *
+     * The returned list should contain the variable names only, without the usual "@" prefix.
+     *
+     * \see setAdditionalExpressionContextVariables()
+     * \since QGIS 3.8
+     */
+    QStringList additionalExpressionContextVariables() const { return mAdditionalExpressionVariables; }
+
+    /**
+     * Sets a list of additional expression context \a variables which are available for use when evaluating
+     * this parameter.
+     *
+     * The additional variables will be added to the variables exposed from the usual expression
+     * context available to the parameter. They can be used to expose variables which are ONLY available
+     * to this parameter.
+     *
+     * The \a variables list should contain the variable names only, without the usual "@" prefix.
+     *
+     * \note Specifying variables via this method is for metadata purposes only. It is the algorithm's responsibility
+     * to correctly set the value of these additional variables in all expression context used when evaluating the parameter,
+     * in whichever way is appropriate for that particular variable.
+     *
+     * \see additionalExpressionContextVariables()
+     * \since QGIS 3.8
+     */
+    void setAdditionalExpressionContextVariables( const QStringList &variables ) { mAdditionalExpressionVariables = variables; }
+
   protected:
 
     //! Parameter name
@@ -543,6 +577,9 @@ class CORE_EXPORT QgsProcessingParameterDefinition
 
     //! Linked vector layer parameter name for dynamic properties
     QString mDynamicLayerParameterName;
+
+    //! Additional expression context variables exposed for use by this parameter
+    QStringList mAdditionalExpressionVariables;
 
     // To allow access to mAlgorithm. We don't want a public setter for this!
     friend class QgsProcessingAlgorithm;

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -315,6 +315,11 @@ bool QgsExpressionContext::isHighlightedVariable( const QString &name ) const
   return mHighlightedVariables.contains( name );
 }
 
+QStringList QgsExpressionContext::highlightedVariables() const
+{
+  return mHighlightedVariables;
+}
+
 void QgsExpressionContext::setHighlightedVariables( const QStringList &variableNames )
 {
   mHighlightedVariables = variableNames;

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -430,6 +430,14 @@ class CORE_EXPORT QgsExpressionContext
     bool isHighlightedVariable( const QString &name ) const;
 
     /**
+     * Returns the current list of variables highlighted within the context.
+     *
+     * \see setHighlightedVariables()
+     * \since QGIS 3.8
+     */
+    QStringList highlightedVariables() const;
+
+    /**
      * Sets the list of variable names within the context intended to be highlighted to the user. This
      * is used by the expression builder to more prominently display these variables.
      * \param variableNames variable names to highlight

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -235,7 +235,23 @@ void QgsAbstractProcessingParameterWidgetWrapper::postInitialize( const QList<Qg
 
 QgsExpressionContext QgsAbstractProcessingParameterWidgetWrapper::createExpressionContext() const
 {
-  return QgsProcessingGuiUtils::createExpressionContext( mProcessingContextGenerator, mWidgetContext, mParameterDefinition ? mParameterDefinition->algorithm() : nullptr, linkedVectorLayer() );
+  QgsExpressionContext context = QgsProcessingGuiUtils::createExpressionContext( mProcessingContextGenerator, mWidgetContext, mParameterDefinition ? mParameterDefinition->algorithm() : nullptr, linkedVectorLayer() );
+  if ( mParameterDefinition && !mParameterDefinition->additionalExpressionContextVariables().isEmpty() )
+  {
+    std::unique_ptr< QgsExpressionContextScope > paramScope = qgis::make_unique< QgsExpressionContextScope >();
+    const QStringList additional = mParameterDefinition->additionalExpressionContextVariables();
+    for ( const QString &var : additional )
+    {
+      paramScope->setVariable( var, QVariant() );
+    }
+    context.appendScope( paramScope.release() );
+
+    // we always highlight additional variables for visibility
+    QStringList highlighted = context.highlightedVariables();
+    highlighted.append( additional );
+    context.setHighlightedVariables( highlighted );
+  }
+  return context;
 }
 
 void QgsAbstractProcessingParameterWidgetWrapper::setDialog( QDialog * )

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1972,6 +1972,12 @@ void TestQgsProcessing::parameterGeneral()
   param.metadata().insert( "p3", 9 );
   QCOMPARE( param.metadata().value( "p3" ).toInt(), 9 );
 
+  QVERIFY( param.additionalExpressionContextVariables().isEmpty() );
+  param.setAdditionalExpressionContextVariables( QStringList() << "a" << "b" );
+  QCOMPARE( param.additionalExpressionContextVariables(), QStringList() << "a" << "b" );
+  std::unique_ptr< QgsProcessingParameterDefinition > param2( param.clone() );
+  QCOMPARE( param2->additionalExpressionContextVariables(), QStringList() << "a" << "b" );
+
   QVariantMap map = param.toVariantMap();
   QgsProcessingParameterBoolean fromMap( "x" );
   QVERIFY( fromMap.fromVariantMap( map ) );

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -551,12 +551,14 @@ void TestQgsExpressionContext::highlighted()
   QgsExpressionContext context;
   QVERIFY( !context.isHighlightedFunction( QStringLiteral( "x" ) ) );
   QVERIFY( !context.isHighlightedVariable( QStringLiteral( "x" ) ) );
+  QVERIFY( context.highlightedVariables().isEmpty() );
   context.setHighlightedFunctions( QStringList() << QStringLiteral( "x" ) << QStringLiteral( "y" ) );
   QVERIFY( context.isHighlightedFunction( QStringLiteral( "x" ) ) );
   QVERIFY( context.isHighlightedFunction( QStringLiteral( "y" ) ) );
   QVERIFY( !context.isHighlightedFunction( QStringLiteral( "z" ) ) );
   QVERIFY( !context.isHighlightedVariable( QStringLiteral( "x" ) ) );
   context.setHighlightedVariables( QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
+  QCOMPARE( context.highlightedVariables(), QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
   QVERIFY( context.isHighlightedVariable( QStringLiteral( "a" ) ) );
   QVERIFY( context.isHighlightedVariable( QStringLiteral( "b" ) ) );
   QVERIFY( !context.isHighlightedVariable( QStringLiteral( "c" ) ) );
@@ -565,6 +567,7 @@ void TestQgsExpressionContext::highlighted()
   context.setHighlightedVariables( QStringList() );
   QVERIFY( !context.isHighlightedFunction( QStringLiteral( "x" ) ) );
   QVERIFY( !context.isHighlightedVariable( QStringLiteral( "a" ) ) );
+  QVERIFY( context.highlightedVariables().isEmpty() );
 }
 
 void TestQgsExpressionContext::globalScope()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -360,8 +360,14 @@ void TestProcessingGui::testWrapperFactoryRegistry()
 void TestProcessingGui::testWrapperGeneral()
 {
   TestParamType param( QStringLiteral( "boolean" ), QStringLiteral( "bool" ) );
+  param.setAdditionalExpressionContextVariables( QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
   QgsProcessingBooleanWidgetWrapper wrapper( &param );
   QCOMPARE( wrapper.type(), QgsProcessingGui::Standard );
+
+  QgsExpressionContext expContext = wrapper.createExpressionContext();
+  QVERIFY( expContext.hasVariable( QStringLiteral( "a" ) ) );
+  QVERIFY( expContext.hasVariable( QStringLiteral( "b" ) ) );
+  QCOMPARE( expContext.highlightedVariables(), QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
 
   QgsProcessingBooleanWidgetWrapper wrapper2( &param, QgsProcessingGui::Batch );
   QCOMPARE( wrapper2.type(), QgsProcessingGui::Batch );


### PR DESCRIPTION
Allows for specifying extra variables which are available to a single parameter at run time.
Specifying variables via this method is for metadata purposes only. It is the algorithm's responsibility to correctly set the value of these additional variables in all expression context used when evaluating
the parameter, in whichever way is appropriate for that particular variable. Currently, it's used when creating the expression contexts for widgets only -- and provides a method to expose run time generated variables to the user when they are setting the value for expression parameters or expressions for dynamic parameters.