### PR TITLE
[RPM] put the SHA commit in the about dialog for unstable builds

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -21,6 +21,7 @@
 %if %{_timestamp} > 0
 # Epoch is set only when building packages from master
 Epoch: %{_timestamp}
+%define configure_with_sha -D SHA=%(sha=%{_relver}; echo ${sha##git})
 %define combinedversion %{epoch}:%{version}
 %define builddate %(date -d @%{_timestamp} '+%a %b %d %Y')
 %else
@@ -230,6 +231,7 @@ gzip ChangeLog
       -D WITH_SERVER:BOOL=TRUE \
       -D WITH_3D:BOOL=TRUE \
       -D USE_OPENCL:BOOL=TRUE \
+      %{configure_with_sha} \
       .
 
 make %{?_smp_mflags}


### PR DESCRIPTION
## Description
As requested by @rduivenvoorde when building unstable RPM packages the GIT sha revision is now visible in the 'About' dialog as it is in Debian/Ubuntu

![Screenshot from 2019-04-07 17-11-52](https://user-images.githubusercontent.com/1818657/55685575-44eeb700-5958-11e9-8754-a392a26a16d4.png)

*No* backport required.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
