### PR TITLE
Make .qgs project file XML element order stable

### DIFF
--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -527,11 +527,14 @@ void QgsMapThemeCollection::readXml( const QDomDocument &doc )
 void QgsMapThemeCollection::writeXml( QDomDocument &doc )
 {
   QDomElement visPresetsElem = doc.createElement( QStringLiteral( "visibility-presets" ) );
-  MapThemeRecordMap::const_iterator it = mMapThemes.constBegin();
-  for ( ; it != mMapThemes.constEnd(); ++ it )
+
+  const auto keys = mMapThemes.keys();
+
+  std::sort( keys.begin(), keys.end() );
+
+  for ( const QString &grpName : qgis::as_const( keys ) )
   {
-    QString grpName = it.key();
-    const MapThemeRecord &rec = it.value();
+    const MapThemeRecord &rec = mMapThemes.value( grpName );
     QDomElement visPresetElem = doc.createElement( QStringLiteral( "visibility-preset" ) );
     visPresetElem.setAttribute( QStringLiteral( "name" ), grpName );
     if ( rec.hasExpandedStateInfo() )

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -528,7 +528,7 @@ void QgsMapThemeCollection::writeXml( QDomDocument &doc )
 {
   QDomElement visPresetsElem = doc.createElement( QStringLiteral( "visibility-presets" ) );
 
-  const auto keys = mMapThemes.keys();
+  auto keys = mMapThemes.keys();
 
   std::sort( keys.begin(), keys.end() );
 

--- a/src/core/qgsobjectcustomproperties.cpp
+++ b/src/core/qgsobjectcustomproperties.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsobjectcustomproperties.h"
+#include "qgis.h"
 
 #include <QDomNode>
 #include <QStringList>
@@ -118,17 +119,22 @@ void QgsObjectCustomProperties::writeXml( QDomNode &parentNode, QDomDocument &do
 
   QDomElement propsElement = doc.createElement( QStringLiteral( "customproperties" ) );
 
-  for ( QMap<QString, QVariant>::const_iterator it = mMap.constBegin(); it != mMap.constEnd(); ++it )
+  auto keys = mMap.keys();
+
+  std::sort( keys.begin(), keys.end() );
+
+  for ( const auto &key : qgis::as_const( keys ) )
   {
     QDomElement propElement = doc.createElement( QStringLiteral( "property" ) );
-    propElement.setAttribute( QStringLiteral( "key" ), it.key() );
-    if ( it.value().canConvert<QString>() )
+    propElement.setAttribute( QStringLiteral( "key" ), key );
+    const QVariant value = mMap.value( key );
+    if ( value.canConvert<QString>() )
     {
-      propElement.setAttribute( QStringLiteral( "value" ), it.value().toString() );
+      propElement.setAttribute( QStringLiteral( "value" ), value.toString() );
     }
-    else if ( it.value().canConvert<QStringList>() )
+    else if ( value.canConvert<QStringList>() )
     {
-      const auto constToStringList = it.value().toStringList();
+      const auto constToStringList = value.toStringList();
       for ( const QString &value : constToStringList )
       {
         QDomElement itemElement = doc.createElement( QStringLiteral( "value" ) );

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -17,6 +17,8 @@
 
 #include "qgsprojectproperty.h"
 #include "qgslogger.h"
+#include "qgis.h"
+#include "qgsmessagelog.h"
 
 #include <QDomDocument>
 #include <QStringList>
@@ -407,14 +409,13 @@ bool QgsProjectPropertyKey::writeXml( QString const &nodeName, QDomElement &elem
 
   if ( ! mProperties.isEmpty() )
   {
-    QHashIterator < QString, QgsProjectProperty * > i( mProperties );
-    while ( i.hasNext() )
+    auto keys = mProperties.keys();
+    std::sort( keys.begin(), keys.end() );
+
+    for ( const auto &key : qgis::as_const( keys ) )
     {
-      i.next();
-      if ( !i.value()->writeXml( i.key(), keyElement, document ) )
-      {
-        return false;
-      }
+      if ( !mProperties.value( key )->writeXml( key, keyElement, document ) )
+        QgsMessageLog::logMessage( tr( "Failed to save project property %1" ).arg( key ) );
     }
   }
 

--- a/src/core/qgsprojectproperty.h
+++ b/src/core/qgsprojectproperty.h
@@ -25,6 +25,7 @@
 #include <QHash>
 #include <QVariant>
 #include <QStringList>
+#include <QCoreApplication>
 
 #include "qgis_core.h"
 
@@ -181,6 +182,8 @@ class CORE_EXPORT QgsProjectPropertyValue : public QgsProjectProperty
 */
 class CORE_EXPORT QgsProjectPropertyKey : public QgsProjectProperty
 {
+    Q_DECLARE_TR_FUNCTIONS( QgsProjectPropertyKey )
+
   public:
 
     /**


### PR DESCRIPTION
Yes, we've all gone through the hell of trying to manage a .qgs project file in a git repository and losing track of what changes and bloating up the repository. All that just because QtXml tries to be creative.
First tests suggest that with this patch the "artistic" nature of QtXml can be tamed.