### PR TITLE
 [processing] Report provider version string alongside QGIS version in log

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsProcessingFeedback : QgsFeedback
 {
 %Docstring
@@ -92,7 +93,7 @@ report the output from executing an external command or subprocess.
 .. seealso:: :py:func:`pushCommandInfo`
 %End
 
-    void pushVersionInfo();
+    void pushVersionInfo( const QgsProcessingProvider *provider = 0 );
 %Docstring
 Pushes a summary of the QGIS (and underlying library) version information to the log.
 

--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -89,6 +89,16 @@ The default implementation returns the same string as name().
 .. seealso:: :py:func:`id`
 %End
 
+    virtual QString versionInfo() const;
+%Docstring
+Returns a version information string for the provider, or an empty string if this
+is not applicable (e.g. for inbuilt Processing providers).
+
+For plugin based providers, this should return the plugin's version identifier.
+
+.. versionadded:: 3.8
+%End
+
     virtual bool canBeActivated() const;
 %Docstring
 Returns ``True`` if the provider can be activated, or ``False`` if it cannot be activated (e.g. due to

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -205,7 +205,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     break
 
             self.clearProgress()
-            self.feedback.pushVersionInfo()
+            self.feedback.pushVersionInfo(self.algorithm().provider())
             self.setProgressText(QCoreApplication.translate('AlgorithmDialog', 'Processing algorithm…'))
 
             self.setInfo(

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsprocessingfeedback.h"
 #include "qgsgeos.h"
+#include "qgsprocessingprovider.h"
 #include <ogr_api.h>
 #include <gdal_version.h>
 #if PROJ_VERSION_MAJOR > 4
@@ -54,7 +55,7 @@ void QgsProcessingFeedback::pushConsoleInfo( const QString &info )
   QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
 }
 
-void QgsProcessingFeedback::pushVersionInfo()
+void QgsProcessingFeedback::pushVersionInfo( const QgsProcessingProvider *provider )
 {
   pushDebugInfo( tr( "QGIS version: %1" ).arg( Qgis::QGIS_VERSION ) );
   if ( QString( Qgis::QGIS_DEV_VERSION ) != QLatin1String( "exported" ) )
@@ -71,6 +72,10 @@ void QgsProcessingFeedback::pushVersionInfo()
 #else
   pushDebugInfo( tr( "PROJ version: %1" ).arg( PJ_VERSION ) );
 #endif
+  if ( provider && !provider->versionInfo().isEmpty() )
+  {
+    pushDebugInfo( tr( "%1 version: %2" ).arg( provider->name(), provider->versionInfo() ) );
+  }
 }
 
 

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -22,6 +22,8 @@
 #include "qgsfeedback.h"
 #include "qgsmessagelog.h"
 
+class QgsProcessingProvider;
+
 /**
  * \class QgsProcessingFeedback
  * \ingroup core
@@ -95,7 +97,7 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * Pushes a summary of the QGIS (and underlying library) version information to the log.
      * \since QGIS 3.4.7
      */
-    void pushVersionInfo();
+    void pushVersionInfo( const QgsProcessingProvider *provider = nullptr );
 
 };
 

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -51,6 +51,11 @@ QString QgsProcessingProvider::longName() const
   return name();
 }
 
+QString QgsProcessingProvider::versionInfo() const
+{
+  return QString();
+}
+
 QStringList QgsProcessingProvider::supportedOutputRasterLayerExtensions() const
 {
   return QgsRasterFileWriter::supportedFormatExtensions();

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -99,6 +99,16 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     virtual QString longName() const;
 
     /**
+     * Returns a version information string for the provider, or an empty string if this
+     * is not applicable (e.g. for inbuilt Processing providers).
+     *
+     * For plugin based providers, this should return the plugin's version identifier.
+     *
+     * \since QGIS 3.8
+     */
+    virtual QString versionInfo() const;
+
+    /**
      * Returns TRUE if the provider can be activated, or FALSE if it cannot be activated (e.g. due to
      * missing external dependencies).
      * \see isActive()


### PR DESCRIPTION
Added whenever an algorithm is run, which belongs to a 3rd party provider implementing the new versionInfo() QgsProcessingProvider method.

Makes logs just a bit more useful, because you can use them to also determine the version of a plugin which was used to execute an algorithm.