### PR TITLE
Port QgsCoordinateReferenceSystem internals to proj v6

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -2428,10 +2428,18 @@ QString QgsCoordinateReferenceSystem::geographicCrsAuthId() const
   {
     return d->mAuthId;
   }
+#if PROJ_VERSION_MAJOR>=6
+  else if ( d->mPj )
+  {
+    QgsProjUtils::proj_pj_unique_ptr geoCrs( proj_crs_get_geodetic_crs( QgsProjContext::get(), d->mPj.get() ) );
+    return geoCrs ? QStringLiteral( "%1:%2" ).arg( proj_get_id_auth_name( geoCrs.get(), 0 ), proj_get_id_code( geoCrs.get(), 0 ) ) : QString();
+  }
+#else
   else if ( d->mCRS )
   {
     return OSRGetAuthorityName( d->mCRS, "GEOGCS" ) + QStringLiteral( ":" ) + OSRGetAuthorityCode( d->mCRS, "GEOGCS" );
   }
+#endif
   else
   {
     return QString();

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1315,12 +1315,38 @@ void QgsCoordinateReferenceSystem::setMapUnits()
                            nullptr );
 
     const QString unitName( outUnitName );
-    if ( unitName.compare( QLatin1String( "degree" ), Qt::CaseInsensitive ) == 0 )
+
+    // proj unit names are freeform -- they differ from authority to authority :(
+    // see https://lists.osgeo.org/pipermail/proj/2019-April/008444.html
+    if ( unitName.compare( QLatin1String( "degree" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "degree minute second" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "degree minute second hemisphere" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "degree minute" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "degree hemisphere" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "degree minute hemisphere" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "hemisphere degree" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "hemisphere degree minute" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "hemisphere degree minute second" ), Qt::CaseInsensitive ) == 0 ||
+         unitName.compare( QLatin1String( "degree (supplier to define representation)" ), Qt::CaseInsensitive ) == 0 )
       d->mMapUnits = QgsUnitTypes::DistanceDegrees;
     else if ( unitName.compare( QLatin1String( "metre" ), Qt::CaseInsensitive ) == 0 )
       d->mMapUnits = QgsUnitTypes::DistanceMeters;
-    else if ( unitName.compare( QLatin1String( "US survey foot" ), Qt::CaseInsensitive ) == 0 )
+    // we don't differentiate between these, suck it imperial users!
+    else if ( unitName.compare( QLatin1String( "US survey foot" ), Qt::CaseInsensitive ) == 0 ||
+              unitName.compare( QLatin1String( "foot" ), Qt::CaseInsensitive ) == 0 )
       d->mMapUnits = QgsUnitTypes::DistanceFeet;
+    else if ( unitName.compare( QLatin1String( "kilometre" ), Qt::CaseInsensitive ) == 0 )
+      d->mMapUnits = QgsUnitTypes::DistanceKilometers;
+    else if ( unitName.compare( QLatin1String( "centimetre" ), Qt::CaseInsensitive ) == 0 )
+      d->mMapUnits = QgsUnitTypes::DistanceCentimeters;
+    else if ( unitName.compare( QLatin1String( "millimetre" ), Qt::CaseInsensitive ) == 0 )
+      d->mMapUnits = QgsUnitTypes::DistanceMillimeters;
+    else if ( unitName.compare( QLatin1String( "Statute mile" ), Qt::CaseInsensitive ) == 0 )
+      d->mMapUnits = QgsUnitTypes::DistanceMiles;
+    else if ( unitName.compare( QLatin1String( "nautical mile" ), Qt::CaseInsensitive ) == 0 )
+      d->mMapUnits = QgsUnitTypes::DistanceNauticalMiles;
+    else if ( unitName.compare( QLatin1String( "yard" ), Qt::CaseInsensitive ) == 0 )
+      d->mMapUnits = QgsUnitTypes::DistanceYards;
     // TODO - maybe more values to handle here?
     else
       d->mMapUnits = QgsUnitTypes::DistanceUnknownUnit;

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1335,11 +1335,11 @@ void QgsCoordinateReferenceSystem::setMapUnits()
     else if ( unitName.compare( QLatin1String( "US survey foot" ), Qt::CaseInsensitive ) == 0 ||
               unitName.compare( QLatin1String( "foot" ), Qt::CaseInsensitive ) == 0 )
       d->mMapUnits = QgsUnitTypes::DistanceFeet;
-    else if ( unitName.compare( QLatin1String( "kilometre" ), Qt::CaseInsensitive ) == 0 )
+    else if ( unitName.compare( QLatin1String( "kilometre" ), Qt::CaseInsensitive ) == 0 )  //#spellok
       d->mMapUnits = QgsUnitTypes::DistanceKilometers;
-    else if ( unitName.compare( QLatin1String( "centimetre" ), Qt::CaseInsensitive ) == 0 )
+    else if ( unitName.compare( QLatin1String( "centimetre" ), Qt::CaseInsensitive ) == 0 )  //#spellok
       d->mMapUnits = QgsUnitTypes::DistanceCentimeters;
-    else if ( unitName.compare( QLatin1String( "millimetre" ), Qt::CaseInsensitive ) == 0 )
+    else if ( unitName.compare( QLatin1String( "millimetre" ), Qt::CaseInsensitive ) == 0 )  //#spellok
       d->mMapUnits = QgsUnitTypes::DistanceMillimeters;
     else if ( unitName.compare( QLatin1String( "Statute mile" ), Qt::CaseInsensitive ) == 0 )
       d->mMapUnits = QgsUnitTypes::DistanceMiles;

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -51,6 +51,7 @@
 #include <cpl_csv.h>
 
 
+
 //! The length of the string "+lat_1="
 const int LAT_PREFIX_LEN = 7;
 
@@ -1276,10 +1277,12 @@ void QgsCoordinateReferenceSystem::setMapUnits()
     return;
   }
 
+#if PROJ_VERSION_MAJOR<6
 #if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(2,5,0)
   // Of interest to us is that this call adds in a unit parameter if
   // one doesn't already exist.
   OSRFixup( d->mCRS );
+#endif
 #endif
 
 #if PROJ_VERSION_MAJOR>=6
@@ -2011,7 +2014,7 @@ bool QgsCoordinateReferenceSystem::loadIds( QHash<int, QString> &wkts )
 
 int QgsCoordinateReferenceSystem::syncDatabase()
 {
-#if 0
+#if 1
   setlocale( LC_ALL, "C" );
   QString dbFilePath = QgsApplication::srsDatabaseFilePath();
   syncDatumTransform( dbFilePath );

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -628,7 +628,7 @@ bool QgsCoordinateReferenceSystem::createFromWkt( const QString &wkt )
   const char *pWkt = ba.data();
 
   OGRErr myInputResult = OSRImportFromWkt( d->mCRS, const_cast< char ** >( & pWkt ) );
-  res = myInputResult != OGRERR_NONE;
+  res = myInputResult == OGRERR_NONE;
   if ( !res )
   {
     QgsDebugMsg( QStringLiteral( "\n---------------------------------------------------------------" ) );

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1369,12 +1369,21 @@ QString QgsCoordinateReferenceSystem::toWkt() const
 {
   if ( d->mWkt.isEmpty() )
   {
+#if PROJ_VERSION_MAJOR>=6
+    // TODO QGIS 4.0 - upgrade to wkt2 (this would be an API break).
+    if ( d->mPj )
+    {
+      const char *const options[] = {"MULTILINE=NO", "INDENTATION_WIDTH=0", nullptr};
+      d->mWkt = QString( proj_as_wkt( QgsProjContext::get(), d->mPj.get(), PJ_WKT1_GDAL, options ) );
+    }
+#else
     char *wkt = nullptr;
     if ( OSRExportToWkt( d->mCRS, &wkt ) == OGRERR_NONE )
     {
       d->mWkt = wkt;
       CPLFree( wkt );
     }
+#endif
   }
   return d->mWkt;
 }

--- a/src/core/qgscoordinatereferencesystem_p.h
+++ b/src/core/qgscoordinatereferencesystem_p.h
@@ -32,6 +32,11 @@
 #include "qgscoordinatereferencesystem.h"
 #include <ogr_srs_api.h>
 
+#if PROJ_VERSION_MAJOR>=6
+#include <proj.h>
+#include "qgsprojutils.h"
+#endif
+
 #ifdef DEBUG
 typedef struct OGRSpatialReferenceHS *OGRSpatialReferenceH;
 #else
@@ -73,6 +78,10 @@ class QgsCoordinateReferenceSystemPrivate : public QSharedData
       {
         mCRS = OSRNewSpatialReference( nullptr );
       }
+#if PROJ_VERSION_MAJOR>=6
+      if ( mIsValid && mPj.get() )
+        mPj.reset( proj_clone( QgsProjContext::get(), mPj.get() ) );
+#endif
     }
 
     ~QgsCoordinateReferenceSystemPrivate()
@@ -107,6 +116,9 @@ class QgsCoordinateReferenceSystemPrivate : public QSharedData
     //! Whether this CRS is properly defined and valid
     bool mIsValid = false;
 
+#if PROJ_VERSION_MAJOR>=6
+    QgsProjUtils::proj_pj_unique_ptr mPj;
+#endif
     OGRSpatialReferenceH mCRS;
 
     QString mValidationHint;

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -84,6 +84,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void projectWithCustomCrs();
     void projectEPSG25833();
     void geoCcsDescription();
+    void geographicCrsAuthId();
 
   private:
     void debugPrint( QgsCoordinateReferenceSystem &crs );
@@ -921,6 +922,17 @@ void TestQgsCoordinateReferenceSystem::geoCcsDescription()
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.authid(), QStringLiteral( "EPSG:4348" ) );
   QCOMPARE( crs.description(), QStringLiteral( "GDA94 (geocentric)" ) );
+}
+
+void TestQgsCoordinateReferenceSystem::geographicCrsAuthId()
+{
+  QgsCoordinateReferenceSystem crs;
+  crs.createFromString( QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( crs.authid(), QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( crs.geographicCrsAuthId(), QStringLiteral( "EPSG:4326" ) );
+  crs.createFromString( QStringLiteral( "EPSG:3825" ) );
+  QCOMPARE( crs.authid(), QStringLiteral( "EPSG:3825" ) );
+  QCOMPARE( crs.geographicCrsAuthId(), QStringLiteral( "EPSG:3824" ) );
 }
 QGSTEST_MAIN( TestQgsCoordinateReferenceSystem )
 #include "testqgscoordinatereferencesystem.moc"

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -713,9 +713,14 @@ void TestQgsCoordinateReferenceSystem::isGeographic()
 void TestQgsCoordinateReferenceSystem::mapUnits()
 {
   QgsCoordinateReferenceSystem myCrs;
-  myCrs.createFromSrid( GEOSRID );
-  QVERIFY( myCrs.mapUnits() == QgsUnitTypes::DistanceDegrees );
+  myCrs.createFromString( QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( myCrs.mapUnits(), QgsUnitTypes::DistanceDegrees );
   debugPrint( myCrs );
+  myCrs.createFromString( QStringLiteral( "EPSG:28355" ) );
+  QCOMPARE( myCrs.mapUnits(), QgsUnitTypes::DistanceMeters );
+  debugPrint( myCrs );
+  myCrs.createFromString( QStringLiteral( "EPSG:26812" ) );
+  QCOMPARE( myCrs.mapUnits(), QgsUnitTypes::DistanceFeet );
 
   // an invalid crs should return unknown unit
   QCOMPARE( QgsCoordinateReferenceSystem().mapUnits(), QgsUnitTypes::DistanceUnknownUnit );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -721,6 +721,8 @@ void TestQgsCoordinateReferenceSystem::mapUnits()
   debugPrint( myCrs );
   myCrs.createFromString( QStringLiteral( "EPSG:26812" ) );
   QCOMPARE( myCrs.mapUnits(), QgsUnitTypes::DistanceFeet );
+  myCrs.createFromString( QStringLiteral( "EPSG:4619" ) );
+  QCOMPARE( myCrs.mapUnits(), QgsUnitTypes::DistanceDegrees );
 
   // an invalid crs should return unknown unit
   QCOMPARE( QgsCoordinateReferenceSystem().mapUnits(), QgsUnitTypes::DistanceUnknownUnit );

--- a/tests/src/python/test_qgsrasterrerderer_createsld.py
+++ b/tests/src/python/test_qgsrasterrerderer_createsld.py
@@ -438,7 +438,7 @@ class TestQgsRasterRendererCreateSld(unittest.TestCase):
         dom, root = self.rendererToSld(self.raster_layer.renderer())
         self.assertOpacity(root, '1.1')
 
-        # check gamma properties from [-100:0] streched to [0:1]
+        # check gamma properties from [-100:0] stretched to [0:1]
         #  and (0:100] stretche dto (1:100]
         # dom, root = self.rendererToSld(rasterRenderer, {'contrast': '-100'})
         # self.assertGamma(root, '0')


### PR DESCRIPTION
This PR ports almost all the internals of QgsCoordinateReferenceSystem across to proj v6, where available. Most notably, it replaces the use of a OGRSpatialReferenceH object as a private member with a proj PJ objec, and uses this with all the proj 6 db querying methods for retrieving projection parameters.

This is a 1:1 port -- there's a lot of further improvements we could do with this class when we can safely drop all the old proj 4 version support. E.g. using wkt v2 (although this may be an API break and might need to be deferred to 4.0), and (most important) avoiding lossy conversion of wkt to proj strings.

Remaining work to be done is upgrading the crs db sync code to use the proj db instead of the (now non-existant) gdal csv files. Until this is done, builds using proj 6 will remain quite broken*.

Sponsored by ICSM


\* that's not a regression caused here