### PR TITLE
[quick] Lower min. Qt version (>=5.9) in two editor widgets

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -13,8 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-import QtQuick 2.11
-import QtQuick.Controls 2.4
+import QtQuick 2.9
+import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.4 as Controls1
 import QtGraphicalEffects 1.0

--- a/src/quickgui/plugin/editor/qgsquicktextedit.qml
+++ b/src/quickgui/plugin/editor/qgsquicktextedit.qml
@@ -13,9 +13,8 @@
  *                                                                         *
  ***************************************************************************/
 
-import QtQuick 2.11
-import QtQuick.Controls 2.4
-import QtQuick 2.5
+import QtQuick 2.9
+import QtQuick.Controls 2.2
 import QgsQuick 0.1 as QgsQuick
 import QtQuick.Layouts 1.3
 


### PR DESCRIPTION
There does not seem to be a reason to strictly require a higher version
of Qt Quick in two of editor widgets. It required Qt 5.11.

Qt Quick and Qt Quick Controls have a bit confusing versioning, see:
https://doc.qt.io/qt-5/qtquickcontrols-index.html

Qt 5.9 = Quick 2.9 + Quick Controls 2.2
