### PR TITLE
[db manager] Rename layer style entry when renaming gpkg tables (fixes #21227)

### DIFF
--- a/python/plugins/db_manager/db_plugins/gpkg/connector.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/connector.py
@@ -634,9 +634,10 @@ class GPKGDBConnector(DBConnector):
             return False
 
         # also rename any styles referring to this table
-        self.gdal_ds.ExecuteSQL('UPDATE layer_styles SET f_table_name = %s WHERE f_table_name = %s' % (quoted_table_new, quoted_table))
-        if gdal.GetLastErrorMsg() != '':
-            return False
+        if self.gdal_ds.GetLayerByName('layer_styles'):
+            self.gdal_ds.ExecuteSQL('UPDATE layer_styles SET f_table_name = %s WHERE f_table_name = %s' % (quoted_table_new, quoted_table))
+            if gdal.GetLastErrorMsg() != '':
+                return False
 
         # we need to reopen after renaming since OGR doesn't update its
         # internal state


### PR DESCRIPTION
This has been already fixed in master and backported to 3.6 using browser data items.
However the fix can't be directly backported to QGIS 3.4 because in 3.4 geopackage
data item does not support renaming.
