### PR TITLE
[QgsQuick] Feature form group styling

### DIFF
--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -253,6 +253,7 @@ Item {
             id: content
             anchors.fill: parent
             clip: true
+            spacing: form.style.group.spacing
             section.property: "Group"
             section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
             section.delegate: Component {
@@ -265,7 +266,9 @@ Item {
                 Text {
                   anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
                   font.bold: true
+                  font.pixelSize: form.style.group.fontPixelSize
                   text: section
+                  color: form.style.group.fontColor
                 }
               }
             }

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -257,18 +257,30 @@ Item {
             section.property: "Group"
             section.labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
             section.delegate: Component {
-              // section header: group box name
-              Rectangle {
+
+            // section header: group box name
+            Rectangle {
                 width: parent.width
                 height: section === "" ? 0 : form.style.group.height
-                color: form.style.group.backgroundColor
+                color: form.style.group.marginColor
 
-                Text {
-                  anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
-                  font.bold: true
-                  font.pixelSize: form.style.group.fontPixelSize
-                  text: section
-                  color: form.style.group.fontColor
+                Rectangle {
+                  anchors.fill: parent
+                  anchors {
+                    leftMargin: form.style.group.leftMargin
+                    rightMargin: form.style.group.rightMargin
+                    topMargin: form.style.group.topMargin
+                    bottomMargin: form.style.group.bottomMargin
+                  }
+                  color: form.style.group.backgroundColor
+
+                  Text {
+                    anchors { horizontalCenter: parent.horizontalCenter; verticalCenter: parent.verticalCenter }
+                    font.bold: true
+                    font.pixelSize: form.style.group.fontPixelSize
+                    text: section
+                    color: form.style.group.fontColor
+                  }
                 }
               }
             }

--- a/src/quickgui/plugin/qgsquickfeatureformstyling.qml
+++ b/src/quickgui/plugin/qgsquickfeatureformstyling.qml
@@ -23,7 +23,10 @@ QtObject {
 
   property QtObject group: QtObject {
     property color backgroundColor: "lightGray"
-    property real height: 30 * QgsQuick.Utils.dp
+    property real height: 64 * QgsQuick.Utils.dp
+    property color fontColor: "black"
+    property int spacing: 10 * QgsQuick.Utils.dp
+    property int fontPixelSize: 24 * QgsQuick.Utils.dp
   }
 
   property QtObject tabs: QtObject {

--- a/src/quickgui/plugin/qgsquickfeatureformstyling.qml
+++ b/src/quickgui/plugin/qgsquickfeatureformstyling.qml
@@ -23,6 +23,11 @@ QtObject {
 
   property QtObject group: QtObject {
     property color backgroundColor: "lightGray"
+    property color marginColor: "black"
+    property real leftMargin: 1 * QgsQuick.Utils.dp
+    property real rightMargin: 1 * QgsQuick.Utils.dp
+    property real topMargin: 1 * QgsQuick.Utils.dp
+    property real bottomMargin: 1 * QgsQuick.Utils.dp
     property real height: 64 * QgsQuick.Utils.dp
     property color fontColor: "black"
     property int spacing: 10 * QgsQuick.Utils.dp


### PR DESCRIPTION
Added basic styling props for groups to FeatureForm and QgsQuickFeatureFormStyling

Sample:
<img width="635" alt="Screenshot 2019-04-08 at 16 53 42" src="https://user-images.githubusercontent.com/6735606/55735330-69629600-5a21-11e9-97ed-055a01dc1bbf.png">
