### PR TITLE
[vertex tool] Tweak vertex markers so that they are not filled

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -281,12 +281,16 @@ QgsVertexTool::QgsVertexTool( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWid
   mFeatureBandMarkers = new QgsRubberBand( canvas );
   mFeatureBandMarkers->setIcon( QgsRubberBand::ICON_CIRCLE );
   mFeatureBandMarkers->setColor( color );
-  mFeatureBandMarkers->setIconSize( QgsGuiUtils::scaleIconSize( 8 ) );
+  mFeatureBandMarkers->setWidth( QgsGuiUtils::scaleIconSize( 2 ) );
+  mFeatureBandMarkers->setBrushStyle( Qt::NoBrush );
+  mFeatureBandMarkers->setIconSize( QgsGuiUtils::scaleIconSize( 6 ) );
   mFeatureBandMarkers->setVisible( false );
 
   mVertexBand = new QgsRubberBand( canvas );
   mVertexBand->setIcon( QgsRubberBand::ICON_CIRCLE );
   mVertexBand->setColor( color );
+  mVertexBand->setWidth( QgsGuiUtils::scaleIconSize( 2 ) );
+  mVertexBand->setBrushStyle( Qt::NoBrush );
   mVertexBand->setIconSize( QgsGuiUtils::scaleIconSize( 15 ) );
   mVertexBand->setVisible( false );
 
@@ -1365,9 +1369,8 @@ void QgsVertexTool::updateLockedFeatureVertices()
         QgsVertexMarker *marker = new QgsVertexMarker( canvas() );
         marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
         marker->setIconSize( QgsGuiUtils::scaleIconSize( 10 ) );
-        marker->setPenWidth( QgsGuiUtils::scaleIconSize( 3 ) );
+        marker->setPenWidth( QgsGuiUtils::scaleIconSize( 2 ) );
         marker->setColor( Qt::red );
-        marker->setFillColor( Qt::red );
         marker->setCenter( toMapCoordinates( mLockedFeature->layer(), vertex->point() ) );
         mLockedFeatureVerticesMarkers.append( marker );
       }
@@ -2313,9 +2316,8 @@ void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, H
     QgsVertexMarker *marker = new QgsVertexMarker( canvas() );
     marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
     marker->setIconSize( QgsGuiUtils::scaleIconSize( 10 ) );
-    marker->setPenWidth( QgsGuiUtils::scaleIconSize( 3 ) );
+    marker->setPenWidth( QgsGuiUtils::scaleIconSize( 2 ) );
     marker->setColor( Qt::blue );
-    marker->setFillColor( Qt::blue );
     marker->setCenter( toMapCoordinates( vertex.layer, geom.vertexAt( vertex.vertexId ) ) );
     mSelectedVerticesMarkers.append( marker );
     return true;


### PR DESCRIPTION
The rationale is that vertices are more difficult to see when they are behind the markers and people liked that in 2.x they were without internal fill.

This changes the following markers:
1. small red circle when you hover mouse on a feature
2. large red circle when you hover mouse on a particular vertex
3. medium red or blue circle when you select vertices (blue) or when you lock feature (red)

This needs some user testing to confirm that the change has a positive impact.

cc @bstroebl 

Before:
![vertex-tool-filled](https://user-images.githubusercontent.com/193367/55801665-d7b56000-5ad6-11e9-8d79-64aa955da097.png)

After:
![image](https://user-images.githubusercontent.com/193367/55801616-beacaf00-5ad6-11e9-96b7-6bf18907a884.png)
