### PR TITLE
Apply SLD PointSymbolizer on single centroid for polygon

### DIFF
--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -3512,6 +3512,7 @@ QgsSymbolLayer *QgsCentroidFillSymbolLayer::createFromSld( QDomElement &element 
 
   std::unique_ptr< QgsCentroidFillSymbolLayer > sl = qgis::make_unique< QgsCentroidFillSymbolLayer >();
   sl->setSubSymbol( marker.release() );
+  sl->setPointOnAllParts( false );
   return sl.release();
 }
 

--- a/tests/src/python/test_qgssymbollayer.py
+++ b/tests/src/python/test_qgssymbollayer.py
@@ -698,6 +698,11 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        mExpectedValue = False
+        mValue = mSymbolLayer.pointOnAllParts()
+        mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
+        assert mExpectedValue == mValue, mMessage
+
         # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.color(), QColor(150, 50, 100))


### PR DESCRIPTION
## Description
SLD 1.0 and StyleEncoding 1.1 specs say that if a line, polygon, or raster geometry is used with PointSymbolizer, then the semantic is to use the centroid of the geometry, or any similar representative point.

When QGIS read an SLD, it applies the point on the centroid of all parts of the multi-polygon and not on the unique centroid of the mutil-polygon.

ST_Centroid is the PostGIS implementation of the Simple Feature standard for SQL and it generates only one point for multi-polygon. So I think SLD PointSymbolizer has to be applied to the single centroid.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
