### PR TITLE
[gdal] Implement the data provider reloadData() function (fixes #20536)

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -526,6 +526,15 @@ void QgsGdalProvider::closeDataset()
   closeCachedGdalHandlesFor( this );
 }
 
+void QgsGdalProvider::reloadData()
+{
+  QMutexLocker locker( mpMutex );
+  closeDataset();
+
+  mHasInit = false;
+  ( void )initIfNeeded();
+}
+
 QString QgsGdalProvider::htmlMetadata()
 {
   QMutexLocker locker( mpMutex );

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -171,6 +171,8 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     bool setNoDataValue( int bandNo, double noDataValue ) override;
     bool remove() override;
 
+    void reloadData() override;
+
     QString validateCreationOptions( const QStringList &createOptions, const QString &format ) override;
     QString validatePyramidsConfigOptions( QgsRaster::RasterPyramidsFormat pyramidsFormat,
                                            const QStringList &configOptions, const QString &fileFormat ) override;


### PR DESCRIPTION
## Description
The gdal provider failed to implement the reloadData() function, resulting in a failure to invalidate the layer cache when the underlying dataset is updated and a reload is requested. 

This fixes a regression, identified by the author of the ArcGIS ImageServer Connector plugin. 

@antmyrhav , this should make you happy :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
