### PR TITLE
Return 501 on 'OperationNotSupported' error

### DIFF
--- a/src/server/services/wcs/qgswcs.cpp
+++ b/src/server/services/wcs/qgswcs.cpp
@@ -74,7 +74,7 @@ namespace QgsWcs
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ) );
+                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )
@@ -93,7 +93,7 @@ namespace QgsWcs
         {
           // Operation not supported
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Request %1 is not supported" ).arg( req ) );
+                                     QStringLiteral( "Request %1 is not supported" ).arg( req ), 501 );
         }
       }
 

--- a/src/server/services/wfs/qgswfs.cpp
+++ b/src/server/services/wfs/qgswfs.cpp
@@ -78,7 +78,7 @@ namespace QgsWfs
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ) );
+                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )
@@ -117,7 +117,7 @@ namespace QgsWfs
         {
           // Operation not supported
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Request %1 is not supported" ).arg( req ) );
+                                     QStringLiteral( "Request %1 is not supported" ).arg( req ), 501 );
         }
       }
 

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -90,8 +90,8 @@ namespace QgsWms
         const QString req = parameters.request();
         if ( req.isEmpty() )
         {
-          throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ) );
+          throw QgsServiceException( QgsServiceException::OGC_OPERATION_NOT_SUPPORTED,
+                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( ( mVersion.compare( QLatin1String( "1.1.1" ) ) == 0 \
@@ -153,8 +153,8 @@ namespace QgsWms
         else
         {
           // Operation not supported
-          throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QString( "Request %1 is not supported" ).arg( req ) );
+          throw QgsServiceException( QgsServiceException::OGC_OPERATION_NOT_SUPPORTED,
+                                     QString( "Request %1 is not supported" ).arg( req ), 501 );
         }
       }
 

--- a/src/server/services/wmts/qgswmts.cpp
+++ b/src/server/services/wmts/qgswmts.cpp
@@ -72,7 +72,7 @@ namespace QgsWmts
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ) );
+                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )
@@ -91,7 +91,7 @@ namespace QgsWmts
         {
           // Operation not supported
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Request %1 is not supported" ).arg( req ) );
+                                     QStringLiteral( "Request %1 is not supported" ).arg( req ), 501 );
         }
       }
 

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -259,6 +259,12 @@ class QgsServerTestBase(unittest.TestCase):
             headers.append(("%s: %s" % (k, rh[k])).encode('utf-8'))
         return b"\n".join(headers) + b"\n\n", bytes(response.body())
 
+    def _assert_status_code(self, status_code, qs, requestMethod=QgsServerRequest.GetMethod, data=None, project=None):
+        request = QgsBufferServerRequest(qs, requestMethod, {}, data)
+        response = QgsBufferServerResponse()
+        self.server.handleRequest(request, response, project)
+        assert response.statusCode() == status_code, "%s != %s" % (response.statusCode(), status_code)
+
 
 class TestQgsServerTestBase(unittest.TestCase):
 

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -92,6 +92,10 @@ class TestQgsServerWFS(QgsServerTestBase):
             query_string, request))
         return header, body
 
+    def test_operation_not_supported(self):
+        qs = '?MAP=%s&SERVICE=WFS&VERSION=1.1.0&REQUEST=NotAValidRequest' % urllib.parse.quote(self.projectPath)
+        self._assert_status_code(501, qs)
+
     def test_project_wfs(self):
         """Test some WFS request"""
         for request in ('GetCapabilities', 'DescribeFeatureType'):

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -88,6 +88,10 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
     def test_getcontext(self):
         self.wms_request_compare('GetContext')
 
+    def test_operation_not_supported(self):
+        qs = '?MAP=%s&SERVICE=WMS&VERSION=1.3.0&REQUEST=NotAValidRequest' % urllib.parse.quote(self.projectPath)
+        self._assert_status_code(501, qs)
+
     def test_describelayer(self):
         # Test DescribeLayer
         self.wms_request_compare('DescribeLayer',

--- a/tests/src/python/test_qgsserver_wmts.py
+++ b/tests/src/python/test_qgsserver_wmts.py
@@ -107,6 +107,10 @@ class TestQgsServerWMTS(QgsServerTestBase):
 
         self.assertXMLEqual(response, expected, msg="request %s failed.\n Query: %s" % (query_string, request))
 
+    def test_operation_not_supported(self):
+        qs = '?MAP=%s&SERVICE=WFS&VERSION=1.0.0&REQUEST=NotAValidRequest' % urllib.parse.quote(self.projectPath)
+        self._assert_status_code(501, qs)
+
     def test_project_wmts(self):
         """Test some WMTS request"""
         for request in ('GetCapabilities',):


### PR DESCRIPTION
## Description
Return 501 HTTP statues code 'OperationNotSupported' Error

According to OGC/OWS standard, 'OperationNotSupported' Error should return 501 but actually return 200.

ref http://docs.opengeospatial.org/is/17-007r1/17-007r1.html - table 21 