### PR TITLE
[server] Fixes WMS 1.3.0 certification

### DIFF
--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -90,7 +90,7 @@ namespace QgsWms
         const QString req = parameters.request();
         if ( req.isEmpty() )
         {
-          throw QgsServiceException( QgsServiceException::OGC_OPERATION_NOT_SUPPORTED,
+          throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
                                      QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
         }
 
@@ -153,7 +153,7 @@ namespace QgsWms
         else
         {
           // Operation not supported
-          throw QgsServiceException( QgsServiceException::OGC_OPERATION_NOT_SUPPORTED,
+          throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
                                      QString( "Request %1 is not supported" ).arg( req ), 501 );
         }
       }

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -131,25 +131,25 @@ namespace QgsWms
   {
     if ( parameters.allLayersNickname().isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     parameters[QgsWmsParameter::LAYERS] );
     }
 
     if ( parameters.format() == QgsWmsParameters::Format::NONE )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     parameters[QgsWmsParameter::FORMAT] );
     }
 
     if ( ! parameters.bbox().isEmpty() && !parameters.rule().isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     QStringLiteral( "BBOX parameter cannot be combined with RULE." ) );
     }
 
     if ( ! parameters.bbox().isEmpty() && parameters.bboxAsRectangle().isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     parameters[QgsWmsParameter::BBOX] );
     }
   }

--- a/src/server/services/wms/qgswmsgetprint.cpp
+++ b/src/server/services/wms/qgswmsgetprint.cpp
@@ -50,7 +50,7 @@ namespace QgsWms
         contentType = QStringLiteral( "application/pdf" );
         break;
       default:
-        throw QgsBadRequestException( QgsServiceException::OGC_INVALID_FORMAT,
+        throw QgsBadRequestException( QgsServiceException::OGC_InvalidFormat,
                                       parameters[QgsWmsParameter::FORMAT] );
         break;
     }

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -59,14 +59,14 @@ namespace QgsWms
 
     if ( layersName.isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     QgsWmsParameter::LAYERS );
     }
 
     QStringList layerList = layersName.split( ',', QString::SkipEmptyParts );
     if ( layerList.isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     QgsWmsParameter::LAYERS );
     }
 
@@ -96,13 +96,13 @@ namespace QgsWms
 
     if ( styleName.isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     QgsWmsParameter::STYLE );
     }
 
     if ( layerName.isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     QgsWmsParameter::LAYERS );
     }
 

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1836,7 +1836,7 @@ namespace QgsWms
 
   void QgsWmsParameters::raiseError( const QString &msg ) const
   {
-    throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE, msg );
+    throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue, msg );
   }
 
   QgsWmsParameter QgsWmsParameters::idParameter( const QgsWmsParameter::Name name, const int id ) const

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -436,7 +436,7 @@ void QgsWmsRenderContext::searchLayersToRenderSld()
       {
         QgsWmsParameter param( QgsWmsParameter::LAYER );
         param.mValue = lname;
-        throw QgsBadRequestException( QgsServiceException::OGC_LAYER_NOT_DEFINED,
+        throw QgsBadRequestException( QgsServiceException::OGC_LayerNotDefined,
                                       param );
       }
     }
@@ -482,7 +482,7 @@ void QgsWmsRenderContext::searchLayersToRenderStyle()
     {
       QgsWmsParameter param( QgsWmsParameter::LAYER );
       param.mValue = nickname;
-      throw QgsBadRequestException( QgsServiceException::OGC_LAYER_NOT_DEFINED,
+      throw QgsBadRequestException( QgsServiceException::OGC_LayerNotDefined,
                                     param );
     }
   }

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -284,7 +284,7 @@ namespace QgsWms
     const QString templateName = mWmsParameters.composerTemplate();
     if ( templateName.isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     QgsWmsParameter::TEMPLATE );
     }
 
@@ -293,14 +293,14 @@ namespace QgsWms
     QgsPrintLayout *sourceLayout( dynamic_cast<QgsPrintLayout *>( lManager->layoutByName( templateName ) ) );
     if ( !sourceLayout )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     mWmsParameters[QgsWmsParameter::TEMPLATE ] );
     }
 
     // Check that layout has at least one page
     if ( sourceLayout->pageCollection()->pageCount() < 1 )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     QStringLiteral( "The template has no pages" ) );
     }
 
@@ -315,14 +315,14 @@ namespace QgsWms
       if ( !atlas || !atlas->enabled() )
       {
         //error
-        throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+        throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                       QStringLiteral( "The template has no atlas enabled" ) );
       }
 
       QgsVectorLayer *cLayer = atlas->coverageLayer();
       if ( !cLayer )
       {
-        throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+        throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                       QStringLiteral( "The atlas has no coverage layer" ) );
       }
 
@@ -333,7 +333,7 @@ namespace QgsWms
         atlas->updateFeatures();
         if ( atlas->count() > maxAtlasFeatures )
         {
-          throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+          throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                         QString( "The project configuration allows printing maximum %1 atlas features at a time" ).arg( maxAtlasFeatures ) );
         }
       }
@@ -353,14 +353,14 @@ namespace QgsWms
         int nAtlasFeatures = atlasPk.size() / pkIndexes.size();
         if ( nAtlasFeatures * pkIndexes.size() != atlasPk.size() ) //Test is atlasPk.size() is a multiple of pkIndexes.size(). Bail out if not
         {
-          throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+          throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                         QStringLiteral( "Wrong number of ATLAS_PK parameters" ) );
         }
 
         //number of atlas features might be restricted
         if ( nAtlasFeatures > maxAtlasFeatures )
         {
-          throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+          throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                         QString( "%1 atlas features have been requestet, but the project configuration only allows printing %2 atlas features at a time" )
                                         .arg( nAtlasFeatures ).arg( maxAtlasFeatures ) );
         }
@@ -526,7 +526,7 @@ namespace QgsWms
     }
     else //unknown format
     {
-      throw QgsBadRequestException( QgsServiceException::OGC_INVALID_FORMAT,
+      throw QgsBadRequestException( QgsServiceException::OGC_InvalidFormat,
                                     mWmsParameters[QgsWmsParameter::FORMAT] );
     }
 
@@ -846,7 +846,7 @@ namespace QgsWms
     {
       QgsWmsParameter param( QgsWmsParameter::I );
       param.mValue = i;
-      throw QgsBadRequestException( QgsServiceException::OGC_INVALID_POINT,
+      throw QgsBadRequestException( QgsServiceException::OGC_InvalidPoint,
                                     param );
     }
 
@@ -854,7 +854,7 @@ namespace QgsWms
     {
       QgsWmsParameter param( QgsWmsParameter::J );
       param.mValue = j;
-      throw QgsBadRequestException( QgsServiceException::OGC_INVALID_POINT,
+      throw QgsBadRequestException( QgsServiceException::OGC_InvalidPoint,
                                     param );
     }
 
@@ -870,7 +870,7 @@ namespace QgsWms
     // The QUERY_LAYERS parameter is Mandatory
     if ( mWmsParameters.queryLayersNickname().isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue,
                                     mWmsParameters[QgsWmsParameter::QUERY_LAYERS] );
     }
 
@@ -887,13 +887,13 @@ namespace QgsWms
       if ( mWmsParameters.j().isEmpty() )
         parameter = mWmsParameters[QgsWmsParameter::J];
 
-      throw QgsBadRequestException( QgsServiceException::QGIS_MISSING_PARAMETER_VALUE, parameter );
+      throw QgsBadRequestException( QgsServiceException::QGIS_MissingParameterValue, parameter );
     }
 
     const QgsWmsParameters::Format infoFormat = mWmsParameters.infoFormat();
     if ( infoFormat == QgsWmsParameters::Format::NONE )
     {
-      throw QgsBadRequestException( QgsServiceException::OGC_INVALID_FORMAT,
+      throw QgsBadRequestException( QgsServiceException::OGC_InvalidFormat,
                                     mWmsParameters[QgsWmsParameter::INFO_FORMAT] );
     }
 
@@ -970,7 +970,7 @@ namespace QgsWms
       QgsRectangle mapExtent = mWmsParameters.bboxAsRectangle();
       if ( !mWmsParameters.bbox().isEmpty() && mapExtent.isEmpty() )
       {
-        throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+        throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                       mWmsParameters[QgsWmsParameter::BBOX] );
       }
 
@@ -1001,12 +1001,12 @@ namespace QgsWms
 
     if ( width <= 0 )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     mWmsParameters[QgsWmsParameter::WIDTH] );
     }
     else if ( height <= 0 )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     mWmsParameters[QgsWmsParameter::HEIGHT] );
     }
 
@@ -1054,7 +1054,7 @@ namespace QgsWms
     QgsRectangle mapExtent = mWmsParameters.bboxAsRectangle();
     if ( !mWmsParameters.bbox().isEmpty() && mapExtent.isEmpty() )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     mWmsParameters[QgsWmsParameter::BBOX] );
     }
 
@@ -1080,12 +1080,12 @@ namespace QgsWms
 
       if ( mWmsParameters.versionAsNumber() >= QgsProjectVersion( 1, 3, 0 ) )
       {
-        code = QgsServiceException::OGC_INVALID_CRS;
+        code = QgsServiceException::OGC_InvalidCRS;
         parameter = mWmsParameters[ QgsWmsParameter::CRS ];
       }
       else
       {
-        code = QgsServiceException::OGC_INVALID_SRS;
+        code = QgsServiceException::OGC_InvalidSRS;
         parameter = mWmsParameters[ QgsWmsParameter::SRS ];
       }
 
@@ -1322,7 +1322,7 @@ namespace QgsWms
       {
         QgsWmsParameter param( QgsWmsParameter::LAYER );
         param.mValue = queryLayer;
-        throw QgsBadRequestException( QgsServiceException::OGC_LAYER_NOT_DEFINED,
+        throw QgsBadRequestException( QgsServiceException::OGC_LayerNotDefined,
                                       param );
       }
       else if ( ( validLayer && !queryableLayer ) || ( !validLayer && mContext.isValidGroup( queryLayer ) ) )
@@ -1359,7 +1359,7 @@ namespace QgsWms
         // Only throw if it's not a group or the group has no queryable children
         if ( ! hasGroupAndQueryable )
         {
-          throw QgsBadRequestException( QgsServiceException::OGC_LAYER_NOT_QUERYABLE,
+          throw QgsBadRequestException( QgsServiceException::OGC_LayerNotQueryable,
                                         param );
         }
       }
@@ -1897,7 +1897,7 @@ namespace QgsWms
     int width = this->width();
     if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     QStringLiteral( "The requested map width is too large" ) );
     }
 
@@ -1919,7 +1919,7 @@ namespace QgsWms
     int height = this->height();
     if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     QStringLiteral( "The requested map height is too large" ) );
     }
 
@@ -1948,7 +1948,7 @@ namespace QgsWms
          || std::numeric_limits<int>::max() / static_cast<uint>( bytes_per_line ) < static_cast<uint>( height )
          || std::numeric_limits<int>::max() / sizeof( uchar * ) < static_cast<uint>( height ) )
     {
-      throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+      throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                     QStringLiteral( "The requested map size is too large" ) );
     }
   }
@@ -2778,7 +2778,7 @@ namespace QgsWms
           QString errorMsg;
           if ( !filterXml.setContent( filter.mFilter, true, &errorMsg ) )
           {
-            throw QgsBadRequestException( QgsServiceException::QGIS_INVALID_PARAMETER_VALUE,
+            throw QgsBadRequestException( QgsServiceException::QGIS_InvalidParameterValue,
                                           QStringLiteral( "Filter string rejected. Error message: %1. The XML string was: %2" ).arg( errorMsg, filter.mFilter ) );
           }
           QDomElement filterElem = filterXml.firstChildElement();
@@ -2992,7 +2992,7 @@ namespace QgsWms
     bool rc = layer->styleManager()->setCurrentStyle( style );
     if ( ! rc )
     {
-      throw QgsBadRequestException( QgsServiceException::OGC_STYLE_NOT_DEFINED,
+      throw QgsBadRequestException( QgsServiceException::OGC_StyleNotDefined,
                                     QStringLiteral( "Style '%1' does not exist for layer '%2'" ).arg( style, layer->name() ) );
     }
   }

--- a/src/server/services/wms/qgswmsserviceexception.h
+++ b/src/server/services/wms/qgswmsserviceexception.h
@@ -46,20 +46,20 @@ namespace QgsWms
        */
       enum ExceptionCode
       {
-        OGC_INVALID_FORMAT,
-        OGC_INVALID_SRS,
-        OGC_LAYER_NOT_DEFINED,
-        OGC_STYLE_NOT_DEFINED,
-        OGC_LAYER_NOT_QUERYABLE,
-        OGC_CURRENT_UPDATE_SEQUENCE,
-        OGC_INVALID_UPDATE_SEQUENCE,
-        OGC_MISSING_DIMENSION_VALUE,
-        OGC_INVALID_DIMENSION_VALUE,
-        OGC_INVALID_POINT, // new in WMS 1.3.0
-        OGC_INVALID_CRS, // new in WMS 1.3.0
-        OGC_OPERATION_NOT_SUPPORTED, // new in WMS 1.3.0
-        QGIS_MISSING_PARAMETER_VALUE,
-        QGIS_INVALID_PARAMETER_VALUE
+        OGC_InvalidFormat,
+        OGC_InvalidSRS,
+        OGC_LayerNotDefined,
+        OGC_StyleNotDefined,
+        OGC_LayerNotQueryable,
+        OGC_CurrentUpdateSequence,
+        OGC_InvalidUpdateSequence,
+        OGC_MissingDimensionValue,
+        OGC_InvalidDimensionValue,
+        OGC_InvalidPoint, // new in WMS 1.3.0
+        OGC_InvalidCRS, // new in WMS 1.3.0
+        OGC_OperationNotSupported, // new in WMS 1.3.0
+        QGIS_MissingParameterValue,
+        QGIS_InvalidParameterValue
       };
       Q_ENUM( ExceptionCode )
 
@@ -115,52 +115,52 @@ namespace QgsWms
 
         switch ( code )
         {
-          case QgsServiceException::QGIS_MISSING_PARAMETER_VALUE:
+          case QgsServiceException::QGIS_MissingParameterValue:
           {
             message = QStringLiteral( "The %1 parameter is missing." ).arg( name );
             break;
           }
-          case QGIS_INVALID_PARAMETER_VALUE:
+          case QGIS_InvalidParameterValue:
           {
             message = QStringLiteral( "The %1 parameter is invalid." ).arg( name );
             break;
           }
-          case OGC_INVALID_FORMAT:
+          case OGC_InvalidFormat:
           {
             message = QStringLiteral( "The format '%1' from %2 is not supported." ).arg( parameter.toString(), name );
             break;
           }
-          case OGC_INVALID_SRS:
+          case OGC_InvalidSRS:
           {
             message = QStringLiteral( "The SRS is not valid." );
             break;
           }
-          case OGC_INVALID_CRS:
+          case OGC_InvalidCRS:
           {
             message = QStringLiteral( "The CRS is not valid." );
             break;
           }
-          case OGC_LAYER_NOT_DEFINED:
+          case OGC_LayerNotDefined:
           {
             message = QStringLiteral( "The layer '%1' does not exist." ).arg( parameter.toString() );
             break;
           }
-          case OGC_LAYER_NOT_QUERYABLE:
+          case OGC_LayerNotQueryable:
           {
             message = QStringLiteral( "The layer '%1' is not queryable." ).arg( parameter.toString() );
             break;
           }
-          case OGC_INVALID_POINT:
+          case OGC_InvalidPoint:
           {
             message = QStringLiteral( "The point '%1' from '%2' is invalid." ).arg( parameter.toString(), name );
             break;
           }
-          case OGC_STYLE_NOT_DEFINED:
-          case OGC_CURRENT_UPDATE_SEQUENCE:
-          case OGC_INVALID_UPDATE_SEQUENCE:
-          case OGC_MISSING_DIMENSION_VALUE:
-          case OGC_INVALID_DIMENSION_VALUE:
-          case OGC_OPERATION_NOT_SUPPORTED:
+          case OGC_StyleNotDefined:
+          case OGC_CurrentUpdateSequence:
+          case OGC_InvalidUpdateSequence:
+          case OGC_MissingDimensionValue:
+          case OGC_InvalidDimensionValue:
+          case OGC_OperationNotSupported:
           {
             break;
           }
@@ -179,17 +179,7 @@ namespace QgsWms
         key.replace( QStringLiteral( "OGC_" ), QString() );
         key.replace( QStringLiteral( "QGIS_" ), QString() );
 
-        // build the exception name
-        QString formattedCode;
-        for ( auto &part : key.split( '_' ) )
-        {
-          part = part.toLower().replace( 0, 1, part[0].toUpper() );
-          part.replace( QStringLiteral( "Srs" ), QStringLiteral( "SRS" ) );
-          part.replace( QStringLiteral( "Crs" ), QStringLiteral( "CRS" ) );
-          formattedCode = QString( "%1%2" ).arg( formattedCode ).arg( part );
-        }
-
-        return formattedCode;
+        return key;
       }
   };
 

--- a/src/server/services/wms/qgswmsserviceexception.h
+++ b/src/server/services/wms/qgswmsserviceexception.h
@@ -184,6 +184,8 @@ namespace QgsWms
         for ( auto &part : key.split( '_' ) )
         {
           part = part.toLower().replace( 0, 1, part[0].toUpper() );
+          part.replace( QStringLiteral( "Srs" ), QStringLiteral( "SRS" ) );
+          part.replace( QStringLiteral( "Crs" ), QStringLiteral( "CRS" ) );
           formattedCode = QString( "%1%2" ).arg( formattedCode ).arg( part );
         }
 

--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -163,7 +163,7 @@ namespace QgsWms
     {
       QgsWmsParameter parameter( QgsWmsParameter::FORMAT );
       parameter.mValue = formatStr;
-      throw QgsBadRequestException( QgsServiceException::OGC_INVALID_FORMAT,
+      throw QgsBadRequestException( QgsServiceException::OGC_InvalidFormat,
                                     parameter );
     }
   }

--- a/tests/src/server/wms/test_qgsserver_wms_exceptions.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_exceptions.cpp
@@ -46,27 +46,27 @@ void TestQgsServerWmsExceptions::cleanupTestCase()
 
 void TestQgsServerWmsExceptions::exception_code()
 {
-  QgsWms::QgsServiceException::ExceptionCode code = QgsWms::QgsServiceException::OGC_INVALID_FORMAT;
+  QgsWms::QgsServiceException::ExceptionCode code = QgsWms::QgsServiceException::OGC_InvalidFormat;
   QgsWms::QgsServiceException exception0( code, QString(), 400 );
   QCOMPARE( exception0.code(), QString( "InvalidFormat" ) );
 
-  code = QgsWms::QgsServiceException::QGIS_INVALID_PARAMETER_VALUE;
+  code = QgsWms::QgsServiceException::QGIS_InvalidParameterValue;
   QgsWms::QgsServiceException exception1( code, QString(), 400 );
   QCOMPARE( exception1.code(), QString( "InvalidParameterValue" ) );
 }
 
 void TestQgsServerWmsExceptions::exception_message()
 {
-  QgsWms::QgsServiceException::ExceptionCode code = QgsWms::QgsServiceException::QGIS_MISSING_PARAMETER_VALUE;
+  QgsWms::QgsServiceException::ExceptionCode code = QgsWms::QgsServiceException::QGIS_MissingParameterValue;
   QgsWms::QgsServiceException exception( code, QgsWms::QgsWmsParameter::LAYER, 400 );
   QCOMPARE( exception.message(), QString( "The LAYER parameter is missing." ) );
 
-  code = QgsWms::QgsServiceException::OGC_INVALID_SRS;
+  code = QgsWms::QgsServiceException::OGC_InvalidSRS;
   QgsWms::QgsServiceException exception_srs( code, QgsWms::QgsWmsParameter::SRS, 400 );
   QCOMPARE( exception_srs.message(), QString( "The SRS is not valid." ) );
   QCOMPARE( exception_srs.code(), QString( "InvalidSRS" ) );
 
-  code = QgsWms::QgsServiceException::OGC_INVALID_CRS;
+  code = QgsWms::QgsServiceException::OGC_InvalidCRS;
   QgsWms::QgsServiceException exception_crs( code, QgsWms::QgsWmsParameter::CRS, 400 );
   QCOMPARE( exception_crs.message(), QString( "The CRS is not valid." ) );
   QCOMPARE( exception_crs.code(), QString( "InvalidCRS" ) );

--- a/tests/src/server/wms/test_qgsserver_wms_exceptions.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_exceptions.cpp
@@ -60,6 +60,16 @@ void TestQgsServerWmsExceptions::exception_message()
   QgsWms::QgsServiceException::ExceptionCode code = QgsWms::QgsServiceException::QGIS_MISSING_PARAMETER_VALUE;
   QgsWms::QgsServiceException exception( code, QgsWms::QgsWmsParameter::LAYER, 400 );
   QCOMPARE( exception.message(), QString( "The LAYER parameter is missing." ) );
+
+  code = QgsWms::QgsServiceException::OGC_INVALID_SRS;
+  QgsWms::QgsServiceException exception_srs( code, QgsWms::QgsWmsParameter::SRS, 400 );
+  QCOMPARE( exception_srs.message(), QString( "The SRS is not valid." ) );
+  QCOMPARE( exception_srs.code(), QString( "InvalidSRS" ) );
+
+  code = QgsWms::QgsServiceException::OGC_INVALID_CRS;
+  QgsWms::QgsServiceException exception_crs( code, QgsWms::QgsWmsParameter::CRS, 400 );
+  QCOMPARE( exception_crs.message(), QString( "The CRS is not valid." ) );
+  QCOMPARE( exception_crs.code(), QString( "InvalidCRS" ) );
 }
 
 QGSTEST_MAIN( TestQgsServerWmsExceptions )


### PR DESCRIPTION
## Description

In OGC WMS 1.3.0, exception codes for invalid CRS/SRS have to be `InvalidSRS`/`InvalidCRS` instead of `InvalidSrs`/`InvalidCrs`.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
