### PR TITLE
[server] Allow server plugin filters to access config path 

### DIFF
--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -259,6 +259,13 @@ void QgsRequestHandler::setParameter( const QString &key, const QString &value )
 {
   if ( !( key.isEmpty() || value.isEmpty() ) )
   {
+    // Warn for potential breaking change if plugin set the MAP parameter
+    // expecting changing the config file path, see PR #9773
+    if ( key.compare( QLatin1String( "MAP" ), Qt::CaseInsensitive ) == 0 )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Changing the 'MAP' parameter will have no effect on config path: use QgsSerververInterface::setConfigFilePath instead" ),
+                                 "Server", Qgis::Warning );
+    }
     mRequest.setParameter( key, value );
   }
 }

--- a/tests/src/python/test_qgsserver_plugins.py
+++ b/tests/src/python/test_qgsserver_plugins.py
@@ -177,6 +177,51 @@ class TestQgsServerPlugins(QgsServerTestBase):
         self.assertEqual(response, expected)
         self.assertEqual(headers2, {'Content-type': 'text/plain'})
 
+    def test_configpath(self):
+        """ Test plugin can read confif path
+        """
+        try:
+            from qgis.server import QgsServerFilter
+            from qgis.core import QgsProject
+        except ImportError:
+            print("QGIS Server plugins are not compiled. Skipping test")
+            return
+
+        d = unitTestDataPath('qgis_server_accesscontrol') + '/'
+        self.projectPath = os.path.join(d, "project.qgs")
+        self.server = QgsServer()
+
+        # global to be modified inside plugin filters
+        globals()['configFilePath2'] = None
+
+        class Filter0(QgsServerFilter):
+            """Body setter, clear body, keep headers"""
+
+            def requestReady(self):
+                global configFilePath2
+                configFilePath2 = self.serverInterface().configFilePath()
+
+        serverIface = self.server.serverInterface()
+        serverIface.registerFilter(Filter0(serverIface), 100)
+
+        # Test using MAP
+        self._execute_request('?service=simple&MAP=%s' % self.projectPath)
+
+        # Check config file path
+        self.assertEqual(configFilePath2, self.projectPath)
+
+        # Reset result
+        globals()['configFilePath2'] = None
+
+        # Test with prqject as argument
+        project = QgsProject()
+        project.read(self.projectPath)
+
+        self._execute_request_project('?service=simple', project=project)
+
+        # Check config file path
+        self.assertEqual(configFilePath2, project.fileName())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Actually, on 'requestReady' plugins filters are only allowed to access the project path with the 'MAP' parameter. They cannot use the QgsServerInterface method `configFilePath()'  because config path is simply not initialized. 

In most use case this is ok except when:
-  A `QgsProject` is directly passed as parameter in the `QgsServer::handleRequest()' method; in this case, there is no way for the plugin to access the project path. 
- A default config file path is used.

This PR:
- Initialize configPath before calling plugin filters methods
- Use the `QgsServerInterface::configFilePath` to retrieve the project when no QgsProject is directly passed as parameter.

With theses modifications, the plugins:
- Can access the configFilePath all cases
- Can modify the config file path using the `QgsServerInterface::setConfigFilePath` method - only when no QgsProject is directly passed as parameter.

There is a potential API breaking change if plugins filters where changing the MAP parameters in `requestReady`, in this situations these plugins should directly use the `setConfigFilePath` method.

A warning is output to logs if QgsRequestHandler::setParameter is called with MAP (case insensitive) as an argument.

