### PR TITLE
[server] fix wmsMaxHeightEnv leftover code

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1905,7 +1905,7 @@ namespace QgsWms
     int wmsMaxHeightProj = QgsServerProjectUtils::wmsMaxHeight( *mProject );
     int wmsMaxHeightEnv = mContext.settings().wmsMaxHeight();
     int wmsMaxHeight;
-    if ( wmsMaxWidthEnv != -1 && wmsMaxWidthProj != -1 )
+    if ( wmsMaxHeightEnv != -1 && wmsMaxHeightProj != -1 )
     {
       // both are set, so we take the more conservative one
       wmsMaxHeight = std::min( wmsMaxHeightProj, wmsMaxHeightEnv );


### PR DESCRIPTION
Signed-off-by: Marco Bernasocchi <marco@opengis.ch>

## Description
this pr fixes a mistake in the managing of wmsMaxHeightEnv and wmsMaxHeightProj
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
