### PR TITLE
fix the QgsMeshLayerProperties constructor

### DIFF
--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -66,7 +66,7 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
   connect( mMeshLayer, &QgsMeshLayer::dataChanged, this, &QgsMeshLayerProperties::syncAndRepaint );
 
 #ifdef HAVE_3D
-  mVector3DWidget = new QgsMeshLayer3DRendererWidget( mMeshLayer, QgisApp::instance()->mapCanvas(), mOptsPage_3DView );
+  mVector3DWidget = new QgsMeshLayer3DRendererWidget( mMeshLayer, canvas, mOptsPage_3DView );
 
   mOptsPage_3DView->setLayout( new QVBoxLayout( mOptsPage_3DView ) );
   mOptsPage_3DView->layout()->addWidget( mVector3DWidget );


### PR DESCRIPTION
In constructor, if HAVE_3D is defined, the "mVector3DWidget is constructed with the mapCanvas instance of the QgisApp instance instead with the QgsMapCanvas instance which is an argument of the constructor. This isan issue if QgisApp doesn't have a QGsMapCanvas instantiated. This fix replace QGisApp 's mapCanvas pointer by the argument of the constructor

