### PR TITLE
fix QgsLayerTreeModel::refreshLayerLegend

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -539,7 +539,7 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer *nodeLayer )
 
   // update children
   int oldNodeCount = rowCount( idx );
-  if ( oldoldNodeCount > 0 ) 
+  if ( oldNodeCount > 0 ) 
   {
     beginRemoveRows( idx, 0, std::max( oldNodeCount - 1, 0 ) );
     removeLegendFromLayer( nodeLayer );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -539,9 +539,11 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer *nodeLayer )
 
   // update children
   int oldNodeCount = rowCount( idx );
-  beginRemoveRows( idx, 0, std::max( oldNodeCount - 1, 0 ) );
-  removeLegendFromLayer( nodeLayer );
-  endRemoveRows();
+  if (oldoldNodeCount>0) {
+    beginRemoveRows( idx, 0, std::max( oldNodeCount - 1, 0 ) );
+    removeLegendFromLayer( nodeLayer );
+    endRemoveRows();
+  }
 
   addLegendToLayer( nodeLayer );
   int newNodeCount = rowCount( idx );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -541,7 +541,7 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer *nodeLayer )
   int oldNodeCount = rowCount( idx );
   if ( oldNodeCount > 0 )
   {
-    beginRemoveRows( idx, 0, std::max( oldNodeCount - 1, 0 ) );
+    beginRemoveRows( idx, 0, oldNodeCount - 1 );
     removeLegendFromLayer( nodeLayer );
     endRemoveRows();
   }

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -539,7 +539,8 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer *nodeLayer )
 
   // update children
   int oldNodeCount = rowCount( idx );
-  if (oldoldNodeCount>0) {
+  if ( oldoldNodeCount > 0 ) 
+  {
     beginRemoveRows( idx, 0, std::max( oldNodeCount - 1, 0 ) );
     removeLegendFromLayer( nodeLayer );
     endRemoveRows();

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -539,7 +539,7 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer *nodeLayer )
 
   // update children
   int oldNodeCount = rowCount( idx );
-  if ( oldNodeCount > 0 ) 
+  if ( oldNodeCount > 0 )
   {
     beginRemoveRows( idx, 0, std::max( oldNodeCount - 1, 0 ) );
     removeLegendFromLayer( nodeLayer );


### PR DESCRIPTION
Guard if the QModelIndex (idx) has no child.