### PR TITLE
Fix loss of renderer style after fixing a layer with a bad path

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1480,7 +1480,7 @@ void QgsVectorLayer::setDataSource( const QString &dataSource, const QString &ba
 
 void QgsVectorLayer::setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag )
 {
-  QgsWkbTypes::GeometryType geomType = mValid && mDataProvider ? geometryType() : QgsWkbTypes::UnknownGeometry;
+  QgsWkbTypes::GeometryType geomType = geometryType();
 
   mDataSource = dataSource;
   setName( baseName );


### PR DESCRIPTION
The guard against invalid layer isn't required here, because we store the expected geometry type in the layer itself and retrieving it doesn't require a valid provider.

Without this, the previous geometry type is always set to unknown and a new default renderer constructed after fixing the layer path.