### PR TITLE
[Backport release-3_6][server] Fallback to unmanaged parameters

### DIFF
--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -526,7 +526,14 @@ QString QgsServerParameters::request() const
 
 QString QgsServerParameters::value( const QString &key ) const
 {
-  return value( QgsServerParameter::name( key ) ).toString();
+  if ( ! mParameters.contains( QgsServerParameter::name( key ) ) )
+  {
+    return mUnmanagedParameters[key];
+  }
+  else
+  {
+    return value( QgsServerParameter::name( key ) ).toString();
+  }
 }
 
 QVariant QgsServerParameters::value( QgsServerParameter::Name name ) const

--- a/tests/src/python/test_qgsserver_request.py
+++ b/tests/src/python/test_qgsserver_request.py
@@ -196,6 +196,11 @@ class QgsServerRequestTest(QgsServerTestBase):
         _check_links(params)
         _check_links(params, 'POST')
 
+    def test_add_parameters(self):
+        request = QgsServerRequest()
+        request.setParameter('FOOBAR', 'foobar')
+        self.assertEqual(request.parameter('FOOBAR'), 'foobar')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsserver_request.py
+++ b/tests/src/python/test_qgsserver_request.py
@@ -200,6 +200,7 @@ class QgsServerRequestTest(QgsServerTestBase):
         request = QgsServerRequest()
         request.setParameter('FOOBAR', 'foobar')
         self.assertEqual(request.parameter('FOOBAR'), 'foobar')
+        self.assertEqual(request.parameter('UNKNOWN'), '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Backport #9776
Follow up: https://lists.osgeo.org/pipermail/qgis-developer/2019-April/056979.html

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
