### PR TITLE
[ogr] Only throw validity error in reloadData() when previously valid

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -4525,10 +4525,11 @@ void QgsOgrProvider::close()
 
 void QgsOgrProvider::reloadData()
 {
+  bool wasValid = mValid;
   forceReload();
   close();
   open( OpenModeSameAsCurrent );
-  if ( !mValid )
+  if ( !mValid && wasValid )
     pushError( tr( "Cannot reopen datasource %1" ).arg( dataSourceUri() ) );
 }
 


### PR DESCRIPTION
## Description
This prevents unwanted error message bar when an invalid (e.g. missing datasource) layer is in the layer tree and the following actions are triggered:
- Removing the invalid layer
- Removing other layers for the layer tree
- Refreshing the canvas via the Refresh action (F5)

Basically, only throw an error when reloading data results in an invalid state only if previously valid.

@nyalldawson , as discussed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
