### PR TITLE
[Bugfix][Server] WMTS: CRS can have axis inverted

### DIFF
--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -533,8 +533,16 @@ namespace QgsWmts
           tmElement.appendChild( tmScaleDenomElem );
 
           QDomElement tmTopLeftCornerElem = doc.createElement( QStringLiteral( "TopLeftCorner" ) );
-          QDomText tmTopLeftCornerText = doc.createTextNode( qgsDoubleToString( tm.left, 6 ) + ' ' + qgsDoubleToString( tm.top, 6 ) );
-          tmTopLeftCornerElem.appendChild( tmTopLeftCornerText );
+          if ( tms.hasAxisInverted )
+          {
+            QDomText tmTopLeftCornerText = doc.createTextNode( qgsDoubleToString( tm.top, 6 ) + ' ' + qgsDoubleToString( tm.left, 6 ) );
+            tmTopLeftCornerElem.appendChild( tmTopLeftCornerText );
+          }
+          else
+          {
+            QDomText tmTopLeftCornerText = doc.createTextNode( qgsDoubleToString( tm.left, 6 ) + ' ' + qgsDoubleToString( tm.top, 6 ) );
+            tmTopLeftCornerElem.appendChild( tmTopLeftCornerText );
+          }
           tmElement.appendChild( tmTopLeftCornerElem );
 
           QDomElement tmTileWidthElem = doc.createElement( QStringLiteral( "TileWidth" ) );

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -99,6 +99,7 @@ namespace QgsWmts
     }
 
     tmi.unit = crs.mapUnits();
+    tmi.hasAxisInverted = crs.hasAxisInverted();
 
     // calculate tile matrix scale denominator
     double scaleDenominator = 0.0;
@@ -186,6 +187,7 @@ namespace QgsWmts
     tms.ref = tmi.ref;
     tms.extent = extent;
     tms.unit = unit;
+    tms.hasAxisInverted = tmi.hasAxisInverted;
     tms.tileMatrixList = tileMatrixList;
 
     return tms;
@@ -282,6 +284,7 @@ namespace QgsWmts
 
           QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsStr );
           tmi.unit = crs.mapUnits();
+          tmi.hasAxisInverted = crs.hasAxisInverted();
 
           QgsCoordinateTransform crsTransform( QgsCoordinateReferenceSystem::fromOgcWmsCrs( GEO_EPSG_CRS_AUTHID ), crs, project );
           try
@@ -327,6 +330,7 @@ namespace QgsWmts
         tms.ref = tmi.ref;
         tms.extent = tmi.extent;
         tms.unit = tmi.unit;
+        tms.hasAxisInverted = tmi.hasAxisInverted;
         tms.tileMatrixList = tileMatrixList;
 
         tmsList.append( tms );
@@ -759,7 +763,7 @@ namespace QgsWmts
     double maxx = tm.left + ( tc + 1 ) * ( tileSize * res );
     double maxy = tm.top - tr * ( tileSize * res );
     QString bbox;
-    if ( tms.ref == "EPSG:4326" )
+    if ( tms.hasAxisInverted )
     {
       bbox = qgsDoubleToString( miny, 6 ) + ',' +
              qgsDoubleToString( minx, 6 ) + ',' +
@@ -820,6 +824,7 @@ namespace QgsWmts
       tmi4326.extent = QgsRectangle( -180, -90, 180, 90 );
       tmi4326.scaleDenominator = 279541132.0143588675418869;
       tmi4326.unit = QgsUnitTypes::DistanceDegrees;
+      tmi4326.hasAxisInverted = true;
       m[tmi4326.ref] = tmi4326;
 
       return m;

--- a/src/server/services/wmts/qgswmtsutils.h
+++ b/src/server/services/wmts/qgswmtsutils.h
@@ -43,6 +43,8 @@ namespace QgsWmts
 
     QgsUnitTypes::DistanceUnit unit = QgsUnitTypes::DistanceMeters;
 
+    bool hasAxisInverted = false;
+
     double scaleDenominator = 0.0;
 
     int lastLevel = -1;
@@ -70,6 +72,8 @@ namespace QgsWmts
     QgsRectangle extent;
 
     QgsUnitTypes::DistanceUnit unit;
+
+    bool hasAxisInverted = false;
 
     QList< tileMatrixDef > tileMatrixList;
   };

--- a/tests/testdata/qgis_server/wmts_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities.txt
@@ -1191,7 +1191,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>0</ows:Identifier>
     <ScaleDenominator>279541132.014359</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>2</MatrixWidth>
@@ -1200,7 +1200,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>1</ows:Identifier>
     <ScaleDenominator>139770566.007179</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>4</MatrixWidth>
@@ -1209,7 +1209,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>2</ows:Identifier>
     <ScaleDenominator>69885283.00359</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>8</MatrixWidth>
@@ -1218,7 +1218,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>3</ows:Identifier>
     <ScaleDenominator>34942641.501795</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>16</MatrixWidth>
@@ -1227,7 +1227,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>4</ows:Identifier>
     <ScaleDenominator>17471320.750897</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>32</MatrixWidth>
@@ -1236,7 +1236,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>5</ows:Identifier>
     <ScaleDenominator>8735660.375449</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>64</MatrixWidth>
@@ -1245,7 +1245,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>6</ows:Identifier>
     <ScaleDenominator>4367830.187724</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>128</MatrixWidth>
@@ -1254,7 +1254,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>7</ows:Identifier>
     <ScaleDenominator>2183915.093862</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>256</MatrixWidth>
@@ -1263,7 +1263,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>8</ows:Identifier>
     <ScaleDenominator>1091957.546931</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>512</MatrixWidth>
@@ -1272,7 +1272,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>9</ows:Identifier>
     <ScaleDenominator>545978.773466</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>1024</MatrixWidth>
@@ -1281,7 +1281,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>10</ows:Identifier>
     <ScaleDenominator>272989.386733</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>2048</MatrixWidth>
@@ -1290,7 +1290,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>11</ows:Identifier>
     <ScaleDenominator>136494.693366</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>4096</MatrixWidth>
@@ -1299,7 +1299,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>12</ows:Identifier>
     <ScaleDenominator>68247.346683</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>8192</MatrixWidth>
@@ -1308,7 +1308,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>13</ows:Identifier>
     <ScaleDenominator>34123.673342</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>16384</MatrixWidth>
@@ -1317,7 +1317,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>14</ows:Identifier>
     <ScaleDenominator>17061.836671</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>32768</MatrixWidth>
@@ -1326,7 +1326,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>15</ows:Identifier>
     <ScaleDenominator>8530.918335</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>65536</MatrixWidth>
@@ -1335,7 +1335,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>16</ows:Identifier>
     <ScaleDenominator>4265.459168</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>131072</MatrixWidth>
@@ -1344,7 +1344,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>17</ows:Identifier>
     <ScaleDenominator>2132.729584</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>262144</MatrixWidth>
@@ -1353,7 +1353,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>18</ows:Identifier>
     <ScaleDenominator>1066.364792</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>524288</MatrixWidth>
@@ -1362,7 +1362,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>19</ows:Identifier>
     <ScaleDenominator>533.182396</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>1048576</MatrixWidth>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
@@ -1191,7 +1191,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>0</ows:Identifier>
     <ScaleDenominator>279541132.014359</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>2</MatrixWidth>
@@ -1200,7 +1200,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>1</ows:Identifier>
     <ScaleDenominator>139770566.007179</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>4</MatrixWidth>
@@ -1209,7 +1209,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>2</ows:Identifier>
     <ScaleDenominator>69885283.00359</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>8</MatrixWidth>
@@ -1218,7 +1218,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>3</ows:Identifier>
     <ScaleDenominator>34942641.501795</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>16</MatrixWidth>
@@ -1227,7 +1227,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>4</ows:Identifier>
     <ScaleDenominator>17471320.750897</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>32</MatrixWidth>
@@ -1236,7 +1236,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>5</ows:Identifier>
     <ScaleDenominator>8735660.375449</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>64</MatrixWidth>
@@ -1245,7 +1245,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>6</ows:Identifier>
     <ScaleDenominator>4367830.187724</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>128</MatrixWidth>
@@ -1254,7 +1254,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>7</ows:Identifier>
     <ScaleDenominator>2183915.093862</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>256</MatrixWidth>
@@ -1263,7 +1263,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>8</ows:Identifier>
     <ScaleDenominator>1091957.546931</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>512</MatrixWidth>
@@ -1272,7 +1272,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>9</ows:Identifier>
     <ScaleDenominator>545978.773466</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>1024</MatrixWidth>
@@ -1281,7 +1281,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>10</ows:Identifier>
     <ScaleDenominator>272989.386733</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>2048</MatrixWidth>
@@ -1290,7 +1290,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>11</ows:Identifier>
     <ScaleDenominator>136494.693366</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>4096</MatrixWidth>
@@ -1299,7 +1299,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>12</ows:Identifier>
     <ScaleDenominator>68247.346683</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>8192</MatrixWidth>
@@ -1308,7 +1308,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>13</ows:Identifier>
     <ScaleDenominator>34123.673342</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>16384</MatrixWidth>
@@ -1317,7 +1317,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>14</ows:Identifier>
     <ScaleDenominator>17061.836671</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>32768</MatrixWidth>
@@ -1326,7 +1326,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>15</ows:Identifier>
     <ScaleDenominator>8530.918335</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>65536</MatrixWidth>
@@ -1335,7 +1335,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>16</ows:Identifier>
     <ScaleDenominator>4265.459168</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>131072</MatrixWidth>
@@ -1344,7 +1344,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>17</ows:Identifier>
     <ScaleDenominator>2132.729584</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>262144</MatrixWidth>
@@ -1353,7 +1353,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>18</ows:Identifier>
     <ScaleDenominator>1066.364792</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>524288</MatrixWidth>
@@ -1362,7 +1362,7 @@ Content-Type: text/xml; charset=utf-8
    <TileMatrix>
     <ows:Identifier>19</ows:Identifier>
     <ScaleDenominator>533.182396</ScaleDenominator>
-    <TopLeftCorner>-180 90</TopLeftCorner>
+    <TopLeftCorner>90 -180</TopLeftCorner>
     <TileWidth>256</TileWidth>
     <TileHeight>256</TileHeight>
     <MatrixWidth>1048576</MatrixWidth>


### PR DESCRIPTION
## Description
The top left element has to respect the axis, like in WMS 1.3.0.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
