### PR TITLE
[processing] ensure that output temporary directory exists (fix #21701)

### DIFF
--- a/python/plugins/processing/algs/qgis/HypsometricCurves.py
+++ b/python/plugins/processing/algs/qgis/HypsometricCurves.py
@@ -95,6 +95,8 @@ class HypsometricCurves(QgisAlgorithm):
         percentage = self.parameterAsBoolean(parameters, self.USE_PERCENTAGE, context)
 
         outputPath = self.parameterAsString(parameters, self.OUTPUT_DIRECTORY, context)
+        if not os.path.exists(outputPath):
+            os.makedirs(outputPath)
 
         rasterDS = gdal.Open(rasterPath, gdal.GA_ReadOnly)
         geoTransform = rasterDS.GetGeoTransform()
@@ -138,7 +140,7 @@ class HypsometricCurves(QgisAlgorithm):
                 continue
 
             fName = os.path.join(
-                outputPath, 'hystogram_%s_%s.csv' % (source.sourceName(), f.id()))
+                outputPath, 'histogram_{}_{}.csv'.format(source.sourceName(), f.id()))
 
             ogrGeom = ogr.CreateGeometryFromWkt(intersectedGeom.asWkt())
             bbox = intersectedGeom.boundingBox()


### PR DESCRIPTION
## Description
Prevent failure in the Hypsometric Curves algorithm when output directory is not exists.
Fixes https://issues.qgis.org/issues/21701

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
