### PR TITLE
[3d] Fix shading of 3D point symbols

### DIFF
--- a/src/3d/shaders/instanced.vert
+++ b/src/3d/shaders/instanced.vert
@@ -21,8 +21,8 @@ void main()
     // which all keep "w" set to 1. correctly we should use translation matrix...
     vec4 offsetPos = inst * vec4(vertexPosition, 1.0) + vec4(pos, 0.0);
 
-    worldNormal = normalize(modelViewNormal * mat3(instNormal) * vertexNormal);
-    worldPosition = vec3(modelView * offsetPos);
+    worldNormal = normalize(mat3(instNormal) * vertexNormal);
+    worldPosition = vec3(offsetPos);
 
     gl_Position = modelViewProjection * offsetPos;
 }


### PR DESCRIPTION
The vertex shader was incorrectly transforming world position and normal
vectors for phong shading. This was causing wrong appearance that was noticeable
when moving/rotating camera (e.g. specular reflection was always in the same place).
This was caused by involving view matrix (i.e. camera position and orientation)
to the vectors, but the world position and normal should be independent from camera.