### PR TITLE
Permit mesh structure update in QgsMeshLayer

### DIFF
--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -178,11 +178,6 @@ double QgsMeshDatasetGroupMetadata::maximum() const
   return mMaximumValue;
 }
 
-bool QgsMeshDatasetSourceInterface::meshHasChanged()
-{
-  return false;
-}
-
 int QgsMeshDatasetSourceInterface::datasetCount( QgsMeshDatasetIndex index ) const
 {
   return datasetCount( index.group() );
@@ -341,4 +336,9 @@ int QgsMesh::vertexCount() const
 int QgsMesh::faceCount() const
 {
   return faces.size();
+}
+
+bool QgsMeshDataSourceInterface::meshHasChanged()
+{
+  return false;
 }

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -58,6 +58,11 @@ QgsMeshDataProvider::QgsMeshDataProvider( const QString &uri, const QgsDataProvi
 {
 }
 
+bool QgsMeshDataProvider::meshHasChanged()
+{
+  return false;
+}
+
 QgsMeshDatasetValue::QgsMeshDatasetValue( double x, double y )
   : mX( x ), mY( y )
 {}

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -58,10 +58,6 @@ QgsMeshDataProvider::QgsMeshDataProvider( const QString &uri, const QgsDataProvi
 {
 }
 
-bool QgsMeshDataProvider::meshHasChanged()
-{
-  return false;
-}
 
 QgsMeshDatasetValue::QgsMeshDatasetValue( double x, double y )
   : mX( x ), mY( y )
@@ -180,6 +176,11 @@ double QgsMeshDatasetGroupMetadata::minimum() const
 double QgsMeshDatasetGroupMetadata::maximum() const
 {
   return mMaximumValue;
+}
+
+bool QgsMeshDatasetSourceInterface::meshHasChanged()
+{
+  return false;
 }
 
 int QgsMeshDatasetSourceInterface::datasetCount( QgsMeshDatasetIndex index ) const

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -408,6 +408,12 @@ class CORE_EXPORT QgsMeshDataSourceInterface SIP_ABSTRACT
      * \since QGIS 3.6
      */
     virtual void populateMesh( QgsMesh *mesh ) const = 0;
+  
+  
+    /**
+     * Give information if mesh has changed
+     */
+    virtual bool meshHasChanged() { return false; }
 };
 
 /**

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -413,7 +413,7 @@ class CORE_EXPORT QgsMeshDataSourceInterface SIP_ABSTRACT
     /**
      * Give information if mesh has changed
      */
-    virtual bool meshHasChanged() { return false; }
+    virtual bool meshHasChanged();
 };
 
 /**

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -408,8 +408,7 @@ class CORE_EXPORT QgsMeshDataSourceInterface SIP_ABSTRACT
      * \since QGIS 3.6
      */
     virtual void populateMesh( QgsMesh *mesh ) const = 0;
-  
-  
+    
     /**
      * Give information if mesh has changed
      */

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -409,9 +409,6 @@ class CORE_EXPORT QgsMeshDataSourceInterface SIP_ABSTRACT
      */
     virtual void populateMesh( QgsMesh *mesh ) const = 0;
     
-    /**
-     * Give information if mesh has changed
-     */
     virtual bool meshHasChanged();
 };
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -218,7 +218,7 @@ void QgsMeshLayer::setTransformContext( const QgsCoordinateTransformContext &tra
 
 void QgsMeshLayer::fillNativeMesh()
 {
-  Q_ASSERT( !mNativeMesh );
+  //Q_ASSERT( !mNativeMesh );
 
   mNativeMesh.reset( new QgsMesh() );
 
@@ -277,8 +277,10 @@ void QgsMeshLayer::assignDefaultStyleToDatasetGroup( int groupIndex )
 
 QgsMapLayerRenderer *QgsMeshLayer::createMapRenderer( QgsRenderContext &rendererContext )
 {
+  bool nativeMeshHasChanged = dataProvider()->meshHasChanged();
+  
   // Native mesh
-  if ( !mNativeMesh )
+  if ( !mNativeMesh || nativeMeshHasChanged )
   {
     // lazy loading of mesh data
     fillNativeMesh();
@@ -291,7 +293,7 @@ QgsMapLayerRenderer *QgsMeshLayer::createMapRenderer( QgsRenderContext &renderer
   mTriangularMesh->update( mNativeMesh.get(), &rendererContext );
 
   // Cache
-  if ( !mRendererCache )
+  if ( !mRendererCache || nativeMeshHasChanged )
     mRendererCache.reset( new QgsMeshLayerRendererCache() );
 
   return new QgsMeshLayerRenderer( this, rendererContext );


### PR DESCRIPTION
## Description
Actually, I am working for mesh editing with QgsMeshLayer. I started to implement a mesh provider relied to  a mesh editor. This editor can manipulate vertices and faces, the provider permit acces to this data.

But it seems that the native mesh of the meshlayer is not updated unless this nativeMesh is null. So, when nativeMesh is not null and vertices and faces changed, the layer is not updated ...

That why I purpose this PR. With thats PR, when update is requested, the layer is informed that the mesh has changed, so it reloads the native mesh and resets the cache.

The responsibility to inform if the mesh has changed is for the provider. The provider also has the responsibility to restore the state to mesh unchanged after the method is called.

In the QgsMeshLayer, this modification involves to remove a Q_ASSERT.

The result of this mesh editor and this PR is that (on a stand alone application using the API) : https://github.com/vcloarec/Mesher



