### PR TITLE
[3d] Fix edge drawing when multiple renderer rules have edges enabled

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -575,8 +575,7 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
 
       // this is probably not the best place for material-specific configuration,
       // maybe this could be more generalized when other materials need some specific treatment
-      QgsLineMaterial *lm = newEntity->findChild<QgsLineMaterial *>();
-      if ( lm )
+      for ( QgsLineMaterial *lm : newEntity->findChildren<QgsLineMaterial *>() )
       {
         connect( mCameraController, &QgsCameraController::viewportChanged, lm, [lm, this]
         {


### PR DESCRIPTION
When using rule-based 3D rendering, if multiple rules were enabled with edge rendering,
only the first rule was getting correctly set up line width for line material.
(the rest were getting some very thick line width and making the 3D view unusable)

cc @nirvn 