### PR TITLE
Remove plugin module path  when unloading

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -28,7 +28,7 @@ QGIS utilities module
 
 """
 
-from qgis.PyQt.QtCore import QCoreApplication, QLocale, QThread
+from qgis.PyQt.QtCore import QCoreApplication, QLocale, QThread, qDebug
 from qgis.PyQt.QtWidgets import QPushButton, QApplication
 from qgis.core import Qgis, QgsMessageLog, qgsfunction, QgsMessageOutput
 from qgis.gui import QgsMessageBar
@@ -452,12 +452,23 @@ def _unloadPluginModules(packageName):
             if hasattr(sys.modules[mod], 'qCleanupResources'):
                 sys.modules[mod].qCleanupResources()
         except:
-            pass
+            # Print stack trace for debug
+            qDebug("qCleanupResources error:\n%s" % traceback.format_exc())
+
+        # try removing path
+        if hasattr(sys.modules[mod], '__path__'):
+            for path in sys.modules[mod].__path__:
+                try:
+                    sys.path.remove(path)
+                except ValueError:
+                    # Discard if path is not there
+                    pass
+
         # try to remove the module from python
         try:
             del sys.modules[mod]
         except:
-            pass
+            qDebug("Error when removing module:\n%s" % traceback.format_exc())
     # remove the plugin entry
     del _plugin_modules[packageName]
 


### PR DESCRIPTION
## Description

Loading plugin add package paths to `sys.path`. 

When unloading plugin, the added paths are not removed from `sys.path`; most of the time this has no incidence but there is a corner case where this makes *loading/unloading/loading* sequence to fail and subsequently **prevent installing correctly plugin from zip** because the zip installer use this sequence for validating plugin.  

This is the case when a plugin package foo has a submodule of the same name - package or file.
```
foobar/
    |-- __init__.py
    |-- foobar.py
```
 In this situation reloading the plugin may load modules in the wrong order: because the path of the plugin is found in `sys.path` submodules can be loaded before parent and cause import errors if  relative imports are used.

This PR add a fix for removing package path from removed module at plugin desactivation.
