### PR TITLE
[processing] Log features that could not be divided in tessellate alg.

### DIFF
--- a/src/3d/processing/qgsalgorithmtessellate.cpp
+++ b/src/3d/processing/qgsalgorithmtessellate.cpp
@@ -79,7 +79,7 @@ QgsTessellateAlgorithm *QgsTessellateAlgorithm::createInstance() const
   return new QgsTessellateAlgorithm();
 }
 
-QgsFeatureList QgsTessellateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
+QgsFeatureList QgsTessellateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )
@@ -106,7 +106,14 @@ QgsFeatureList QgsTessellateAlgorithm::processFeature( const QgsFeature &feature
         t.addPolygon( *p, 0 );
       }
       QgsGeometry g( t.asMultiPolygon() );
-      g.translate( bounds.xMinimum(), bounds.yMinimum() );
+      if ( !g.isEmpty() )
+      {
+        g.translate( bounds.xMinimum(), bounds.yMinimum() );
+      }
+      else
+      {
+        feedback->reportError( QObject::tr( "Feature ID %1 could not be divided into triangular components." ).arg( f.id() ) );
+      }
       f.setGeometry( g );
     }
   }


### PR DESCRIPTION
## Description
@nyalldawson , little addition to your tessellate algorithm: print feature IDs in the algorithm log that fail to properly divide into triangular components. It's useful in identifying failing polygons for large datasets.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
