### PR TITLE
[QgsQuick] Handle empty config for CheckBox widget

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickcheckbox.qml
+++ b/src/quickgui/plugin/editor/qgsquickcheckbox.qml
@@ -38,7 +38,7 @@ Item {
     height: customStyle.fields.height
     id: checkBox
     leftPadding: 0
-    checked: value == config['CheckedState']
+    checked: config['CheckedState'] ? value == config['CheckedState'] : value
 
     indicator: Rectangle {
                 implicitWidth: customStyle.fields.height
@@ -60,13 +60,14 @@ Item {
                 }
         }
     onCheckedChanged: {
-      valueChanged( checked ? config['CheckedState'] : config['UncheckedState'], false )
+      valueChanged( checked ? (config['CheckedState'] ? config['CheckedState'] : true) :
+                              (config['UncheckedState'] ? config['UncheckedState'] : false), false )
       forceActiveFocus()
     }
 
     // Workaround to get a signal when the value has changed
     onCurrentValueChanged: {
-      checked = currentValue == config['CheckedState']
+      checked = config['CheckedState'] ? currentValue == config['CheckedState'] : currentValue
     }
   }
 }

--- a/src/quickgui/plugin/editor/qgsquickcheckbox.qml
+++ b/src/quickgui/plugin/editor/qgsquickcheckbox.qml
@@ -25,6 +25,12 @@ import QgsQuick 0.1 as QgsQuick
 Item {
   signal valueChanged( var value, bool isNull )
 
+  /**
+   * Handling missing config value for un/checked state for boolean field
+   */
+  property var checkedState: getConfigValue(config['CheckedState'], true)
+  property var uncheckedState: getConfigValue(config['UncheckedState'], false)
+
   id: fieldItem
   enabled: !readOnly
   height: childrenRect.height
@@ -33,12 +39,18 @@ Item {
     left: parent.left
   }
 
+  function getConfigValue(configValue, defaultValue) {
+     if (typeof value === "boolean" && !configValue) {
+         return defaultValue
+     } else return configValue
+  }
+
   CheckBox {
     property var currentValue: value
     height: customStyle.fields.height
     id: checkBox
     leftPadding: 0
-    checked: config['CheckedState'] ? value == config['CheckedState'] : value
+    checked: value === fieldItem.checkedState
 
     indicator: Rectangle {
                 implicitWidth: customStyle.fields.height
@@ -60,14 +72,13 @@ Item {
                 }
         }
     onCheckedChanged: {
-      valueChanged( checked ? (config['CheckedState'] ? config['CheckedState'] : true) :
-                              (config['UncheckedState'] ? config['UncheckedState'] : false), false )
+      valueChanged( checked ? fieldItem.checkedState : fieldItem.uncheckedState, false )
       forceActiveFocus()
     }
 
     // Workaround to get a signal when the value has changed
     onCurrentValueChanged: {
-      checked = config['CheckedState'] ? currentValue == config['CheckedState'] : currentValue
+      checked = currentValue === fieldItem.checkedState
     }
   }
 }

--- a/src/quickgui/plugin/editor/qgsquickcheckbox.qml
+++ b/src/quickgui/plugin/editor/qgsquickcheckbox.qml
@@ -56,7 +56,7 @@ Item {
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: checkBox.currentValue = !checkBox.currentValue
+                    onClicked: checkBox.checked = !checkBox.checked
                 }
         }
     onCheckedChanged: {


### PR DESCRIPTION
Widget config values "CheckedState" and "UncheckedState" in QgsEditorWidgetSetup are empty for a boolean field although default is true/false. That was causing a problem while setting checkbox.