### PR TITLE
Fix exception when reloading plugins

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -445,6 +445,9 @@ def _unloadPluginModules(packageName):
     mods = _plugin_modules[packageName]
 
     for mod in mods:
+        if not mod in sys.modules:
+            continue
+
         # if it looks like a Qt resource file, try to do a cleanup
         # otherwise we might experience a segfault next time the plugin is loaded
         # because Qt will try to access invalid plugin resource data


### PR DESCRIPTION
Not sure which recent commit introduced this, but a python exception is thrown whenever a plugin is reloaded now.