### PR TITLE
Add NMEA GST Message for GPSInformation.Accuracies

### DIFF
--- a/external/nmea/info.h
+++ b/external/nmea/info.h
@@ -115,6 +115,15 @@ typedef struct _nmeaINFO
   double  speed;      //!< Speed over the ground in kilometers/hour
   double  direction;  //!< Track angle in degrees True
   double  declination; //!< Magnetic variation degrees (Easterly var. subtracts from true course)
+  
+  double  rms_pr;     //!< RMS value of the pseudorange residuals; 
+					            //!< includes carrier phase residuals during periods of RTK (float) and RTK (fixed) processing
+  double  err_major;  //!< Error ellipse semi-major axis 1 sigma error, in meters
+  double  err_minor;  //!< Error ellipse semi-minor axis 1 sigma error, in meters
+  double  err_ori;    //!< Error ellipse orientation, degrees from true north
+  double  sig_lat;    //!< Latitude 1 sigma error, in meters
+  double  sig_lon;    //!< Longitude 1 sigma error, in meters
+  double  sig_alt;    //!< Height 1 sigma error, in meters
 
   nmeaSATINFO satinfo; //!< Satellites information
 

--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -141,21 +141,20 @@ int nmea_pack_type( const char *buff, int buff_sz )
 
   if ( buff_sz < 5 )
     return GPNON;
-  else if ( 0 == memcmp( buff, P_HEADS[0], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[0], 6 ) )
     return GPGGA;
-  else if ( 0 == memcmp( buff, P_HEADS[1], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[1], 6 ) )
     return GPGSA;
-  else if ( 0 == memcmp( buff, P_HEADS[2], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[2], 6 ) )
     return GPGSV;
-  else if ( 0 == memcmp( buff, P_HEADS[3], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[3], 6 ) )
     return GPRMC;
-  else if ( 0 == memcmp( buff, P_HEADS[4], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[4], 6 ) )
     return GPVTG;
-  else if ( 0 == memcmp( buff, P_HEADS[5], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[5], 6 ) )
     return GPRMC;
-  else if ( 0 == memcmp( buff, P_HEADS[6], 5 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[6], 6 ) )
     return GPGST;
-
 
   return GPNON;
 }

--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -133,7 +133,8 @@ int nmea_pack_type( const char *buff, int buff_sz )
     "GPGSV",
     "GPRMC",
     "GPVTG",
-    "GNRMC",
+    "GNRMC",    
+    "GPGST",
   };
 
   NMEA_ASSERT( buff );
@@ -152,6 +153,9 @@ int nmea_pack_type( const char *buff, int buff_sz )
     return GPVTG;
   else if ( 0 == memcmp( buff, P_HEADS[5], 5 ) )
     return GPRMC;
+  else if ( 0 == memcmp( buff, P_HEADS[6], 5 ) )
+    return GPGST;
+
 
   return GPNON;
 }
@@ -207,6 +211,7 @@ int nmea_find_tail( const char *buff, int buff_sz, int *res_crc )
   return nread;
 }
 
+
 /**
  * \brief Parse GGA packet from buffer.
  * @param buff a constant character pointer of packet buffer.
@@ -238,6 +243,42 @@ int nmea_parse_GPGGA( const char *buff, int buff_sz, nmeaGPGGA *pack )
   if ( 0 != _nmea_parse_time( &time_buff[0], ( int )strlen( &time_buff[0] ), &( pack->utc ) ) )
   {
     nmea_error( "GPGGA time parse error!" );
+    return 0;
+  }
+
+  return 1;
+}
+
+/**
+ * \brief Parse GST packet from buffer.
+ * @param buff a constant character pointer of packet buffer.
+ * @param buff_sz buffer size.
+ * @param pack a pointer of packet which will filled by function.
+ * @return 1 (true) - if parsed successfully or 0 (false) - if fail.
+ */
+int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack )
+{
+  char time_buff[NMEA_TIMEPARSE_BUF];
+
+  NMEA_ASSERT( buff && pack );
+
+  memset( pack, 0, sizeof( nmeaGPGGA ) );
+
+  nmea_trace_buff( buff, buff_sz );
+
+  if ( 8 != nmea_scanf( buff, buff_sz,
+                         "$GPGST,%s,%f,%f,%f,%f,%f,%f,%f*",
+                         &( time_buff[0] ),
+                         &( pack->rms_pr ), &( pack->err_major ), &( pack->err_minor ), &( pack->err_ori ),
+                         &( pack->sig_lat ), &( pack->sig_lon ), &( pack->sig_alt ) ) )
+  {
+    nmea_error( "GPGST parse error!" );
+    return 0;
+  }
+
+  if ( 0 != _nmea_parse_time( &time_buff[0], ( int )strlen( &time_buff[0] ), &( pack->utc ) ) )
+  {
+    nmea_error( "GPGST time parse error!" );
     return 0;
   }
 
@@ -424,6 +465,29 @@ void nmea_GPGGA2info( nmeaGPGGA *pack, nmeaINFO *info )
   info->lat = ( ( pack->ns == 'N' ) ? pack->lat : -( pack->lat ) );
   info->lon = ( ( pack->ew == 'E' ) ? pack->lon : -( pack->lon ) );
   info->smask |= GPGGA;
+}
+
+/**
+ * \brief Fill nmeaINFO structure by GST packet data.
+ * @param pack a pointer of packet structure.
+ * @param info a pointer of summary information structure.
+ */
+void nmea_GPGST2info( nmeaGPGST *pack, nmeaINFO *info )
+{
+  NMEA_ASSERT( pack && info );
+
+  info->utc.hour = pack->utc.hour;
+  info->utc.min = pack->utc.min;
+  info->utc.sec = pack->utc.sec;
+  info->utc.msec = pack->utc.msec;
+  info->rms_pr = pack->rms_pr;
+  info->err_major = pack->err_major;
+  info->err_minor = pack->err_minor;
+  info->err_ori = pack->err_ori;
+  info->sig_lat = pack->sig_lat;
+  info->sig_lon = pack->sig_lon;
+  info->sig_alt = pack->sig_alt;
+  info->smask |= GPGST;
 }
 
 /**

--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -261,7 +261,7 @@ int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack )
 
   NMEA_ASSERT( buff && pack );
 
-  memset( pack, 0, sizeof( nmeaGPGGA ) );
+  memset( pack, 0, sizeof( nmeaGPGST ) );
 
   nmea_trace_buff( buff, buff_sz );
 

--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -136,24 +136,27 @@ int nmea_pack_type( const char *buff, int buff_sz )
     "GNRMC",    
     "GPGST",
   };
+  
+  // BUFFER_SIZE = size(P_HEADS) - 1;
+  int buffer_size = 6;
 
   NMEA_ASSERT( buff );
 
-  if ( buff_sz < 5 )
+  if ( buff_sz < buffer_size )
     return GPNON;
-  else if ( 0 == memcmp( buff, P_HEADS[0], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[0], buffer_size ) )
     return GPGGA;
-  else if ( 0 == memcmp( buff, P_HEADS[1], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[1], buffer_size ) )
     return GPGSA;
-  else if ( 0 == memcmp( buff, P_HEADS[2], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[2], buffer_size ) )
     return GPGSV;
-  else if ( 0 == memcmp( buff, P_HEADS[3], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[3], buffer_size ) )
     return GPRMC;
-  else if ( 0 == memcmp( buff, P_HEADS[4], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[4], buffer_size ) )
     return GPVTG;
-  else if ( 0 == memcmp( buff, P_HEADS[5], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[5], buffer_size ) )
     return GPRMC;
-  else if ( 0 == memcmp( buff, P_HEADS[6], 6 ) )
+  else if ( 0 == memcmp( buff, P_HEADS[6], buffer_size ) )
     return GPGST;
 
   return GPNON;

--- a/external/nmea/parse.h
+++ b/external/nmea/parse.h
@@ -38,12 +38,14 @@ int nmea_pack_type( const char *buff, int buff_sz );
 int nmea_find_tail( const char *buff, int buff_sz, int *res_crc );
 
 int nmea_parse_GPGGA( const char *buff, int buff_sz, nmeaGPGGA *pack );
+int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack );
 int nmea_parse_GPGSA( const char *buff, int buff_sz, nmeaGPGSA *pack );
 int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack );
 int nmea_parse_GPRMC( const char *buff, int buff_sz, nmeaGPRMC *pack );
 int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack );
 
 void nmea_GPGGA2info( nmeaGPGGA *pack, nmeaINFO *info );
+void nmea_GPGST2info( nmeaGPGTA *pack, nmeaINFO *info );
 void nmea_GPGSA2info( nmeaGPGSA *pack, nmeaINFO *info );
 void nmea_GPGSV2info( nmeaGPGSV *pack, nmeaINFO *info );
 void nmea_GPRMC2info( nmeaGPRMC *pack, nmeaINFO *info );

--- a/external/nmea/parse.h
+++ b/external/nmea/parse.h
@@ -45,7 +45,7 @@ int nmea_parse_GPRMC( const char *buff, int buff_sz, nmeaGPRMC *pack );
 int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack );
 
 void nmea_GPGGA2info( nmeaGPGGA *pack, nmeaINFO *info );
-void nmea_GPGST2info( nmeaGPGTA *pack, nmeaINFO *info );
+void nmea_GPGST2info( nmeaGPGST *pack, nmeaINFO *info );
 void nmea_GPGSA2info( nmeaGPGSA *pack, nmeaINFO *info );
 void nmea_GPGSV2info( nmeaGPGSV *pack, nmeaINFO *info );
 void nmea_GPRMC2info( nmeaGPRMC *pack, nmeaINFO *info );

--- a/external/nmea/sentence.c
+++ b/external/nmea/sentence.c
@@ -38,6 +38,12 @@ void nmea_zero_GPGGA( nmeaGPGGA *pack )
   pack->diff_units = 'M';
 }
 
+void nmea_zero_GPGST( nmeaGPGST *pack )
+{
+  memset( pack, 0, sizeof( nmeaGPGST ) );
+  nmea_time_now( &pack->utc );
+}
+
 void nmea_zero_GPGSA( nmeaGPGSA *pack )
 {
   memset( pack, 0, sizeof( nmeaGPGSA ) );

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -30,7 +30,7 @@ enum nmeaPACKTYPE
   GPGSA   = 0x0002,   //!< GSA - GPS receiver operating mode, SVs used for navigation, and DOP values.
   GPGSV   = 0x0004,   //!< GSV - Number of SVs in view, PRN numbers, elevation, azimuth & SNR values.
   GPRMC   = 0x0008,   //!< RMC - Recommended Minimum Specific GPS/TRANSIT Data.
-  GPVTG   = 0x0010    //!< VTG - Actual track made good and speed over ground.
+  GPVTG   = 0x0010,   //!< VTG - Actual track made good and speed over ground.
   GPGST   = 0x0012    //!< GST - GPS Pseudorange Noise Statistics
 };
 

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -70,8 +70,6 @@ typedef struct _nmeaGPGST
   double  sig_lat;    //!< Latitude 1 sigma error, in meters
   double  sig_lon;    //!< Longitude 1 sigma error, in meters
   double  sig_alt;    //!< Height 1 sigma error, in meters
-  double  rms_h;      //!< Horizontal RMS, derived from sig_lat and sig_lon
-  double  rms_v;      //!< Vertical RMS, derived from sig_alt
   
 } nmeaGPGST;
 

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -31,6 +31,7 @@ enum nmeaPACKTYPE
   GPGSV   = 0x0004,   //!< GSV - Number of SVs in view, PRN numbers, elevation, azimuth & SNR values.
   GPRMC   = 0x0008,   //!< RMC - Recommended Minimum Specific GPS/TRANSIT Data.
   GPVTG   = 0x0010    //!< VTG - Actual track made good and speed over ground.
+  GPGST   = 0x0012    //!< GST - GPS Pseudorange Noise Statistics
 };
 
 /**
@@ -56,7 +57,7 @@ typedef struct _nmeaGPGGA
 } nmeaGPGGA;
   
 /**
- * GGA packet information structure (Global Positioning System Fix Data)
+ * GST packet information structure (GPS Pseudorange Noise Statistics)
  */
 typedef struct _nmeaGPGST
 {

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -54,6 +54,25 @@ typedef struct _nmeaGPGGA
   int     dgps_sid;   //!< DGPS station ID number
 
 } nmeaGPGGA;
+  
+/**
+ * GGA packet information structure (Global Positioning System Fix Data)
+ */
+typedef struct _nmeaGPGST
+{
+  nmeaTIME utc;       //!< UTC of position fix
+  double  rms_pr;     //!< RMS value of the pseudorange residuals; 
+                      //!< includes carrier phase residuals during periods of RTK (float) and RTK (fixed) processing
+  double  err_major;  //!< Error ellipse semi-major axis 1 sigma error, in meters
+  double  err_minor;  //!< Error ellipse semi-minor axis 1 sigma error, in meters
+  double  err_ori;    //!< Error ellipse orientation, degrees from true north
+  double  sig_lat;    //!< Latitude 1 sigma error, in meters
+  double  sig_lon;    //!< Longitude 1 sigma error, in meters
+  double  sig_alt;    //!< Height 1 sigma error, in meters
+  double  rms_h;      //!< Horizontal RMS, derived from sig_lat and sig_lon
+  double  rms_v;      //!< Vertical RMS, derived from sig_alt
+  
+} nmeaGPGST;
 
 /**
  * GSA packet information structure (Satellite status)
@@ -117,6 +136,7 @@ typedef struct _nmeaGPVTG
 } nmeaGPVTG;
 
 void nmea_zero_GPGGA( nmeaGPGGA *pack );
+void nmea_zero_GPGST( nmeaGPGST *pack );
 void nmea_zero_GPGSA( nmeaGPGSA *pack );
 void nmea_zero_GPGSV( nmeaGPGSV *pack );
 void nmea_zero_GPRMC( nmeaGPRMC *pack );

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -28,6 +28,9 @@
 #include "gmath.h"
 #include "info.h"
 
+// for sqrt
+#include <math.h>
+
 #define KNOTS_TO_KMH 1.852
 
 QgsNmeaConnection::QgsNmeaConnection( QIODevice *device )
@@ -126,6 +129,13 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
         }
+        else if ( substring.startsWith( QLatin1String( "$GPGST" ) ) )
+        {
+          QgsDebugMsg( substring );
+          processRmcSentence( ba.data(), ba.length() );
+          mStatus = GPSDataReceived;
+          QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
+        }
         emit nmeaSentenceReceived( substring );  // added to be able to save raw data
       }
     }
@@ -155,6 +165,23 @@ void QgsNmeaConnection::processGgaSentence( const char *data, int len )
     mLastGPSInformation.elevation = result.elv;
     mLastGPSInformation.quality = result.sig;
     mLastGPSInformation.satellitesUsed = result.satinuse;
+  }
+}
+
+void QgsNmeaConnection::processGstSentence( const char *data, int len )
+{
+  nmeaGPGST result;
+  if ( nmea_parse_GPGST( data, len, &result ) )
+  {
+    //update mLastGPSInformation
+    double sig_lat = result.sig_lat;
+    double sig_lon = result.sig_lon;
+    double sig_alt = result.sig_alt;
+   
+    // Horizontal RMS
+    mLastGPSInformation.hacc = sqrt( ( pow( sig_lat, 2 ) + pow( sig_lon, 2 ) ) / 2.0 );
+    // Vertical RMS
+    mLastGPSInformation.vacc = sqrt( pow( sig_alt, 2 ) );
   }
 }
 

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -132,7 +132,7 @@ void QgsNmeaConnection::processStringBuffer()
         else if ( substring.startsWith( QLatin1String( "$GPGST" ) ) )
         {
           QgsDebugMsg( substring );
-          processRmcSentence( ba.data(), ba.length() );
+          processGstSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
           QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
         }

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -181,7 +181,7 @@ void QgsNmeaConnection::processGstSentence( const char *data, int len )
     // Horizontal RMS
     mLastGPSInformation.hacc = sqrt( ( pow( sig_lat, 2 ) + pow( sig_lon, 2 ) ) / 2.0 );
     // Vertical RMS
-    mLastGPSInformation.vacc = sqrt( pow( sig_alt, 2 ) );
+    mLastGPSInformation.vacc = sig_alt;
   }
 }
 

--- a/src/core/gps/qgsnmeaconnection.h
+++ b/src/core/gps/qgsnmeaconnection.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsNmeaConnection: public QgsGpsConnection
     //! process GSA sentence
     void processGsaSentence( const char *data, int len );
     //! process GST sentence
-	  void processGstSentence(const char *data, int len);
+	  void processGstSentence( const char *data, int len );
 
 };
 

--- a/src/core/gps/qgsnmeaconnection.h
+++ b/src/core/gps/qgsnmeaconnection.h
@@ -56,6 +56,9 @@ class CORE_EXPORT QgsNmeaConnection: public QgsGpsConnection
     void processVtgSentence( const char *data, int len );
     //! process GSA sentence
     void processGsaSentence( const char *data, int len );
+    //! process GST sentence
+	  void processGstSentence(const char *data, int len);
+
 };
 
 #endif // QGSNMEACONNECTION_H


### PR DESCRIPTION
## Description

The core feature "GPSInformation" allways shows -1.0m vor Vertical and Horizontal Accuracy... This is handled by the NMEA message GST which was not implemented yet... I added that. 

As "accuracy" definition I used the approach described at [Calculating Vrms and Hrms from nmea data](https://gis.stackexchange.com/questions/217481/calculating-vrms-and-hrms-from-nmea-data/315536?newreg=84d02d6dd2934cd6ac139e9f94818aa3)

Fixes #21933