### PR TITLE
[symbology] Fix custom dash pattern for line with an hairline (i.e. 0) width

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -194,12 +194,13 @@ void QgsSimpleLineSymbolLayer::startRender( QgsSymbolRenderContext &context )
   mPen.setColor( penColor );
   double scaledWidth = context.renderContext().convertToPainterUnits( mWidth, mWidthUnit, mWidthMapUnitScale );
   mPen.setWidthF( scaledWidth );
-  if ( mUseCustomDashPattern && !qgsDoubleNear( scaledWidth, 0 ) )
+  if ( mUseCustomDashPattern )
   {
     mPen.setStyle( Qt::CustomDashLine );
 
     //scale pattern vector
-    double dashWidthDiv = scaledWidth;
+    double dashWidthDiv = qgsDoubleNear( scaledWidth, 0 ) ? 1.0 : scaledWidth;
+
     //fix dash pattern width in Qt 4.8
     QStringList versionSplit = QString( qVersion() ).split( '.' );
     if ( versionSplit.size() > 1


### PR DESCRIPTION
## Description
@nyalldawson , SLYR's pretty good at spotting issues with corner scenarios in our symbology code :) 

Turns out that, for the last 6-9 years, using hairline has pen width for simple line breaks (i.e. disables) custom dash patterns. This PR addresses that.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
