### PR TITLE
Fix point picking precision for point parameters in processing dialog

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2206,8 +2206,8 @@ void QgsProcessingPointPanel::clear()
 void QgsProcessingPointPanel::setValue( const QgsPointXY &point, const QgsCoordinateReferenceSystem &crs )
 {
   QString newText = QStringLiteral( "%1,%2" )
-                    .arg( QString::number( point.x(), 'g', 18 ) )
-                    .arg( QString::number( point.y(), 'g', 18 ) );
+                    .arg( QString::number( point.x(), 'f' ) )
+                    .arg( QString::number( point.y(), 'f' ) );
 
   mCrs = crs;
   if ( mCrs.isValid() )

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2205,7 +2205,10 @@ void QgsProcessingPointPanel::clear()
 
 void QgsProcessingPointPanel::setValue( const QgsPointXY &point, const QgsCoordinateReferenceSystem &crs )
 {
-  QString newText = QStringLiteral( "%1,%2" ).arg( point.x() ).arg( point.y() );
+  QString newText = QStringLiteral( "%1,%2" )
+                    .arg( QString::number( point.x(), 'g', 18 ) )
+                    .arg( QString::number( point.y(), 'g', 18 ) );
+
   mCrs = crs;
   if ( mCrs.isValid() )
   {

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -2841,19 +2841,23 @@ void TestProcessingGui::testPointPanel()
   QCOMPARE( panel->value().toString(), QStringLiteral( "200,250 [EPSG:3111]" ) );
   QCOMPARE( spy.count(), 2 );
 
+  panel->setValue( QgsPointXY( 123456.123456789122, 654321.987654321012 ), QgsCoordinateReferenceSystem() );
+  QCOMPARE( panel->value().toString(), QStringLiteral( "123456.123456789122,654321.987654321012" ) );
+  QCOMPARE( spy.count(), 3 );
+
   QVERIFY( !panel->mLineEdit->showClearButton() );
   panel->setAllowNull( true );
   QVERIFY( panel->mLineEdit->showClearButton() );
   panel->clear();
   QVERIFY( !panel->value().isValid() );
-  QCOMPARE( spy.count(), 3 );
+  QCOMPARE( spy.count(), 4 );
 
   QgsMapCanvas canvas;
   canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28356" ) ) );
   panel->setMapCanvas( &canvas );
   panel->updatePoint( QgsPointXY( 1.5, -3.5 ) );
   QCOMPARE( panel->value().toString(), QStringLiteral( "1.5,-3.5 [EPSG:28356]" ) );
-  QCOMPARE( spy.count(), 4 );
+  QCOMPARE( spy.count(), 5 );
 
   panel.reset();
 }

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -2834,15 +2834,15 @@ void TestProcessingGui::testPointPanel()
   QSignalSpy spy( panel.get(), &QgsProcessingPointPanel::changed );
 
   panel->setValue( QgsPointXY( 100, 150 ), QgsCoordinateReferenceSystem() );
-  QCOMPARE( panel->value().toString(), QStringLiteral( "100,150" ) );
+  QCOMPARE( panel->value().toString(), QStringLiteral( "100.000000,150.000000" ) );
   QCOMPARE( spy.count(), 1 );
 
   panel->setValue( QgsPointXY( 200, 250 ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ) );
-  QCOMPARE( panel->value().toString(), QStringLiteral( "200,250 [EPSG:3111]" ) );
+  QCOMPARE( panel->value().toString(), QStringLiteral( "200.000000,250.000000 [EPSG:3111]" ) );
   QCOMPARE( spy.count(), 2 );
 
-  panel->setValue( QgsPointXY( 123456.123456789122, 654321.987654321012 ), QgsCoordinateReferenceSystem() );
-  QCOMPARE( panel->value().toString(), QStringLiteral( "123456.123456789122,654321.987654321012" ) );
+  panel->setValue( QgsPointXY( 123456.123456789, 654321.987654321 ), QgsCoordinateReferenceSystem() );
+  QCOMPARE( panel->value().toString(), QStringLiteral( "123456.123457,654321.987654" ) );
   QCOMPARE( spy.count(), 3 );
 
   QVERIFY( !panel->mLineEdit->showClearButton() );
@@ -2856,7 +2856,7 @@ void TestProcessingGui::testPointPanel()
   canvas.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28356" ) ) );
   panel->setMapCanvas( &canvas );
   panel->updatePoint( QgsPointXY( 1.5, -3.5 ) );
-  QCOMPARE( panel->value().toString(), QStringLiteral( "1.5,-3.5 [EPSG:28356]" ) );
+  QCOMPARE( panel->value().toString(), QStringLiteral( "1.500000,-3.500000 [EPSG:28356]" ) );
   QCOMPARE( spy.count(), 5 );
 
   panel.reset();
@@ -2879,8 +2879,8 @@ void TestProcessingGui::testPointWrapper()
     QCOMPARE( spy.count(), 1 );
     if ( type != QgsProcessingGui::Modeler )
     {
-      QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "1,2" ) );
-      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1,2" ) );
+      QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "1.000000,2.000000" ) );
+      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000" ) );
     }
     else
     {
@@ -2891,8 +2891,8 @@ void TestProcessingGui::testPointWrapper()
     QCOMPARE( spy.count(), 2 );
     if ( type != QgsProcessingGui::Modeler )
     {
-      QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "1,2 [EPSG:3111]" ) );
-      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1,2 [EPSG:3111]" ) );
+      QCOMPARE( wrapper.widgetValue().toString(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
+      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
     }
     else
     {
@@ -2939,8 +2939,8 @@ void TestProcessingGui::testPointWrapper()
     QCOMPARE( spy2.count(), 1 );
     if ( type != QgsProcessingGui::Modeler )
     {
-      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper2.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1,2" ) );
-      QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "1,2" ) );
+      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper2.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000" ) );
+      QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "1.000000,2.000000" ) );
     }
     else
     {
@@ -2952,8 +2952,8 @@ void TestProcessingGui::testPointWrapper()
     QCOMPARE( spy2.count(), 2 );
     if ( type != QgsProcessingGui::Modeler )
     {
-      QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "1,2 [EPSG:3111]" ) );
-      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper2.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1,2 [EPSG:3111]" ) );
+      QCOMPARE( wrapper2.widgetValue().toString(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
+      QCOMPARE( static_cast< QgsProcessingPointPanel * >( wrapper2.wrappedWidget() )->mLineEdit->text(), QStringLiteral( "1.000000,2.000000 [EPSG:3111]" ) );
     }
     else
     {


### PR DESCRIPTION
## Description

When user click on map to select a point for a point parameter in a qgis processing, position is converted to string with only 6 significant digits, which cause a lack of precision in the end. 

I just set the precision to 18 to be consistent with the past behavior (when code was in python)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
