### PR TITLE
[processing] New options to autofill batch processing dialog

### DIFF
--- a/python/gui/auto_generated/qgsfindfilesbypatternwidget.sip.in
+++ b/python/gui/auto_generated/qgsfindfilesbypatternwidget.sip.in
@@ -67,8 +67,6 @@ Constructor for QgsFindFilesByPatternDialog, with the specified ``parent`` widge
     QStringList files() const;
 %Docstring
 Returns the list of files found by the dialog.
-
-.. seealso:: :py:func:`filesFound`
 %End
 
 };

--- a/python/gui/auto_generated/qgsfindfilesbypatternwidget.sip.in
+++ b/python/gui/auto_generated/qgsfindfilesbypatternwidget.sip.in
@@ -1,0 +1,82 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsfindfilesbypatternwidget.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsFindFilesByPatternWidget : QWidget
+{
+%Docstring
+A reusable widget for finding files (recursively) by file pattern.
+
+.. versionadded:: 3.8
+%End
+
+%TypeHeaderCode
+#include "qgsfindfilesbypatternwidget.h"
+%End
+  public:
+
+    QgsFindFilesByPatternWidget( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsFindFilesByPatternWidget, with the specified ``parent`` widget.
+%End
+
+    QStringList files() const;
+%Docstring
+Returns the list of files found by the dialog.
+
+.. seealso:: :py:func:`filesFound`
+%End
+
+  signals:
+
+    void filesFound( const QStringList &files );
+%Docstring
+Emitted after files are found in the dialog.
+
+.. seealso:: :py:func:`files`
+%End
+
+};
+
+class QgsFindFilesByPatternDialog : QDialog
+{
+%Docstring
+A dialog for finding files (recursively) by file pattern.
+
+.. versionadded:: 3.8
+%End
+
+%TypeHeaderCode
+#include "qgsfindfilesbypatternwidget.h"
+%End
+  public:
+
+    QgsFindFilesByPatternDialog( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsFindFilesByPatternDialog, with the specified ``parent`` widget.
+%End
+
+    QStringList files() const;
+%Docstring
+Returns the list of files found by the dialog.
+
+.. seealso:: :py:func:`filesFound`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsfindfilesbypatternwidget.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgsfindfilesbypatternwidget.sip.in
+++ b/python/gui/auto_generated/qgsfindfilesbypatternwidget.sip.in
@@ -30,16 +30,20 @@ Constructor for QgsFindFilesByPatternWidget, with the specified ``parent`` widge
 
     QStringList files() const;
 %Docstring
-Returns the list of files found by the dialog.
+Returns the list of files found by the dialog. This may be empty if
+no matching files were found.
 
-.. seealso:: :py:func:`filesFound`
+.. seealso:: :py:func:`findComplete`
 %End
 
   signals:
 
-    void filesFound( const QStringList &files );
+    void findComplete( const QStringList &files );
 %Docstring
 Emitted after files are found in the dialog.
+
+The ``files`` argument contains a list of all matching files found. This may be empty if
+no matching files were found.
 
 .. seealso:: :py:func:`files`
 %End
@@ -66,7 +70,8 @@ Constructor for QgsFindFilesByPatternDialog, with the specified ``parent`` widge
 
     QStringList files() const;
 %Docstring
-Returns the list of files found by the dialog.
+Returns the list of files found by the dialog. This may be empty if
+no matching files were found.
 %End
 
 };

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -113,6 +113,7 @@
 %Include auto_generated/qgsfeatureselectiondlg.sip
 %Include auto_generated/qgsfieldcombobox.sip
 %Include auto_generated/qgsfieldexpressionwidget.sip
+%Include auto_generated/qgsfindfilesbypatternwidget.sip
 %Include auto_generated/qgsfeaturelistcombobox.sip
 %Include auto_generated/qgsfieldvalidator.sip
 %Include auto_generated/qgsfieldvalueslineedit.sip

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -78,7 +78,7 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         load_layers = self.mainWidget().checkLoadLayersOnCompletion.isChecked()
         project = QgsProject.instance() if load_layers else None
 
-        for row in range(len(self.mainWidget().batchRowCount())):
+        for row in range(self.mainWidget().batchRowCount()):
             col = 0
             parameters = {}
             for param in self.algorithm().parameterDefinitions():

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -78,7 +78,7 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         load_layers = self.mainWidget().checkLoadLayersOnCompletion.isChecked()
         project = QgsProject.instance() if load_layers else None
 
-        for row in range(self.mainWidget().tblParameters.rowCount()):
+        for row in range(len(self.mainWidget().batchRowCount())):
             col = 0
             parameters = {}
             for param in self.algorithm().parameterDefinitions():
@@ -98,7 +98,7 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     continue
 
                 count_visible_outputs += 1
-                widget = self.mainWidget().tblParameters.cellWidget(row, col)
+                widget = self.mainWidget().tblParameters.cellWidget(row + 1, col)
                 text = widget.getValue()
                 if out.checkValueIsAcceptable(text):
                     if isinstance(out, (QgsProcessingParameterRasterDestination,

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -544,9 +544,18 @@ class BatchPanel(BASE, WIDGET):
             wrapper.postInitialize(list(wrappers.values()))
 
     def removeRows(self):
-        if self.tblParameters.rowCount() > 2:
-            self.wrappers.pop()
-            self.tblParameters.setRowCount(self.tblParameters.rowCount() - 1)
+        rows = set()
+        for index in self.tblParameters.selectedIndexes():
+            if index.row() == 0:
+                continue
+            rows.add(index.row())
+
+        for row in sorted(rows, reverse=True):
+            if self.tblParameters.rowCount() <= 2:
+                break
+
+            del self.wrappers[row - 1]
+            self.tblParameters.removeRow(row)
 
     def toggleAdvancedMode(self, checked):
         for column, param in enumerate(self.alg.parameterDefinitions()):

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -96,7 +96,7 @@ class BatchPanelFillWidget(QToolButton):
     def __init__(self, parameterDefinition, column, panel, parent=None):
         super().__init__(parent)
 
-        self.setBackgroundRole(QPalette.Window)
+        self.setBackgroundRole(QPalette.Button)
         self.setAutoFillBackground(True)
 
         self.parameterDefinition = parameterDefinition

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -46,24 +46,32 @@ from qgis.PyQt.QtCore import (
     QFileInfo,
     QCoreApplication
 )
-from qgis.core import (Qgis,
-                       QgsApplication,
-                       QgsSettings,
-                       QgsProperty,  # NOQA - must be here for saved file evaluation
-                       QgsProject,
-                       QgsProcessingFeatureSourceDefinition,  # NOQA - must be here for saved file evaluation
-                       QgsCoordinateReferenceSystem,  # NOQA - must be here for saved file evaluation
-                       QgsProcessingParameterDefinition,
-                       QgsProcessingModelAlgorithm,
-                       QgsProcessingParameterFile,
-                       QgsProcessingParameterMapLayer,
-                       QgsProcessingParameterRasterLayer,
-                       QgsProcessingParameterMeshLayer,
-                       QgsProcessingParameterVectorLayer,
-                       QgsProcessingParameterFeatureSource)
-from qgis.gui import (QgsProcessingParameterWidgetContext,
-                      QgsProcessingContextGenerator,
-                      QgsFindFilesByPatternDialog)
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsSettings,
+    QgsProperty,  # NOQA - must be here for saved file evaluation
+    QgsProject,
+    QgsProcessingFeatureSourceDefinition,  # NOQA - must be here for saved file evaluation
+    QgsCoordinateReferenceSystem,  # NOQA - must be here for saved file evaluation
+    QgsProcessingParameterDefinition,
+    QgsProcessingModelAlgorithm,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterMapLayer,
+    QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterMeshLayer,
+    QgsProcessingParameterVectorLayer,
+    QgsProcessingParameterFeatureSource,
+    QgsProcessingParameterRasterDestination,
+    QgsProcessingParameterVectorDestination,
+    QgsProcessingParameterFeatureSink,
+    QgsProcessingOutputLayerDefinition
+)
+from qgis.gui import (
+    QgsProcessingParameterWidgetContext,
+    QgsProcessingContextGenerator,
+    QgsFindFilesByPatternDialog
+)
 from qgis.utils import iface
 
 from processing.gui.wrappers import WidgetWrapperFactory, WidgetWrapper
@@ -171,7 +179,6 @@ class BatchPanelFillWidget(QToolButton):
 
 
 class BatchPanel(BASE, WIDGET):
-
     PARAMETERS = "PARAMETERS"
     OUTPUTS = "OUTPUTS"
 
@@ -457,3 +464,45 @@ class BatchPanel(BASE, WIDGET):
         for column, param in enumerate(self.alg.parameterDefinitions()):
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
                 self.tblParameters.setColumnHidden(column, not checked)
+
+    def parametersForRow(self, row, destinationProject=None, warnOnInvalid=True):
+        """
+        Returns the parameters dictionary corresponding to a row in the batch table
+        """
+        col = 0
+        parameters = {}
+        for param in self.alg.parameterDefinitions():
+            if param.flags() & QgsProcessingParameterDefinition.FlagHidden or param.isDestination():
+                continue
+            wrapper = self.wrappers[row][col]
+            parameters[param.name()] = wrapper.parameterValue()
+            if warnOnInvalid and not param.checkValueIsAcceptable(wrapper.parameterValue()):
+                self.parent.messageBar().pushMessage("",
+                                                     self.tr('Wrong or missing parameter value: {0} (row {1})').format(
+                                                         param.description(), row + 1),
+                                                     level=Qgis.Warning, duration=5)
+                return {}
+            col += 1
+        count_visible_outputs = 0
+        for out in self.alg.destinationParameterDefinitions():
+            if out.flags() & QgsProcessingParameterDefinition.FlagHidden:
+                continue
+
+            count_visible_outputs += 1
+            widget = self.tblParameters.cellWidget(row + 1, col)
+            text = widget.getValue()
+            if not warnOnInvalid or out.checkValueIsAcceptable(text):
+                if isinstance(out, (QgsProcessingParameterRasterDestination,
+                                    QgsProcessingParameterVectorDestination,
+                                    QgsProcessingParameterFeatureSink)):
+                    # load rasters and sinks on completion
+                    parameters[out.name()] = QgsProcessingOutputLayerDefinition(text, destinationProject)
+                else:
+                    parameters[out.name()] = text
+                col += 1
+            else:
+                self.parent.messageBar().pushMessage("", self.tr('Wrong or missing output value: {0} (row {1})').format(
+                    out.description(), row + 1),
+                    level=Qgis.Warning, duration=5)
+                return {}
+        return parameters

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -312,6 +312,7 @@ class BatchPanel(BASE, WIDGET):
         self.context_generator = ContextGenerator(self.processing_context)
 
         self.column_to_parameter_definition = {}
+        self.parameter_to_column = {}
 
         self.initWidgets()
 
@@ -340,6 +341,7 @@ class BatchPanel(BASE, WIDGET):
                 self.tblParameters.setColumnHidden(column, True)
 
             self.column_to_parameter_definition[column] = param.name()
+            self.parameter_to_column[param.name()] = column
             column += 1
 
         for out in self.alg.destinationParameterDefinitions():
@@ -347,6 +349,7 @@ class BatchPanel(BASE, WIDGET):
                 self.tblParameters.setHorizontalHeaderItem(
                     column, QTableWidgetItem(out.description()))
                 self.column_to_parameter_definition[column] = out.name()
+                self.parameter_to_column[out.name()] = column
                 column += 1
 
         self.addFillRow()
@@ -558,9 +561,9 @@ class BatchPanel(BASE, WIDGET):
             self.tblParameters.removeRow(row)
 
     def toggleAdvancedMode(self, checked):
-        for column, param in enumerate(self.alg.parameterDefinitions()):
+        for param in self.alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
-                self.tblParameters.setColumnHidden(column, not checked)
+                self.tblParameters.setColumnHidden(self.parameter_to_column[param.name()], not checked)
 
     def parametersForRow(self, row, destinationProject=None, warnOnInvalid=True):
         """

--- a/python/plugins/processing/ui/widgetBatchPanel.ui
+++ b/python/plugins/processing/ui/widgetBatchPanel.ui
@@ -89,9 +89,6 @@
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
      </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
     </widget>
    </item>
    <item row="0" column="3">

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -277,6 +277,7 @@ SET(QGIS_GUI_SRCS
   qgsfilecontentsourcelineedit.cpp
   qgsfilewidget.cpp
   qgsfilterlineedit.cpp
+  qgsfindfilesbypatternwidget.cpp
   qgsfloatingwidget.cpp
   qgsfocuswatcher.cpp
   qgsfontbutton.cpp
@@ -452,6 +453,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsfeatureselectiondlg.h
   qgsfieldcombobox.h
   qgsfieldexpressionwidget.h
+  qgsfindfilesbypatternwidget.h
   qgsfeaturelistcombobox.h
   qgsfieldvalidator.h
   qgsfieldvalueslineedit.h

--- a/src/gui/qgsfindfilesbypatternwidget.cpp
+++ b/src/gui/qgsfindfilesbypatternwidget.cpp
@@ -103,7 +103,7 @@ void QgsFindFilesByPatternWidget::find()
   disconnect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::cancel );
   connect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::find );
 
-  emit filesFound( mFiles );
+  emit findComplete( mFiles );
 }
 
 void QgsFindFilesByPatternWidget::cancel()
@@ -135,7 +135,7 @@ QgsFindFilesByPatternDialog::QgsFindFilesByPatternDialog( QWidget *parent )
   setLayout( vLayout );
 
   mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
-  connect( mWidget, &QgsFindFilesByPatternWidget::filesFound, this, [ = ]( const QStringList & files )
+  connect( mWidget, &QgsFindFilesByPatternWidget::findComplete, this, [ = ]( const QStringList & files )
   {
     mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !files.empty() );
   } );

--- a/src/gui/qgsfindfilesbypatternwidget.cpp
+++ b/src/gui/qgsfindfilesbypatternwidget.cpp
@@ -1,0 +1,147 @@
+/***************************************************************************
+    qgsfindfilesbypatternwidget.cpp
+    -----------------------------
+    begin                : April 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsfindfilesbypatternwidget.h"
+#include "qgsgui.h"
+#include "qgssettings.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QDialogButtonBox>
+
+
+QgsFindFilesByPatternWidget::QgsFindFilesByPatternWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+
+  mFolderWidget->setStorageMode( QgsFileWidget::GetDirectory );
+  mResultsTable->setColumnCount( 2 );
+
+  mResultsTable->setHorizontalHeaderLabels( QStringList() << tr( "File" ) << tr( "Directory" ) );
+  mResultsTable->horizontalHeader()->setSectionResizeMode( 0, QHeaderView::Stretch );
+  mResultsTable->horizontalHeader()->setSectionResizeMode( 1, QHeaderView::Stretch );
+
+  connect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::find );
+
+  QgsSettings settings;
+  mFolderWidget->setFilePath( settings.value( QStringLiteral( "qgis/lastFindRecursiveFolder" ) ).toString() );
+  mFindButton->setEnabled( !mFolderWidget->filePath().isEmpty() );
+  connect( mFolderWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & filePath )
+  {
+    QgsSettings settings;
+    settings.setValue( QStringLiteral( "qgis/lastFindRecursiveFolder" ), filePath );
+    mFindButton->setEnabled( !filePath.isEmpty() );
+  } );
+
+}
+
+void QgsFindFilesByPatternWidget::find()
+{
+  mFindButton->setText( tr( "Cancel" ) );
+  disconnect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::find );
+  connect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::cancel );
+  mCanceled = false;
+
+  mResultsTable->setRowCount( 0 );
+  mFiles.clear();
+
+  const QString pattern = mPatternLineEdit->text();
+  const QString path = mFolderWidget->filePath();
+
+  QDir startDir( path );
+
+  QStringList filter;
+  if ( !pattern.isEmpty() )
+    filter << pattern;
+
+  QDirIterator it( path, filter, QDir::AllEntries | QDir::NoSymLinks | QDir::NoDotAndDotDot, mRecursiveCheckBox->isChecked() ? QDirIterator::Subdirectories : QDirIterator::NoIteratorFlags );
+  QStringList files;
+  while ( it.hasNext() )
+  {
+    const QString fullPath = it.next();
+    mFiles << fullPath;
+
+    QFileInfo fi( fullPath );
+
+    const QString toolTip = QDir::toNativeSeparators( fullPath );
+    const QString fileName = fi.fileName();
+    const QString relativeDirectory = QDir::toNativeSeparators( startDir.relativeFilePath( fi.dir().absolutePath() ) );
+    const QString fullDirectory = QDir::toNativeSeparators( fi.dir().absolutePath() );
+
+    QTableWidgetItem *fileNameItem = new QTableWidgetItem( fileName );
+    fileNameItem->setToolTip( toolTip );
+    fileNameItem->setFlags( fileNameItem->flags() ^ Qt::ItemIsEditable );
+
+    QTableWidgetItem *directoryItem = new QTableWidgetItem( relativeDirectory );
+    directoryItem->setToolTip( fullDirectory );
+    directoryItem->setFlags( directoryItem->flags() ^ Qt::ItemIsEditable );
+
+    const int row = mResultsTable->rowCount();
+    mResultsTable->insertRow( row );
+    mResultsTable->setItem( row, 0, fileNameItem );
+    mResultsTable->setItem( row, 1, directoryItem );
+
+    QCoreApplication::processEvents();
+    if ( mCanceled )
+      break;
+  }
+
+  mFindButton->setText( tr( "Find Files" ) );
+  disconnect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::cancel );
+  connect( mFindButton, &QPushButton::clicked, this, &QgsFindFilesByPatternWidget::find );
+
+  emit filesFound( mFiles );
+}
+
+void QgsFindFilesByPatternWidget::cancel()
+{
+  mCanceled = true;
+}
+
+
+//
+// QgsFindFilesByPatternDialog
+//
+
+QgsFindFilesByPatternDialog::QgsFindFilesByPatternDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setWindowTitle( tr( "Find Files by Pattern" ) );
+  setObjectName( "QgsFindFilesByPatternDialog" );
+
+  QgsGui::enableAutoGeometryRestore( this );
+
+  QVBoxLayout *vLayout = new QVBoxLayout();
+  mWidget = new QgsFindFilesByPatternWidget();
+
+  vLayout->addWidget( mWidget );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  vLayout->addWidget( mButtonBox );
+  setLayout( vLayout );
+
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+  connect( mWidget, &QgsFindFilesByPatternWidget::filesFound, this, [ = ]( const QStringList & files )
+  {
+    mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( !files.empty() );
+  } );
+}
+
+QStringList QgsFindFilesByPatternDialog::files() const
+{
+  return mWidget->files();
+}

--- a/src/gui/qgsfindfilesbypatternwidget.h
+++ b/src/gui/qgsfindfilesbypatternwidget.h
@@ -41,8 +41,9 @@ class GUI_EXPORT QgsFindFilesByPatternWidget : public QWidget, private Ui::QgsFi
     QgsFindFilesByPatternWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
-     * Returns the list of files found by the dialog.
-     * \see filesFound()
+     * Returns the list of files found by the dialog. This may be empty if
+     * no matching files were found.
+     * \see findComplete()
      */
     QStringList files() const { return mFiles; }
 
@@ -51,9 +52,12 @@ class GUI_EXPORT QgsFindFilesByPatternWidget : public QWidget, private Ui::QgsFi
     /**
      * Emitted after files are found in the dialog.
      *
+     * The \a files argument contains a list of all matching files found. This may be empty if
+     * no matching files were found.
+     *
      * \see files()
      */
-    void filesFound( const QStringList &files );
+    void findComplete( const QStringList &files );
 
   private slots:
 
@@ -84,7 +88,8 @@ class GUI_EXPORT QgsFindFilesByPatternDialog : public QDialog
     QgsFindFilesByPatternDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
-     * Returns the list of files found by the dialog.
+     * Returns the list of files found by the dialog. This may be empty if
+     * no matching files were found.
      */
     QStringList files() const;
 

--- a/src/gui/qgsfindfilesbypatternwidget.h
+++ b/src/gui/qgsfindfilesbypatternwidget.h
@@ -1,0 +1,99 @@
+/***************************************************************************
+    qgsfindfilesbypatternwidget.h
+    -----------------------------
+    begin                : April 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSFINDFILESBYPATTERNWIDGET_H
+#define QGSFINDFILESBYPATTERNWIDGET_H
+
+#include "ui_qgsfindfilesbypatternwidget.h"
+#include "qgis_gui.h"
+
+#include <QDialog>
+
+class QDialogButtonBox;
+
+/**
+ * \class QgsFindFilesByPatternWidget
+ * \ingroup gui
+ * A reusable widget for finding files (recursively) by file pattern.
+ * \since QGIS 3.8
+ */
+class GUI_EXPORT QgsFindFilesByPatternWidget : public QWidget, private Ui::QgsFindFilesByPatternWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsFindFilesByPatternWidget, with the specified \a parent widget.
+     */
+    QgsFindFilesByPatternWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns the list of files found by the dialog.
+     * \see filesFound()
+     */
+    QStringList files() const { return mFiles; }
+
+  signals:
+
+    /**
+     * Emitted after files are found in the dialog.
+     *
+     * \see files()
+     */
+    void filesFound( const QStringList &files );
+
+  private slots:
+
+    void find();
+    void cancel();
+
+  private:
+
+    bool mCanceled = false;
+    QStringList mFiles;
+};
+
+/**
+ * \class QgsFindFilesByPatternDialog
+ * \ingroup gui
+ * A dialog for finding files (recursively) by file pattern.
+ * \since QGIS 3.8
+ */
+class GUI_EXPORT QgsFindFilesByPatternDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsFindFilesByPatternDialog, with the specified \a parent widget.
+     */
+    QgsFindFilesByPatternDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns the list of files found by the dialog.
+     * \see filesFound()
+     */
+    QStringList files() const;
+
+  private:
+
+    QgsFindFilesByPatternWidget *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
+
+};
+
+#endif // QGSFINDFILESBYPATTERNWIDGET_H

--- a/src/gui/qgsfindfilesbypatternwidget.h
+++ b/src/gui/qgsfindfilesbypatternwidget.h
@@ -85,7 +85,6 @@ class GUI_EXPORT QgsFindFilesByPatternDialog : public QDialog
 
     /**
      * Returns the list of files found by the dialog.
-     * \see filesFound()
      */
     QStringList files() const;
 

--- a/src/ui/qgsfindfilesbypatternwidget.ui
+++ b/src/ui/qgsfindfilesbypatternwidget.ui
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsFindFilesByPatternWidgetBase</class>
+ <widget class="QWidget" name="QgsFindFilesByPatternWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>542</width>
+    <height>286</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="mFindButton">
+     <property name="text">
+      <string>Find Files</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>File pattern</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLineEdit" name="mPatternLineEdit">
+     <property name="placeholderText">
+      <string>Pattern to match, e.g. *.shp</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Look in</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="mRecursiveCheckBox">
+     <property name="text">
+      <string>Search recursively</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="3">
+    <widget class="QTableWidget" name="mResultsTable"/>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QgsFileWidget" name="mFolderWidget"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mPatternLineEdit</tabstop>
+  <tabstop>mFolderWidget</tabstop>
+  <tabstop>mRecursiveCheckBox</tabstop>
+  <tabstop>mFindButton</tabstop>
+  <tabstop>mResultsTable</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR reworks how Processing's batch dialog can be autopopulated. Previously, users could double-click a column header in order to "copy down" the top row's value to all other rows. This was very hidden, yet an important feature for users to utilise!

In this PR the dialog has been reworked to add a new "Autofill" row at the top of the table. Clicking on the Autofill option for any column opens a drop down menu with available fill options. The existing "fill down" option has been moved to this menu (so double-click header no longer works), and several new options have been added:

- "Calculate by expression":  Selecting it allows users to create a new QGIS expression to use to update all existing values within that column. Existing parameter values (including those from other columns) are available for use inside the expression via @variables. E.g. this allows setting output file names to complex expressions like ```'/home/me/stuff/buffer_' || left(@input, 30) || '_' || @distance || '.shp'```

- "Add values by expression": This option adds news rows using the values from an expression
which returns an array. (As opposed to "Calculate by Expression", which works only on existing rows). The intended use case is to allow populating the batch dialog using complex numeric series, e.g. those created by the `generate_series` expression function. For example, adding rows for a batch buffer using the expression `generate_series(100, 1000, 50)` results in new rows with values 100, 150, 200, .... 1000.

- "Add Files by Pattern…" (available for file/layer parameters only): Adds new rows to the table for matching files found using a file pattern and folder (with an option to search recursively)

Together, these options make the batch execution mode for Processing much more user friendly and powerful.

Sponsored by North Road, thanks to SLYR