### PR TITLE
[ui] Improvements to the font marker character widget

### DIFF
--- a/src/gui/symbology/characterwidget.cpp
+++ b/src/gui/symbology/characterwidget.cpp
@@ -43,6 +43,9 @@
 **
 ****************************************************************************/
 
+#include "characterwidget.h"
+#include "qgsapplication.h"
+
 #include <QFontDatabase>
 #include <QMouseEvent>
 #include <QPaintEvent>
@@ -50,8 +53,6 @@
 #include <QPen>
 #include <QPoint>
 #include <QToolTip>
-
-#include "characterwidget.h"
 
 CharacterWidget::CharacterWidget( QWidget *parent )
   : QWidget( parent )
@@ -62,7 +63,7 @@ CharacterWidget::CharacterWidget( QWidget *parent )
 void CharacterWidget::setFont( const QFont &font )
 {
   mDisplayFont.setFamily( font.family() );
-  mSquareSize = std::max( 24, QFontMetrics( mDisplayFont ).xHeight() * 3 );
+  mSquareSize = std::max( 34, QFontMetrics( mDisplayFont ).xHeight() * 3 );
   adjustSize();
   update();
 }
@@ -70,7 +71,7 @@ void CharacterWidget::setFont( const QFont &font )
 void CharacterWidget::setFontSize( double fontSize )
 {
   mDisplayFont.setPointSizeF( fontSize );
-  mSquareSize = std::max( 24, QFontMetrics( mDisplayFont ).xHeight() * 3 );
+  mSquareSize = std::max( 34, QFontMetrics( mDisplayFont ).xHeight() * 3 );
   adjustSize();
   update();
 }
@@ -81,7 +82,7 @@ void CharacterWidget::setFontStyle( const QString &fontStyle )
   const QFont::StyleStrategy oldStrategy = mDisplayFont.styleStrategy();
   mDisplayFont = fontDatabase.font( mDisplayFont.family(), fontStyle, mDisplayFont.pointSize() );
   mDisplayFont.setStyleStrategy( oldStrategy );
-  mSquareSize = std::max( 24, QFontMetrics( mDisplayFont ).xHeight() * 3 );
+  mSquareSize = std::max( 34, QFontMetrics( mDisplayFont ).xHeight() * 3 );
   adjustSize();
   update();
 }
@@ -144,7 +145,8 @@ void CharacterWidget::mousePressEvent( QMouseEvent *event )
 void CharacterWidget::paintEvent( QPaintEvent *event )
 {
   QPainter painter( this );
-  painter.fillRect( event->rect(), QBrush( Qt::white ) );
+  QPalette palette = qApp->palette();
+  painter.fillRect( event->rect(), QBrush( palette.color( QPalette::Base ) ) );
   painter.setFont( mDisplayFont );
 
   QRect redrawRect = event->rect();
@@ -153,7 +155,7 @@ void CharacterWidget::paintEvent( QPaintEvent *event )
   int beginColumn = redrawRect.left() / mSquareSize;
   int endColumn = redrawRect.right() / mSquareSize;
 
-  painter.setPen( QPen( Qt::gray ) );
+  painter.setPen( QPen( palette.color( QPalette::Mid ) ) );
   for ( int row = beginRow; row <= endRow; ++row )
   {
     for ( int column = beginColumn; column <= endColumn; ++column )
@@ -163,18 +165,16 @@ void CharacterWidget::paintEvent( QPaintEvent *event )
   }
 
   QFontMetrics fontMetrics( mDisplayFont );
-  painter.setPen( QPen( Qt::black ) );
   for ( int row = beginRow; row <= endRow; ++row )
   {
-
     for ( int column = beginColumn; column <= endColumn; ++column )
     {
-
       int key = row * mColumns + column;
       painter.setClipRect( column * mSquareSize, row * mSquareSize, mSquareSize, mSquareSize );
+      painter.setPen( QPen( palette.color( key == mLastKey ? QPalette::HighlightedText : QPalette::WindowText ) ) );
 
       if ( key == mLastKey )
-        painter.fillRect( column * mSquareSize + 1, row * mSquareSize + 1, mSquareSize, mSquareSize, QBrush( Qt::red ) );
+        painter.fillRect( column * mSquareSize + 1, row * mSquareSize + 1, mSquareSize, mSquareSize, QBrush( palette.color( QPalette::Highlight ) ) );
 
       painter.drawText( column * mSquareSize + ( mSquareSize / 2 ) - fontMetrics.width( QChar( key ) ) / 2,
                         row * mSquareSize + 4 + fontMetrics.ascent(),

--- a/src/gui/symbology/characterwidget.h
+++ b/src/gui/symbology/characterwidget.h
@@ -154,7 +154,7 @@ class GUI_EXPORT CharacterWidget : public QWidget
 
   private:
     QFont mDisplayFont;
-    int mColumns = 16;
+    int mColumns = 13;
     int mLastKey = -1;
     int mSquareSize = 24;
 };

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3207,6 +3207,7 @@ QgsFontMarkerSymbolLayerWidget::QgsFontMarkerSymbolLayerWidget( QgsVectorLayer *
                                     << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
   mOffsetUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMetersInMapUnits << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
                                << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
+
   widgetChar = new CharacterWidget;
   scrollArea->setWidget( widgetChar );
 

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -321,6 +321,12 @@
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0" rowspan="2">
       <widget class="QgsScrollArea" name="scrollArea">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>158</height>
+        </size>
+       </property>
        <widget class="QWidget" name="scrollAreaWidgetContents">
         <property name="geometry">
          <rect>


### PR DESCRIPTION
## Description
- Declare a minimum height to avoid narrow selection area
- Use application color palette instead of hardcoded values
- Decrease number of columns to better fit in the style dock

The looks of the characters widget remains less than ideal but the PR improves the situation quite a lot. It also gets rid of "error" red, which I always thought was misleading to users.

Before (left) vs. PR:
![image](https://user-images.githubusercontent.com/1728657/56888495-4bc3a200-6a9e-11e9-92c9-3b6b8da20f4e.png)
_Notice how little height the widget had before, making it very unpleasant to use_

By avoiding hard-coded values, it also blends better on dark(er) themes:
![image](https://user-images.githubusercontent.com/1728657/56888513-57af6400-6a9e-11e9-85e3-cc62a8ca9c10.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
