### PR TITLE
[needs-docs] Tweak custom dash button appearance

### DIFF
--- a/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbollayerwidget.sip.in
@@ -125,6 +125,9 @@ Creates a new QgsSimpleLineSymbolLayerWidget.
 
     void updatePatternIcon();
 
+    virtual void resizeEvent( QResizeEvent *event );
+
+
 };
 
 

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -153,6 +153,8 @@ class GUI_EXPORT QgsSimpleLineSymbolLayerWidget : public QgsSymbolLayerWidget, p
     //creates a new icon for the 'change pattern' button
     void updatePatternIcon();
 
+    void resizeEvent( QResizeEvent *event ) override;
+
   private slots:
 
     void updateAssistantSymbol();

--- a/src/ui/symbollayer/widget_simpleline.ui
+++ b/src/ui/symbollayer/widget_simpleline.ui
@@ -225,30 +225,6 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_12">
-     <item>
-      <widget class="QPushButton" name="mChangePatternButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QgsUnitSelectionWidget" name="mDashPatternUnitWidget" native="true">
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="4" column="3">
     <widget class="QgsPropertyOverrideButton" name="mJoinStyleDDBtn">
      <property name="text">
@@ -286,6 +262,46 @@
    </item>
    <item row="9" column="2" colspan="2">
     <widget class="QComboBox" name="mRingFilterComboBox"/>
+   </item>
+   <item row="7" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="horizontalLayout_12">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Maximum</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>1</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mChangePatternButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsUnitSelectionWidget" name="mDashPatternUnitWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- remove "Change" label and replace with larger dash preview icon.
The "change" text is unnecessary and adds to dialog clutter, better
to use the space for a wider preview icon (especially given that
the previous narrow icon never really showed enough of the pattern
to be useful!)

- don't offset the line in the preview if the symbol has an offset
set

- respond correctly to dash pattern, line width unit changes, cap
style changes

- show a nice big preview tooltip on hover

![image](https://user-images.githubusercontent.com/1829991/56933604-ef0ec880-6b2b-11e9-80cf-5d62f1ea6cfa.png)


