### PR TITLE
[symbology] Unlock string as character for font markers

### DIFF
--- a/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsmarkersymbollayer.sip.in
@@ -867,11 +867,15 @@ class QgsFontMarkerSymbolLayer : QgsMarkerSymbolLayer
 #include "qgsmarkersymbollayer.h"
 %End
   public:
+
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,
-                              QChar chr = DEFAULT_FONTMARKER_CHR,
+                              QString chr = DEFAULT_FONTMARKER_CHR,
                               double pointSize = DEFAULT_FONTMARKER_SIZE,
                               const QColor &color = DEFAULT_FONTMARKER_COLOR,
                               double angle = DEFAULT_FONTMARKER_ANGLE );
+%Docstring
+Constructs a font marker symbol layer.
+%End
 
     ~QgsFontMarkerSymbolLayer();
 
@@ -923,16 +927,16 @@ Sets the font ``family`` for the font which will be used to render the point.
 .. seealso:: :py:func:`fontFamily`
 %End
 
-    QChar character() const;
+    QString character() const;
 %Docstring
-Returns the character used when rendering points.
+Returns the character(s) used when rendering points.
 
 .. seealso:: :py:func:`setCharacter`
 %End
 
-    void setCharacter( QChar ch );
+    void setCharacter( QString chr );
 %Docstring
-Sets the character used when rendering points.
+Sets the character(s) used when rendering points.
 
 .. seealso:: :py:func:`character`
 %End

--- a/python/gui/auto_generated/symbology/characterwidget.sip.in
+++ b/python/gui/auto_generated/symbology/characterwidget.sip.in
@@ -103,6 +103,15 @@ Sets the currently selected ``character`` in the widget.
 .. seealso:: :py:func:`characterSelected`
 %End
 
+    void clearCharacter();
+%Docstring
+Clears the currently selected character in the widget.
+
+.. seealso:: :py:func:`character`
+
+.. seealso:: :py:func:`setCharacter`
+%End
+
   signals:
 
     void characterSelected( QChar character );

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -800,8 +800,10 @@ class CORE_EXPORT QgsRasterMarkerSymbolLayer : public QgsMarkerSymbolLayer
 class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 {
   public:
+
+    //! Constructs a font marker symbol layer.
     QgsFontMarkerSymbolLayer( const QString &fontFamily = DEFAULT_FONTMARKER_FONT,
-                              QChar chr = DEFAULT_FONTMARKER_CHR,
+                              QString chr = DEFAULT_FONTMARKER_CHR,
                               double pointSize = DEFAULT_FONTMARKER_SIZE,
                               const QColor &color = DEFAULT_FONTMARKER_COLOR,
                               double angle = DEFAULT_FONTMARKER_ANGLE );
@@ -853,18 +855,18 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     void setFontFamily( const QString &family ) { mFontFamily = family; }
 
     /**
-     * Returns the character used when rendering points.
+     * Returns the character(s) used when rendering points.
      *
      * \see setCharacter()
      */
-    QChar character() const { return mChr; }
+    QString character() const { return mString; }
 
     /**
-     * Sets the character used when rendering points.
+     * Sets the character(s) used when rendering points.
      *
      * \see character()
      */
-    void setCharacter( QChar ch ) { mChr = ch; }
+    void setCharacter( QString chr ) { mString = chr; }
 
     QColor strokeColor() const override { return mStrokeColor; }
     void setStrokeColor( const QColor &color ) override { mStrokeColor = color; }
@@ -958,7 +960,7 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
 
     QString mFontFamily;
     QFontMetrics *mFontMetrics = nullptr;
-    QChar mChr;
+    QString mString;
 
     double mChrWidth = 0;
     QPointF mChrOffset;

--- a/src/gui/symbology/characterwidget.cpp
+++ b/src/gui/symbology/characterwidget.cpp
@@ -122,6 +122,12 @@ void CharacterWidget::setCharacter( QChar character )
   update();
 }
 
+void CharacterWidget::clearCharacter()
+{
+  mLastKey = -1;
+  update();
+}
+
 QSize CharacterWidget::sizeHint() const
 {
   return QSize( mColumns * mSquareSize, ( 65536 / mColumns ) * mSquareSize );

--- a/src/gui/symbology/characterwidget.h
+++ b/src/gui/symbology/characterwidget.h
@@ -142,6 +142,13 @@ class GUI_EXPORT CharacterWidget : public QWidget
      */
     void setCharacter( QChar character );
 
+    /**
+     * Clears the currently selected character in the widget.
+     * \see character()
+     * \see setCharacter()
+     */
+    void clearCharacter();
+
   signals:
 
     /**

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3308,7 +3308,10 @@ void QgsFontMarkerSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
 
   widgetChar->blockSignals( true );
   widgetChar->setFont( layerFont );
-  widgetChar->setCharacter( mLayer->character() );
+  if ( mLayer->character().length() == 1 )
+  {
+    widgetChar->setCharacter( mLayer->character().at( 0 ) );
+  }
   widgetChar->blockSignals( false );
   whileBlocking( mCharLineEdit )->setText( mLayer->character() );
 
@@ -3394,26 +3397,26 @@ void QgsFontMarkerSymbolLayerWidget::setCharacterFromText( const QString &text )
     return;
 
   // take the last character of a string for a better experience when users cycle through several characters on their keyboard
-  QChar chr = text.at( text.length() - 1 );
+  QString character = text;
   if ( text.contains( QRegularExpression( QStringLiteral( "^0x[0-9a-fA-F]{1,4}$" ) ) ) )
   {
     bool ok = false;
     unsigned int value = text.toUInt( &ok, 0 );
     if ( ok )
-      chr = QChar( value );
-  }
-  else if ( text.contains( QRegularExpression( QStringLiteral( "^[0-9]{1,}$" ) ) ) )
-  {
-    bool ok = false;
-    unsigned int value = text.toUInt( &ok, 10 );
-    if ( ok )
-      chr = QChar( value );
+      character = QChar( value );
   }
 
-  if ( chr != mLayer->character() )
+  if ( character != mLayer->character() )
   {
-    mLayer->setCharacter( chr );
-    whileBlocking( widgetChar )->setCharacter( mLayer->character() );
+    mLayer->setCharacter( character );
+    if ( mLayer->character().length() == 1 )
+    {
+      whileBlocking( widgetChar )->setCharacter( mLayer->character().at( 0 ) );
+    }
+    else
+    {
+      widgetChar->clearCharacter();
+    }
     emit changed();
   }
 }

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -306,14 +306,14 @@
    <item row="14" column="0">
     <widget class="QLabel" name="label_12">
      <property name="text">
-      <string>Character</string>
+      <string>Character(s)</string>
      </property>
     </widget>
    </item>
    <item row="14" column="1" colspan="2">
     <widget class="QLineEdit" name="mCharLineEdit">
      <property name="toolTip">
-      <string>Type in a character directly, or enter its decimal/hexadecimal value.</string>
+      <string>Type in characters directly, or enter a character's hexadecimal value.</string>
      </property>
     </widget>
    </item>

--- a/tests/src/core/testqgsfontmarker.cpp
+++ b/tests/src/core/testqgsfontmarker.cpp
@@ -129,7 +129,7 @@ void TestQgsFontMarkerSymbol::fontMarkerSymbol()
   mFontMarkerLayer->setColor( Qt::blue );
   QFont font = QgsFontUtils::getStandardTestFont( QStringLiteral( "Bold" ) );
   mFontMarkerLayer->setFontFamily( font.family() );
-  mFontMarkerLayer->setCharacter( 'A' );
+  mFontMarkerLayer->setCharacter( QChar( 'A' ) );
   mFontMarkerLayer->setSize( 12 );
   QVERIFY( imageCheck( "fontmarker" ) );
 }
@@ -139,7 +139,7 @@ void TestQgsFontMarkerSymbol::fontMarkerSymbolStroke()
   mFontMarkerLayer->setColor( Qt::blue );
   QFont font = QgsFontUtils::getStandardTestFont( QStringLiteral( "Bold" ) );
   mFontMarkerLayer->setFontFamily( font.family() );
-  mFontMarkerLayer->setCharacter( 'A' );
+  mFontMarkerLayer->setCharacter( QChar( 'A' ) );
   mFontMarkerLayer->setSize( 30 );
   mFontMarkerLayer->setStrokeWidth( 3.5 );
   QVERIFY( imageCheck( "fontmarker_outline" ) );
@@ -151,7 +151,7 @@ void TestQgsFontMarkerSymbol::bounds()
   QFont font = QgsFontUtils::getStandardTestFont( QStringLiteral( "Bold" ) );
   mFontMarkerLayer->setFontFamily( font.family() );
   //use a narrow character to test that width is correctly calculated
-  mFontMarkerLayer->setCharacter( 'l' );
+  mFontMarkerLayer->setCharacter( QChar( 'l' ) );
   mFontMarkerLayer->setSize( 12 );
   mFontMarkerLayer->setStrokeWidth( 0 );
   mFontMarkerLayer->setDataDefinedProperty( QgsSymbolLayer::PropertySize, QgsProperty::fromExpression( QStringLiteral( "min(\"importance\" * 4.47214, 7.07106)" ) ) );


### PR DESCRIPTION
## Description
Well, why not going all the way! Our font marker has supported drawing a multi-character string via data-defined expression, let's expose this in the main UI now that we have a line edit to do so:
![image](https://user-images.githubusercontent.com/1728657/56954589-5a2ac000-6b69-11e9-953d-5420407cfb44.png)

This unlocks straight forward emoji character (which technically are two utf-8 characters) and more.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
