### PR TITLE
Round values in ExtentFromLayer processing algorithm

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -334,7 +334,7 @@ qgis:polygoncentroids: >
   NOTE: This algorithm is deprecated and the generic "centroids" algorithm (which works for line and multi geometry layers) should be used instead.
 
 qgis:polygonfromlayerextent: >
-  This algorithm takes a map layer and generates a new vector layer with the minimum bounding box (rectangle polygon with N-S orientation) that covers the input layer. The extent can be enlarged to a rounded value.
+  This algorithm takes a map layer and generates a new vector layer with the minimum bounding box (rectangle polygon with N-S orientation) that covers the input layer. Optionally, the extent can be enlarged to a rounded value.
 
 qgis:polygonize:  >
   This algorithm takes a lines layer and creates a polygon layer, with polygons generated from the lines in the input layer.

--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -334,7 +334,7 @@ qgis:polygoncentroids: >
   NOTE: This algorithm is deprecated and the generic "centroids" algorithm (which works for line and multi geometry layers) should be used instead.
 
 qgis:polygonfromlayerextent: >
-  This algorithm takes a map layer and generates a new vector layer with the minimum bounding box (rectangle with N-S orientation) that covers the input layer.
+  This algorithm takes a map layer and generates a new vector layer with the minimum bounding box (rectangle polygon with N-S orientation) that covers the input layer. The extent can be enlarged to a rounded value.
 
 qgis:polygonize:  >
   This algorithm takes a lines layer and creates a polygon layer, with polygons generated from the lines in the input layer.

--- a/python/plugins/processing/algs/qgis/ExtentFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ExtentFromLayer.py
@@ -64,7 +64,7 @@ class ExtentFromLayer(QgisAlgorithm):
         return QgsApplication.iconPath("/algorithms/mAlgorithmExtractLayerExtent.svg")
 
     def tags(self):
-        return self.tr('polygon,from,vector,raster,extent,envelope,bounds,bounding,boundary,layer,round,rounded').split(',')
+        return self.tr('polygon,vector,raster,extent,envelope,bounds,bounding,boundary,layer,round,rounded').split(',')
 
     def group(self):
         return self.tr('Layer tools')
@@ -78,7 +78,8 @@ class ExtentFromLayer(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterMapLayer(self.INPUT, self.tr('Input layer')))
         self.addParameter(QgsProcessingParameterNumber(self.ROUND_TO,
-                                                       self.tr('Round values to'), minValue=0,
+                                                       self.tr('Round values to'),
+                                                       minValue=0,
                                                        defaultValue=0,
                                                        type=QgsProcessingParameterNumber.Double))
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extent'), type=QgsProcessing.TypeVectorPolygon))
@@ -93,7 +94,6 @@ class ExtentFromLayer(QgisAlgorithm):
         layer = self.parameterAsLayer(parameters, self.INPUT, context)
 
         round_to = self.parameterAsDouble(parameters, self.ROUND_TO, context)
-
 
         fields = QgsFields()
         fields.append(QgsField('MINX', QVariant.Double))

--- a/python/plugins/processing/algs/qgis/ExtentFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ExtentFromLayer.py
@@ -40,7 +40,8 @@ from qgis.core import (QgsApplication,
                        QgsProcessing,
                        QgsProcessingException,
                        QgsProcessingParameterMapLayer,
-                       QgsProcessingParameterNumber,
+                       QgsProcessingParameterDistance,
+                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSink,
                        QgsFields)
 
@@ -77,11 +78,15 @@ class ExtentFromLayer(QgisAlgorithm):
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterMapLayer(self.INPUT, self.tr('Input layer')))
-        self.addParameter(QgsProcessingParameterNumber(self.ROUND_TO,
-                                                       self.tr('Round values to'),
-                                                       minValue=0,
-                                                       defaultValue=0,
-                                                       type=QgsProcessingParameterNumber.Double))
+
+        round_to_parameter = QgsProcessingParameterDistance(self.ROUND_TO,
+                                                            self.tr('Round values to'),
+                                                            parentParameterName=self.INPUT,
+                                                            minValue=0,
+                                                            defaultValue=0)
+        round_to_parameter.setFlags(round_to_parameter.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(round_to_parameter)
+
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extent'), type=QgsProcessing.TypeVectorPolygon))
 
     def name(self):

--- a/python/plugins/processing/tests/testdata/expected/polygon_from_extent_rounded_2.gml
+++ b/python/plugins/processing/tests/testdata/expected/polygon_from_extent_rounded_2.gml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ polygon_from_extent_rounded_2.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-2</gml:X><gml:Y>-4</gml:Y></gml:coord>
+      <gml:coord><gml:X>12</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:polygon_from_extent_rounded_2 fid="polygon_from_extent_rounded_2.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2,-4 12,-4 12,6 -2,6 -2,-4</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:MINX>-2</ogr:MINX>
+      <ogr:MINY>-4</ogr:MINY>
+      <ogr:MAXX>12</ogr:MAXX>
+      <ogr:MAXY>6</ogr:MAXY>
+      <ogr:CNTX>5</ogr:CNTX>
+      <ogr:CNTY>1</ogr:CNTY>
+      <ogr:AREA>140</ogr:AREA>
+      <ogr:PERIM>48</ogr:PERIM>
+      <ogr:HEIGHT>10</ogr:HEIGHT>
+      <ogr:WIDTH>14</ogr:WIDTH>
+    </ogr:polygon_from_extent_rounded_2>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/polygon_from_extent_rounded_2.xsd
+++ b/python/plugins/processing/tests/testdata/expected/polygon_from_extent_rounded_2.xsd
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="polygon_from_extent_rounded_2" type="ogr:polygon_from_extent_rounded_2_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="polygon_from_extent_rounded_2_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="MINX" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="MINY" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="MAXX" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="MAXY" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="CNTX" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="CNTY" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="AREA" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="PERIM" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="HEIGHT" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="WIDTH" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1801,4 +1801,30 @@ tests:
         name: expected/multipoint_delaunay.gml
         type: vector
 
+  - algorithm: qgis:polygonfromlayerextent
+    name: Polygon from layer extent rounded to 0
+    params:
+      BY_FEATURE: false
+      INPUT:
+        name: polys.gml
+        type: vector
+      ROUND_TO: 0.0
+    results:
+      OUTPUT:
+        name: expected/polygon_from_extent.gml
+        type: vector
+
+  - algorithm: qgis:polygonfromlayerextent
+    name: Polygon from layer extent rounded to 2
+    params:
+      BY_FEATURE: false
+      INPUT:
+        name: lines.gml
+        type: vector
+      ROUND_TO: 2.0
+    results:
+      OUTPUT:
+        name: expected/polygon_from_extent_rounded_2.gml
+        type: vector
+
 # See ../README.md for a description of the file format


### PR DESCRIPTION
## Description
This change adds a parameter to the processing algorithm 'polygonfromlayerextent' to round the bbox values to a certain interval. The bbox can only be enlarged to ensure it will always cover the input data set. (So xmin and ymin are rounded down and xmax and ymax are rounded up.
 ## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
