### PR TITLE
Doxygen for QgsSymbolLayer::setRenderingPass

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayer.sip.in
@@ -288,7 +288,20 @@ layer may use it to specify the units for the line width.
     virtual QgsMapUnitScale mapUnitScale() const;
 
     void setRenderingPass( int renderingPass );
+%Docstring
+Specifies the rendering pass in which this symbol layer should be rendered.
+The lower the number, the lower the symbol will be rendered.
+0: first pass, 1: second pass, ...
+Defaults to 0
+%End
+
     int renderingPass() const;
+%Docstring
+Specifies the rendering pass in which this symbol layer should be rendered.
+The lower the number, the lower the symbol will be rendered.
+0: first pass, 1: second pass, ...
+Defaults to 0
+%End
 
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 %Docstring

--- a/src/core/symbology/qgssymbollayer.cpp
+++ b/src/core/symbology/qgssymbollayer.cpp
@@ -176,7 +176,6 @@ QgsSymbolLayer::QgsSymbolLayer( QgsSymbol::SymbolType type, bool locked )
   : mType( type )
   , mEnabled( true )
   , mLocked( locked )
-  , mRenderingPass( 0 )
 
 {
   mPaintEffect = QgsPaintEffectRegistry::defaultStack();
@@ -216,6 +215,16 @@ bool QgsSymbolLayer::isCompatibleWithSymbol( QgsSymbol *symbol ) const
     return true;
 
   return symbol->type() == mType;
+}
+
+void QgsSymbolLayer::setRenderingPass( int renderingPass )
+{
+  mRenderingPass = renderingPass;
+}
+
+int QgsSymbolLayer::renderingPass() const
+{
+  return mRenderingPass;
 }
 
 QSet<QString> QgsSymbolLayer::usedAttributes( const QgsRenderContext &context ) const

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -308,9 +308,21 @@ class CORE_EXPORT QgsSymbolLayer
     virtual void setMapUnitScale( const QgsMapUnitScale &scale ) { Q_UNUSED( scale ); }
     virtual QgsMapUnitScale mapUnitScale() const { return QgsMapUnitScale(); }
 
-    // used only with rending with symbol levels is turned on (0 = first pass, 1 = second, ...)
-    void setRenderingPass( int renderingPass ) { mRenderingPass = renderingPass; }
-    int renderingPass() const { return mRenderingPass; }
+    /**
+     * Specifies the rendering pass in which this symbol layer should be rendered.
+     * The lower the number, the lower the symbol will be rendered.
+     * 0: first pass, 1: second pass, ...
+     * Defaults to 0
+     */
+    void setRenderingPass( int renderingPass );
+
+    /**
+     * Specifies the rendering pass in which this symbol layer should be rendered.
+     * The lower the number, the lower the symbol will be rendered.
+     * 0: first pass, 1: second pass, ...
+     * Defaults to 0
+     */
+    int renderingPass() const;
 
     /**
      * Returns the set of attributes referenced by the layer. This includes attributes
@@ -419,7 +431,7 @@ class CORE_EXPORT QgsSymbolLayer
 
     bool mLocked;
     QColor mColor;
-    int mRenderingPass;
+    int mRenderingPass = 0;
 
     QgsPropertyCollection mDataDefinedProperties;
 


### PR DESCRIPTION
Missing API dox for symbol level / rendering pass management