### PR TITLE
[processing] populate batch interface with rows when multiple layers selected (fix #21859)

### DIFF
--- a/python/plugins/processing/gui/BatchInputSelectionPanel.py
+++ b/python/plugins/processing/gui/BatchInputSelectionPanel.py
@@ -86,13 +86,11 @@ class BatchInputSelectionPanel(QWidget):
 
         if not (isinstance(self.param, QgsProcessingParameterMultipleLayers) and
                 self.param.layerType == dataobjects.TYPE_FILE):
-            selectLayerAction = QAction(
-                QCoreApplication.translate('BatchInputSelectionPanel', 'Select from Open Layers…'), self.pushButton)
+            selectLayerAction = QAction(self.tr('Select from Open Layers…'), self.pushButton)
             selectLayerAction.triggered.connect(self.showLayerSelectionDialog)
             popupmenu.addAction(selectLayerAction)
 
-        selectFileAction = QAction(
-            QCoreApplication.translate('BatchInputSelectionPanel', 'Select from File System…'), self.pushButton)
+        selectFileAction = QAction(self.tr('Select from File System…'), self.pushButton)
         selectFileAction.triggered.connect(self.showFileSelectionDialog)
         popupmenu.addAction(selectFileAction)
 
@@ -146,13 +144,13 @@ class BatchInputSelectionPanel(QWidget):
 
     def showFileSelectionDialog(self):
         settings = QgsSettings()
-        text = str(self.text.text())
+        text = self.text.text()
         if os.path.isdir(text):
             path = text
         elif os.path.isdir(os.path.dirname(text)):
             path = os.path.dirname(text)
         elif settings.contains('/Processing/LastInputPath'):
-            path = str(settings.value('/Processing/LastInputPath'))
+            path = settings.value('/Processing/LastInputPath')
         else:
             path = ''
 
@@ -161,7 +159,7 @@ class BatchInputSelectionPanel(QWidget):
         if ret:
             files = list(ret)
             settings.setValue('/Processing/LastInputPath',
-                              os.path.dirname(str(files[0])))
+                              os.path.dirname(files[0]))
             for i, filename in enumerate(files):
                 files[i] = dataobjects.getRasterSublayer(filename, self.param)
             if len(files) == 1:

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -36,6 +36,10 @@ from qgis.core import (Qgis,
                        QgsApplication,
                        QgsSettings,
                        QgsProperty,
+                       QgsProcessingParameterMapLayer,
+                       QgsProcessingParameterRasterLayer,
+                       QgsProcessingParameterVectorLayer,
+                       QgsProcessingParameterFile,
                        QgsProcessingFeatureSourceDefinition,
                        QgsCoordinateReferenceSystem,
                        QgsProcessingParameterDefinition,
@@ -46,6 +50,7 @@ from qgis.utils import iface
 
 from processing.gui.wrappers import WidgetWrapperFactory, WidgetWrapper
 from processing.gui.BatchOutputSelectionPanel import BatchOutputSelectionPanel
+from processing.gui.BatchInputSelectionPanel import BatchInputSelectionPanel
 
 from processing.tools import dataobjects
 from processing.tools.dataobjects import createContext
@@ -292,9 +297,16 @@ class BatchPanel(BASE, WIDGET):
             if param.flags() & QgsProcessingParameterDefinition.FlagHidden or param.isDestination():
                 continue
 
-            wrapper = WidgetWrapperFactory.create_wrapper(param, self.parent, row, column)
-            wrappers[param.name()] = wrapper
-            self.setCellWrapper(row, column, wrapper, context)
+            if isinstance(param, (QgsProcessingParameterMapLayer, QgsProcessingParameterRasterLayer,
+                                  QgsProcessingParameterVectorLayer, QgsProcessingParameterFile)):
+                self.tblParameters.setCellWidget(
+                    row, column, BatchInputSelectionPanel(
+                        param, row, column, self.parent))
+            else:
+                wrapper = WidgetWrapperFactory.create_wrapper(param, self.parent, row, column)
+                wrappers[param.name()] = wrapper
+                self.setCellWrapper(row, column, wrapper, context)
+
             column += 1
 
         for out in self.alg.destinationParameterDefinitions():

--- a/python/plugins/processing/gui/ParameterGuiUtils.py
+++ b/python/plugins/processing/gui/ParameterGuiUtils.py
@@ -84,7 +84,7 @@ def getFileFilter(param):
     elif param.type() == 'fileDestination':
         return param.fileFilter() + ';;' + tr('All files (*.*)')
 
-    if param.defaultFileExtension():
+    if hasattr(param, 'defaultFileExtension') and param.defaultFileExtension():
         return tr('Default extension') + ' (*.' + param.defaultFileExtension() + ')'
     else:
         return ''


### PR DESCRIPTION
## Description
Use custom widget for layer inputs in the batch dialog instead of corresponding specialized widget wrappers. This is necessary to allow automatic addition of new rows in the batch dialog when multiple layers are selected.

Fixes https://issues.qgis.org/issues/21859.
This is a backport of #9850 to the LTR branch

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
