### PR TITLE
[ui] Fix broken text annotation background color

### DIFF
--- a/src/app/qgsannotationwidget.cpp
+++ b/src/app/qgsannotationwidget.cpp
@@ -74,6 +74,18 @@ QgsAnnotationWidget::QgsAnnotationWidget( QgsMapCanvasAnnotationItem *item, QWid
   mMapMarkerButton->setMessageBar( QgisApp::instance()->messageBar() );
   mFrameStyleButton->setMapCanvas( QgisApp::instance()->mapCanvas() );
   mFrameStyleButton->setMessageBar( QgisApp::instance()->messageBar() );
+
+  connect( mFrameStyleButton, &QgsSymbolButton::changed, this, &QgsAnnotationWidget::frameStyleChanged );
+}
+
+QColor QgsAnnotationWidget::backgroundColor()
+{
+  return mFrameStyleButton->symbol() ? mFrameStyleButton->symbol()->color() : QColor();
+}
+
+void QgsAnnotationWidget::frameStyleChanged()
+{
+  emit backgroundColorChanged( backgroundColor() );
 }
 
 void QgsAnnotationWidget::apply()

--- a/src/app/qgsannotationwidget.h
+++ b/src/app/qgsannotationwidget.h
@@ -33,9 +33,17 @@ class APP_EXPORT QgsAnnotationWidget: public QWidget, private Ui::QgsAnnotationW
 {
     Q_OBJECT
   public:
+
     QgsAnnotationWidget( QgsMapCanvasAnnotationItem *item, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
 
+    //! Returns the annotation frame symbol fill color
+    QColor backgroundColor();
+
     void apply();
+
+  private:
+
+    void frameStyleChanged();
 
   signals:
 
@@ -43,6 +51,7 @@ class APP_EXPORT QgsAnnotationWidget: public QWidget, private Ui::QgsAnnotationW
     void backgroundColorChanged( const QColor &color );
 
   private:
+
     QgsMapCanvasAnnotationItem *mItem = nullptr;
 
     void blockAllSignals( bool block );

--- a/src/app/qgstextannotationdialog.cpp
+++ b/src/app/qgstextannotationdialog.cpp
@@ -38,7 +38,7 @@ QgsTextAnnotationDialog::QgsTextAnnotationDialog( QgsMapCanvasAnnotationItem *it
   mStackedWidget->addWidget( mEmbeddedWidget );
   mStackedWidget->setCurrentWidget( mEmbeddedWidget );
   connect( mEmbeddedWidget, &QgsAnnotationWidget::backgroundColorChanged, this, &QgsTextAnnotationDialog::backgroundColorChanged );
-  mTextEdit->setAttribute( Qt::WA_TranslucentBackground );
+
   if ( mItem && mItem->annotation() )
   {
     QgsTextAnnotation *annotation = static_cast< QgsTextAnnotation * >( mItem->annotation() );
@@ -53,6 +53,7 @@ QgsTextAnnotationDialog::QgsTextAnnotationDialog( QgsMapCanvasAnnotationItem *it
   mFontColorButton->setContext( QStringLiteral( "symbology" ) );
 
   setCurrentFontPropertiesToGui();
+  backgroundColorChanged( mEmbeddedWidget->backgroundColor() );
 
   QObject::connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsTextAnnotationDialog::applyTextToItem );
   QObject::connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsTextAnnotationDialog::showHelp );
@@ -86,6 +87,7 @@ void QgsTextAnnotationDialog::backgroundColorChanged( const QColor &color )
   QPalette p = mTextEdit->viewport()->palette();
   p.setColor( QPalette::Base, color );
   mTextEdit->viewport()->setPalette( p );
+  mTextEdit->setStyleSheet( QStringLiteral( "QTextEdit { background-color: %1; }" ).arg( color.name() ) );
 }
 
 void QgsTextAnnotationDialog::applyTextToItem()


### PR DESCRIPTION
## Description
The text annotation widget text edit background was broken in two ways:
1. under non-default themes, the text edit background was missing altogether; this is fixed, see before (left) vs. PR (right):
![image](https://user-images.githubusercontent.com/1728657/57003730-d74e4780-6bf2-11e9-87e8-b74a13c46ade.png)
2. following the text annotation widget update's to have symbol styling annotation frames, the dynamic background change of the text edit widget got broken; this is fixed:
![peek8H870Z](https://user-images.githubusercontent.com/1728657/57003767-2f854980-6bf3-11e9-9c25-2fa2685eb90d.gif)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
