### PR TITLE
Allow the use of Fids filtering with other filters

### DIFF
--- a/python/core/auto_generated/qgsfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
@@ -114,6 +114,22 @@ so the default check will be omitted.
 :return: ``True`` if a feature was written to f
 %End
 
+    virtual bool nextFeatureMultiFilters( QgsFeature &f );
+%Docstring
+By default, the iterator will fetch all features and check if the feature is
+compliant with all filters.
+If you have a more sophisticated metodology (SQL request for the features...)
+and you are sure, that any feature you return from fetchFeature will match
+if the request was FilterFids you can just redirect this call to fetchFeature
+so the default check will be omitted.
+
+:param f: The feature to write to
+
+:return: ``True`` if a feature was written to f
+
+.. versionadded:: 3.12
+%End
+
     void geometryToDestinationCrs( QgsFeature &feature, const QgsCoordinateTransform &transform ) const;
 %Docstring
 Transforms ``feature``'s geometry according to the specified coordinate ``transform``.

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -81,6 +81,12 @@ Examples:
       GeometryAbortOnInvalid,
     };
 
+    enum FilterCombination
+    {
+      UseLast,
+      OperatorAND
+    };
+
     class OrderByClause
 {
 %Docstring
@@ -738,6 +744,33 @@ For example, this should be set on requests that are issued from an
 expression function.
 
 .. versionadded:: 3.4
+%End
+
+    void setFilterHandling( FilterCombination handlingMethod );
+%Docstring
+Sets the FilterCombination to use when handling filter.
+
+Implemented method are:
+- UseLast : Return features that fit the last filter set (other than rectangle)
+- OperatorAND : Return features that fit all the filters.
+
+Default behavior is UseLast.
+
+.. versionadded:: 3.12
+%End
+
+    QgsFeatureRequest::FilterCombination filterHandling() const;
+%Docstring
+Returns the filter handling method
+
+.. versionadded:: 3.12
+%End
+
+    bool hasValidFilter( FilterType filterType ) const;
+%Docstring
+Returns ``True`` if the given filter type can be used and is valid.
+
+.. versionadded:: 3.12
 %End
 
   protected:

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -65,17 +65,41 @@ QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *sour
     mFeatureIdList = mSource->mSpatialIndex->intersects( mFilterRect );
     QgsDebugMsg( "Features returned by spatial index: " + QString::number( mFeatureIdList.count() ) );
   }
-  else if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
+  if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     mUsingFeatureIdList = true;
     QgsFeatureMap::const_iterator it = mSource->mFeatures.constFind( mRequest.filterFid() );
     if ( it != mSource->mFeatures.constEnd() )
-      mFeatureIdList.append( mRequest.filterFid() );
+    {
+      if ( !mFeatureIdList.isEmpty() )
+      {
+        if ( mFeatureIdList.contains( mRequest.filterFid() ) )
+        {
+          mFeatureIdList.clear();
+          mFeatureIdList.append( mRequest.filterFid() ) ;
+        }
+        else
+        {
+          mFeatureIdList.clear();
+        }
+      }
+      else
+      {
+        mFeatureIdList.append( mRequest.filterFid() );
+      }
+    }
   }
-  else if ( mRequest.filterType() == QgsFeatureRequest::FilterFids )
+  else if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFids ) )
   {
     mUsingFeatureIdList = true;
-    mFeatureIdList = mRequest.filterFids().toList();
+    if ( !mFeatureIdList.isEmpty() )
+    {
+      mFeatureIdList = mFeatureIdList.toSet().intersect( mRequest.filterFids() ).toList();
+    }
+    else
+    {
+      mFeatureIdList = mRequest.filterFids().toList();
+    }
   }
   else
   {

--- a/src/core/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/core/providers/ogr/qgsogrfeatureiterator.cpp
@@ -126,7 +126,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   QgsAttributeList attrs = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();
 
   // ensure that all attributes required for expression filter are being fetched
-  if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
   {
     //ensure that all fields required for filter expressions are prepared
     QSet<int> attributeIndexes = request.filterExpression()->referencedAttributeIndexes( mSource->mFields );
@@ -148,7 +148,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
     mRequest.setSubsetOfAttributes( attrs );
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterExpression && request.filterExpression()->needsGeometry() )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) && request.filterExpression()->needsGeometry() )
   {
     mFetchGeometry = true;
   }
@@ -178,7 +178,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
       OGR_L_SetSpatialFilter( mOgrLayerOri, nullptr );
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterExpression
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression )
        && QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
   {
     QgsSqlExpressionCompiler *compiler = nullptr;
@@ -320,13 +320,13 @@ bool QgsOgrFeatureIterator::fetchFeature( QgsFeature &feature )
   if ( mClosed || !mOgrLayer )
     return false;
 
-  if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
+  if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     bool result = fetchFeatureWithId( mRequest.filterFid(), feature );
     close(); // the feature has been read or was not found: we have finished here
     return result;
   }
-  else if ( mRequest.filterType() == QgsFeatureRequest::FilterFids )
+  else if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFids ) )
   {
     while ( mFilterFidsIt != mFilterFids.end() )
     {

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -128,6 +128,20 @@ class CORE_EXPORT QgsAbstractFeatureIterator
     virtual bool nextFeatureFilterFids( QgsFeature &f );
 
     /**
+     * By default, the iterator will fetch all features and check if the feature is
+     * compliant with all filters.
+     * If you have a more sophisticated metodology (SQL request for the features...)
+     * and you are sure, that any feature you return from fetchFeature will match
+     * if the request was FilterFids you can just redirect this call to fetchFeature
+     * so the default check will be omitted.
+     *
+     * \param f The feature to write to
+     * \returns  TRUE if a feature was written to f
+     * \since QGIS 3.12
+     */
+    virtual bool nextFeatureMultiFilters( QgsFeature &f );
+
+    /**
      * Transforms \a feature's geometry according to the specified coordinate \a transform.
      * If \a feature has no geometry or \a transform is invalid then calling this method
      * has no effect and will be shortcut.

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -87,6 +87,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mTransformErrorCallback = rh.mTransformErrorCallback;
   mTimeout = rh.mTimeout;
   mRequestMayBeNested = rh.mRequestMayBeNested;
+  mCombinationMethod = rh.mCombinationMethod;
   return *this;
 }
 
@@ -335,6 +336,16 @@ QgsFeatureRequest &QgsFeatureRequest::setRequestMayBeNested( bool requestMayBeNe
   return *this;
 }
 
+void QgsFeatureRequest::setFilterHandling( FilterCombination handlingMethod )
+{
+  mCombinationMethod = handlingMethod;
+}
+
+QgsFeatureRequest::FilterCombination QgsFeatureRequest::filterHandling() const
+{
+  return mCombinationMethod;
+}
+
 
 #include "qgsfeatureiterator.h"
 #include "qgslogger.h"
@@ -525,4 +536,30 @@ QString QgsFeatureRequest::OrderBy::dump() const
   }
 
   return results.join( QStringLiteral( ", " ) );
+}
+
+bool QgsFeatureRequest::hasValidFilter( FilterType filterType ) const
+{
+  if ( mCombinationMethod != UseLast )
+  {
+    switch ( filterType )
+    {
+      case ( FilterNone ):
+        return true ;
+
+      case ( FilterFid ):
+        return filterFid() != -1 ;
+
+      case ( FilterExpression ):
+        if ( filterExpression() )
+          return filterExpression()->isValid();
+        else
+          return false;
+
+      case ( FilterFids ):
+        return !filterFids().isEmpty();
+    }
+  }
+  else
+    return mFilter == filterType;
 }

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -39,7 +39,7 @@ QgsFeatureRequest::QgsFeatureRequest( const QgsFeatureIds &fids )
   , mFilterFids( fids )
   , mFlags( nullptr )
 {
-
+  fidsTrigger = true;
 }
 
 QgsFeatureRequest::QgsFeatureRequest( const QgsRectangle &rect )
@@ -68,6 +68,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mFilterRect = rh.mFilterRect;
   mFilterFid = rh.mFilterFid;
   mFilterFids = rh.mFilterFids;
+  fidsTrigger = rh.fidsTrigger;
   if ( rh.mFilterExpression )
   {
     mFilterExpression.reset( new QgsExpression( *rh.mFilterExpression ) );
@@ -106,6 +107,7 @@ QgsFeatureRequest &QgsFeatureRequest::setFilterFid( QgsFeatureId fid )
 
 QgsFeatureRequest &QgsFeatureRequest::setFilterFids( const QgsFeatureIds &fids )
 {
+  fidsTrigger = true;
   mFilter = FilterFids;
   mFilterFids = fids;
   return *this;
@@ -557,7 +559,7 @@ bool QgsFeatureRequest::hasValidFilter( FilterType filterType ) const
           return false;
 
       case ( FilterFids ):
-        return !filterFids().isEmpty();
+        return fidsTrigger;
     }
   }
   else

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -101,6 +101,15 @@ class CORE_EXPORT QgsFeatureRequest
     };
 
     /**
+     * Filter handling behavior
+     */
+    enum FilterCombination
+    {
+      UseLast        = 0,   //! default behavior-- setting a new filter replaces any existing filters.
+      OperatorAND    = 1    //! stack filters
+    };
+
+    /**
      * \ingroup core
      * The OrderByClause class represents an order by clause for a QgsFeatureRequest.
      *
@@ -704,6 +713,33 @@ class CORE_EXPORT QgsFeatureRequest
      */
     QgsFeatureRequest &setRequestMayBeNested( bool requestMayBeNested );
 
+    /**
+     * Sets the FilterCombination to use when handling filter.
+     *
+     * Implemented method are:
+     *  - UseLast : Return features that fit the last filter set (other than rectangle)
+     *  - OperatorAND : Return features that fit all the filters.
+     *
+     * Default behavior is UseLast.
+     *
+     * \since QGIS 3.12
+     */
+    void setFilterHandling( FilterCombination handlingMethod );
+
+    /**
+     * Returns the filter handling method
+     *
+     * \since QGIS 3.12
+     */
+    QgsFeatureRequest::FilterCombination filterHandling() const;
+
+    /**
+     * Returns TRUE if the given filter type can be used and is valid.
+     *
+     * \since QGIS 3.12
+     */
+    bool hasValidFilter( FilterType filterType ) const;
+
   protected:
     FilterType mFilter = FilterNone;
     QgsRectangle mFilterRect;
@@ -723,6 +759,7 @@ class CORE_EXPORT QgsFeatureRequest
     QgsCoordinateTransformContext mTransformContext;
     int mTimeout = -1;
     int mRequestMayBeNested = false;
+    FilterCombination mCombinationMethod = UseLast;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -745,6 +745,7 @@ class CORE_EXPORT QgsFeatureRequest
     QgsRectangle mFilterRect;
     QgsFeatureId mFilterFid = -1;
     QgsFeatureIds mFilterFids;
+    bool fidsTrigger = false;
     std::unique_ptr< QgsExpression > mFilterExpression;
     QgsExpressionContext mExpressionContext;
     Flags mFlags;

--- a/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
+++ b/src/providers/arcgisrest/qgsafsfeatureiterator.cpp
@@ -62,11 +62,11 @@ QgsAfsFeatureIterator::QgsAfsFeatureIterator( QgsAfsFeatureSource *source, bool 
   }
 
   QgsFeatureIds requestIds;
-  if ( mRequest.filterType() == QgsFeatureRequest::FilterFids )
+  if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFids ) )
   {
     requestIds = mRequest.filterFids();
   }
-  else if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
+  else if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     requestIds.insert( mRequest.filterFid() );
   }
@@ -161,9 +161,7 @@ bool QgsAfsFeatureIterator::fetchFeature( QgsFeature &f )
       return result;
     }
 
-    case QgsFeatureRequest::FilterFids:
-    case QgsFeatureRequest::FilterExpression:
-    case QgsFeatureRequest::FilterNone:
+    default:
     {
       while ( mFeatureIterator < mSource->sharedData()->featureCount() )
       {

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -85,7 +85,7 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   QgsAttributeList attrs = subsetOfAttributes ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();
 
   // ensure that all attributes required for expression filter are being fetched
-  if ( subsetOfAttributes && request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( subsetOfAttributes && ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) ) )
   {
     //ensure that all fields required for filter expressions are prepared
     QSet<int> attributeIndexes = request.filterExpression()->referencedAttributeIndexes( mSource->mFields );
@@ -108,7 +108,8 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   // get geometry col if requested and table has spatial column
   if ( (
          !( request.flags() & QgsFeatureRequest::NoGeometry )
-         || ( request.filterType() == QgsFeatureRequest::FilterExpression && request.filterExpression()->needsGeometry() )
+         || ( ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
+              && request.filterExpression()->needsGeometry() )
        )
        && mSource->isSpatial() )
   {
@@ -145,7 +146,8 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   }
 
   // set fid filter
-  if ( request.filterType() == QgsFeatureRequest::FilterFid && !mSource->mFidColName.isEmpty() )
+  if ( ( request.hasValidFilter( QgsFeatureRequest::FilterFid ) )
+       && !mSource->mFidColName.isEmpty() )
   {
     QString fidfilter = QStringLiteral( " %1 = %2" ).arg( mSource->mFidColName, QString::number( request.filterFid() ) );
     // set attribute filter
@@ -157,8 +159,8 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
     mStatement += fidfilter;
     filterAdded = true;
   }
-  else if ( request.filterType() == QgsFeatureRequest::FilterFids && !mSource->mFidColName.isEmpty()
-            && !mRequest.filterFids().isEmpty() )
+  else if ( ( ( request.hasValidFilter( QgsFeatureRequest::FilterFids ) ) && !mSource->mFidColName.isEmpty()
+              && !mRequest.filterFids().isEmpty() ) )
   {
     QString delim;
     QString inClause = QStringLiteral( "%1 IN (" ).arg( mSource->mFidColName );
@@ -189,7 +191,7 @@ void QgsDb2FeatureIterator::BuildStatement( const QgsFeatureRequest &request )
 
   mExpressionCompiled = false;
   mCompileStatus = NoCompilation;
-  if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
   {
     QgsDebugMsg( QStringLiteral( "compileExpressions: %1" ).arg( QgsSettings().value( "qgis/compileExpressions", true ).toString() ) );
     if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -94,7 +94,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
     }
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterFid )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     QgsDebugMsg( QStringLiteral( "Configuring for returning single id" ) );
     if ( mFilterRect.isNull() || mFeatureIds.contains( request.filterFid() ) )
@@ -136,7 +136,8 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
          !( mRequest.flags() & QgsFeatureRequest::NoGeometry )
          || mTestGeometry
          || ( mTestSubset && mSource->mSubsetExpression->needsGeometry() )
-         || ( request.filterType() == QgsFeatureRequest::FilterExpression && request.filterExpression()->needsGeometry() )
+         || ( request.hasValidFilter( QgsFeatureRequest::FilterExpression )
+              && request.filterExpression()->needsGeometry() )
        )
      )
   {
@@ -149,7 +150,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   }
 
   // ensure that all attributes required for expression filter are being fetched
-  if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
   {
     QgsAttributeList attrs = request.subsetOfAttributes();
     //ensure that all fields required for filter expressions are prepared

--- a/src/providers/gpx/qgsgpxfeatureiterator.cpp
+++ b/src/providers/gpx/qgsgpxfeatureiterator.cpp
@@ -92,7 +92,7 @@ bool QgsGPXFeatureIterator::fetchFeature( QgsFeature &feature )
   if ( mClosed )
     return false;
 
-  if ( mRequest.filterType() == QgsFeatureRequest::FilterFid )
+  if ( mRequest.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     bool res = readFid( feature );
     close();

--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -234,7 +234,7 @@ bool QgsGrassFeatureIterator::fetchFeature( QgsFeature &feature )
   // TODO: locking each feature is too expensive. What happens with map structures if lines are
   // written/rewritten/deleted? Can be read simultaneously?
   mSource->mLayer->map()->lockReadWrite(); // locks only in editing mode
-  bool filterById = mRequest.filterType() == QgsFeatureRequest::FilterFid;
+  bool filterById = mRequest.hasValidFilter( QgsFeatureRequest::FilterFid ) ;
   int cat = 0;
   int type = 0;
   int lid = 0;

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -104,7 +104,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   if ( subsetOfAttributes )
   {
     // ensure that all attributes required for expression filter are being fetched
-    if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+    if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
     {
       //ensure that all fields required for filter expressions are prepared
       QSet<int> attributeIndexes = request.filterExpression()->referencedAttributeIndexes( mSource->mFields );
@@ -134,7 +134,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
 
   // get geometry col
   if ( ( !( request.flags() & QgsFeatureRequest::NoGeometry )
-         || ( request.filterType() == QgsFeatureRequest::FilterExpression && request.filterExpression()->needsGeometry() )
+         || ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) && request.filterExpression()->needsGeometry() )
        )
        && mSource->isSpatial() )
   {
@@ -184,7 +184,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   }
 
   // set fid filter
-  if ( request.filterType() == QgsFeatureRequest::FilterFid && !mSource->mFidColName.isEmpty() )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterFid ) && !mSource->mFidColName.isEmpty() )
   {
     QString fidfilter = QStringLiteral( " [%1] = %2" ).arg( mSource->mFidColName, FID_TO_STRING( request.filterFid() ) );
     // set attribute filter
@@ -196,8 +196,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
     mStatement += fidfilter;
     filterAdded = true;
   }
-  else if ( request.filterType() == QgsFeatureRequest::FilterFids && !mSource->mFidColName.isEmpty()
-            && !mRequest.filterFids().isEmpty() )
+  else if ( request.hasValidFilter( QgsFeatureRequest::FilterFids ) && !mSource->mFidColName.isEmpty() )
   {
     QString delim;
     QString inClause = QStringLiteral( "%1 IN (" ).arg( mSource->mFidColName );
@@ -230,7 +229,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
   //NOTE - must be last added!
   mExpressionCompiled = false;
   mCompileStatus = NoCompilation;
-  if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
   {
     if ( QgsSettings().value( QStringLiteral( "qgis/compileExpressions" ), true ).toBool() )
     {

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -29,7 +29,7 @@
 QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsPostgresFeatureSource>( source, ownSource, request )
 {
-  if ( request.filterType() == QgsFeatureRequest::FilterFids && request.filterFids().isEmpty() )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterFids ) && request.filterFids().isEmpty() )
   {
     mClosed = true;
     iteratorClosed();
@@ -88,19 +88,19 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     whereClause = QgsPostgresUtils::andWhereClauses( whereClause, '(' + mSource->mSqlWhereClause + ')' );
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterFid )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     QString fidWhereClause = QgsPostgresUtils::whereClause( mRequest.filterFid(), mSource->mFields, mConn, mSource->mPrimaryKeyType, mSource->mPrimaryKeyAttrs, mSource->mShared );
 
     whereClause = QgsPostgresUtils::andWhereClauses( whereClause, fidWhereClause );
   }
-  else if ( request.filterType() == QgsFeatureRequest::FilterFids )
+  else if ( request.hasValidFilter( QgsFeatureRequest::FilterFids ) )
   {
     QString fidsWhereClause = QgsPostgresUtils::whereClause( mRequest.filterFids(), mSource->mFields, mConn, mSource->mPrimaryKeyType, mSource->mPrimaryKeyAttrs, mSource->mShared );
 
     whereClause = QgsPostgresUtils::andWhereClauses( whereClause, fidsWhereClause );
   }
-  else if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
   {
     // ensure that all attributes required for expression filter are being fetched
     if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -78,7 +78,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
     }
   }
 
-  if ( request.filterType() == QgsFeatureRequest::FilterFid )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterFid ) )
   {
     whereClause = whereClauseFid();
     if ( ! whereClause.isEmpty() )
@@ -86,7 +86,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
       whereClauses.append( whereClause );
     }
   }
-  else if ( request.filterType() == QgsFeatureRequest::FilterFids )
+  else if ( request.hasValidFilter( QgsFeatureRequest::FilterFids ) )
   {
     if ( request.filterFids().isEmpty() )
     {
@@ -98,10 +98,10 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
     }
   }
   //IMPORTANT - this MUST be the last clause added!
-  else if ( request.filterType() == QgsFeatureRequest::FilterExpression )
+  if ( request.hasValidFilter( QgsFeatureRequest::FilterExpression ) )
   {
     // ensure that all attributes required for expression filter are being fetched
-    if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && request.filterType() == QgsFeatureRequest::FilterExpression )
+    if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )
     {
       QgsAttributeList attrs = request.subsetOfAttributes();
       //ensure that all fields required for filter expressions are prepared

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -759,6 +759,7 @@ void TestQgsLayerTree::testSymbolText()
             << QStringLiteral( "bbbb" )
             << QStringLiteral( "cccc" )
             << QStringLiteral( "7" ) );
+
   //cleanup
   delete m;
   delete root;

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -101,7 +101,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         # cross join
         query = toPercent("SELECT * FROM france_parts,points")
         vl = QgsVectorLayer("?query=%s" % query, "tt", "virtual")
-
+        self.assertEqual(vl.getFeature(3).isValid(), True)
         self.assertEqual(vl.featureCount(), l0.featureCount() * l1.featureCount())
 
         # test with FilterFid requests
@@ -491,7 +491,6 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         query = toPercent("SELECT * FROM france_parts")
         l4 = QgsVectorLayer("?query=%s&uid=ObjectId" % query, "tt", "virtual")
         self.assertEqual(l4.isValid(), True)
-
         self.assertEqual(l4.dataProvider().wkbType(), 6)
         self.assertEqual(l4.dataProvider().crs().postgisSrid(), 4326)
 
@@ -710,6 +709,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(ml.featureCount(), vl.featureCount())
 
     def test_ProjectDependencies(self):
+        QgsProject.instance().removeAllMapLayers()
         # make a virtual layer with living references and save it to a project
         l1 = QgsVectorLayer(os.path.join(self.testDataDir, "france_parts.shp"), "france_parts", "ogr", QgsVectorLayer.LayerOptions(False))
         self.assertEqual(l1.isValid(), True)
@@ -747,6 +747,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsProject.instance().read()
 
         # make sure the 3 layers are loaded back
+        print(QgsProject.instance().mapLayers(), 'LINE 750')
         self.assertEqual(len(QgsProject.instance().mapLayers()), 3)
 
     def test_relative_paths(self):
@@ -1013,7 +1014,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         df.setQuery('select * from mem_no_uid')
         vl = QgsVectorLayer(df.toString(), "vl", "virtual")
         self.assertEqual(vl.isValid(), True)
-
+        self.assertEqual(vl.getFeature(5).isValid(), True)
         # make sure the returned id with a filter is the same as
         # if there is no filter
         req = QgsFeatureRequest().setFilterRect(QgsRectangle(4.5, -1, 5.5, 1))


### PR DESCRIPTION
## Description
This PR aims to revisit filters, by adding a filter operator that will dictate how filters can interact with each other.

Currently only the AND operation is implemented in this PR, but with the current groundwork the OR operator could be implemented also.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
