### PR TITLE
Fix #20124 allow reload mesh

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -133,6 +133,9 @@ QgsMeshLayer cannot be copied.
     virtual bool writeXml( QDomNode &layer_node, QDomDocument &doc, const QgsReadWriteContext &context ) const;
 
 
+    virtual void reload();
+
+
     QString providerType() const;
 %Docstring
 Returns the provider type for this layer

--- a/src/app/mesh/qgsmeshdatasetgrouptreeview.cpp
+++ b/src/app/mesh/qgsmeshdatasetgrouptreeview.cpp
@@ -317,7 +317,7 @@ void QgsMeshDatasetGroupTreeModel::addTreeItem( const QString &groupName, bool i
 
 QModelIndex QgsMeshDatasetGroupTreeModel::groupIndexToModelIndex( int groupIndex )
 {
-  if ( groupIndex < 0 )
+  if ( groupIndex < 0 || !mDatasetGroupIndexToItem.contains( groupIndex ) )
     return QModelIndex();
 
   const auto item = mDatasetGroupIndexToItem[groupIndex];

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -457,6 +457,27 @@ bool QgsMeshLayer::writeXml( QDomNode &layer_node, QDomDocument &document, const
   return writeSymbology( layer_node, document, errorMsg, context );
 }
 
+void QgsMeshLayer::reload()
+{
+  if ( mDataProvider && mDataProvider->isValid() )
+  {
+
+    mDataProvider->reloadData();
+
+    //reload the mesh structure
+    if ( !mNativeMesh )
+      mNativeMesh.reset( new QgsMesh );
+
+    dataProvider()->populateMesh( mNativeMesh.get() );
+
+    //clear the TriangularMesh
+    mTriangularMesh.reset( new QgsTriangularMesh() );
+
+    //clear the rendererCache
+    mRendererCache.reset( new QgsMeshLayerRendererCache() );
+  }
+}
+
 bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvider::ProviderOptions &options )
 {
   delete mDataProvider;

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -146,6 +146,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     bool readXml( const QDomNode &layer_node, QgsReadWriteContext &context ) override;
     bool writeXml( QDomNode &layer_node, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
 
+    void reload() override;
+
     //! Returns the provider type for this layer
     QString providerType() const;
 

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -77,6 +77,8 @@ class QgsMdalProvider : public QgsMeshDataProvider
                               const QVector<double> &times
                             ) override;
 
+    void reloadData() override;
+
     /**
      * Returns file filters for meshes and datasets to be used in Open File Dialogs
      * \param fileMeshFiltersString file mesh filters
@@ -102,6 +104,7 @@ class QgsMdalProvider : public QgsMeshDataProvider
   private:
     QVector<QgsMeshVertex> vertices( ) const;
     QVector<QgsMeshFace> faces( ) const;
+    void loadData();
     MeshH mMeshH;
     QStringList mExtraDatasetUris;
     QgsCoordinateReferenceSystem mCrs;

--- a/tests/testdata/mesh/quad_and_triangle_vertex_scalar_incompatible_mesh.dat
+++ b/tests/testdata/mesh/quad_and_triangle_vertex_scalar_incompatible_mesh.dat
@@ -1,0 +1,23 @@
+DATASET
+OBJTYPE "mesh2d"
+RT_JULIAN 2433282.500000
+BEGSCL
+ND 6
+NC 2
+NAME "VertexScalarDataset"
+TIMEUNITS se
+TS 0        0.000000
+1
+2
+3
+2
+1
+0
+TS 0        3600.000000
+2
+3
+4
+3
+2
+0
+ENDDS


### PR DESCRIPTION
## Description
This PR allows to update a mesh layer if mesh data or dataset groups change outside QGIS application.

A crash bug have been fixed. This crash on opening  a project file and appeared when a dataset groups became invalid or was incompatible before QGIS re-open the project.

The code changes are not important because the handle of invalid dataset group and invalid dataset was quite safe before this PR. This invalid data are simply not displayed in the GUI. This invalid data appears when dataset groups file are invalid or not compatible with the mesh. If the user fix his files, reloading the mesh layer permit to display again the data.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
