### PR TITLE
Add REGEXP SQL syntax support to spatialite provider and python connections 

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -646,6 +646,12 @@ def spatialite_connect(*args, **kwargs):
     """returns a dbapi2.Connection to a SpatiaLite db
 using the "mod_spatialite" extension (python3)"""
     import sqlite3
+    import re
+
+    def fcnRegexp(pattern, string):
+        result = re.search(pattern, string)
+        return True if result else False
+
     con = sqlite3.dbapi2.connect(*args, **kwargs)
     con.enable_load_extension(True)
     cur = con.cursor()
@@ -670,6 +676,7 @@ using the "mod_spatialite" extension (python3)"""
         raise RuntimeError("Cannot find any suitable spatialite module")
     cur.close()
     con.enable_load_extension(False)
+    con.create_function("regexp", 2, fcnRegexp)
     return con
 
 

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -19,6 +19,7 @@
 #include "qgssqliteutils.h"
 
 #include <QFileInfo>
+#include <QRegularExpression>
 #include <cstdlib> // atoi
 
 #ifdef _MSC_VER
@@ -642,20 +643,13 @@ error:
 
 static void fcnRegexp( sqlite3_context *ctx, int /*argc*/, sqlite3_value *argv[] )
 {
-  // Get arguments and check their values
-  QRegExp arg1( reinterpret_cast<const char *>( sqlite3_value_text( argv[0] ) ) );
-  QString arg2( reinterpret_cast<const char *>( sqlite3_value_text( argv[1] ) ) );
-  if ( !arg1.isValid() )
+  QRegularExpression re( reinterpret_cast<const char *>( sqlite3_value_text( argv[0] ) ) );
+  QString string( reinterpret_cast<const char *>( sqlite3_value_text( argv[1] ) ) );
+
+  if ( !re.isValid() )
     return sqlite3_result_error( ctx, "invalid operand", -1 );
 
-  // Set the pattern matching syntax to a Perl-like one. This is the default in Qt 4.x but Qt 5
-  // changes this to a greedy one (QRegExp::RegExp2). To make sure the behaviour of our application
-  // doesn't change depending on the build environment, we make sure to always set the same pattern
-  // matching syntax.
-  arg1.setPatternSyntax( QRegExp::RegExp );
-  // Perform the actual matching and return the result. Note that Qt's QRegExp returns -1 if the regex
-  // doesn't match and the position in the string otherwise; SQLite expects a 0 for not found and a 1 for found.
-  sqlite3_result_int( ctx, arg1.indexIn( arg2 ) >= 0 );
+  sqlite3_result_int( ctx, string.contains( re ) );
 }
 
 

--- a/tests/src/python/test_db_manager_spatialite.py
+++ b/tests/src/python/test_db_manager_spatialite.py
@@ -109,6 +109,20 @@ class TestPyQgsDBManagerSpatialite(unittest.TestCase):
             pass
         self.assertFalse(connection_succeeded, 'exception should have been raised')
 
+    def testExecuteRegExp(self):
+        """This test checks for REGEXP syntax support, which is enabled in Qgis.utils' spatialite_connection()"""
+
+        connection_name = 'testListLayer'
+        plugin = createDbPlugin('spatialite')
+        uri = QgsDataSourceUri()
+        uri.setDatabase(self.test_spatialite)
+        self.assertTrue(plugin.addConnection(connection_name, uri))
+
+        connection = createDbPlugin('spatialite', connection_name)
+        connection.connect()
+        db = connection.database()
+        db.connector._execute(None, 'SELECT \'ABC\' REGEXP \'[CBA]\'')
+
     def testListLayer(self):
         connection_name = 'testListLayer'
         plugin = createDbPlugin('spatialite')

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -701,6 +701,16 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(set(indexed_columns), set(['name', 'number']))
         con.close()
 
+    def testSubsetStringRegexp(self):
+        """Check that the provider supports the REGEXP syntax"""
+
+        testPath = "dbname=%s table='test_filter' (geometry) key='id'" % self.dbname
+        vl = QgsVectorLayer(testPath, 'test', 'spatialite')
+        self.assertTrue(vl.isValid())
+        vl.setSubsetString('"name" REGEXP \'[txe]\'')
+        self.assertEqual(vl.featureCount(), 4)
+        del(vl)
+
     def testSubsetStringExtent_bug17863(self):
         """Check that the extent is correct when applied in the ctor and when
         modified after a subset string is set """


### PR DESCRIPTION
## Description
Because REGEXP is the swiss army knife we all need, and sqlite makes it easy to add support for it, let's unlock this useful feature for our spatialite provider (comes in handy when setting filters).

The PR also adds support for this syntax via the python connections made through Qgis.utils's spatialite_connection. The latter means we can use REGEXP in our SQL queries from within DB Manager, 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
