### PR TITLE
Install full set of application icons on Linux

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,19 +1,22 @@
 #icons
-## application icon
+set(sizes 8x8 16x16 22x22 24x24 32x32 36x36 42x42 48x48 64x64 72x72 80x80 96x96 128x128 192x192 256x256 512x512)
+
+# Install application icon
 install(FILES ${CMAKE_SOURCE_DIR}/images/icons/qgis_icon.svg RENAME qgis.svg DESTINATION share/icons/hicolor/scalable/apps)
-install(FILES ${CMAKE_SOURCE_DIR}/images/icons/qgis-icon-16x16.png RENAME qgis.png DESTINATION share/icons/hicolor/16x16/apps)
-install(FILES ${CMAKE_SOURCE_DIR}/images/icons/qgis-icon-512x512.png RENAME qgis.png DESTINATION share/icons/hicolor/512x512/apps)
+foreach(size ${sizes})
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/qgis-icon${size}.png RENAME qgis.png DESTINATION share/icons/hicolor/${size}/apps/)
+endforeach()
 
 # Install MIME type icon
 install(FILES ${CMAKE_SOURCE_DIR}/images/icons/qgis_mime_icon.svg RENAME qgis-mime.svg DESTINATION share/icons/hicolor/scalable/mimetypes)
-foreach(size 8x8 16x16 22x22 24x24 32x32 36x36 42x42 48x48 64x64 72x72 80x80 96x96 128x128 192x192 256x256 512x512)
-  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons//qgis-mime-icon${size}.png RENAME qgis-mime.png DESTINATION share/icons/hicolor/${size}/mimetypes/)
+foreach(size ${sizes})
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/qgis-mime-icon${size}.png RENAME qgis-mime.png DESTINATION share/icons/hicolor/${size}/mimetypes/)
 endforeach()
 
 # Install QGIS file formats icons
 foreach(_type qgs qlr qml qpt)
   install(FILES ${CMAKE_SOURCE_DIR}/images/icons/qgis_${_type}_icon.svg RENAME qgis_${_type}.svg DESTINATION share/icons/hicolor/scalable/mimetypes/)
-  foreach(size 8x8 16x16 22x22 24x24 32x32 36x36 42x42 48x48 64x64 72x72 80x80 96x96 128x128 192x192 256x256 512x512)
+  foreach(size ${sizes})
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/qgis-${_type}${size}.png RENAME qgis-${_type}.png DESTINATION share/icons/hicolor/${size}/mimetypes/)
   endforeach()
 endforeach()


### PR DESCRIPTION
Icons were already available in linux/icons directory.
Tidy linux/CMakeLists.txt.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
