### PR TITLE
Proxy to handle dataset groups for QgsMdalProvider

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -440,6 +440,13 @@ Associate dataset with the mesh
 emits dataChanged when successful
 %End
 
+    virtual void addUriDataset( const QString &uri );
+%Docstring
+Associate uri dataset with the mesh
+
+Doesn't load the dataSet, this method is called before all the dataset groups are loaded when opening
+%End
+
     virtual QStringList extraDatasets() const = 0;
 %Docstring
 Returns list of additional dataset file URIs added using addDataset() calls.
@@ -535,8 +542,9 @@ On success, the mesh's dataset group count is changed
 
 .. versionadded:: 3.6
 %End
-};
 
+    virtual void reloadExtraDatasetUris();
+};
 
 class QgsMeshDataProvider: QgsDataProvider, QgsMeshDataSourceInterface, QgsMeshDatasetSourceInterface
 {
@@ -560,6 +568,9 @@ Responsible for reading native mesh data
 %Docstring
 Ctor
 %End
+
+    virtual QDomElement writeProxyToXml( QDomDocument &document ) const;
+    virtual void readProxyFromXml( const QDomNode &layer_node );
 
   signals:
     void datasetGroupsAdded( int count );

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -445,6 +445,8 @@ emits dataChanged when successful
 Associate uri dataset with the mesh
 
 Doesn't load the dataSet, this method is called before all the dataset groups are loaded when opening
+
+.. versionadded:: 3.10
 %End
 
     virtual QStringList extraDatasets() const = 0;
@@ -545,12 +547,16 @@ On success, the mesh's dataset group count is changed
 
     virtual void reloadExtraDatasetUris();
 %Docstring
-reload the extras dataset groups from uri
+reloads the extras dataset groups from uri
+
+.. versionadded:: 3.10
 %End
 
     virtual void reloadPersistDatasetGroups();
 %Docstring
-reload the dataset groups come from calculation
+reloads the dataset groups come from calculation
+
+.. versionadded:: 3.10
 %End
 };
 
@@ -579,12 +585,16 @@ Ctor
 
     virtual QDomElement writeProxyToXml( QDomDocument &document ) const;
 %Docstring
-write proxy data
+writes proxy data
+
+.. versionadded:: 3.10
 %End
 
     virtual void readProxyFromXml( const QDomNode &layer_node );
 %Docstring
-read proxy data
+reads proxy data
+
+.. versionadded:: 3.10
 %End
 
   signals:

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -544,6 +544,14 @@ On success, the mesh's dataset group count is changed
 %End
 
     virtual void reloadExtraDatasetUris();
+%Docstring
+reload the extras dataset groups from uri
+%End
+
+    virtual void reloadPersistDatasetGroups();
+%Docstring
+reload the dataset groups come from calculation
+%End
 };
 
 class QgsMeshDataProvider: QgsDataProvider, QgsMeshDataSourceInterface, QgsMeshDatasetSourceInterface
@@ -570,7 +578,14 @@ Ctor
 %End
 
     virtual QDomElement writeProxyToXml( QDomDocument &document ) const;
+%Docstring
+write proxy data
+%End
+
     virtual void readProxyFromXml( const QDomNode &layer_node );
+%Docstring
+read proxy data
+%End
 
   signals:
     void datasetGroupsAdded( int count );

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -442,6 +442,8 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
      * \brief Associate uri dataset with the mesh
      *
      * Doesn't load the dataSet, this method is called before all the dataset groups are loaded when opening
+	 *
+	 * \since QGIS 3.10
      */
     virtual void addUriDataset( const QString &uri ) {Q_UNUSED( uri );}
 
@@ -540,7 +542,19 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
                                       const QVector<double> &times
                                     ) = 0;
 
+    /**
+     * \brief reloads the extras dataset groups from uri
+	 *
+	 * \since QGIS 3.10
+     */
     virtual void reloadExtraDatasetUris() {}
+
+    /**
+     * \brief reloads the dataset groups come from calculation
+	 *
+	 * \since QGIS 3.10
+     */
+    virtual void reloadPersistDatasetGroups() {}
 };
 
 /**
@@ -561,7 +575,18 @@ class CORE_EXPORT QgsMeshDataProvider: public QgsDataProvider, public QgsMeshDat
     //! Ctor
     QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
 
+    /**
+     * \brief writes proxy data
+	 *
+	 * \since QGIS 3.10
+     */
     virtual QDomElement writeProxyToXml( QDomDocument &document ) const {Q_UNUSED( document ); return QDomElement();}
+
+    /**
+     * \brief reads proxy data
+	 *
+	 * \since QGIS 3.10
+     */
     virtual void readProxyFromXml( const QDomNode &layer_node ) {Q_UNUSED( layer_node );}
 
   signals:

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -439,6 +439,13 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
     virtual bool addDataset( const QString &uri ) = 0;
 
     /**
+     * \brief Associate uri dataset with the mesh
+     *
+     * Doesn't load the dataSet, this method is called before all the dataset groups are loaded when opening
+     */
+    virtual void addUriDataset( const QString &uri ) {Q_UNUSED( uri );}
+
+    /**
      * Returns list of additional dataset file URIs added using addDataset() calls.
      */
     virtual QStringList extraDatasets() const = 0;
@@ -532,8 +539,9 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
                                       const QVector<QgsMeshDataBlock> &datasetActive,
                                       const QVector<double> &times
                                     ) = 0;
-};
 
+    virtual void reloadExtraDatasetUris() {}
+};
 
 /**
  * \ingroup core
@@ -552,6 +560,9 @@ class CORE_EXPORT QgsMeshDataProvider: public QgsDataProvider, public QgsMeshDat
   public:
     //! Ctor
     QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &providerOptions );
+
+    virtual QDomElement writeProxyToXml( QDomDocument &document ) const {Q_UNUSED( document ); return QDomElement();}
+    virtual void readProxyFromXml( const QDomNode &layer_node ) {Q_UNUSED( layer_node );}
 
   signals:
     //! Emitted when some new dataset groups have been added

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -442,8 +442,8 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
      * \brief Associate uri dataset with the mesh
      *
      * Doesn't load the dataSet, this method is called before all the dataset groups are loaded when opening
-	 *
-	 * \since QGIS 3.10
+    *
+    * \since QGIS 3.10
      */
     virtual void addUriDataset( const QString &uri ) {Q_UNUSED( uri );}
 
@@ -544,15 +544,15 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
 
     /**
      * \brief reloads the extras dataset groups from uri
-	 *
-	 * \since QGIS 3.10
+    *
+    * \since QGIS 3.10
      */
     virtual void reloadExtraDatasetUris() {}
 
     /**
      * \brief reloads the dataset groups come from calculation
-	 *
-	 * \since QGIS 3.10
+    *
+    * \since QGIS 3.10
      */
     virtual void reloadPersistDatasetGroups() {}
 };
@@ -577,15 +577,15 @@ class CORE_EXPORT QgsMeshDataProvider: public QgsDataProvider, public QgsMeshDat
 
     /**
      * \brief writes proxy data
-	 *
-	 * \since QGIS 3.10
+    *
+    * \since QGIS 3.10
      */
     virtual QDomElement writeProxyToXml( QDomDocument &document ) const {Q_UNUSED( document ); return QDomElement();}
 
     /**
      * \brief reads proxy data
-	 *
-	 * \since QGIS 3.10
+    *
+    * \since QGIS 3.10
      */
     virtual void readProxyFromXml( const QDomNode &layer_node ) {Q_UNUSED( layer_node );}
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -402,15 +402,7 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     {
       QString uri = context.pathResolver().readPath( elemUri.text() );
 
-//      #ifdef QGISDEBUG
-//            QgsDebugMsg( QStringLiteral( "extra dataset (res %1): %2" ).arg( res ).arg( uri ) );
-//      #else
-//            ( void )res; // avoid unused warning in release builds
-//      #endif
-
-//      need to leave this control ??
-
-      mDataProvider->addUriDataset( uri ); //indeed addDataset( uri ) because the dataset will be reloaded and the proxy updated with reloadExtraDatasetUris() below
+      mDataProvider->addUriDataset( uri ); //instead of addDataset( uri ) because the dataset will be reloaded and the proxy will be updated with reloadExtraDatasetUris() below
 
       elemUri = elemUri.nextSiblingElement( QStringLiteral( "uri" ) );
     }
@@ -418,6 +410,7 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
 
   mDataProvider->readProxyFromXml( layer_node );
   mDataProvider->reloadExtraDatasetUris();
+  mDataProvider->reloadPersistDatasetGroups();
 
   QString errorMsg;
   readSymbology( layer_node, errorMsg, context );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -402,16 +402,22 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     {
       QString uri = context.pathResolver().readPath( elemUri.text() );
 
-      bool res = mDataProvider->addDataset( uri );
-#ifdef QGISDEBUG
-      QgsDebugMsg( QStringLiteral( "extra dataset (res %1): %2" ).arg( res ).arg( uri ) );
-#else
-      ( void )res; // avoid unused warning in release builds
-#endif
+//      #ifdef QGISDEBUG
+//            QgsDebugMsg( QStringLiteral( "extra dataset (res %1): %2" ).arg( res ).arg( uri ) );
+//      #else
+//            ( void )res; // avoid unused warning in release builds
+//      #endif
+
+//      need to leave this control ??
+
+      mDataProvider->addUriDataset( uri ); //indeed addDataset( uri ) because the dataset will be reloaded and the proxy updated with reloadExtraDatasetUris() below
 
       elemUri = elemUri.nextSiblingElement( QStringLiteral( "uri" ) );
     }
   }
+
+  mDataProvider->readProxyFromXml( layer_node );
+  mDataProvider->reloadExtraDatasetUris();
 
   QString errorMsg;
   readSymbology( layer_node, errorMsg, context );
@@ -450,6 +456,8 @@ bool QgsMeshLayer::writeXml( QDomNode &layer_node, QDomDocument &document, const
       elemExtraDatasets.appendChild( elemUri );
     }
     layer_node.appendChild( elemExtraDatasets );
+
+    layer_node.appendChild( mDataProvider->writeProxyToXml( document ) );
   }
 
   // renderer specific settings

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -831,7 +831,7 @@ void QgsMdalProviderDatasetProxy::readFromXml( const QDomElement &elementTable )
     {
       mdalGroupIndexes.append( QgsMdalDatasetIndex( elemIndex.attribute( "mdal-index" ).toInt(), persistFile ) );
     }
-	
+
     elemIndex = elemIndex.nextSiblingElement( QStringLiteral( "mdal-dataset-group-index" ) );
   }
 }

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -617,9 +617,9 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
 
   layer.reload();
 
-  //test if dataset presence
+  //test if dataset is present
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 1 );
-  QCOMPARE( layer.dataProvider()->datasetGroupCount(), 1 );
+  QCOMPARE( layer.dataProvider()->datasetGroupCount(), 2 );
 
   //copy again the qad_and_triangle_vertex_scalar.dat to the temporary testFile
   copyToTemporaryFile( dataSetFile_1, testFileDataSet );
@@ -641,7 +641,7 @@ void TestQgsMeshLayer::test_reload_extra_dataset()
 
   //test dataset presence
   QCOMPARE( layer.dataProvider()->extraDatasets().count(), 2 );
-  QCOMPARE( layer.dataProvider()->datasetGroupCount(), 1 );
+  QCOMPARE( layer.dataProvider()->datasetGroupCount(), 3 );
 
   //copy again the qad_and_triangle_vertex_scalar.dat to the temporary testFile
   copyToTemporaryFile( dataSetFile_1, testFileDataSet );


### PR DESCRIPTION
## Description
This PR allows `QgsMdalProvider` to manage dataset groups, including not valid or not compatible mesh.
To do that, a proxy is integrated to the provider. This proxy has to help the provider to return dataset data from an index. Indexes are persistent, they are not removed when dataset groups are invalid or not compatible, and provider return empty dataset groups when their indexes are used. This proxy allow objects to access the dataset groups by index even if the position of the dataset groups changes for the provider.

**New classes implemented :**

_QgsMdalDatasetIndex :_ 
Instance of this class represents an index and is associated to a datatset group loaded by the provider. Its role is to return a reference to a dataset group known by the provider.

_QgsMdalProviderDatasetProxy :_ 
Handle the QgsMeshDataProviderDataSetIndex to help the provider to retrieve the dataset groups.

The proxy is populated when the provider is created and when dataset groups are added. After, when provider is reloaded, the table present in the proxy is updated to keep acces to all the dataset group.
This approach needs to modify the` QgsMeshLayer::writeXml()` and `QgsMeshLayer::readXml()` methods, in order to save the proxy data and to consider it when loading.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
