### PR TITLE
[QgsQuick] Fix of value relation widget

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickvaluerelation.qml
+++ b/src/quickgui/plugin/editor/qgsquickvaluerelation.qml
@@ -28,7 +28,7 @@ Item {
 
   id: fieldItem
   enabled: !readOnly
-  height: customStyle.height
+  height: customStyle.fields.height
   anchors {
     left: parent.left
     right: parent.right
@@ -51,16 +51,18 @@ Item {
 
     Component.onCompleted: {
       currentMap = QgsQuick.Utils.createValueRelationCache(config)
+      var valueInKeys = false
       var keys = Object.keys(currentMap)
       for(var i=0; i< keys.length; i++)
       {
         var currentKey = keys[i]
+        if (value == currentKey) valueInKeys = true
         var valueText = currentMap[currentKey]
         listModel.append( { text: valueText } )
         reversedMap[valueText] = currentKey;
       }
       model = listModel
-      currentIndex = find(currentMap[value])
+      currentIndex = valueInKeys ? find(currentMap[value]) : -1
     }
 
     onCurrentTextChanged: {
@@ -69,7 +71,7 @@ Item {
 
     // Workaround to get a signal when the value has changed
     onCurrentValueChanged: {
-      currentIndex = find(currentMap[value])
+      currentIndex = currentMap ? find(currentMap[value]) : -1
     }
 
   }


### PR DESCRIPTION
Due to last changes in QgsQuick regarding passing style object, styling property has been updated (widget had 0 height without fix).
Before:
<img width="635" alt="Screenshot 2019-05-06 at 12 37 11" src="https://user-images.githubusercontent.com/6735606/57220506-dc990100-6ffb-11e9-8724-60ee148994bf.png">
After:
<img width="637" alt="Screenshot 2019-05-06 at 12 38 09" src="https://user-images.githubusercontent.com/6735606/57220514-e28ee200-6ffb-11e9-90e2-b06ca7d58d7f.png">


Fixed case when (current) value is not matching values in relation map (it generated error while creating component, e.g maple value is missing in value map, therefore error and empty widget: `file:///Users/vsklencar/lutra/qgis/QGIS_INSTALL/QGIS.app/Contents/MacOS/qml/QgsQuick/qgsquickvaluerelation.qml:72: TypeError: Cannot read property 'Maple' of undefined`).
Before:
<img width="636" alt="Screenshot 2019-05-06 at 12 35 41" src="https://user-images.githubusercontent.com/6735606/57220539-00f4dd80-6ffc-11e9-9281-32c25c3b26d4.png">
After:
<img width="634" alt="Screenshot 2019-05-06 at 12 34 38" src="https://user-images.githubusercontent.com/6735606/57220555-0eaa6300-6ffc-11e9-9220-5a13740a772d.png">
