### PR TITLE
remove redundant /profiles when QGIS_CUSTOM_CONFIG_PATH is set

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -176,8 +176,7 @@ void QgsApplication::init( QString profileFolder )
   {
     if ( getenv( "QGIS_CUSTOM_CONFIG_PATH" ) )
     {
-      QString envProfileFolder = getenv( "QGIS_CUSTOM_CONFIG_PATH" );
-      profileFolder = envProfileFolder + QDir::separator() + "profiles";
+      profileFolder = getenv( "QGIS_CUSTOM_CONFIG_PATH" );
     }
     else
     {


### PR DESCRIPTION
Signed-off-by: Marco Bernasocchi <marco@opengis.ch>

## Description
setting QGIS_CUSTOM_CONFIG_PATH on server results in an almost correct behaviour. The only issue is the duplication of `/profiles` in the generated path since `QgsUserProfileManager::resolveProfilesFolder` already adds a `/profiles` to the path.

QGIS desktop is not touched by this since the profileFolder is setup in main.

`export QGIS_CUSTOM_CONFIG_PATH=/io`
then running QGIS server generates:
`14:26:56 INFO Server[23]: User DB PATH: /io/profiles/profiles/default/qgis.db`

QGIS Desktop generates:

User DB PATH: /io/profiles/default/qgis.db`

```
4:26:56 INFO Server[23]: Qgis Server Settings: 
14:26:56 INFO Server[23]:   - QGIS_OPTIONS_PATH / '' (Override the default path for user configuration): '' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_PARALLEL_RENDERING / '/qgis/parallel_rendering' (Activate/Deactivate parallel rendering for WMS getMap request): 'true' (read from ENVIRONMENT_VARIABLE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_MAX_THREADS / '/qgis/max_threads' (Number of threads to use when parallel rendering is activated): '4' (read from ENVIRONMENT_VARIABLE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_LOG_LEVEL / '' (Log level): '0' (read from ENVIRONMENT_VARIABLE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_LOG_FILE / '' (Log file): '' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_LOG_STDERR / '' (Activate/Deactivate logging to stderr): 'true' (read from ENVIRONMENT_VARIABLE)
14:26:56 INFO Server[23]:   - QGIS_PROJECT_FILE / '' (QGIS project file): '' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - MAX_CACHE_LAYERS / '' (Specify the maximum number of cached layers): '100' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_CACHE_DIRECTORY / '/cache/directory' (Specify the cache directory): '/io/profiles/profiles/default/cache' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_CACHE_SIZE / '/cache/size' (Specify the cache size): '52428800' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_SHOW_GROUP_SEPARATOR / '/locale/showGroupSeparator' (Show group (thousands) separator): 'false' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE / '/locale/userLocale' (Override system locale): '' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_WMS_MAX_HEIGHT / '/qgis/max_wms_height' (Maximum height for a WMS request. The lower one of this and the project configuration is used.): '-1' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]:   - QGIS_SERVER_WMS_MAX_WIDTH / '/qgis/max_wms_width' (Maximum width for a WMS request. The most conservative between this and the project one is used): '-1' (read from DEFAULT_VALUE)
14:26:56 INFO Server[23]: Ini file used to initialize settings: /io/profiles/profiles/default/QGIS/QGIS3.ini
14:26:56 INFO Server[23]: cacheDirectory: /io/profiles/profiles/default/cache/
14:26:56 INFO Server[23]: maximumCacheSize: 52428800
14:26:56 INFO Server[23]: Prefix  PATH: /usr
14:26:56 INFO Server[23]: Plugin  PATH: /usr/lib64/qgis/plugins
14:26:56 INFO Server[23]: PkgData PATH: /usr/share/qgis
14:26:56 INFO Server[23]: User DB PATH: /io/profiles/profiles/default/qgis.db
14:26:56 INFO Server[23]: Auth DB PATH: /io/profiles/profiles/default/qgis-auth.db
14:26:56 INFO Server[23]: SVG PATHS: /usr/share/qgis/svg///io/profiles/profiles/default/svg/
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
