### PR TITLE
Add method to retrieve map extent to QgsRenderContext

### DIFF
--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -184,6 +184,22 @@ than the actual visible portion of that layer.
    should never be used to determine the actual visible extent of a map render.
 
 .. seealso:: :py:func:`setExtent`
+
+.. seealso:: :py:func:`mapExtent`
+%End
+
+    QgsRectangle mapExtent() const;
+%Docstring
+Returns the original extent of the map being rendered.
+
+Unlike extent(), this extent is always in the final destination CRS for the map
+render and represents the exact bounds of the map being rendered.
+
+.. seealso:: :py:func:`extent`
+
+.. seealso:: :py:func:`setMapExtent`
+
+.. versionadded:: 3.4.8
 %End
 
     const QgsMapToPixel &mapToPixel() const;
@@ -263,6 +279,22 @@ to the map. It may be larger than the actual visible area, but MUST contain at l
 entire visible area.
 
 .. seealso:: :py:func:`setExtent`
+
+.. seealso:: :py:func:`setMapExtent`
+%End
+
+    void setMapExtent( const QgsRectangle &extent );
+%Docstring
+Sets the original ``extent`` of the map being rendered.
+
+Unlike setExtent(), this extent is always in the final destination CRS for the map
+render and represents the exact bounds of the map being rendered.
+
+.. seealso:: :py:func:`mapExtent`
+
+.. seealso:: :py:func:`setExtent`
+
+.. versionadded:: 3.4.8
 %End
 
     void setDrawEditingInformation( bool b );

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -43,6 +43,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mCoordTransform( rh.mCoordTransform )
   , mDistanceArea( rh.mDistanceArea )
   , mExtent( rh.mExtent )
+  , mOriginalMapExtent( rh.mOriginalMapExtent )
   , mMapToPixel( rh.mMapToPixel )
   , mRenderingStopped( rh.mRenderingStopped )
   , mScaleFactor( rh.mScaleFactor )
@@ -70,6 +71,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mPainter = rh.mPainter;
   mCoordTransform = rh.mCoordTransform;
   mExtent = rh.mExtent;
+  mOriginalMapExtent = rh.mOriginalMapExtent;
   mMapToPixel = rh.mMapToPixel;
   mRenderingStopped = rh.mRenderingStopped;
   mScaleFactor = rh.mScaleFactor;
@@ -157,6 +159,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   QgsRenderContext ctx;
   ctx.setMapToPixel( mapSettings.mapToPixel() );
   ctx.setExtent( mapSettings.visibleExtent() );
+  ctx.setMapExtent( mapSettings.visibleExtent() );
   ctx.setFlag( DrawEditingInfo, mapSettings.testFlag( QgsMapSettings::DrawEditingInfo ) );
   ctx.setFlag( ForceVectorOutput, mapSettings.testFlag( QgsMapSettings::ForceVectorOutput ) );
   ctx.setFlag( UseAdvancedEffects, mapSettings.testFlag( QgsMapSettings::UseAdvancedEffects ) );

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -233,8 +233,21 @@ class CORE_EXPORT QgsRenderContext
      * should never be used to determine the actual visible extent of a map render.
      *
      * \see setExtent()
+     * \see mapExtent()
      */
     const QgsRectangle &extent() const { return mExtent; }
+
+    /**
+     * Returns the original extent of the map being rendered.
+     *
+     * Unlike extent(), this extent is always in the final destination CRS for the map
+     * render and represents the exact bounds of the map being rendered.
+     *
+     * \see extent()
+     * \see setMapExtent()
+     * \since QGIS 3.4.8
+     */
+    QgsRectangle mapExtent() const { return mOriginalMapExtent; }
 
     const QgsMapToPixel &mapToPixel() const {return mMapToPixel;}
 
@@ -312,8 +325,21 @@ class CORE_EXPORT QgsRenderContext
      * entire visible area.
      *
      * \see setExtent()
+     * \see setMapExtent()
      */
     void setExtent( const QgsRectangle &extent ) {mExtent = extent;}
+
+    /**
+     * Sets the original \a extent of the map being rendered.
+     *
+     * Unlike setExtent(), this extent is always in the final destination CRS for the map
+     * render and represents the exact bounds of the map being rendered.
+     *
+     * \see mapExtent()
+     * \see setExtent()
+     * \since QGIS 3.4.8
+     */
+    void setMapExtent( const QgsRectangle &extent ) { mOriginalMapExtent = extent; }
 
     void setDrawEditingInformation( bool b );
 
@@ -511,6 +537,7 @@ class CORE_EXPORT QgsRenderContext
     QgsDistanceArea mDistanceArea;
 
     QgsRectangle mExtent;
+    QgsRectangle mOriginalMapExtent;
 
     QgsMapToPixel mMapToPixel;
 

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -21,7 +21,8 @@ from qgis.core import (QgsRenderContext,
                        QgsCoordinateReferenceSystem,
                        QgsMapUnitScale,
                        QgsUnitTypes,
-                       QgsProject)
+                       QgsProject,
+                       QgsRectangle)
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QPainter, QImage
 from qgis.testing import start_app, unittest
@@ -45,6 +46,9 @@ class TestQgsRenderContext(unittest.TestCase):
         c.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         self.assertEqual(c.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
 
+        c.setMapExtent(QgsRectangle(1, 2, 3, 4))
+        self.assertEqual(c.mapExtent(), QgsRectangle(1, 2, 3, 4))
+
     def testCopyConstructor(self):
         """
         Test the copy constructor
@@ -52,9 +56,11 @@ class TestQgsRenderContext(unittest.TestCase):
         c1 = QgsRenderContext()
 
         c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
+        c1.setMapExtent(QgsRectangle(1, 2, 3, 4))
 
         c2 = QgsRenderContext(c1)
         self.assertEqual(c2.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
+        self.assertEqual(c2.mapExtent(), QgsRectangle(1, 2, 3, 4))
 
         c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         c2 = QgsRenderContext(c1)
@@ -92,6 +98,9 @@ class TestQgsRenderContext(unittest.TestCase):
         test QgsRenderContext.fromMapSettings()
         """
         ms = QgsMapSettings()
+        ms.setOutputSize(QSize(1000, 1000))
+        ms.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
+        ms.setExtent(QgsRectangle(10000, 20000, 30000, 40000))
 
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
         rc = QgsRenderContext.fromMapSettings(ms)
@@ -100,6 +109,8 @@ class TestQgsRenderContext(unittest.TestCase):
         ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
         rc = QgsRenderContext.fromMapSettings(ms)
         self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
+
+        self.assertEqual(rc.mapExtent(), QgsRectangle(10000, 20000, 30000, 40000))
 
     def testRenderMetersInMapUnits(self):
 


### PR DESCRIPTION
Previously only a "layer clipping extent" was available for retrieval
from a QgsRenderContext instance, yet there's a need for rendering
operations to have access to the original full extent of the map
being rendered.

Required for an upcoming bug fix.