### PR TITLE
 [FEATURE] Add order by support to expression aggregate and concatenation functions

### DIFF
--- a/python/core/auto_generated/qgsaggregatecalculator.sip.in
+++ b/python/core/auto_generated/qgsaggregatecalculator.sip.in
@@ -66,6 +66,8 @@ to a data provider for remote calculation.
       QString filter;
 
       QString delimiter;
+
+      QgsFeatureRequest::OrderBy orderBy;
     };
 
     QgsAggregateCalculator( const QgsVectorLayer *layer );

--- a/resources/function_help/json/aggregate
+++ b/resources/function_help/json/aggregate
@@ -7,7 +7,8 @@
 	{"arg":"aggregate", "description":"a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>min</li><li>max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li><li>collect: create an aggregated multipart geometry</li></ul>"},
 	{"arg":"expression", "description":"sub expression or field name to aggregate"},
 	{"arg":"filter", "optional":true, "description":"optional filter expression to limit the features used for calculating the aggregate. Fields and geometry are from the features on the joined layer. The source feature can be accessed with the variable @parent."},
-	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values for 'concatenate' aggregate"}
+	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values for 'concatenate' aggregate"},
+	{"arg":"order_by", "optional":true, "description":"optional filter expression to order the features used for calculating the aggregate. Fields and geometry are from the features on the joined layer."}
   ],
   "examples": [
 	{ "expression":"aggregate(layer:='rail_stations',aggregate:='sum',expression:=\"passengers\")", "returns":"sum of all values from the passengers field in the rail_stations layer"},

--- a/resources/function_help/json/array_agg
+++ b/resources/function_help/json/array_agg
@@ -5,7 +5,8 @@
   "arguments": [
     {"arg": "expression", "description": "sub expression of field to aggregate"},
     {"arg": "group_by", "optional": true, "description": "optional expression to use to group aggregate calculations"},
-    {"arg": "filter", "optional": true, "description": "optional expression to use to filter features used to calculate aggregate"}
+    {"arg": "filter", "optional": true, "description": "optional expression to use to filter features used to calculate aggregate"},
+    {"arg": "order_by", "optional": true, "description": "optional expression to use to order features used to calculate aggregate"}
   ],
   "examples": [
     { "expression": "array_agg(\"name\",group_by:=\"state\")", "returns":"list of name values, grouped by state field"}

--- a/resources/function_help/json/concatenate_unique
+++ b/resources/function_help/json/concatenate_unique
@@ -1,7 +1,7 @@
 {
-  "name": "concatenate",
+  "name": "concatenate_unique",
   "type": "function",
-  "description": "Returns all aggregated strings from a field or expression joined by a delimiter.",
+  "description": "Returns all unique strings from a field or expression joined by a delimiter.",
   "arguments": [
 	{"arg":"expression", "description":"sub expression of field to aggregate"},
 	{"arg":"group_by", "optional":true, "description":"optional expression to use to group aggregate calculations"},
@@ -10,6 +10,6 @@
 	{"arg":"order_by", "optional":true, "description":"optional expression to use to order features used to calculate aggregate"}
   ],
   "examples": [
-	{ "expression":"concatenate(\"town_name\",group_by:=\"state\",concatenator:=',')", "returns":"comma separated list of town_names, grouped by state field"}
+	{ "expression":"concatenate(\"town_name\",group_by:=\"state\",concatenator:=',')", "returns":"comma separated list of unique town_names, grouped by state field"}
   ]
 }

--- a/resources/function_help/json/relation_aggregate
+++ b/resources/function_help/json/relation_aggregate
@@ -6,7 +6,8 @@
 	{"arg":"relation", "description":"a string, representing a relation ID"},
 	{"arg":"aggregate", "description":"a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>min</li><li>max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li></ul>"},
 	{"arg":"expression", "description":"sub expression or field name to aggregate"},
-	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values for 'concatenate' aggregate"}
+	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values for 'concatenate' aggregate"},
+	{"arg":"filter", "optional":true, "description":"optional filter expression to order the features used for calculating the aggregate. Fields and geometry are from the features on the joined layer."}
   ],
   "examples": [
 	{ "expression":"relation_aggregate(relation:='my_relation',aggregate:='mean',expression:=\"passengers\")", "returns":"mean value of all matching child features using the 'my_relation' relation"},

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -39,6 +39,7 @@ void QgsAggregateCalculator::setParameters( const AggregateParameters &parameter
 {
   mFilterExpression = parameters.filter;
   mDelimiter = parameters.delimiter;
+  mOrderBy = parameters.orderBy;
 }
 
 QVariant QgsAggregateCalculator::calculate( QgsAggregateCalculator::Aggregate aggregate,
@@ -82,6 +83,8 @@ QVariant QgsAggregateCalculator::calculate( QgsAggregateCalculator::Aggregate ag
                                          QgsFeatureRequest::NoFlags :
                                          QgsFeatureRequest::NoGeometry )
                               .setSubsetOfAttributes( lst, mLayer->fields() );
+  if ( !mOrderBy.empty() )
+    request.setOrderBy( mOrderBy );
   if ( !mFilterExpression.isEmpty() )
     request.setFilterExpression( mFilterExpression );
   if ( context )

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -22,6 +22,7 @@
 #include "qgsstatisticalsummary.h"
 #include "qgsdatetimestatisticalsummary.h"
 #include "qgsstringstatisticalsummary.h"
+#include "qgsfeaturerequest.h"
 #include <QVariant>
 
 
@@ -103,6 +104,12 @@ class CORE_EXPORT QgsAggregateCalculator
        * \see QgsAggregateCalculator::delimiter()
        */
       QString delimiter;
+
+      /**
+       * Optional order by clauses.
+       * \since QGIS 3.8
+       */
+      QgsFeatureRequest::OrderBy orderBy;
     };
 
     /**
@@ -182,6 +189,9 @@ class CORE_EXPORT QgsAggregateCalculator
 
     //! Filter expression, or empty for no filter
     QString mFilterExpression;
+
+    //! Order by clause
+    QgsFeatureRequest::OrderBy mOrderBy;
 
     //! Delimiter to use for concatenate aggregate
     QString mDelimiter;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1734,6 +1734,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "filter no matching max" ) << "aggregate('test','max',\"col1\", \"col1\" > 1000000 )" << false << QVariant();
 
       QTest::newRow( "filter by @parent attribute" ) << "aggregate(layer:='child_layer', aggregate:='min', expression:=\"col3\", filter:=\"parent\"=attribute(@parent,'col1'))" << false << QVariant( 1 );
+
+      // order by
+      QTest::newRow( "string concatenate order by" ) << "aggregate('test','concatenate',\"col2\",concatenator:=' , ',order_by:=col1)" << false << QVariant( "test3 , test1 , test2 , test4" );
+      QTest::newRow( "array agg concatenate order by" ) << "aggregate('test','array_agg',\"col2\",order_by:=col1)" << false << QVariant( QVariantList() << "test3" << "test1" << "test2" << "test4" );
     }
 
     void aggregate()
@@ -1805,7 +1809,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "min_length" ) << "min_length(\"col2\")" << false << QVariant( 0 );
       QTest::newRow( "max_length" ) << "max_length(\"col2\")" << false << QVariant( 7 );
       QTest::newRow( "concatenate" ) << "concatenate(\"col2\",concatenator:=',')" << false << QVariant( "test,,test333,test4,,test4" );
+      QTest::newRow( "concatenate with order" ) << "concatenate(\"col2\",concatenator:=',', order_by:=col1)" << false << QVariant( ",test4,test333,test,,test4" );
+      QTest::newRow( "concatenate with order" ) << "concatenate(\"col2\",concatenator:=',', order_by:=col2)" << false << QVariant( "test,test333,test4,test4,," );
       QTest::newRow( "concatenate unique" ) << "concatenate_unique(\"col4\",concatenator:=',')" << false << QVariant( ",test" );
+      QTest::newRow( "concatenate unique 2" ) << "concatenate_unique(\"col2\",concatenator:=',')" << false << QVariant( "test,,test333,test4" );
+      QTest::newRow( "concatenate unique with order" ) << "concatenate_unique(\"col2\",concatenator:=',', order_by:=col2)" << false << QVariant( "test,test333,test4," );
+
+      QTest::newRow( "array agg" ) << "array_agg(\"col2\")" << false << QVariant( QVariantList() << "test" << "" << "test333" << "test4" << "" << "test4" );
+      QTest::newRow( "array agg with order" ) << "array_agg(\"col2\",order_by:=col2)" << false << QVariant( QVariantList() << "test" << "test333" << "test4" << "test4" << "" << "" );
 
       QTest::newRow( "geometry collect" ) << "geom_to_wkt(collect($geometry))" << false << QVariant( QStringLiteral( "MultiPoint ((0 0),(1 0),(2 0),(3 0),(5 0))" ) );
       QTest::newRow( "geometry collect with null geometry first" ) << "geom_to_wkt(collect($geometry, filter:=\"col3\"=3))" << false << QVariant( QStringLiteral( "MultiPoint ((5 0))" ) );
@@ -1931,6 +1942,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "relation aggregate count 2" ) << "relation_aggregate('my_rel','count',\"col3\")" << 3 << false << QVariant( 2 );
       QTest::newRow( "relation aggregate count 2" ) << "relation_aggregate('my_rel','count',\"col3\")" << 6 << false << QVariant( 0 );
       QTest::newRow( "relation aggregate concatenation" ) << "relation_aggregate('my_rel','concatenate',to_string(\"col3\"),concatenator:=',')" << 3 << false << QVariant( "2,7" );
+
+      QTest::newRow( "relation aggregate concatenation with order" ) << "relation_aggregate('my_rel','concatenate',to_string(\"col2\"),concatenator:=',', order_by:=col2)" << 4 << false << QVariant( "test,test333," );
+      QTest::newRow( "relation aggregate concatenation with order 2" ) << "relation_aggregate('my_rel','concatenate',to_string(\"col2\"),concatenator:=',', order_by:=col3)" << 4 << false << QVariant( ",test,test333" );
 
       QTest::newRow( "named relation aggregate 1" ) << "relation_aggregate(relation:='my_rel',aggregate:='sum',expression:=\"col3\")" << 4 << false << QVariant( 5 );
       QTest::newRow( "relation aggregate sub expression 1" ) << "relation_aggregate('my_rel','sum',\"col3\" * 2)" << 4 << false << QVariant( 10 );

--- a/tests/src/python/test_qgsaggregatecalculator.py
+++ b/tests/src/python/test_qgsaggregatecalculator.py
@@ -21,6 +21,7 @@ from qgis.core import (QgsAggregateCalculator,
                        QgsExpressionContext,
                        QgsExpressionContextScope,
                        QgsGeometry,
+                       QgsFeatureRequest,
                        NULL
                        )
 from qgis.PyQt.QtCore import QDateTime, QDate, QTime
@@ -151,6 +152,20 @@ class TestQgsAggregateCalculator(unittest.TestCase):
             val, ok = agg.calculate(t, 'flddbl')
             self.assertFalse(ok)
 
+        # with order by
+        agg = QgsAggregateCalculator(layer)
+        val, ok = agg.calculate(QgsAggregateCalculator.ArrayAggregate, 'fldint')
+        self.assertEqual(val, [4, 2, 3, 2, 5, NULL, 8])
+        params = QgsAggregateCalculator.AggregateParameters()
+        params.orderBy = QgsFeatureRequest.OrderBy([QgsFeatureRequest.OrderByClause('fldint')])
+        agg.setParameters(params)
+        val, ok = agg.calculate(QgsAggregateCalculator.ArrayAggregate, 'fldint')
+        self.assertEqual(val, [2, 2, 3, 4, 5, 8, NULL])
+        params.orderBy = QgsFeatureRequest.OrderBy([QgsFeatureRequest.OrderByClause('flddbl')])
+        agg.setParameters(params)
+        val, ok = agg.calculate(QgsAggregateCalculator.ArrayAggregate, 'fldint')
+        self.assertEqual(val, [2, 2, 4, 8, 3, 5, NULL])
+
     def testString(self):
         """ Test calculation of aggregates on string fields"""
 
@@ -207,6 +222,18 @@ class TestQgsAggregateCalculator(unittest.TestCase):
                   ]:
             val, ok = agg.calculate(t, 'fldstring')
             self.assertFalse(ok)
+
+        # with order by
+        agg = QgsAggregateCalculator(layer)
+        val, ok = agg.calculate(QgsAggregateCalculator.ArrayAggregate, 'fldstring')
+        self.assertEqual(val, ['cc', 'aaaa', 'bbbbbbbb', 'aaaa', 'eeee', '', 'eeee', '', 'dddd'])
+        params = QgsAggregateCalculator.AggregateParameters()
+        params.orderBy = QgsFeatureRequest.OrderBy([QgsFeatureRequest.OrderByClause('fldstring')])
+        agg.setParameters(params)
+        val, ok = agg.calculate(QgsAggregateCalculator.ArrayAggregate, 'fldstring')
+        self.assertEqual(val, ['', '', 'aaaa', 'aaaa', 'bbbbbbbb', 'cc', 'dddd', 'eeee', 'eeee'])
+        val, ok = agg.calculate(QgsAggregateCalculator.StringConcatenate, 'fldstring')
+        self.assertEqual(val, 'aaaaaaaabbbbbbbbccddddeeeeeeee')
 
     def testDateTime(self):
         """ Test calculation of aggregates on date/datetime fields"""


### PR DESCRIPTION
Because certain aggregates and concatenation requires results in
a certain order, this change allows specific control of the order
features are added to the aggregate during an expression evaluation.

E.g.

concatenate("Station",concatenator:=',', order_by:="Station")

will give a comma separated list of station names in alphabetical
order, rather than layer feature order.

Sponsored by SMEC/SJ