### PR TITLE
[RPM] Add qt5-qtbase-private-devel build dep for F30+

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -376,7 +376,7 @@ new subdirectory called `build` or `build-qt5` in it.
     3.9.1. Install build dependencies
     =================================
 
-  dnf install qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel
+  dnf install qt5-qtbase-private-devel qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel
 
 To build QGIS server additional dependencies are required:
 

--- a/doc/INSTALL.html
+++ b/doc/INSTALL.html
@@ -615,7 +615,7 @@ new subdirectory called `build` or `build-qt5` in it.
 <H3>3.9.1. Install build dependencies</H3>
 
 <div class="code"><PRE>
-dnf install qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel
+dnf install qt5-qtbase-private-devel qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel
 </PRE></div>
 
 <P>

--- a/doc/linux.t2t
+++ b/doc/linux.t2t
@@ -270,7 +270,7 @@ new subdirectory called `build` or `build-qt5` in it.
 === Install build dependencies ===
 
 ```
-dnf install qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel
+dnf install qt5-qtbase-private-devel qt5-qtwebkit-devel qt5-qtlocation-devel qt5-qttools-static qca-qt5-devel qca-qt5-ossl qt5-qt3d-devel python3-qt5-devel python3-qscintilla-qt5-devel qscintilla-qt5-devel python3-qscintilla-devel python3-qscintilla-qt5 clang flex bison geos-devel gdal-devel sqlite-devel libspatialite-devel qt5-qtsvg-devel spatialindex-devel expat-devel proj-devel qwt-qt5-devel gsl-devel postgresql-devel cmake python3-future gdal-python3 python3-psycopg2 python3-PyYAML python3-pygments python3-jinja2 python3-OWSLib qca-qt5-ossl qwt-qt5-devel qtkeychain-qt5-devel qwt-devel sip-devel libzip-devel exiv2-devel
 ```
 
 To build QGIS server additional dependencies are required:

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -114,6 +114,14 @@ BuildRequires:  qtkeychain-qt5-devel
 BuildRequires:  qt5-qtserialport-devel
 BuildRequires:  qt5-qt3d-devel
 
+# In F30+ qt5-qtbase-devel has been splitted
+# in qt5-qtbase-private-devel and qt5-qtbase-private-devel
+# qt5-qtbase-private-devel is neede by 
+# external/qspatialite/qsql_spatialite.cpp:49:10
+%if 0%{?fedora} >= 30
+BuildRequires:  qt5-qtbase-private-devel
+%endif
+
 # Qwt stuff
 BuildRequires:  qwt-devel
 BuildRequires:  qwt-qt5-devel

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -114,7 +114,7 @@ BuildRequires:  qtkeychain-qt5-devel
 BuildRequires:  qt5-qtserialport-devel
 BuildRequires:  qt5-qt3d-devel
 
-# In F30+ qt5-qtbase-devel has been splitted
+# In F30+ qt5-qtbase-devel has been split
 # in qt5-qtbase-devel and qt5-qtbase-private-devel
 # qt5-qtbase-private-devel is needed by 
 # external/qspatialite/qsql_spatialite.cpp:49:10

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -115,8 +115,8 @@ BuildRequires:  qt5-qtserialport-devel
 BuildRequires:  qt5-qt3d-devel
 
 # In F30+ qt5-qtbase-devel has been splitted
-# in qt5-qtbase-private-devel and qt5-qtbase-private-devel
-# qt5-qtbase-private-devel is neede by 
+# in qt5-qtbase-devel and qt5-qtbase-private-devel
+# qt5-qtbase-private-devel is needed by 
 # external/qspatialite/qsql_spatialite.cpp:49:10
 %if 0%{?fedora} >= 30
 BuildRequires:  qt5-qtbase-private-devel


### PR DESCRIPTION
## Description

`qt5-qtbase-devel` package as been split (yesterday) in Fedora 30

Error:
```
BUILDSTDERR: /builddir/build/BUILD/qgis-3.7.0/external/qspatialite/qsql_spatialite.cpp:49:10: fatal error: QtSql/private/qsqlcachedresult_p.h: No such file or directory
BUILDSTDERR:    49 | #include <QtSql/private/qsqlcachedresult_p.h>
BUILDSTDERR:       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
BUILDSTDERR: compilation terminated.
BUILDSTDERR: make[2]: *** [src/providers/spatialite/qspatialite/CMakeFiles/qsqlspatialite.dir/build.make:74: src/providers/spatialite/qspatialite/CMakeFiles/qsqlspatialite.dir/qsql_spatialite.cpp.o] Error 1
```
See https://copr-be.cloud.fedoraproject.org/results/dani/qgis-testing/fedora-30-x86_64/00906202-qgis/build.log.gz

Fixes https://github.com/daniviga/QGIS/issues/2

**Needs backport** to 3.4 and 3.6 for the next LTR and stable builds on Fedora 30+

/cc @m-kuhn 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
