### PR TITLE
[effects] when creating the preview image, disable effects to avoid 'double-apply'

### DIFF
--- a/src/gui/symbology/qgslayerpropertieswidget.cpp
+++ b/src/gui/symbology/qgslayerpropertieswidget.cpp
@@ -34,6 +34,7 @@
 #include "qgssymbol.h" //for the unit
 #include "qgspanelwidget.h"
 #include "qgsmapcanvas.h"
+#include "qgspainteffect.h"
 #include "qgsproject.h"
 #include "qgsvectorlayer.h"
 #include "qgsexpressioncontextutils.h"
@@ -312,7 +313,17 @@ void QgsLayerPropertiesWidget::emitSignalChanged()
   emit changed();
 
   // also update paint effect preview
+  bool paintEffectToggled = false;
+  if ( mLayer->paintEffect() && mLayer->paintEffect()->enabled() )
+  {
+    mLayer->paintEffect()->setEnabled( false );
+    paintEffectToggled = true;
+  }
   mEffectWidget->setPreviewPicture( QgsSymbolLayerUtils::symbolLayerPreviewPicture( mLayer, QgsUnitTypes::RenderMillimeters, QSize( 80, 80 ) ) );
+  if ( paintEffectToggled )
+  {
+    mLayer->paintEffect()->setEnabled( true );
+  }
   emit widgetChanged();
 }
 


### PR DESCRIPTION
## Description
The issue (likely unreported) is shown in this screencast: https://www.youtube.com/watch?v=nTT6Or1ukj8&feature=youtu.be

@nyalldawson , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
