### PR TITLE
[nodetool] chained add vertex at endpoint

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2046,7 +2046,7 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
   {
     if ( mMouseAtEndpoint->vertexId != 0 )
     {
-      // If we were adding at the end of the featue, we need to update the index
+      // If we were adding at the end of the feature, we need to update the index
       mMouseAtEndpoint.reset( new Vertex( mMouseAtEndpoint->layer, mMouseAtEndpoint->fid, mMouseAtEndpoint->vertexId + 1 ) );
     }
     // And then we just restart the drag

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2040,6 +2040,18 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
 
   setHighlightedVertices( mSelectedVertices );  // update positions of existing highlighted vertices
   setHighlightedVerticesVisible( true );  // time to show highlighted vertices again
+
+  // restart startDraggingAddVertexAtEndpoint right after it finishes
+  if ( addingAtEndpoint )
+  {
+    if ( mMouseAtEndpoint->vertexId != 0 )
+    {
+      // If we were adding at the end of the featue, we need to update the index
+      mMouseAtEndpoint.reset( new Vertex( mMouseAtEndpoint->layer, mMouseAtEndpoint->fid, mMouseAtEndpoint->vertexId + 1 ) );
+    }
+    // And then we just restart the drag
+    startDraggingAddVertexAtEndpoint( mapPoint );
+  }
 }
 
 

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -387,6 +387,7 @@ void TestQgsVertexTool::testAddVertexAtEndpoint()
   mouseMove( 1, 3 ); // first we need to move to the vertex
   mouseClick( 1, 3 + offsetInMapUnits, Qt::LeftButton );
   mouseClick( 2, 3, Qt::LeftButton );
+  mouseClick( 2, 3, Qt::RightButton ); // we need a right click to stop adding new nodes
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
   QCOMPARE( mLayerLine->getFeature( mFidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3, 2 3)" ) );
@@ -401,10 +402,30 @@ void TestQgsVertexTool::testAddVertexAtEndpoint()
   mouseMove( 2, 1 ); // first we need to move to the vertex
   mouseClick( 2 + offsetInMapUnits, 1, Qt::LeftButton );
   mouseClick( 2, 2, Qt::LeftButton );
+  mouseClick( 2, 2, Qt::RightButton ); // we need a right click to stop adding new nodes
 
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
   QCOMPARE( mLayerLine->getFeature( mFidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 2, 2 1, 1 1, 1 3)" ) );
 
+  mLayerLine->undoStack()->undo();
+  QCOMPARE( mLayerLine->undoStack()->index(), 1 );
+
+  QCOMPARE( mLayerLine->getFeature( mFidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3)" ) );
+
+  // add three vertices at once
+
+  mouseMove( 2, 1 ); // first we need to move to the vertex
+  mouseClick( 2 + offsetInMapUnits, 1, Qt::LeftButton );
+  mouseClick( 2, 2, Qt::LeftButton );
+  mouseClick( 2, 3, Qt::LeftButton );
+  mouseClick( 2, 4, Qt::LeftButton );
+  mouseClick( 2, 2, Qt::RightButton ); // we need a right click to stop adding new nodes
+
+  QCOMPARE( mLayerLine->undoStack()->index(), 4 );
+  QCOMPARE( mLayerLine->getFeature( mFidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 4, 2 3, 2 2, 2 1, 1 1, 1 3)" ) );
+
+  mLayerLine->undoStack()->undo();
+  mLayerLine->undoStack()->undo();
   mLayerLine->undoStack()->undo();
   QCOMPARE( mLayerLine->undoStack()->index(), 1 );
 


### PR DESCRIPTION
## Description

This PR allows to digitize several points at once when extending a line using the node tool.
This removes the frustration of having to click on the small add vertex button each time.

![node](https://user-images.githubusercontent.com/1894106/57455522-98139c80-726b-11e9-93b5-973fbb192c46.gif)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] (N/A) Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] (N/A) Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] (N/A) New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

edit : changed a test according to new behaviour, which now passes