### PR TITLE
[themes] Fix field expression widget not playing nice with themes

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -72,8 +72,6 @@ QgsFieldExpressionWidget::QgsFieldExpressionWidget( QWidget *parent )
                      << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
 
   mCombo->installEventFilter( this );
-
-  mComboPalette = mCombo->lineEdit()->palette();
 }
 
 void QgsFieldExpressionWidget::setExpressionDialogTitle( const QString &title )
@@ -340,10 +338,10 @@ void QgsFieldExpressionWidget::currentFieldChanged()
 
 void QgsFieldExpressionWidget::updateLineEditStyle( const QString &expression )
 {
-  QPalette palette( mComboPalette );
+  QString stylesheet;
   if ( !isEnabled() )
   {
-    palette.setColor( QPalette::Text, Qt::gray );
+    stylesheet = QStringLiteral( "QLineEdit { color: %1; } Qt::gray );" ).arg( QColor( Qt::gray ).name() );
   }
   else
   {
@@ -363,10 +361,10 @@ void QgsFieldExpressionWidget::updateLineEditStyle( const QString &expression )
 
     if ( isExpression && !isValid )
     {
-      palette.setColor( QPalette::Text, Qt::red );
+      stylesheet = QStringLiteral( "QLineEdit { color: %1; } Qt::gray );" ).arg( QColor( Qt::red ).name() );
     }
   }
-  mCombo->lineEdit()->setPalette( palette );
+  mCombo->lineEdit()->setStyleSheet( stylesheet );
 }
 
 bool QgsFieldExpressionWidget::isExpressionValid( const QString &expressionStr )

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -249,7 +249,6 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     const QgsExpressionContextGenerator *mExpressionContextGenerator = nullptr;
     QString mBackupExpression;
     bool mAllowEvalErrors = false;
-    QPalette mComboPalette;
 
     friend class TestQgsFieldExpressionWidget;
 };


### PR DESCRIPTION
## Description
Everyday brings a new theme compatibility issue to fix. This time around, it has to do with the field expression widget.

Here's a screenshot of the issue being fixed here:
![image](https://user-images.githubusercontent.com/1728657/57510056-f99d3f00-732f-11e9-9c71-5c2d731dc98a.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
