### PR TITLE
Change the httpd template to use Apache 2.4 style

### DIFF
--- a/ms-windows/osgeo4w/httpd.conf.tmpl
+++ b/ms-windows/osgeo4w/httpd.conf.tmpl
@@ -20,6 +20,9 @@ Alias /@package@/ @osgeo4w@/apps/@package@/bin/
 <Directory "@osgeo4w@/apps/@package@/bin/">
     SetHandler fcgid-script
     Options ExecCGI
-    Order allow,deny
-    Allow from all
+    # Order/Allow is for Apache 2.2
+    #Order allow,deny
+    #Allow from all
+    # Require is for Apache 2.4
+    Require all granted
 </Directory>


### PR DESCRIPTION
## Description

See https://lists.osgeo.org/pipermail/qgis-user/2019-May/043020.html

The httpd.conf template uses the Apache 2.2 type configuration. 
Using this small patch it will work with current Apache 2.4 on Windows