### PR TITLE
floating widget for advanced input next to the cursor

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -614,6 +614,7 @@
         <file>themes/default/mActionPanHighlightFeature.svg</file>
         <file>themes/default/cadtools/construction.svg</file>
         <file>themes/default/cadtools/delta.svg</file>
+        <file>themes/default/cadtools/floater.svg</file>
         <file>themes/default/cadtools/cad.svg</file>
         <file>themes/default/cadtools/lock.svg</file>
         <file>themes/default/cadtools/parallel.svg</file>

--- a/images/themes/default/cadtools/floater.svg
+++ b/images/themes/default/cadtools/floater.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFEE7F;stroke:#80752A;stroke-width:1.1256;stroke-linecap:square;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFEE7F;stroke:#B8A93D;stroke-width:1.1256;}
+	
+		.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;stroke:#000000;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<g>
+	<path class="st0" d="M22.8,22.5V11H8.9v11.5H22.8z"/>
+	<path class="st1" d="M21.6,20.9H17"/>
+	<path class="st1" d="M21.6,19.2h-6.9"/>
+	<path class="st1" d="M21.6,17.6H17"/>
+	<path class="st1" d="M21.6,15.9h-6.9"/>
+	<path class="st1" d="M21.6,14.3H17"/>
+	<path class="st1" d="M21.6,12.6h-6.9"/>
+</g>
+<path class="st2" d="M12.9,7.6L1.7,1.5l4.8,11.9l1.9-3.1l3.8,4.1l1.4-1.4L9.8,9C9.8,9,12.9,7.6,12.9,7.6z"/>
+</svg>

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -163,12 +163,6 @@ Create an advanced digitizing dock widget
 :param parent: The parent
 %End
 
-    virtual void hideEvent( QHideEvent * );
-
-%Docstring
-Disables the CAD tools when hiding the dock
-%End
-
     bool canvasKeyPressEventFilter( QKeyEvent *e );
 %Docstring
 Filter key events to e.g. toggle construction mode or adapt constraints
@@ -338,6 +332,54 @@ Updates canvas item that displays constraints on the ma
 .. versionadded:: 3.0
 %End
 
+    void setX( const QString &value );
+%Docstring
+Set and lock the X ``value``.
+Can be used to set constraints.
+
+.. note::
+
+   The value is a QString, as it could be an expression.
+
+.. versionadded:: 3.8
+%End
+
+    void setY( const QString &value );
+%Docstring
+Set and lock the Y ``value``.
+Can be used to set constraints.
+
+.. note::
+
+   The value is a QString, as it could be an expression.
+
+.. versionadded:: 3.8
+%End
+
+    void setAngle( const QString &value );
+%Docstring
+Set and lock the angle ``value``.
+Can be used to set constraints.
+
+.. note::
+
+   The value is a QString, as it could be an expression.
+
+.. versionadded:: 3.8
+%End
+
+    void setDistance( const QString &value );
+%Docstring
+Set and lock the distance ``value``.
+Can be used to set constraints.
+
+.. note::
+
+   The value is a QString, as it could be an expression.
+
+.. versionadded:: 3.8
+%End
+
   signals:
 
     void pushWarning( const QString &message );
@@ -359,6 +401,186 @@ when a constraint is toggled.
 
 :param point: The last known digitizing point. Can be used to emulate a mouse event.
 %End
+
+
+    void cadEnabledChanged( bool enabled );
+%Docstring
+Emitted whenever CAD is enabled or disabled
+
+:param enabled: Whether CAD is enabled or not.
+
+.. versionadded:: 3.8
+%End
+
+    void valueXChanged( const QString &value );
+%Docstring
+Emitted whenever the X ``value`` changes (either the mouse moved, or the user changed the input).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void valueYChanged( const QString &value );
+%Docstring
+Emitted whenever the Y ``value`` changes (either the mouse moved, or the user changed the input).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void valueAngleChanged( const QString &value );
+%Docstring
+Emitted whenever the angle ``value`` changes (either the mouse moved, or the user changed the input).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void valueDistanceChanged( const QString &value );
+%Docstring
+Emitted whenever the distance ``value`` changes (either the mouse moved, or the user changed the input).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void lockXChanged( bool locked );
+%Docstring
+Emitted whenever the X parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void lockYChanged( bool locked );
+%Docstring
+Emitted whenever the Y parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void lockAngleChanged( bool locked );
+%Docstring
+Emitted whenever the angle parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+%End
+
+    void lockDistanceChanged( bool locked );
+%Docstring
+Emitted whenever the distance parameter is ``locked``.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. versionadded:: 3.8
+%End
+
+    void relativeXChanged( bool relative );
+%Docstring
+Emitted whenever the X parameter is toggled between absolute and relative.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param relative: Whether the X parameter is relative or not.
+
+.. versionadded:: 3.8
+%End
+
+    void relativeYChanged( bool relative );
+%Docstring
+Emitted whenever the Y parameter is toggled between absolute and relative.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param relative: Whether the Y parameter is relative or not.
+
+.. versionadded:: 3.8
+%End
+
+    void relativeAngleChanged( bool relative );
+%Docstring
+Emitted whenever the angleX parameter is toggled between absolute and relative.
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param relative: Whether the angle parameter is relative or not.
+
+.. versionadded:: 3.8
+%End
+
+
+    void enabledChangedX( bool enabled );
+%Docstring
+Emitted whenever the X field is enabled or disabled. Depending on the context, some parameters
+do not make sense (e.g. you need a previous point to define a distance).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param enabled: Whether the X parameter is enabled or not.
+
+.. versionadded:: 3.8
+%End
+
+    void enabledChangedY( bool enabled );
+%Docstring
+Emitted whenever the Y field is enabled or disabled. Depending on the context, some parameters
+do not make sense (e.g. you need a previous point to define a distance).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param enabled: Whether the Y parameter is enabled or not.
+
+.. versionadded:: 3.8
+%End
+
+    void enabledChangedAngle( bool enabled );
+%Docstring
+Emitted whenever the angle field is enabled or disabled. Depending on the context, some parameters
+do not make sense (e.g. you need a previous point to define a distance).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param enabled: Whether the angle parameter is enabled or not.
+
+.. versionadded:: 3.8
+%End
+
+    void enabledChangedDistance( bool enabled );
+%Docstring
+Emitted whenever the distance field is enabled or disabled. Depending on the context, some parameters
+do not make sense (e.g. you need a previous point to define a distance).
+Could be used by widgets that must reflect the current advanced digitizing state.
+
+:param enabled: Whether the distance parameter is enabled or not.
+
+.. versionadded:: 3.8
+%End
+
+    void focusOnXRequested();
+%Docstring
+Emitted whenever the X field should get the focus using the shortcuts (X).
+Could be used by widgets to capture the focus when a field is being edited.
+
+.. versionadded:: 3.8
+%End
+
+    void focusOnYRequested();
+%Docstring
+Emitted whenever the Y field should get the focus using the shortcuts (Y).
+Could be used by widgets to capture the focus when a field is being edited.
+
+.. versionadded:: 3.8
+%End
+
+    void focusOnAngleRequested();
+%Docstring
+Emitted whenever the angle field should get the focus using the shortcuts (A).
+Could be used by widgets to capture the focus when a field is being edited.
+
+.. versionadded:: 3.8
+%End
+
+    void focusOnDistanceRequested();
+%Docstring
+Emitted whenever the distance field should get the focus using the shortcuts (D).
+Could be used by widgets to capture the focus when a field is being edited.
+
+.. versionadded:: 3.8
+%End
+
 
   private:
     //! event filter for line edits in the dock UI (angle/distance/x/y line edits)

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -42,6 +42,11 @@ by implementing filters called from QgsMapToolAdvancedDigitizing.
       Parallel
     };
 
+    enum WidgetSetMode
+    {
+      ReturnPressed,
+    };
+
 
     class CadConstraint
 {
@@ -332,10 +337,12 @@ Updates canvas item that displays constraints on the ma
 .. versionadded:: 3.0
 %End
 
-    void setX( const QString &value );
+    void setX( const QString &value, WidgetSetMode mode );
 %Docstring
-Set and lock the X ``value``.
-Can be used to set constraints.
+Set the X ``value`` on the widget.
+Can be used to set constraints by external widgets.
+
+:param mode: What type of interaction to emulate
 
 .. note::
 
@@ -344,10 +351,12 @@ Can be used to set constraints.
 .. versionadded:: 3.8
 %End
 
-    void setY( const QString &value );
+    void setY( const QString &value, WidgetSetMode mode );
 %Docstring
-Set and lock the Y ``value``.
-Can be used to set constraints.
+Set the Y ``value`` on the widget.
+Can be used to set constraints by external widgets.
+
+:param mode: What type of interaction to emulate
 
 .. note::
 
@@ -356,10 +365,12 @@ Can be used to set constraints.
 .. versionadded:: 3.8
 %End
 
-    void setAngle( const QString &value );
+    void setAngle( const QString &value, WidgetSetMode mode );
 %Docstring
-Set and lock the angle ``value``.
-Can be used to set constraints.
+Set the angle ``value`` on the widget.
+Can be used to set constraints by external widgets.
+
+:param mode: What type of interaction to emulate
 
 .. note::
 
@@ -368,10 +379,12 @@ Can be used to set constraints.
 .. versionadded:: 3.8
 %End
 
-    void setDistance( const QString &value );
+    void setDistance( const QString &value, WidgetSetMode mode );
 %Docstring
-Set and lock the distance ``value``.
-Can be used to set constraints.
+Set the distance ``value`` on the widget.
+Can be used to set constraints by external widgets.
+
+:param mode: What type of interaction to emulate
 
 .. note::
 
@@ -379,6 +392,8 @@ Can be used to set constraints.
 
 .. versionadded:: 3.8
 %End
+
+
 
   signals:
 

--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -339,56 +339,60 @@ Updates canvas item that displays constraints on the ma
 
     void setX( const QString &value, WidgetSetMode mode );
 %Docstring
-Set the X ``value`` on the widget.
+Set the X value on the widget.
 Can be used to set constraints by external widgets.
 
 :param mode: What type of interaction to emulate
+:param value: The value (as a QString, as it could be an expression)
 
 .. note::
 
-   The value is a QString, as it could be an expression.
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
 
     void setY( const QString &value, WidgetSetMode mode );
 %Docstring
-Set the Y ``value`` on the widget.
+Set the Y value on the widget.
 Can be used to set constraints by external widgets.
 
 :param mode: What type of interaction to emulate
+:param value: The value (as a QString, as it could be an expression)
 
 .. note::
 
-   The value is a QString, as it could be an expression.
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
 
     void setAngle( const QString &value, WidgetSetMode mode );
 %Docstring
-Set the angle ``value`` on the widget.
+Set the angle value on the widget.
 Can be used to set constraints by external widgets.
 
 :param mode: What type of interaction to emulate
+:param value: The value (as a QString, as it could be an expression)
 
 .. note::
 
-   The value is a QString, as it could be an expression.
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
 
     void setDistance( const QString &value, WidgetSetMode mode );
 %Docstring
-Set the distance ``value`` on the widget.
+Set the distance value on the widget.
 Can be used to set constraints by external widgets.
 
 :param mode: What type of interaction to emulate
+:param value: The value (as a QString, as it could be an expression)
 
 .. note::
 
-   The value is a QString, as it could be an expression.
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -422,7 +426,11 @@ when a constraint is toggled.
 %Docstring
 Emitted whenever CAD is enabled or disabled
 
-:param enabled: Whether CAD is enabled or not.
+:param enabled: Whether CAD is enabled or not
+
+.. note::
+
+   unstable API (will likely change).
 
 .. versionadded:: 3.8
 %End
@@ -432,6 +440,10 @@ Emitted whenever CAD is enabled or disabled
 Emitted whenever the X ``value`` changes (either the mouse moved, or the user changed the input).
 Could be used by widgets that must reflect the current advanced digitizing state.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -439,6 +451,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 %Docstring
 Emitted whenever the Y ``value`` changes (either the mouse moved, or the user changed the input).
 Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -448,6 +464,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 Emitted whenever the angle ``value`` changes (either the mouse moved, or the user changed the input).
 Could be used by widgets that must reflect the current advanced digitizing state.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -455,6 +475,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 %Docstring
 Emitted whenever the distance ``value`` changes (either the mouse moved, or the user changed the input).
 Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -464,6 +488,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 Emitted whenever the X parameter is ``locked``.
 Could be used by widgets that must reflect the current advanced digitizing state.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -472,6 +500,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 Emitted whenever the Y parameter is ``locked``.
 Could be used by widgets that must reflect the current advanced digitizing state.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -479,12 +511,22 @@ Could be used by widgets that must reflect the current advanced digitizing state
 %Docstring
 Emitted whenever the angle parameter is ``locked``.
 Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
+
+.. versionadded:: 3.8
 %End
 
     void lockDistanceChanged( bool locked );
 %Docstring
 Emitted whenever the distance parameter is ``locked``.
 Could be used by widgets that must reflect the current advanced digitizing state.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -496,6 +538,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
 :param relative: Whether the X parameter is relative or not.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -506,6 +552,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
 :param relative: Whether the Y parameter is relative or not.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -515,6 +565,10 @@ Emitted whenever the angleX parameter is toggled between absolute and relative.
 Could be used by widgets that must reflect the current advanced digitizing state.
 
 :param relative: Whether the angle parameter is relative or not.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -528,6 +582,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
 :param enabled: Whether the X parameter is enabled or not.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -538,6 +596,10 @@ do not make sense (e.g. you need a previous point to define a distance).
 Could be used by widgets that must reflect the current advanced digitizing state.
 
 :param enabled: Whether the Y parameter is enabled or not.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -550,6 +612,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
 :param enabled: Whether the angle parameter is enabled or not.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -561,6 +627,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 
 :param enabled: Whether the distance parameter is enabled or not.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -568,6 +638,10 @@ Could be used by widgets that must reflect the current advanced digitizing state
 %Docstring
 Emitted whenever the X field should get the focus using the shortcuts (X).
 Could be used by widgets to capture the focus when a field is being edited.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End
@@ -577,6 +651,10 @@ Could be used by widgets to capture the focus when a field is being edited.
 Emitted whenever the Y field should get the focus using the shortcuts (Y).
 Could be used by widgets to capture the focus when a field is being edited.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -585,6 +663,10 @@ Could be used by widgets to capture the focus when a field is being edited.
 Emitted whenever the angle field should get the focus using the shortcuts (A).
 Could be used by widgets to capture the focus when a field is being edited.
 
+.. note::
+
+   unstable API (will likely change)
+
 .. versionadded:: 3.8
 %End
 
@@ -592,6 +674,10 @@ Could be used by widgets to capture the focus when a field is being edited.
 %Docstring
 Emitted whenever the distance field should get the focus using the shortcuts (D).
 Could be used by widgets to capture the focus when a field is being edited.
+
+.. note::
+
+   unstable API (will likely change)
 
 .. versionadded:: 3.8
 %End

--- a/python/gui/auto_generated/qgsadvanceddigitizingfloater.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingfloater.sip.in
@@ -59,6 +59,9 @@ Note that the floater may be active but not visible (e.g. if the mouse is not ov
 .. versionadded:: 3.8
 %End
 
+  private:
+    //! event filter to track mouse position
+    bool eventFilter( QObject *obj, QEvent *event );
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsadvanceddigitizingfloater.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingfloater.sip.in
@@ -1,0 +1,70 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsadvanceddigitizingfloater.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsAdvancedDigitizingFloater : QWidget
+{
+%Docstring
+The QgsAdvancedDigitizingFloater class is widget that floats
+next to the mouse pointer, and allow interaction with the AdvancedDigitizing
+feature. It proxies display and actions to QgsMapToolAdvancedDigitizingDockWidget.
+
+.. note::
+
+   This class is a technology preview and unstable API.
+
+.. versionadded:: 3.8
+%End
+
+%TypeHeaderCode
+#include "qgsadvanceddigitizingfloater.h"
+%End
+  public:
+
+    explicit QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+%Docstring
+Create an advanced digitizing floater widget
+
+:param canvas: The map canvas on which the widget operates
+:param cadDockWidget: The cadDockWidget to which the floater belongs
+
+.. versionadded:: 3.8
+%End
+
+    bool active();
+%Docstring
+Whether the floater is active or not.
+Note that the floater may be active but not visible (e.g. if the mouse is not over the canvas).
+
+.. versionadded:: 3.8
+%End
+
+  public slots:
+
+    void setActive( bool active );
+%Docstring
+Set whether the floater should be active or not.
+Note that the floater may be active but not visible (e.g. if the mouse is not over the canvas).
+
+:param active:
+
+.. versionadded:: 3.8
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsadvanceddigitizingfloater.h                               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -54,6 +54,7 @@
 %Include auto_generated/qgisinterface.sip
 %Include auto_generated/qgsactionmenu.sip
 %Include auto_generated/qgsadvanceddigitizingdockwidget.sip
+%Include auto_generated/qgsadvanceddigitizingfloater.sip
 %Include auto_generated/qgsaggregatetoolbutton.sip
 %Include auto_generated/qgsattributedialog.sip
 %Include auto_generated/qgsattributeform.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -214,6 +214,7 @@ SET(QGIS_GUI_SRCS
   qgsactionmenu.cpp
   qgsadvanceddigitizingcanvasitem.cpp
   qgsadvanceddigitizingdockwidget.cpp
+  qgsadvanceddigitizingfloater.cpp
   qgsaggregatetoolbutton.cpp
   qgsattributedialog.cpp
   qgsattributeform.cpp
@@ -401,6 +402,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgisinterface.h
   qgsactionmenu.h
   qgsadvanceddigitizingdockwidget.h
+  qgsadvanceddigitizingfloater.h
   qgsaggregatetoolbutton.h
   qgsattributedialog.h
   qgsattributeform.h

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -165,57 +165,69 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
 void QgsAdvancedDigitizingDockWidget::setX( const QString &value, WidgetSetMode mode )
 {
   mXLineEdit->setText( value );
-  if( mode == WidgetSetMode::ReturnPressed){
+  if ( mode == WidgetSetMode::ReturnPressed )
+  {
     mXLineEdit->returnPressed();
   }
-  else if ( mode == WidgetSetMode::FocusOut){
-    QEvent *e = new QEvent(QEvent::FocusOut);
-    QCoreApplication::postEvent(mXLineEdit, e);
+  else if ( mode == WidgetSetMode::FocusOut )
+  {
+    QEvent *e = new QEvent( QEvent::FocusOut );
+    QCoreApplication::postEvent( mXLineEdit, e );
   }
-  else if ( mode == WidgetSetMode::TextEdited){
-    mXLineEdit->textEdited(value);
+  else if ( mode == WidgetSetMode::TextEdited )
+  {
+    mXLineEdit->textEdited( value );
   }
 }
 void QgsAdvancedDigitizingDockWidget::setY( const QString &value, WidgetSetMode mode )
 {
   mYLineEdit->setText( value );
-  if( mode == WidgetSetMode::ReturnPressed){
+  if ( mode == WidgetSetMode::ReturnPressed )
+  {
     mYLineEdit->returnPressed();
   }
-  else if ( mode == WidgetSetMode::FocusOut){
-    QEvent *e = new QEvent(QEvent::FocusOut);
-    QCoreApplication::postEvent(mYLineEdit, e);
+  else if ( mode == WidgetSetMode::FocusOut )
+  {
+    QEvent *e = new QEvent( QEvent::FocusOut );
+    QCoreApplication::postEvent( mYLineEdit, e );
   }
-  else if ( mode == WidgetSetMode::TextEdited){
-    mYLineEdit->textEdited(value);
+  else if ( mode == WidgetSetMode::TextEdited )
+  {
+    mYLineEdit->textEdited( value );
   }
 }
 void QgsAdvancedDigitizingDockWidget::setAngle( const QString &value, WidgetSetMode mode )
 {
   mAngleLineEdit->setText( value );
-  if( mode == WidgetSetMode::ReturnPressed){
+  if ( mode == WidgetSetMode::ReturnPressed )
+  {
     mAngleLineEdit->returnPressed();
   }
-  else if ( mode == WidgetSetMode::FocusOut){
-    QEvent *e = new QEvent(QEvent::FocusOut);
-    QCoreApplication::postEvent(mAngleLineEdit, e);
+  else if ( mode == WidgetSetMode::FocusOut )
+  {
+    QEvent *e = new QEvent( QEvent::FocusOut );
+    QCoreApplication::postEvent( mAngleLineEdit, e );
   }
-  else if ( mode == WidgetSetMode::TextEdited){
-    mAngleLineEdit->textEdited(value);
+  else if ( mode == WidgetSetMode::TextEdited )
+  {
+    mAngleLineEdit->textEdited( value );
   }
 }
 void QgsAdvancedDigitizingDockWidget::setDistance( const QString &value, WidgetSetMode mode )
 {
   mDistanceLineEdit->setText( value );
-  if( mode == WidgetSetMode::ReturnPressed){
+  if ( mode == WidgetSetMode::ReturnPressed )
+  {
     mDistanceLineEdit->returnPressed();
   }
-  else if ( mode == WidgetSetMode::FocusOut){
-    QEvent *e = new QEvent(QEvent::FocusOut);
-    QCoreApplication::postEvent(mDistanceLineEdit, e);
+  else if ( mode == WidgetSetMode::FocusOut )
+  {
+    QEvent *e = new QEvent( QEvent::FocusOut );
+    QCoreApplication::postEvent( mDistanceLineEdit, e );
   }
-  else if ( mode == WidgetSetMode::TextEdited){
-    mDistanceLineEdit->textEdited(value);
+  else if ( mode == WidgetSetMode::TextEdited )
+  {
+    mDistanceLineEdit->textEdited( value );
   }
 }
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -14,6 +14,8 @@
  ***************************************************************************/
 
 #include <QMenu>
+#include <QEvent>
+#include <QCoreApplication>
 
 #include <cmath>
 
@@ -160,25 +162,61 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   disable();
 }
 
-void QgsAdvancedDigitizingDockWidget::setX( const QString &value )
+void QgsAdvancedDigitizingDockWidget::setX( const QString &value, WidgetSetMode mode )
 {
   mXLineEdit->setText( value );
-  mXLineEdit->returnPressed();
+  if( mode == WidgetSetMode::ReturnPressed){
+    mXLineEdit->returnPressed();
+  }
+  else if ( mode == WidgetSetMode::FocusOut){
+    QEvent *e = new QEvent(QEvent::FocusOut);
+    QCoreApplication::postEvent(mXLineEdit, e);
+  }
+  else if ( mode == WidgetSetMode::TextEdited){
+    mXLineEdit->textEdited(value);
+  }
 }
-void QgsAdvancedDigitizingDockWidget::setY( const QString &value )
+void QgsAdvancedDigitizingDockWidget::setY( const QString &value, WidgetSetMode mode )
 {
   mYLineEdit->setText( value );
-  mYLineEdit->returnPressed();
+  if( mode == WidgetSetMode::ReturnPressed){
+    mYLineEdit->returnPressed();
+  }
+  else if ( mode == WidgetSetMode::FocusOut){
+    QEvent *e = new QEvent(QEvent::FocusOut);
+    QCoreApplication::postEvent(mYLineEdit, e);
+  }
+  else if ( mode == WidgetSetMode::TextEdited){
+    mYLineEdit->textEdited(value);
+  }
 }
-void QgsAdvancedDigitizingDockWidget::setAngle( const QString &value )
+void QgsAdvancedDigitizingDockWidget::setAngle( const QString &value, WidgetSetMode mode )
 {
   mAngleLineEdit->setText( value );
-  mAngleLineEdit->returnPressed();
+  if( mode == WidgetSetMode::ReturnPressed){
+    mAngleLineEdit->returnPressed();
+  }
+  else if ( mode == WidgetSetMode::FocusOut){
+    QEvent *e = new QEvent(QEvent::FocusOut);
+    QCoreApplication::postEvent(mAngleLineEdit, e);
+  }
+  else if ( mode == WidgetSetMode::TextEdited){
+    mAngleLineEdit->textEdited(value);
+  }
 }
-void QgsAdvancedDigitizingDockWidget::setDistance( const QString &value )
+void QgsAdvancedDigitizingDockWidget::setDistance( const QString &value, WidgetSetMode mode )
 {
   mDistanceLineEdit->setText( value );
-  mDistanceLineEdit->returnPressed();
+  if( mode == WidgetSetMode::ReturnPressed){
+    mDistanceLineEdit->returnPressed();
+  }
+  else if ( mode == WidgetSetMode::FocusOut){
+    QEvent *e = new QEvent(QEvent::FocusOut);
+    QCoreApplication::postEvent(mDistanceLineEdit, e);
+  }
+  else if ( mode == WidgetSetMode::TextEdited){
+    mDistanceLineEdit->textEdited(value);
+  }
 }
 
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -74,6 +74,13 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
       Parallel       //!< Parallel
     };
 
+    /**
+     * Type of interaction to simulate when editing values from external widget
+     */
+    enum WidgetSetMode {
+      ReturnPressed, FocusOut, TextEdited
+    };
+
 
     /**
      * \ingroup gui
@@ -344,36 +351,42 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void updateCadPaintItem();
 
     /**
-    * Set and lock the X \a value.
-    * Can be used to set constraints.
+    * Set the X \a value on the widget.
+    * Can be used to set constraints by external widgets.
+    * \param mode What type of interaction to emulate
     * \note The value is a QString, as it could be an expression.
     * \since QGIS 3.8
     */
-    void setX( const QString &value );
+    void setX( const QString &value, WidgetSetMode mode );
 
     /**
-    * Set and lock the Y \a value.
-    * Can be used to set constraints.
+    * Set the Y \a value on the widget.
+    * Can be used to set constraints by external widgets.
+    * \param mode What type of interaction to emulate
     * \note The value is a QString, as it could be an expression.
     * \since QGIS 3.8
     */
-    void setY( const QString &value );
+    void setY( const QString &value, WidgetSetMode mode );
 
     /**
-    * Set and lock the angle \a value.
-    * Can be used to set constraints.
+    * Set the angle \a value on the widget.
+    * Can be used to set constraints by external widgets.
+    * \param mode What type of interaction to emulate
     * \note The value is a QString, as it could be an expression.
     * \since QGIS 3.8
     */
-    void setAngle( const QString &value );
+    void setAngle( const QString &value, WidgetSetMode mode );
 
     /**
-    * Set and lock the distance \a value.
-    * Can be used to set constraints.
+    * Set the distance \a value on the widget.
+    * Can be used to set constraints by external widgets.
+    * \param mode What type of interaction to emulate
     * \note The value is a QString, as it could be an expression.
     * \since QGIS 3.8
     */
-    void setDistance( const QString &value );
+    void setDistance( const QString &value, WidgetSetMode mode );
+
+
 
   signals:
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -77,7 +77,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
      * Type of interaction to simulate when editing values from external widget
      */
-    enum WidgetSetMode {
+    enum WidgetSetMode
+    {
       ReturnPressed, FocusOut, TextEdited
     };
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "ui_qgsadvanceddigitizingdockwidgetbase.h"
+#include "qgsadvanceddigitizingfloater.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 #include "qgsdockwidget.h"
@@ -30,6 +31,7 @@
 
 
 class QgsAdvancedDigitizingCanvasItem;
+class QgsAdvancedDigitizingFloater;
 class QgsMapCanvas;
 class QgsMapTool;
 class QgsMapToolAdvancedDigitizing;
@@ -200,11 +202,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     explicit QgsAdvancedDigitizingDockWidget( QgsMapCanvas *canvas, QWidget *parent = nullptr );
 
     /**
-     * Disables the CAD tools when hiding the dock
-     */
-    void hideEvent( QHideEvent * ) override;
-
-    /**
      * Filter key events to e.g. toggle construction mode or adapt constraints
      *
      * \param e A mouse event (may be modified)
@@ -346,6 +343,38 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      */
     void updateCadPaintItem();
 
+    /**
+    * Set and lock the X \a value.
+    * Can be used to set constraints.
+    * \note The value is a QString, as it could be an expression.
+    * \since QGIS 3.8
+    */
+    void setX( const QString &value );
+
+    /**
+    * Set and lock the Y \a value.
+    * Can be used to set constraints.
+    * \note The value is a QString, as it could be an expression.
+    * \since QGIS 3.8
+    */
+    void setY( const QString &value );
+
+    /**
+    * Set and lock the angle \a value.
+    * Can be used to set constraints.
+    * \note The value is a QString, as it could be an expression.
+    * \since QGIS 3.8
+    */
+    void setAngle( const QString &value );
+
+    /**
+    * Set and lock the distance \a value.
+    * Can be used to set constraints.
+    * \note The value is a QString, as it could be an expression.
+    * \since QGIS 3.8
+    */
+    void setDistance( const QString &value );
+
   signals:
 
     /**
@@ -367,6 +396,169 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * \param point The last known digitizing point. Can be used to emulate a mouse event.
      */
     void pointChanged( const QgsPointXY &point );
+
+    //! Signals for external widgets that need to update according to current values
+
+    /**
+    * Emitted whenever CAD is enabled or disabled
+    *
+    * \param enabled Whether CAD is enabled or not.
+    * \since QGIS 3.8
+    */
+    void cadEnabledChanged( bool enabled );
+
+    /**
+    * Emitted whenever the X \a value changes (either the mouse moved, or the user changed the input).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void valueXChanged( const QString &value );
+
+    /**
+    * Emitted whenever the Y \a value changes (either the mouse moved, or the user changed the input).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void valueYChanged( const QString &value );
+
+    /**
+    * Emitted whenever the angle \a value changes (either the mouse moved, or the user changed the input).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void valueAngleChanged( const QString &value );
+
+    /**
+    * Emitted whenever the distance \a value changes (either the mouse moved, or the user changed the input).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void valueDistanceChanged( const QString &value );
+
+    /**
+    * Emitted whenever the X parameter is \a locked.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void lockXChanged( bool locked );
+
+    /**
+    * Emitted whenever the Y parameter is \a locked.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void lockYChanged( bool locked );
+
+    /**
+    * Emitted whenever the angle parameter is \a locked.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    */
+    void lockAngleChanged( bool locked );
+
+    /**
+    * Emitted whenever the distance parameter is \a locked.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \since QGIS 3.8
+    */
+    void lockDistanceChanged( bool locked );
+
+    /**
+    * Emitted whenever the X parameter is toggled between absolute and relative.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param relative Whether the X parameter is relative or not.
+    * \since QGIS 3.8
+    */
+    void relativeXChanged( bool relative );
+
+    /**
+    * Emitted whenever the Y parameter is toggled between absolute and relative.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param relative Whether the Y parameter is relative or not.
+    * \since QGIS 3.8
+    */
+    void relativeYChanged( bool relative );
+
+    /**
+    * Emitted whenever the angleX parameter is toggled between absolute and relative.
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param relative Whether the angle parameter is relative or not.
+    * \since QGIS 3.8
+    */
+    void relativeAngleChanged( bool relative );
+
+    // relativeDistanceChanged doesn't exist as distance is always relative
+
+    /**
+    * Emitted whenever the X field is enabled or disabled. Depending on the context, some parameters
+    * do not make sense (e.g. you need a previous point to define a distance).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param enabled Whether the X parameter is enabled or not.
+    * \since QGIS 3.8
+    */
+    void enabledChangedX( bool enabled );
+
+    /**
+    * Emitted whenever the Y field is enabled or disabled. Depending on the context, some parameters
+    * do not make sense (e.g. you need a previous point to define a distance).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param enabled Whether the Y parameter is enabled or not.
+    * \since QGIS 3.8
+    */
+    void enabledChangedY( bool enabled );
+
+    /**
+    * Emitted whenever the angle field is enabled or disabled. Depending on the context, some parameters
+    * do not make sense (e.g. you need a previous point to define a distance).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param enabled Whether the angle parameter is enabled or not.
+    * \since QGIS 3.8
+    */
+    void enabledChangedAngle( bool enabled );
+
+    /**
+    * Emitted whenever the distance field is enabled or disabled. Depending on the context, some parameters
+    * do not make sense (e.g. you need a previous point to define a distance).
+    * Could be used by widgets that must reflect the current advanced digitizing state.
+    *
+    * \param enabled Whether the distance parameter is enabled or not.
+    * \since QGIS 3.8
+    */
+    void enabledChangedDistance( bool enabled );
+
+    /**
+    * Emitted whenever the X field should get the focus using the shortcuts (X).
+    * Could be used by widgets to capture the focus when a field is being edited.
+    * \since QGIS 3.8
+    */
+    void focusOnXRequested();
+
+    /**
+    * Emitted whenever the Y field should get the focus using the shortcuts (Y).
+    * Could be used by widgets to capture the focus when a field is being edited.
+    * \since QGIS 3.8
+    */
+    void focusOnYRequested();
+
+    /**
+    * Emitted whenever the angle field should get the focus using the shortcuts (A).
+    * Could be used by widgets to capture the focus when a field is being edited.
+    * \since QGIS 3.8
+    */
+    void focusOnAngleRequested();
+
+    /**
+    * Emitted whenever the distance field should get the focus using the shortcuts (D).
+    * Could be used by widgets to capture the focus when a field is being edited.
+    * \since QGIS 3.8
+    */
+    void focusOnDistanceRequested();
+
 
   private slots:
     //! Sets the additional constraint by clicking on the perpendicular/parallel buttons
@@ -468,6 +660,9 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     CadCapacities mCapacities = nullptr;
 
     bool mCurrentMapToolSupportsCad = false;
+
+    // Pointer to the floater
+    QgsAdvancedDigitizingFloater *mFloater = nullptr;
 
     // CAD properties
     //! is CAD currently enabled for current map tool

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -76,6 +76,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     /**
      * Type of interaction to simulate when editing values from external widget
+     * \note unstable API (will likely change)
+     * \since QGIS 3.8
      */
     enum WidgetSetMode
     {
@@ -352,37 +354,41 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void updateCadPaintItem();
 
     /**
-    * Set the X \a value on the widget.
+    * Set the X value on the widget.
     * Can be used to set constraints by external widgets.
     * \param mode What type of interaction to emulate
-    * \note The value is a QString, as it could be an expression.
+    * \param value The value (as a QString, as it could be an expression)
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void setX( const QString &value, WidgetSetMode mode );
 
     /**
-    * Set the Y \a value on the widget.
+    * Set the Y value on the widget.
     * Can be used to set constraints by external widgets.
     * \param mode What type of interaction to emulate
-    * \note The value is a QString, as it could be an expression.
+    * \param value The value (as a QString, as it could be an expression)
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void setY( const QString &value, WidgetSetMode mode );
 
     /**
-    * Set the angle \a value on the widget.
+    * Set the angle value on the widget.
     * Can be used to set constraints by external widgets.
     * \param mode What type of interaction to emulate
-    * \note The value is a QString, as it could be an expression.
+    * \param value The value (as a QString, as it could be an expression)
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void setAngle( const QString &value, WidgetSetMode mode );
 
     /**
-    * Set the distance \a value on the widget.
+    * Set the distance value on the widget.
     * Can be used to set constraints by external widgets.
     * \param mode What type of interaction to emulate
-    * \note The value is a QString, as it could be an expression.
+    * \param value The value (as a QString, as it could be an expression)
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void setDistance( const QString &value, WidgetSetMode mode );
@@ -416,7 +422,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever CAD is enabled or disabled
     *
-    * \param enabled Whether CAD is enabled or not.
+    * \param enabled Whether CAD is enabled or not
+    * \note unstable API (will likely change).
     * \since QGIS 3.8
     */
     void cadEnabledChanged( bool enabled );
@@ -424,6 +431,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the X \a value changes (either the mouse moved, or the user changed the input).
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void valueXChanged( const QString &value );
@@ -431,6 +439,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the Y \a value changes (either the mouse moved, or the user changed the input).
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void valueYChanged( const QString &value );
@@ -438,6 +447,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the angle \a value changes (either the mouse moved, or the user changed the input).
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void valueAngleChanged( const QString &value );
@@ -445,6 +455,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the distance \a value changes (either the mouse moved, or the user changed the input).
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void valueDistanceChanged( const QString &value );
@@ -452,6 +463,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the X parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void lockXChanged( bool locked );
@@ -459,6 +471,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the Y parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void lockYChanged( bool locked );
@@ -466,12 +479,15 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the angle parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
+    * \since QGIS 3.8
     */
     void lockAngleChanged( bool locked );
 
     /**
     * Emitted whenever the distance parameter is \a locked.
     * Could be used by widgets that must reflect the current advanced digitizing state.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void lockDistanceChanged( bool locked );
@@ -481,6 +497,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param relative Whether the X parameter is relative or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void relativeXChanged( bool relative );
@@ -490,6 +507,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param relative Whether the Y parameter is relative or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void relativeYChanged( bool relative );
@@ -499,6 +517,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param relative Whether the angle parameter is relative or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void relativeAngleChanged( bool relative );
@@ -511,6 +530,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param enabled Whether the X parameter is enabled or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void enabledChangedX( bool enabled );
@@ -521,6 +541,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param enabled Whether the Y parameter is enabled or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void enabledChangedY( bool enabled );
@@ -531,6 +552,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param enabled Whether the angle parameter is enabled or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void enabledChangedAngle( bool enabled );
@@ -541,6 +563,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     * Could be used by widgets that must reflect the current advanced digitizing state.
     *
     * \param enabled Whether the distance parameter is enabled or not.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void enabledChangedDistance( bool enabled );
@@ -548,6 +571,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the X field should get the focus using the shortcuts (X).
     * Could be used by widgets to capture the focus when a field is being edited.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void focusOnXRequested();
@@ -555,6 +579,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the Y field should get the focus using the shortcuts (Y).
     * Could be used by widgets to capture the focus when a field is being edited.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void focusOnYRequested();
@@ -562,6 +587,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the angle field should get the focus using the shortcuts (A).
     * Could be used by widgets to capture the focus when a field is being edited.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void focusOnAngleRequested();
@@ -569,6 +595,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
     * Emitted whenever the distance field should get the focus using the shortcuts (D).
     * Could be used by widgets to capture the focus when a field is being edited.
+    * \note unstable API (will likely change)
     * \since QGIS 3.8
     */
     void focusOnDistanceRequested();

--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -21,6 +21,7 @@
 #include "qgsmessagelog.h"
 #include "qgsmapcanvas.h"
 #include "qgssettings.h"
+#include "qgsfocuswatcher.h"
 
 QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QWidget( canvas->viewport() ), mMapCanvas( canvas ), mCadDockWidget( cadDockWidget )
@@ -71,11 +72,26 @@ QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas
   connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::enabledChangedAngle, this, &QgsAdvancedDigitizingFloater::enabledChangedAngle );
   connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::enabledChangedDistance, this, &QgsAdvancedDigitizingFloater::enabledChangedDistance );
 
-  // Connect our line edits signals to update cadDockWidget's state
-  connect( mXLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setX( mXLineEdit->text() ); } );
-  connect( mYLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setY( mYLineEdit->text() ); } );
-  connect( mAngleLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setAngle( mAngleLineEdit->text() ); } );
-  connect( mDistanceLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setDistance( mDistanceLineEdit->text() ); } );
+  // Connect our line edits signals to update cadDockWidget's state (implementation copied from QgsAdvancedDigitizingDockWidget)
+  connect( mXLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setX( mXLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::ReturnPressed ); } );
+  connect( mYLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setY( mYLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::ReturnPressed ); } );
+  connect( mAngleLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setAngle( mAngleLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::ReturnPressed ); } );
+  connect( mDistanceLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setDistance( mDistanceLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::ReturnPressed ); } );
+
+  connect( mXLineEdit, &QLineEdit::textEdited, cadDockWidget, [ = ]() { cadDockWidget->setX( mXLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::TextEdited ); } );
+  connect( mYLineEdit, &QLineEdit::textEdited, cadDockWidget, [ = ]() { cadDockWidget->setY( mYLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::TextEdited ); } );
+  connect( mAngleLineEdit, &QLineEdit::textEdited, cadDockWidget, [ = ]() { cadDockWidget->setAngle( mAngleLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::TextEdited ); } );
+  connect( mDistanceLineEdit, &QLineEdit::textEdited, cadDockWidget, [ = ]() { cadDockWidget->setDistance( mDistanceLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::TextEdited ); } );
+
+  QgsFocusWatcher *xWatcher = new QgsFocusWatcher( mXLineEdit );
+  connect( xWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setX( mXLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  QgsFocusWatcher *yWatcher = new QgsFocusWatcher( mYLineEdit );
+  connect( yWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setY( mYLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  QgsFocusWatcher *angleWatcher = new QgsFocusWatcher( mAngleLineEdit );
+  connect( angleWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setAngle( mAngleLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  QgsFocusWatcher *distanceWatcher = new QgsFocusWatcher( mDistanceLineEdit );
+  connect( distanceWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setDistance( mDistanceLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+
 }
 
 bool QgsAdvancedDigitizingFloater::eventFilter( QObject *obj, QEvent *event )

--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -1,0 +1,309 @@
+/***************************************************************************
+  qgsadvanceddigitizingfloater.cpp  -  floater for CAD tools
+  ----------------------
+  begin                : May 2019
+  copyright            : (C) Olivier Dalang
+  email                : olivier.dalang@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QMouseEvent>
+#include <QEnterEvent>
+#include <QLocale>
+
+#include "qgsadvanceddigitizingfloater.h"
+#include "qgsmessagelog.h"
+#include "qgsmapcanvas.h"
+#include "qgssettings.h"
+
+QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
+  : QWidget( canvas->viewport() ), mMapCanvas( canvas ), mCadDockWidget( cadDockWidget )
+{
+  setupUi( this );
+  setWindowFlag( Qt::FramelessWindowHint );
+  setAttribute( Qt::WA_TransparentForMouseEvents );
+
+  setActive( QgsSettings().value( QStringLiteral( "/Cad/Floater" ), false ).toBool() );
+
+  hideIfDisabled();
+
+  // This is required to be able to track mouse move events
+  mMapCanvas->viewport()->installEventFilter( this );
+  mMapCanvas->viewport()->setMouseTracking( true );
+
+  // We reuse cadDockWidget's eventFilter for the CAD specific shortcuts
+  mAngleLineEdit->installEventFilter( cadDockWidget );
+  mDistanceLineEdit->installEventFilter( cadDockWidget );
+  mXLineEdit->installEventFilter( cadDockWidget );
+  mYLineEdit->installEventFilter( cadDockWidget );
+
+  // Connect all cadDockWidget's signals to update the widget's display
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::cadEnabledChanged, this, &QgsAdvancedDigitizingFloater::hideIfDisabled );
+
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::valueXChanged, this, &QgsAdvancedDigitizingFloater::changeX );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::valueYChanged, this, &QgsAdvancedDigitizingFloater::changeY );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::valueAngleChanged, this, &QgsAdvancedDigitizingFloater::changeAngle );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::valueDistanceChanged, this, &QgsAdvancedDigitizingFloater::changeDistance );
+
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::lockXChanged, this, &QgsAdvancedDigitizingFloater::changeLockX );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::lockYChanged, this, &QgsAdvancedDigitizingFloater::changeLockY );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::lockAngleChanged, this, &QgsAdvancedDigitizingFloater::changeLockAngle );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::lockDistanceChanged, this, &QgsAdvancedDigitizingFloater::changeLockDistance );
+
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::relativeXChanged, this, &QgsAdvancedDigitizingFloater::changeRelativeX );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::relativeYChanged, this, &QgsAdvancedDigitizingFloater::changeRelativeY );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::relativeAngleChanged, this, &QgsAdvancedDigitizingFloater::changeRelativeAngle );
+  // distance is always relative
+
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::focusOnXRequested, this, &QgsAdvancedDigitizingFloater::focusOnX );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::focusOnYRequested, this, &QgsAdvancedDigitizingFloater::focusOnY );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::focusOnAngleRequested, this, &QgsAdvancedDigitizingFloater::focusOnAngle );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::focusOnDistanceRequested, this, &QgsAdvancedDigitizingFloater::focusOnDistance );
+
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::enabledChangedX, this, &QgsAdvancedDigitizingFloater::enabledChangedX );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::enabledChangedY, this, &QgsAdvancedDigitizingFloater::enabledChangedY );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::enabledChangedAngle, this, &QgsAdvancedDigitizingFloater::enabledChangedAngle );
+  connect( cadDockWidget, &QgsAdvancedDigitizingDockWidget::enabledChangedDistance, this, &QgsAdvancedDigitizingFloater::enabledChangedDistance );
+
+  // Connect our line edits signals to update cadDockWidget's state
+  connect( mXLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setX( mXLineEdit->text() ); } );
+  connect( mYLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setY( mYLineEdit->text() ); } );
+  connect( mAngleLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setAngle( mAngleLineEdit->text() ); } );
+  connect( mDistanceLineEdit, &QLineEdit::returnPressed, cadDockWidget, [ = ]() { cadDockWidget->setDistance( mDistanceLineEdit->text() ); } );
+}
+
+bool QgsAdvancedDigitizingFloater::eventFilter( QObject *obj, QEvent *event )
+{
+  if ( mCadDockWidget->cadEnabled() && mActive )
+  {
+    if ( event->type() == QEvent::MouseMove )
+    {
+      // We update the position when mouse moves
+      QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>( event );
+      updatePos( mouseEvent->pos() );
+    }
+    else if ( event->type() == QEvent::Enter )
+    {
+      // We show the widget when mouse enters
+      QEnterEvent  *enterEvent = dynamic_cast<QEnterEvent *>( event );
+      updatePos( enterEvent->pos() );
+      setVisible( true );
+    }
+    else if ( event->type() == QEvent::Leave )
+    {
+      // We hide the widget when mouse leaves
+      setVisible( false );
+    }
+  }
+  return QWidget::eventFilter( obj, event );
+}
+
+bool QgsAdvancedDigitizingFloater::active()
+{
+  return mActive;
+}
+
+void QgsAdvancedDigitizingFloater::setActive( bool active )
+{
+  QgsSettings().setValue( QStringLiteral( "/Cad/Floater" ), active );
+
+  mActive = active;
+
+  hideIfDisabled();
+}
+
+void QgsAdvancedDigitizingFloater::updatePos( const QPoint &pos )
+{
+  // We hardcode a small delta between the mouse position and the widget's position
+  move( pos + QPoint( 15, 5 ) );
+}
+
+void QgsAdvancedDigitizingFloater::hideIfDisabled()
+{
+  if ( ! mCadDockWidget->cadEnabled() || ! mActive )
+  {
+    setVisible( false );
+  }
+}
+
+void QgsAdvancedDigitizingFloater::changeX( const QString &text )
+{
+  mXLineEdit->setText( text );
+}
+
+void QgsAdvancedDigitizingFloater::changeY( const QString &text )
+{
+  mYLineEdit->setText( text );
+}
+
+void QgsAdvancedDigitizingFloater::changeDistance( const QString &text )
+{
+  mDistanceLineEdit->setText( text );
+}
+
+void QgsAdvancedDigitizingFloater::changeAngle( const QString &text )
+{
+  mAngleLineEdit->setText( text );
+}
+
+void QgsAdvancedDigitizingFloater::changeLockX( bool locked )
+{
+  if ( !locked )
+  {
+    mXLineEdit->setStyleSheet( QString() );
+    mXLabel->setStyleSheet( QString() );
+  }
+  else
+  {
+    mXLineEdit->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+    mXLabel->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+  }
+}
+
+void QgsAdvancedDigitizingFloater::changeLockY( bool locked )
+{
+  if ( !locked )
+  {
+    mYLineEdit->setStyleSheet( QString() );
+    mYLabel->setStyleSheet( QString() );
+  }
+  else
+  {
+    mYLineEdit->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+    mYLabel->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+  }
+}
+
+void QgsAdvancedDigitizingFloater::changeLockDistance( bool locked )
+{
+  if ( !locked )
+  {
+    mDistanceLineEdit->setStyleSheet( QString() );
+    mDistanceLabel->setStyleSheet( QString() );
+  }
+  else
+  {
+    mDistanceLineEdit->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+    mDistanceLabel->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+  }
+}
+
+void QgsAdvancedDigitizingFloater::changeLockAngle( bool locked )
+{
+  if ( !locked )
+  {
+    mAngleLineEdit->setStyleSheet( QString() );
+    mAngleLabel->setStyleSheet( QString() );
+  }
+  else
+  {
+    mAngleLineEdit->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+    mAngleLabel->setStyleSheet( QStringLiteral( "font-weight: bold" ) );
+  }
+}
+
+
+void QgsAdvancedDigitizingFloater::changeRelativeX( bool relative )
+{
+  if ( !relative )
+  {
+    mXLabel->setText( "x" );
+  }
+  else
+  {
+    mXLabel->setText( "Δx" );
+  }
+}
+
+void QgsAdvancedDigitizingFloater::changeRelativeY( bool relative )
+{
+  if ( !relative )
+  {
+    mYLabel->setText( "y" );
+  }
+  else
+  {
+    mYLabel->setText( "Δy" );
+  }
+}
+
+// distance is always relative
+
+void QgsAdvancedDigitizingFloater::changeRelativeAngle( bool relative )
+{
+  if ( !relative )
+  {
+    mAngleLabel->setText( "a" );
+  }
+  else
+  {
+    mAngleLabel->setText( "Δa" );
+  }
+}
+
+void QgsAdvancedDigitizingFloater::focusOnX()
+{
+  if ( mActive )
+  {
+    mXLineEdit->setFocus();
+    mXLineEdit->selectAll();
+  }
+}
+
+void QgsAdvancedDigitizingFloater::focusOnY()
+{
+  if ( mActive )
+  {
+    mYLineEdit->setFocus();
+    mYLineEdit->selectAll();
+  }
+}
+
+void QgsAdvancedDigitizingFloater::focusOnDistance()
+{
+  if ( mActive )
+  {
+    mDistanceLineEdit->setFocus();
+    mDistanceLineEdit->selectAll();
+  }
+}
+
+void QgsAdvancedDigitizingFloater::focusOnAngle()
+{
+  if ( mActive )
+  {
+    mAngleLineEdit->setFocus();
+    mAngleLineEdit->selectAll();
+  }
+}
+
+
+void QgsAdvancedDigitizingFloater::enabledChangedX( bool enabled )
+{
+  mXLineEdit->setVisible( enabled );
+  mXLabel->setVisible( enabled );
+}
+
+void QgsAdvancedDigitizingFloater::enabledChangedY( bool enabled )
+{
+  mYLineEdit->setVisible( enabled );
+  mYLabel->setVisible( enabled );
+}
+
+void QgsAdvancedDigitizingFloater::enabledChangedDistance( bool enabled )
+{
+  mDistanceLineEdit->setVisible( enabled );
+  mDistanceLabel->setVisible( enabled );
+}
+
+void QgsAdvancedDigitizingFloater::enabledChangedAngle( bool enabled )
+{
+  mAngleLineEdit->setVisible( enabled );
+  mAngleLabel->setVisible( enabled );
+}

--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -85,13 +85,13 @@ QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas
   connect( mDistanceLineEdit, &QLineEdit::textEdited, cadDockWidget, [ = ]() { cadDockWidget->setDistance( mDistanceLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::TextEdited ); } );
 
   QgsFocusWatcher *xWatcher = new QgsFocusWatcher( mXLineEdit );
-  connect( xWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setX( mXLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  connect( xWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [ = ]() { cadDockWidget->setX( mXLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
   QgsFocusWatcher *yWatcher = new QgsFocusWatcher( mYLineEdit );
-  connect( yWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setY( mYLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  connect( yWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [ = ]() { cadDockWidget->setY( mYLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
   QgsFocusWatcher *angleWatcher = new QgsFocusWatcher( mAngleLineEdit );
-  connect( angleWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setAngle( mAngleLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  connect( angleWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [ = ]() { cadDockWidget->setAngle( mAngleLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
   QgsFocusWatcher *distanceWatcher = new QgsFocusWatcher( mDistanceLineEdit );
-  connect( distanceWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [=](){ cadDockWidget->setDistance( mDistanceLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
+  connect( distanceWatcher, &QgsFocusWatcher::focusOut, cadDockWidget, [ = ]() { cadDockWidget->setDistance( mDistanceLineEdit->text(), QgsAdvancedDigitizingDockWidget::WidgetSetMode::FocusOut ); } );
 
 }
 

--- a/src/gui/qgsadvanceddigitizingfloater.cpp
+++ b/src/gui/qgsadvanceddigitizingfloater.cpp
@@ -27,8 +27,9 @@ QgsAdvancedDigitizingFloater::QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas
   : QWidget( canvas->viewport() ), mMapCanvas( canvas ), mCadDockWidget( cadDockWidget )
 {
   setupUi( this );
-  setWindowFlag( Qt::FramelessWindowHint );
+
   setAttribute( Qt::WA_TransparentForMouseEvents );
+  adjustSize();
 
   setActive( QgsSettings().value( QStringLiteral( "/Cad/Floater" ), false ).toBool() );
 
@@ -235,6 +236,7 @@ void QgsAdvancedDigitizingFloater::changeRelativeX( bool relative )
   {
     mXLabel->setText( "Δx" );
   }
+  adjustSize();
 }
 
 void QgsAdvancedDigitizingFloater::changeRelativeY( bool relative )
@@ -247,6 +249,7 @@ void QgsAdvancedDigitizingFloater::changeRelativeY( bool relative )
   {
     mYLabel->setText( "Δy" );
   }
+  adjustSize();
 }
 
 // distance is always relative
@@ -261,6 +264,7 @@ void QgsAdvancedDigitizingFloater::changeRelativeAngle( bool relative )
   {
     mAngleLabel->setText( "Δa" );
   }
+  adjustSize();
 }
 
 void QgsAdvancedDigitizingFloater::focusOnX()
@@ -304,22 +308,26 @@ void QgsAdvancedDigitizingFloater::enabledChangedX( bool enabled )
 {
   mXLineEdit->setVisible( enabled );
   mXLabel->setVisible( enabled );
+  adjustSize();
 }
 
 void QgsAdvancedDigitizingFloater::enabledChangedY( bool enabled )
 {
   mYLineEdit->setVisible( enabled );
   mYLabel->setVisible( enabled );
+  adjustSize();
 }
 
 void QgsAdvancedDigitizingFloater::enabledChangedDistance( bool enabled )
 {
   mDistanceLineEdit->setVisible( enabled );
   mDistanceLabel->setVisible( enabled );
+  adjustSize();
 }
 
 void QgsAdvancedDigitizingFloater::enabledChangedAngle( bool enabled )
 {
   mAngleLineEdit->setVisible( enabled );
   mAngleLabel->setVisible( enabled );
+  adjustSize();
 }

--- a/src/gui/qgsadvanceddigitizingfloater.h
+++ b/src/gui/qgsadvanceddigitizingfloater.h
@@ -118,6 +118,11 @@ class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsA
     //! Whether the floater is enabled.
     bool mActive = false;
 
+  private:
+#ifdef SIP_RUN
+    //! event filter to track mouse position
+    bool eventFilter( QObject *obj, QEvent *event );
+#endif
 };
 
 #endif // QGSADVANCEDDIGITIZINGFLOATER_H

--- a/src/gui/qgsadvanceddigitizingfloater.h
+++ b/src/gui/qgsadvanceddigitizingfloater.h
@@ -32,6 +32,7 @@ class QgsAdvancedDigitizingDockWidget;
 * \brief The QgsAdvancedDigitizingFloater class is widget that floats
 * next to the mouse pointer, and allow interaction with the AdvancedDigitizing
 * feature. It proxies display and actions to QgsMapToolAdvancedDigitizingDockWidget.
+* \since QGIS 3.8
 */
 class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsAdvancedDigitizingFloaterBase
 {
@@ -53,9 +54,9 @@ class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsA
     /**
     * Set whether the floater should be active or not.
     * Note that the floater may be active but not visible (e.g. if the mouse is not over the canvas).
-    * \since QGIS 3.8
     *
     * \param active
+    * \since QGIS 3.8
     */
     void setActive( bool active );
 
@@ -97,7 +98,7 @@ class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsA
     bool eventFilter( QObject *obj, QEvent *event ) override SIP_SKIP;
 
     /**
-    * Move the widget to a new cursor position. A hard-coded offet will be added.
+    * Move the widget to a new cursor position. A hard-coded offset will be added.
     * \param pos position of the cursor
     */
     void updatePos( const QPoint &pos );

--- a/src/gui/qgsadvanceddigitizingfloater.h
+++ b/src/gui/qgsadvanceddigitizingfloater.h
@@ -32,6 +32,7 @@ class QgsAdvancedDigitizingDockWidget;
 * \brief The QgsAdvancedDigitizingFloater class is widget that floats
 * next to the mouse pointer, and allow interaction with the AdvancedDigitizing
 * feature. It proxies display and actions to QgsMapToolAdvancedDigitizingDockWidget.
+* \note This class is a technology preview and unstable API.
 * \since QGIS 3.8
 */
 class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsAdvancedDigitizingFloaterBase

--- a/src/gui/qgsadvanceddigitizingfloater.h
+++ b/src/gui/qgsadvanceddigitizingfloater.h
@@ -1,0 +1,115 @@
+/***************************************************************************
+    qgsadvanceddigitizingfloater.cpp  -  floater for CAD tools
+    ----------------------
+    begin                : May 2019
+    copyright            : (C) Olivier Dalang
+    email                : olivier.dalang@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSADVANCEDDIGITIZINGFLOATER
+#define QGSADVANCEDDIGITIZINGFLOATER
+
+#include <QWidget>
+#include <QString>
+
+#include "ui_qgsadvanceddigitizingfloaterbase.h"
+#include "qgsadvanceddigitizingdockwidget.h"
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+
+class QgsMapCanvas;
+class QgsAdvancedDigitizingDockWidget;
+
+/**
+* \ingroup gui
+* \brief The QgsAdvancedDigitizingFloater class is widget that floats
+* next to the mouse pointer, and allow interaction with the AdvancedDigitizing
+* feature. It proxies display and actions to QgsMapToolAdvancedDigitizingDockWidget.
+*/
+class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsAdvancedDigitizingFloaterBase
+{
+    Q_OBJECT
+
+  public:
+
+    explicit QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
+
+    /**
+    * Whether the floater is active or not.
+    * Note that the floater may be active but not visible (e.g. if the mouse is not over the canvas).
+    * \since QGIS 3.8
+    */
+    bool active();
+
+  public slots:
+
+    /**
+    * Set whether the floater should be active or not.
+    * Note that the floater may be active but not visible (e.g. if the mouse is not over the canvas).
+    * \since QGIS 3.8
+    *
+    * \param active
+    */
+    void setActive( bool active );
+
+  private slots:
+
+    void changeX( const QString &text );
+    void changeY( const QString &text );
+    void changeDistance( const QString &text );
+    void changeAngle( const QString &text );
+    void changeLockX( bool locked );
+    void changeLockY( bool locked );
+    void changeLockDistance( bool locked );
+    void changeLockAngle( bool locked );
+    void changeRelativeX( bool relative );
+    void changeRelativeY( bool relative );
+    // void changeRelativeDistance( bool relative );  // doesn't happen
+    void changeRelativeAngle( bool relative );
+    void focusOnX();
+    void focusOnY();
+    void focusOnAngle();
+    void focusOnDistance();
+    void enabledChangedX( bool enabled );
+    void enabledChangedY( bool enabled );
+    void enabledChangedAngle( bool enabled );
+    void enabledChangedDistance( bool enabled );
+
+  private:
+
+    //! pointer to map canvas
+    QgsMapCanvas *mMapCanvas = nullptr;
+
+    //! pointer to map cad docker widget
+    QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
+
+    /**
+    * event filter to track mouse position
+    * \note defined as private in Python bindings
+    */
+    bool eventFilter( QObject *obj, QEvent *event ) override SIP_SKIP;
+
+    /**
+    * Move the widget to a new cursor position. A hard-coded offet will be added.
+    * \param pos position of the cursor
+    */
+    void updatePos( const QPoint &pos );
+
+    /**
+    * Hides the widget if either the floater or the cadDockWidget is disabled.
+    */
+    void hideIfDisabled();
+
+    //! Whether the floater is enabled.
+    bool mActive = false;
+
+};
+
+#endif // QGSADVANCEDDIGITIZINGFLOATER_H

--- a/src/gui/qgsadvanceddigitizingfloater.h
+++ b/src/gui/qgsadvanceddigitizingfloater.h
@@ -41,6 +41,12 @@ class GUI_EXPORT QgsAdvancedDigitizingFloater : public QWidget, private Ui::QgsA
 
   public:
 
+    /**
+     * Create an advanced digitizing floater widget
+     * \param canvas The map canvas on which the widget operates
+     * \param cadDockWidget The cadDockWidget to which the floater belongs
+     * \since QGIS 3.8
+     */
     explicit QgsAdvancedDigitizingFloater( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 
     /**

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -54,6 +54,8 @@
       <addaction name="mPerpendicularAction"/>
       <addaction name="separator"/>
       <addaction name="mSettingsAction"/>
+      <addaction name="separator"/>
+      <addaction name="mToggleFloaterAction"/>
      </widget>
     </item>
     <item>
@@ -466,6 +468,18 @@
     </property>
    </action>
   </widget>
+  <action name="mToggleFloaterAction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/cadtools/floater.svg</normaloff>:/images/themes/default/cadtools/floater.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Toggle Floater</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsAdvancedDigitizingFloaterBase</class>
+ <widget class="QWidget" name="QgsAdvancedDigitizingFloaterBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>150</width>
+    <height>120</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>6</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>0</number>
+   </property>
+   <item row="3" column="1">
+    <widget class="QLabel" name="mAngleLabel">
+     <property name="text">
+      <string>Δa</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QLineEdit" name="mDistanceLineEdit">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="frame">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QLineEdit" name="mAngleLineEdit">
+     <property name="minimumSize">
+      <size>
+       <width>40</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="frame">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="3">
+    <widget class="QLineEdit" name="mXLineEdit">
+     <property name="minimumSize">
+      <size>
+       <width>40</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="frame">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="mXLabel">
+     <property name="text">
+      <string>x</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLabel" name="mYLabel">
+     <property name="text">
+      <string>y</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QLineEdit" name="mYLineEdit">
+     <property name="minimumSize">
+      <size>
+       <width>40</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="frame">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="mDistanceLabel">
+     <property name="text">
+      <string>d</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/ui/qgsadvanceddigitizingfloaterbase.ui
+++ b/src/ui/qgsadvanceddigitizingfloaterbase.ui
@@ -6,13 +6,56 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>150</width>
-    <height>120</height>
+    <width>279</width>
+    <height>142</height>
    </rect>
+  </property>
+  <property name="palette">
+   <palette>
+    <active>
+     <colorrole role="Base">
+      <brush brushstyle="SolidPattern">
+       <color alpha="127">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </active>
+    <inactive>
+     <colorrole role="Base">
+      <brush brushstyle="SolidPattern">
+       <color alpha="127">
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </inactive>
+    <disabled>
+     <colorrole role="Base">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>240</red>
+        <green>240</green>
+        <blue>240</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </disabled>
+   </palette>
+  </property>
+  <property name="autoFillBackground">
+   <bool>true</bool>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QLineEdit{background-color: rgba(255,255,255,127)}</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
-    <number>0</number>
+    <number>2</number>
    </property>
    <property name="topMargin">
     <number>0</number>
@@ -24,31 +67,38 @@
     <number>0</number>
    </property>
    <property name="horizontalSpacing">
-    <number>6</number>
+    <number>2</number>
    </property>
    <property name="verticalSpacing">
     <number>0</number>
    </property>
-   <item row="3" column="1">
-    <widget class="QLabel" name="mAngleLabel">
+   <item row="2" column="1">
+    <widget class="QLabel" name="mDistanceLabel">
      <property name="text">
-      <string>Δa</string>
+      <string>d</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
-   <item row="2" column="3">
-    <widget class="QLineEdit" name="mDistanceLineEdit">
-     <property name="toolTip">
-      <string/>
-     </property>
+   <item row="3" column="1">
+    <widget class="QLabel" name="mAngleLabel">
      <property name="text">
-      <string>-</string>
-     </property>
-     <property name="frame">
-      <bool>false</bool>
+      <string>a</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="mXLabel">
+     <property name="text">
+      <string>x</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -71,6 +121,22 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="3">
+    <widget class="QLineEdit" name="mDistanceLineEdit">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="frame">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="3">
     <widget class="QLineEdit" name="mXLineEdit">
      <property name="minimumSize">
@@ -90,17 +156,13 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QLabel" name="mXLabel">
-     <property name="text">
-      <string>x</string>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="1">
     <widget class="QLabel" name="mYLabel">
      <property name="text">
       <string>y</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -122,26 +184,6 @@
       <bool>false</bool>
      </property>
     </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="mDistanceLabel">
-     <property name="text">
-      <string>d</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="3">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Description

This PR adds a toggleable widget that shows the advanced input coordinates next to the cursor, which is more comfortable than the dock widget which may be far away (esp. on big screens).

On small screens, it is also nice since it is now possible to use advanced input even with the Advanced Digitizing dock widget hidden.

**Sponsored by Kanton Schaffhausen in collaboration with OPENGIS.ch**

![floater](https://user-images.githubusercontent.com/1894106/57621065-caced500-758a-11e9-90c5-dcfbd98ffb37.gif)


## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] (N/A) Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] (N/A) New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
