### PR TITLE
Allow adding attachments in qgz files

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -976,6 +976,34 @@ Returns the current auxiliary storage.
 .. versionadded:: 3.0
 %End
 
+    QString attachedFile( const QString &fileName ) const;
+%Docstring
+Returns the path to an attached file known by ``fileName``.
+
+.. note::
+
+   Attached files are only supported by QGZ file based projects
+
+.. seealso:: :py:func:`collectAttachedFiles`
+
+.. versionadded:: 3.8
+%End
+
+    QgsStringMap attachedFiles() const;
+%Docstring
+Returns a map of all attached files with relative paths and real paths.
+
+.. note::
+
+   Attached files are only supported by QGZ file based projects
+
+.. seealso:: :py:func:`collectAttachedFiles`
+
+.. seealso:: :py:func:`attachedFile`
+
+.. versionadded:: 3.8
+%End
+
     const QgsProjectMetadata &metadata() const;
 %Docstring
 Returns a reference to the project's metadata store.
@@ -1390,6 +1418,31 @@ Emitted when the project dirty status changes.
 :param dirty: ``True`` if the project is in a dirty state and has pending unsaved changes.
 
 .. versionadded:: 3.2
+%End
+
+    void collectAttachedFiles( QgsStringMap &files /In,Out/ );
+%Docstring
+Emitted whenever the project is saved to a qgz file.
+This can be used to package additional files into the qgz file by modifying the ``files`` map.
+
+Map keys represent relative paths inside the qgz file, map values represent the path to
+the source file.
+
+In python, append additional files to the map and return the modified map.
+
+.. code-block:: python
+
+       QgsProject.instance().collectAttachedFiles.connect(lambda files: files + ['/absolute/path/to/my/attachment.txt'])
+
+.. note::
+
+   Only will be emitted with QGZ project files
+
+.. seealso:: :py:func:`attachedFiles`
+
+.. seealso:: :py:func:`attachedFile`
+
+.. versionadded:: 3.8
 %End
 
   public slots:

--- a/python/core/auto_generated/qgsziputils.sip.in
+++ b/python/core/auto_generated/qgsziputils.sip.in
@@ -39,7 +39,7 @@ Unzip a zip file in an output directory.
 .. versionadded:: 3.0
 %End
 
-  bool zip( const QString &zip, const QStringList &files );
+  bool zip( const QString &zip, const QStringList &files, const QString &root = QString() );
 %Docstring
 Zip the list of files in the zip file. If the zip file already exists or is
 empty, an error is returned. If an input file does not exist, an error is
@@ -47,6 +47,7 @@ also returned.
 
 :param zip: The zip filename
 :param files: The absolute path to files to embed within the zip
+:param root: The root path in which the files are located. This is used to determine the relative path inside the zip file.
 
 .. versionadded:: 3.0
 %End

--- a/src/core/qgsarchive.cpp
+++ b/src/core/qgsarchive.cpp
@@ -61,7 +61,7 @@ bool QgsArchive::zip( const QString &filename )
   QFile tmpFile( tempPath + QDir::separator() + uuid );
 
   // zip content
-  if ( ! QgsZipUtils::zip( tmpFile.fileName(), mFiles ) )
+  if ( ! QgsZipUtils::zip( tmpFile.fileName(), mFiles, dir() ) )
   {
     QString err = QObject::tr( "Unable to zip content" );
     QgsMessageLog::logMessage( err, QStringLiteral( "QgsArchive" ) );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2763,9 +2763,25 @@ bool QgsProject::zip( const QString &filename )
     return false;
   }
 
+  QgsStringMap attachedFiles;
+  emit collectAttachedFiles( attachedFiles );
+
   // create the archive
   archive->addFile( qgsFile.fileName() );
   archive->addFile( asFileName );
+
+  // add additional collected attachment files
+  auto attachedFilesIterator = attachedFiles.constBegin();
+  while ( attachedFilesIterator != attachedFiles.constEnd() )
+  {
+    QString filepath = info.path() + QDir::separator() + attachedFilesIterator.key();
+    QDir().mkpath( QFileInfo( filepath ).dir().path() );
+    if ( QFile::copy( attachedFilesIterator.value(), filepath ) )
+      archive->addFile( filepath );
+    else
+      QgsMessageLog::logMessage( QStringLiteral( "Could not copy file '%1' to '%2'" ).arg( attachedFilesIterator.value(), filepath ) );
+    ++attachedFilesIterator;
+  }
 
   // zip
   if ( !archive->zip( filename ) )
@@ -2954,6 +2970,21 @@ const QgsAuxiliaryStorage *QgsProject::auxiliaryStorage() const
 QgsAuxiliaryStorage *QgsProject::auxiliaryStorage()
 {
   return mAuxiliaryStorage.get();
+}
+
+QString QgsProject::attachedFile( const QString &fileName ) const
+{
+  return mArchive->dir() + QDir::separator() + fileName;
+}
+
+QgsStringMap QgsProject::attachedFiles() const
+{
+  QgsStringMap files;
+  QString dir = mArchive->dir();
+  const QStringList tempFiles = mArchive->files();
+  for ( const QString &tempFile : tempFiles )
+    files.insert( tempFile, dir + QDir::separator() + tempFile );
+  return files;
 }
 
 const QgsProjectMetadata &QgsProject::metadata() const

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -980,7 +980,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * \note Attached files are only supported by QGZ file based projects
      * \see collectAttachedFiles()
-     * \see attachedFile( fileName )
+     * \see attachedFile()
      * \since QGIS 3.8
      */
     QgsStringMap attachedFiles() const;
@@ -1363,7 +1363,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * \note Only will be emitted with QGZ project files
      * \see attachedFiles()
-     * \see attachedFile( fileName )
+     * \see attachedFile()
      * \since QGIS 3.8
      */
     void collectAttachedFiles( QgsStringMap &files SIP_INOUT );

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -967,6 +967,25 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QgsAuxiliaryStorage *auxiliaryStorage();
 
     /**
+     * Returns the path to an attached file known by \a fileName.
+     *
+     * \note Attached files are only supported by QGZ file based projects
+     * \see collectAttachedFiles()
+     * \since QGIS 3.8
+     */
+    QString attachedFile( const QString &fileName ) const;
+
+    /**
+     * Returns a map of all attached files with relative paths and real paths.
+     *
+     * \note Attached files are only supported by QGZ file based projects
+     * \see collectAttachedFiles()
+     * \see attachedFile( fileName )
+     * \since QGIS 3.8
+     */
+    QgsStringMap attachedFiles() const;
+
+    /**
      * Returns a reference to the project's metadata store.
      * \see setMetadata()
      * \see metadataChanged()
@@ -1328,6 +1347,26 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \since QGIS 3.2
      */
     void isDirtyChanged( bool dirty );
+
+    /**
+     * Emitted whenever the project is saved to a qgz file.
+     * This can be used to package additional files into the qgz file by modifying the \a files map.
+     *
+     * Map keys represent relative paths inside the qgz file, map values represent the path to
+     * the source file.
+     *
+     * In python, append additional files to the map and return the modified map.
+     *
+     * \code{.py}
+     *   QgsProject.instance().collectAttachedFiles.connect(lambda files: files + ['/absolute/path/to/my/attachment.txt'])
+     * \endcode
+     *
+     * \note Only will be emitted with QGZ project files
+     * \see attachedFiles()
+     * \see attachedFile( fileName )
+     * \since QGIS 3.8
+     */
+    void collectAttachedFiles( QgsStringMap &files SIP_INOUT );
 
   public slots:
 

--- a/src/core/qgsziputils.h
+++ b/src/core/qgsziputils.h
@@ -54,9 +54,10 @@ namespace QgsZipUtils
    *  also returned.
    * \param zip The zip filename
    * \param files The absolute path to files to embed within the zip
+   * \param root The root path in which the files are located. This is used to determine the relative path inside the zip file.
    * \since QGIS 3.0
    */
-  CORE_EXPORT bool zip( const QString &zip, const QStringList &files );
+  CORE_EXPORT bool zip( const QString &zip, const QStringList &files, const QString &root = QString() );
 };
 
 #endif //QGSZIPUTILS_H


### PR DESCRIPTION
Allows packaging any kind of files into a qgz file.

There is a new signal `QgsProject::collectAttachedFiles` which allows plugins or core code to attach files.

There are the methods `QgsProject::attachedFile( filename )` and `QgsProject::attachedFiles()` to get access to those files.

Main open question: should attached files be forced into a subdirectory `/resources` or `/attachments` inside the zip to avoid name collisions.