### PR TITLE
[Processing] Define boolean output

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingoutputs.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingoutputs.sip.in
@@ -41,6 +41,8 @@ as generated layers or calculated values.
       sipType = sipType_QgsProcessingOutputNumber;
     else if ( sipCpp->type() == QgsProcessingOutputString::typeName() )
       sipType = sipType_QgsProcessingOutputString;
+    else if ( sipCpp->type() == QgsProcessingOutputBoolean::typeName() )
+      sipType = sipType_QgsProcessingOutputBoolean;
     else if ( sipCpp->type() == QgsProcessingOutputFolder::typeName() )
       sipType = sipType_QgsProcessingOutputFolder;
     else if ( sipCpp->type() == QgsProcessingOutputFile::typeName() )
@@ -311,6 +313,31 @@ Returns the type name for the output class.
 %End
     virtual QString type() const;
 
+};
+
+class QgsProcessingOutputBoolean : QgsProcessingOutputDefinition
+{
+%Docstring
+A boolean output for processing algorithms.
+
+.. versionadded:: 3.8
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingoutputs.h"
+%End
+  public:
+
+    QgsProcessingOutputBoolean( const QString &name, const QString &description = QString() );
+%Docstring
+Constructor for :py:class:`QgsProcessingOutputNumber`.
+%End
+
+    static QString typeName();
+%Docstring
+Returns the type name for the output class.
+%End
+    virtual QString type() const;
 };
 
 class QgsProcessingOutputFolder : QgsProcessingOutputDefinition

--- a/python/plugins/processing/core/outputs.py
+++ b/python/plugins/processing/core/outputs.py
@@ -42,6 +42,7 @@ from qgis.core import (QgsExpressionContext,
                        QgsProcessingOutputHtml,
                        QgsProcessingOutputNumber,
                        QgsProcessingOutputString,
+                       QgsProcessingOutputBoolean,
                        QgsProcessingOutputFolder,
                        QgsProcessingOutputMultipleLayers)
 
@@ -93,6 +94,8 @@ def getOutputFromString(s):
                 out = QgsProcessingOutputNumber(name, description)
             elif token.lower().strip().startswith('outputstring'):
                 out = QgsProcessingOutputString(name, description)
+            elif token.lower().strip().startswith('outputboolean'):
+                out = QgsProcessingOutputBoolean(name, description)
 #            elif token.lower().strip().startswith('extent'):
 #                out = OutputExtent()
 

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -164,7 +164,7 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         createTable = False
 
         for out in self.algorithm().outputDefinitions():
-            if isinstance(out, (QgsProcessingOutputNumber, QgsProcessingOutputString)):
+            if isinstance(out, (QgsProcessingOutputNumber, QgsProcessingOutputString, QgsProcessingOutputBoolean)):
                 createTable = True
                 break
 

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -655,7 +655,8 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
       << QgsProcessingParameterString::typeName()
       << QgsProcessingParameterAuthConfig::typeName(),
       QStringList() << QgsProcessingOutputNumber::typeName()
-      << QgsProcessingOutputString::typeName() );
+      << QgsProcessingOutputString::typeName()
+      << QgsProcessingOutputBoolean::typeName() );
 
   for ( const QgsProcessingModelChildParameterSource &source : qgis::as_const( sources ) )
   {

--- a/src/core/processing/qgsprocessingoutputs.cpp
+++ b/src/core/processing/qgsprocessingoutputs.cpp
@@ -55,6 +55,10 @@ QgsProcessingOutputString::QgsProcessingOutputString( const QString &name, const
   : QgsProcessingOutputDefinition( name, description )
 {}
 
+QgsProcessingOutputBoolean::QgsProcessingOutputBoolean( const QString &name, const QString &description )
+  : QgsProcessingOutputDefinition( name, description )
+{}
+
 QgsProcessingOutputFolder::QgsProcessingOutputFolder( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )
 {}

--- a/src/core/processing/qgsprocessingoutputs.h
+++ b/src/core/processing/qgsprocessingoutputs.h
@@ -57,6 +57,8 @@ class CORE_EXPORT QgsProcessingOutputDefinition
       sipType = sipType_QgsProcessingOutputNumber;
     else if ( sipCpp->type() == QgsProcessingOutputString::typeName() )
       sipType = sipType_QgsProcessingOutputString;
+    else if ( sipCpp->type() == QgsProcessingOutputBoolean::typeName() )
+      sipType = sipType_QgsProcessingOutputBoolean;
     else if ( sipCpp->type() == QgsProcessingOutputFolder::typeName() )
       sipType = sipType_QgsProcessingOutputFolder;
     else if ( sipCpp->type() == QgsProcessingOutputFile::typeName() )
@@ -307,6 +309,28 @@ class CORE_EXPORT QgsProcessingOutputString : public QgsProcessingOutputDefiniti
     static QString typeName() { return QStringLiteral( "outputString" ); }
     QString type() const override { return typeName(); }
 
+};
+
+/**
+ * \class QgsProcessingOutputBoolean
+ * \ingroup core
+ * A boolean output for processing algorithms.
+  * \since QGIS 3.8
+ */
+class CORE_EXPORT QgsProcessingOutputBoolean : public QgsProcessingOutputDefinition
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingOutputNumber.
+     */
+    QgsProcessingOutputBoolean( const QString &name, const QString &description = QString() );
+
+    /**
+     * Returns the type name for the output class.
+     */
+    static QString typeName() { return QStringLiteral( "outputBoolean" ); }
+    QString type() const override { return typeName(); }
 };
 
 /**

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -171,7 +171,8 @@ QStringList QgsProcessingBooleanWidgetWrapper::compatibleOutputTypes() const
          << QgsProcessingOutputFile::typeName()
          << QgsProcessingOutputRasterLayer::typeName()
          << QgsProcessingOutputVectorLayer::typeName()
-         << QgsProcessingOutputString::typeName();
+         << QgsProcessingOutputString::typeName()
+         << QgsProcessingOutputBoolean::typeName();
 }
 
 QList<int> QgsProcessingBooleanWidgetWrapper::compatibleDataTypes() const


### PR DESCRIPTION
## Description
In processing, if an algorithm has a boolean as an output, it cannot be defined as boolean but as a number.

To be more precise in algorithms description, the commit add QgsProcessingOutputBoolean.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
