### PR TITLE
Templates on welcome page

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -976,6 +976,8 @@ Returns the current auxiliary storage.
 .. versionadded:: 3.0
 %End
 
+
+
     const QgsProjectMetadata &metadata() const;
 %Docstring
 Returns a reference to the project's metadata store.
@@ -1391,6 +1393,7 @@ Emitted when the project dirty status changes.
 
 .. versionadded:: 3.2
 %End
+
 
   public slots:
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -74,7 +74,7 @@ SET(QGIS_APP_SRCS
   qgsstatusbarscalewidget.cpp
   qgsvectorlayerloadstyledialog.cpp
   qgsversioninfo.cpp
-  qgswelcomepageitemsmodel.cpp
+  qgsrecentprojectsitemsmodel.cpp
   qgswelcomepage.cpp
 
   qgsmaptooladdfeature.cpp
@@ -312,7 +312,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsstatusbarscalewidget.h
   qgsvectorlayerloadstyledialog.h
   qgsversioninfo.h
-  qgswelcomepageitemsmodel.h
+  qgsrecentprojectsitemsmodel.h
   qgswelcomepage.h
 
   qgsmaptooladdfeature.h

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -72,6 +72,7 @@ SET(QGIS_APP_SRCS
   qgsstatusbarcoordinateswidget.cpp
   qgsstatusbarmagnifierwidget.cpp
   qgsstatusbarscalewidget.cpp
+  qgstemplateprojectsmodel.cpp
   qgsvectorlayerloadstyledialog.cpp
   qgsversioninfo.cpp
   qgsrecentprojectsitemsmodel.cpp
@@ -310,6 +311,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsstatusbarcoordinateswidget.h
   qgsstatusbarmagnifierwidget.h
   qgsstatusbarscalewidget.h
+  qgstemplateprojectsmodel.h
   qgsvectorlayerloadstyledialog.h
   qgsversioninfo.h
   qgsrecentprojectsitemsmodel.h

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -64,6 +64,7 @@ SET(QGIS_APP_SRCS
   qgsmaplayerstylecategoriesmodel.cpp
   qgsmaplayerstyleguiutils.cpp
   qgsmapsavedialog.cpp
+  qgsprojectlistitemdelegate.cpp
   qgspuzzlewidget.cpp
   qgsversionmigration.cpp
   qgsrulebasedlabelingwidget.cpp
@@ -305,6 +306,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsmaplayerstyleguiutils.h
   qgsmapsavedialog.h
   qgspuzzlewidget.h
+  qgsprojectlistitemdelegate.h
   qgsrulebasedlabelingwidget.h
   qgssnappinglayertreemodel.h
   qgssnappingwidget.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4271,8 +4271,7 @@ void QgisApp::saveRecentProjectPath( bool savePreviewImage )
   int pinnedCount = 0;
   int nonPinnedPos = 0;
   bool pinnedTop = true;
-  const auto constMRecentProjects = mRecentProjects;
-  for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : constMRecentProjects )
+  for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : qgis::as_const( mRecentProjects ) )
   {
     if ( recentProject.pin )
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1919,7 +1919,7 @@ void QgisApp::readRecentProjects()
     const auto constOldRecentProjects = oldRecentProjects;
     for ( const QString &project : constOldRecentProjects )
     {
-      QgsWelcomePageItemsModel::RecentProjectData data;
+      QgsRecentProjectItemsModel::RecentProjectData data;
       data.path = project;
       data.title = project;
 
@@ -1944,7 +1944,7 @@ void QgisApp::readRecentProjects()
   const int maxProjects = QgsSettings().value( QStringLiteral( "maxRecentProjects" ), 20, QgsSettings::App ).toInt();
   for ( int i = 0; i < projectKeys.count(); ++i )
   {
-    QgsWelcomePageItemsModel::RecentProjectData data;
+    QgsRecentProjectItemsModel::RecentProjectData data;
     settings.beginGroup( QString::number( projectKeys.at( i ) ) );
     data.title = settings.value( QStringLiteral( "title" ) ).toString();
     data.path = settings.value( QStringLiteral( "path" ) ).toString();
@@ -4196,7 +4196,7 @@ void QgisApp::updateRecentProjectPaths()
   mRecentProjectsMenu->clear();
 
   const auto constMRecentProjects = mRecentProjects;
-  for ( const QgsWelcomePageItemsModel::RecentProjectData &recentProject : constMRecentProjects )
+  for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : constMRecentProjects )
   {
     QAction *action = mRecentProjectsMenu->addAction( QStringLiteral( "%1 (%2)" ).arg( recentProject.title != recentProject.path ? recentProject.title : QFileInfo( recentProject.path ).completeBaseName(),
                       QDir::toNativeSeparators( recentProject.path ) ) );
@@ -4209,7 +4209,7 @@ void QgisApp::updateRecentProjectPaths()
   }
 
   std::vector< QgsNative::RecentProjectProperties > recentProjects;
-  for ( const QgsWelcomePageItemsModel::RecentProjectData &recentProject : qgis::as_const( mRecentProjects ) )
+  for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : qgis::as_const( mRecentProjects ) )
   {
     QgsNative::RecentProjectProperties project;
     project.title = recentProject.title;
@@ -4229,7 +4229,7 @@ void QgisApp::saveRecentProjectPath( bool savePreviewImage )
   readRecentProjects();
 
   // Get canonical absolute path
-  QgsWelcomePageItemsModel::RecentProjectData projectData;
+  QgsRecentProjectItemsModel::RecentProjectData projectData;
   projectData.path = QgsProject::instance()->absoluteFilePath();
   QString templateDirName = QgsSettings().value( QStringLiteral( "qgis/projectTemplateDir" ),
                             QgsApplication::qgisSettingsDirPath() + "project_templates" ).toString();
@@ -4282,7 +4282,7 @@ void QgisApp::saveRecentProjectPath( bool savePreviewImage )
   int nonPinnedPos = 0;
   bool pinnedTop = true;
   const auto constMRecentProjects = mRecentProjects;
-  for ( const QgsWelcomePageItemsModel::RecentProjectData &recentProject : constMRecentProjects )
+  for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : constMRecentProjects )
   {
     if ( recentProject.pin )
     {
@@ -4334,7 +4334,7 @@ void QgisApp::saveRecentProjects()
   int idx = 0;
 
   const auto constMRecentProjects = mRecentProjects;
-  for ( const QgsWelcomePageItemsModel::RecentProjectData &recentProject : constMRecentProjects )
+  for ( const QgsRecentProjectItemsModel::RecentProjectData &recentProject : constMRecentProjects )
   {
     ++idx;
     settings.beginGroup( QStringLiteral( "UI/recentProjects/%1" ).arg( idx ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -841,8 +841,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   connect( mMapCanvas, &QgsMapCanvas::layersChanged, this, &QgisApp::showMapCanvas );
 
-  mCentralContainer->setCurrentIndex( mProjOpen ? 0 : 1 );
-
   // a bar to warn the user with non-blocking messages
   startProfile( QStringLiteral( "Message bar" ) );
   mInfoBar = new QgsMessageBar( centralWidget );
@@ -1490,6 +1488,32 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   {
     mCentralContainer->setCurrentIndex( 0 );
   } );
+
+  // As the last thing set the welcome page and restore dock and panel visibility
+
+  connect( mCentralContainer, &QStackedWidget::currentChanged, this, [ this ]( int index )
+  {
+    QgsSettings settings;
+
+    if ( index == 1 ) // welcomepage
+    {
+      if ( settings.value( QStringLiteral( "UI/allWidgetsVisible" ), true ).toBool() )
+      {
+        toggleReducedView( false );
+        settings.setValue( QStringLiteral( "UI/widgetsHiddenForWelcomePage" ), true );
+      }
+    }
+    else
+    {
+      if ( settings.value( QStringLiteral( "UI/widgetsHiddenForWelcomePage" ), false ).toBool() && !QgsSettings().value( QStringLiteral( "UI/allWidgetsVisible" ), true ).toBool() )
+      {
+        toggleReducedView( true );
+      }
+      settings.setValue( QStringLiteral( "UI/widgetsHiddenForWelcomePage" ), false );
+    }
+  } );
+
+  mCentralContainer->setCurrentIndex( 1 );
 } // QgisApp ctor
 
 QgisApp::QgisApp()
@@ -6777,8 +6801,8 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
         }
       }
 
-      this->menuBar()->setVisible( false );
-      this->statusBar()->setVisible( false );
+      menuBar()->setVisible( false );
+      statusBar()->setVisible( false );
 
       settings.setValue( QStringLiteral( "UI/hiddenToolBarsActive" ), toolBarsActive );
     }
@@ -6833,8 +6857,8 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
         toolBar->setVisible( true );
       }
     }
-    this->menuBar()->setVisible( true );
-    this->statusBar()->setVisible( true );
+    menuBar()->setVisible( true );
+    statusBar()->setVisible( true );
 
     settings.remove( QStringLiteral( "UI/hiddenToolBarsActive" ) );
     settings.remove( QStringLiteral( "UI/hiddenDocksTitle" ) );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1091,6 +1091,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void onSnappingConfigChanged();
 
+    void generateProjectAttachedFiles( QgsStringMap &files );
+
     /**
      * Triggers validation of the specified \a crs.
      */
@@ -1763,6 +1765,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void activeLayerChanged( QgsMapLayer *layer );
 
   private:
+    void createPreviewImage( const QString &path );
     void startProfile( const QString &name );
     void endProfile();
     void functionProfile( void ( QgisApp::*fnc )(), QgisApp *instance, const QString &name );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -149,7 +149,7 @@ class QgsNetworkRequestParameters;
 #include "qgsconfig.h"
 #include "qgspointxy.h"
 #include "qgsmimedatautils.h"
-#include "qgswelcomepageitemsmodel.h"
+#include "qgsrecentprojectsitemsmodel.h"
 #include "qgsraster.h"
 #include "qgsrasterminmaxorigin.h"
 #include "qgsmaplayeractionregistry.h"
@@ -2165,7 +2165,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QSplashScreen *mSplash = nullptr;
     //! list of recently opened/saved project files
-    QList<QgsWelcomePageItemsModel::RecentProjectData> mRecentProjects;
+    QList<QgsRecentProjectItemsModel::RecentProjectData> mRecentProjects;
 
     //! Currently open layout designer dialogs
     QSet<QgsLayoutDesignerDialog *> mLayoutDesignerDialogs;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1062,6 +1062,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void triggerCrashHandler();
 
+    //! Create a new file from a template project
+    bool fileNewFromTemplate( const QString &fileName );
+
   protected:
 
     //! Handle state changes (WindowTitleChange)
@@ -1316,8 +1319,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void fileOpenAfterLaunch();
     //! After project read, set any auto-opened project as successful
     void fileOpenedOKAfterLaunch();
-    //! Create a new file from a template project
-    bool fileNewFromTemplate( const QString &fileName );
     void fileNewFromTemplateAction( QAction *qAction );
     void fileNewFromDefaultTemplate();
     //! Calculate new rasters from existing ones

--- a/src/app/qgsprojectlistitemdelegate.cpp
+++ b/src/app/qgsprojectlistitemdelegate.cpp
@@ -1,0 +1,173 @@
+/***************************************************************************
+
+               ----------------------------------------------------
+              date                 : 22.5.2019
+              copyright            : (C) 2019 by Matthias Kuhn
+              email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprojectlistitemdelegate.h"
+#include "qgis.h"
+
+#include <QApplication>
+#include <QPainter>
+#include <QTextDocument>
+#include <QAbstractTextDocumentLayout>
+
+QgsProjectListItemDelegate::QgsProjectListItemDelegate( QObject *parent )
+  : QStyledItemDelegate( parent )
+  , mRoundedRectSizePixels( static_cast<int>( Qgis::UI_SCALE_FACTOR * QApplication::fontMetrics().height() * 0.5 ) )
+{
+
+}
+
+void QgsProjectListItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+{
+  painter->save();
+
+  QTextDocument doc;
+  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
+
+  QAbstractTextDocumentLayout::PaintContext ctx;
+  QStyleOptionViewItem optionV4 = option;
+
+  QColor color = optionV4.palette.color( QPalette::Active, QPalette::Window );
+  if ( option.state & QStyle::State_Selected && option.state & QStyle::State_HasFocus )
+  {
+    color.setAlpha( 40 );
+    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::HighlightedText ) );
+
+    QStyle *style = QApplication::style();
+    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
+  }
+  else if ( option.state & QStyle::State_Enabled )
+  {
+    if ( option.state & QStyle::State_Selected )
+    {
+      color.setAlpha( 40 );
+    }
+    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::Text ) );
+
+    QStyle *style = QApplication::style();
+    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
+  }
+  else
+  {
+    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Disabled, QPalette::Text ) );
+  }
+
+  painter->setRenderHint( QPainter::Antialiasing );
+  painter->setPen( QColor( 0, 0, 0, 0 ) );
+  painter->setBrush( QBrush( color ) );
+  painter->drawRoundedRect( option.rect.left() + 0.625 * mRoundedRectSizePixels, option.rect.top() + 0.625 * mRoundedRectSizePixels,
+                            option.rect.width() - 2 * 0.625 * mRoundedRectSizePixels, option.rect.height() - 2 * 0.625 * mRoundedRectSizePixels, mRoundedRectSizePixels, mRoundedRectSizePixels );
+
+  int titleSize = static_cast<int>( QApplication::fontMetrics().height() * 1.1 );
+  int textSize = static_cast<int>( titleSize * 0.85 );
+
+  doc.setHtml( QStringLiteral( "<div style='font-size:%1px'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( QString::number( titleSize ),
+               index.data( QgsProjectListItemDelegate::TitleRole ).toString(),
+               index.data( QgsProjectListItemDelegate::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
+               mShowPath ? index.data( QgsProjectListItemDelegate::NativePathRole ).toString() : QString(),
+               index.data( QgsProjectListItemDelegate::CrsRole ).toString() ) );
+  doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );
+
+  if ( !icon.isNull() )
+  {
+    painter->drawPixmap( option.rect.left() + 1.25 * mRoundedRectSizePixels, option.rect.top() + 1.25 * mRoundedRectSizePixels, icon );
+  }
+
+  painter->translate( option.rect.left() + ( !icon.isNull() ? icon.width() + 3.125 * mRoundedRectSizePixels : 1.875 * mRoundedRectSizePixels ), option.rect.top() + 1.875 * mRoundedRectSizePixels );
+  ctx.clip = QRect( 0, 0, option.rect.width() - ( !icon.isNull() ? icon.width() - 4.375 * mRoundedRectSizePixels : 3.125 *  mRoundedRectSizePixels ), option.rect.height() - 3.125 * mRoundedRectSizePixels );
+  doc.documentLayout()->draw( painter, ctx );
+
+  painter->restore();
+}
+
+QSize QgsProjectListItemDelegate::sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const
+{
+  QTextDocument doc;
+  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
+
+  int width;
+  if ( option.rect.width() < 450 )
+  {
+    width = 450;
+  }
+  else
+  {
+    width = option.rect.width();
+  }
+
+  int titleSize = QApplication::fontMetrics().height() * 1.1;
+  int textSize = titleSize * 0.85;
+
+  doc.setHtml( QStringLiteral( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( titleSize )
+               .arg( index.data( QgsProjectListItemDelegate::TitleRole ).toString(),
+                     index.data( QgsProjectListItemDelegate::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
+                     index.data( QgsProjectListItemDelegate::NativePathRole ).toString(),
+                     index.data( QgsProjectListItemDelegate::CrsRole ).toString() ) );
+  doc.setTextWidth( width - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );
+
+  return QSize( width, std::max( ( double ) doc.size().height() + 1.25 * mRoundedRectSizePixels, static_cast<double>( icon.height() ) ) + 2.5 * mRoundedRectSizePixels );
+}
+
+bool QgsProjectListItemDelegate::showPath() const
+{
+  return mShowPath;
+}
+
+void QgsProjectListItemDelegate::setShowPath( bool value )
+{
+  mShowPath = value;
+}
+
+QgsProjectPreviewImage::QgsProjectPreviewImage() = default;
+
+QgsProjectPreviewImage::QgsProjectPreviewImage( const QString &path )
+{
+  loadImageFromFile( path );
+}
+
+QgsProjectPreviewImage::QgsProjectPreviewImage( const QImage &image )
+{
+  mImage = image;
+}
+
+void QgsProjectPreviewImage::loadImageFromFile( const QString &path )
+{
+  mImage = QImage( path );
+}
+
+void QgsProjectPreviewImage::setImage( const QImage &image )
+{
+  mImage = image;
+}
+
+QPixmap QgsProjectPreviewImage::pixmap() const
+{
+  //nicely round corners so users don't get paper cuts
+  QImage previewImage( mImage.size(), QImage::Format_ARGB32 );
+  previewImage.fill( Qt::transparent );
+  QPainter previewPainter( &previewImage );
+  previewPainter.setRenderHint( QPainter::Antialiasing, true );
+  previewPainter.setPen( Qt::NoPen );
+  previewPainter.setBrush( Qt::black );
+  previewPainter.drawRoundedRect( 0, 0, previewImage.width(), previewImage.height(), 8, 8 );
+  previewPainter.setCompositionMode( QPainter::CompositionMode_SourceIn );
+  previewPainter.drawImage( 0, 0, mImage );
+  previewPainter.end();
+  return QPixmap::fromImage( previewImage );
+}
+
+bool QgsProjectPreviewImage::isNull() const
+{
+  return mImage.isNull();
+}

--- a/src/app/qgsprojectlistitemdelegate.h
+++ b/src/app/qgsprojectlistitemdelegate.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+
+               ----------------------------------------------------
+              date                 : 22.5.2019
+              copyright            : (C) 2019 by Matthias Kuhn
+              email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROJECTLISTITEMDELEGATE_H
+#define QGSPROJECTLISTITEMDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+class QgsProjectPreviewImage
+{
+  public:
+    QgsProjectPreviewImage();
+    QgsProjectPreviewImage( const QString &path );
+    QgsProjectPreviewImage( const QImage &image );
+
+    void loadImageFromFile( const QString &path );
+    void setImage( const QImage &image );
+    QPixmap pixmap() const;
+
+    bool isNull() const;
+
+  private:
+    QImage mImage;
+};
+
+class QgsProjectListItemDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+    enum Role
+    {
+      TitleRole = Qt::UserRole + 1,
+      PathRole = Qt::UserRole + 2,
+      NativePathRole = Qt::UserRole + 3,
+      CrsRole = Qt::UserRole + 4,
+      PinRole = Qt::UserRole + 5
+    };
+
+    explicit QgsProjectListItemDelegate( QObject *parent = nullptr );
+    void paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+    QSize sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
+
+    bool showPath() const;
+    void setShowPath( bool value );
+
+  private:
+
+    int mRoundedRectSizePixels = 5;
+    bool mShowPath = true;
+    QColor mColor = Qt::white;
+};
+
+#endif // QGSPROJECTLISTITEMDELEGATE_H

--- a/src/app/qgsrecentprojectsitemsmodel.cpp
+++ b/src/app/qgsrecentprojectsitemsmodel.cpp
@@ -19,6 +19,7 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsmessagelog.h"
 #include "qgsprojectstorageregistry.h"
+#include "qgsprojectlistitemdelegate.h"
 
 #include <QApplication>
 #include <QAbstractTextDocumentLayout>
@@ -28,104 +29,6 @@
 #include <QPainter>
 #include <QTextDocument>
 #include <QDir>
-
-QgsRecentProjectItemDelegate::QgsRecentProjectItemDelegate( QObject *parent )
-  : QStyledItemDelegate( parent )
-  , mRoundedRectSizePixels( Qgis::UI_SCALE_FACTOR * QApplication::fontMetrics().height() * 0.5 )
-{
-
-}
-
-void QgsRecentProjectItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
-{
-  painter->save();
-
-  QTextDocument doc;
-  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
-
-  QAbstractTextDocumentLayout::PaintContext ctx;
-  QStyleOptionViewItem optionV4 = option;
-
-  QColor color = optionV4.palette.color( QPalette::Active, QPalette::Window );
-  if ( option.state & QStyle::State_Selected && option.state & QStyle::State_HasFocus )
-  {
-    color.setAlpha( 40 );
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::HighlightedText ) );
-
-    QStyle *style = QApplication::style();
-    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
-  }
-  else if ( option.state & QStyle::State_Enabled )
-  {
-    if ( option.state & QStyle::State_Selected )
-    {
-      color.setAlpha( 40 );
-    }
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::Text ) );
-
-    QStyle *style = QApplication::style();
-    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
-  }
-  else
-  {
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Disabled, QPalette::Text ) );
-  }
-
-  painter->setRenderHint( QPainter::Antialiasing );
-  painter->setPen( QColor( 0, 0, 0, 0 ) );
-  painter->setBrush( QBrush( color ) );
-  painter->drawRoundedRect( option.rect.left() + 0.625 * mRoundedRectSizePixels, option.rect.top() + 0.625 * mRoundedRectSizePixels,
-                            option.rect.width() - 2 * 0.625 * mRoundedRectSizePixels, option.rect.height() - 2 * 0.625 * mRoundedRectSizePixels, mRoundedRectSizePixels, mRoundedRectSizePixels );
-
-  int titleSize = QApplication::fontMetrics().height() * 1.1;
-  int textSize = titleSize * 0.85;
-
-  doc.setHtml( QStringLiteral( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( titleSize )
-               .arg( index.data( QgsRecentProjectItemsModel::TitleRole ).toString(),
-                     index.data( QgsRecentProjectItemsModel::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
-                     index.data( QgsRecentProjectItemsModel::NativePathRole ).toString(),
-                     index.data( QgsRecentProjectItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );
-
-  if ( !icon.isNull() )
-  {
-    painter->drawPixmap( option.rect.left() + 1.25 * mRoundedRectSizePixels, option.rect.top() + 1.25 * mRoundedRectSizePixels, icon );
-  }
-
-  painter->translate( option.rect.left() + ( !icon.isNull() ? icon.width() + 3.125 * mRoundedRectSizePixels : 1.875 * mRoundedRectSizePixels ), option.rect.top() + 1.875 * mRoundedRectSizePixels );
-  ctx.clip = QRect( 0, 0, option.rect.width() - ( !icon.isNull() ? icon.width() - 4.375 * mRoundedRectSizePixels : 3.125 *  mRoundedRectSizePixels ), option.rect.height() - 3.125 * mRoundedRectSizePixels );
-  doc.documentLayout()->draw( painter, ctx );
-
-  painter->restore();
-}
-
-QSize QgsRecentProjectItemDelegate::sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const
-{
-  QTextDocument doc;
-  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
-
-  int width;
-  if ( option.rect.width() < 450 )
-  {
-    width = 450;
-  }
-  else
-  {
-    width = option.rect.width();
-  }
-
-  int titleSize = QApplication::fontMetrics().height() * 1.1;
-  int textSize = titleSize * 0.85;
-
-  doc.setHtml( QStringLiteral( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( titleSize )
-               .arg( index.data( QgsRecentProjectItemsModel::TitleRole ).toString(),
-                     index.data( QgsRecentProjectItemsModel::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
-                     index.data( QgsRecentProjectItemsModel::NativePathRole ).toString(),
-                     index.data( QgsRecentProjectItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( width - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );
-
-  return QSize( width, std::max( ( double ) doc.size().height() + 1.25 * mRoundedRectSizePixels, static_cast<double>( icon.height() ) ) + 2.5 * mRoundedRectSizePixels );
-}
 
 QgsRecentProjectItemsModel::QgsRecentProjectItemsModel( QObject *parent )
   : QAbstractListModel( parent )
@@ -152,13 +55,13 @@ QVariant QgsRecentProjectItemsModel::data( const QModelIndex &index, int role ) 
   switch ( role )
   {
     case Qt::DisplayRole:
-    case TitleRole:
+    case QgsProjectListItemDelegate::TitleRole:
       return mRecentProjects.at( index.row() ).title != mRecentProjects.at( index.row() ).path ? mRecentProjects.at( index.row() ).title : QFileInfo( mRecentProjects.at( index.row() ).path ).completeBaseName();
-    case PathRole:
+    case QgsProjectListItemDelegate::PathRole:
       return mRecentProjects.at( index.row() ).path;
-    case NativePathRole:
+    case QgsProjectListItemDelegate::NativePathRole:
       return QDir::toNativeSeparators( mRecentProjects.at( index.row() ).path );
-    case CrsRole:
+    case QgsProjectListItemDelegate::CrsRole:
       if ( !mRecentProjects.at( index.row() ).crs.isEmpty() )
       {
         QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mRecentProjects.at( index.row() ).crs );
@@ -168,7 +71,7 @@ QVariant QgsRecentProjectItemsModel::data( const QModelIndex &index, int role ) 
       {
         return QString();
       }
-    case PinRole:
+    case QgsProjectListItemDelegate::PinRole:
       return mRecentProjects.at( index.row() ).pin;
     case Qt::DecorationRole:
     {
@@ -241,47 +144,4 @@ void QgsRecentProjectItemsModel::recheckProject( const QModelIndex &index )
   const RecentProjectData &projectData = mRecentProjects.at( index.row() );
   projectData.exists = QFile::exists( ( projectData.path ) );
   projectData.checkedExists = true;
-}
-
-QgsProjectPreviewImage::QgsProjectPreviewImage() = default;
-
-QgsProjectPreviewImage::QgsProjectPreviewImage( const QString &path )
-{
-  loadImageFromFile( path );
-}
-
-QgsProjectPreviewImage::QgsProjectPreviewImage( const QImage &image )
-{
-  mImage = image;
-}
-
-void QgsProjectPreviewImage::loadImageFromFile( const QString &path )
-{
-  mImage = QImage( path );
-}
-
-void QgsProjectPreviewImage::setImage( const QImage &image )
-{
-  mImage = image;
-}
-
-QPixmap QgsProjectPreviewImage::pixmap() const
-{
-  //nicely round corners so users don't get paper cuts
-  QImage previewImage( mImage.size(), QImage::Format_ARGB32 );
-  previewImage.fill( Qt::transparent );
-  QPainter previewPainter( &previewImage );
-  previewPainter.setRenderHint( QPainter::Antialiasing, true );
-  previewPainter.setPen( Qt::NoPen );
-  previewPainter.setBrush( Qt::black );
-  previewPainter.drawRoundedRect( 0, 0, previewImage.width(), previewImage.height(), 8, 8 );
-  previewPainter.setCompositionMode( QPainter::CompositionMode_SourceIn );
-  previewPainter.drawImage( 0, 0, mImage );
-  previewPainter.end();
-  return QPixmap::fromImage( previewImage );
-}
-
-bool QgsProjectPreviewImage::isNull() const
-{
-  return mImage.isNull();
 }

--- a/src/app/qgsrecentprojectsitemsmodel.cpp
+++ b/src/app/qgsrecentprojectsitemsmodel.cpp
@@ -13,7 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgswelcomepageitemsmodel.h"
+#include "qgsrecentprojectsitemsmodel.h"
 
 #include "qgsapplication.h"
 #include "qgscoordinatereferencesystem.h"
@@ -29,14 +29,14 @@
 #include <QTextDocument>
 #include <QDir>
 
-QgsWelcomePageItemDelegate::QgsWelcomePageItemDelegate( QObject *parent )
+QgsRecentProjectItemDelegate::QgsRecentProjectItemDelegate( QObject *parent )
   : QStyledItemDelegate( parent )
   , mRoundedRectSizePixels( Qgis::UI_SCALE_FACTOR * QApplication::fontMetrics().height() * 0.5 )
 {
 
 }
 
-void QgsWelcomePageItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+void QgsRecentProjectItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
 {
   painter->save();
 
@@ -81,10 +81,10 @@ void QgsWelcomePageItemDelegate::paint( QPainter *painter, const QStyleOptionVie
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QStringLiteral( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( titleSize )
-               .arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString(),
-                     index.data( QgsWelcomePageItemsModel::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
-                     index.data( QgsWelcomePageItemsModel::NativePathRole ).toString(),
-                     index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
+               .arg( index.data( QgsRecentProjectItemsModel::TitleRole ).toString(),
+                     index.data( QgsRecentProjectItemsModel::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
+                     index.data( QgsRecentProjectItemsModel::NativePathRole ).toString(),
+                     index.data( QgsRecentProjectItemsModel::CrsRole ).toString() ) );
   doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );
 
   if ( !icon.isNull() )
@@ -99,7 +99,7 @@ void QgsWelcomePageItemDelegate::paint( QPainter *painter, const QStyleOptionVie
   painter->restore();
 }
 
-QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const
+QSize QgsRecentProjectItemDelegate::sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const
 {
   QTextDocument doc;
   QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
@@ -118,22 +118,22 @@ QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem &option, 
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QStringLiteral( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3%4</span><br>%5<br>%6</div>" ).arg( textSize ).arg( titleSize )
-               .arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString(),
-                     index.data( QgsWelcomePageItemsModel::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
-                     index.data( QgsWelcomePageItemsModel::NativePathRole ).toString(),
-                     index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
+               .arg( index.data( QgsRecentProjectItemsModel::TitleRole ).toString(),
+                     index.data( QgsRecentProjectItemsModel::PinRole ).toBool() ? QStringLiteral( "<img src=\"qrc:/images/themes/default/pin.svg\">" ) : QString(),
+                     index.data( QgsRecentProjectItemsModel::NativePathRole ).toString(),
+                     index.data( QgsRecentProjectItemsModel::CrsRole ).toString() ) );
   doc.setTextWidth( width - ( !icon.isNull() ? icon.width() + 4.375 * mRoundedRectSizePixels : 4.375 * mRoundedRectSizePixels ) );
 
   return QSize( width, std::max( ( double ) doc.size().height() + 1.25 * mRoundedRectSizePixels, static_cast<double>( icon.height() ) ) + 2.5 * mRoundedRectSizePixels );
 }
 
-QgsWelcomePageItemsModel::QgsWelcomePageItemsModel( QObject *parent )
+QgsRecentProjectItemsModel::QgsRecentProjectItemsModel( QObject *parent )
   : QAbstractListModel( parent )
 {
 
 }
 
-void QgsWelcomePageItemsModel::setRecentProjects( const QList<RecentProjectData> &recentProjects )
+void QgsRecentProjectItemsModel::setRecentProjects( const QList<RecentProjectData> &recentProjects )
 {
   beginResetModel();
   mRecentProjects = recentProjects;
@@ -141,13 +141,13 @@ void QgsWelcomePageItemsModel::setRecentProjects( const QList<RecentProjectData>
 }
 
 
-int QgsWelcomePageItemsModel::rowCount( const QModelIndex &parent ) const
+int QgsRecentProjectItemsModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
   return mRecentProjects.size();
 }
 
-QVariant QgsWelcomePageItemsModel::data( const QModelIndex &index, int role ) const
+QVariant QgsRecentProjectItemsModel::data( const QModelIndex &index, int role ) const
 {
   switch ( role )
   {
@@ -204,7 +204,7 @@ QVariant QgsWelcomePageItemsModel::data( const QModelIndex &index, int role ) co
 }
 
 
-Qt::ItemFlags QgsWelcomePageItemsModel::flags( const QModelIndex &index ) const
+Qt::ItemFlags QgsRecentProjectItemsModel::flags( const QModelIndex &index ) const
 {
   if ( !index.isValid() || !rowCount( index.parent() ) )
     return Qt::NoItemFlags;
@@ -231,24 +231,24 @@ Qt::ItemFlags QgsWelcomePageItemsModel::flags( const QModelIndex &index ) const
   return flags;
 }
 
-void QgsWelcomePageItemsModel::pinProject( const QModelIndex &index )
+void QgsRecentProjectItemsModel::pinProject( const QModelIndex &index )
 {
   mRecentProjects.at( index.row() ).pin = true;
 }
 
-void QgsWelcomePageItemsModel::unpinProject( const QModelIndex &index )
+void QgsRecentProjectItemsModel::unpinProject( const QModelIndex &index )
 {
   mRecentProjects.at( index.row() ).pin = false;
 }
 
-void QgsWelcomePageItemsModel::removeProject( const QModelIndex &index )
+void QgsRecentProjectItemsModel::removeProject( const QModelIndex &index )
 {
   beginRemoveRows( index, index.row(), index.row() );
   mRecentProjects.removeAt( index.row() );
   endRemoveRows();
 }
 
-void QgsWelcomePageItemsModel::recheckProject( const QModelIndex &index )
+void QgsRecentProjectItemsModel::recheckProject( const QModelIndex &index )
 {
   const RecentProjectData &projectData = mRecentProjects.at( index.row() );
   projectData.exists = QFile::exists( ( projectData.path ) );

--- a/src/app/qgsrecentprojectsitemsmodel.h
+++ b/src/app/qgsrecentprojectsitemsmodel.h
@@ -20,6 +20,25 @@
 #include <QStringList>
 #include <QStyledItemDelegate>
 
+class QgsMapCanvas;
+
+class QgsProjectPreviewImage
+{
+  public:
+    QgsProjectPreviewImage();
+    QgsProjectPreviewImage( const QString &path );
+    QgsProjectPreviewImage( const QImage &image );
+
+    void loadImageFromFile( const QString &path );
+    void setImage( const QImage &image );
+    QPixmap pixmap() const;
+
+    bool isNull() const;
+
+  private:
+    QImage mImage;
+};
+
 class QgsRecentProjectItemDelegate : public QStyledItemDelegate
 {
     Q_OBJECT

--- a/src/app/qgsrecentprojectsitemsmodel.h
+++ b/src/app/qgsrecentprojectsitemsmodel.h
@@ -20,12 +20,12 @@
 #include <QStringList>
 #include <QStyledItemDelegate>
 
-class QgsWelcomePageItemDelegate : public QStyledItemDelegate
+class QgsRecentProjectItemDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 
   public:
-    explicit QgsWelcomePageItemDelegate( QObject *parent = nullptr );
+    explicit QgsRecentProjectItemDelegate( QObject *parent = nullptr );
     void paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
     QSize sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
 
@@ -34,7 +34,7 @@ class QgsWelcomePageItemDelegate : public QStyledItemDelegate
     int mRoundedRectSizePixels = 5;
 };
 
-class QgsWelcomePageItemsModel : public QAbstractListModel
+class QgsRecentProjectItemsModel : public QAbstractListModel
 {
     Q_OBJECT
 
@@ -60,7 +60,7 @@ class QgsWelcomePageItemsModel : public QAbstractListModel
       mutable bool exists = false;
     };
 
-    explicit QgsWelcomePageItemsModel( QObject *parent = nullptr );
+    explicit QgsRecentProjectItemsModel( QObject *parent = nullptr );
 
     void setRecentProjects( const QList<RecentProjectData> &recentProjects );
 
@@ -77,4 +77,4 @@ class QgsWelcomePageItemsModel : public QAbstractListModel
     QList<RecentProjectData> mRecentProjects;
 };
 
-#endif // QGSWELCOMEPAGEITEMSMODEL_H
+#endif // QGSRECENTPROJECTITEMSMODEL_H

--- a/src/app/qgsrecentprojectsitemsmodel.h
+++ b/src/app/qgsrecentprojectsitemsmodel.h
@@ -43,7 +43,7 @@ class QgsRecentProjectItemsModel : public QAbstractListModel
 
     void setRecentProjects( const QList<RecentProjectData> &recentProjects );
 
-    int rowCount( const QModelIndex &parent ) const override;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
 

--- a/src/app/qgsrecentprojectsitemsmodel.h
+++ b/src/app/qgsrecentprojectsitemsmodel.h
@@ -22,51 +22,11 @@
 
 class QgsMapCanvas;
 
-class QgsProjectPreviewImage
-{
-  public:
-    QgsProjectPreviewImage();
-    QgsProjectPreviewImage( const QString &path );
-    QgsProjectPreviewImage( const QImage &image );
-
-    void loadImageFromFile( const QString &path );
-    void setImage( const QImage &image );
-    QPixmap pixmap() const;
-
-    bool isNull() const;
-
-  private:
-    QImage mImage;
-};
-
-class QgsRecentProjectItemDelegate : public QStyledItemDelegate
-{
-    Q_OBJECT
-
-  public:
-    explicit QgsRecentProjectItemDelegate( QObject *parent = nullptr );
-    void paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-    QSize sizeHint( const QStyleOptionViewItem &option, const QModelIndex &index ) const override;
-
-  private:
-
-    int mRoundedRectSizePixels = 5;
-};
-
 class QgsRecentProjectItemsModel : public QAbstractListModel
 {
     Q_OBJECT
 
   public:
-    enum Role
-    {
-      TitleRole = Qt::UserRole + 1,
-      PathRole = Qt::UserRole + 2,
-      NativePathRole = Qt::UserRole + 3,
-      CrsRole = Qt::UserRole + 4,
-      PinRole = Qt::UserRole + 5
-    };
-
     struct RecentProjectData
     {
       bool operator==( const RecentProjectData &other ) const { return other.path == this->path; }

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgis.h"
 #include "qgsprojectlistitemdelegate.h"
+#include "qgsproject.h"
 
 #include <QStandardPaths>
 #include <QDir>

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -52,9 +52,18 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
   QStandardItem *emptyProjectItem = new QStandardItem();
 
   emptyProjectItem->setData( tr( "New empty project" ), QgsProjectListItemDelegate::TitleRole );
+  emptyProjectItem->setFlags( Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsEnabled ) ;
   QSize previewSize( 250, 177 );
   QImage image( previewSize, QImage::Format_ARGB32 );
   image.fill( Qt::white );
+  QPainter painter( &image );
+  painter.setOpacity( 0.5 );
+  QRect rect( 20, 20, 210, 137 );
+  QPen pen;
+  pen.setStyle( Qt::DashLine );
+  pen.setColor( Qt::gray );
+  painter.setPen( pen );
+  painter.drawRect( rect );
   QgsProjectPreviewImage previewImage( image );
   emptyProjectItem->setData( previewImage.pixmap(), Qt::DecorationRole );
 

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -1,0 +1,103 @@
+/***************************************************************************
+
+               ----------------------------------------------------
+              date                 : 16.5.2019
+              copyright            : (C) 2019 by Matthias Kuhn
+              email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstemplateprojectsmodel.h"
+#include "qgsziputils.h"
+#include "qgssettings.h"
+#include "qgsapplication.h"
+#include "qgis.h"
+#include "qgsrecentprojectsitemsmodel.h"
+
+#include <QStandardPaths>
+#include <QDir>
+#include <QCryptographicHash>
+#include <QPainter>
+
+#include <memory>
+
+
+QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
+  : QStandardItemModel( parent )
+{
+  const QStringList paths = QStandardPaths::standardLocations( QStandardPaths::AppDataLocation );
+  QString templateDirName = QgsSettings().value( QStringLiteral( "qgis/projectTemplateDir" ),
+                            QgsApplication::qgisSettingsDirPath() + QStringLiteral( "project_templates" ) ).toString();
+
+  for ( const QString &templatePath : paths )
+  {
+    const QString path = templatePath + QDir::separator() + QStringLiteral( "project_templates" );
+    scanDirectory( path );
+    mFileSystemWatcher.addPath( path );
+  }
+
+  scanDirectory( templateDirName );
+  mFileSystemWatcher.addPath( templateDirName );
+
+  connect( &mFileSystemWatcher, &QFileSystemWatcher::directoryChanged, this, &QgsTemplateProjectsModel::scanDirectory );
+
+  setColumnCount( 1 );
+}
+
+void QgsTemplateProjectsModel::scanDirectory( const QString &path )
+{
+  QDir dir = QDir( path );
+  const QFileInfoList files = dir.entryInfoList( QStringList() << QStringLiteral( "*.qgs" ) << QStringLiteral( "*.qgz" ) );
+
+  // Remove any template from this directory)
+  for ( int i = rowCount() - 1; i >= 0; --i )
+  {
+    if ( index( i, 0 ).data( QgsRecentProjectItemsModel::NativePathRole ).toString().startsWith( path ) )
+    {
+      removeRow( i );
+    }
+  }
+
+  // Refill with templates from this directory
+  for ( const QFileInfo &file : files )
+  {
+    std::unique_ptr<QStandardItem> item = qgis::make_unique<QStandardItem>( file.fileName() ) ;
+
+    const QString fileId = QCryptographicHash::hash( file.filePath().toUtf8(), QCryptographicHash::Sha224 ).toHex();
+
+    QStringList files;
+    QDir().mkpath( mTemporaryDir.filePath( fileId ) );
+
+    QgsZipUtils::unzip( file.filePath(), mTemporaryDir.filePath( fileId ), files );
+
+    QString filename( mTemporaryDir.filePath( fileId ) + QDir::separator() + QStringLiteral( "preview.png" ) );
+
+    QImage thumbnail( filename );
+    if ( !thumbnail.isNull() )
+    {
+      //nicely round corners so users don't get paper cuts
+      QImage previewImage( thumbnail.size(), QImage::Format_ARGB32 );
+      previewImage.fill( Qt::transparent );
+      QPainter previewPainter( &previewImage );
+      previewPainter.setRenderHint( QPainter::Antialiasing, true );
+      previewPainter.setPen( Qt::NoPen );
+      previewPainter.setBrush( Qt::black );
+      previewPainter.drawRoundedRect( 0, 0, previewImage.width(), previewImage.height(), 8, 8 );
+      previewPainter.setCompositionMode( QPainter::CompositionMode_SourceIn );
+      previewPainter.drawImage( 0, 0, thumbnail );
+      previewPainter.end();
+      item->setData( QPixmap::fromImage( previewImage ), Qt::DecorationRole );
+    }
+    item->setData( file.baseName(), QgsRecentProjectItemsModel::TitleRole );
+    item->setData( file.filePath(), QgsRecentProjectItemsModel::NativePathRole );
+
+    item->setFlags( Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsEnabled ) ;
+    appendRow( item.release() );
+  }
+}

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -48,6 +48,17 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
   connect( &mFileSystemWatcher, &QFileSystemWatcher::directoryChanged, this, &QgsTemplateProjectsModel::scanDirectory );
 
   setColumnCount( 1 );
+
+  QStandardItem *emptyProjectItem = new QStandardItem();
+
+  emptyProjectItem->setData( tr( "New empty project" ), QgsRecentProjectItemsModel::TitleRole );
+  QSize previewSize( 250, 177 );
+  QImage image( previewSize, QImage::Format_ARGB32 );
+  image.fill( Qt::white );
+  QgsProjectPreviewImage previewImage( image );
+  emptyProjectItem->setData( previewImage.pixmap(), Qt::DecorationRole );
+
+  appendRow( emptyProjectItem );
 }
 
 void QgsTemplateProjectsModel::scanDirectory( const QString &path )
@@ -78,21 +89,11 @@ void QgsTemplateProjectsModel::scanDirectory( const QString &path )
 
     QString filename( mTemporaryDir.filePath( fileId ) + QDir::separator() + QStringLiteral( "preview.png" ) );
 
-    QImage thumbnail( filename );
+    QgsProjectPreviewImage thumbnail( filename );
+
     if ( !thumbnail.isNull() )
     {
-      //nicely round corners so users don't get paper cuts
-      QImage previewImage( thumbnail.size(), QImage::Format_ARGB32 );
-      previewImage.fill( Qt::transparent );
-      QPainter previewPainter( &previewImage );
-      previewPainter.setRenderHint( QPainter::Antialiasing, true );
-      previewPainter.setPen( Qt::NoPen );
-      previewPainter.setBrush( Qt::black );
-      previewPainter.drawRoundedRect( 0, 0, previewImage.width(), previewImage.height(), 8, 8 );
-      previewPainter.setCompositionMode( QPainter::CompositionMode_SourceIn );
-      previewPainter.drawImage( 0, 0, thumbnail );
-      previewPainter.end();
-      item->setData( QPixmap::fromImage( previewImage ), Qt::DecorationRole );
+      item->setData( thumbnail.pixmap(), Qt::DecorationRole );
     }
     item->setData( file.baseName(), QgsRecentProjectItemsModel::TitleRole );
     item->setData( file.filePath(), QgsRecentProjectItemsModel::NativePathRole );

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -51,11 +51,17 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
 
   QStandardItem *emptyProjectItem = new QStandardItem();
 
-  emptyProjectItem->setData( tr( "New empty project" ), QgsProjectListItemDelegate::TitleRole );
+  emptyProjectItem->setData( tr( "New Empty Project" ), QgsProjectListItemDelegate::TitleRole );
+  connect( QgsProject::instance(), &QgsProject::crsChanged, this, [emptyProjectItem]() { emptyProjectItem->setData( QgsProject::instance()->crs().description(), QgsProjectListItemDelegate::CrsRole ); } );
+  emptyProjectItem->setData( QgsProject::instance()->crs().description(), QgsProjectListItemDelegate::CrsRole );
   emptyProjectItem->setFlags( Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsEnabled ) ;
   QSize previewSize( 250, 177 );
   QImage image( previewSize, QImage::Format_ARGB32 );
-  image.fill( Qt::white );
+  QgsSettings settings;
+  int myRed = settings.value( QStringLiteral( "qgis/default_canvas_color_red" ), 255 ).toInt();
+  int myGreen = settings.value( QStringLiteral( "qgis/default_canvas_color_green" ), 255 ).toInt();
+  int myBlue = settings.value( QStringLiteral( "qgis/default_canvas_color_blue" ), 255 ).toInt();
+  image.fill( QColor( myRed, myGreen, myBlue ) );
   QPainter painter( &image );
   painter.setOpacity( 0.5 );
   QRect rect( 20, 20, 210, 137 );
@@ -75,7 +81,7 @@ void QgsTemplateProjectsModel::scanDirectory( const QString &path )
   QDir dir = QDir( path );
   const QFileInfoList files = dir.entryInfoList( QStringList() << QStringLiteral( "*.qgs" ) << QStringLiteral( "*.qgz" ) );
 
-  // Remove any template from this directory)
+  // Remove any template from this directory
   for ( int i = rowCount() - 1; i >= 0; --i )
   {
     if ( index( i, 0 ).data( QgsProjectListItemDelegate::NativePathRole ).toString().startsWith( path ) )

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -18,7 +18,7 @@
 #include "qgssettings.h"
 #include "qgsapplication.h"
 #include "qgis.h"
-#include "qgsrecentprojectsitemsmodel.h"
+#include "qgsprojectlistitemdelegate.h"
 
 #include <QStandardPaths>
 #include <QDir>
@@ -51,7 +51,7 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
 
   QStandardItem *emptyProjectItem = new QStandardItem();
 
-  emptyProjectItem->setData( tr( "New empty project" ), QgsRecentProjectItemsModel::TitleRole );
+  emptyProjectItem->setData( tr( "New empty project" ), QgsProjectListItemDelegate::TitleRole );
   QSize previewSize( 250, 177 );
   QImage image( previewSize, QImage::Format_ARGB32 );
   image.fill( Qt::white );
@@ -69,7 +69,7 @@ void QgsTemplateProjectsModel::scanDirectory( const QString &path )
   // Remove any template from this directory)
   for ( int i = rowCount() - 1; i >= 0; --i )
   {
-    if ( index( i, 0 ).data( QgsRecentProjectItemsModel::NativePathRole ).toString().startsWith( path ) )
+    if ( index( i, 0 ).data( QgsProjectListItemDelegate::NativePathRole ).toString().startsWith( path ) )
     {
       removeRow( i );
     }
@@ -95,8 +95,8 @@ void QgsTemplateProjectsModel::scanDirectory( const QString &path )
     {
       item->setData( thumbnail.pixmap(), Qt::DecorationRole );
     }
-    item->setData( file.baseName(), QgsRecentProjectItemsModel::TitleRole );
-    item->setData( file.filePath(), QgsRecentProjectItemsModel::NativePathRole );
+    item->setData( file.baseName(), QgsProjectListItemDelegate::TitleRole );
+    item->setData( file.filePath(), QgsProjectListItemDelegate::NativePathRole );
 
     item->setFlags( Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsEnabled ) ;
     appendRow( item.release() );

--- a/src/app/qgstemplateprojectsmodel.h
+++ b/src/app/qgstemplateprojectsmodel.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+
+               ----------------------------------------------------
+              date                 : 16.5.2019
+              copyright            : (C) 2019 by Matthias Kuhn
+              email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTEMPLATEPROJECTSMODEL_H
+#define QGSTEMPLATEPROJECTSMODEL_H
+
+#include <QStandardItemModel>
+#include <QFileSystemWatcher>
+#include <QTemporaryDir>
+
+class QgsTemplateProjectsModel : public QStandardItemModel
+{
+    Q_OBJECT
+
+  public:
+    QgsTemplateProjectsModel( QObject *parent = nullptr );
+
+  private slots:
+
+  private:
+    void scanDirectory( const QString &path );
+
+    QFileSystemWatcher mFileSystemWatcher;
+
+    QTemporaryDir mTemporaryDir;
+};
+
+
+#endif // QGSTEMPLATEPROJECTSMODEL_H

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -56,9 +56,9 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
   centerLayout->setMargin( 0 );
 
   int titleSize = static_cast<int>( QApplication::fontMetrics().height() * 1.4 );
-  QLabel *recentProjectsTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( QString::number( titleSize ), tr( "Recent Projects" ) ) );
-  recentProjectsTitle->setContentsMargins( titleSize / 2, titleSize / 6, 0, 0 );
-  centerLayout->addWidget( recentProjectsTitle, 0, 0 );
+  mRecentProjectsTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( QString::number( titleSize ), tr( "Recent Projects" ) ) );
+  mRecentProjectsTitle->setContentsMargins( titleSize / 2, titleSize / 6, 0, 0 );
+  centerLayout->addWidget( mRecentProjectsTitle, 0, 0 );
 
   mRecentProjectsListView = new QListView();
   mRecentProjectsListView->setResizeMode( QListView::Adjust );
@@ -121,6 +121,7 @@ QgsWelcomePage::~QgsWelcomePage()
 void QgsWelcomePage::setRecentProjects( const QList<QgsRecentProjectItemsModel::RecentProjectData> &recentProjects )
 {
   mRecentProjectsModel->setRecentProjects( recentProjects );
+  updateRecentProjectsVisibility();
 }
 
 void QgsWelcomePage::recentProjectItemActivated( const QModelIndex &index )
@@ -254,4 +255,11 @@ void QgsWelcomePage::showContextMenuForTemplates( QPoint point )
   }
 
   menu->popup( mTemplateProjectsListView->mapToGlobal( point ) );
+}
+
+void QgsWelcomePage::updateRecentProjectsVisibility()
+{
+  bool visible = mRecentProjectsModel->rowCount() > 0;
+  mRecentProjectsListView->setVisible( visible );
+  mRecentProjectsTitle->setVisible( visible );
 }

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -136,6 +136,8 @@ void QgsWelcomePage::recentProjectItemActivated( const QModelIndex &index )
 
 void QgsWelcomePage::templateProjectItemActivated( const QModelIndex &index )
 {
+  if ( index.data( QgsProjectListItemDelegate::NativePathRole ).isNull() )
+    QgisApp::instance()->newProject();
   QgisApp::instance()->fileNewFromTemplate( index.data( QgsProjectListItemDelegate::NativePathRole ).toString() );
 }
 

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -230,7 +230,7 @@ void QgsWelcomePage::showContextMenuForTemplates( QPoint point )
 
   if ( fileInfo.isWritable() )
   {
-    QAction *deleteFileAction = new QAction( tr( "Delete template" ) );
+    QAction *deleteFileAction = new QAction( tr( "Delete Template…" ), menu );
     connect( deleteFileAction, &QAction::triggered, this, [this, fileInfo, index]
     {
       QMessageBox msgBox( this );

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -234,7 +234,7 @@ void QgsWelcomePage::showContextMenuForTemplates( QPoint point )
     connect( deleteFileAction, &QAction::triggered, this, [this, fileInfo, index]
     {
       QMessageBox msgBox( this );
-      msgBox.setWindowTitle( tr( "Delete template" ) );
+      msgBox.setWindowTitle( tr( "Delete Template" ) );
       msgBox.setText( tr( "Do you want to delete the template %1? This action can not be undone." ).arg( index.data( QgsRecentProjectItemsModel::TitleRole ).toString() ) );
       auto deleteButton = msgBox.addButton( tr( "Delete" ), QMessageBox::YesRole );
       msgBox.addButton( QMessageBox::Cancel );

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -48,22 +48,17 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
 
   mainLayout->addLayout( layout );
 
-  QTabWidget *centerTabWidget = new QTabWidget;
+  QWidget *centerContainer = new QWidget;
+  QGridLayout *centerLayout = new QGridLayout;
+  centerContainer->setLayout( centerLayout );
+
+  centerLayout->setContentsMargins( 0, 0, 0, 0 );
+  centerLayout->setMargin( 0 );
 
   int titleSize = static_cast<int>( QApplication::fontMetrics().height() * 1.4 );
-
-  centerTabWidget->setStyleSheet( QStringLiteral( "QTabBar { font-size: %1pt } " ).arg( titleSize ) );
-
-  mTemplateProjectsModel = new QgsTemplateProjectsModel( this );
-  mTemplateProjectsListView = new QListView();
-  mTemplateProjectsListView->setResizeMode( QListView::Adjust );
-  mTemplateProjectsListView->setModel( mTemplateProjectsModel );
-  QgsProjectListItemDelegate *recentProjectsDelegate = new QgsProjectListItemDelegate( mTemplateProjectsListView );
-  mTemplateProjectsListView->setItemDelegate( recentProjectsDelegate );
-  mTemplateProjectsListView->setContextMenuPolicy( Qt::CustomContextMenu );
-  connect( mTemplateProjectsListView, &QListView::customContextMenuRequested, this, &QgsWelcomePage::showContextMenuForTemplates );
-
-  centerTabWidget->addTab( mTemplateProjectsListView, tr( "Project Templates" ) );
+  QLabel *recentProjectsTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( QString::number( titleSize ), tr( "Recent Projects" ) ) );
+  recentProjectsTitle->setContentsMargins( titleSize / 2, titleSize / 6, 0, 0 );
+  centerLayout->addWidget( recentProjectsTitle, 0, 0 );
 
   mRecentProjectsListView = new QListView();
   mRecentProjectsListView->setResizeMode( QListView::Adjust );
@@ -72,16 +67,27 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
 
   mRecentProjectsModel = new QgsRecentProjectItemsModel( mRecentProjectsListView );
   mRecentProjectsListView->setModel( mRecentProjectsModel );
-  QgsProjectListItemDelegate *templateProjectsDelegate = new QgsProjectListItemDelegate( mRecentProjectsListView );
+  QgsProjectListItemDelegate *recentProjectsDelegate = new QgsProjectListItemDelegate( mRecentProjectsListView );
+  mRecentProjectsListView->setItemDelegate( recentProjectsDelegate );
+
+  centerLayout->addWidget( mRecentProjectsListView, 1, 0 );
+
+  layout->addWidget( centerContainer );
+
+  QLabel *templatesTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( titleSize ).arg( tr( "Templates" ) ) );
+  templatesTitle->setContentsMargins( titleSize / 2, titleSize / 6, 0, 0 );
+  centerLayout->addWidget( templatesTitle, 0, 1 );
+
+  mTemplateProjectsModel = new QgsTemplateProjectsModel( this );
+  mTemplateProjectsListView = new QListView();
+  mTemplateProjectsListView->setResizeMode( QListView::Adjust );
+  mTemplateProjectsListView->setModel( mTemplateProjectsModel );
+  QgsProjectListItemDelegate *templateProjectsDelegate = new QgsProjectListItemDelegate( mTemplateProjectsListView );
   templateProjectsDelegate->setShowPath( false );
-  mRecentProjectsListView->setItemDelegate( templateProjectsDelegate );
-
-  centerTabWidget->addTab( mRecentProjectsListView, tr( "Recent Projects" ) );
-
-  centerTabWidget->setCurrentIndex( QgsSettings().value( QStringLiteral( "qgis/welcome_screen_page" ), 0 ).toInt() );
-  connect( centerTabWidget, &QTabWidget::currentChanged, this, []( int index ) { QgsSettings().setValue( QStringLiteral( "qgis/welcome_screen_page" ), index ); } );
-
-  mainLayout->addWidget( centerTabWidget );
+  mTemplateProjectsListView->setItemDelegate( templateProjectsDelegate );
+  mTemplateProjectsListView->setContextMenuPolicy( Qt::CustomContextMenu );
+  connect( mTemplateProjectsListView, &QListView::customContextMenuRequested, this, &QgsWelcomePage::showContextMenuForTemplates );
+  centerLayout->addWidget( mTemplateProjectsListView, 1, 1 );
 
   mVersionInformation = new QTextBrowser;
   mVersionInformation->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Maximum );

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -247,7 +247,7 @@ void QgsWelcomePage::showContextMenuForTemplates( QPoint point )
     {
       QMessageBox msgBox( this );
       msgBox.setWindowTitle( tr( "Delete Template" ) );
-      msgBox.setText( tr( "Do you want to delete the template %1? This action can not be undone." ).arg( index.data( QgsRecentProjectItemsModel::TitleRole ).toString() ) );
+      msgBox.setText( tr( "Do you want to delete the template %1? This action can not be undone." ).arg( index.data( QgsProjectListItemDelegate::TitleRole ).toString() ) );
       auto deleteButton = msgBox.addButton( tr( "Delete" ), QMessageBox::YesRole );
       msgBox.addButton( QMessageBox::Cancel );
       msgBox.setIcon( QMessageBox::Question );

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -69,12 +69,17 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
   mRecentProjectsListView->setModel( mRecentProjectsModel );
   QgsProjectListItemDelegate *recentProjectsDelegate = new QgsProjectListItemDelegate( mRecentProjectsListView );
   mRecentProjectsListView->setItemDelegate( recentProjectsDelegate );
+  connect( mRecentProjectsModel, &QAbstractItemModel::rowsRemoved, this, [this]
+  {
+    updateRecentProjectsVisibility();
+  }
+         );
 
   centerLayout->addWidget( mRecentProjectsListView, 1, 0 );
 
   layout->addWidget( centerContainer );
 
-  QLabel *templatesTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( titleSize ).arg( tr( "Templates" ) ) );
+  QLabel *templatesTitle = new QLabel( QStringLiteral( "<div style='font-size:%1px;font-weight:bold'>%2</div>" ).arg( titleSize ).arg( tr( "Project Templates" ) ) );
   templatesTitle->setContentsMargins( titleSize / 2, titleSize / 6, 0, 0 );
   centerLayout->addWidget( templatesTitle, 0, 1 );
 

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -24,6 +24,7 @@
 #include "qgsstringutils.h"
 #include "qgsfileutils.h"
 #include "qgstemplateprojectsmodel.h"
+#include "qgsprojectlistitemdelegate.h"
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -49,7 +50,7 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
 
   QTabWidget *centerTabWidget = new QTabWidget;
 
-  int titleSize = QApplication::fontMetrics().height() * 1.4;
+  int titleSize = static_cast<int>( QApplication::fontMetrics().height() * 1.4 );
 
   centerTabWidget->setStyleSheet( QStringLiteral( "QTabBar { font-size: %1pt } " ).arg( titleSize ) );
 
@@ -57,7 +58,8 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
   mTemplateProjectsListView = new QListView();
   mTemplateProjectsListView->setResizeMode( QListView::Adjust );
   mTemplateProjectsListView->setModel( mTemplateProjectsModel );
-  mTemplateProjectsListView->setItemDelegate( new QgsRecentProjectItemDelegate( mTemplateProjectsListView ) );
+  QgsProjectListItemDelegate *recentProjectsDelegate = new QgsProjectListItemDelegate( mTemplateProjectsListView );
+  mTemplateProjectsListView->setItemDelegate( recentProjectsDelegate );
   mTemplateProjectsListView->setContextMenuPolicy( Qt::CustomContextMenu );
   connect( mTemplateProjectsListView, &QListView::customContextMenuRequested, this, &QgsWelcomePage::showContextMenuForTemplates );
 
@@ -70,7 +72,9 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
 
   mRecentProjectsModel = new QgsRecentProjectItemsModel( mRecentProjectsListView );
   mRecentProjectsListView->setModel( mRecentProjectsModel );
-  mRecentProjectsListView->setItemDelegate( new QgsRecentProjectItemDelegate( mRecentProjectsListView ) );
+  QgsProjectListItemDelegate *templateProjectsDelegate = new QgsProjectListItemDelegate( mRecentProjectsListView );
+  templateProjectsDelegate->setShowPath( false );
+  mRecentProjectsListView->setItemDelegate( templateProjectsDelegate );
 
   centerTabWidget->addTab( mRecentProjectsListView, tr( "Recent Projects" ) );
 
@@ -120,7 +124,7 @@ void QgsWelcomePage::recentProjectItemActivated( const QModelIndex &index )
 
 void QgsWelcomePage::templateProjectItemActivated( const QModelIndex &index )
 {
-  QgisApp::instance()->fileNewFromTemplate( index.data( QgsRecentProjectItemsModel::NativePathRole ).toString() );
+  QgisApp::instance()->fileNewFromTemplate( index.data( QgsProjectListItemDelegate::NativePathRole ).toString() );
 }
 
 void QgsWelcomePage::versionInfoReceived()
@@ -143,8 +147,8 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
   if ( !index.isValid() )
     return;
 
-  bool pin = mRecentProjectsModel->data( index, QgsRecentProjectItemsModel::PinRole ).toBool();
-  QString path = mRecentProjectsModel->data( index, QgsRecentProjectItemsModel::PathRole ).toString();
+  bool pin = mRecentProjectsModel->data( index, QgsProjectListItemDelegate::PinRole ).toBool();
+  QString path = mRecentProjectsModel->data( index, QgsProjectListItemDelegate::PathRole ).toString();
   if ( path.isEmpty() )
     return;
 
@@ -218,7 +222,7 @@ void QgsWelcomePage::showContextMenuForTemplates( QPoint point )
   if ( !index.isValid() )
     return;
 
-  QFileInfo fileInfo( index.data( QgsRecentProjectItemsModel::NativePathRole ).toString() );
+  QFileInfo fileInfo( index.data( QgsProjectListItemDelegate::NativePathRole ).toString() );
 
   QMenu *menu = new QMenu();
 

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -25,6 +25,7 @@
 
 class QgsVersionInfo;
 class QListView;
+class QLabel;
 
 class QgsWelcomePage : public QWidget
 {
@@ -50,10 +51,13 @@ class QgsWelcomePage : public QWidget
     void showContextMenuForTemplates( QPoint point );
 
   private:
+    void updateRecentProjectsVisibility();
+
     QgsRecentProjectItemsModel *mRecentProjectsModel = nullptr;
     QTextBrowser *mVersionInformation = nullptr;
     QgsVersionInfo *mVersionInfo = nullptr;
     QListView *mRecentProjectsListView = nullptr;
+    QLabel *mRecentProjectsTitle = nullptr;
     QListView *mTemplateProjectsListView = nullptr;
     QStandardItemModel *mTemplateProjectsModel = nullptr;
 };

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -19,6 +19,7 @@
 #include <QWidget>
 #include <QTextBrowser>
 #include <QStandardItemModel>
+#include <QFileSystemWatcher>
 
 #include "qgsrecentprojectsitemsmodel.h"
 
@@ -43,8 +44,10 @@ class QgsWelcomePage : public QWidget
 
   private slots:
     void recentProjectItemActivated( const QModelIndex &index );
+    void templateProjectItemActivated( const QModelIndex &index );
     void versionInfoReceived();
     void showContextMenuForProjects( QPoint point );
+    void showContextMenuForTemplates( QPoint point );
 
   private:
     QgsRecentProjectItemsModel *mRecentProjectsModel = nullptr;

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -13,13 +13,14 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSWELCOMEDIALOG_H
-#define QGSWELCOMEDIALOG_H
+#ifndef QGSWELCOMEPAGE_H
+#define QGSWELCOMEPAGE_H
 
 #include <QWidget>
 #include <QTextBrowser>
+#include <QStandardItemModel>
 
-#include "qgswelcomepageitemsmodel.h"
+#include "qgsrecentprojectsitemsmodel.h"
 
 class QgsVersionInfo;
 class QListView;
@@ -33,7 +34,7 @@ class QgsWelcomePage : public QWidget
 
     ~QgsWelcomePage() override;
 
-    void setRecentProjects( const QList<QgsWelcomePageItemsModel::RecentProjectData> &recentProjects );
+    void setRecentProjects( const QList<QgsRecentProjectItemsModel::RecentProjectData> &recentProjects );
 
   signals:
     void projectRemoved( int row );
@@ -41,15 +42,17 @@ class QgsWelcomePage : public QWidget
     void projectUnpinned( int row );
 
   private slots:
-    void itemActivated( const QModelIndex &index );
+    void recentProjectItemActivated( const QModelIndex &index );
     void versionInfoReceived();
     void showContextMenuForProjects( QPoint point );
 
   private:
-    QgsWelcomePageItemsModel *mModel = nullptr;
+    QgsRecentProjectItemsModel *mRecentProjectsModel = nullptr;
     QTextBrowser *mVersionInformation = nullptr;
     QgsVersionInfo *mVersionInfo = nullptr;
     QListView *mRecentProjectsListView = nullptr;
+    QListView *mTemplateProjectsListView = nullptr;
+    QStandardItemModel *mTemplateProjectsModel = nullptr;
 };
 
-#endif // QGSWELCOMEDIALOG_H
+#endif // QGSWELCOMEPAGE_H

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -982,7 +982,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \note Not available in Python bindings
      * \note Attached files are only supported by QGZ file based projects
      * \see collectAttachedFiles()
-     * \see attachedFile( fileName )
+     * \see attachedFile()
      * \since QGIS 3.8
      */
     QgsStringMap attachedFiles() const SIP_SKIP;
@@ -1360,7 +1360,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \note Not available in Python bindings
      * \note Only will be emitted with QGZ project files
      * \see attachedFiles()
-     * \see attachedFile( fileName )
+     * \see attachedFile()
      * \since QGIS 3.8
      */
     void collectAttachedFiles( QgsStringMap &files SIP_INOUT ) SIP_SKIP;

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -967,6 +967,27 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QgsAuxiliaryStorage *auxiliaryStorage();
 
     /**
+     * Returns the path to an attached file known by \a fileName.
+     *
+     * \note Not available in Python bindings
+     * \note Attached files are only supported by QGZ file based projects
+     * \see collectAttachedFiles()
+     * \since QGIS 3.8
+     */
+    QString attachedFile( const QString &fileName ) const SIP_SKIP;
+
+    /**
+     * Returns a map of all attached files with relative paths and real paths.
+     *
+     * \note Not available in Python bindings
+     * \note Attached files are only supported by QGZ file based projects
+     * \see collectAttachedFiles()
+     * \see attachedFile( fileName )
+     * \since QGIS 3.8
+     */
+    QgsStringMap attachedFiles() const SIP_SKIP;
+
+    /**
      * Returns a reference to the project's metadata store.
      * \see setMetadata()
      * \see metadataChanged()
@@ -1328,6 +1349,21 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \since QGIS 3.2
      */
     void isDirtyChanged( bool dirty );
+
+    /**
+     * Emitted whenever the project is saved to a qgz file.
+     * This can be used to package additional files into the qgz file by modifying the \a files map.
+     *
+     * Map keys represent relative paths inside the qgz file, map values represent the path to
+     * the source file.
+     *
+     * \note Not available in Python bindings
+     * \note Only will be emitted with QGZ project files
+     * \see attachedFiles()
+     * \see attachedFile( fileName )
+     * \since QGIS 3.8
+     */
+    void collectAttachedFiles( QgsStringMap &files SIP_INOUT ) SIP_SKIP;
 
   public slots:
 


### PR DESCRIPTION
Shows the available templates on the home screen.

Templates can be shipped through the current user profile path or an [AppData path](https://doc.qt.io/qt-5/qstandardpaths.html) with the suffix `project_templates` (That needs docs for sysadmins ;) ).
If the template is in qgz format, the embedded preview.png will be shown as a thumbnail for additional user happiness.

Since there is now a preview image inside the zip, this could also be used on modern operating systems to be extracted and shown in the file explorer thumbnail (not part of this PR ;) ).

![image](https://user-images.githubusercontent.com/588407/57869008-543d0c00-7804-11e9-9a62-9c7aa31f1bc2.png)


Sponsored by the QGIS project