### PR TITLE
[oauth2] Verify replies still exist and attribute gets are valid

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -390,6 +390,12 @@ void QgsAuthOAuth2Method::onReplyFinished()
 {
   QgsMessageLog::logMessage( tr( "Network reply finished" ), AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
   QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
+  if ( !reply )
+  {
+    QString msg = tr( "Network reply finished but no reply object accessible" );
+    QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+    return;
+  }
   QgsMessageLog::logMessage( tr( "Results: %1" ).arg( QString( reply->readAll() ) ),
                              AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
 }
@@ -413,12 +419,22 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
 
   // TODO: update debug messages to output to QGIS
 
-  int status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-  msg = tr( "Network error, HTTP status: %1" ).arg(
-          reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString() );
-  QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
+  QVariant status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
+  if ( !status.isValid() )
+  {
+    msg = tr( "Network error but no reply object attributes found" );
+    QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+    return;
+  }
+  QVariant phrase = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
+  if ( phrase.isValid() )
+  {
+    msg = tr( "Network error, HTTP status: %1" ).arg( phrase.toString() );
+    QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
+  }
 
-  if ( status == 401 )
+
+  if ( status.toInt() == 401 )
   {
     msg = tr( "Attempting token refresh…" );
     QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
@@ -454,6 +470,12 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
 void QgsAuthOAuth2Method::onRefreshFinished( QNetworkReply::NetworkError err )
 {
   QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
+  if ( !reply )
+  {
+    QString msg = tr( "Token refresh finished but no reply object accessible" );
+    QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+    return;
+  }
   if ( err != QNetworkReply::NoError )
   {
     QgsMessageLog::logMessage( tr( "Token refresh error: %1" ).arg( reply->errorString() ),


### PR DESCRIPTION
## Description
Fixes unreported crash, due to access on nonexistent replies.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
