### PR TITLE
[ui] Improve UX by adding an original source label when changing / updating layer data source

### DIFF
--- a/python/gui/auto_generated/qgsdatasourceselectdialog.sip.in
+++ b/python/gui/auto_generated/qgsdatasourceselectdialog.sip.in
@@ -52,6 +52,19 @@ Constructs a QgsDataSourceSelectDialog, optionally filtering by layer type
 Sets layer type filter to ``layerType`` and activates the filtering
 %End
 
+    void setDescription( const QString description );
+%Docstring
+Sets a description label
+
+:param description: a description string
+
+.. note::
+
+   the description will be displayed at the bottom of the dialog
+
+.. versionadded:: 3.8
+%End
+
     QgsMimeDataUtils::Uri uri() const;
 %Docstring
 Returns the (possibly invalid) uri of the selected data source

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7164,6 +7164,7 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
   QgsMapLayerType layerType( layer->type() );
 
   QgsDataSourceSelectDialog dlg( mBrowserModel, true, layerType );
+  dlg.setDescription( tr( "Original source URI: %1" ).arg( layer->publicSource() ) );
 
   if ( dlg.exec() == QDialog::Accepted )
   {

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -162,6 +162,30 @@ void QgsDataSourceSelectDialog::showFilterWidget( bool visible )
   }
 }
 
+void QgsDataSourceSelectDialog::setDescription( const QString description )
+{
+  if ( !description.isEmpty() )
+  {
+    if ( !mDescriptionLabel )
+    {
+      mDescriptionLabel = new QLabel();
+      mDescriptionLabel->setWordWrap( true );
+      mDescriptionLabel->setMargin( 4 );
+      verticalLayout->insertWidget( 1, mDescriptionLabel );
+    }
+    mDescriptionLabel->setText( description );
+  }
+  else
+  {
+    if ( mDescriptionLabel )
+    {
+      verticalLayout->removeWidget( mDescriptionLabel );
+      delete mDescriptionLabel;
+      mDescriptionLabel = nullptr;
+    }
+  }
+}
+
 void QgsDataSourceSelectDialog::setFilter()
 {
   QString filter = mLeFilter->text();

--- a/src/gui/qgsdatasourceselectdialog.h
+++ b/src/gui/qgsdatasourceselectdialog.h
@@ -16,7 +16,6 @@
 #ifndef QGSDATASOURCESELECTDIALOG_H
 #define QGSDATASOURCESELECTDIALOG_H
 
-#include <QObject>
 #include "ui_qgsdatasourceselectdialog.h"
 
 #include "qgis_gui.h"
@@ -25,6 +24,8 @@
 #include "qgsbrowsermodel.h"
 #include "qgsbrowserproxymodel.h"
 
+#include <QObject>
+#include <QLabel>
 
 /**
  * \ingroup gui
@@ -69,6 +70,14 @@ class GUI_EXPORT QgsDataSourceSelectDialog: public QDialog, private Ui::QgsDataS
     void setLayerTypeFilter( QgsMapLayerType layerType );
 
     /**
+     * Sets a description label
+     * \param description a description string
+     * \note the description will be displayed at the bottom of the dialog
+     * \since 3.8
+     */
+    void setDescription( const QString description );
+
+    /**
      * Returns the (possibly invalid) uri of the selected data source
      */
     QgsMimeDataUtils::Uri uri() const;
@@ -98,6 +107,7 @@ class GUI_EXPORT QgsDataSourceSelectDialog: public QDialog, private Ui::QgsDataS
     std::unique_ptr<QgsBrowserModel> mBrowserModel;
     bool mOwnModel = true;
     QgsMimeDataUtils::Uri mUri;
+    QLabel *mDescriptionLabel = nullptr;
 
 };
 


### PR DESCRIPTION
## Description
Updating the data source for a layer flagged as having a missing one has a tiny flaw: there is no indication of the original data source URI. This is a crucial bit of information which we _do_ have when presented with the missing layers dialog open opening a project but not when we use the missing data source indicator.

This PR fixes this UI/UX gap by adding the possibility to append a description text to the data source selector dialog:
![image](https://user-images.githubusercontent.com/1728657/58000451-01649c80-7b03-11e9-8f28-40b84adc3745.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
