### PR TITLE
update alternative Docker image from Cosmic to Disco

### DIFF
--- a/.docker/qgis3-build-deps-disco.dockerfile
+++ b/.docker/qgis3-build-deps-disco.dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu:18.10
+FROM      ubuntu:19.04
 MAINTAINER Denis Rouzaud <denis@opengis.ch>
 
 LABEL Description="Docker container with QGIS dependencies" Vendor="QGIS.org" Version="1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,15 +117,15 @@ matrix:
       # COSMIC DOCKER BUILD ON CRON OR TAG
       ##########################################################
     - os: linux
-      name: cosmic docker build 🐠
+      name: disco docker build 🐠
       if: repo = qgis/QGIS AND (tag IS PRESENT OR type = cron)
       services: docker
       env:
         - TRAVIS_CONFIG=docker_image
-        - CCACHE_DIR=${HOME}/.ccache_docker_build_cosmic
+        - CCACHE_DIR=${HOME}/.ccache_docker_build_disco
         - TRIGGER_PYQGIS_DOC=TRUE
-        - DOCKER_TAG="$( echo $TRAVIS_BRANCH | sed 's/master/latest/' )_cosmic"
-        - DOCKER_BUILD_DEPS_FILE=qgis3-build-deps-cosmic.dockerfile
+        - DOCKER_TAG="$( echo $TRAVIS_BRANCH | sed 's/master/latest/' )_disco"
+        - DOCKER_BUILD_DEPS_FILE=qgis3-build-deps-disco.dockerfile
 
 
 


### PR DESCRIPTION
Main reason is to bring newer SIP version in the Docker.

It's not the Docker image used in tests (so Qt version will stay the same) but the one used to build PyQGIS api docs.