### PR TITLE
Fix identify on map in relation reference widget

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -72,7 +72,7 @@ determines if the foreign key is shown in a combox box or a read-only line edit
 
     bool allowMapIdentification();
 %Docstring
-determines if the widge offers the possibility to select the related feature on the map (using a dedicated map tool)
+determines if the widget offers the possibility to select the related feature on the map (using a dedicated map tool)
 %End
     void setAllowMapIdentification( bool allowMapIdentification );
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -41,7 +41,7 @@
 #include "qgsfeatureiterator.h"
 #include "qgsfeaturelistcombobox.h"
 #include "qgsexpressioncontextutils.h"
-
+#include "qgsfeaturefiltermodel.h"
 
 QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget *parent )
   : QWidget( parent )
@@ -746,7 +746,7 @@ void QgsRelationReferenceWidget::featureIdentified( const QgsFeature &feature )
   }
   else
   {
-    mComboBox->setCurrentIndex( mComboBox->findData( feature.id(), QgsAttributeTableModel::FeatureIdRole ) );
+    mComboBox->setCurrentIndex( mComboBox->findData( feature.attribute( mReferencedFieldIdx ), QgsFeatureFilterModel::Role::IdentifierValueRole ) );
     mFeature = feature;
   }
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -99,7 +99,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool readOnlySelector() { return mReadOnlySelector; }
     void setReadOnlySelector( bool readOnly );
 
-    //! determines if the widge offers the possibility to select the related feature on the map (using a dedicated map tool)
+    //! determines if the widget offers the possibility to select the related feature on the map (using a dedicated map tool)
     bool allowMapIdentification() { return mAllowMapIdentification; }
     void setAllowMapIdentification( bool allowMapIdentification );
 

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -359,13 +359,13 @@ void TestQgsRelationReferenceWidget::testIdentifyOnMap()
   QTimer::singleShot( 300, [&] { loop.quit(); } );
   loop.exec();
   QgsFeature feature;
-  mLayer2->getFeatures( QStringLiteral( R"(pk = %1)" ).arg( 11 ) ).nextFeature( feature );
+  mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 11 ) ).nextFeature( feature );
   QVERIFY( feature.isValid() );
   QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 11 );
   w.featureIdentified( feature );
   QCOMPARE( w.mComboBox->currentData( Qt::DisplayRole ).toInt(), 11 );
 
-  mLayer2->getFeatures( QStringLiteral( R"(pk = %1)" ).arg( 10 ) ).nextFeature( feature );
+  mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 10 ) ).nextFeature( feature );
   QVERIFY( feature.isValid() );
   QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 10 );
   w.featureIdentified( feature );

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -47,6 +47,7 @@ class TestQgsRelationReferenceWidget : public QObject
     void testChainFilterDeleteForeignKey();
     void testInvalidRelation();
     void testSetGetForeignKey();
+    void testIdentifyOnMap();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -338,6 +339,39 @@ void TestQgsRelationReferenceWidget::testSetGetForeignKey()
   w.setForeignKey( QVariant( QVariant::Int ) );
   Q_ASSERT( w.foreignKey().isNull() );
   QCOMPARE( spy.count(), 3 );
+}
+
+
+// Test issue https://issues.qgis.org/issues/22071
+// Relation reference widget wrong feature when "on map identification"
+void TestQgsRelationReferenceWidget::testIdentifyOnMap()
+{
+  QWidget parentWidget;
+  QgsRelationReferenceWidget w( &parentWidget );
+  QVERIFY( mLayer1->startEditing() );
+  w.setRelation( *mRelation, true );
+  w.setAllowMapIdentification( true );
+  w.init();
+  QEventLoop loop;
+  // Populate model (I tried to listen to signals but the module reload() runs twice
+  // (the first load triggers a second one which does the population of the combo)
+  // and I haven't fin a way to properly wait for it.
+  QTimer::singleShot( 300, [&] { loop.quit(); } );
+  loop.exec();
+  QgsFeature feature;
+  mLayer2->getFeatures( QStringLiteral( R"(pk = %1)" ).arg( 11 ) ).nextFeature( feature );
+  QVERIFY( feature.isValid() );
+  QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 11 );
+  w.featureIdentified( feature );
+  QCOMPARE( w.mComboBox->currentData( Qt::DisplayRole ).toInt(), 11 );
+
+  mLayer2->getFeatures( QStringLiteral( R"(pk = %1)" ).arg( 10 ) ).nextFeature( feature );
+  QVERIFY( feature.isValid() );
+  QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 10 );
+  w.featureIdentified( feature );
+  QCOMPARE( w.mComboBox->currentData( Qt::DisplayRole ).toInt(), 10 );
+
+  mLayer1->rollBack();
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
Fixes #22071 - Relation reference widget wrong feature when "on map identification"
