### PR TITLE
Abort symbol rendering early if render job is cancelled

### DIFF
--- a/src/core/symbology/qgsarrowsymbollayer.cpp
+++ b/src/core/symbology/qgsarrowsymbollayer.cpp
@@ -727,6 +727,9 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
     {
       for ( int pIdx = 0; pIdx < points.size() - 1; pIdx += 2 )
       {
+        if ( context.renderContext().renderingStopped() )
+          break;
+
         mExpressionScope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_GEOMETRY_POINT_NUM, pIdx + 1, true ) );
         _resolveDataDefined( context );
 
@@ -778,6 +781,9 @@ void QgsArrowSymbolLayer::renderPolyline( const QPolygonF &points, QgsSymbolRend
       // only straight arrows
       for ( int pIdx = 0; pIdx < points.size() - 1; pIdx++ )
       {
+        if ( context.renderContext().renderingStopped() )
+          break;
+
         mExpressionScope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_GEOMETRY_POINT_NUM, pIdx + 1, true ) );
         _resolveDataDefined( context );
 

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -611,12 +611,12 @@ class CORE_EXPORT QgsShapeburstFillSymbolLayer : public QgsFillSymbolLayer
     /* distance transform of a 1d function using squared distance */
     void distanceTransform1d( double *f, int n, int *v, double *z, double *d );
     /* distance transform of 2d function using squared distance */
-    void distanceTransform2d( double *im, int width, int height );
+    void distanceTransform2d( double *im, int width, int height, QgsRenderContext &context );
     /* distance transform of a binary QImage */
-    double *distanceTransform( QImage *im );
+    double *distanceTransform( QImage *im, QgsRenderContext &context );
 
     /* fills a QImage with values from an array of doubles containing squared distance transform values */
-    void dtArrayToQImage( double *array, QImage *im, QgsColorRamp *ramp, double layerAlpha = 1, bool useWholeShape = true, int maxPixelDistance = 0 );
+    void dtArrayToQImage( double *array, QImage *im, QgsColorRamp *ramp, QgsRenderContext &context, double layerAlpha = 1, bool useWholeShape = true, int maxPixelDistance = 0 );
 
 #ifdef SIP_RUN
     QgsShapeburstFillSymbolLayer( const QgsShapeburstFillSymbolLayer &other );

--- a/src/core/symbology/qgsheatmaprenderer.cpp
+++ b/src/core/symbology/qgsheatmaprenderer.cpp
@@ -148,6 +148,9 @@ bool QgsHeatmapRenderer::renderFeature( const QgsFeature &feature, QgsRenderCont
     int pointY = pixel.y() / mRenderQuality;
     for ( int x = std::max( pointX - mRadiusPixels, 0 ); x < std::min( pointX + mRadiusPixels, width ); ++x )
     {
+      if ( context.renderingStopped() )
+        break;
+
       for ( int y = std::max( pointY - mRadiusPixels, 0 ); y < std::min( pointY + mRadiusPixels, height ); ++y )
       {
         int index = y * width + x;
@@ -221,7 +224,7 @@ void QgsHeatmapRenderer::stopRender( QgsRenderContext &context )
 
 void QgsHeatmapRenderer::renderImage( QgsRenderContext &context )
 {
-  if ( !context.painter() || !mGradientRamp )
+  if ( !context.painter() || !mGradientRamp || context.renderingStopped() )
   {
     return;
   }
@@ -238,6 +241,9 @@ void QgsHeatmapRenderer::renderImage( QgsRenderContext &context )
   QColor pixColor;
   for ( int heightIndex = 0; heightIndex < image.height(); ++heightIndex )
   {
+    if ( context.renderingStopped() )
+      break;
+
     QRgb *scanLine = reinterpret_cast< QRgb * >( image.scanLine( heightIndex ) );
     for ( int widthIndex = 0; widthIndex < image.width(); ++widthIndex )
     {

--- a/src/core/symbology/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.cpp
@@ -247,6 +247,11 @@ bool QgsInvertedPolygonRenderer::renderFeature( const QgsFeature &feature, QgsRe
 void QgsInvertedPolygonRenderer::stopRender( QgsRenderContext &context )
 {
   QgsFeatureRenderer::stopRender( context );
+  if ( context.renderingStopped() )
+  {
+    mSubRenderer->stopRender( mContext );
+    return;
+  }
 
   if ( !mSubRenderer )
   {

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -1147,6 +1147,9 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineInterval( const QPolygonF &p
     int pointNum = 0;
     for ( int i = 0; i < symbolPoints.size(); ++ i )
     {
+      if ( context.renderContext().renderingStopped() )
+        break;
+
       const QPointF pt = symbolPoints[i];
       const QPointF startPt = angleStartPoints[i];
       const QPointF endPt = angleEndPoints[i];
@@ -1169,6 +1172,9 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineInterval( const QPolygonF &p
     QPointF lastPt = points[0];
     for ( int i = 1; i < points.count(); ++i )
     {
+      if ( context.renderContext().renderingStopped() )
+        break;
+
       const QPointF &pt = points[i];
 
       if ( lastPt == pt ) // must not be equal!
@@ -1259,6 +1265,9 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineVertex( const QPolygonF &poi
     int pointNum = 0;
     while ( context.renderContext().geometry()->nextVertex( vId, vPoint ) )
     {
+      if ( context.renderContext().renderingStopped() )
+        break;
+
       scope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_GEOMETRY_POINT_NUM, ++pointNum, true ) );
 
       if ( ( placement == QgsTemplatedLineSymbolLayerBase::Vertex && vId.type == QgsVertexId::SegmentVertex )

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -327,10 +327,13 @@ void QgsPointDistanceRenderer::stopRender( QgsRenderContext &context )
 
   //printInfoDisplacementGroups(); //just for debugging
 
-  const auto constMClusteredGroups = mClusteredGroups;
-  for ( const ClusteredGroup &group : constMClusteredGroups )
+  if ( !context.renderingStopped() )
   {
-    drawGroup( group, context );
+    const auto constMClusteredGroups = mClusteredGroups;
+    for ( const ClusteredGroup &group : constMClusteredGroups )
+    {
+      drawGroup( group, context );
+    }
   }
 
   mClusteredGroups.clear();

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -949,27 +949,30 @@ void QgsRuleBasedRenderer::stopRender( QgsRenderContext &context )
   //
 
   // go through all levels
-  const auto constMRenderQueue = mRenderQueue;
-  for ( const RenderLevel &level : constMRenderQueue )
+  if ( !context.renderingStopped() )
   {
-    //QgsDebugMsg(QString("level %1").arg(level.zIndex));
-    // go through all jobs at the level
-    for ( const RenderJob *job : qgis::as_const( level.jobs ) )
+    const auto constMRenderQueue = mRenderQueue;
+    for ( const RenderLevel &level : constMRenderQueue )
     {
-      context.expressionContext().setFeature( job->ftr.feat );
-      //QgsDebugMsg(QString("job fid %1").arg(job->f->id()));
-      // render feature - but only with symbol layers with specified zIndex
-      QgsSymbol *s = job->symbol;
-      int count = s->symbolLayerCount();
-      for ( int i = 0; i < count; i++ )
+      //QgsDebugMsg(QString("level %1").arg(level.zIndex));
+      // go through all jobs at the level
+      for ( const RenderJob *job : qgis::as_const( level.jobs ) )
       {
-        // TODO: better solution for this
-        // renderFeatureWithSymbol asks which symbol layer to draw
-        // but there are multiple transforms going on!
-        if ( s->symbolLayer( i )->renderingPass() == level.zIndex )
+        context.expressionContext().setFeature( job->ftr.feat );
+        //QgsDebugMsg(QString("job fid %1").arg(job->f->id()));
+        // render feature - but only with symbol layers with specified zIndex
+        QgsSymbol *s = job->symbol;
+        int count = s->symbolLayerCount();
+        for ( int i = 0; i < count; i++ )
         {
-          int flags = job->ftr.flags;
-          renderFeatureWithSymbol( job->ftr.feat, job->symbol, context, i, flags & FeatIsSelected, flags & FeatDrawMarkers );
+          // TODO: better solution for this
+          // renderFeatureWithSymbol asks which symbol layer to draw
+          // but there are multiple transforms going on!
+          if ( s->symbolLayer( i )->renderingPass() == level.zIndex )
+          {
+            int flags = job->ftr.flags;
+            renderFeatureWithSymbol( job->ftr.feat, job->symbol, context, i, flags & FeatIsSelected, flags & FeatDrawMarkers );
+          }
         }
       }
     }

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -764,6 +764,9 @@ class GeometryRestorer
 
 void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &context, int layer, bool selected, bool drawVertexMarker, int currentVertexMarkerType, double currentVertexMarkerSize )
 {
+  if ( context.renderingStopped() )
+    return;
+
   const QgsGeometry geom = feature.geometry();
   if ( geom.isNull() )
   {
@@ -918,6 +921,9 @@ void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &cont
 
       for ( int i = 0; i < mp.numGeometries(); ++i )
       {
+        if ( context.renderingStopped() )
+          break;
+
         mSymbolRenderContext->setGeometryPartNum( i + 1 );
         if ( needsExpressionContext )
           mSymbolRenderContext->expressionContextScope()->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_GEOMETRY_PART_NUM, i + 1, true ) );
@@ -948,6 +954,9 @@ void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &cont
       const unsigned int num = geomCollection.numGeometries();
       for ( unsigned int i = 0; i < num; ++i )
       {
+        if ( context.renderingStopped() )
+          break;
+
         mSymbolRenderContext->setGeometryPartNum( i + 1 );
         if ( needsExpressionContext )
           mSymbolRenderContext->expressionContextScope()->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_GEOMETRY_PART_NUM, i + 1, true ) );
@@ -999,6 +1008,9 @@ void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &cont
         const QList<unsigned int> &listPartIndex = iter->second;
         for ( int idx = 0; idx < listPartIndex.size(); ++idx )
         {
+          if ( context.renderingStopped() )
+            break;
+
           const unsigned i = listPartIndex[idx];
           mSymbolRenderContext->setGeometryPartNum( i + 1 );
           if ( needsExpressionContext )
@@ -1046,7 +1058,7 @@ void QgsSymbol::renderFeature( const QgsFeature &feature, QgsRenderContext &cont
 
   if ( drawVertexMarker )
   {
-    if ( !markers.isEmpty() )
+    if ( !markers.isEmpty() && !context.renderingStopped() )
     {
       const auto constMarkers = markers;
       for ( QPointF marker : constMarkers )
@@ -1590,6 +1602,9 @@ void QgsMarkerSymbol::renderPoint( QPointF point, const QgsFeature *f, QgsRender
   const auto constMLayers = mLayers;
   for ( QgsSymbolLayer *symbolLayer : constMLayers )
   {
+    if ( context.renderingStopped() )
+      break;
+
     if ( !symbolLayer->enabled() )
       continue;
 
@@ -1826,6 +1841,9 @@ void QgsLineSymbol::renderPolyline( const QPolygonF &points, const QgsFeature *f
   const auto constMLayers = mLayers;
   for ( QgsSymbolLayer *symbolLayer : constMLayers )
   {
+    if ( context.renderingStopped() )
+      break;;
+
     if ( !symbolLayer->enabled() )
       continue;
 
@@ -1908,6 +1926,9 @@ void QgsFillSymbol::renderPolygon( const QPolygonF &points, QList<QPolygonF> *ri
   const auto constMLayers = mLayers;
   for ( QgsSymbolLayer *symbolLayer : constMLayers )
   {
+    if ( context.renderingStopped() )
+      break;
+
     if ( !symbolLayer->enabled() )
       continue;
 


### PR DESCRIPTION
Some symbol rendering operations take a long time, especially
if settings are accidentally ridiculous (e.g. changing a marker
line with interval 1 mm to map units on a small scale map can
result in millions+ of markers being rendered for a single
feature). If we don't abort these operations responsively,
then the render job can become effectively "stuck" and sit
burning away CPU for no good reason (or in some cases lock the
QGIS ui as a result).

Instead, for possibly length symbol rendering operations we
check at reasonable places for the QgsRenderContext::renderingStopped()
flag and if it's set, abort the rendering quickly and gracefully.
