### PR TITLE
[processing] use correct parent layer parameter in v.net.distance algorithm (fix #22013)

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.net.distance.txt
+++ b/python/plugins/processing/algs/grass7/description/v.net.distance.txt
@@ -13,7 +13,7 @@ QgsProcessingParameterNumber|threshold|Threshold for connecting nodes to the net
 *QgsProcessingParameterString|to_where|To WHERE conditions of SQL statement without 'where' keyword|None|True|True
 *QgsProcessingParameterField|arc_column|Arc forward/both direction(s) cost column (number)|None|input|0|False|True
 *QgsProcessingParameterField|arc_backward_column|Arc backward direction cost column (number)|None|input|0|False|True
-*QgsProcessingParameterField|node_column|Node cost column (number)|None|from_layer|0|False|True
+*QgsProcessingParameterField|node_column|Node cost column (number)|None|flayer|0|False|True
 *QgsProcessingParameterBoolean|-g|Use geodesic calculation for longitude-latitude locations|False|True
 *QgsProcessingParameterBoolean|-l|Write each output path as one line, not as original input segments|False|True
 QgsProcessingParameterVectorDestination|output|Network_Distance


### PR DESCRIPTION
## Description
Set correct parent layer parameter for field parameter in the v.net.distance GRASS algorithm. Fixes https://issues.qgis.org/issues/22013.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
