### PR TITLE
[processing] use correct file extension in r.in.lidar.info (fix #21910)

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.in.lidar.info.txt
+++ b/python/plugins/processing/algs/grass7/description/r.in.lidar.info.txt
@@ -1,7 +1,7 @@
 r.in.lidar
 r.in.lidar.info - Extract information from LAS file
 Raster (r.*)
-QgsProcessingParameterFile|input|LAS input file|QgsProcessingParameterFile.File|txt|None|False
+QgsProcessingParameterFile|input|LAS input file|QgsProcessingParameterFile.File|las|None|False
 Hardcoded|-p
 Hardcoded|-g
 Hardcoded|-s


### PR DESCRIPTION
## Description
Fix file extension in the input parameter, allowing to select LAS files using GUI.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
