### PR TITLE
move QgsHighlight style setting in a static method

### DIFF
--- a/python/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/gui/auto_generated/qgsidentifymenu.sip.in
@@ -148,6 +148,13 @@ exec
 :param pos: the position where the menu will be executed
 %End
 
+    static void styleHighlight( QgsHighlight *highlight );
+%Docstring
+Applies style from the settings to the highlight
+
+.. versionadded:: 3.8
+%End
+
   protected:
     virtual void closeEvent( QCloseEvent *e );
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -16,6 +16,35 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QCloseEvent>
+#include <QLabel>
+#include <QAction>
+#include <QTreeWidgetItem>
+#include <QPixmap>
+#include <QMenu>
+#include <QClipboard>
+#include <QDesktopWidget>
+#include <QMenuBar>
+#include <QPushButton>
+#include <QPrinter>
+#include <QPrintDialog>
+#include <QDesktopServices>
+#include <QMessageBox>
+#include <QComboBox>
+#include <QTextDocument>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QRegExp>
+
+//graph
+#include <qwt_plot.h>
+#include <qwt_plot_curve.h>
+#include <qwt_symbol.h>
+#include <qwt_legend.h>
+#include "qgscolorramp.h" // for random colors
+
 #include "qgisapp.h"
 #include "qgsapplication.h"
 #include "qgsactionmanager.h"
@@ -50,35 +79,8 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsidentifymenu.h"
 
-#include <QCloseEvent>
-#include <QLabel>
-#include <QAction>
-#include <QTreeWidgetItem>
-#include <QPixmap>
-#include <QMenu>
-#include <QClipboard>
-#include <QDesktopWidget>
-#include <QMenuBar>
-#include <QPushButton>
-#include <QPrinter>
-#include <QPrintDialog>
-#include <QDesktopServices>
-#include <QMessageBox>
-#include <QComboBox>
-#include <QTextDocument>
-#include <QNetworkRequest>
-#include <QNetworkReply>
-#include <QFileDialog>
-#include <QFileInfo>
-#include <QRegExp>
-
-//graph
-#include <qwt_plot.h>
-#include <qwt_plot_curve.h>
-#include <qwt_symbol.h>
-#include <qwt_legend.h>
-#include "qgscolorramp.h" // for random colors
 
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent ) : QgsWebView( parent )
 {
@@ -1807,17 +1809,7 @@ void QgsIdentifyResultsDialog::highlightFeature( QTreeWidgetItem *item )
     highlight->setWidth( 2 );
   }
 
-  QgsSettings settings;
-  QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
-  int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
-  double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
-  double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
-
-  highlight->setColor( color ); // sets also fill with default alpha
-  color.setAlpha( alpha );
-  highlight->setFillColor( color ); // sets fill with alpha
-  highlight->setBuffer( buffer );
-  highlight->setMinWidth( minWidth );
+  QgsIdentifyMenu::styleHighlight( highlight );
   highlight->show();
   mHighlights.insert( featItem, highlight );
 }
@@ -2119,7 +2111,7 @@ void QgsIdentifyResultsDialog::formatChanged( int index )
     return;
   }
 
-  QgsRaster::IdentifyFormat format = ( QgsRaster::IdentifyFormat ) combo->itemData( index, Qt::UserRole ).toInt();
+  QgsRaster::IdentifyFormat format = static_cast<QgsRaster::IdentifyFormat>( combo->itemData( index, Qt::UserRole ).toInt() );
   QgsDebugMsg( QStringLiteral( "format = %1" ).arg( format ) );
   QgsRasterLayer *layer = qobject_cast<QgsRasterLayer *>( combo->itemData( index, Qt::UserRole + 1 ).value<QObject *>() );
   if ( !layer )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -42,6 +42,8 @@
 #include "qgsfeaturelistcombobox.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturefiltermodel.h"
+#include "qgsidentifymenu.h"
+
 
 QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget *parent )
   : QWidget( parent )
@@ -636,17 +638,7 @@ void QgsRelationReferenceWidget::highlightFeature( QgsFeature f, CanvasExtent ca
   // highlight
   deleteHighlight();
   mHighlight = new QgsHighlight( mCanvas, f, mReferencedLayer );
-  QgsSettings settings;
-  QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
-  int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
-  double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
-  double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
-
-  mHighlight->setColor( color ); // sets also fill with default alpha
-  color.setAlpha( alpha );
-  mHighlight->setFillColor( color ); // sets fill with alpha
-  mHighlight->setBuffer( buffer );
-  mHighlight->setMinWidth( minWidth );
+  QgsIdentifyMenu::styleHighlight( mHighlight );
   mHighlight->show();
 
   QTimer *timer = new QTimer( this );

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -617,19 +617,25 @@ void QgsIdentifyMenu::handleMenuHover()
       continue;
 
     QgsHighlight *hl = new QgsHighlight( mCanvas, result.mFeature.geometry(), vl );
-    QgsSettings settings;
-    QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
-    int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
-    double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
-    double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
-    hl->setColor( color ); // sets also fill with default alpha
-    color.setAlpha( alpha );
-    hl->setFillColor( color ); // sets fill with alpha
-    hl->setBuffer( buffer );
-    hl->setMinWidth( minWidth );
+    styleHighlight( hl );
     mRubberBands.append( hl );
     connect( vl, &QObject::destroyed, this, &QgsIdentifyMenu::layerDestroyed );
   }
+}
+
+void QgsIdentifyMenu::styleHighlight( QgsHighlight *highlight )
+{
+  QgsSettings settings;
+  QColor color = QColor( settings.value( QStringLiteral( "Map/highlight/color" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.name() ).toString() );
+  int alpha = settings.value( QStringLiteral( "Map/highlight/colorAlpha" ), Qgis::DEFAULT_HIGHLIGHT_COLOR.alpha() ).toInt();
+  double buffer = settings.value( QStringLiteral( "Map/highlight/buffer" ), Qgis::DEFAULT_HIGHLIGHT_BUFFER_MM ).toDouble();
+  double minWidth = settings.value( QStringLiteral( "Map/highlight/minWidth" ), Qgis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM ).toDouble();
+
+  highlight->setColor( color ); // sets also fill with default alpha
+  color.setAlpha( alpha );
+  highlight->setFillColor( color ); // sets fill with alpha
+  highlight->setBuffer( buffer );
+  highlight->setMinWidth( minWidth );
 }
 
 void QgsIdentifyMenu::deleteRubberBands()

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -160,6 +160,13 @@ class GUI_EXPORT QgsIdentifyMenu : public QMenu
      */
     QList<QgsMapToolIdentify::IdentifyResult> exec( const QList<QgsMapToolIdentify::IdentifyResult> &idResults, QPoint pos );
 
+    /**
+     * Applies style from the settings to the highlight
+     *
+     * \since QGIS 3.8
+     */
+    static void styleHighlight( QgsHighlight *highlight );
+
   protected:
     void closeEvent( QCloseEvent *e ) override;
 


### PR DESCRIPTION
small decrease of code duplication

I moved the code to `QgsIdentifyMenu::styleHighlight`. I don't love the place but couldn't find a better place.