### PR TITLE
 Highlight instead of flashing features when browsing list of attribute table

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsDualView : QStackedWidget
 {
 %Docstring
@@ -38,7 +39,6 @@ and the attributes for the currently selected feature are shown in a form.
     enum FeatureListBrowsingAction
     {
       NoAction,
-      FlashFeature,
       PanToFeature,
       ZoomToFeature,
     };
@@ -49,6 +49,7 @@ Constructor
 
 :param parent: The parent widget
 %End
+    ~QgsDualView();
 
     void init( QgsVectorLayer *layer,
                QgsMapCanvas *mapCanvas,
@@ -263,6 +264,15 @@ Emitted when a filter expression is set using the view.
 Emitted when the form changes mode.
 
 :param mode: new mode
+%End
+
+    void viewModeChanged( QgsDualView::ViewMode mode );
+%Docstring
+Emitted when the mode of the view changes
+
+:param mode: the new mode
+
+.. versionadded:: 3.8
 %End
 
     void showContextMenuExternally( QgsActionMenu *menu, QgsFeatureId fid );

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -30,6 +30,8 @@ class QgsFeatureRequest;
 class QSignalMapper;
 class QgsMapLayerAction;
 class QgsScrollArea;
+class QgsHighlight;
+
 
 /**
  * \ingroup gui
@@ -72,7 +74,6 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     enum FeatureListBrowsingAction
     {
       NoAction = 0, //!< No action is done
-      FlashFeature, //!< The feature is highlighted with a flash
       PanToFeature, //!< The map is panned to the center of the feature bounding-box
       ZoomToFeature, //!< The map is zoomed to contained the feature bounding-box
     };
@@ -83,6 +84,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      * \param parent  The parent widget
      */
     explicit QgsDualView( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    ~QgsDualView() override;
 
     /**
      * Has to be called to initialize the dual view.
@@ -288,6 +290,13 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void formModeChanged( QgsAttributeEditorContext::Mode mode );
 
     /**
+     * Emitted when the mode of the view changes
+     * \param mode the new mode
+     * \since QGIS 3.8
+     */
+    void viewModeChanged( QgsDualView::ViewMode mode );
+
+    /**
      * Emitted when selecting context menu on the feature list to create the context menu individually
      * \param menu context menu
      * \param fid feature id of the selected feature
@@ -372,6 +381,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void panZoomGroupButtonToggled( QAbstractButton *button, bool checked );
 
+    void highlightFeatureButtonClicked( bool clicked );
+
   private:
 
     /**
@@ -386,6 +397,9 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void insertRecentlyUsedDisplayExpression( const QString &expression );
     void updateEditSelectionProgress( int progress, int count );
     void panOrZoomToFeature( const QgsFeatureIds &featureset );
+    void highlightFeature();
+    void deleteHighlight();
+    void onCurrentViewChanged( int index );
 
     QgsAttributeEditorContext mEditorContext;
     QgsAttributeTableModel *mMasterModel = nullptr;
@@ -407,6 +421,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     // If the current feature is set, while the form is still not initialized
     // we will temporarily save it in here and set it on init
     QgsFeature mTempAttributeFormFeature;
+    QgsHighlight *mHighlight = nullptr;
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeTable;

--- a/src/ui/qgsdualviewbase.ui
+++ b/src/ui/qgsdualviewbase.ui
@@ -132,6 +132,9 @@
            </sizepolicy>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="spacing">
+            <number>1</number>
+           </property>
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -143,9 +146,6 @@
            </property>
            <property name="bottomMargin">
             <number>0</number>
-           </property>
-           <property name="spacing">
-            <number>1</number>
            </property>
            <item>
             <widget class="QToolButton" name="mFirstFeatureButton">
@@ -259,7 +259,7 @@
             </spacer>
            </item>
            <item>
-            <widget class="QToolButton" name="mFlashButton">
+            <widget class="QToolButton" name="mHighlightButton">
              <property name="toolTip">
               <string>Highlight currently edited feature on map</string>
              </property>
@@ -277,6 +277,19 @@
               <bool>true</bool>
              </property>
             </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
            <item>
             <widget class="QToolButton" name="mAutoPanButton">


### PR DESCRIPTION
depends on #10064

This makes the browsing a bit nicer.

Also, the highlighting is now an option, i.e. can be deactivated when panning/zooming.

The fact that the feature cache in the attribute table generally doesn't have geometry makes the switching a bit laggy when features are highlighted and/or auto pan activated.
It might be interesting to enable the geometry on the cache when using these options, but going back and forth would invalidate the cache. This is out of scope of this PR.