### PR TITLE
[processing] split GRASS r.sun algorithm into two (fix #21637)

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.sun.incidout.txt
+++ b/python/plugins/processing/algs/grass7/description/r.sun.incidout.txt
@@ -1,0 +1,31 @@
+r.sun
+r.sun.incidout - Solar irradiance and irradiation model ( for the set local time).
+Raster (r.*)
+QgsProcessingParameterRasterLayer|elevation|Elevation layer [meters]|None|False
+QgsProcessingParameterRasterLayer|aspect|Aspect layer [decimal degrees]|None|False
+QgsProcessingParameterNumber|aspect_value|A single value of the orientation (aspect), 270 is south|QgsProcessingParameterNumber.Double|270.0|True|0.0|360.0
+QgsProcessingParameterRasterLayer|slope|Name of the input slope raster map (terrain slope or solar panel inclination) [decimal degrees]|None|False
+QgsProcessingParameterNumber|slope_value|A single value of inclination (slope)|QgsProcessingParameterNumber.Double|0.0|True|0.0|360.0
+QgsProcessingParameterRasterLayer|linke|Name of the Linke atmospheric turbidity coefficient input raster map|None|True
+QgsProcessingParameterRasterLayer|albedo|Name of the ground albedo coefficient input raster map|None|True
+QgsProcessingParameterNumber|albedo_value|A single value of the ground albedo coefficient|QgsProcessingParameterNumber.Double|0.2|True|0.0|360.0
+QgsProcessingParameterRasterLayer|lat|Name of input raster map containing latitudes [decimal degrees]|None|True
+QgsProcessingParameterRasterLayer|long|Name of input raster map containing longitudes [decimal degrees]|None|True
+QgsProcessingParameterRasterLayer|coeff_bh|Name of real-sky beam radiation coefficient input raster map|None|True
+QgsProcessingParameterRasterLayer|coeff_dh|Name of real-sky diffuse radiation coefficient input raster map|None|True
+QgsProcessingParameterRasterLayer|horizon_basemap|The horizon information input map basename|None|True
+QgsProcessingParameterNumber|horizon_step|Angle step size for multidirectional horizon [degrees]|QgsProcessingParameterNumber.Double|None|True|0.0|360.0
+QgsProcessingParameterNumber|day|No. of day of the year (1-365)|QgsProcessingParameterNumber.Integer|1|False|1|365
+*QgsProcessingParameterNumber|step|Time step when computing all-day radiation sums [decimal hours]|QgsProcessingParameterNumber.Double|0.5|True|0
+*QgsProcessingParameterNumber|declination|Declination value (overriding the internally computed value) [radians]|QgsProcessingParameterNumber.Double|None|True|None|None
+*QgsProcessingParameterNumber|distance_step|Sampling distance step coefficient (0.5-1.5)|QgsProcessingParameterNumber.Double|1.0|True|0.5|1.5
+*QgsProcessingParameterNumber|npartitions|Read the input files in this number of chunks|QgsProcessingParameterNumber.Integer|1|True|1|None
+*QgsProcessingParameterNumber|civil_time|Civil time zone value, if none, the time will be local solar time|QgsProcessingParameterNumber.Double|None|True|0.0|None
+QgsProcessingParameterNumber|time|Local (solar) time (decimal hours)|QgsProcessingParameterNumber.Double|None|False|0.0|24.0
+QgsProcessingParameterBoolean|-p|Do not incorporate the shadowing effect of terrain|False
+*QgsProcessingParameterBoolean|-m|Use the low-memory version of the program|False
+QgsProcessingParameterRasterDestination|incidout|incidence angle raster map|None|True
+QgsProcessingParameterRasterDestination|beam_rad|Beam irradiance [W.m-2]|None|True
+QgsProcessingParameterRasterDestination|diff_rad|Diffuse irradiance [W.m-2]|None|True
+QgsProcessingParameterRasterDestination|refl_rad|Ground reflected irradiance [W.m-2]|None|True
+QgsProcessingParameterRasterDestination|glob_rad|Global (total) irradiance/irradiation [W.m-2]|None|True

--- a/python/plugins/processing/algs/grass7/description/r.sun.insoltime.txt
+++ b/python/plugins/processing/algs/grass7/description/r.sun.insoltime.txt
@@ -1,5 +1,5 @@
 r.sun
-Solar irradiance and irradiation model.
+r.sun.insoltime - Solar irradiance and irradiation model (daily sums).
 Raster (r.*)
 QgsProcessingParameterRasterLayer|elevation|Elevation layer [meters]|None|False
 QgsProcessingParameterRasterLayer|aspect|Aspect layer [decimal degrees]|None|False
@@ -23,9 +23,8 @@ QgsProcessingParameterNumber|day|No. of day of the year (1-365)|QgsProcessingPar
 *QgsProcessingParameterNumber|civil_time|Civil time zone value, if none, the time will be local solar time|QgsProcessingParameterNumber.Double|None|True|0.0|None
 QgsProcessingParameterBoolean|-p|Do not incorporate the shadowing effect of terrain|False
 *QgsProcessingParameterBoolean|-m|Use the low-memory version of the program|False
-QgsProcessingParameterRasterDestination|incidout|incidence angle raster map|None|True 
-QgsProcessingParameterRasterDestination|beam_rad|Irradiation [Wh.m-2.day-1]|None|True
 QgsProcessingParameterRasterDestination|insol_time|Insolation time [h] |None|True
-QgsProcessingParameterRasterDestination|diff_rad|Diffuse irradiation [Wh.m-2.day-1]|None|True
-QgsProcessingParameterRasterDestination|refl_rad|Ground reflected irradiation [Wh.m-2.day-1]|None|True 
-QgsProcessingParameterRasterDestination|glob_rad|Global (total) irradiance/irradiation [Wh.m-2.day-1]|None|True
+QgsProcessingParameterRasterDestination|beam_rad|Irradiation raster map [Wh.m-2.day-1]|None|True
+QgsProcessingParameterRasterDestination|diff_rad|Irradiation raster map [Wh.m-2.day-1]|None|True
+QgsProcessingParameterRasterDestination|refl_rad|Irradiation raster map [Wh.m-2.day-1]|None|True
+QgsProcessingParameterRasterDestination|glob_rad|Irradiance/irradiation raster map [Wh.m-2.day-1]|None|True

--- a/python/plugins/processing/tests/testdata/grass7_algorithms_raster_tests.yaml
+++ b/python/plugins/processing/tests/testdata/grass7_algorithms_raster_tests.yaml
@@ -461,41 +461,87 @@ tests:
         hash: 95e064f05759606bc60f1dfa88931f545c066629c1f07919156ac03b
         type: rasterhash
 
-  - algorithm: grass7:r.sun
-    name: GRASS7 r.sun
+  - algorithm: grass7:r.sun.insoltime
+    name: GRASS7 r.sun (insoltime)
     params:
       -m: false
       -p: false
+      GRASS_RASTER_FORMAT_META: ''
+      GRASS_RASTER_FORMAT_OPT: ''
       GRASS_REGION_CELLSIZE_PARAMETER: 0.0
-      GRASS_REGION_PARAMETER: 344500.0,358400.0,6682800.0,6693700.0
+      albedo_value: 0.2
       aspect:
-        name: custom/grass7/float_raster.tif
-        type: raster
-      day: 1
-      declination: 0.0
-      distance_step: 1.0
-      elevation:
         name: custom/grass7/raster_6class.tif
         type: raster
+      aspect_value: 270.0
+      day: 1
+      distance_step: 1.0
+      elevation:
+        name: custom/grass7/float_raster.tif
+        type: raster
+      npartitions: 1
       slope:
         name: custom/grass7/float_raster.tif
         type: raster
+      slope_value: 0.0
       step: 0.5
     results:
       beam_rad:
-        hash: c43a64c35cd5999888b1dc7099249a54f37df8658cbe9c30b92627e5
+        hash: 4428e6601576375c17cb0d37f74e3317db218b9660d3e9483f444279
         type: rasterhash
       diff_rad:
-        hash: ecaa83578ab6eaf24a48f2fc265e8f1deff743c145af9c85cd39bceb
+        hash: a05bb9e71f3a539b74a07235b5873738d3049960c8b2b5fd37cc7826
         type: rasterhash
       glob_rad:
-        hash: 3917bc5633ce2225c864055d4b3c952b87461cbe48093b8fd9738215
+        hash: 511d713ab666e171167a9a137ea246eefc90042e149ded73281362fa
         type: rasterhash
       insol_time:
-        hash: 64851f59edafe67d007da78f33b7491b949d5be3eca83ef513e2b11f
+        hash: 45954c661088e55d7740f7b9b89e21217a34d25868f751e8d0a67d31
         type: rasterhash
       refl_rad:
-        hash: cd2002486c5117db9c493e365ff6983faf1ea92b1bbea87569d3ebdd
+        hash: 278011afa98bcdfd87a2c476bc4abac96266a2a13ac9d20696733941
+        type: rasterhash
+
+  - algorithm: grass7:r.sun.incidout
+    name: GRASS7 r.sun (incidout)
+    params:
+      -m: false
+      -p: false
+      GRASS_RASTER_FORMAT_META: ''
+      GRASS_RASTER_FORMAT_OPT: ''
+      GRASS_REGION_CELLSIZE_PARAMETER: 0.0
+      albedo_value: 0.2
+      aspect:
+        name: custom/grass7/raster_6class.tif
+        type: raster
+      aspect_value: 270.0
+      day: 1
+      distance_step: 1.0
+      elevation:
+        name: custom/grass7/float_raster.tif
+        type: raster
+      npartitions: 1
+      slope:
+        name: custom/grass7/float_raster.tif
+        type: raster
+      slope_value: 0.0
+      step: 0.5
+      time: 8.0
+    results:
+      beam_rad:
+        hash: b2459789ef2f04adc13a02d016f314594eaaf6f89e42fdf35d06e46b
+        type: rasterhash
+      diff_rad:
+        hash: 7dbe38013812f372389f1ce1b60eae6755e005326e2373472ec65443
+        type: rasterhash
+      glob_rad:
+        hash: 41e68104b039b794efb580a52c79e61af84261f9fad8b2aaedce0316
+        type: rasterhash
+      incidout:
+        hash: 5cd5e5a410da7593d2e0d3ad3cb01818cebddfb73d0439fcf8b30d05
+        type: rasterhash
+      refl_rad:
+        hash: 5ac2d870ae11d726a16809cda2915b248f0180f3eedc0c7a4c8d8de5
         type: rasterhash
 
 #  - algorithm: grass7:r.stats.quantile.out
@@ -1772,7 +1818,7 @@ tests:
       stream_raster:
         hash: 916672ce0c35295100bcdc56bc60e26841b9cbb384924ae4f54648a8
         type: rasterhash
-        
+
   - algorithm: grass7:r.geomorphon
     name: Test (grass7:r.geomorphon)
     params:
@@ -1792,4 +1838,3 @@ tests:
       forms:
         hash: e1a1fc36d53e2ac801632f9e2271922d2b1340869f2db82d5edaeb0e
         type: rasterhash
-  


### PR DESCRIPTION
## Description
r.sun has two opeartional modes which are mutually exclusive, using them together makes algorithm unusable. Also required parameter for one of the modes is missed from the description file. This PR splits r.sun algorithm into two separate tools, similarly to some other modules and also adds missed "time" parameter.

Fixes https://issues.qgis.org/issues/21637. Tests updated accordingly.

Marked for backporting to LTR, as it fixes broken algorithm.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
