### PR TITLE
[processing] fixed iterating execution of algs when output is temporary

### DIFF
--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -332,7 +332,7 @@ def executeIterating(alg, parameters, paramToIter, context, feedback):
             if out.name() not in outputs:
                 continue
 
-            o = outputs[out.name()]            
+            o = outputs[out.name()]
             if isinstance(o, QgsProperty):
                 dest = o.valueAsString(context.expressionContext())[0]
             elif isinstance(o, QgsProcessingOutputLayerDefinition):

--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -28,10 +28,13 @@ from qgis.core import (Qgis,
                        QgsProcessingFeedback,
                        QgsProcessingUtils,
                        QgsMessageLog,
+                       QgsProcessing,
                        QgsProcessingException,
                        QgsProcessingFeatureSourceDefinition,
                        QgsProcessingFeatureSource,
                        QgsProcessingParameters,
+                       QgsProcessingOutputLayerDefinition,
+                       QgsProperty,
                        QgsProject,
                        QgsFeatureRequest,
                        QgsFeature,
@@ -329,8 +332,15 @@ def executeIterating(alg, parameters, paramToIter, context, feedback):
             if out.name() not in outputs:
                 continue
 
-            o = outputs[out.name()]
-            parameters[out.name()] = QgsProcessingUtils.generateIteratingDestination(o, i, context)
+            o = outputs[out.name()]            
+            if isinstance(o, QgsProperty):
+                dest = o.valueAsString(context.expressionContext())[0]
+            elif isinstance(o, QgsProcessingOutputLayerDefinition):
+                dest = o.sink.valueAsString(context.expressionContext())[0]
+            else:
+                dest = str(o)
+            if dest != QgsProcessing.TEMPORARY_OUTPUT:
+                parameters[out.name()] = QgsProcessingUtils.generateIteratingDestination(o, i, context)
         feedback.setProgressText(QCoreApplication.translate('AlgorithmExecutor', 'Executing iteration {0}/{1}…').format(i + 1, len(sink_list)))
         feedback.setProgress(i * 100 / len(sink_list))
         ret, results = execute(alg, parameters, context, feedback)


### PR DESCRIPTION
fixes #21524

## Description

When a temporary output was selected for an algorithm executed in iterative mode, output destination for that output was not correctly managed. The TEMPORARY_OUTPUT constant was understood as a filename, which was causing errors.  With this change, it is correctly interpreted, and all algorithms in the iterative process will have that output saved as a temporary output.

I have made this patch in the python part of Processing, but maybe it would be better to add it in the C++ part. Specifically here:  https://qgis.org/api/qgsprocessingutils_8cpp_source.html#l00689

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
