### PR TITLE
[processing][needs-docs] allow to switch from batch dialog to single UI (fix #16893)

### DIFF
--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -24,7 +24,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 from pprint import pformat
 import time
 
-from qgis.PyQt.QtWidgets import QMessageBox
+from qgis.PyQt.QtWidgets import QMessageBox, QPushButton, QDialogButtonBox
 from qgis.PyQt.QtCore import Qt, QCoreApplication
 
 from qgis.core import (QgsProcessingParameterDefinition,
@@ -65,6 +65,18 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         self.setWindowTitle(self.tr('Batch Processing - {0}').format(self.algorithm().displayName()))
         self.setMainWidget(BatchPanel(self, self.algorithm()))
         self.hideShortHelp()
+
+        self.btnRunSingle = QPushButton(self.tr("Run as Single Process…"))
+        self.btnRunSingle.clicked.connect(self.runAsSingle)
+        self.buttonBox().addButton(self.btnRunSingle, QDialogButtonBox.ResetRole) # reset role to ensure left alignment
+
+    def runAsSingle(self):
+        self.close()
+
+        from processing.gui.AlgorithmDialog import AlgorithmDialog
+        dlg = AlgorithmDialog(self.algorithm().create(), parent=iface.mainWindow())
+        dlg.show()
+        dlg.exec_()
 
     def runAlgorithm(self):
         alg_parameters = []


### PR DESCRIPTION
## Description
Algorithm dialog allows easily to switch to the batch processing interface, however reversed switch is not possible. This adds a button to the batch dialog allowing users to switch to single-shot execution.

Fixes https://issues.qgis.org/issues/16893

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
