### PR TITLE
[db_manager] apply comment to the correct column when altering table column (fix #21425)

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -922,7 +922,8 @@ class PostGisDBConnector(DBConnector):
         # comment the column
         if comment is not None:
             schema, tablename = self.getSchemaTableName(table)
-            sql = u"COMMENT ON COLUMN %s.%s.%s is '%s'" % (schema, tablename, column, comment)
+            column_name = new_name if new_name is not None and new_name != column else column
+            sql = u"COMMENT ON COLUMN %s.%s.%s IS '%s'" % (schema, tablename, column_name, comment)
             self._execute(c, sql)
 
         self._commit()


### PR DESCRIPTION
## Description
In the DB Manager GUI for editing a column (Table → Edit table → Edit column) among other thing it is possible to define a comment for a column. But if column renamed at the same time, query which sets comment still use old (already changed) column name. Affects only PostgreSQL/PostGIS.

Fixes https://issues.qgis.org/issues/21425

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit