### PR TITLE
[processing] Handle case of folder of shapefiles in build vrt alg

### DIFF
--- a/python/plugins/processing/algs/qgis/Datasources2Vrt.py
+++ b/python/plugins/processing/algs/qgis/Datasources2Vrt.py
@@ -38,6 +38,7 @@ from qgis.core import (QgsProcessingFeedback,
                        QgsProcessingException,
                        QgsProviderRegistry)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
+from processing.tools.vector import resolveSourceToFilepath
 
 
 class Datasources2Vrt(QgisAlgorithm):
@@ -127,14 +128,11 @@ class Datasources2Vrt(QgisAlgorithm):
 
             feedback.setProgress(int(current * total))
 
-            inFile = layer.source()            
+            inFile = layer.source()
             srcDS = ogr.Open(inFile, 0)
             if srcDS is None:
-                #might be a shapefile loaded as a directory of shapefiles. We try to resolve the uri to a filepath
-                sourceParts = QgsProviderRegistry.instance().decodeUri('ogr', inFile)
-                if sourceParts.get("layerName"):
-                    inFile = os.path.join(sourceParts.get("path"), sourceParts.get("layerName") + ".shp")
-                    srcDS = ogr.Open(inFile, 0)
+                inFile = resolveSourceToFilepath(inFile)
+                srcDS = ogr.Open(inFile, 0)
                 if srcDS is None:
                     raise QgsProcessingException(
                         self.tr('Invalid datasource: {}'.format(inFile)))

--- a/python/plugins/processing/tools/vector.py
+++ b/python/plugins/processing/tools/vector.py
@@ -21,8 +21,11 @@ __author__ = 'Victor Olaya'
 __date__ = 'February 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
+import os
 from qgis.core import (NULL,
-                       QgsFeatureRequest)
+                       QgsFeatureRequest,
+                       QgsProviderRegistry,
+                       QgsVectorFileWriter)
 
 
 def resolveFieldIndex(source, attr):
@@ -111,3 +114,20 @@ def checkMinDistance(point, index, distance, points):
             return False
 
     return True
+
+
+def resolveSourceToFilepath(source):
+    #Tries to resolve a uri-like source (i.e /path/|layername=points) to a valid filepath (/path/points.shp)
+    sourceParts = QgsProviderRegistry.instance().decodeUri('ogr', source)
+    folder = sourceParts.get("path")
+    layerName = sourceParts.get("layerName")
+    if layerName:
+        if os.path.exists(folder):
+            if os.path.isdir(folder):
+                for ext in QgsVectorFileWriter.supportedFormatExtensions():
+                    f = os.path.join(folder, "%s.%s" % (layerName, ext))
+                    if os.path.exists(f):
+                        return f
+            else:
+                return folder
+    return source


### PR DESCRIPTION
#fixes 21519

## Description

If a shapefile (i.e /my/data/points.shp) was loaded by loading a directory of shapefiles, its source wont be the filepath, but instead a uri-like thing such as /my/data|layername=points.

Although that file can be read by the external tool that creates the virtual vector, that source string won't work. I added a patch to try to resolve the uri-like source to a regular filepath.

It's just a patch for this tool, but this might affect other tools as well (basically, all the ones with external apps, like SAGA, etc), which wont work with shpafiles loaded as part of a folder. 

Ideally, there should be a method to resolve the source to a valid filepath if possible, but I couldnt find it. I am making the PR in any case, to get some discussion about this.

I will be happy to improve this if someone points me in the direction of such method of workflow, in case it exists.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
