### PR TITLE
[FEATURE][processing] new algorithm point to layer

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/point_to_layer.gml
+++ b/python/plugins/processing/tests/testdata/expected/point_to_layer.gml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ point_to_layer.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>1000000</gml:X><gml:Y>1550000</gml:Y></gml:coord>
+      <gml:coord><gml:X>1000000</gml:X><gml:Y>1550000</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                  
+  <gml:featureMember>
+    <ogr:point_to_layer fid="point_to_layer.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:3857"><gml:coordinates>1000000,1550000</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+    </ogr:point_to_layer>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1847,6 +1847,15 @@ tests:
         name: expected/polygon_from_extent_rounded_2.gml
         type: vector
 
+  - algorithm: native:pointtolayer
+    name: Test (native:pointtolayer)
+    params:
+      INPUT: 1000000.000000,1550000.000000 [EPSG:3857]
+    results:
+      OUTPUT:
+        name: expected/point_to_layer.gml
+        type: vector
+
   - algorithm: qgis:climbalongline
     name: Climb line layer with DTM
     params:

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -80,6 +80,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmarrayoffsetlines.cpp
   processing/qgsalgorithmpolygonstolines.cpp
   processing/qgsalgorithmpointonsurface.cpp
+  processing/qgsalgorithmpointtolayer.cpp
   processing/qgsalgorithmpointsalonggeometry.cpp
   processing/qgsalgorithmprojectpointcartesian.cpp
   processing/qgsalgorithmpromotetomultipart.cpp

--- a/src/analysis/processing/qgsalgorithmpointtolayer.cpp
+++ b/src/analysis/processing/qgsalgorithmpointtolayer.cpp
@@ -1,0 +1,71 @@
+/***************************************************************************
+                         qgsalgorithmpointtolayer.cpp
+                         ---------------------
+    begin                : May 2019
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmpointtolayer.h"
+
+///@cond PRIVATE
+
+QString QgsPointToLayerAlgorithm::name() const
+{
+  return QStringLiteral( "pointtolayer" );
+}
+
+void QgsPointToLayerAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterPoint( QStringLiteral( "INPUT" ), QObject::tr( "Point" ) ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Point" ), QgsProcessing::TypeVectorPolygon ) );
+}
+
+QString QgsPointToLayerAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm creates a new vector layer that contains a single feature with geometry matching a point parameter.\n\n"
+                      "It can be used in models to convert a point into a layer which can be used for other algorithms which require "
+                      "a layer based input." );
+}
+
+QgsPointToLayerAlgorithm *QgsPointToLayerAlgorithm::createInstance() const
+{
+  return new QgsPointToLayerAlgorithm();
+}
+
+QVariantMap QgsPointToLayerAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  QgsCoordinateReferenceSystem crs = parameterAsPointCrs( parameters, QStringLiteral( "INPUT" ), context );
+  QgsGeometry geom = QgsGeometry::fromPointXY( parameterAsPoint( parameters, QStringLiteral( "INPUT" ), context ) );
+
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "id" ), QVariant::Int ) );
+
+  QString dest;
+  std::unique_ptr< QgsFeatureSink > sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, QgsWkbTypes::Point, crs ) );
+  if ( !sink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+
+  QgsFeature f;
+  f.setAttributes( QgsAttributes() << 1 );
+  f.setGeometry( geom );
+  sink->addFeature( f, QgsFeatureSink::FastInsert );
+
+  feedback->setProgress( 100 );
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+///@endcond
+

--- a/src/analysis/processing/qgsalgorithmpointtolayer.h
+++ b/src/analysis/processing/qgsalgorithmpointtolayer.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+                         qgsalgorithmpointtolayer.h
+                         ---------------------
+    begin                : May 2019
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMPOINTTOLAYER_H
+#define QGSALGORITHMPOINTTOLAYER_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native point to layer algorithm.
+ */
+class QgsPointToLayerAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsPointToLayerAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override { return QObject::tr( "Create layer from point" ); }
+    QStringList tags() const override { return QObject::tr( "point,layer,polygon,create,new" ).split( ',' ); }
+    QString group() const override { return QObject::tr( "Vector geometry" ); }
+    QString groupId() const override { return QStringLiteral( "vectorgeometry" ); }
+    QString shortHelpString() const override;
+    QgsPointToLayerAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMPOINTTOLAYER_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -74,6 +74,7 @@
 #include "qgsalgorithmpackage.h"
 #include "qgsalgorithmarrayoffsetlines.h"
 #include "qgsalgorithmpointonsurface.h"
+#include "qgsalgorithmpointtolayer.h"
 #include "qgsalgorithmpointsalonggeometry.h"
 #include "qgsalgorithmprojectpointcartesian.h"
 #include "qgsalgorithmpromotetomultipart.h"
@@ -215,6 +216,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsPackageAlgorithm() );
   addAlgorithm( new QgsCreateArrayOffsetLinesAlgorithm() );
   addAlgorithm( new QgsPointOnSurfaceAlgorithm() );
+  addAlgorithm( new QgsPointToLayerAlgorithm() );
   addAlgorithm( new QgsPointsAlongGeometryAlgorithm() );
   addAlgorithm( new QgsProjectPointCartesianAlgorithm() );
   addAlgorithm( new QgsPromoteToMultipartAlgorithm() );


### PR DESCRIPTION
## Description

Added a new "point to layer" algorithm. Just like `extent to layer`, it can be used in models to convert a point into a layer which can be used for other algorithms which require a layer based input.

Implementation was copied and adapted from the `extent to layer` algorithm. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] (N/A) Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] (N/A) Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] (?) This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] (N/A) New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
