### PR TITLE
Fix (?) crash when filtering layer with attachment field

### DIFF
--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -230,7 +230,7 @@ void QgsExternalResourceWidget::loadDocument( const QString &path )
 #ifdef WITH_QTWEBKIT
     if ( mDocumentViewerContent == Web )
     {
-      mWebView->setUrl( QUrl::fromEncoded( resolvedPath.toUtf8() ) );
+      mWebView->load( QUrl::fromEncoded( resolvedPath.toUtf8() ) );
       mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
     }
 #endif


### PR DESCRIPTION
Fixes #21775

@elpaso I'm not confident, but somehow this fixed the crash for me. I can't find any good docs on the difference between setUrl and load here, and where one should be preferred over another...

Do you mind testing this for me and see if it fixes the crash for you too?