### PR TITLE
fix loading of the default style from QML file (fix #21691)

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -799,24 +799,15 @@ QString QgsMapLayer::baseURI( PropertyType type ) const
 {
   QString myURI = publicSource();
 
-  // if file is using the VSIFILE mechanism, remove the prefix
-  if ( myURI.startsWith( QLatin1String( "/vsigzip/" ), Qt::CaseInsensitive ) )
+  // first get base path for delimited text, spatialite and OGR layers,
+  // as in these cases URI may contain layer name and/or additional
+  // information. This also strips prefix in case if VSIFILE mechanism
+  // is used
+  if ( providerType() == QLatin1String( "ogr" ) || providerType() == QLatin1String( "delimitedtext" ) ||
+       providerType() == QLatin1String( "spatialite" ) )
   {
-    myURI.remove( 0, 9 );
-  }
-  else if ( myURI.startsWith( QLatin1String( "/vsizip/" ), Qt::CaseInsensitive ) &&
-            myURI.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) )
-  {
-    // ideally we should look for .qml file inside zip file
-    myURI.remove( 0, 8 );
-  }
-  else if ( myURI.startsWith( QLatin1String( "/vsitar/" ), Qt::CaseInsensitive ) &&
-            ( myURI.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) ||
-              myURI.endsWith( QLatin1String( ".tar.gz" ), Qt::CaseInsensitive ) ||
-              myURI.endsWith( QLatin1String( ".tgz" ), Qt::CaseInsensitive ) ) )
-  {
-    // ideally we should look for .qml file inside tar file
-    myURI.remove( 0, 8 );
+    QVariantMap components = QgsProviderRegistry::instance()->decodeUri( providerType(), myURI );
+    myURI = components["path"].toString();
   }
 
   QFileInfo myFileInfo( myURI );

--- a/tests/src/python/test_qgsmaplayer.py
+++ b/tests/src/python/test_qgsmaplayer.py
@@ -20,6 +20,9 @@ from qgis.core import (QgsReadWriteContext,
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.QtCore import QTemporaryDir
+from utilities import unitTestDataPath
+
+TEST_DATA_DIR = unitTestDataPath()
 
 start_app()
 
@@ -113,6 +116,27 @@ class TestQgsMapLayer(unittest.TestCase):
         _, result = layer.saveNamedStyle(style_path)
         self.assertTrue(result)
         self.assertTrue(os.path.exists(style_path))
+
+    def testStyleUri(self):
+        # shapefile
+        layer = QgsVectorLayer(os.path.join(TEST_DATA_DIR, 'points.shp'), "layer", "ogr")
+        uri = layer.styleURI()
+        self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'points.qml'))
+
+        # geopackage without and with layername
+        layer = QgsVectorLayer(os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.gpkg'), "layer", "ogr")
+        uri = layer.styleURI()
+        self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.qml'))
+
+        layer = QgsVectorLayer("{}|layername=bug_17795".format(os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.gpkg')), "layer", "ogr")
+        uri = layer.styleURI()
+        self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'provider', 'bug_17795.qml'))
+
+        # delimited text
+        uri = 'file://{}?type=csv&detectTypes=yes&geomType=none'.format(os.path.join(TEST_DATA_DIR, 'delimitedtext', 'test.csv'))
+        layer = QgsVectorLayer(uri, "layer", "delimitedtext")
+        uri = layer.styleURI()
+        self.assertEqual(uri, os.path.join(TEST_DATA_DIR, 'delimitedtext', 'test.qml'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
When loading a layer QGIS tries also to apply default style to it and one of the options for default style is a QML file with the same name as layer file. This works fine for simple layers like shapefiles, but fails when layer URI is not a canonical file path, e.g. for GeoPackages (`/path/to/layer|layername=name`) or delimited text or SpatiaLite.

This PR is an attempt to partially fix the issue and allows loading default style from the QML file with the same name as GeoPackage/SpatiaLite/CSV layer file has. Note that it will work only for GeoPackage/SpatiaLite files containing single layer and when QML file has the same name as GeoPackage/SpatiaLite, not with the name of the layer inside it.

Fixes https://issues.qgis.org/issues/21691. With tests

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit