### PR TITLE
Fix spatialite handling of JSON arrays

### DIFF
--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -59,7 +59,7 @@ Constructor for QgsValueRelationFieldFormatter.
 
     static QStringList valueToStringList( const QVariant &value );
 %Docstring
-Utility to convert an array or a string representation of an array ``value`` to a string list
+Utility to convert an array or a string representation of an (C style: {1,2...}) array in the form ``value`` to a string list
 
 .. versionadded:: 3.2
 %End

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -59,7 +59,7 @@ Constructor for QgsValueRelationFieldFormatter.
 
     static QStringList valueToStringList( const QVariant &value );
 %Docstring
-Utility to convert an array or a string representation of an (C style: {1,2...}) array in the form ``value`` to a string list
+Utility to convert a list or a string representation of an (hstore style: {1,2...}) list in ``value`` to a string list
 
 .. versionadded:: 3.2
 %End

--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -322,12 +322,14 @@ Exports all attributes from a QgsFeature as a JSON map type.
 %End
 
 
-    static QVariantList parseArray( const QString &json, QVariant::Type type );
+    static QVariantList parseArray( const QString &json, QVariant::Type type = QVariant::Invalid );
 %Docstring
-Parse a simple array (depth=1).
+Parse a simple array (depth=1)
 
 :param json: the JSON to parse
-:param type: the type of the elements
+:param type: optional variant type of the elements, if specified (and not Invalid),
+             the array items will be converted to the type, and discarded if
+             the conversion is not possible.
 
 .. versionadded:: 3.0
 %End

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -22,6 +22,10 @@
 #include "qgsapplication.h"
 #include "qgsexpressioncontextutils.h"
 
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
 #include <QSettings>
 
 bool orderByKeyLessThan( const QgsValueRelationFieldFormatter::ValueRelationItem &p1, const QgsValueRelationFieldFormatter::ValueRelationItem &p2 )
@@ -164,11 +168,49 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
 
 QStringList QgsValueRelationFieldFormatter::valueToStringList( const QVariant &value )
 {
+  // Note: the recommended way to pass a value is QVariant::StringList but
+  //       for back compatibility a string representation either in the form
+  //       of a JSON array or in the form of {"quoted_str", 1, ... } is
+  //       also accepted
   QStringList checkList;
   if ( value.type() == QVariant::StringList )
+  {
     checkList = value.toStringList();
+  }
   else if ( value.type() == QVariant::String )
-    checkList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
+  {
+    // This must be an array representation
+    auto newVal { value };
+    if ( newVal.toString().trimmed().startsWith( '{' ) )
+    {
+      newVal = QVariant( newVal.toString().trimmed().mid( 1 ).chopped( 1 ).prepend( '[' ).append( ']' ) );
+    }
+    if ( newVal.toString().trimmed().startsWith( '[' ) )
+    {
+      try
+      {
+        for ( auto &element : json::parse( newVal.toString().toStdString() ) )
+        {
+          if ( element.is_number_integer() )
+          {
+            checkList << QString::number( element.get<int>() );
+          }
+          else if ( element.is_number_unsigned() )
+          {
+            checkList << QString::number( element.get<unsigned>() );
+          }
+          else if ( element.is_string() )
+          {
+            checkList << QString::fromStdString( element.get<std::string>() );
+          }
+        }
+      }
+      catch ( json::parse_error ex )
+      {
+        qDebug() << QString::fromStdString( ex.what() );
+      }
+    }
+  }
   else if ( value.type() == QVariant::List )
   {
     QVariantList valuesList( value.toList( ) );

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -168,10 +168,6 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
 
 QStringList QgsValueRelationFieldFormatter::valueToStringList( const QVariant &value )
 {
-  // Note: the recommended way to pass a value is QVariant::StringList but
-  //       for back compatibility a string representation either in the form
-  //       of a JSON array or in the form of {"quoted_str", 1, ... } is
-  //       also accepted
   QStringList checkList;
   if ( value.type() == QVariant::StringList )
   {
@@ -183,7 +179,7 @@ QStringList QgsValueRelationFieldFormatter::valueToStringList( const QVariant &v
     auto newVal { value };
     if ( newVal.toString().trimmed().startsWith( '{' ) )
     {
-      newVal = QVariant( newVal.toString().trimmed().mid( 1 ).chopped( 1 ).prepend( '[' ).append( ']' ) );
+      newVal = QVariant( newVal.toString().trimmed().mid( 1 ).mid( 0, newVal.toString().length() - 2 ).prepend( '[' ).append( ']' ) );
     }
     if ( newVal.toString().trimmed().startsWith( '[' ) )
     {

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const override;
 
     /**
-     * Utility to convert an array or a string representation of an array \a value to a string list
+     * Utility to convert an array or a string representation of an (C style: {1,2...}) array in the form \a value to a string list
      * \since QGIS 3.2
      */
     static QStringList valueToStringList( const QVariant &value );

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const override;
 
     /**
-     * Utility to convert an array or a string representation of an (C style: {1,2...}) array in the form \a value to a string list
+     * Utility to convert a list or a string representation of an (hstore style: {1,2...}) list in \a value to a string list
      * \since QGIS 3.2
      */
     static QStringList valueToStringList( const QVariant &value );

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -347,7 +347,7 @@ QVariantList QgsJsonUtils::parseArray( const QString &json, QVariant::Type type 
       }
       else if ( item.is_null() )
       {
-        // do nothing: the default is null
+        v = QVariant( type );
       }
       else
       {

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -347,7 +347,8 @@ QVariantList QgsJsonUtils::parseArray( const QString &json, QVariant::Type type 
       }
       else if ( item.is_null() )
       {
-        v = QVariant( type );
+        // Fallback to int
+        v = QVariant( type == QVariant::Type::Invalid ? QVariant::Type::Int : type );
       }
       else
       {

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -315,28 +315,69 @@ QString QgsJsonUtils::exportAttributes( const QgsFeature &feature, QgsVectorLaye
 
 QVariantList QgsJsonUtils::parseArray( const QString &json, QVariant::Type type )
 {
-  QJsonParseError error;
-  const QJsonDocument jsonDoc = QJsonDocument::fromJson( json.toUtf8(), &error );
+  QString errorMessage;
   QVariantList result;
-  if ( error.error != QJsonParseError::NoError )
+  try
   {
-    QgsLogger::warning( QStringLiteral( "Cannot parse json (%1): %2" ).arg( error.errorString(), json ) );
-    return result;
+    const auto jObj { json::parse( json.toStdString() ) };
+    if ( ! jObj.is_array() )
+    {
+      throw json::parse_error::create( 0, 0, QStringLiteral( "JSON value must be an array" ).toStdString() );
+    }
+    for ( const auto &item : jObj )
+    {
+      // Create a QVariant from the array item
+      QVariant v;
+      if ( item.is_number_integer() )
+      {
+        v = item.get<int>();
+      }
+      else if ( item.is_number_unsigned() )
+      {
+        v = item.get<unsigned>();
+      }
+      else if ( item.is_number_float() )
+      {
+        // Note: it's a double and not a float on purpose
+        v = item.get<double>();
+      }
+      else if ( item.is_string() )
+      {
+        v = QString::fromStdString( item.get<std::string>() );
+      }
+      else if ( item.is_null() )
+      {
+        // do nothing: the default is null
+      }
+      else
+      {
+        // do nothing and discard the item
+      }
+
+      // If a destination type was specified (it's not invalid), try to convert
+      if ( type != QVariant::Invalid )
+      {
+        if ( ! v.convert( static_cast<int>( type ) ) )
+        {
+          QgsLogger::warning( QStringLiteral( "Cannot convert json array element to specified type, ignoring: %1" ).arg( v.toString() ) );
+        }
+        else
+        {
+          result.push_back( v );
+        }
+      }
+      else
+      {
+        result.push_back( v );
+      }
+    }
   }
-  if ( !jsonDoc.isArray() )
+  catch ( json::parse_error ex )
   {
-    QgsLogger::warning( QStringLiteral( "Cannot parse json (%1) as array: %2" ).arg( error.errorString(), json ) );
-    return result;
+    errorMessage = ex.what();
+    QgsLogger::warning( QStringLiteral( "Cannot parse json (%1): %2" ).arg( ex.what(), json ) );
   }
-  const auto constArray = jsonDoc.array();
-  for ( const QJsonValue &cur : constArray )
-  {
-    QVariant curVariant = cur.toVariant();
-    if ( curVariant.convert( type ) )
-      result.append( curVariant );
-    else
-      QgsLogger::warning( QStringLiteral( "Cannot convert json array element: %1" ).arg( cur.toString() ) );
-  }
+
   return result;
 }
 

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -328,18 +328,20 @@ class CORE_EXPORT QgsJsonUtils
         const QVector<QVariant> &attributeWidgetCaches = QVector<QVariant>() ) SIP_SKIP;
 
     /**
-     * Parse a simple array (depth=1).
+     * Parse a simple array (depth=1)
      * \param json the JSON to parse
-     * \param type the type of the elements
+     * \param type optional variant type of the elements, if specified (and not Invalid),
+     *        the array items will be converted to the type, and discarded if
+     *        the conversion is not possible.
      * \since QGIS 3.0
      */
-    static QVariantList parseArray( const QString &json, QVariant::Type type );
+    static QVariantList parseArray( const QString &json, QVariant::Type type = QVariant::Invalid );
 
 
     /**
      * Converts a QVariant \a v to a json object
      * \note Not available in Python bindings
-     * \since QGIS 3.10
+     * \since QGIS 3.8
      */
     static json jsonFromVariant( const QVariant &v ) SIP_SKIP;
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -115,6 +115,9 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
      */
     int columnCount() const;
 
+    //! Returns the variant type of the fk
+    QVariant::Type fkType() const;
+
     //! Sets the values for the widgets, re-creates the cache when required
     void populate( );
 

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -581,7 +581,10 @@ QVariant QgsSpatiaLiteFeatureIterator::getFeatureAttribute( sqlite3_stmt *stmt, 
     {
       // assume arrays are stored as JSON
       QVariant result = QVariant( QgsJsonUtils::parseArray( txt, subType ) );
-      result.convert( type );
+      if ( ! result.convert( static_cast<int>( type ) ) )
+      {
+        QgsDebugMsgLevel( QStringLiteral( "Could not convert JSON value to requested QVariant type" ).arg( txt ), 3 );
+      }
       return result;
     }
     return txt;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -44,6 +44,9 @@ email                : a.furieri@lqt.it
 #include <QDir>
 #include <QRegularExpression>
 
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
 
 const QString SPATIALITE_KEY = QStringLiteral( "spatialite" );
 const QString SPATIALITE_DESCRIPTION = QStringLiteral( "SpatiaLite data provider" );
@@ -662,6 +665,10 @@ static TypeSubType getVariantType( const QString &type )
     TypeSubType subType = getVariantType( type.mid( SPATIALITE_ARRAY_PREFIX.length(),
                                           type.length() - SPATIALITE_ARRAY_PREFIX.length() - SPATIALITE_ARRAY_SUFFIX.length() ) );
     return TypeSubType( subType.first == QVariant::String ? QVariant::StringList : QVariant::List, subType.first );
+  }
+  else if ( type == QLatin1String( "jsonarray" ) )
+  {
+    return TypeSubType( QVariant::List, QVariant::Invalid );
   }
   else
     // for sure any SQLite value can be represented as SQLITE_TEXT
@@ -4385,6 +4392,7 @@ bool QgsSpatiaLiteProvider::changeAttributeValues( const QgsChangedAttributesMap
           first = false;
 
         QVariant::Type type = fld.type();
+        const auto typeName { fld.typeName() };
 
         if ( val.isNull() || !val.isValid() )
         {
@@ -4398,8 +4406,27 @@ bool QgsSpatiaLiteProvider::changeAttributeValues( const QgsChangedAttributesMap
         }
         else if ( type == QVariant::StringList || type == QVariant::List )
         {
-          // binding an array value
-          sql += QStringLiteral( "%1=%2" ).arg( QgsSqliteUtils::quotedIdentifier( fld.name() ), QgsSqliteUtils::quotedString( QgsJsonUtils::encodeValue( val ) ) );
+          // binding an array value, parse JSON
+          QString jRepr;
+          try
+          {
+            const auto jObj { QgsJsonUtils::jsonFromVariant( val ) };
+            if ( ! jObj.is_array() )
+            {
+              throw json::parse_error::create( 0, 0, tr( "JSON value must be an array" ).toStdString() );
+            }
+            jRepr = QString::fromStdString( jObj.dump( ) );
+            sql += QStringLiteral( "%1=%2" ).arg( QgsSqliteUtils::quotedIdentifier( fld.name() ),  QgsSqliteUtils::quotedString( jRepr ) );
+          }
+          catch ( json::exception ex )
+          {
+            const auto errM { tr( "Field type is JSON but the value cannot be converted to JSON array: %1" ).arg( ex.what() ) };
+            auto msgPtr { static_cast<char *>( sqlite3_malloc( errM.length() + 1 ) ) };
+            strcpy( static_cast<char *>( msgPtr ), errM.toStdString().c_str() );
+            errMsg = msgPtr;
+            handleError( jRepr, errMsg, true );
+            return false;
+          }
         }
         else
         {

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -34,162 +34,199 @@ class TestQgsJsonUtils : public QObject
     Q_ENUM( JsonAlgs )
 
     Q_OBJECT
+
   private slots:
-    void testStringList()
-    {
-      QStringList list;
-
-      {
-        const QString json = QgsJsonUtils::encodeValue( list );
-        QCOMPARE( json, QString( "[]" ) );
-        const QVariant back = QgsJsonUtils::parseArray( json, QVariant::String );
-        QCOMPARE( back.toStringList(), list );
-      }
-
-      {
-        list << QStringLiteral( "one" ) << QStringLiteral( "<',\"\\>" ) << QStringLiteral( "two" );
-        const QString json = QgsJsonUtils::encodeValue( list );
-        QCOMPARE( json, QString( "[\"one\",\"<',\\\"\\\\>\",\"two\"]" ) );
-        const QVariant back = QgsJsonUtils::parseArray( json, QVariant::String );
-        QCOMPARE( back.toStringList(), list );
-      }
-    }
-
-    void testIntList()
-    {
-      QVariantList list;
-
-      {
-        list << 1 << -2;
-        const QString json = QgsJsonUtils::encodeValue( list );
-        QCOMPARE( json, QString( "[1,-2]" ) );
-        const QVariantList back = QgsJsonUtils::parseArray( json, QVariant::Int );
-        QCOMPARE( back, list );
-        QCOMPARE( back.at( 0 ).type(), QVariant::Int );
-      }
-
-      {
-        // check invalid entries are ignored
-        const QVariantList back = QgsJsonUtils::parseArray( QStringLiteral( "[1,\"a\",-2]" ), QVariant::Int );
-        QCOMPARE( back, list );
-      }
-    }
-
-    void testDoubleList()
-    {
-      QVariantList list;
-
-      list << 1.0 << -2.2456;
-      const QString json = QgsJsonUtils::encodeValue( list );
-      QCOMPARE( json, QString( "[1,-2.2456]" ) );
-      const QVariantList back = QgsJsonUtils::parseArray( json, QVariant::Double );
-      QCOMPARE( back, list );
-      QCOMPARE( back.at( 0 ).type(), QVariant::Double );
-    }
-
-    void testExportAttributesJson_data()
-    {
-      QTest::addColumn<JsonAlgs>( "jsonAlg" );
-      QTest::newRow( "Use json" ) << JsonAlgs::Json;
-      QTest::newRow( "Use old string concat" ) << JsonAlgs::String;
-    }
-
-    void testExportAttributesJson()
-    {
-
-      QFETCH( enum JsonAlgs, jsonAlg );
-
-      QgsVectorLayer vl { QStringLiteral( "Point?field=fldtxt:string&field=fldint:integer&field=flddbl:double" ), QStringLiteral( "mem" ), QStringLiteral( "memory" ) };
-      QgsFeature feature { vl.fields() };
-      feature.setAttributes( QgsAttributes() << QStringLiteral( "a value" ) << 1 << 2.0 );
-
-      if ( jsonAlg == JsonAlgs::Json )  // 0.0022
-      {
-        QBENCHMARK
-        {
-          json j { QgsJsonUtils::exportAttributesToJsonObject( feature, &vl ) };
-          QCOMPARE( QString::fromStdString( j.dump() ), QStringLiteral( R"raw({"flddbl":2.0,"fldint":1,"fldtxt":"a value"})raw" ) );
-        }
-      }
-      else // 0.0032
-      {
-        QBENCHMARK
-        {
-          const auto json { QgsJsonUtils::exportAttributes( feature, &vl ) };
-          QCOMPARE( json, QStringLiteral( "{\"fldtxt\":\"a value\",\n\"fldint\":1,\n\"flddbl\":2}" ) );
-        }
-      }
-    }
-
-    void testExportFeatureJson()
-    {
-
-
-      QgsVectorLayer vl { QStringLiteral( "Polygon?field=fldtxt:string&field=fldint:integer&field=flddbl:double" ), QStringLiteral( "mem" ), QStringLiteral( "memory" ) };
-      QgsFeature feature { vl.fields() };
-      feature.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POLYGON((1.12 1.34,5.45 1.12,5.34 5.33,1.56 5.2,1.12 1.34),(2 2, 3 2, 3 3, 2 3,2 2))" ) ) );
-      feature.setAttributes( QgsAttributes() << QStringLiteral( "a value" ) << 1 << 2.0 );
-
-      QgsJsonExporter exporter { &vl };
-
-      const auto expectedJson { QStringLiteral( "{\"bbox\":[[1.12,1.12,5.45,5.33]],\"geometry\":{\"coordinates\":"
-                                "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
-                                "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
-                                ",\"id\":0,\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}"
-                                ",\"type\":\"Feature\"}" ) };
-
-      const auto j { exporter.exportFeatureToJsonObject( feature ) };
-      QCOMPARE( QString::fromStdString( j.dump() ),  expectedJson );
-      const auto json { exporter.exportFeature( feature ) };
-      QCOMPARE( json, expectedJson );
-    }
-
-
-    void testExportGeomToJson()
-    {
-      const QMap<QString, QString> testWkts
-      {
-        {
-          {
-            QStringLiteral( "LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)" ),
-            QStringLiteral( R"json({"coordinates":[[-71.16,42.259],[-71.161,42.259],[-71.161,42.259]],"type":"LineString"})json" )
-          },
-          {
-            QStringLiteral( "MULTILINESTRING((-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932), (-70 43.56, -67 44.68))" ),
-            QStringLiteral( R"json({"coordinates":[[[-71.16,42.259],[-71.161,42.259],[-71.161,42.259]],[[-70.0,43.56],[-67.0,44.68]]],"type":"MultiLineString"})json" )
-          },
-          { QStringLiteral( "POINT(-71.064544 42.28787)" ), QStringLiteral( R"json({"coordinates":[-71.065,42.288],"type":"Point"})json" ) },
-          { QStringLiteral( "MULTIPOINT(-71.064544 42.28787, -71.1776585052917 42.3902909739571)" ), QStringLiteral( R"json({"coordinates":[[-71.065,42.288],[-71.178,42.39]],"type":"MultiPoint"})json" ) },
-          {
-            QStringLiteral( "POLYGON((-71.1776585052917 42.3902909739571,-71.1776820268866 42.3903701743239,"
-                            "-71.1776063012595 42.3903825660754,-71.1775826583081 42.3903033653531,-71.1776585052917 42.3902909739571))" ),
-            QStringLiteral( R"json({"coordinates":[[[-71.178,42.39],[-71.178,42.39],[-71.178,42.39],[-71.178,42.39],[-71.178,42.39]]],"type":"Polygon"})json" )
-          },
-          {
-            QStringLiteral( "MULTIPOLYGON(((1 1,5 1,5 5,1 5,1 1),(2 2, 3 2, 3 3, 2 3,2 2)),((3 3,6 2,6 4,3 3)))" ),
-            QStringLiteral( R"json({"coordinates":[[[[1.0,1.0],[5.0,1.0],[5.0,5.0],[1.0,5.0],[1.0,1.0]],[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],[[[3.0,3.0],[6.0,2.0],[6.0,4.0],[3.0,3.0]]]],"type":"MultiPolygon"})json" )
-          },
-          // Note: CIRCULARSTRING json is very long, we will check first three vertices only
-          { QStringLiteral( "CIRCULARSTRING(220268 150415,220227 150505,220227 150406)" ), QStringLiteral( R"json({"coordinates":[[220268.0,150415.0],[220268.7,150415.535],[220269.391,150416.081])json" ) },
-        }
-      };
-
-      for ( const auto &w : testWkts.toStdMap() )
-      {
-        const auto g { QgsGeometry::fromWkt( w.first ) };
-        QVERIFY( !g.isNull( ) );
-        if ( w.first.startsWith( QStringLiteral( "CIRCULARSTRING" ) ) )
-        {
-          QVERIFY( g.asJson( 3 ).startsWith( w.second ) );
-          QCOMPARE( QString::fromStdString( g.asJsonObject( 3 )["type"].dump() ), QStringLiteral( R"("LineString")" ) );
-        }
-        else
-        {
-          QCOMPARE( g.asJson( 3 ), w.second );
-        }
-      }
-    }
+    void testStringList();
+    void testJsonArray();
+    void testIntList();
+    void testDoubleList();
+    void testExportAttributesJson_data();
+    void testExportAttributesJson();
+    void testExportFeatureJson();
+    void testExportGeomToJson();
 };
+
+
+
+void TestQgsJsonUtils::testStringList()
+{
+  QStringList list;
+
+  {
+    const QString json = QgsJsonUtils::encodeValue( list );
+    QCOMPARE( json, QString( "[]" ) );
+    const QVariant back = QgsJsonUtils::parseArray( json, QVariant::String );
+    QCOMPARE( back.toStringList(), list );
+  }
+
+  {
+    list << QStringLiteral( "one" ) << QStringLiteral( "<',\"\\>" ) << QStringLiteral( "two" );
+    const QString json = QgsJsonUtils::encodeValue( list );
+    QCOMPARE( json, QString( "[\"one\",\"<',\\\"\\\\>\",\"two\"]" ) );
+    const QVariant back = QgsJsonUtils::parseArray( json, QVariant::String );
+    QCOMPARE( back.toStringList(), list );
+  }
+}
+
+void TestQgsJsonUtils::testJsonArray()
+{
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1,2,3])", QVariant::Int ), QVariantList() << 1 << 2 << 3 );
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1,2,3])" ), QVariantList() << 1 << 2 << 3 );
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1,2,3])", QVariant::Double ), QVariantList() << 1.0 << 2.0 << 3.0 );
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1.0,2.0,3.0])" ), QVariantList() << 1.0 << 2.0 << 3.0 );
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1.234567,2.00003e+4,-3.01234e-02])" ), QVariantList() << 1.234567 << 2.00003e+4 << -3.01234e-2 );
+  // Strings
+  QCOMPARE( QgsJsonUtils::parseArray( R"(["one", "two", "three"])" ), QVariantList() << "one" << "two" << "three" );
+  QCOMPARE( QgsJsonUtils::parseArray( R"(["one,comma", "two[]brackets", "three\"escaped"])" ), QVariantList() << "one,comma" << "two[]brackets" << "three\"escaped" );
+  // Nested (not implemented: discard deeper levels)
+  //QCOMPARE( QgsJsonUtils::parseArray( R"([1.0,[2.0,5.0],3.0])" ), QVariantList() << 1.0 << 3.0 );
+  // Mixed types
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1,"a",2.0])" ), QVariantList() << 1 << "a" << 2.0 );
+  // discarded ...
+  QCOMPARE( QgsJsonUtils::parseArray( R"([1,"a",2.0])", QVariant::Int ), QVariantList() << 1 << 2.0 );
+  // Try invalid JSON
+  QCOMPARE( QgsJsonUtils::parseArray( R"(not valid json here)" ), QVariantList() );
+  QCOMPARE( QgsJsonUtils::parseArray( R"(not valid json here)", QVariant::Int ), QVariantList() );
+  // Empty
+  QCOMPARE( QgsJsonUtils::parseArray( R"([])", QVariant::Int ), QVariantList() );
+  QCOMPARE( QgsJsonUtils::parseArray( "", QVariant::Int ), QVariantList() );
+  // Nulls
+  QCOMPARE( QgsJsonUtils::parseArray( R"([null, null])" ), QVariantList() << QVariant() << QVariant() );
+}
+
+void TestQgsJsonUtils::testIntList()
+{
+  QVariantList list;
+
+  {
+    list << 1 << -2;
+    const QString json = QgsJsonUtils::encodeValue( list );
+    QCOMPARE( json, QString( "[1,-2]" ) );
+    const QVariantList back = QgsJsonUtils::parseArray( json, QVariant::Int );
+    QCOMPARE( back, list );
+    QCOMPARE( back.at( 0 ).type(), QVariant::Int );
+  }
+
+  {
+    // check invalid entries are ignored
+    const QVariantList back = QgsJsonUtils::parseArray( QStringLiteral( "[1,\"a\",-2]" ), QVariant::Int );
+    QCOMPARE( back, list );
+  }
+}
+
+void TestQgsJsonUtils::testDoubleList()
+{
+  QVariantList list;
+
+  list << 1.0 << -2.2456;
+  const QString json = QgsJsonUtils::encodeValue( list );
+  QCOMPARE( json, QString( "[1,-2.2456]" ) );
+  const QVariantList back = QgsJsonUtils::parseArray( json, QVariant::Double );
+  QCOMPARE( back, list );
+  QCOMPARE( back.at( 0 ).type(), QVariant::Double );
+}
+
+void TestQgsJsonUtils::testExportAttributesJson_data()
+{
+  QTest::addColumn<JsonAlgs>( "JsonAlgs" );
+  QTest::newRow( "Use json" ) << JsonAlgs::Json;
+  QTest::newRow( "Use old string concat" ) << JsonAlgs::String;
+}
+
+void TestQgsJsonUtils::testExportAttributesJson()
+{
+
+  QFETCH( enum JsonAlgs, JsonAlgs );
+
+  QgsVectorLayer vl { QStringLiteral( "Point?field=fldtxt:string&field=fldint:integer&field=flddbl:double" ), QStringLiteral( "mem" ), QStringLiteral( "memory" ) };
+  QgsFeature feature { vl.fields() };
+  feature.setAttributes( QgsAttributes() << QStringLiteral( "a value" ) << 1 << 2.0 );
+
+  if ( JsonAlgs == JsonAlgs::Json )  // 0.0022
+  {
+    QBENCHMARK
+    {
+      json j { QgsJsonUtils::exportAttributesToJsonObject( feature, &vl ) };
+      QCOMPARE( QString::fromStdString( j.dump() ), QStringLiteral( R"raw({"flddbl":2.0,"fldint":1,"fldtxt":"a value"})raw" ) );
+    }
+  }
+  else // 0.0032
+  {
+    QBENCHMARK
+    {
+      const auto json { QgsJsonUtils::exportAttributes( feature, &vl ) };
+      QCOMPARE( json, QStringLiteral( "{\"fldtxt\":\"a value\",\n\"fldint\":1,\n\"flddbl\":2}" ) );
+    }
+  }
+}
+
+void TestQgsJsonUtils::testExportFeatureJson()
+{
+
+
+  QgsVectorLayer vl { QStringLiteral( "Polygon?field=fldtxt:string&field=fldint:integer&field=flddbl:double" ), QStringLiteral( "mem" ), QStringLiteral( "memory" ) };
+  QgsFeature feature { vl.fields() };
+  feature.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POLYGON((1.12 1.34,5.45 1.12,5.34 5.33,1.56 5.2,1.12 1.34),(2 2, 3 2, 3 3, 2 3,2 2))" ) ) );
+  feature.setAttributes( QgsAttributes() << QStringLiteral( "a value" ) << 1 << 2.0 );
+
+  QgsJsonExporter exporter { &vl };
+
+  const auto expectedJson { QStringLiteral( "{\"bbox\":[[1.12,1.12,5.45,5.33]],\"geometry\":{\"coordinates\":"
+                            "[[[1.12,1.34],[5.45,1.12],[5.34,5.33],[1.56,5.2],[1.12,1.34]],"
+                            "[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],\"type\":\"Polygon\"}"
+                            ",\"id\":0,\"properties\":{\"flddbl\":2.0,\"fldint\":1,\"fldtxt\":\"a value\"}"
+                            ",\"type\":\"Feature\"}" ) };
+
+  const auto j { exporter.exportFeatureToJsonObject( feature ) };
+  QCOMPARE( QString::fromStdString( j.dump() ),  expectedJson );
+  const auto json { exporter.exportFeature( feature ) };
+  QCOMPARE( json, expectedJson );
+}
+
+void TestQgsJsonUtils::testExportGeomToJson()
+{
+  const QMap<QString, QString> testWkts
+  {
+    {
+      {
+        QStringLiteral( "LINESTRING(-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932)" ),
+        QStringLiteral( R"json({"coordinates":[[-71.16,42.259],[-71.161,42.259],[-71.161,42.259]],"type":"LineString"})json" )
+      },
+      {
+        QStringLiteral( "MULTILINESTRING((-71.160281 42.258729,-71.160837 42.259113,-71.161144 42.25932), (-70 43.56, -67 44.68))" ),
+        QStringLiteral( R"json({"coordinates":[[[-71.16,42.259],[-71.161,42.259],[-71.161,42.259]],[[-70.0,43.56],[-67.0,44.68]]],"type":"MultiLineString"})json" )
+      },
+      { QStringLiteral( "POINT(-71.064544 42.28787)" ), QStringLiteral( R"json({"coordinates":[-71.065,42.288],"type":"Point"})json" ) },
+      { QStringLiteral( "MULTIPOINT(-71.064544 42.28787, -71.1776585052917 42.3902909739571)" ), QStringLiteral( R"json({"coordinates":[[-71.065,42.288],[-71.178,42.39]],"type":"MultiPoint"})json" ) },
+      {
+        QStringLiteral( "POLYGON((-71.1776585052917 42.3902909739571,-71.1776820268866 42.3903701743239,"
+                        "-71.1776063012595 42.3903825660754,-71.1775826583081 42.3903033653531,-71.1776585052917 42.3902909739571))" ),
+        QStringLiteral( R"json({"coordinates":[[[-71.178,42.39],[-71.178,42.39],[-71.178,42.39],[-71.178,42.39],[-71.178,42.39]]],"type":"Polygon"})json" )
+      },
+      {
+        QStringLiteral( "MULTIPOLYGON(((1 1,5 1,5 5,1 5,1 1),(2 2, 3 2, 3 3, 2 3,2 2)),((3 3,6 2,6 4,3 3)))" ),
+        QStringLiteral( R"json({"coordinates":[[[[1.0,1.0],[5.0,1.0],[5.0,5.0],[1.0,5.0],[1.0,1.0]],[[2.0,2.0],[3.0,2.0],[3.0,3.0],[2.0,3.0],[2.0,2.0]]],[[[3.0,3.0],[6.0,2.0],[6.0,4.0],[3.0,3.0]]]],"type":"MultiPolygon"})json" )
+      },
+      // Note: CIRCULARSTRING json is very long, we will check first three vertices only
+      { QStringLiteral( "CIRCULARSTRING(220268 150415,220227 150505,220227 150406)" ), QStringLiteral( R"json({"coordinates":[[220268.0,150415.0],[220268.7,150415.535],[220269.391,150416.081])json" ) },
+    }
+  };
+
+  for ( const auto &w : testWkts.toStdMap() )
+  {
+    const auto g { QgsGeometry::fromWkt( w.first ) };
+    QVERIFY( !g.isNull( ) );
+    if ( w.first.startsWith( QStringLiteral( "CIRCULARSTRING" ) ) )
+    {
+      QVERIFY( g.asJson( 3 ).startsWith( w.second ) );
+      QCOMPARE( QString::fromStdString( g.asJsonObject( 3 )["type"].dump() ), QStringLiteral( R"("LineString")" ) );
+    }
+    else
+    {
+      QCOMPARE( g.asJson( 3 ), w.second );
+    }
+  }
+}
 
 QGSTEST_MAIN( TestQgsJsonUtils )
 #include "testqgsjsonutils.moc"

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -91,19 +91,17 @@ void TestQgsJsonUtils::testJsonArray()
   QCOMPARE( QgsJsonUtils::parseArray( R"([])", QVariant::Int ), QVariantList() );
   QCOMPARE( QgsJsonUtils::parseArray( "", QVariant::Int ), QVariantList() );
   // Nulls
-  QCOMPARE( QgsJsonUtils::parseArray( R"([null, null])" ), QVariantList() << QVariant() << QVariant() );
-  QVERIFY( QVariant().isValid() );
   for ( const QVariant &value : QgsJsonUtils::parseArray( R"([null, null])" ) )
   {
     QVERIFY( value.isNull() );
-    // This would fail because the expected type is not set and an invalid QVariant is created:
-    // QVERIFY( value.isValid() );
+    QVERIFY( value.isValid() );
+    QCOMPARE( value, QVariant( QVariant::Type::Int ) );
   }
-  QCOMPARE( QgsJsonUtils::parseArray( R"([null, null])", QVariant::Type::Int ), QVariantList() << QVariant( QVariant::Type::Int ) << QVariant( QVariant::Type::Int ) );
-  for ( const QVariant &value : QgsJsonUtils::parseArray( R"([null, null])", QVariant::Type::Int ) )
+  for ( const QVariant &value : QgsJsonUtils::parseArray( R"([null, null])", QVariant::Type::Double ) )
   {
     QVERIFY( value.isNull() );
     QVERIFY( value.isValid() );
+    QCOMPARE( value, QVariant( QVariant::Type::Double ) );
   }
 }
 

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -92,6 +92,19 @@ void TestQgsJsonUtils::testJsonArray()
   QCOMPARE( QgsJsonUtils::parseArray( "", QVariant::Int ), QVariantList() );
   // Nulls
   QCOMPARE( QgsJsonUtils::parseArray( R"([null, null])" ), QVariantList() << QVariant() << QVariant() );
+  QVERIFY( QVariant().isValid() );
+  for ( const QVariant &value : QgsJsonUtils::parseArray( R"([null, null])" ) )
+  {
+    QVERIFY( value.isNull() );
+    // This would fail because the expected type is not set and an invalid QVariant is created:
+    // QVERIFY( value.isValid() );
+  }
+  QCOMPARE( QgsJsonUtils::parseArray( R"([null, null])", QVariant::Type::Int ), QVariantList() << QVariant( QVariant::Type::Int ) << QVariant( QVariant::Type::Int ) );
+  for ( const QVariant &value : QgsJsonUtils::parseArray( R"([null, null])", QVariant::Type::Int ) )
+  {
+    QVERIFY( value.isNull() );
+    QVERIFY( value.isValid() );
+  }
 }
 
 void TestQgsJsonUtils::testIntList()

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -278,7 +278,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
 
   QCOMPARE( w_municipality.mTableWidget->rowCount(), 1 );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
-  QCOMPARE( w_municipality.value(), QVariantList( { 1 } ) );
+  QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 1 } ) ) );
 
   // Filter by geometry
   cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 1 ), $geometry)" );
@@ -312,7 +312,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
 
   // Check with passing a variant list
   w_municipality.setValue( QVariantList( {1, 2} ) );
-  QCOMPARE( w_municipality.value(), QVariantList( { 2, 1 } ) );
+  QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 2, 1 } ) ) );
 
   // Check values are checked
   f3.setAttribute( QStringLiteral( "fk_municipality" ), QStringLiteral( "{1,2}" ) );
@@ -322,7 +322,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
-  QCOMPARE( w_municipality.value(), QVariantList( {2, 1 } ) );
+  QCOMPARE( w_municipality.value(), QVariant( QVariantList( {2, 1 } ) ) );
 
 }
 
@@ -694,7 +694,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
 
   // FEATURE 1
   w_favoriteauthors.setFeature( vl_json->getFeature( 1 ) );
-  QCOMPARE( w_favoriteauthors.value(), QVariantList() << 1 << 3 );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( { 1, 3 } ) ) );
   //check if first feature checked correctly (1,3)                                          pk
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );   // 1
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked ); // 2
@@ -709,7 +709,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
   w_favoriteauthors.mTableWidget->item( 4, 0 )->setCheckState( Qt::Checked );
 
   //check if first feature checked correctly (1,2,3,5)
-  QCOMPARE( w_favoriteauthors.value(), QVariantList( {1, 2, 3, 5} ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( {1, 2, 3, 5} ) ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Checked );
@@ -730,7 +730,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
 
   // FEATURE 2
   w_favoriteauthors.setFeature( vl_json->getFeature( 2 ) );
-  QCOMPARE( w_favoriteauthors.value(), QVariantList( {2, 5} ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( {2, 5} ) ) );
   //check if second feature checked correctly
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
@@ -743,7 +743,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
   // FEATURE 4
   w_favoriteauthors.setFeature( vl_json->getFeature( 4 ) );
   //check if first feature checked correctly (NULL)
-  QCOMPARE( w_favoriteauthors.value(), QVariantList() );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList() ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
@@ -755,7 +755,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
   // FEATURE 5
   w_favoriteauthors.setFeature( vl_json->getFeature( 5 ) );
   //check if first feature checked correctly (blank)
-  QCOMPARE( w_favoriteauthors.value(), QVariantList( ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( ) ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
@@ -851,7 +851,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
 
   // FEATURE 1
   w_favoriteauthors.setFeature( vl_json->getFeature( 1 ) );
-  QCOMPARE( w_favoriteauthors.value(), QVariantList( ) << "1gamma" << "3johnson\"quote" );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( { "1gamma", "3johnson\"quote" } ) ) );
   //check if first feature checked correctly (1,3)                                          pk
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );   // 1
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked ); // 2
@@ -866,7 +866,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
   w_favoriteauthors.mTableWidget->item( 4, 0 )->setCheckState( Qt::Checked );
 
   //check if first feature checked correctly (1,2,3,5)
-  QCOMPARE( w_favoriteauthors.value(), QVariantList() << "1gamma" << "2helm,comma" << "3johnson\"quote" << "5adams'singlequote" );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( { "1gamma", "2helm,comma", "3johnson\"quote", "5adams'singlequote" } ) ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Checked );
@@ -887,7 +887,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
 
   // FEATURE 2
   w_favoriteauthors.setFeature( vl_json->getFeature( 2 ) );
-  QCOMPARE( w_favoriteauthors.value(), QVariantList() << "2helm,comma" <<  "5adams'singlequote" );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( { "2helm,comma", "5adams'singlequote" } ) ) );
   //check if second feature checked correctly
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
@@ -900,7 +900,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
   // FEATURE 4
   w_favoriteauthors.setFeature( vl_json->getFeature( 4 ) );
   //check if first feature checked correctly (NULL)
-  QCOMPARE( w_favoriteauthors.value(), QVariantList( ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList( ) ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
@@ -912,7 +912,7 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
   // FEATURE 5
   w_favoriteauthors.setFeature( vl_json->getFeature( 5 ) );
   //check if first feature checked correctly (blank)
-  QCOMPARE( w_favoriteauthors.value(), QVariantList() );
+  QCOMPARE( w_favoriteauthors.value(), QVariant( QVariantList() ) );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -302,11 +302,11 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "2" ) );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "1" ) );
-  QCOMPARE( w_municipality.value(), QVariantList( { 1 } ) );
+  QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 1 } ) ) );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
   w_municipality.setValue( QStringLiteral( "{1,2}" ) );
-  QCOMPARE( w_municipality.value(), QVariantList( { 2, 1 } ) );
+  QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 2, 1 } ) ) );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
 

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -878,12 +878,10 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
   vl_json->changeAttributeValue( 1, fk_field_idx, w_favoriteauthors.value() );
   // check if stored correctly
   vl_json->commitChanges();
-  QVariantList expected_vl;
-  expected_vl << "1gamma" << "2helm,comma" << "3johnson\"quote" << "5adams'singlequote";
   QgsFeature f = vl_json->getFeature( 1 );
   QVariant attribute = f.attribute( fk_field );
-  QList<QVariant> value = attribute.toList();
-  QCOMPARE( value, expected_vl );
+  QVariantList value = attribute.toList();
+  QCOMPARE( value, QVariantList( { "1gamma", "2helm,comma", "3johnson\"quote", "5adams'singlequote" } ) );
 
   // FEATURE 2
   w_favoriteauthors.setFeature( vl_json->getFeature( 2 ) );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -27,6 +27,7 @@
 #include <QComboBox>
 #include "qgsgui.h"
 #include <gdal_version.h>
+#include <nlohmann/json.hpp>
 
 class TestQgsValueRelationWidgetWrapper : public QObject
 {
@@ -50,6 +51,8 @@ class TestQgsValueRelationWidgetWrapper : public QObject
     void testZeroIndexInRelatedTable();
     void testWithJsonInPostgres();
     void testWithJsonInGPKG();
+    void testWithJsonInSpatialite();
+    void testWithJsonInSpatialiteTextFk();
 };
 
 void TestQgsValueRelationWidgetWrapper::initTestCase()
@@ -221,7 +224,6 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
 
 }
 
-
 void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
 {
   // create a vector layer
@@ -276,7 +278,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
 
   QCOMPARE( w_municipality.mTableWidget->rowCount(), 1 );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
-  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{1}" ) );
+  QCOMPARE( w_municipality.value(), QVariantList( { 1 } ) );
 
   // Filter by geometry
   cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 1 ), $geometry)" );
@@ -300,13 +302,17 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "2" ) );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "1" ) );
-  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{1}" ) );
+  QCOMPARE( w_municipality.value(), QVariantList( { 1 } ) );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
   w_municipality.setValue( QStringLiteral( "{1,2}" ) );
-  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{2,1}" ) );
+  QCOMPARE( w_municipality.value(), QVariantList( { 2, 1 } ) );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+
+  // Check with passing a variant list
+  w_municipality.setValue( QVariantList( {1, 2} ) );
+  QCOMPARE( w_municipality.value(), QVariantList( { 2, 1 } ) );
 
   // Check values are checked
   f3.setAttribute( QStringLiteral( "fk_municipality" ), QStringLiteral( "{1,2}" ) );
@@ -316,7 +322,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
-  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{2,1}" ) );
+  QCOMPARE( w_municipality.value(), QVariantList( {2, 1 } ) );
 
 }
 
@@ -483,8 +489,11 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInPostgres()
   QCOMPARE( w_favoriteauthors_b.mTableWidget->item( 4, 0 )->checkState(), Qt::Checked );
   QCOMPARE( w_favoriteauthors_b.mTableWidget->item( 5, 0 )->text(), QStringLiteral( "Ken Follett" ) );
   QCOMPARE( w_favoriteauthors_b.mTableWidget->item( 5, 0 )->checkState(), Qt::Checked );
-}
 
+  // check value from widget wrapper
+  QCOMPARE( w_favoriteauthors_b.value().toStringList(), QStringList() << "4" << "5" << "6" );
+
+}
 
 void TestQgsValueRelationWidgetWrapper::testWithJsonInGPKG()
 {
@@ -614,6 +623,305 @@ void TestQgsValueRelationWidgetWrapper::testWithJsonInGPKG()
 #endif
 }
 
+void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialite()
+{
+
+  const auto fk_field { QStringLiteral( "json_content" ) };
+  // create ogr gpkg layers
+  QString myFileName( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  QString myTempDirName = tempDir.path();
+  QString myTempFileName = myTempDirName + QStringLiteral( "/valuerelation_widget_wrapper_test.spatialite.sqlite" );
+  QFile::copy( myFileName + QStringLiteral( "/valuerelation_widget_wrapper_test.spatialite.sqlite" ),
+               myTempFileName );
+  QFileInfo myMapFileInfo( myTempFileName );
+  QgsVectorLayer *vl_json = new QgsVectorLayer( QStringLiteral( R"(dbname='%1' table="%2")" )
+      .arg( myMapFileInfo.filePath() ).arg( QStringLiteral( "json" ) ),
+      QStringLiteral( "test" ),
+      QStringLiteral( "spatialite" ) );
+  QgsVectorLayer *vl_authors = new QgsVectorLayer( QStringLiteral( R"(dbname='%1' table="%2")" )
+      .arg( myMapFileInfo.filePath() ).arg( QStringLiteral( "authors" ) ),
+      QStringLiteral( "test" ),
+      QStringLiteral( "spatialite" ) );
+  const auto fk_field_idx { vl_json->fields().indexOf( fk_field ) };
+
+  QVERIFY( vl_json->isValid() );
+  QVERIFY( vl_authors->isValid() );
+
+  QgsProject::instance()->addMapLayer( vl_json, false, false );
+  QgsProject::instance()->addMapLayer( vl_authors, false, false );
+  vl_json->startEditing();
+
+  // build a value relation widget wrapper for authors
+  // fk_field is a json array type
+  QgsValueRelationWidgetWrapper w_favoriteauthors( vl_json, fk_field_idx, nullptr, nullptr );
+  QVariantMap cfg_favoriteautors;
+  cfg_favoriteautors.insert( QStringLiteral( "Layer" ), vl_authors->id() );
+  cfg_favoriteautors.insert( QStringLiteral( "Key" ),  QStringLiteral( "pk" ) );
+  cfg_favoriteautors.insert( QStringLiteral( "Value" ), QStringLiteral( "name" ) );
+  cfg_favoriteautors.insert( QStringLiteral( "AllowMulti" ), true );
+  cfg_favoriteautors.insert( QStringLiteral( "NofColumns" ), 1 );
+  cfg_favoriteautors.insert( QStringLiteral( "AllowNull" ), false );
+  cfg_favoriteautors.insert( QStringLiteral( "OrderByValue" ), false );
+  cfg_favoriteautors.insert( QStringLiteral( "UseCompleter" ), false );
+  w_favoriteauthors.setConfig( cfg_favoriteautors );
+  w_favoriteauthors.widget();
+  w_favoriteauthors.setEnabled( true );
+
+  //check if set up nice
+  QCOMPARE( w_favoriteauthors.mTableWidget->rowCount(), 7 );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Erich Gamma" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "1" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Richard Helm" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "2" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->text(), QStringLiteral( "Ralph Johnson" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "3" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->text(), QStringLiteral( "John Vlissides" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "4" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->text(), QStringLiteral( "Douglas Adams" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "5" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->text(), QStringLiteral( "Ken Follett" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "6" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->text(), QStringLiteral( "Gabriel García Márquez" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  /* Test data:
+  pk: 1 [1,3]
+  pk: 2 [2,5]
+  pk: 3 [4,6,7]
+  pk: 4 NULL
+  pk: 5 blank
+  */
+
+  // FEATURE 1
+  w_favoriteauthors.setFeature( vl_json->getFeature( 1 ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariantList() << 1 << 3 );
+  //check if first feature checked correctly (1,3)                                          pk
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );   // 1
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked ); // 2
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Checked );   // 3
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked ); // 4
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Unchecked ); // 5
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked ); // 6
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked ); // 7
+
+  //check other authors
+  w_favoriteauthors.mTableWidget->item( 1, 0 )->setCheckState( Qt::Checked );
+  w_favoriteauthors.mTableWidget->item( 4, 0 )->setCheckState( Qt::Checked );
+
+  //check if first feature checked correctly (1,2,3,5)
+  QCOMPARE( w_favoriteauthors.value(), QVariantList( {1, 2, 3, 5} ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  vl_json->changeAttributeValue( 1, fk_field_idx, w_favoriteauthors.value() );
+  // check if stored correctly
+  vl_json->commitChanges();
+  QVariantList expected_vl;
+  expected_vl << "1" << "2" << "3" << "5";
+  QgsFeature f = vl_json->getFeature( 1 );
+  QVariant attribute = f.attribute( fk_field );
+  QList<QVariant> value = attribute.toList();
+  QCOMPARE( value, expected_vl );
+
+  // FEATURE 2
+  w_favoriteauthors.setFeature( vl_json->getFeature( 2 ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariantList( {2, 5} ) );
+  //check if second feature checked correctly
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  // FEATURE 4
+  w_favoriteauthors.setFeature( vl_json->getFeature( 4 ) );
+  //check if first feature checked correctly (NULL)
+  QCOMPARE( w_favoriteauthors.value(), QVariantList() );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  // FEATURE 5
+  w_favoriteauthors.setFeature( vl_json->getFeature( 5 ) );
+  //check if first feature checked correctly (blank)
+  QCOMPARE( w_favoriteauthors.value(), QVariantList( ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+}
+
+
+void TestQgsValueRelationWidgetWrapper::testWithJsonInSpatialiteTextFk()
+{
+
+  const auto fk_field { QStringLiteral( "json_content_text" ) };
+  // create ogr gpkg layers
+  QString myFileName( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  QString myTempDirName = tempDir.path();
+  QString myTempFileName = myTempDirName + QStringLiteral( "/valuerelation_widget_wrapper_test.spatialite.sqlite" );
+  QFile::copy( myFileName + QStringLiteral( "/valuerelation_widget_wrapper_test.spatialite.sqlite" ),
+               myTempFileName );
+  QFileInfo myMapFileInfo( myTempFileName );
+  QgsVectorLayer *vl_json = new QgsVectorLayer( QStringLiteral( R"(dbname='%1' table="%2")" )
+      .arg( myMapFileInfo.filePath() ).arg( QStringLiteral( "json" ) ),
+      QStringLiteral( "test" ),
+      QStringLiteral( "spatialite" ) );
+  QgsVectorLayer *vl_authors = new QgsVectorLayer( QStringLiteral( R"(dbname='%1' table="%2")" )
+      .arg( myMapFileInfo.filePath() ).arg( QStringLiteral( "authors" ) ),
+      QStringLiteral( "test" ),
+      QStringLiteral( "spatialite" ) );
+  const auto fk_field_idx { vl_json->fields().indexOf( fk_field ) };
+
+  QVERIFY( vl_json->isValid() );
+  QVERIFY( vl_authors->isValid() );
+
+  QgsProject::instance()->addMapLayer( vl_json, false, false );
+  QgsProject::instance()->addMapLayer( vl_authors, false, false );
+  vl_json->startEditing();
+
+  // build a value relation widget wrapper for authors
+  // fk_field is a json array type
+  QgsValueRelationWidgetWrapper w_favoriteauthors( vl_json, fk_field_idx, nullptr, nullptr );
+  QVariantMap cfg_favoriteautors;
+  cfg_favoriteautors.insert( QStringLiteral( "Layer" ), vl_authors->id() );
+  cfg_favoriteautors.insert( QStringLiteral( "Key" ),  QStringLiteral( "pk_text" ) );
+  cfg_favoriteautors.insert( QStringLiteral( "Value" ), QStringLiteral( "name" ) );
+  cfg_favoriteautors.insert( QStringLiteral( "AllowMulti" ), true );
+  cfg_favoriteautors.insert( QStringLiteral( "NofColumns" ), 1 );
+  cfg_favoriteautors.insert( QStringLiteral( "AllowNull" ), false );
+  cfg_favoriteautors.insert( QStringLiteral( "OrderByValue" ), false );
+  cfg_favoriteautors.insert( QStringLiteral( "UseCompleter" ), false );
+  w_favoriteauthors.setConfig( cfg_favoriteautors );
+  w_favoriteauthors.widget();
+  w_favoriteauthors.setEnabled( true );
+
+  //check if set up nice
+  QCOMPARE( w_favoriteauthors.mTableWidget->rowCount(), 7 );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Erich Gamma" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "1gamma" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Richard Helm" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "2helm,comma" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->text(), QStringLiteral( "Ralph Johnson" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "3johnson\"quote" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->text(), QStringLiteral( "John Vlissides" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "4vlissides" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->text(), QStringLiteral( "Douglas Adams" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "5adams'singlequote" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->text(), QStringLiteral( "Ken Follett" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "6follett{}" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->text(), QStringLiteral( "Gabriel García Márquez" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "7garcìa][" ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  /* Test data:
+
+    Keys:
+    "1gamma"
+    "2helm,comma"
+    "3johnson""quote"
+    "4vlissides"
+    "5adams'singlequote"
+    "6follett{}"
+    "7garcìa]["
+
+    Data:
+    1 "[1,3]" "[""1gamma"", ""3johnson\""quote""]
+    2 "[2,5]" "[""2helm,comma"", ""5adams'singlequote""]"
+    3 "[4,6,7]" "[""4vlissides"", ""6follett{}"" , ""7garcìa][""]"
+    5
+    7 ""  ""
+
+  */
+
+  // FEATURE 1
+  w_favoriteauthors.setFeature( vl_json->getFeature( 1 ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariantList( ) << "1gamma" << "3johnson\"quote" );
+  //check if first feature checked correctly (1,3)                                          pk
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );   // 1
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked ); // 2
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Checked );   // 3
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked ); // 4
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Unchecked ); // 5
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked ); // 6
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked ); // 7
+
+  //check other authors
+  w_favoriteauthors.mTableWidget->item( 1, 0 )->setCheckState( Qt::Checked );
+  w_favoriteauthors.mTableWidget->item( 4, 0 )->setCheckState( Qt::Checked );
+
+  //check if first feature checked correctly (1,2,3,5)
+  QCOMPARE( w_favoriteauthors.value(), QVariantList() << "1gamma" << "2helm,comma" << "3johnson\"quote" << "5adams'singlequote" );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  vl_json->changeAttributeValue( 1, fk_field_idx, w_favoriteauthors.value() );
+  // check if stored correctly
+  vl_json->commitChanges();
+  QVariantList expected_vl;
+  expected_vl << "1gamma" << "2helm,comma" << "3johnson\"quote" << "5adams'singlequote";
+  QgsFeature f = vl_json->getFeature( 1 );
+  QVariant attribute = f.attribute( fk_field );
+  QList<QVariant> value = attribute.toList();
+  QCOMPARE( value, expected_vl );
+
+  // FEATURE 2
+  w_favoriteauthors.setFeature( vl_json->getFeature( 2 ) );
+  QCOMPARE( w_favoriteauthors.value(), QVariantList() << "2helm,comma" <<  "5adams'singlequote" );
+  //check if second feature checked correctly
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  // FEATURE 4
+  w_favoriteauthors.setFeature( vl_json->getFeature( 4 ) );
+  //check if first feature checked correctly (NULL)
+  QCOMPARE( w_favoriteauthors.value(), QVariantList( ) );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+  // FEATURE 5
+  w_favoriteauthors.setFeature( vl_json->getFeature( 5 ) );
+  //check if first feature checked correctly (blank)
+  QCOMPARE( w_favoriteauthors.value(), QVariantList() );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 1, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 2, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 3, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 4, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 5, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_favoriteauthors.mTableWidget->item( 6, 0 )->checkState(), Qt::Unchecked );
+
+}
 
 QGSTEST_MAIN( TestQgsValueRelationWidgetWrapper )
 #include "testqgsvaluerelationwidgetwrapper.moc"

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -163,6 +163,12 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         sql += "VALUES (1, '[\"toto\",\"tutu\"]', '[1,-2,724562]', '[1.0, -232567.22]', GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326))"
         cur.execute(sql)
 
+        # table with different array types, stored as JSON
+        sql = "CREATE TABLE test_arrays_write (Id INTEGER NOT NULL PRIMARY KEY, array JSONARRAY NOT NULL, strings JSONSTRINGLIST NOT NULL, ints JSONINTEGERLIST NOT NULL, reals JSONREALLIST NOT NULL)"
+        cur.execute(sql)
+        sql = "SELECT AddGeometryColumn('test_arrays_write', 'Geometry', 4326, 'POLYGON', 'XY')"
+        cur.execute(sql)
+
         # 2 tables with relations
         sql = "PRAGMA foreign_keys = ON;"
         cur.execute(sql)
@@ -532,6 +538,45 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(read_back['strings'], new_f['strings'])
         self.assertEqual(read_back['ints'], new_f['ints'])
         self.assertEqual(read_back['reals'], new_f['reals'])
+
+    def test_arrays_write(self):
+        """Test writing of layers with arrays"""
+        l = QgsVectorLayer("dbname=%s table=test_arrays_write (geometry)" % self.dbname, "test_arrays", "spatialite")
+        self.assertTrue(l.isValid())
+
+        new_f = QgsFeature(l.fields())
+        new_f['id'] = 2
+        new_f['array'] = ['simple', '"doubleQuote"', "'quote'", 'back\\slash']
+        new_f['strings'] = ['simple', '"doubleQuote"', "'quote'", 'back\\slash']
+        new_f['ints'] = [1, 2, 3, 4]
+        new_f['reals'] = [1e67, 1e-56]
+        r, fs = l.dataProvider().addFeatures([new_f])
+        self.assertTrue(r)
+
+        read_back = l.getFeature(new_f['id'])
+        self.assertEqual(read_back['id'], new_f['id'])
+        self.assertEqual(read_back['array'], new_f['array'])
+        self.assertEqual(read_back['strings'], new_f['strings'])
+        self.assertEqual(read_back['ints'], new_f['ints'])
+        self.assertEqual(read_back['reals'], new_f['reals'])
+
+        new_f = QgsFeature(l.fields())
+        new_f['id'] = 3
+        new_f['array'] = [1, 1.2345, '"doubleQuote"', "'quote'", 'back\\slash']
+        new_f['strings'] = ['simple', '"doubleQuote"', "'quote'", 'back\\slash']
+        new_f['ints'] = [1, 2, 3, 4]
+        new_f['reals'] = [1e67, 1e-56]
+        r, fs = l.dataProvider().addFeatures([new_f])
+        self.assertTrue(r)
+
+        read_back = l.getFeature(new_f['id'])
+        self.assertEqual(read_back['id'], new_f['id'])
+        self.assertEqual(read_back['array'], new_f['array'])
+        self.assertEqual(read_back['strings'], new_f['strings'])
+        self.assertEqual(read_back['ints'], new_f['ints'])
+        self.assertEqual(read_back['reals'], new_f['reals'])
+
+        read_back = l.getFeature(new_f['id'])
 
     def test_discover_relation(self):
         artist = QgsVectorLayer("dbname=%s table=test_relation_a (geometry)" % self.dbname, "test_relation_a", "spatialite")

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -130,7 +130,12 @@ class TestQgsValueRelationFieldFormatter(unittest.TestCase):
         _test([1, 2, 3], ["1", "2", "3"])
         _test("{1,2,3}", ["1", "2", "3"])
         _test(['1', '2', '3'], ["1", "2", "3"])
-        _test('not an array', ['not an array'])
+        _test('not an array', [])
+        _test('[1,2,3]', ["1", "2", "3"])
+        _test('{1,2,3}', ["1", "2", "3"])
+        _test('{"1","2","3"}', ["1", "2", "3"])
+        _test('["1","2","3"]', ["1", "2", "3"])
+        _test(r'["a string,comma","a string\"quote", "another string[]"]', ['a string,comma', 'a string"quote', 'another string[]'])
 
     def test_expressionRequiresFormScope(self):
 


### PR DESCRIPTION

Fixes #21986

plus:

- fix multiple string keys with commas in value relation widget
- more robust JSON and array (un)marshalling
- uniform array representation in value relation widgets
- lot of test coverage
- automatic QVariant type conversions in JSON utils
