### PR TITLE
Fix raster calculator invalid expressions

### DIFF
--- a/src/analysis/raster/qgsrastercalclexer.ll
+++ b/src/analysis/raster/qgsrastercalclexer.ll
@@ -36,6 +36,7 @@
   #ifdef _MSC_VER
   #define YY_NO_UNISTD_H
   #endif
+
 %}
 
 white       [ \t\r\n]+
@@ -80,7 +81,11 @@ raster_band_ref_quoted  \"(\\.|[^"])*\"
 {raster_band_ref_quoted} { return RASTER_BAND_REF; }
 
 {white}    /* skip blanks and tabs */
+
+[a-z][a-z0-9_]* { return yytext[0]; } /* other unknown tokens */
+
 %%
+
 
 void set_raster_input_buffer(const char* buffer)
 {

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -573,6 +573,20 @@ void TestQgsRasterCalculator::findNodes()
   QCOMPARE( _test( QStringLiteral( "2 + 3" ), QgsRasterCalcNode::Type::tNumber ).length(), 2 );
   QCOMPARE( _test( QStringLiteral( "2 + 3" ), QgsRasterCalcNode::Type::tOperator ).length(), 1 );
 
+  // Test parser with valid and invalid expressions
+  QString errorString;
+  const QgsRasterCalcNode *node { QgsRasterCalcNode::parseRasterCalcString( QString( ), errorString ) };
+  QVERIFY( ! node );
+  QVERIFY( ! errorString.isEmpty() );
+  errorString = QString();
+  node = QgsRasterCalcNode::parseRasterCalcString( QStringLiteral( "log10(2)" ), errorString );
+  QVERIFY( node );
+  QVERIFY( errorString.isEmpty() );
+  errorString = QString();
+  node = QgsRasterCalcNode::parseRasterCalcString( QStringLiteral( "not_a_function(2)" ), errorString );
+  QVERIFY( ! node );
+  QVERIFY( ! errorString.isEmpty() );
+
 }
 
 void TestQgsRasterCalculator::testRasterEntries()


### PR DESCRIPTION
Tell the user that is invalid instead of
silently ignoring undefined functions.

Fixes #29824
