### PR TITLE
[labeling][ui] Fix broken multiline alignment combo box

### DIFF
--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -133,9 +133,13 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
   mFieldExpressionWidget->setEnabled( mMode == Labels );
   mLabelingFrame->setEnabled( mMode == Labels );
 
-  updateWidgetForFormat( lyr.format() );
-
   blockInitSignals( true );
+
+  mGeometryGenerator->setText( lyr.geometryGenerator );
+  mGeometryGeneratorGroupBox->setChecked( lyr.geometryGeneratorEnabled );
+  mGeometryGeneratorType->setCurrentIndex( mGeometryGeneratorType->findData( lyr.geometryGeneratorType ) );
+
+  updateWidgetForFormat( lyr.format() );
 
   mFieldExpressionWidget->setRow( -1 );
   mFieldExpressionWidget->setField( lyr.fieldName );
@@ -229,7 +233,18 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
   wrapCharacterEdit->setText( lyr.wrapChar );
   mAutoWrapLengthSpinBox->setValue( lyr.autoWrapLength );
   mAutoWrapTypeComboBox->setCurrentIndex( lyr.useMaxLineLengthForAutoWrap ? 0 : 1 );
-  mFontMultiLineAlignComboBox->setCurrentIndex( lyr.multilineAlign );
+
+  if ( ( int ) lyr.multilineAlign < mFontMultiLineAlignComboBox->count() )
+  {
+    mFontMultiLineAlignComboBox->setCurrentIndex( lyr.multilineAlign );
+  }
+  else
+  {
+    // the default pal layer settings for multiline alignment is to follow label placement, which isn't always available
+    // revert to left alignment in such case
+    mFontMultiLineAlignComboBox->setCurrentIndex( 0 );
+  }
+
   chkPreserveRotation->setChecked( lyr.preserveRotation );
 
   mPreviewBackgroundBtn->setColor( lyr.previewBkgrdColor );
@@ -252,10 +267,6 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
   mFontMaxPixelSpinBox->setValue( lyr.fontMaxPixelSize );
 
   mZIndexSpinBox->setValue( lyr.zIndex );
-
-  mGeometryGenerator->setText( lyr.geometryGenerator );
-  mGeometryGeneratorGroupBox->setChecked( lyr.geometryGeneratorEnabled );
-  mGeometryGeneratorType->setCurrentIndex( mGeometryGeneratorType->findData( lyr.geometryGeneratorType ) );
 
   mDataDefinedProperties = lyr.dataDefinedProperties();
 


### PR DESCRIPTION
## Description
- setup geometry generator ui stuff first to properly initiate combobox
- for line and polygons, don't set combobox to a missing item, default to left alignment

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
