### PR TITLE
[processing] fix NDVI calculation

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/RasterCalculatorWidgets.py
@@ -122,7 +122,7 @@ WIDGET, BASE = uic.loadUiType(
 
 class ExpressionWidget(BASE, WIDGET):
 
-    _expressions = {"NDVI": "([NIR] - [Red]) % ([NIR] + [Red])"}
+    _expressions = {"NDVI": "([NIR] - [Red]) / ([NIR] + [Red])"}
 
     def __init__(self, options):
         super(ExpressionWidget, self).__init__(None)


### PR DESCRIPTION
## Description
NDVI Calculation in Processing Raster calculator with default formula added something like:

```
(B4@1 - B8@1) % (B4@1 + B8@1)
```

`%` gave some troubles. This PR just replace `%` with `/`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
