### PR TITLE
attribute table shortcuts when docked [needs-docs]

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -1193,6 +1193,18 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
     connect( this, &QObject::destroyed, mDock, &QWidget::close );
     QgisApp::instance()->addDockWidget( Qt::BottomDockWidgetArea, mDock );
     updateTitle();
+
+    // To prevent "QAction::event: Ambiguous shortcut overload"
+    QgsDebugMsg( QStringLiteral( "Remove shortcuts from attribute table already defined in main window" ) );
+    mActionCopySelectedRows->setShortcut( QKeySequence() );
+    mActionPasteFeatures->setShortcut( QKeySequence() );
+    mActionCutSelectedRows->setShortcut( QKeySequence() );
+    mActionZoomMapToSelectedRows->setShortcut( QKeySequence() );
+    mActionRemoveSelection->setShortcut( QKeySequence() );
+    mActionSelectAll->setShortcut( QKeySequence() );
+    // duplicated on Main Window, with different semantics
+    mActionPanMapToSelectedRows->setShortcut( QKeySequence() );
+    mActionSearchForm->setShortcut( QKeySequence() );
   }
   else
   {
@@ -1221,6 +1233,19 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
     updateTitle();
     mDialog->restoreGeometry( QgsSettings().value( QStringLiteral( "Windows/BetterAttributeTable/geometry" ) ).toByteArray() );
     mDialog->show();
+
+    // restore attribute table shortcuts in window mode
+    QgsDebugMsg( QStringLiteral( "Restore attribute table dialog shortcuts in window mode" ) );
+    // duplicated on Main Window
+    mActionCopySelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+C", Q_NULLPTR ) );
+    mActionPasteFeatures->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+V", Q_NULLPTR ) );
+    mActionCutSelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+X", Q_NULLPTR ) );
+    mActionZoomMapToSelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+J", nullptr ) );
+    mActionRemoveSelection->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+Shift+A", Q_NULLPTR ) );
+    mActionSelectAll->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+A", Q_NULLPTR ) );
+    // duplicated on Main Window, with different semantics
+    mActionPanMapToSelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+P", Q_NULLPTR ) );
+    mActionSearchForm->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+F", Q_NULLPTR ) );
   }
 }
 

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -1235,7 +1235,7 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
     mDialog->show();
 
     // restore attribute table shortcuts in window mode
-    QgsDebugMsg( QStringLiteral( "Restore attribute table dialog shortcuts in window mode" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Restore attribute table dialog shortcuts in window mode" ), 2 );
     // duplicated on Main Window
     mActionCopySelectedRows->setShortcut( QKeySequence( QKeySequence::Copy ) );
     mActionPasteFeatures->setShortcut( QKeySequence( QKeySequence::Paste ) );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -1195,7 +1195,7 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
     updateTitle();
 
     // To prevent "QAction::event: Ambiguous shortcut overload"
-    QgsDebugMsg( QStringLiteral( "Remove shortcuts from attribute table already defined in main window" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Remove shortcuts from attribute table already defined in main window" ), 2 );
     mActionCopySelectedRows->setShortcut( QKeySequence() );
     mActionPasteFeatures->setShortcut( QKeySequence() );
     mActionCutSelectedRows->setShortcut( QKeySequence() );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -1237,15 +1237,15 @@ void QgsAttributeTableDialog::toggleDockMode( bool docked )
     // restore attribute table shortcuts in window mode
     QgsDebugMsg( QStringLiteral( "Restore attribute table dialog shortcuts in window mode" ) );
     // duplicated on Main Window
-    mActionCopySelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+C", Q_NULLPTR ) );
-    mActionPasteFeatures->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+V", Q_NULLPTR ) );
-    mActionCutSelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+X", Q_NULLPTR ) );
-    mActionZoomMapToSelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+J", nullptr ) );
-    mActionRemoveSelection->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+Shift+A", Q_NULLPTR ) );
-    mActionSelectAll->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+A", Q_NULLPTR ) );
+    mActionCopySelectedRows->setShortcut( QKeySequence( QKeySequence::Copy ) );
+    mActionPasteFeatures->setShortcut( QKeySequence( QKeySequence::Paste ) );
+    mActionCutSelectedRows->setShortcut( QKeySequence( QKeySequence::Cut ) );
+    mActionZoomMapToSelectedRows->setShortcut( QStringLiteral( "Ctrl+J" ) );
+    mActionRemoveSelection->setShortcut( QStringLiteral( "Ctrl+Shift+A" ) );
+    mActionSelectAll->setShortcut( QStringLiteral( "Ctrl+A" ) );
     // duplicated on Main Window, with different semantics
-    mActionPanMapToSelectedRows->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+P", Q_NULLPTR ) );
-    mActionSearchForm->setShortcut( QApplication::translate( "QgsAttributeTableDialog", "Ctrl+F", Q_NULLPTR ) );
+    mActionPanMapToSelectedRows->setShortcut( QStringLiteral( "Ctrl+P" ) );
+    mActionSearchForm->setShortcut( QStringLiteral( "Ctrl+F" ) );
   }
 }
 

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -393,9 +393,6 @@
    <property name="toolTip">
     <string>Save edits (Ctrl+S)</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+S</string>
-   </property>
   </action>
   <action name="mActionReload">
    <property name="icon">
@@ -590,9 +587,6 @@
    </property>
    <property name="toolTip">
     <string>Delete field (Ctrl+L)</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+L</string>
    </property>
   </action>
   <action name="mActionAddAttribute">


### PR DESCRIPTION
## Description

We have the same shortcuts assigned to the main window and to the attribute table.

When the attribute table is docked, both (the main window and the attribute table) have conflicting shortcuts. When they are separated as two different windows, events goes to the focused one, and we don't have conflicts.

The error logged on the console was:
```
QAction::event: Ambiguous shortcut overload: Ctrl+J
```

To solve this issue, I'm using the attribute table dock/undock event to remove and recreate the shortcuts. I had to test this manually and it works.

Users reported this limitation just the <kbd>Ctrl</kbd>+<kbd>J</kbd> and <kbd>Ctrl</kbd>+<kbd>C</kbd> shortcuts, but there are more. I review all overlapping shortcuts.

This PR fixes #29633. This also fixes the duplicated #29945.

From the discussion on #29633, I agree with @nyalldawson and I'm also proposing the removal of two shortcuts on the attribute panel:

| Shortcut | Action | 
| --- | --- | 
|<kbd>Ctrl</kbd>+<kbd>L</kbd> | Delete field | 
| <kbd>Ctrl</kbd>+<kbd>S</kbd>| Save edits | 

Delete field is not a common operation. 

After the table is docked, we were not able to use <kbd>Ctrl</kbd>+<kbd>S</kbd> for saving features. Even when the table is undocked, save feature edits using the same shortcut as save project is dangerous. 

We still have <kbd>Ctrl</kbd>+<kbd>E</kbd> (toggle edit shortcut) to stop editing that works either when the table is docked or undocked.

### Documentation

On the documentation, we need to remove references to these two shortcuts that are not available any more in the attribute table:

| Shortcut | Action | 
| --- | --- | 
|<kbd>Ctrl</kbd>+<kbd>L</kbd> | Delete field | 
| <kbd>Ctrl</kbd>+<kbd>S</kbd>| Save edits | 

That is enough, I think. Eventually, if we keep a list of all QGIS shortcuts, we also need to update that list.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

Closes #29633, fix #29945,