### PR TITLE
More verbose message when deleting a layout page

### DIFF
--- a/src/app/layout/qgslayoutappmenuprovider.cpp
+++ b/src/app/layout/qgslayoutappmenuprovider.cpp
@@ -119,7 +119,7 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
     connect( removePageAction, &QAction::triggered, this, [layout, page]()
     {
       if ( QMessageBox::question( nullptr, tr( "Remove Page" ),
-                                  tr( "Remove page from layout?" ),
+                                  tr( "Remove page from layout? The items will be moved to the first page." ),
                                   QMessageBox::Yes | QMessageBox::No ) == QMessageBox::Yes )
       {
         layout->pageCollection()->deletePage( page );


### PR DESCRIPTION
## Description
Relates to #26618 (i think a proper fix would be to keep the items where they are but at least now people are aware of what's about to happen)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
