### PR TITLE
[processing] add default value to user filter matrix (fix #29999)

### DIFF
--- a/python/plugins/processing/algs/saga/description/UserDefinedFilter.txt
+++ b/python/plugins/processing/algs/saga/description/UserDefinedFilter.txt
@@ -2,5 +2,5 @@ User Defined Filter
 grid_filter
 QgsProcessingParameterRasterLayer|INPUT|Grid|None|False
 QgsProcessingParameterFeatureSource|FILTER|Filter Matrix|5|None|True
-QgsProcessingParameterMatrix|FILTER_3X3|Default Filter Matrix (3x3)|3|True|1;2;3
+QgsProcessingParameterMatrix|FILTER_3X3|Default Filter Matrix (3x3)|3|True|1;2;3|,,,,,,,,
 QgsProcessingParameterRasterDestination|RESULT|Filtered Grid


### PR DESCRIPTION
## Description
Correctly initialize "Default filter matrix" parameter with empty 3x3 table. Fixes #29999.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
