### PR TITLE
fix #30003 crash in mesh calculator

### DIFF
--- a/src/app/mesh/qgsmeshcalculatordialog.cpp
+++ b/src/app/mesh/qgsmeshcalculatordialog.cpp
@@ -464,6 +464,9 @@ void QgsMeshCalculatorDialog::useAllTimesFromLayer()
 
 QString QgsMeshCalculatorDialog::currentDatasetGroup() const
 {
+  if ( mDatasetsListWidget->count() == 0 )
+    return QString();
+
   const QList<QListWidgetItem *> items = mDatasetsListWidget->selectedItems();
   if ( !items.empty() )
     return items[0]->text();


### PR DESCRIPTION
fix #30003

QGIS 3.4 does not have mesh calculator, no need of backport 