### PR TITLE
fix #30028 Closing Vertex Edititor crashes the app

### DIFF
--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -18,6 +18,8 @@
 
 #include <memory>
 
+#include <QPointer>
+
 #include "qgis_app.h"
 #include "qgsmaptooladvanceddigitizing.h"
 #include "qgsgeometry.h"
@@ -447,7 +449,7 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! Locked feature for the vertex editor
     std::unique_ptr<QgsLockedFeature> mLockedFeature;
     //! Dock widget which allows editing vertices
-    std::unique_ptr<QgsVertexEditor> mVertexEditor;
+    QPointer<QgsVertexEditor> mVertexEditor;
 
     /**
      * Data structure that stores alternative features to the currently selected (locked) feature.


### PR DESCRIPTION
fix #30028

double delete of mVertexEditor (`unique_ptr` in context of Qt's events)