### PR TITLE
small improvements to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve QGIS.
 title: ''
-labels: 'Bug report'
+labels: 'Bug'
 assignees: ''
 
 ---
@@ -30,17 +30,9 @@ If the issue concerns a **third party plugin**, then it **cannot** be fixed by t
 3. Scroll down to '....'
 4. See error -->
 
+**QGIS and OS versions**
 
-**Desktop environment (please complete the following information):**
-
- - OS and version:
-
-**QGIS version**
-
-*Please add information available in QGIS menu help/about*
-
-  - QGIS Version: [e.g. 3.4.5]
-  - Full library versions:
+<!-- In the QGIS menu help/about, click in the dialog, Ctrl+A and then Ctrl+C. Finally paste here -->
 
 **Additional context**
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,10 @@ exemptLabels:
   - Merge After Thaw
 # Label to use when marking an issue as stale
 staleLabel: stale
+
+# # Limit to only `issues` or `pulls`
+only: pulls
+
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   The QGIS project highly values your contribution and would love to see

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -60,6 +60,7 @@
 #endif
 #include <QStatusBar>
 #include <QStringList>
+#include <QSysInfo>
 #include <QTcpSocket>
 #include <QTextStream>
 #include <QtGlobal>
@@ -4498,6 +4499,10 @@ void QgisApp::about()
 #ifdef QGISDEBUG
     versionString += "</tr><tr><td colspan=4>" + tr( "This copy of QGIS writes debugging output." ) + "</td>";
 #endif
+
+    versionString += QLatin1String( "</tr><tr>" );
+
+    versionString += "<td>" + tr( "OS Version" ) + "</td><td>" + QSysInfo::prettyProductName() + "</td>";
 
     versionString += QLatin1String( "</tr></table></div></body></html>" );
 


### PR DESCRIPTION
## Description

* Fix template about missing `Bug` label since `Bug report` has been removed
* Until we have a decision on the mailing list, disable stale bot on issues cc @wonder-sk 
* Simplify the template about QGIS/OS environment

I can manually backport for the OS.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
