### PR TITLE
Don't append full traceback to QgsProcessingExceptions

### DIFF
--- a/python/core/core.sip.in
+++ b/python/core/core.sip.in
@@ -108,13 +108,18 @@ done:
 
 %VirtualErrorHandler processing_exception_handler
     PyObject *exception, *value, *traceback;
+
     // if an explicit QgsProcessingException was raised, we don't retrieve
     // and append the trace. It's too noisy for these "expected" type errors.
     // For all other exceptions, it's likely a coding error in the algorithm,
     // so we DO retrieve the full traceback for debugging.
+    PyGILState_STATE gstate;
+    gstate = PyGILState_Ensure();
     PyTypeObject* err = reinterpret_cast< PyTypeObject* >( PyErr_Occurred() );
+    const bool isProcessingException = err && QString( err->tp_name ) == QStringLiteral( "QgsProcessingException" );
+
     QString what;
-    if ( err && QString( err->tp_name ) == QStringLiteral( "QgsProcessingException" ) )
+    if ( isProcessingException )
     {
       PyObject *type, *value, *traceback;
       PyErr_Fetch( &type, &value, &traceback );
@@ -122,9 +127,11 @@ done:
       what = QString::fromUtf8( PyUnicode_AsUTF8( str ) );
       Py_XDECREF( str );
       PyErr_Restore( type, value, traceback );
+      PyGILState_Release( gstate );
     }
     else
     {
+      PyGILState_Release( gstate );
       QString trace = getTraceback();
       QgsLogger::critical( trace );
       what = trace;

--- a/python/core/core.sip.in
+++ b/python/core/core.sip.in
@@ -107,8 +107,28 @@ done:
 %Include core_auto.sip
 
 %VirtualErrorHandler processing_exception_handler
-    QString trace = getTraceback();
-    QgsLogger::critical( trace );
+    PyObject *exception, *value, *traceback;
+    // if an explicit QgsProcessingException was raised, we don't retrieve
+    // and append the trace. It's too noisy for these "expected" type errors.
+    // For all other exceptions, it's likely a coding error in the algorithm,
+    // so we DO retrieve the full traceback for debugging.
+    PyTypeObject* err = reinterpret_cast< PyTypeObject* >( PyErr_Occurred() );
+    QString what;
+    if ( err && QString( err->tp_name ) == QStringLiteral( "QgsProcessingException" ) )
+    {
+      PyObject *type, *value, *traceback;
+      PyErr_Fetch( &type, &value, &traceback );
+      PyObject* str = PyObject_Str( value );
+      what = QString::fromUtf8( PyUnicode_AsUTF8( str ) );
+      Py_XDECREF( str );
+      PyErr_Restore( type, value, traceback );
+    }
+    else
+    {
+      QString trace = getTraceback();
+      QgsLogger::critical( trace );
+      what = trace;
+    }
     SIP_RELEASE_GIL( sipGILState );
-    throw QgsProcessingException( trace );
+    throw QgsProcessingException( what );
 %End

--- a/python/core/core.sip.in
+++ b/python/core/core.sip.in
@@ -123,9 +123,17 @@ done:
     {
       PyObject *type, *value, *traceback;
       PyErr_Fetch( &type, &value, &traceback );
-      PyObject* str = PyObject_Str( value );
-      what = QString::fromUtf8( PyUnicode_AsUTF8( str ) );
-      Py_XDECREF( str );
+      // check whether the object is already a unicode string
+      if ( PyUnicode_Check( value) )
+      {
+        what = QString::fromUtf8( PyUnicode_AsUTF8( value ) );
+      }
+      else
+      {
+        PyObject* str = PyObject_Str( value );
+        what = QString::fromUtf8( PyUnicode_AsUTF8( str ) );
+        Py_XDECREF( str );
+      }
       PyErr_Restore( type, value, traceback );
       PyGILState_Release( gstate );
     }


### PR DESCRIPTION
This is too noisy for these expected exceptions -- instead, only
show the traceback for other exceptions (Which are likely a result
of Python coding errors, so they are useful for debugging)

(No plans to backport this)
