### PR TITLE
[WFS provider] Avoid dangling download progress dialog

### DIFF
--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -158,6 +158,7 @@ class QgsWFSFeatureDownloader: public QgsWfsRequest
     QTimer *mTimer = nullptr;
     QgsWFSFeatureHitsAsyncRequest mFeatureHitsAsyncRequest;
     qint64 mTotalDownloadedFeatureCount;
+    QMutex mMutexCreateProgressDialog;
 };
 
 //! Downloader thread


### PR DESCRIPTION
While investigating #27384, which I failed to reproduce, I noticed
another - minor - issue when loading layers from a local GeoServer
instance. Very often (easily triggered by reloading layers with F5),
one or several download progress window would be displayed ~ 4 seconds
after the refresh had finished. This was due to a race between the
creation and destruction of this window.
