### PR TITLE
[needs-docs] Append a local, user writable folder to proj 6 search paths

### DIFF
--- a/python/core/auto_generated/qgsprojutils.sip.in
+++ b/python/core/auto_generated/qgsprojutils.sip.in
@@ -29,6 +29,16 @@ Utility functions for working with the proj library.
 Returns the proj library major version number.
 %End
 
+    static QStringList searchPaths();
+%Docstring
+Returns the current list of Proj file search paths.
+
+.. note::
+
+   Only available on builds based on Proj >= 6.0. Builds based on
+   earlier Proj versions will always return an empty list.
+%End
+
 };
 
 /************************************************************************

--- a/src/core/qgsprojutils.h
+++ b/src/core/qgsprojutils.h
@@ -53,6 +53,14 @@ class CORE_EXPORT QgsProjUtils
       return PROJ_VERSION_MAJOR;
     }
 
+    /**
+     * Returns the current list of Proj file search paths.
+     *
+     * \note Only available on builds based on Proj >= 6.0. Builds based on
+     * earlier Proj versions will always return an empty list.
+     */
+    static QStringList searchPaths();
+
 #ifndef SIP_RUN
 #if PROJ_VERSION_MAJOR >= 6
 

--- a/tests/src/core/testqgsprojutils.cpp
+++ b/tests/src/core/testqgsprojutils.cpp
@@ -35,6 +35,7 @@ class TestQgsProjUtils: public QObject
     void threadSafeContext();
     void usesAngularUnits();
     void axisOrderIsSwapped();
+    void searchPath();
 
 };
 
@@ -94,6 +95,15 @@ void TestQgsProjUtils::axisOrderIsSwapped()
   QVERIFY( !QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
   crs.reset( proj_create( context, "urn:ogc:def:crs:EPSG::4326" ) );
   QVERIFY( QgsProjUtils::axisOrderIsSwapped( crs.get() ) );
+#endif
+}
+
+void TestQgsProjUtils::searchPath()
+{
+#if PROJ_VERSION_MAJOR>=6
+  // ensure local user-writable path is present in Proj search paths
+  const QStringList paths = QgsProjUtils::searchPaths();
+  QVERIFY( paths.contains( QgsApplication::qgisSettingsDirPath() + QStringLiteral( "proj" ) ) );
 #endif
 }
 


### PR DESCRIPTION
Now, proj will search in the current user profile "proj" folder (e.g.
.local/share/QGIS/QGIS3/profiles/default/proj" on linux) for
grid files and other proj helper files.

This allows users (and plugins) to install grid files and make them
available for use in QGIS without requiring administrator access
to the system.
