### PR TITLE
Fix "default layout templates" button

### DIFF
--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -96,6 +96,7 @@ QgsLayoutManagerDialog::QgsLayoutManagerDialog( QWidget *parent, Qt::WindowFlags
   QMap<QString, QString> userTemplateMap = defaultTemplates( true );
   addTemplates( userTemplateMap );
 
+  // TODO QGIS 4: Remove this, default templates should not be shipped in the application folder
   mDefaultTemplatesDir = QgsApplication::pkgDataPath() + "/composer_templates";
   QMap<QString, QString> defaultTemplateMap = defaultTemplates( false );
   addTemplates( defaultTemplateMap );

--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -101,6 +101,8 @@ QgsLayoutManagerDialog::QgsLayoutManagerDialog( QWidget *parent, Qt::WindowFlags
   addTemplates( defaultTemplateMap );
   addTemplates( otherTemplates() );
 
+  mTemplatesDefaultDirBtn->setToolTip( tr( "Use <i>Settings --> Options --> Layouts --> Layout Paths</i> to configure the folders in which QGIS will search for print layout templates." ) );
+
   toggleButtons();
 }
 
@@ -148,6 +150,7 @@ void QgsLayoutManagerDialog::addTemplates( const QMap<QString, QString> &templat
 
 void QgsLayoutManagerDialog::activate()
 {
+  updateTemplateButtonEnabledState();
   raise();
   setWindowState( windowState() & ~Qt::WindowMinimized );
   activateWindow();
@@ -163,9 +166,8 @@ QMap<QString, QString> QgsLayoutManagerDialog::defaultTemplates( bool fromUser )
 QMap<QString, QString> QgsLayoutManagerDialog::otherTemplates() const
 {
   QMap<QString, QString> templateMap;
-  QStringList paths = QgsApplication::layoutTemplatePaths();
-  const auto constPaths = paths;
-  for ( const QString &path : constPaths )
+  const QStringList paths = QgsApplication::layoutTemplatePaths();
+  for ( const QString &path : paths )
   {
     QMap<QString, QString> templates = templatesFromPath( path );
     QMap<QString, QString>::const_iterator templateIt = templates.constBegin();
@@ -285,7 +287,14 @@ void QgsLayoutManagerDialog::mTemplate_currentIndexChanged( int indx )
 
 void QgsLayoutManagerDialog::mTemplatesDefaultDirBtn_pressed()
 {
-  openLocalDirectory( mDefaultTemplatesDir );
+  if ( QDir( mDefaultTemplatesDir ).exists() )
+    openLocalDirectory( mDefaultTemplatesDir );
+  else
+  {
+    const QStringList paths = QgsApplication::layoutTemplatePaths();
+    if ( !paths.empty() )
+      openLocalDirectory( paths.at( 0 ) );
+  }
 }
 
 void QgsLayoutManagerDialog::mTemplatesUserDirBtn_pressed()
@@ -329,6 +338,11 @@ void QgsLayoutManagerDialog::openLocalDirectory( const QString &localDirPath )
   {
     QDesktopServices::openUrl( QUrl::fromLocalFile( localDirPath ) );
   }
+}
+
+void QgsLayoutManagerDialog::updateTemplateButtonEnabledState()
+{
+  mTemplatesDefaultDirBtn->setEnabled( QDir( mDefaultTemplatesDir ).exists() || !QgsApplication::layoutTemplatePaths().empty() );
 }
 
 #ifdef Q_OS_MAC

--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -94,12 +94,12 @@ QgsLayoutManagerDialog::QgsLayoutManagerDialog( QWidget *parent, Qt::WindowFlags
 
   mUserTemplatesDir = QgsApplication::qgisSettingsDirPath() + "/composer_templates";
   QMap<QString, QString> userTemplateMap = defaultTemplates( true );
-  this->addTemplates( userTemplateMap );
+  addTemplates( userTemplateMap );
 
   mDefaultTemplatesDir = QgsApplication::pkgDataPath() + "/composer_templates";
   QMap<QString, QString> defaultTemplateMap = defaultTemplates( false );
-  this->addTemplates( defaultTemplateMap );
-  this->addTemplates( this->otherTemplates() );
+  addTemplates( defaultTemplateMap );
+  addTemplates( otherTemplates() );
 
   toggleButtons();
 }
@@ -187,13 +187,12 @@ QMap<QString, QString> QgsLayoutManagerDialog::templatesFromPath( const QString 
     return templateMap;
   }
 
-  QFileInfoList fileInfoList = templateDir.entryInfoList( QDir::Files );
-  QFileInfoList::const_iterator infoIt = fileInfoList.constBegin();
-  for ( ; infoIt != fileInfoList.constEnd(); ++infoIt )
+  const QFileInfoList fileInfoList = templateDir.entryInfoList( QDir::Files );
+  for ( const QFileInfo &info : fileInfoList )
   {
-    if ( infoIt->suffix().compare( QLatin1String( "qpt" ), Qt::CaseInsensitive ) == 0 )
+    if ( info.suffix().compare( QLatin1String( "qpt" ), Qt::CaseInsensitive ) == 0 )
     {
-      templateMap.insert( infoIt->baseName(), infoIt->absoluteFilePath() );
+      templateMap.insert( info.baseName(), info.absoluteFilePath() );
     }
   }
   return templateMap;

--- a/src/app/layout/qgslayoutmanagerdialog.h
+++ b/src/app/layout/qgslayoutmanagerdialog.h
@@ -48,7 +48,7 @@ class QgsLayoutManagerDialog: public QDialog, private Ui::QgsLayoutManagerBase
 
     /**
      * Returns the default templates (key: template name, value: absolute path to template file)
-     * \param fromUser whether to return user templates from ~/.qgis/composer_templates
+     * \param fromUser whether to return user templates from [profile folder]/composer_templates
      */
     QMap<QString, QString> defaultTemplates( bool fromUser = false ) const;
     QMap<QString, QString> otherTemplates() const;
@@ -56,9 +56,11 @@ class QgsLayoutManagerDialog: public QDialog, private Ui::QgsLayoutManagerBase
     QMap<QString, QString> templatesFromPath( const QString &path ) const;
 
     /**
-     * Open local directory with user's system, creating it if not present
+     * Opens local directory with user's system and tries to create it if not present
      */
     void openLocalDirectory( const QString &localDirPath );
+
+    void updateTemplateButtonEnabledState();
 
     QString mDefaultTemplatesDir;
     QString mUserTemplatesDir;


### PR DESCRIPTION
This changes the behavior of the open default layout templates folder to fall back to the configured layout templates if there is no composer_template folder in the pkgData path or completely deactivate the button if there is no such folder present and no layout template paths are configured.

The previous behavior was to always try to create and open a composer_template folder in pkgData, where pkgData is the application installation folder which in almost every case is a system directory, not writable by the user and therefore the button was in almost every case ending up in an error message.

Fixes https://github.com/qgis/QGIS/issues/30064