### PR TITLE
[cad] fix graphical glitches

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -266,6 +266,13 @@ Adds point to the CAD point list
 .. versionadded:: 3.0
 %End
 
+    void removePreviousPoint();
+%Docstring
+Remove previous point in the CAD point list
+
+.. versionadded:: 3.8
+%End
+
     void setPoints( const QList<QgsPointXY> &points );
 %Docstring
 Configures list of current CAD points

--- a/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
@@ -117,6 +117,8 @@ This method is protected because it should be a decision of the map tool and not
 .. versionadded:: 3.0
 %End
 
+
+
   public:
 
     virtual void cadCanvasPressEvent( QgsMapMouseEvent *e );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -1148,6 +1148,7 @@ void QgsAdvancedDigitizingDockWidget::addPoint( const QgsPointXY &point )
   }
 
   updateCapacity();
+  updateCadPaintItem();
 }
 
 void QgsAdvancedDigitizingDockWidget::removePreviousPoint()
@@ -1158,6 +1159,7 @@ void QgsAdvancedDigitizingDockWidget::removePreviousPoint()
   int i = pointsCount() > 1 ? 1 : 0;
   mCadPointList.removeAt( i );
   updateCapacity();
+  updateCadPaintItem();
 }
 
 void QgsAdvancedDigitizingDockWidget::clearPoints()
@@ -1166,6 +1168,7 @@ void QgsAdvancedDigitizingDockWidget::clearPoints()
   mSnappedSegment.clear();
 
   updateCapacity();
+  updateCadPaintItem();
 }
 
 void QgsAdvancedDigitizingDockWidget::updateCurrentPoint( const QgsPointXY &point )
@@ -1179,6 +1182,7 @@ void QgsAdvancedDigitizingDockWidget::updateCurrentPoint( const QgsPointXY &poin
   {
     mCadPointList[0] = point;
   }
+  updateCadPaintItem();
 }
 
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -287,6 +287,12 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     void addPoint( const QgsPointXY &point );
 
     /**
+     * Remove previous point in the CAD point list
+     * \since QGIS 3.8
+     */
+    void removePreviousPoint();
+
+    /**
      * Configures list of current CAD points
      *
      * Some map tools may find it useful to override list of CAD points that is otherwise
@@ -660,8 +666,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     //! update the current point in the CAD point list
     void updateCurrentPoint( const QgsPointXY &point );
-    //! remove previous point in the CAD point list
-    void removePreviousPoint();
+
 
     /**
      * filters key press

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -107,6 +107,9 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      */
     void setAutoSnapEnabled( bool enabled ) { mAutoSnapEnabled = enabled; }
 
+
+    QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
+
   public:
 
     /**
@@ -172,7 +175,6 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     void onCurrentLayerChanged();
 
   private:
-    QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
 
     //! Whether to allow use of advanced digitizing dock at this point
     bool mAdvancedDigitizingAllowed = true;

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -586,11 +586,7 @@ void QgsMapToolCapture::undo()
     mCaptureCurve.deleteVertex( vertexToRemove );
     mSnappingMatches.removeAt( vertexToRemove.vertex );
 
-    // If Cad is enabled, update the points accordingly
-    if ( mCadDockWidget->cadEnabled() )
-    {
-      mCadDockWidget->removePreviousPoint();
-    }
+    mCadDockWidget->removePreviousPoint();
 
     validateGeometry();
   }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -31,6 +31,7 @@
 #include "qgsvertexmarker.h"
 #include "qgssettings.h"
 #include "qgsapplication.h"
+#include "qgsadvanceddigitizingdockwidget.h"
 
 #include <QAction>
 #include <QCursor>
@@ -584,6 +585,12 @@ void QgsMapToolCapture::undo()
     vertexToRemove.vertex = size() - 1;
     mCaptureCurve.deleteVertex( vertexToRemove );
     mSnappingMatches.removeAt( vertexToRemove.vertex );
+
+    // If Cad is enabled, update the points accordingly
+    if ( mCadDockWidget->cadEnabled() )
+    {
+      mCadDockWidget->removePreviousPoint();
+    }
 
     validateGeometry();
   }


### PR DESCRIPTION
## Description

This PR fixes some minor glitches with the advanced CAD canvas item :
- the CadWidget point list is now updated accordingly when a point is deleted while digitizing
- the canvas item is properly repainted when the point list changes, removing some phantom lines (that was really minor...)

before
![before](https://user-images.githubusercontent.com/1894106/58868189-1e30d080-86bc-11e9-94de-500fe208ebb9.gif)

after
![after](https://user-images.githubusercontent.com/1894106/58868190-1ec96700-86bc-11e9-973c-f29c04ad57f1.gif)


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] (no issue) Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] (?) This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
