### PR TITLE
Update CI postgres 11.0-2.5

### DIFF
--- a/.ci/travis/linux/docker-compose.travis.yml
+++ b/.ci/travis/linux/docker-compose.travis.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: kartoza/postgis:9.5-2.2
+    image: kartoza/postgis:11.0-2.5
     environment:
       - ALLOW_IP_RANGE="172.18.0.0/16"
 


### PR DESCRIPTION
Not much of an advantage yet.
I might need to update for some tests, so I wanted to see beforehand if there's any problems for existing tests.