### PR TITLE
Fix some issues with WFS connection dialog

### DIFF
--- a/python/gui/auto_generated/qgsnewhttpconnection.sip.in
+++ b/python/gui/auto_generated/qgsnewhttpconnection.sip.in
@@ -98,6 +98,7 @@ Returns the "test connection" button.
 
 
 
+
     virtual QString wfsSettingsKey( const QString &base, const QString &connectionName ) const;
 %Docstring
 Returns the QSettings key for WFS related settings for the connection.

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -239,6 +239,11 @@ QPushButton *QgsNewHttpConnection::testConnectButton()
   return mTestConnectionButton;
 }
 
+QgsAuthSettingsWidget *QgsNewHttpConnection::authSettingsWidget()
+{
+  return mAuthSettings;
+}
+
 QPushButton *QgsNewHttpConnection::wfsVersionDetectButton()
 {
   return mWfsVersionDetectButton;

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -165,9 +165,10 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
 
 void QgsNewHttpConnection::wfsVersionCurrentIndexChanged( int index )
 {
-  cbxWfsFeaturePaging->setEnabled( index == 0 || index >= 3 );
-  lblPageSize->setEnabled( cbxWfsFeaturePaging->isChecked() && ( index == 0 || index >= 3 ) );
-  txtPageSize->setEnabled( cbxWfsFeaturePaging->isChecked() && ( index == 0 || index >= 3 ) );
+  // For now 2019-06-06, leave paging checkable for some WFS version 1.1 servers with support
+  cbxWfsFeaturePaging->setEnabled( index == 0 || index >= 2 );
+  lblPageSize->setEnabled( cbxWfsFeaturePaging->isChecked() && ( index == 0 || index >= 2 ) );
+  txtPageSize->setEnabled( cbxWfsFeaturePaging->isChecked() && ( index == 0 || index >= 2 ) );
   cbxWfsIgnoreAxisOrientation->setEnabled( index != 1 );
 }
 
@@ -322,14 +323,16 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   txtReferer->setText( settings.value( wmsKey + "/referer" ).toString() );
   txtMaxNumFeatures->setText( settings.value( wfsKey + "/maxnumfeatures" ).toString() );
 
-  bool pagingEnabled = settings.value( wfsKey + "/pagingenabled", true ).toBool();
+  // Only default to paging enabled if WFS 2.0.0 or higher
+  bool pagingEnabled = settings.value( wfsKey + "/pagingenabled", ( versionIdx == 0 || versionIdx >= 3 ) ).toBool();
   txtPageSize->setText( settings.value( wfsKey + "/pagesize" ).toString() );
   cbxWfsFeaturePaging->setChecked( pagingEnabled );
 
   // Enable/disable these items per WFS versions
-  txtPageSize->setEnabled( pagingEnabled && ( versionIdx == 0 || versionIdx >= 3 ) );
-  lblPageSize->setEnabled( pagingEnabled && ( versionIdx == 0 || versionIdx >= 3 ) );
-  cbxWfsFeaturePaging->setEnabled( versionIdx == 0 || versionIdx >= 3 );
+  // For now 2019-06-06, leave paging checkable for some WFS version 1.1 servers with support
+  txtPageSize->setEnabled( pagingEnabled && ( versionIdx == 0 || versionIdx >= 2 ) );
+  lblPageSize->setEnabled( pagingEnabled && ( versionIdx == 0 || versionIdx >= 2 ) );
+  cbxWfsFeaturePaging->setEnabled( versionIdx == 0 || versionIdx >= 2 );
   cbxWfsIgnoreAxisOrientation->setEnabled( versionIdx != 1 );
 }
 

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -165,9 +165,9 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
 
 void QgsNewHttpConnection::wfsVersionCurrentIndexChanged( int index )
 {
-  cbxWfsFeaturePaging->setEnabled( index == 0 || index == 3 );
-  lblPageSize->setEnabled( index == 0 || index == 3 );
-  txtPageSize->setEnabled( index == 0 || index == 3 );
+  cbxWfsFeaturePaging->setEnabled( index == 0 || index >= 3 );
+  lblPageSize->setEnabled( cbxWfsFeaturePaging->isChecked() && ( index == 0 || index >= 3 ) );
+  txtPageSize->setEnabled( cbxWfsFeaturePaging->isChecked() && ( index == 0 || index >= 3 ) );
   cbxWfsIgnoreAxisOrientation->setEnabled( index != 1 );
 }
 
@@ -321,9 +321,11 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   txtPageSize->setText( settings.value( wfsKey + "/pagesize" ).toString() );
   cbxWfsFeaturePaging->setChecked( pagingEnabled );
 
-  txtPageSize->setEnabled( pagingEnabled );
-  lblPageSize->setEnabled( pagingEnabled );
-  cbxWfsFeaturePaging->setEnabled( pagingEnabled );
+  // Enable/disable these items per WFS versions
+  txtPageSize->setEnabled( pagingEnabled && ( versionIdx == 0 || versionIdx >= 3 ) );
+  lblPageSize->setEnabled( pagingEnabled && ( versionIdx == 0 || versionIdx >= 3 ) );
+  cbxWfsFeaturePaging->setEnabled( versionIdx == 0 || versionIdx >= 3 );
+  cbxWfsIgnoreAxisOrientation->setEnabled( versionIdx != 1 );
 }
 
 QUrl QgsNewHttpConnection::urlTrimmed() const

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -117,6 +117,12 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     QPushButton *testConnectButton();
 
     /**
+     * Returns the current authentication settings widget.
+     * \since QGIS 3.8
+     */
+    QgsAuthSettingsWidget *authSettingsWidget() SIP_SKIP;
+
+    /**
      * Returns the "WFS version detect" button.
      * \since QGIS 3.2
      */

--- a/src/providers/wfs/qgswfsnewconnection.cpp
+++ b/src/providers/wfs/qgswfsnewconnection.cpp
@@ -35,7 +35,15 @@ QgsWFSNewConnection::~QgsWFSNewConnection()
 void QgsWFSNewConnection::versionDetectButton()
 {
   delete mCapabilities;
-  mCapabilities = new QgsWfsCapabilities( urlTrimmed().toString() );
+
+  // Honor any defined authentication settings
+  QgsDataSourceUri uri = QgsDataSourceUri();
+  uri.setParam( QStringLiteral( "url" ), urlTrimmed().toString() );
+  uri.setUsername( authSettingsWidget()->username() );
+  uri.setPassword( authSettingsWidget()->password() );
+  uri.setAuthConfigId( authSettingsWidget()->configId() );
+
+  mCapabilities = new QgsWfsCapabilities( uri.uri( false ) );
   connect( mCapabilities, &QgsWfsCapabilities::gotCapabilities, this, &QgsWFSNewConnection::capabilitiesReplyFinished );
   const bool synchronous = false;
   const bool forceRefresh = true;


### PR DESCRIPTION
## Description
Fix WFS connection version-related GUI widget enabling/disabling:
- When saved with feature paging disabled, caused option to never be reenabled
- When loading settings, feature paging now constrained to WFS version
- WFS 2.0.0 capabilities are no longer constrained to just that version,
  allowing versions above as well.

Fix WFS connection's version Detect button, which did not support auth:
- Adds support for auth system to Detect button
- Adds QgsNewHttpConnection protected member to access auth settings

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
