### PR TITLE
[oauth2] Fix token refresh timeout cancellation with singleshot timer

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -23,7 +23,6 @@
 #include "qgso2.h"
 #include "qgsauthoauth2config.h"
 #include "qgsauthoauth2edit.h"
-#include "qgsguiutils.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
@@ -169,8 +168,6 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
         connect( &r_timer, &QTimer::timeout, &rloop, &QEventLoop::quit );
         r_timer.start();
 
-        QgsTemporaryCursorOverride waitCursor( Qt::WaitCursor );
-
         // Asynchronously attempt the refresh
         // TODO: This already has a timed reply setup in O2 base class (and in QgsNetworkAccessManager!)
         //       May need to address this or app crashes will occur!
@@ -182,8 +179,6 @@ bool QgsAuthOAuth2Method::updateNetworkRequest( QNetworkRequest &request, const 
         {
           r_timer.stop();
         }
-
-        waitCursor.release();
 
         // refresh result should set o2 to (un)linked
       }


### PR DESCRIPTION
## Description
Fix token refresh timeout cancellation with singleshot timer.

- Previously, if there was an error that caused the `O2::refreshFinished` signal not to be fired, the interface would freeze due to `QEventLoop::ExcludeUserInputEvents` when running the loop. This ensures there is no input events ignored and that the loop is quit regardless of any refresh response issue.

Also, avoid O2 library error by checking for refresh token and URL first.

- This led to issues if the token refresh URL was optionally left blank; the refresh would still be attempted when it should be skipped and a new access token be requested instead.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
