### PR TITLE
Fix reshape for snapped point with Z

### DIFF
--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -121,9 +121,11 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
     bbox.combineExtentWith( points().at( i ).x(), points().at( i ).y() );
   }
 
-  QgsLineString reshapeLineString( points() );
-  if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) )
-    reshapeLineString.addZValue( defaultZValue() );
+
+  QgsPointSequence pts;
+  QVector<QgsPoint> points;
+  captureCurve()->points( pts );
+  QgsLineString reshapeLineString( pts );
 
   //query all the features that intersect bounding box of capture line
   QgsFeatureIterator fit = vlayer->getFeatures( QgsFeatureRequest().setFilterRect( bbox ).setNoAttributes() );
@@ -143,7 +145,7 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
     {
       // in case of a binding line, we just want to update the line from
       // the starting point and not both side
-      if ( isBinding && !geom.asPolyline().contains( points().first() ) )
+      if ( isBinding && !geom.asPolyline().contains( pts.constFirst() ) )
         continue;
 
       reshapeReturn = geom.reshapeGeometry( reshapeLineString );


### PR DESCRIPTION
## Description

Reshape tool doesn't take care of snapped Z values. Indeed, `QgsMapToolCapture::points()` returns QgsPointXY and not map point snapped (with Z). So, we need to use snapped points from the captureCurve.

I haven't changed `QVector<QgsPointXY> QgsMapToolCapture::points()` to `QVector<QgsPoint> QgsMapToolCapture::points()` (or rename `QVector<QgsPointXY> QgsMapToolCapture::pointsXY()`) because it's a bugfix, I think it breaks the API. What do you think about that?

With this fix
![reshape_snapped_z](https://user-images.githubusercontent.com/7521540/59024648-a5b04800-8852-11e9-88e4-7b17d52771ef.gif)

cc @ponceta

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
