### PR TITLE
Fix snap geometries crash

### DIFF
--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -135,6 +135,15 @@ void QgsOverlayUtils::difference( const QgsFeatureSource &sourceA, const QgsFeat
       if ( !geometriesB.isEmpty() )
       {
         QgsGeometry geomB = QgsGeometry::unaryUnion( geometriesB );
+        if ( !geomB.lastError().isEmpty() )
+        {
+          // This may happen if input geometries from a layer do not line up well (for example polygons
+          // that are nearly touching each other, but there is a very tiny overlap or gap at one of the edges).
+          // It is possible to get rid of this issue in two steps:
+          // 1. snap geometries with a small tolerance (e.g. 1cm) using QgsGeometrySnapperSingleSource
+          // 2. fix geometries (removes polygons collapsed to lines etc.) using MakeValid
+          throw QgsProcessingException( QStringLiteral( "%1\n\n%2" ).arg( QObject::tr( "GEOS geoprocessing error: unary union failed." ), geomB.lastError() ) );
+        }
         geom = geom.difference( geomB );
       }
 

--- a/src/analysis/vector/qgsgeometrysnappersinglesource.cpp
+++ b/src/analysis/vector/qgsgeometrysnappersinglesource.cpp
@@ -244,7 +244,7 @@ static bool snapLineString( QgsLineString *linestring, QgsSpatialIndex &index, Q
     if ( !newVerticesAlongSegment.isEmpty() )
     {
       // sort by distance along the segment
-      std::sort( newVerticesAlongSegment.begin(), newVerticesAlongSegment.end(), []( const AnchorAlongSegment & p1, const AnchorAlongSegment & p2 )
+      std::sort( newVerticesAlongSegment.begin(), newVerticesAlongSegment.end(), []( AnchorAlongSegment p1, AnchorAlongSegment p2 )
       {
         return p1.along < p2.along;
       } );

--- a/src/analysis/vector/qgsgeometrysnappersinglesource.cpp
+++ b/src/analysis/vector/qgsgeometrysnappersinglesource.cpp
@@ -244,9 +244,9 @@ static bool snapLineString( QgsLineString *linestring, QgsSpatialIndex &index, Q
     if ( !newVerticesAlongSegment.isEmpty() )
     {
       // sort by distance along the segment
-      std::sort( newVerticesAlongSegment.begin(), newVerticesAlongSegment.end(), []( AnchorAlongSegment p1, AnchorAlongSegment p2 )
+      std::sort( newVerticesAlongSegment.begin(), newVerticesAlongSegment.end(), []( const AnchorAlongSegment & p1, const AnchorAlongSegment & p2 )
       {
-        return ( p1.along < p2.along ? -1 : ( p1.along > p2.along ) );
+        return p1.along < p2.along;
       } );
 
       // insert new vertices


### PR DESCRIPTION
A crash may happen when running the alg with 'snap to anchor nodes (single layer only)' behavior. It turns out that I made a mistake while porting the algorithm to std::sort - originally the sorting function used -1/0/+1 for comparison, while std::sort wants '<' operator returning true/false. Due to inconsistent results from the comparison function, std::sort would end up corrupting the array and memory even beyond the range, causing crashes.

Related to #29400 (but does not fix it)