### PR TITLE
Pixel perfect rendering of xyz tiles at native resolutions

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -113,9 +113,10 @@ class QgsAmsProvider : public QgsRasterDataProvider
     //! Helper structure to store a cached tile image with its rectangle
     typedef struct TileImage
     {
-      TileImage( const QRectF &r, const QImage &i ): rect( r ), img( i ) {}
+      TileImage( const QRectF &r, const QImage &i, bool smooth ): rect( r ), img( i ), smooth( smooth ) {}
       QRectF rect; //!< Destination rectangle for a tile (in screen coordinates)
       QImage img;  //!< Cached tile to be drawn
+      bool smooth;
     } TileImage;
 
   protected:

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -336,9 +336,10 @@ class QgsWmsProvider : public QgsRasterDataProvider
     //! Helper structure to store a cached tile image with its rectangle
     typedef struct TileImage
     {
-      TileImage( const QRectF &r, const QImage &i ): rect( r ), img( i ) {}
+      TileImage( const QRectF &r, const QImage &i, bool smooth ): rect( r ), img( i ), smooth( smooth ) {}
       QRectF rect; //!< Destination rectangle for a tile (in screen coordinates)
       QImage img;  //!< Cached tile to be drawn
+      bool smooth; //!< Whether to use antialiasing/smooth transforms when rendering tile
     } TileImage;
     //! Gets tiles from a different resolution to cover the missing areas
     void fetchOtherResTiles( QgsTileMode tileMode, const QgsRectangle &viewExtent, int imageWidth, QList<QRectF> &missing, double tres, int resOffset, QList<TileImage> &otherResTiles );


### PR DESCRIPTION
For xyz/mapserver tiles, disable the smooth pixmap transform when we are rendering at native tile resolutions (or just close enough to). This allows pixel-perfect rendering of tiles at native resolutions.