### PR TITLE
Fix crash when closing QGIS with open layout designer windows

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -966,7 +966,7 @@ void QgsLayoutDesignerDialog::setMasterLayout( QgsMasterLayoutInterface *layout 
 
   QObject *obj = dynamic_cast< QObject * >( mMasterLayout );
   if ( obj )
-    connect( obj, &QObject::destroyed, [ = ]
+    connect( obj, &QObject::destroyed, this, [ = ]
   {
     this->close();
     QgsApplication::sendPostedEvents( nullptr, QEvent::DeferredDelete );


### PR DESCRIPTION
Qt connections to a lambda ALWAYS should have a context object, or the connection lasts forever, even after the object which made the connection is deleted.
