### PR TITLE
[arcgisrest] Fix parsing of imageserver raster layer

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -172,8 +172,19 @@ QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &optio
 
   const QString serviceUrl = dataSource.param( QStringLiteral( "url" ) );
   mServiceInfo = QgsArcGisRestUtils::getServiceInfo( serviceUrl, authcfg, mErrorTitle, mError, mRequestHeaders );
-  const QString layerUrl = dataSource.param( QStringLiteral( "url" ) ) + "/" + dataSource.param( QStringLiteral( "layer" ) );
-  mLayerInfo = QgsArcGisRestUtils::getLayerInfo( layerUrl, authcfg, mErrorTitle, mError, mRequestHeaders );
+
+  QString layerUrl;
+  if ( mServiceInfo.value( QStringLiteral( "serviceDataType" ) ).toString().startsWith( QLatin1String( "esriImageService" ) ) )
+  {
+    layerUrl = serviceUrl;
+    mLayerInfo = mServiceInfo;
+    mImageServer = true;
+  }
+  else
+  {
+    layerUrl = dataSource.param( QStringLiteral( "url" ) ) + "/" + dataSource.param( QStringLiteral( "layer" ) );
+    mLayerInfo = QgsArcGisRestUtils::getLayerInfo( layerUrl, authcfg, mErrorTitle, mError, mRequestHeaders );
+  }
 
   const QVariantMap extentData = mLayerInfo.value( QStringLiteral( "extent" ) ).toMap();
   mExtent.setXMinimum( extentData[QStringLiteral( "xmin" )].toDouble() );
@@ -262,6 +273,7 @@ QgsAmsProvider::QgsAmsProvider( const QgsAmsProvider &other, const QgsDataProvid
   , mSubLayerVisibilities( other.mSubLayerVisibilities )
   , mRequestHeaders( other.mRequestHeaders )
   , mTiled( other.mTiled )
+  , mImageServer( other.mImageServer )
   , mLayerMetadata( other.mLayerMetadata )
   , mResolutions( other.mResolutions )
 // intentionally omitted:
@@ -627,7 +639,7 @@ QImage QgsAmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int
       return mCachedImage;
     }
 
-    QUrl requestUrl( dataSource.param( QStringLiteral( "url" ) ) + "/export" );
+    QUrl requestUrl( dataSource.param( QStringLiteral( "url" ) ) + ( mImageServer ? "/exportImage" : "/export" ) );
     requestUrl.addQueryItem( QStringLiteral( "bbox" ), QStringLiteral( "%1,%2,%3,%4" ).arg( viewExtent.xMinimum(), 0, 'f', -1 ).arg( viewExtent.yMinimum(), 0, 'f', -1 ).arg( viewExtent.xMaximum(), 0, 'f', -1 ).arg( viewExtent.yMaximum(), 0, 'f', -1 ) );
     requestUrl.addQueryItem( QStringLiteral( "size" ), QStringLiteral( "%1,%2" ).arg( pixelWidth ).arg( pixelHeight ) );
     requestUrl.addQueryItem( QStringLiteral( "format" ), dataSource.param( QStringLiteral( "format" ) ) );

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -139,6 +139,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QgsStringMap mRequestHeaders;
     int mTileReqNo = 0;
     bool mTiled = false;
+    bool mImageServer = false;
     QgsLayerMetadata mLayerMetadata;
     QList< double > mResolutions;
 };

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -1314,7 +1314,7 @@ void QgsArcGisRestUtils::visitServiceItems( const std::function< void( const QSt
   {
     const QVariantMap serviceMap = service.toMap();
     const QString serviceType = serviceMap.value( QStringLiteral( "type" ) ).toString();
-    if ( serviceType != QLatin1String( "MapServer" ) && serviceType != QLatin1String( "FeatureServer" ) )
+    if ( serviceType != QLatin1String( "MapServer" ) && serviceType != QLatin1String( "FeatureServer" ) && serviceType != QLatin1String( "ImageServer" ) )
       continue;
 
     const QString serviceName = serviceMap.value( QStringLiteral( "name" ) ).toString();
@@ -1369,5 +1369,12 @@ void QgsArcGisRestUtils::addLayerItems( const std::function< void( const QString
     {
       visitor( parentLayerId, id, name, description, parentUrl + '/' + id, false, authid, format );
     }
+  }
+
+  if ( serviceData.value( QStringLiteral( "serviceDataType" ) ).toString().startsWith( QLatin1String( "esriImageService" ) ) )
+  {
+    const QString name = serviceData.value( QStringLiteral( "name" ) ).toString();
+    const QString description = serviceData.value( QStringLiteral( "description" ) ).toString();
+    visitor( 0, 0, name, description, parentUrl, false, authid, format );
   }
 }


### PR DESCRIPTION
## Description
QGIS' arcgis rest's raster provider (aka ArcGisMapServer) already supports image server layers, this PR fixes the parsing by the provider to enable such layer to work.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
