### PR TITLE
[arcgisrest] Fix drawing of large areas for non-tiled raster layers

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -140,6 +140,8 @@ class QgsAmsProvider : public QgsRasterDataProvider
     int mTileReqNo = 0;
     bool mTiled = false;
     bool mImageServer = false;
+    int mMaxImageWidth = 4096;
+    int mMaxImageHeight = 4096;
     QgsLayerMetadata mLayerMetadata;
     QList< double > mResolutions;
 };


### PR DESCRIPTION
## Description
This PR fixes a failure by the arcgis map server provider to tale into account the maximum width / height pixel allowed by a given layer, resulting in a failure to render an area exceeding those limits. Practically speaking, this means most layers would fail to print for an 300dpi A3 map export.



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
