### PR TITLE
Update help Url for Core plugins in official doc

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Guidance: https://docs.qgis.org/2.18/en/docs/user_manual/plugins/plugins_metasearch.html#managing-catalog-services -->
+<!-- Guidance: https://docs.qgis.org/testing/en/docs/user_manual/plugins/core_plugins/plugins_metasearch.html#managing-catalog-services -->
 <qgsCSWConnections version="1.0">
     <csw name="USA: Data.gov CSW" url="https://catalog.data.gov/csw-all"/>
     <csw name="Danmark: National CSW (geodata-info)" url="https://geodata-info.dk/srv/dan/csw"/>

--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -137,10 +137,10 @@ def get_help_url():
     else:
         version = '.'.join([major, minor])
 
-    path = '%s/%s/docs/user_manual/plugins/plugins_metasearch.html' % \
+    path = '%s/%s/docs/user_manual/plugins/core_plugins/plugins_metasearch.html' % \
            (version, locale_name)
 
-    return '/'.join(['http://docs.qgis.org', path])
+    return '/'.join(['https://docs.qgis.org', path])
 
 
 def open_url(url):

--- a/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
@@ -545,5 +545,5 @@ void eVisDatabaseConnectionGui::pbtnRunQuery_clicked()
 
 void eVisDatabaseConnectionGui::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "plugins/plugins_evis.html#database-connection" ) );
+  QgsHelp::openHelp( QStringLiteral( "plugins/core_plugins/plugins_evis.html#database-connection" ) );
 }

--- a/src/plugins/geometry_checker/qgsgeometrycheckerdialog.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerdialog.cpp
@@ -112,5 +112,5 @@ void QgsGeometryCheckerDialog::closeEvent( QCloseEvent *ev )
 
 void QgsGeometryCheckerDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "plugins/plugins_geometry_checker.html" ) );
+  QgsHelp::openHelp( QStringLiteral( "plugins/core_plugins/plugins_geometry_checker.html" ) );
 }

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -690,7 +690,7 @@ void QgsGeorefPluginGui::localHistogramStretch()
 // Info slots
 void QgsGeorefPluginGui::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );
+  QgsHelp::openHelp( QStringLiteral( "plugins/core_plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );
 }
 
 // Comfort slots

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -239,7 +239,7 @@ void QgsOfflineEditingPluginGui::buttonBox_rejected()
 
 void QgsOfflineEditingPluginGui::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "plugins/plugins_offline_editing.html" ) );
+  QgsHelp::openHelp( QStringLiteral( "plugins/core_plugins/plugins_offline_editing.html" ) );
 }
 
 void QgsOfflineEditingPluginGui::restoreState()

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -336,5 +336,5 @@ void rulesDialog::clearRules()
 
 void rulesDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "plugins/plugins_topology_checker.html" ) );
+  QgsHelp::openHelp( QStringLiteral( "plugins/core_plugins/plugins_topology_checker.html" ) );
 }


### PR DESCRIPTION
because these links will be broken when https://github.com/qgis/QGIS-Documentation/pull/3731 is merged.
Since my repeated requests for a more automatic check and update (or redirection) of help links struggle to attract attention, this is the last time I fix a broken doc link in this repository. Even if it's by my fault. Fwiw.
PS: This is neither a complaint.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
