### PR TITLE
Support relative paths for virtual layers when saving projects

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -78,7 +78,6 @@
 #include "qgsvectorlayerrenderer.h"
 #include "qgsvectorlayerundocommand.h"
 #include "qgsvectorlayerfeaturecounter.h"
-#include "qgsvirtuallayerdefinition.h"
 #include "qgspoint.h"
 #include "qgsrenderer.h"
 #include "qgssymbollayer.h"

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1836,8 +1836,6 @@ QString QgsVectorLayer::encodedSource( const QString &source, const QgsReadWrite
   else if ( providerType() == QLatin1String( "virtual" ) )
   {
     QUrl urlSource = QUrl::fromEncoded( src.toLatin1() );
-    QUrl url = QUrl::fromEncoded( src.toLatin1() );
-    QUrl urlSourceLayer;
     QStringList theURIParts;
 
     QUrlQuery query = QUrlQuery( urlSource.query() );
@@ -1912,8 +1910,6 @@ QString QgsVectorLayer::decodedSource( const QString &source, const QString &pro
   else if ( provider == QLatin1String( "virtual" ) )
   {
     QUrl urlSource = QUrl::fromEncoded( src.toLatin1() );
-    QUrl url = QUrl::fromEncoded( src.toLatin1() );
-    QUrl urlSourceLayer;
     QStringList theURIParts;
 
     QUrlQuery query = QUrlQuery( urlSource.query() );


### PR DESCRIPTION
At the moment, virtual layers are always saved with absolute paths for the source layers. This pull request alters this behavior to respect the project setting of relative or absolute paths.

Fixes #29481

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
