### PR TITLE
QObjectUniquePtr

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -979,6 +979,7 @@ SET(QGIS_CORE_HDRS
   qgstilecache.h
   qgstracer.h
   qgstranslationcontext.h
+  qobjectuniqueptr.h 
 
   qgsvectordataprovider.h
   qgsvectorlayercache.h

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -137,6 +137,11 @@ class QObjectUniquePtr
       return mPtr.isNull();
     }
 
+    /**
+     * Checks if the pointer managed by this object is ``nullptr``.
+     * If it is not ``nullptr`` TRUE will be returned, if it is ``nullptr``
+     * FALSE will be returned.
+     */
     inline bool operator bool() const
     {
       return !mPtr.isNull();

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -21,6 +21,8 @@
 #ifndef QOBJECTUNIQUEPTR_H
 #define QOBJECTUNIQUEPTR_H
 
+#define SIP_NO_FILE
+
 #include <qsharedpointer.h>
 #include <qtypeinfo.h>
 
@@ -142,7 +144,7 @@ class QObjectUniquePtr
      * If it is not ``nullptr`` TRUE will be returned, if it is ``nullptr``
      * FALSE will be returned.
      */
-    inline bool operator bool() const
+    inline operator bool() const
     {
       return !mPtr.isNull();
     }

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -1,0 +1,106 @@
+#ifndef QOBJECTUNIQUEPTR_H
+#define QOBJECTUNIQUEPTR_H
+
+#include <qsharedpointer.h>
+#include <qtypeinfo.h>
+
+class QVariant;
+
+template <class T>
+class QObjectUniquePtr
+{
+    Q_STATIC_ASSERT_X( !std::is_pointer<T>::value, "QObjectUniquePtr's template type must not be a pointer type" );
+
+    template<typename U>
+    struct TypeSelector
+    {
+      typedef QObject Type;
+    };
+    template<typename U>
+    struct TypeSelector<const U>
+    {
+      typedef const QObject Type;
+    };
+    typedef typename TypeSelector<T>::Type QObjectType;
+    QWeakPointer<QObjectType> wp;
+  public:
+    inline QObjectUniquePtr() { }
+    inline QObjectUniquePtr( T *p ) : wp( p ) { }
+    // compiler-generated copy/move ctor/assignment operators are fine!
+
+    ~QObjectUniquePtr() { delete wp.data(); }
+
+    inline void swap( QObjectUniquePtr &other ) { wp.swap( other.wp ); }
+
+    inline QObjectUniquePtr<T> &operator=( T *p )
+    { wp.assign( static_cast<QObjectType *>( p ) ); return *this; }
+
+    inline T *data() const
+    { return static_cast<T *>( wp.data() ); }
+    inline T *operator->() const
+    { return data(); }
+    inline T &operator*() const
+    { return *data(); }
+    inline operator T *() const
+    { return data(); }
+
+    inline bool isNull() const
+    { return wp.isNull(); }
+
+    inline void clear()
+    { wp.clear(); }
+
+    T *release() { T *p = qobject_cast<T *>( wp.data() ); wp.clear(); return p; }
+
+    void reset( T *p = nullptr ) { delete wp.data(); wp = p; }
+};
+template <class T> Q_DECLARE_TYPEINFO_BODY( QObjectUniquePtr<T>, Q_MOVABLE_TYPE );
+
+template <class T>
+inline bool operator==( const T *o, const QObjectUniquePtr<T> &p )
+{ return o == p.operator->(); }
+
+template<class T>
+inline bool operator==( const QObjectUniquePtr<T> &p, const T *o )
+{ return p.operator->() == o; }
+
+template <class T>
+inline bool operator==( T *o, const QObjectUniquePtr<T> &p )
+{ return o == p.operator->(); }
+
+template<class T>
+inline bool operator==( const QObjectUniquePtr<T> &p, T *o )
+{ return p.operator->() == o; }
+
+template<class T>
+inline bool operator==( const QObjectUniquePtr<T> &p1, const QObjectUniquePtr<T> &p2 )
+{ return p1.operator->() == p2.operator->(); }
+
+template <class T>
+inline bool operator!=( const T *o, const QObjectUniquePtr<T> &p )
+{ return o != p.operator->(); }
+
+template<class T>
+inline bool operator!= ( const QObjectUniquePtr<T> &p, const T *o )
+{ return p.operator->() != o; }
+
+template <class T>
+inline bool operator!=( T *o, const QObjectUniquePtr<T> &p )
+{ return o != p.operator->(); }
+
+template<class T>
+inline bool operator!= ( const QObjectUniquePtr<T> &p, T *o )
+{ return p.operator->() != o; }
+
+template<class T>
+inline bool operator!= ( const QObjectUniquePtr<T> &p1, const QObjectUniquePtr<T> &p2 )
+{ return p1.operator->() != p2.operator->() ; }
+
+template<typename T>
+QObjectUniquePtr<T>
+QObjectUniquePtrFromVariant( const QVariant &variant )
+{
+  return QObjectUniquePtr<T>( qobject_cast<T *>( QtSharedPointer::weakPointerFromVariant_internal( variant ).data() ) );
+}
+
+#endif // QOBJECTUNIQUEPTR_H

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -92,6 +92,14 @@ class QObjectUniquePtr
     }
 
     /**
+     * Returns the raw pointer to the managed QObject.
+     */
+    inline T *get() const
+    {
+      return static_cast<T *>( mPtr.data() );
+    }
+
+    /**
      * Returns a raw pointer to the managed QObject.
      */
     inline T *operator->() const
@@ -121,6 +129,11 @@ class QObjectUniquePtr
     inline bool isNull() const
     {
       return mPtr.isNull();
+    }
+
+    inline bool operator bool() const
+    {
+      return !mPtr.isNull();
     }
 
     inline void clear()

--- a/src/core/qobjectuniqueptr.h
+++ b/src/core/qobjectuniqueptr.h
@@ -30,6 +30,9 @@ class QVariant;
  * Keeps a pointer to a QObject and deletes it whenever this object is deleted.
  * It keeps a weak pointer to the QObject internally and will be set to ``nullptr``
  * whenever the QObject is deleted.
+ *
+ * \ingroup core
+ * \since QGIS 3.8
  */
 template <class T>
 class QObjectUniquePtr
@@ -72,6 +75,9 @@ class QObjectUniquePtr
       delete mPtr.data();
     }
 
+    /**
+     * Swaps the pointer managed by this instance with the pointer managed by \a other.
+     */
     inline void swap( QObjectUniquePtr &other )
     {
       mPtr.swap( other.mPtr );
@@ -136,11 +142,18 @@ class QObjectUniquePtr
       return !mPtr.isNull();
     }
 
+    /**
+     * Clears the pointer. The managed object is set to ``nullptr`` and will not be deleted.
+     */
     inline void clear()
     {
       mPtr.clear();
     }
 
+    /**
+     * Clears the pointer and returns it. The managed object will not be deleted and it is the callers
+     * responsibility to guarantee that no memory is leaked.
+     */
     inline T *release()
     {
       T *p = qobject_cast<T *>( mPtr.data() );

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -219,6 +219,7 @@ SET(TESTS
  testqgsmimedatautils.cpp
  testqgsofflineediting.cpp
  testqgstranslateproject.cpp
+ testqobjectuniqueptr.cpp
    )
 
 IF(WITH_QTWEBKIT)

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -100,7 +100,7 @@ void TestQObjectUniquePtr::testOperatorArrow()
   QObject *o = new QObject();
   o->setObjectName( "Teddy" );
   QObjectUniquePtr<QObject> obj( o );
-  QCOMPARE( obj->objectName(), "Teddy" );
+  QCOMPARE( obj->objectName(), QStringLiteral( "Teddy" ) );
 }
 
 QGSTEST_MAIN( TestQObjectUniquePtr )

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+  testqobjectuniqueptr.cpp
+  --------------------------------------
+  Date                 :
+  Copyright            : (C) 2019 by Matthias Kuhn
+  Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qobjectuniqueptr.h"
+
+#include "qgstest.h"
+
+class TestQObjectUniquePtr : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void testMemLeak();
+    void testParentDeletedFirst();
+    void testParentDeletedAfter();
+};
+
+
+
+void TestQObjectUniquePtr::testMemLeak()
+{
+  QObject *myobj = new QObject();
+  QObjectUniquePtr<QObject> obj( myobj );
+}
+
+void TestQObjectUniquePtr::testParentDeletedFirst()
+{
+  QObject *parent = new QObject();
+  QObject *child = new QObject( parent );
+
+  QObjectUniquePtr<QObject> obj( child );
+  QVERIFY( !obj.isNull() );
+
+  delete parent;
+  QVERIFY( obj.isNull() );
+}
+
+void TestQObjectUniquePtr::testParentDeletedAfter()
+{
+  QObject *parent = new QObject();
+  QObject *child = new QObject( parent );
+  QPointer<QObject> observer( child );
+
+  {
+    QObjectUniquePtr<QObject> obj( child );
+    QVERIFY( !observer.isNull() );
+  }
+  QVERIFY( observer.isNull() );
+
+
+  // Basically shouldn't crash because of double delete on this line
+  delete parent;
+  QVERIFY( observer.isNull() );
+}
+
+QGSTEST_MAIN( TestQObjectUniquePtr )
+#include "testqobjectuniqueptr.moc"

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -29,6 +29,7 @@ class TestQObjectUniquePtr : public QObject
     void testOperatorBool();
     void testSwap();
     void testOperatorArrow();
+    void testDeleteLater();
 };
 
 void TestQObjectUniquePtr::testMemLeak()
@@ -101,6 +102,27 @@ void TestQObjectUniquePtr::testOperatorArrow()
   o->setObjectName( "Teddy" );
   QObjectUniquePtr<QObject> obj( o );
   QCOMPARE( obj->objectName(), QStringLiteral( "Teddy" ) );
+}
+
+void TestQObjectUniquePtr::testDeleteLater()
+{
+  int argc;
+  QCoreApplication ca( argc, nullptr );
+  QObject *o = new QObject();
+  QObject *o2 = new QObject();
+
+  QObjectUniquePtr<QObject> obj( o );
+  QObjectUniquePtr<QObject> obj2( o2 );
+
+  obj2->deleteLater();
+  obj->deleteLater();
+
+  obj2.reset();
+
+  connect( o, &QObject::destroyed, &ca, &QCoreApplication::quit );
+  ca.exec();
+  QVERIFY( obj.isNull() );
+  QVERIFY( obj2.isNull() );
 }
 
 QGSTEST_MAIN( TestQObjectUniquePtr )

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -43,9 +43,13 @@ void TestQObjectUniquePtr::testParentDeletedFirst()
 
   QObjectUniquePtr<QObject> obj( child );
   QVERIFY( !obj.isNull() );
+  QVERIFY( obj );
+  QCOMPARE( child, obj.get() );
+  QCOMPARE( child, obj.data() );
 
   delete parent;
   QVERIFY( obj.isNull() );
+  QVERIFY( !obj );
 }
 
 void TestQObjectUniquePtr::testParentDeletedAfter()

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -106,8 +106,6 @@ void TestQObjectUniquePtr::testOperatorArrow()
 
 void TestQObjectUniquePtr::testDeleteLater()
 {
-  int argc;
-  QCoreApplication ca( argc, nullptr );
   QObject *o = new QObject();
   QObject *o2 = new QObject();
 
@@ -119,8 +117,8 @@ void TestQObjectUniquePtr::testDeleteLater()
 
   obj2.reset();
 
-  connect( o, &QObject::destroyed, &ca, &QCoreApplication::quit );
-  ca.exec();
+  connect( o, &QObject::destroyed, QgsApplication::instance(), &QgsApplication::quit );
+  QgsApplication::instance()->exec();
   QVERIFY( obj.isNull() );
   QVERIFY( obj2.isNull() );
 }

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -26,9 +26,10 @@ class TestQObjectUniquePtr : public QObject
     void testMemLeak();
     void testParentDeletedFirst();
     void testParentDeletedAfter();
+    void testOperatorBool();
+    void testSwap();
+    void testOperatorArrow();
 };
-
-
 
 void TestQObjectUniquePtr::testMemLeak()
 {
@@ -68,6 +69,38 @@ void TestQObjectUniquePtr::testParentDeletedAfter()
   // Basically shouldn't crash because of double delete on this line
   delete parent;
   QVERIFY( observer.isNull() );
+}
+
+void TestQObjectUniquePtr::testOperatorBool()
+{
+  QObjectUniquePtr<QObject> obj;
+  QVERIFY( !obj );
+  QObjectUniquePtr<QObject> obj2( new QObject() );
+  QVERIFY( obj2 );
+}
+
+void TestQObjectUniquePtr::testSwap()
+{
+  QObject *o = new QObject();
+  QObjectUniquePtr<QObject> obj;
+  QObjectUniquePtr<QObject> obj2( o );
+  obj.swap( obj2 );
+  QCOMPARE( o, obj.get() );
+  QCOMPARE( nullptr, obj2.get() );
+
+  QObject *o2 = new QObject();
+  QObjectUniquePtr<QObject> obj3( o2 );
+  obj.swap( obj3 );
+  QCOMPARE( o, obj3.get() );
+  QCOMPARE( o2, obj.get() );
+}
+
+void TestQObjectUniquePtr::testOperatorArrow()
+{
+  QObject *o = new QObject();
+  o->setName( "Teddy" );
+  QObjectUniquePtr<QObject> obj( o );
+  QCOMPARE( obj->name(), "Teddy" );
 }
 
 QGSTEST_MAIN( TestQObjectUniquePtr )

--- a/tests/src/core/testqobjectuniqueptr.cpp
+++ b/tests/src/core/testqobjectuniqueptr.cpp
@@ -98,9 +98,9 @@ void TestQObjectUniquePtr::testSwap()
 void TestQObjectUniquePtr::testOperatorArrow()
 {
   QObject *o = new QObject();
-  o->setName( "Teddy" );
+  o->setObjectName( "Teddy" );
   QObjectUniquePtr<QObject> obj( o );
-  QCOMPARE( obj->name(), "Teddy" );
+  QCOMPARE( obj->objectName(), "Teddy" );
 }
 
 QGSTEST_MAIN( TestQObjectUniquePtr )


### PR DESCRIPTION
Is basically a `QPointer` with ownership.

The encapsulated QObject will be deleted as soon as the (any) `QObjectUniquePtr` scopes out.