### PR TITLE
[dbmanager] allow to import GEOMETRY tables

### DIFF
--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -31,7 +31,8 @@ from qgis.core import (
     Qgis,
     QgsApplication,
     QgsSettings,
-    QgsMapLayerType
+    QgsMapLayerType,
+    QgsWkbTypes
 )
 from ..db_plugins import createDbPlugin
 
@@ -522,8 +523,28 @@ class Database(DbItemObject):
     def tables(self, schema=None, sys_tables=False):
         tables = self.connector.getTables(schema.name if schema else None, sys_tables)
         if tables is not None:
-            tables = [self.tablesFactory(x, self, schema) for x in tables]
-        return tables
+            ret = []
+            for t in tables:
+                table = self.tablesFactory(t, self, schema)
+                ret.append(table)
+
+                # Similarly to what to browser does, if the geom type is generic geometry,
+                # we additionnly add three copies of the layer to allow importing
+                if isinstance(table, VectorTable):
+                    if table.geomType == 'GEOMETRY':
+                        point_table = self.tablesFactory(t, self, schema)
+                        point_table.geomType = 'POINT'
+                        ret.append(point_table)
+
+                        line_table = self.tablesFactory(t, self, schema)
+                        line_table.geomType = 'LINESTRING'
+                        ret.append(line_table)
+
+                        poly_table = self.tablesFactory(t, self, schema)
+                        poly_table.geomType = 'POLYGON'
+                        ret.append(poly_table)
+
+        return ret
 
     def createTable(self, table, fields, schema=None):
         field_defs = [x.definition() for x in fields]
@@ -692,6 +713,13 @@ class Table(DbItemObject):
         geomCol = self.geomColumn if self.type in [Table.VectorType, Table.RasterType] else ""
         uniqueCol = self.getValidQgisUniqueFields(True) if self.isView else None
         uri.setDataSource(schema, self.name, geomCol if geomCol else None, None, uniqueCol.name if uniqueCol else "")
+        uri.setSrid(str(self.srid))
+        for f in self.fields():
+            if f.primaryKey:
+                uri.setKeyColumn(f.name)
+                break
+        uri.setWkbType(QgsWkbTypes.parseType(self.geomType))
+
         return uri
 
     def mimeUri(self):


### PR DESCRIPTION
## Description

Currently, adding a generic `Geometry` postgres layer from the DBManager fails with 
```
CRITICAL    Layer is not valid : The layer dbname='postgres' host=127.0.0.1 port=5432 user='postgres' password='postgres' table="public"."test_mixed" (geom) sql= is not a valid layer and can not be added to the map. Reason: 
```

I used a similar approach that what's used in the browser and the add layer dialog : additionally to the actual table, "fake" tables are shown for each WkbType. This works well and doesn't require too many changes, as we can just add the WkbType in the item's mime data, and everything works (drag&drop, add layer context menu...).

![image](https://user-images.githubusercontent.com/1894106/59292870-2ec5e580-8c7e-11e9-8cec-bf65d1963889.png)

It's not really ideal in terms of UX, as it's a bit confusing to see what is actually one table displayed several times. But I thought this is acceptable since it's already like this in the browser and in the add layer dialog.

In the browser and add dialog, "fake" tables are shown only if the feature type is found amongst the first 100 first rows of the table (it seems). In this PR, to avoid this additional query, to allow working with empty tables, all types are shown in all cases. Reusing the C++ logic for this (in QgsPostgresConn) would require deeper changes to the plugin.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] (N/A) Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] (N/A) Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] (N/A) Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] (will see...) This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] (N/A) New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit






