### PR TITLE
Expose some more auth manager methods to Python

### DIFF
--- a/python/core/auto_generated/auth/qgsauthmanager.sip.in
+++ b/python/core/auto_generated/auth/qgsauthmanager.sip.in
@@ -717,10 +717,34 @@ trustedCaCertsPemText get concatenated string of all trusted CA certificates
 
 
 
+    bool passwordHelperEnabled() const;
+%Docstring
+Password helper enabled getter
+
+.. note::
+
+   Available in Python bindings since QGIS 3.8.0
+%End
+
+    void setPasswordHelperEnabled( bool enabled );
+%Docstring
+Password helper enabled setter
+
+.. note::
+
+   Available in Python bindings since QGIS 3.8.0
+%End
 
 
 
+    bool passwordHelperSync();
+%Docstring
+Store the password manager into the wallet
 
+.. note::
+
+   Available in Python bindings since QGIS 3.8.0
+%End
 
     static const QString AUTH_PASSWORD_HELPER_DISPLAY_NAME;
 

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -644,15 +644,15 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
     /**
      * Password helper enabled getter
-     * \note not available in Python bindings
+     * \note Available in Python bindings since QGIS 3.8.0
      */
-    bool passwordHelperEnabled() const SIP_SKIP;
+    bool passwordHelperEnabled() const;
 
     /**
      * Password helper enabled setter
-     * \note not available in Python bindings
+     * \note Available in Python bindings since QGIS 3.8.0
      */
-    void setPasswordHelperEnabled( bool enabled ) SIP_SKIP;
+    void setPasswordHelperEnabled( bool enabled );
 
     /**
      * Password helper logging enabled getter
@@ -668,9 +668,9 @@ class CORE_EXPORT QgsAuthManager : public QObject
 
     /**
      * Store the password manager into the wallet
-     * \note not available in Python bindings
+     * \note Available in Python bindings since QGIS 3.8.0
      */
-    bool passwordHelperSync() SIP_SKIP;
+    bool passwordHelperSync();
 
     //! The display name of the password helper (platform dependent)
     static const QString AUTH_PASSWORD_HELPER_DISPLAY_NAME;


### PR DESCRIPTION
These methods either
- only wrap QSettings values (so there's no added security gained
by not exposing them -- it's currently easily possible to achieve
the same results via direct QSettings manipulation)

OR

- are required to allow fully automated QGIS deployment/startup scripts which rely on auth manager functionality

In the case of passwordHelperSync(), this is required in order to allow deployment scripts to set a master database password and store it in user's password wallets. Without it, it's ONLY possible to use auth manager functionality by forcing a "set master password" prompt to show during the deployment script, which is scary and intimidating for users, and breaks automated deployments.

In the use case I'm hitting currently, we need to expose a number of services by default which utilise oauth2 authentication. In this case there is nothing sensitive stored locally, so the deployment script will create a random password, set it as the auth manager master password, and then sync this password into the user's wallet. They'll never need to know what this password is, and will never be asked it. (The only password prompts they'll ever see are the 3rd party oauth2 provider prompt).

If there's an alternative approach to achieving this goal, please let me know!
