### PR TITLE
Defer zoom to first loaded layer extent for layers with broken paths

### DIFF
--- a/src/gui/layertree/qgslayertreemapcanvasbridge.h
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.h
@@ -102,6 +102,7 @@ class GUI_EXPORT QgsLayerTreeMapCanvasBridge : public QObject
   private slots:
     void nodeVisibilityChanged();
     void nodeCustomPropertyChanged( QgsLayerTreeNode *node, const QString &key );
+    void layersAdded( const QList<QgsMapLayer *> &layers );
 
   private:
     //! Fill canvasLayers and overviewLayers lists from node and its descendants
@@ -120,6 +121,7 @@ class GUI_EXPORT QgsLayerTreeMapCanvasBridge : public QObject
 
     bool mHasFirstLayer;
     bool mHasLayersLoaded;
+    bool mHasValidLayersLoaded = false;
     bool mUpdatingProjectLayerOrder = false;
 
     QgsCoordinateReferenceSystem mFirstCRS;


### PR DESCRIPTION
If the first layers loaded into a project is non-valid (e.g. qlrs pointing to a broken path), then defer the default zoom to the layer's extent
until AFTER the layer path is fixed

Avoids the situation where a user:
- loads a broken qlr
- canvas goes to a invalid extent, since the first loaded layer has an invalid extent
- user fixes the layer path, but there's no visible changes -- because the canvas
is pointing to some random location
