### PR TITLE
Update default values with "apply on update" on split

### DIFF
--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -352,9 +352,10 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QVect
       mLayer->changeGeometry( feat.id(), featureGeom );
 
       //insert new features
-      for ( int i = 0; i < newGeometries.size(); ++i )
+      QgsAttributeMap attributeMap = feat.attributes().toMap();
+      for ( const QgsGeometry &geom : qgis::as_const( newGeometries ) )
       {
-        QgsFeature f = QgsVectorLayerUtils::createFeature( mLayer, newGeometries.at( i ), feat.attributes().toMap() );
+        QgsFeature f = QgsVectorLayerUtils::createFeature( mLayer, geom, attributeMap );
         mLayer->addFeature( f );
       }
 

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -507,9 +507,11 @@ QgsFeatureList QgsVectorLayerUtils::createFeatures( const QgsVectorLayer *layer,
 
       // 2. client side default expression
       // note - deliberately not using else if!
+      QgsDefaultValue defaultValueDefinition = layer->defaultValueDefinition( idx );
       if ( ( v.isNull() || ( hasUniqueConstraint
-                             && uniqueValueCaches[ idx ].contains( v ) ) )
-           && layer->defaultValueDefinition( idx ).isValid() )
+                             && uniqueValueCaches[ idx ].contains( v ) )
+             || defaultValueDefinition.applyOnUpdate() )
+           && defaultValueDefinition.isValid() )
       {
         // client side default expression set - takes precedence over all. Why? Well, this is the only default
         // which QGIS users have control over, so we assume that they're deliberately overriding any

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -263,6 +263,10 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         # we do not expect the default value expression to take precedence over the attribute map
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'a', 2: 6.0})
         self.assertEqual(f.attributes(), ['a', NULL, 6.0])
+        # default value takes precedence if it's apply on update
+        layer.setDefaultValueDefinition(2, QgsDefaultValue('3*4', True))
+        f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'a', 2: 6.0})
+        self.assertEqual(f.attributes(), ['a', NULL, 12.0])
         # layer with default value expression based on geometry
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*$x'))
         f = QgsVectorLayerUtils.createFeature(layer, g)


### PR DESCRIPTION
Default values with "apply on update" should always be recalculated without a possibility to override.

Fix https://github.com/qgis/QGIS/issues/30164