### PR TITLE
[arcgis] Browser and source selector should only return appropriate layer type

### DIFF
--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -103,7 +103,7 @@ void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &servic
   {
     std::unique_ptr< QgsAfsServiceItem > serviceItem = qgis::make_unique< QgsAfsServiceItem >( parent, name, url, url, authcfg, headers );
     items.append( serviceItem.release() );
-  }, serviceData, baseUrl );
+  }, serviceData, baseUrl, QgsArcGisRestUtils::Vector );
 }
 
 void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &parentUrl, const QString &authcfg, const QgsStringMap &headers, QgsDataItem *parent )
@@ -129,7 +129,7 @@ void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceD
       layerItems.insert( id, layerItem.release() );
     }
 
-  }, serviceData, parentUrl );
+  }, serviceData, parentUrl, QgsArcGisRestUtils::Vector );
 
   // create groups
   for ( auto it = layerItems.constBegin(); it != layerItems.constEnd(); ++it )

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -82,7 +82,7 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
 
       if ( !visitItemsRecursive( url, nameItem ) )
         res = false;
-    }, serviceInfoMap, baseUrl );
+    }, serviceInfoMap, baseUrl, QgsArcGisRestUtils::Vector );
 
     QMap< QString, QList<QStandardItem *> > layerItems;
     QMap< QString, QString > parents;
@@ -121,7 +121,7 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
 
         layerItems.insert( layerId, QList<QStandardItem *>() << idItem << nameItem << abstractItem << filterItem );
       }
-    }, serviceInfoMap, baseItemUrl );
+    }, serviceInfoMap, baseItemUrl, QgsArcGisRestUtils::Vector );
 
     // create layer groups
     for ( auto it = layerItems.constBegin(); it != layerItems.constEnd(); ++it )

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -104,7 +104,7 @@ void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &servic
   {
     std::unique_ptr< QgsAmsServiceItem > serviceItem = qgis::make_unique< QgsAmsServiceItem >( parent, name, url, url, authcfg, headers );
     items.append( serviceItem.release() );
-  }, serviceData, baseUrl );
+  }, serviceData, baseUrl, QgsArcGisRestUtils::Raster );
 }
 
 void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &parentUrl, const QString &authcfg, const QgsStringMap &headers, QgsDataItem *parent )
@@ -122,7 +122,7 @@ void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceD
     std::unique_ptr< QgsAmsLayerItem > layerItem = qgis::make_unique< QgsAmsLayerItem >( parent, name, url, id, name, authid, format, authcfg, headers );
     layerItems.insert( id, layerItem.release() );
 
-  }, serviceData, parentUrl );
+  }, serviceData, parentUrl, QgsArcGisRestUtils::Raster );
 
   // create groups
   for ( auto it = layerItems.constBegin(); it != layerItems.constEnd(); ++it )

--- a/src/providers/arcgisrest/qgsamssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsamssourceselect.cpp
@@ -93,7 +93,7 @@ bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
 
       if ( !visitItemsRecursive( url, nameItem ) )
         res = false;
-    }, serviceInfoMap, baseUrl );
+    }, serviceInfoMap, baseUrl, QgsArcGisRestUtils::Raster );
 
     QMap< QString, QList<QStandardItem *> > layerItems;
     QMap< QString, QString > parents;
@@ -123,7 +123,7 @@ bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
       mAvailableCRS[name] = QList<QString>()  << authid;
 
       layerItems.insert( layerId, QList<QStandardItem *>() << idItem << nameItem << abstractItem << filterItem );
-    }, serviceInfoMap, baseItemUrl );
+    }, serviceInfoMap, baseItemUrl, QgsArcGisRestUtils::Raster );
 
     // create layer groups
     for ( auto it = layerItems.constBegin(); it != layerItems.constEnd(); ++it )

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -51,6 +51,17 @@ class QgsFeatureRenderer;
 class QgsArcGisRestUtils
 {
   public:
+
+    /**
+     * Service types
+     */
+    enum ServiceTypeFilter
+    {
+      AllTypes, //!< All types
+      Vector,   //!< Vector type
+      Raster   //!< Raster type
+    };
+
     static QVariant::Type mapEsriFieldType( const QString &esriFieldType );
     static QgsWkbTypes::Type mapEsriGeometryType( const QString &esriGeometryType );
     static std::unique_ptr< QgsAbstractGeometry > parseEsriGeoJSON( const QVariantMap &geometryData, const QString &esriGeometryType, bool readM, bool readZ, QgsCoordinateReferenceSystem *crs = nullptr );
@@ -96,8 +107,8 @@ class QgsArcGisRestUtils
     static QUrl parseUrl( const QUrl &url );
     static void adjustBaseUrl( QString &baseUrl, const QString name );
     static void visitFolderItems( const std::function<void ( const QString &folderName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl );
-    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl );
-    static void addLayerItems( const std::function<void ( const QString &parentLayerId, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl );
+    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl, const ServiceTypeFilter filter = QgsArcGisRestUtils::AllTypes );
+    static void addLayerItems( const std::function<void ( const QString &parentLayerId, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid, const QString &format )> &visitor, const QVariantMap &serviceData, const QString &parentUrl, const ServiceTypeFilter filter = QgsArcGisRestUtils::AllTypes );
 };
 
 class QgsArcGisAsyncQuery : public QObject


### PR DESCRIPTION
## Description
This PR fixes the arcgis rest providers' browser data items and source selector to _only_ show the appropriate layer type (i.e. raster provider should only show raster layer items, etc.). 

@nyalldawson , review welcomed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
