### PR TITLE
[needs-docs] Add --version|-v cli option to qgis executable

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -114,6 +114,28 @@ typedef SInt32 SRefCon;
 #endif
 
 /**
+ * Print QGIS version
+ */
+void version( )
+{
+  QStringList msg;
+
+  msg
+      << QStringLiteral( "QGIS " ) << VERSION << QStringLiteral( " '" ) << RELEASE_NAME << QStringLiteral( "' (" )
+      << QGSVERSION << QStringLiteral( ")\n" );
+
+#ifdef Q_OS_WIN
+  MessageBox( nullptr,
+              msg.join( QString() ).toLocal8Bit().constData(),
+              "QGIS version",
+              MB_OK );
+#else
+  std::cerr << msg.join( QString() ).toLocal8Bit().constData();
+#endif
+
+} // version()
+
+/**
  * Print usage text
  */
 void usage( const QString &appName )
@@ -121,8 +143,6 @@ void usage( const QString &appName )
   QStringList msg;
 
   msg
-      << QStringLiteral( "QGIS - " ) << VERSION << QStringLiteral( " '" ) << RELEASE_NAME << QStringLiteral( "' (" )
-      << QGSVERSION << QStringLiteral( ")\n" )
       << QStringLiteral( "QGIS is a user friendly Open Source Geographic Information System.\n" )
       << QStringLiteral( "Usage: " ) << appName <<  QStringLiteral( " [OPTION] [FILE]\n" )
       << QStringLiteral( "  OPTION:\n" )
@@ -604,6 +624,11 @@ int main( int argc, char *argv[] )
         {
           usage( args[0] );
           return 2;
+        }
+        else if ( arg == QLatin1String( "--version" ) || arg == QLatin1String( "-v" ) )
+        {
+          version();
+          return EXIT_SUCCESS;
         }
         else if ( arg == QLatin1String( "--nologo" ) || arg == QLatin1String( "-n" ) )
         {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -126,7 +126,7 @@ void version( )
               "QGIS version",
               MB_OK );
 #else
-  std::cerr << msg.toStdString();
+  std::cout << msg.toStdString();
 #endif
 
 } // version()
@@ -190,7 +190,7 @@ void usage( const QString &appName )
               "QGIS command line options",
               MB_OK );
 #else
-  std::cerr << msg.join( QString() ).toLocal8Bit().constData();
+  std::cout << msg.join( QString() ).toLocal8Bit().constData();
 #endif
 
 } // usage()
@@ -620,7 +620,7 @@ int main( int argc, char *argv[] )
         if ( arg == QLatin1String( "--help" ) || arg == QLatin1String( "-?" ) )
         {
           usage( args[0] );
-          return 2;
+          return EXIT_SUCCESS;
         }
         else if ( arg == QLatin1String( "--version" ) || arg == QLatin1String( "-v" ) )
         {

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -118,19 +118,15 @@ typedef SInt32 SRefCon;
  */
 void version( )
 {
-  QStringList msg;
-
-  msg
-      << QStringLiteral( "QGIS " ) << VERSION << QStringLiteral( " '" ) << RELEASE_NAME << QStringLiteral( "' (" )
-      << QGSVERSION << QStringLiteral( ")\n" );
+  const QString msg = QStringLiteral( "QGIS %1 '%2' (%3)\n" ).arg( VERSION ).arg( RELEASE_NAME ).arg( QGSVERSION );
 
 #ifdef Q_OS_WIN
   MessageBox( nullptr,
-              msg.join( QString() ).toLocal8Bit().constData(),
+              msg,
               "QGIS version",
               MB_OK );
 #else
-  std::cerr << msg.join( QString() ).toLocal8Bit().constData();
+  std::cerr << msg.toStdString();
 #endif
 
 } // version()
@@ -146,6 +142,7 @@ void usage( const QString &appName )
       << QStringLiteral( "QGIS is a user friendly Open Source Geographic Information System.\n" )
       << QStringLiteral( "Usage: " ) << appName <<  QStringLiteral( " [OPTION] [FILE]\n" )
       << QStringLiteral( "  OPTION:\n" )
+      << QStringLiteral( "\t[--version]\tdisplay version information and exit\n" )
       << QStringLiteral( "\t[--snapshot filename]\temit snapshot of loaded datasets to given file\n" )
       << QStringLiteral( "\t[--width width]\twidth of snapshot to emit\n" )
       << QStringLiteral( "\t[--height height]\theight of snapshot to emit\n" )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -119,17 +119,8 @@ typedef SInt32 SRefCon;
 void version( )
 {
   const QString msg = QStringLiteral( "QGIS %1 '%2' (%3)\n" ).arg( VERSION ).arg( RELEASE_NAME ).arg( QGSVERSION );
-
-#ifdef Q_OS_WIN
-  MessageBox( nullptr,
-              msg,
-              "QGIS version",
-              MB_OK );
-#else
   std::cout << msg.toStdString();
-#endif
-
-} // version()
+}
 
 /**
  * Print usage text


### PR DESCRIPTION
## Description

This adds a new CLI option `--version|-v` to display the QGIS version and exit. I removed the version information from `--help|-?`. I've checked other softwares and `--help` option usually just shows the usage information, without version. We are following the same approach.

This closes #30083.

### Output

I've checked some other softwares to see if there was a common version syntax. Each one has his own format, usually in just one line. 

```
jgr@zoe:~/dev/cpp/QGIS$ ../build-QGIS-Desktop-Default/output/bin/qgis -v
QGIS 3.7.0-Master 'Master' (38c8e757aa)
jgr@zoe:~/dev/cpp/QGIS$ firefox --version
Mozilla Firefox 67.0.1
jgr@zoe:~/dev/cpp/QGIS$ psql --version
psql (PostgreSQL) 10.8 (Ubuntu 10.8-0ubuntu0.18.10.1)
jgr@zoe:~/dev/cpp/QGIS$ python3 --version
Python 3.6.8
jgr@zoe:~$ google-chrome --version
Google Chrome 73.0.3683.103
```

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
