### PR TITLE
Always use the correct legend size when rendering legends

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -174,7 +174,7 @@ void QgsLayoutItemLegend::draw( QgsLayoutItemRenderContext &context )
   }
 
   QgsLegendRenderer legendRenderer( mLegendModel.get(), mSettings );
-  legendRenderer.setLegendSize( mSizeToContents ? QSize() : rect().size() );
+  legendRenderer.setLegendSize( rect().size() );
 
   legendRenderer.drawLegend( context.renderContext() );
 


### PR DESCRIPTION
No existing known bugs caused by this, but it should be done anyway
and will help make future legend related work less confusing...
