### PR TITLE
Allow setting the default for new projects to "no projection"

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -462,8 +462,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   leLayerGlobalCrs->setCrs( mLayerDefaultCrs );
 
   const QString defaultProjectCrs = mSettings->value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString();
-  leProjectGlobalCrs->setCrs( QgsCoordinateReferenceSystem( defaultProjectCrs ) );
   leProjectGlobalCrs->setOptionVisible( QgsProjectionSelectionWidget::DefaultCrs, false );
+  leProjectGlobalCrs->setOptionVisible( QgsProjectionSelectionWidget::CrsNotSet, true );
+  leProjectGlobalCrs->setNotSetText( tr( "No projection (or unknown/non-Earth projection)" ) );
+  leProjectGlobalCrs->setCrs( QgsCoordinateReferenceSystem( defaultProjectCrs ) );
   leProjectGlobalCrs->setMessage(
     tr( "<h1>Default projection for new projects</h1>"
         "Select a projection that should be used for new projects that are created in QGIS."

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -464,6 +464,11 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   const QString defaultProjectCrs = mSettings->value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString();
   leProjectGlobalCrs->setCrs( QgsCoordinateReferenceSystem( defaultProjectCrs ) );
   leProjectGlobalCrs->setOptionVisible( QgsProjectionSelectionWidget::DefaultCrs, false );
+  leProjectGlobalCrs->setMessage(
+    tr( "<h1>Default projection for new projects</h1>"
+        "Select a projection that should be used for new projects that are created in QGIS."
+      ) );
+
   const QgsGui::ProjectCrsBehavior projectCrsBehavior = mSettings->enumValue( QStringLiteral( "/projections/newProjectCrsBehavior" ),  QgsGui::UseCrsOfFirstLayerAdded, QgsSettings::App );
   switch ( projectCrsBehavior )
   {

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -171,9 +171,11 @@ void QgsProjectionSelectionWidget::selectCrs()
   //find out crs id of current proj4 string
   QgsProjectionSelectionDialog dlg( this );
   dlg.setMessage( mMessage );
-  if ( mCrs.isValid() )
+  dlg.setCrs( mCrs );
+
+  if ( optionVisible( QgsProjectionSelectionWidget::CrsOption::CrsNotSet ) )
   {
-    dlg.setCrs( mCrs );
+    dlg.setShowNoProjection( true );
   }
 
   if ( dlg.exec() )


### PR DESCRIPTION
* It's possible to create a new project with "no projection"
* It's also possible to set a default projection
* But it's not possible to set the "default projection for new projects" to "no projection"

It was possible in QGIS 2 to have OTF disabled by default so this restores an analog to this setting, so it's effectively a regression

![Screenshot from 2019-06-14 12-34-36](https://user-images.githubusercontent.com/588407/59503534-ec302300-8ea0-11e9-8084-65529d780bc1.png)

Also adds some additional improvements.

I'd like to backport this to 3.4 too (except for the correction of the title of the projection selection text for translation reasons)