### PR TITLE
[Backport release-3_4]GetContext: Fix hidden attribute value based on tree layer visibility

### DIFF
--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -284,11 +284,11 @@ namespace QgsWms
           // visibility
           if ( treeLayer->itemVisibilityChecked() )
           {
-            layerElem.setAttribute( QStringLiteral( "hidden" ), QStringLiteral( "true" ) );
+            layerElem.setAttribute( QStringLiteral( "hidden" ), QStringLiteral( "false" ) );
           }
           else
           {
-            layerElem.setAttribute( QStringLiteral( "hidden" ), QStringLiteral( "false" ) );
+            layerElem.setAttribute( QStringLiteral( "hidden" ), QStringLiteral( "true" ) );
           }
 
           // layer group

--- a/tests/testdata/qgis_server/getcontext.txt
+++ b/tests/testdata/qgis_server/getcontext.txt
@@ -13,7 +13,7 @@ Content-Type: text/xml; charset=utf-8
   </ows:BoundingBox>
  </General>
  <ResourceList>
-  <Layer group="groupwithoutshortname" hidden="true" queryable="false" id="testlayer3" name="testlayer3" opacity="1">
+  <Layer group="groupwithoutshortname" hidden="false" queryable="false" id="testlayer3" name="testlayer3" opacity="1">
    <ows:Title>testlayer3</ows:Title>
    <ows:OutputFormat>image/png</ows:OutputFormat>
    <Server default="true" service="urn:ogc:serviceType:WMS" version="1.3.0">
@@ -26,7 +26,7 @@ Content-Type: text/xml; charset=utf-8
     </Style>
    </StyleList>
   </Layer>
-  <Layer group="groupwithshortname" hidden="true" queryable="true" id="testlayer2" name="testlayer2" opacity="1">
+  <Layer group="groupwithshortname" hidden="false" queryable="true" id="testlayer2" name="testlayer2" opacity="1">
    <ows:Title>testlayer2</ows:Title>
    <ows:OutputFormat>image/png</ows:OutputFormat>
    <Server default="true" service="urn:ogc:serviceType:WMS" version="1.3.0">
@@ -39,7 +39,7 @@ Content-Type: text/xml; charset=utf-8
     </Style>
    </StyleList>
   </Layer>
-  <Layer hidden="true" queryable="true" id="testlayer_èé" name="testlayer èé" opacity="1">
+  <Layer hidden="false" queryable="true" id="testlayer_èé" name="testlayer èé" opacity="1">
    <ows:Title>A test vector layer</ows:Title>
    <ows:OutputFormat>image/png</ows:OutputFormat>
    <Server default="true" service="urn:ogc:serviceType:WMS" version="1.3.0">
@@ -53,7 +53,7 @@ Content-Type: text/xml; charset=utf-8
     </Style>
    </StyleList>
   </Layer>
-  <Layer hidden="true" queryable="true" id="layer_with_short_name" name="layer_with_short_name" opacity="1">
+  <Layer hidden="false" queryable="true" id="layer_with_short_name" name="layer_with_short_name" opacity="1">
    <ows:Title>A Layer with a short name</ows:Title>
    <ows:OutputFormat>image/png</ows:OutputFormat>
    <Server default="true" service="urn:ogc:serviceType:WMS" version="1.3.0">


### PR DESCRIPTION
## Description
Manually backport #30215 

The tree layer method itemVisibilityChecked has not been well interpreted.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
