### PR TITLE
[needs-docs] Ensure layer legend graphics are horizontally scrollable (fixes #28050)

### DIFF
--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -208,6 +208,9 @@ Emitted when a current layer is changed
     virtual void dropEvent( QDropEvent *event );
 
 
+    virtual void resizeEvent( QResizeEvent *event );
+
+
   protected slots:
 
     void modelRowsInserted( const QModelIndex &index, int start, int end );

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -164,6 +164,15 @@ Returns list of indicators associated with a particular layer tree node.
 .. versionadded:: 3.2
 %End
 
+    int layerMarkWidth() const;
+%Docstring
+Returns width of contextual menu mark, at right of layer node items.
+
+.. seealso:: :py:func:`setLayerMarkWidth`
+
+.. versionadded:: 3.8
+%End
+
 
 
   public slots:
@@ -184,6 +193,15 @@ Enhancement of QTreeView.expandAll() that also records expanded state in layer t
 Enhancement of QTreeView.collapseAll() that also records expanded state in layer tree nodes
 
 .. versionadded:: 2.18
+%End
+
+    void setLayerMarkWidth( int width );
+%Docstring
+Set width of contextual menu mark, at right of layer node items.
+
+.. seealso:: :py:func:`layerMarkWidth`
+
+.. versionadded:: 3.8
 %End
 
   signals:
@@ -223,6 +241,7 @@ Emitted when a current layer is changed
     void onModelReset();
 
   protected:
+
 
 };
 

--- a/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
@@ -15,6 +15,7 @@
 
 #include "qgslayertreeembeddedwidgetsimpl.h"
 
+#include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QSlider>
@@ -34,9 +35,14 @@ QgsLayerTreeOpacityWidget::QgsLayerTreeOpacityWidget( QgsMapLayer *layer )
   QLabel *l = new QLabel( QStringLiteral( "Opacity" ), this );
   mSlider = new QSlider( Qt::Horizontal, this );
   mSlider->setRange( 0, 1000 );
+  int sliderW = static_cast< int >( QFontMetricsF( font() ).width( 'X' ) * 16 * Qgis::UI_SCALE_FACTOR );
+  mSlider->setMinimumWidth( sliderW / 2 );
+  mSlider->setMaximumWidth( sliderW );
   QHBoxLayout *lay = new QHBoxLayout();
+  QSpacerItem *spacerItem = new QSpacerItem( 1, 0, QSizePolicy::MinimumExpanding, QSizePolicy::Minimum );
   lay->addWidget( l );
   lay->addWidget( mSlider );
+  lay->addItem( spacerItem );
   setLayout( lay );
 
   // timer for delayed transparency update - for more responsive GUI

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -58,7 +58,7 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
   setItemDelegate( new QgsLayerTreeViewItemDelegate( this ) );
   setStyle( new QgsLayerTreeViewProxyStyle( this ) );
 
-  setLayerMarkWidth( static_cast< int >( QFontMetricsF( font() ).width( 'X' ) * 1.75 * Qgis::UI_SCALE_FACTOR ) );
+  setLayerMarkWidth( static_cast< int >( QFontMetricsF( font() ).width( 'l' ) * Qgis::UI_SCALE_FACTOR ) );
 
   connect( this, &QTreeView::collapsed, this, &QgsLayerTreeView::updateExpandedStateToNode );
   connect( this, &QTreeView::expanded, this, &QgsLayerTreeView::updateExpandedStateToNode );

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -163,14 +163,22 @@ void QgsLayerTreeView::modelRowsInserted( const QModelIndex &index, int start, i
         {
           QModelIndex index = layerTreeModel()->legendNode2index( legendNodes[i] );
           QWidget *wdgt = provider->createWidget( layer, i );
-          // Since column is resized to contents, limit the expanded width of embedded widgets,
-          // if they are not already limited, e.g. have the defaut MAX value.
+          // Since column is resized to contents, limit the expanded width of embedded
+          //  widgets, if they are not already limited, e.g. have the default MAX value.
           // Else, embedded widget may grow very wide due to large legend graphics.
-          // TODO: Max width could be a configured setting.
-          if ( wdgt->maximumWidth() == QWIDGETSIZE_MAX )
-          {
-            wdgt->setMaximumWidth( 250 );
-          }
+          // NOTE: This approach DOES NOT work right. It causes horizontal scroll
+          //       bar to disappear if the embedded widget is expanded and part
+          //       of the last layer in the panel, even if much wider legend items
+          //       are expanded above it. The correct width-limiting method should
+          //       be setting fixed-width, hidpi-aware embedded widget items in a
+          //       layout and appending an expanding QSpacerItem to end. This ensures
+          //       full width is always created in the column by the embedded widget.
+          //       See QgsLayerTreeOpacityWidget
+          //if ( wdgt->maximumWidth() == QWIDGETSIZE_MAX )
+          //{
+          //  wdgt->setMaximumWidth( 250 );
+          //}
+
           setIndexWidget( index, wdgt );
         }
       }

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -58,6 +58,8 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
   setItemDelegate( new QgsLayerTreeViewItemDelegate( this ) );
   setStyle( new QgsLayerTreeViewProxyStyle( this ) );
 
+  setLayerMarkWidth( static_cast< int >( QFontMetricsF( font() ).width( 'X' ) * 1.75 * Qgis::UI_SCALE_FACTOR ) );
+
   connect( this, &QTreeView::collapsed, this, &QgsLayerTreeView::updateExpandedStateToNode );
   connect( this, &QTreeView::expanded, this, &QgsLayerTreeView::updateExpandedStateToNode );
 }

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -48,6 +48,9 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
   header()->setStretchLastSection( false );
   header()->setSectionResizeMode( QHeaderView::ResizeToContents );
 
+  // If vertically scrolling by item, legend graphics can get clipped
+  setVerticalScrollMode( QAbstractItemView::ScrollPerPixel );
+
   setSelectionMode( ExtendedSelection );
   setDefaultDropAction( Qt::MoveAction );
 

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -26,6 +26,7 @@
 
 #include <QMenu>
 #include <QContextMenuEvent>
+#include <QHeaderView>
 
 #include "qgslayertreeviewindicator.h"
 #include "qgslayertreeviewitemdelegate.h"
@@ -42,6 +43,10 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
   setDropIndicatorShown( true );
   setEditTriggers( EditKeyPressed );
   setExpandsOnDoubleClick( false ); // normally used for other actions
+
+  // Ensure legend graphics are scrollable
+  header()->setStretchLastSection( false );
+  header()->setSectionResizeMode( QHeaderView::ResizeToContents );
 
   setSelectionMode( ExtendedSelection );
   setDefaultDropAction( Qt::MoveAction );

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -159,7 +159,16 @@ void QgsLayerTreeView::modelRowsInserted( const QModelIndex &index, int start, i
         if ( QgsLayerTreeEmbeddedWidgetProvider *provider = QgsGui::layerTreeEmbeddedWidgetRegistry()->provider( providerId ) )
         {
           QModelIndex index = layerTreeModel()->legendNode2index( legendNodes[i] );
-          setIndexWidget( index, provider->createWidget( layer, i ) );
+          QWidget *wdgt = provider->createWidget( layer, i );
+          // Since column is resized to contents, limit the expanded width of embedded widgets,
+          // if they are not already limited, e.g. have the defaut MAX value.
+          // Else, embedded widget may grow very wide due to large legend graphics.
+          // TODO: Max width could be a configured setting.
+          if ( wdgt->maximumWidth() == QWIDGETSIZE_MAX )
+          {
+            wdgt->setMaximumWidth( 250 );
+          }
+          setIndexWidget( index, wdgt );
         }
       }
     }

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -505,3 +505,17 @@ void QgsLayerTreeView::dropEvent( QDropEvent *event )
   }
   QTreeView::dropEvent( event );
 }
+
+void QgsLayerTreeView::resizeEvent( QResizeEvent *event )
+{
+  // Since last column is resized to content (instead of stretched), the active
+  // selection rectangle ends at width of widest visible item in tree,
+  // regardless of which item is selected. This causes layer indicators to
+  // become 'inactive' (not clickable and no tool tip) unless their rectangle
+  // enters the view item's selection (active) rectangle.
+  // Always resetting the minimum section size relative to the viewport ensures
+  // the view item's selection rectangle extends to the right edge of the
+  // viewport, which allows indicators to become active again.
+  header()->setMinimumSectionSize( viewport()->width() );
+  QTreeView::resizeEvent( event );
+}

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -154,6 +154,13 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      */
     QList<QgsLayerTreeViewIndicator *> indicators( QgsLayerTreeNode *node ) const;
 
+    /**
+     * Returns width of contextual menu mark, at right of layer node items.
+     * \see setLayerMarkWidth
+     * \since QGIS 3.8
+     */
+    int layerMarkWidth() const { return mLayerMarkWidth; }
+
 ///@cond PRIVATE
 
     /**
@@ -183,6 +190,13 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      * \since QGIS 2.18
      */
     void collapseAllNodes();
+
+    /**
+     * Set width of contextual menu mark, at right of layer node items.
+     * \see layerMarkWidth
+     * \since QGIS 3.8
+     */
+    void setLayerMarkWidth( int width ) { mLayerMarkWidth = width; }
 
   signals:
     //! Emitted when a current layer is changed
@@ -227,6 +241,9 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     QHash< QgsLayerTreeNode *, QList<QgsLayerTreeViewIndicator *> > mIndicators;
     //! Used by the item delegate for identification of which indicator has been clicked
     QPoint mLastReleaseMousePos;
+
+    //! Width of contextual menu mark for layer nodes
+    int mLayerMarkWidth;
 
     // friend so it can access viewOptions() method and mLastReleaseMousePos without making them public
     friend class QgsLayerTreeViewItemDelegate;

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -200,6 +200,8 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
 
     void dropEvent( QDropEvent *event ) override;
 
+    void resizeEvent( QResizeEvent *event ) override;
+
   protected slots:
 
     void modelRowsInserted( const QModelIndex &index, int start, int end );

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
@@ -19,7 +19,9 @@
 #include "qgslayertreeview.h"
 #include "qgslayertreeviewindicator.h"
 
+#include <QBrush>
 #include <QHelpEvent>
+#include <QPen>
 #include <QToolTip>
 
 /// @cond PRIVATE
@@ -96,6 +98,16 @@ void QgsLayerTreeViewItemDelegate::paint( QPainter *painter, const QStyleOptionV
       mode = QIcon::Disabled;
     else if ( opt.state & QStyle::State_Selected )
       mode = QIcon::Selected;
+
+    // Draw indicator background, for when floating over text content
+    qreal bradius = spacing;
+    QBrush pb = painter->brush();
+    QPen pp = painter->pen();
+    painter->setBrush( opt.palette.midlight() );
+    painter->setPen( QPen( QBrush( opt.palette.mid() ), 0.25 ) );
+    painter->drawRoundedRect( rect, bradius, bradius );
+    painter->setBrush( pb );
+    painter->setPen( pp );
 
     indicator->icon().paint( painter, rect, Qt::AlignCenter, mode );
   }

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
@@ -33,7 +33,7 @@ QgsLayerTreeViewProxyStyle::QgsLayerTreeViewProxyStyle( QgsLayerTreeView *treeVi
 
 QRect QgsLayerTreeViewProxyStyle::subElementRect( QStyle::SubElement element, const QStyleOption *option, const QWidget *widget ) const
 {
-  if ( element == SE_ItemViewItemText || element == SE_LayerTreeItemIndicator )
+  if ( element == SE_LayerTreeItemIndicator )
   {
     if ( const QStyleOptionViewItem *vopt = qstyleoption_cast<const QStyleOptionViewItem *>( option ) )
     {
@@ -42,17 +42,11 @@ QRect QgsLayerTreeViewProxyStyle::subElementRect( QStyle::SubElement element, co
         int count = mLayerTreeView->indicators( node ).count();
         if ( count )
         {
+          QRect vpr = mLayerTreeView->viewport()->rect();
           QRect r = QProxyStyle::subElementRect( SE_ItemViewItemText, option, widget );
           int indiWidth = r.height() * count;
-          int textWidth = r.width() - indiWidth;
-          if ( element == SE_LayerTreeItemIndicator )
-          {
-            return QRect( r.left() + textWidth, r.top(), indiWidth, r.height() );
-          }
-          else if ( element == SE_ItemViewItemText )
-          {
-            return QRect( r.left(), r.top(), textWidth, r.height() );
-          }
+          int vpIndiWidth = vpr.width() - indiWidth;
+          return QRect( vpIndiWidth, r.top(), indiWidth, r.height() );
         }
       }
     }

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
@@ -49,7 +49,7 @@ QRect QgsLayerTreeViewProxyStyle::subElementRect( QStyle::SubElement element, co
           QRect r = QProxyStyle::subElementRect( SE_ItemViewItemText, option, widget );
           int indiWidth = r.height() * count;
           int spacing = r.height() / 10;
-          int vpIndiWidth = vpr.width() - indiWidth - spacing - mLayerTreeView->layerMarkWidth() - spacing;
+          int vpIndiWidth = vpr.width() - indiWidth - spacing - mLayerTreeView->layerMarkWidth();
           return QRect( vpIndiWidth, r.top(), indiWidth, r.height() );
         }
       }
@@ -82,28 +82,15 @@ void QgsLayerTreeViewItemDelegate::paint( QPainter *painter, const QStyleOptionV
   initStyleOption( &opt, index );
 
   QRect tRect = mLayerTreeView->style()->subElementRect( QStyle::SE_ItemViewItemText, &opt, mLayerTreeView );
-  int tSpacing = tRect.height() / 6;
   int tPadding = tRect.height() / 10;
 
   // Draw layer context menu mark
   QRect mRect( mLayerTreeView->viewport()->rect().right() - mLayerTreeView->layerMarkWidth(), tRect.top() + tPadding, mLayerTreeView->layerMarkWidth(), tRect.height() - tPadding * 2 );
-  qreal ex = mRect.x() + 0.5 + mRect.width() / 2;
-  qreal eradius = tSpacing * 0.5;
-  qreal bradius = tPadding;
   QBrush pb = painter->brush();
   QPen pp = painter->pen();
-  painter->setPen( QPen( QBrush( opt.palette.mid() ), 0.25 ) );
-  // background
-  painter->setBrush( QBrush( opt.palette.midlight() ) );
-  painter->drawRoundedRect( mRect, bradius, bradius );
-  // mark
   painter->setPen( QPen( Qt::NoPen ) );
-  painter->setBrush( QBrush( Qt::darkGray ) );
-  painter->drawEllipse( QPointF( ex, mRect.top() + tSpacing * 1.25 ), eradius, eradius );
-  painter->drawEllipse( QPointF( ex, mRect.top() + tSpacing * 2.75 ), eradius, eradius );
-  painter->drawEllipse( QPointF( ex, mRect.top() + tSpacing * 4.25 ), eradius, eradius );
-  painter->setBrush( pb );
-  painter->setPen( pp );
+  painter->setBrush( QBrush( opt.palette.mid() ) );
+  painter->drawRect( mRect );
 
   const QList<QgsLayerTreeViewIndicator *> indicators = mLayerTreeView->indicators( node );
   if ( indicators.isEmpty() )
@@ -194,40 +181,18 @@ void QgsLayerTreeViewItemDelegate::onClicked( const QModelIndex &index )
   if ( !node )
     return;
 
+  const QList<QgsLayerTreeViewIndicator *> indicators = mLayerTreeView->indicators( node );
+  if ( indicators.isEmpty() )
+    return;
+
   QStyleOptionViewItem opt( mLayerTreeView->viewOptions() );
   opt.rect = mLayerTreeView->visualRect( index );
   initStyleOption( &opt, index );
   _fixStyleOption( opt );
 
-  QPoint pos = mLayerTreeView->mLastReleaseMousePos;
-
-  QRect tRect = mLayerTreeView->style()->subElementRect( QStyle::SE_ItemViewItemText, &opt, mLayerTreeView );
-  int spacing = tRect.height() / 10;
-  QRect mRect( mLayerTreeView->viewport()->rect().right() - mLayerTreeView->layerMarkWidth() - spacing * 2, tRect.top(), mLayerTreeView->layerMarkWidth(), tRect.height() );
-
-  if ( mRect.contains( pos ) )
-  {
-    QgsLayerTreeViewMenuProvider *menuProvider = mLayerTreeView->menuProvider();
-    if ( !menuProvider )
-    {
-      return;
-    }
-
-    QMenu *menu = menuProvider->createContextMenu();
-    if ( menu && menu->actions().count() != 0 )
-    {
-      menu->exec( mLayerTreeView->viewport()->mapToGlobal( pos ) );
-    }
-    delete menu;
-    return;
-  }
-
-  const QList<QgsLayerTreeViewIndicator *> indicators = mLayerTreeView->indicators( node );
-  if ( indicators.isEmpty() )
-    return;
-
   QRect indRect = mLayerTreeView->style()->subElementRect( static_cast<QStyle::SubElement>( QgsLayerTreeViewProxyStyle::SE_LayerTreeItemIndicator ), &opt, mLayerTreeView );
 
+  QPoint pos = mLayerTreeView->mLastReleaseMousePos;
   if ( indRect.contains( pos ) )
   {
     int indicatorIndex = ( pos.x() - indRect.left() ) / indRect.height();

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
@@ -104,6 +104,8 @@ void QgsLayerTreeViewItemDelegate::paint( QPainter *painter, const QStyleOptionV
   for ( QgsLayerTreeViewIndicator *indicator : indicators )
   {
     QRect rect( x + spacing, indRect.top() + spacing, h - spacing * 2, h - spacing * 2 );
+    // Add a little more padding so the icon does not look misaligned to background
+    QRect iconRect( x + spacing * 2, indRect.top() + spacing * 2, h - spacing * 4, h - spacing * 4 );
     x += h;
 
     QIcon::Mode mode = QIcon::Normal;
@@ -122,7 +124,7 @@ void QgsLayerTreeViewItemDelegate::paint( QPainter *painter, const QStyleOptionV
     painter->setBrush( pb );
     painter->setPen( pp );
 
-    indicator->icon().paint( painter, rect, Qt::AlignCenter, mode );
+    indicator->icon().paint( painter, iconRect, Qt::AlignCenter, mode );
   }
 }
 

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.h
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.h
@@ -37,7 +37,7 @@ class QgsLayerTreeView;
 #include <QStyledItemDelegate>
 
 /**
- * Proxy style to make the item text rect shorter so that indicators fit in without colliding with text
+ * Proxy style for layer items with indicators
  */
 class QgsLayerTreeViewProxyStyle : public QgsProxyStyle
 {


### PR DESCRIPTION
## Description
This fixes #28050 by allowing the Layers panel QTreeView to horizontally scroll.

![layer-panel_horiz-scroll2](https://user-images.githubusercontent.com/1295919/59541490-c1ed5e00-8ebe-11e9-87fc-91d7d316a870.gif)

It also offers the following:
- Layer titles can be fully viewed (no elide).
- The width of the layer panel no longer needs resized via its splitter as often, reducing canvas redraws.
- When the tree view has many groups or nesting, it is simpler to scroll right than resize panel.

Even though the changes are small, the result may be confusing for some users, because users can end up with the following, even though layers are loaded:

<img width="185" alt="layers-panel_scrolled-blank" src="https://user-images.githubusercontent.com/1295919/59541529-f06b3900-8ebe-11e9-9d7f-cb475c702122.png">

To solve this, I tinkered with the following:
- Auto-reset horizontal scrollbar to position 0 after a delay, but not while user is still scrolling or has the input device pressed. While the reset worked, the timer could trigger at inopportune times.
- Add a scroll area to _just_ the WMS graphic. This proved to be tricky and not as simple/clean as scrolling the whole tree.

**Proposed horizontal scrollbar reset solution**
Assuming that just leaving it as is (user in control of scrolling) is not acceptable UX, a small button in toolbar or tall/thin button to the left of tree view could offer a quick means of reseting the horizontal scroll bar on one click.

However, I have left a reset button out of this PR, so it can be backported to `release-3_4` branch as an initial fix.

---

The other commit, to limit the max width of embedded legend widgets could also be tied to a user setting, though this would be a 'feature'.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
