### PR TITLE
Convert "Grass7AlgorithmProvider.settingName" to a class attribute.

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -40,10 +40,7 @@ pluginPath = os.path.normpath(os.path.join(
 
 class Grass7AlgorithmProvider(QgsProcessingProvider):
 
-    # Subclasses of `Grass7AlgorithmProvider` should override `descriptionFolder`
-    # and set its value to their own description folder.
     descriptionFolder = Grass7Utils.grassDescriptionPath()
-
     activateSetting = "ACTIVATE_GRASS7"
 
     def __init__(self):
@@ -52,8 +49,9 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
 
     def load(self):
         ProcessingConfig.settingIcons[self.name()] = self.icon()
-        ProcessingConfig.addSetting(Setting(self.name(), self.activateSetting,
-                                            self.tr('Activate'), True))
+        if self.activateSetting:
+            ProcessingConfig.addSetting(Setting(self.name(), self.activateSetting,
+                                                self.tr('Activate'), True))
         if isMac():
             ProcessingConfig.addSetting(Setting(
                 self.name(),
@@ -85,7 +83,8 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         return True
 
     def unload(self):
-        ProcessingConfig.removeSetting(self.activateSetting)
+        if self.activateSetting:
+            ProcessingConfig.removeSetting(self.activateSetting)
         if isMac():
             ProcessingConfig.removeSetting(Grass7Utils.GRASS_FOLDER)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_LOG_COMMANDS)
@@ -94,10 +93,13 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_USE_VEXTERNAL)
 
     def isActive(self):
-        return ProcessingConfig.getSetting(self.activateSetting)
+        if self.activateSetting:
+            return ProcessingConfig.getSetting(self.activateSetting)
+        return True
 
     def setActive(self, active):
-        ProcessingConfig.setSettingValue(self.activateSetting, active)
+        if self.activateSetting:
+            ProcessingConfig.setSettingValue(self.activateSetting, active)
 
     def createAlgsList(self):
         algs = []

--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -44,13 +44,15 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
     # and set its value to their own description folder.
     descriptionFolder = Grass7Utils.grassDescriptionPath()
 
+    activateSetting = "ACTIVATE_GRASS7"
+
     def __init__(self):
         super().__init__()
         self.algs = []
 
     def load(self):
         ProcessingConfig.settingIcons[self.name()] = self.icon()
-        ProcessingConfig.addSetting(Setting(self.name(), 'ACTIVATE_GRASS7',
+        ProcessingConfig.addSetting(Setting(self.name(), self.activateSetting,
                                             self.tr('Activate'), True))
         if isMac():
             ProcessingConfig.addSetting(Setting(
@@ -83,7 +85,7 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         return True
 
     def unload(self):
-        ProcessingConfig.removeSetting('ACTIVATE_GRASS7')
+        ProcessingConfig.removeSetting(self.activateSetting)
         if isMac():
             ProcessingConfig.removeSetting(Grass7Utils.GRASS_FOLDER)
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_LOG_COMMANDS)
@@ -92,10 +94,10 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         ProcessingConfig.removeSetting(Grass7Utils.GRASS_USE_VEXTERNAL)
 
     def isActive(self):
-        return ProcessingConfig.getSetting('ACTIVATE_GRASS7')
+        return ProcessingConfig.getSetting(self.activateSetting)
 
     def setActive(self, active):
-        ProcessingConfig.setSettingValue('ACTIVATE_GRASS7', active)
+        ProcessingConfig.setSettingValue(self.activateSetting, active)
 
     def createAlgsList(self):
         algs = []


### PR DESCRIPTION
Subclasses of `Grass7AlgorithmProvider` were using the same setting name as
the parent class (i.e. 'ACTIVATE_GRASS7'). This was causing a `KeyError`
when QGIS was being closed.

With this commit we convert the setting name key to a class attribute.
This way we reduce code maintenance and we reduce the number of methods
that `Grass7AlgorithmProvider` subclasses need to override.

Fixes #30241
Continues #9202
