### PR TITLE
Synchronize status bar messages

### DIFF
--- a/python/gui/auto_generated/qgsstatusbar.sip.in
+++ b/python/gui/auto_generated/qgsstatusbar.sip.in
@@ -88,6 +88,15 @@ Removes any temporary message being shown.
 .. seealso:: :py:func:`showMessage`
 %End
 
+    void setParentStatusBar( QStatusBar *statusBar );
+%Docstring
+Sets the parent status bar.
+Messages that are shown on the parent status bar will be intercepted
+and shown on this status bar too.
+
+.. versionadded:: 3.8
+%End
+
 
   protected:
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3053,6 +3053,7 @@ void QgisApp::createStatusBar()
   statusBar()->setFont( statusBarFont );
 
   mStatusBar = new QgsStatusBar();
+  mStatusBar->setParentStatusBar( QMainWindow::statusBar() );
   mStatusBar->setFont( statusBarFont );
 
   statusBar()->addPermanentWidget( mStatusBar, 10 );

--- a/src/gui/qgsstatusbar.cpp
+++ b/src/gui/qgsstatusbar.cpp
@@ -21,6 +21,7 @@
 #include <QPalette>
 #include <QTimer>
 #include <QEvent>
+#include <QStatusBar>
 
 QgsStatusBar::QgsStatusBar( QWidget *parent )
   : QWidget( parent )
@@ -89,6 +90,17 @@ void QgsStatusBar::showMessage( const QString &text, int timeout )
 void QgsStatusBar::clearMessage()
 {
   mLineEdit->setText( QString() );
+}
+
+void QgsStatusBar::setParentStatusBar( QStatusBar *statusBar )
+{
+  if ( mParentStatusBar )
+    mParentStatusBar->disconnect( mShowMessageConnection );
+
+  mParentStatusBar = statusBar;
+
+  if ( mParentStatusBar )
+    mShowMessageConnection = connect( mParentStatusBar, &QStatusBar::messageChanged, this, [this]( const QString & message ) { showMessage( message ); } );
 }
 
 void QgsStatusBar::changeEvent( QEvent *event )

--- a/src/gui/qgsstatusbar.h
+++ b/src/gui/qgsstatusbar.h
@@ -24,6 +24,7 @@
 
 class QHBoxLayout;
 class QLineEdit;
+class QStatusBar;
 
 /**
  * \class QgsStatusBar
@@ -100,6 +101,15 @@ class GUI_EXPORT QgsStatusBar : public QWidget
      */
     void clearMessage();
 
+    /**
+     * Sets the parent status bar.
+     * Messages that are shown on the parent status bar will be intercepted
+     * and shown on this status bar too.
+     *
+     * \since QGIS 3.8
+     */
+    void setParentStatusBar( QStatusBar *statusBar );
+
 
   protected:
 
@@ -110,6 +120,8 @@ class GUI_EXPORT QgsStatusBar : public QWidget
     QHBoxLayout *mLayout = nullptr;
     QLineEdit *mLineEdit = nullptr;
     QTimer *mTempMessageTimer = nullptr;
+    QStatusBar *mParentStatusBar = nullptr;
+    QMetaObject::Connection mShowMessageConnection;
 
 };
 


### PR DESCRIPTION
Status bar messages can be set on QActions (QAction::setStatusTip) and will then be forwarded to the toplevel parent widget's status bar.
This API / functionality was broken since QGIS 3.4

Fixes #30249
