### PR TITLE
Fix handling of relative paths for XYZ tiles using file:/// URLs

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2036,6 +2036,22 @@ QString QgsRasterLayer::encodedSource( const QString &source, const QgsReadWrite
       }
     }
   }
+  else if ( providerType() == "wms" )
+  {
+    // handle relative paths to XYZ tiles
+    QgsDataSourceUri uri;
+    uri.setEncodedUri( src );
+    QUrl srcUrl( uri.param( QStringLiteral( "url" ) ) );
+    if ( srcUrl.isLocalFile() )
+    {
+      // relative path will become "file:./x.txt"
+      QString relSrcUrl = context.pathResolver().writePath( srcUrl.toLocalFile() );
+      uri.removeParam( QStringLiteral( "url" ) );  // needed because setParam() would insert second "url" key
+      uri.setParam( QStringLiteral( "url" ), QUrl::fromLocalFile( relSrcUrl ).toString() );
+      src = uri.encodedUri();
+      handled = true;
+    }
+  }
 
   if ( !handled )
     src = context.pathResolver().writePath( src );
@@ -2124,6 +2140,19 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
       // in QgsRasterLayer::readXml
     }
     // <<< BACKWARD COMPATIBILITY < 1.9
+
+    // handle relative paths to XYZ tiles
+    QgsDataSourceUri uri;
+    uri.setEncodedUri( src );
+    QUrl srcUrl( uri.param( QStringLiteral( "url" ) ) );
+    if ( srcUrl.isLocalFile() )  // file-based URL? convert to relative path
+    {
+      QString absSrcUrl = context.pathResolver().readPath( srcUrl.toLocalFile() );
+      uri.removeParam( QStringLiteral( "url" ) );  // needed because setParam() would insert second "url" key
+      uri.setParam( QStringLiteral( "url" ), QUrl::fromLocalFile( absSrcUrl ).toString() );
+      src = uri.encodedUri();
+    }
+
   }
   else
   {


### PR DESCRIPTION
XYZ tiles raster layer supports usage of file-based URLs, so it should also support saving of URLs as relative paths in project files.
