### PR TITLE
do not use unique_ptr for QGraphicsItem

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingcanvasitem.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsAdvancedDigitizingCanvasItem : QgsMapCanvasItem
 {
 %Docstring
@@ -24,8 +25,6 @@ The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CA
 
     virtual void paint( QPainter *painter );
 
-
-  protected:
 
 };
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -28,7 +28,6 @@ QgsAdvancedDigitizingCanvasItem::QgsAdvancedDigitizingCanvasItem( QgsMapCanvas *
   , mSnapPen( QPen( QColor( 127, 0, 0, 150 ), 1 ) )
   , mSnapLinePen( QPen( QColor( 127, 0, 0, 150 ), 1, Qt::DashLine ) )
   , mCursorPen( QPen( QColor( 127, 127, 127, 255 ), 1 ) )
-  , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
   , mAdvancedDigitizingDockWidget( cadDockWidget )
 {
 }
@@ -253,15 +252,4 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     painter->drawLine( curPointPix + QPointF( -5, +5 ),
                        curPointPix + QPointF( +5, -5 ) );
   }
-
-
-  QgsPointLocator::Match match = mAdvancedDigitizingDockWidget->mapPointMatch();
-  if ( match.isValid() )
-  {
-    mSnapIndicator->setMatch( match );
-    mSnapIndicator->setVisible( true );
-  }
-  else
-    mSnapIndicator->setVisible( false );
-
 }

--- a/src/gui/qgsadvanceddigitizingcanvasitem.h
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.h
@@ -20,7 +20,7 @@
 
 #include "qgsmapcanvasitem.h"
 #include "qgis_gui.h"
-#include "qgssnapindicator.h"
+
 
 class QgsAdvancedDigitizingDockWidget;
 
@@ -35,17 +35,13 @@ class GUI_EXPORT QgsAdvancedDigitizingCanvasItem : public QgsMapCanvasItem
 
     void paint( QPainter *painter ) override;
 
-  protected:
+  private:
     QPen mLockedPen;
     QPen mConstruction1Pen;
     QPen mConstruction2Pen;
     QPen mSnapPen;
     QPen mSnapLinePen;
     QPen mCursorPen;
-    //! Snapping indicators
-    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
-
-  private:
     QgsAdvancedDigitizingDockWidget *mAdvancedDigitizingDockWidget = nullptr;
 };
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -42,6 +42,7 @@
 QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *canvas, QWidget *parent )
   : QgsDockWidget( parent )
   , mMapCanvas( canvas )
+  , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
   , mCommonAngleConstraint( QgsSettings().value( QStringLiteral( "/Cad/CommonAngle" ), 90 ).toDouble() )
 {
   setupUi( this );
@@ -670,6 +671,17 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   e->setMapPoint( point );
 
   mSnapMatch = context.snappingUtils->snapToMap( point );
+
+  if ( mSnapMatch.isValid() )
+  {
+    mSnapIndicator->setMatch( mSnapMatch );
+    mSnapIndicator->setVisible( true );
+  }
+  else
+  {
+    mSnapIndicator->setVisible( false );
+  }
+
   /*
    * Constraints are applied in 2D, they are always called when using the tool
    * but they do not take into account if when you snap on a vertex it has

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -28,6 +28,7 @@
 #include "qgsmessagebaritem.h"
 #include "qgspointxy.h"
 #include "qgspointlocator.h"
+#include "qgssnapindicator.h"
 
 
 class QgsAdvancedDigitizingCanvasItem;
@@ -702,6 +703,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsAdvancedDigitizingCanvasItem *mCadPaintItem = nullptr;
+    //! Snapping indicator
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
     CadCapacities mCapacities = nullptr;
 

--- a/src/gui/qgssnapindicator.h
+++ b/src/gui/qgssnapindicator.h
@@ -56,7 +56,8 @@ class GUI_EXPORT QgsSnapIndicator
 
     QgsMapCanvas *mCanvas;
     QgsPointLocator::Match mMatch;
-    std::unique_ptr<QgsVertexMarker> mSnappingMarker;
+    QgsVertexMarker *mSnappingMarker = nullptr;
+    QMetaObject::Connection mCanvasDestroyedConnection;
 };
 
 #endif // QGSSNAPINDICATOR_H


### PR DESCRIPTION
since the ownership of the item is transferred to the scene
this leads to a crash when deleting the object holding the pointer

since the ownership is transferred back when removing the item, one should
take care of resetting the pointer no canvas deletion

this should fix #28962

