### PR TITLE
Add option for RFC7946 (no crs) ogr GeoJSON creation

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1081,8 +1081,8 @@ class QgsVectorFileWriterMetadataContainer
 
       layerOptions.insert( QStringLiteral( "RFC7946" ), new QgsVectorFileWriter::BoolOption(
                              QObject::tr( "Whether to use RFC 7946 standard. "
-                                          "Otherwise GeoJSON 2008 initial version will be used. "
-                                          "Default is NO (thus GeoJSON 2008)." ),
+                                          "If disabled GeoJSON 2008 initial version will be used. "
+                                          "Default is NO (thus GeoJSON 2008). See also Documentation (via Help button)" ),
                              false // Default value
                            ) );
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1079,6 +1079,13 @@ class QgsVectorFileWriterMetadataContainer
                              15 // Default value
                            ) );
 
+      layerOptions.insert( QStringLiteral( "RFC7946" ), new QgsVectorFileWriter::BoolOption(
+                             QObject::tr( "Whether to use RFC 7946 standard. "
+                                          "Otherwise GeoJSON 2008 initial version will be used. "
+                                          "Default is NO (thus GeoJSON 2008)." ),
+                             false // Default value
+                           ) );
+
       driverMetadata.insert( QStringLiteral( "GeoJSON" ),
                              QgsVectorFileWriter::MetaData(
                                QStringLiteral( "GeoJSON" ),


### PR DESCRIPTION
## Description

See https://github.com/qgis/QGIS/issues/30257

Adding this OGR option, a geojson can be created without the
crs part in it (now it always has).

Not sure what is better: defaulting to False (which is current behaviour), OR change the default behaviour to the newer (current) version of geojson spec. I'd opt for changing the default behaviour to be honest (as then it is valid geojson according to current spec)

If there are any OGR creation tests, I'm happy to create a test for this too (but I need a pointer to the test then :-) )
