### PR TITLE
WMS provider: Extract TileSet layer title and abstract from matching …

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -670,6 +670,45 @@ void QgsWmsCapabilities::parseCapability( QDomElement const &e, QgsWmsCapability
     }
   }
 
+  // Layers in a WMS-C Capabilities TileSet do not have layer title or abstract
+  // still those could be present in a Layer list.
+  if ( !mTileLayersSupported.isEmpty() )
+  {
+    QHash<QString, QString> titles;
+    QHash<QString, QString> abstracts;
+
+    // Build layer identifier - title|abstract mapping
+    for ( const QgsWmsLayerProperty &layer : qgis::as_const( mLayersSupported ) )
+    {
+      if ( !layer.name.isEmpty() )
+      {
+        if ( !layer.title.isEmpty() )
+        {
+          titles.insert( layer.name, layer.title );
+        }
+
+        if ( !layer.abstract.isEmpty() )
+        {
+          abstracts.insert( layer.name, layer.abstract );
+        }
+      }
+    }
+
+    // If tile layer title|abstract is empty, try to use one from a matching layer
+    for ( QgsWmtsTileLayer &tileLayer : mTileLayersSupported )
+    {
+      if ( tileLayer.title.isEmpty() && titles.contains( tileLayer.identifier ) )
+      {
+        tileLayer.title = titles.value( tileLayer.identifier );
+      }
+
+      if ( tileLayer.abstract.isEmpty() && abstracts.contains( tileLayer.identifier ) )
+      {
+        tileLayer.abstract = abstracts.value( tileLayer.identifier );
+      }
+    }
+  }
+
   QgsDebugMsg( QStringLiteral( "exiting." ) );
 }
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2204,6 +2204,20 @@ QString QgsWmsProvider::htmlMetadata()
       metadata += QLatin1String( "</th></tr>" );
 
       metadata += QLatin1String( "<tr><td class=\"strong\">" );
+      metadata += tr( "Title" );
+      metadata += QLatin1String( "</td>" );
+      metadata += QLatin1String( "<td>" );
+      metadata += l.title;
+      metadata += QLatin1String( "</td></tr>" );
+
+      metadata += QLatin1String( "<tr><td class=\"strong\">" );
+      metadata += tr( "Abstract" );
+      metadata += QLatin1String( "</td>" );
+      metadata += QLatin1String( "<td>" );
+      metadata += l.abstract;
+      metadata += QLatin1String( "</td></tr>" );
+
+      metadata += QLatin1String( "<tr><td class=\"strong\">" );
       metadata += tr( "Selected" );
       metadata += QLatin1String( "</td>" );
       metadata += QLatin1String( "<td class=\"strong\">" );

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -82,6 +82,10 @@ ADD_QGIS_TEST(wmscapabilitiestest
               testqgswmscapabilities.cpp)
 TARGET_LINK_LIBRARIES(qgis_wmscapabilitiestest wmsprovider_a)
 
+ADD_QGIS_TEST(wmsccapabilitiestest
+              testqgswmsccapabilities.cpp)
+TARGET_LINK_LIBRARIES(qgis_wmsccapabilitiestest wmsprovider_a)
+
 ADD_QGIS_TEST(wmsprovidertest
               testqgswmsprovider.cpp)
 TARGET_LINK_LIBRARIES(qgis_wmsprovidertest wmsprovider_a)

--- a/tests/src/providers/testqgswmsccapabilities.cpp
+++ b/tests/src/providers/testqgswmsccapabilities.cpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+    testqgswmsccapabilities.cpp
+    ---------------------
+    begin                : July 2019
+    copyright            : (C) 2019 by Maris Nartiss
+    email                : maris dot nartiss at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QFile>
+#include <QObject>
+#include "qgstest.h"
+#include <qgswmscapabilities.h>
+#include <qgsapplication.h>
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the WMS-C capabilities parser
+ * implemented as QgsWmsCapabilities::parseTileSetProfile
+ */
+class TestQgsWmscCapabilities: public QObject
+{
+    Q_OBJECT
+  private slots:
+
+    void initTestCase()
+    {
+      QgsApplication::init();
+      QgsApplication::initQgis();
+
+      QFile file( QStringLiteral( TEST_DATA_DIR ) + "/provider/wms-c_Capabilities.xml" );
+      QVERIFY( file.open( QIODevice::ReadOnly | QIODevice::Text ) );
+      const QByteArray content = file.readAll();
+      QVERIFY( content.size() > 0 );
+      const QgsWmsParserSettings config;
+
+      mCapabilities = new QgsWmsCapabilities();
+      QVERIFY( mCapabilities->parseResponse( content, config ) );
+    }
+
+    void cleanupTestCase()
+    {
+      delete mCapabilities;
+      QgsApplication::exitQgis();
+    }
+
+    // WMS-C works as an ordinary WMS
+    // check ordinary WMS layers
+    void layers()
+    {
+      QCOMPARE( mCapabilities->supportedLayers().size(), 4 );
+
+      // check identifiers
+      QCOMPARE( mCapabilities->supportedLayers()[0].name, QString( "layerwtwa" ) );
+      QCOMPARE( mCapabilities->supportedLayers()[1].name, QString( "layerwtna" ) );
+      QCOMPARE( mCapabilities->supportedLayers()[2].name, QString( "layerntwa" ) );
+      QCOMPARE( mCapabilities->supportedLayers()[3].name, QString( "layerntna" ) );
+
+      // check layer title extraction
+      QCOMPARE( mCapabilities->supportedLayers()[0].title, QString( "This is a layer title" ) );
+      QCOMPARE( mCapabilities->supportedLayers()[1].title, QString( "A layer with a title and without an abstract" ) );
+      QVERIFY( mCapabilities->supportedLayers()[2].title.isEmpty() );
+      QVERIFY( mCapabilities->supportedLayers()[3].title.isEmpty() );
+
+      // check layer abstract extraction
+      QCOMPARE( mCapabilities->supportedLayers()[0].abstract, QString( "This is a layer abstract" ) );
+      QVERIFY( mCapabilities->supportedLayers()[1].abstract.isEmpty() );
+      QCOMPARE( mCapabilities->supportedLayers()[2].abstract, QString( "A layer without a title and with an abstract" ) );
+      QVERIFY( mCapabilities->supportedLayers()[3].abstract.isEmpty() );
+
+      // check bounding box
+      QgsWmsBoundingBoxProperty bb;
+      bb.box = QgsRectangle( 295000, 150000, 785000, 460000 );
+      bb.crs = QString( "EPSG:3059" );
+      QCOMPARE( mCapabilities->supportedLayers()[0].boundingBoxes.size(), 1 );
+      QCOMPARE( mCapabilities->supportedLayers()[0].boundingBoxes[0].crs, bb.crs );
+      QCOMPARE( mCapabilities->supportedLayers()[0].boundingBoxes[0].box, bb.box );
+    }
+
+    // check TileLayers from VendorSpecificCapabilities
+    // values should be identical to layer ones
+    void tileLayers()
+    {
+      QCOMPARE( mCapabilities->supportedTileLayers().size(), 4 );
+
+      // check identifiers
+      QCOMPARE( mCapabilities->supportedTileLayers()[0].identifier, QString( "layerwtwa" ) );
+      QCOMPARE( mCapabilities->supportedTileLayers()[1].identifier, QString( "layerwtna" ) );
+      QCOMPARE( mCapabilities->supportedTileLayers()[2].identifier, QString( "layerntwa" ) );
+      QCOMPARE( mCapabilities->supportedTileLayers()[3].identifier, QString( "layerntna" ) );
+
+      // check layer title extraction
+      // bug #30262
+      QCOMPARE( mCapabilities->supportedTileLayers()[0].title, QString( "This is a layer title" ) );
+      QCOMPARE( mCapabilities->supportedTileLayers()[1].title, QString( "A layer with a title and without an abstract" ) );
+      QVERIFY( mCapabilities->supportedTileLayers()[2].title.isEmpty() );
+      QVERIFY( mCapabilities->supportedTileLayers()[3].title.isEmpty() );
+
+      // check layer abstract extraction
+      // bug #30262
+      QCOMPARE( mCapabilities->supportedTileLayers()[0].abstract, QString( "This is a layer abstract" ) );
+      QVERIFY( mCapabilities->supportedTileLayers()[1].abstract.isEmpty() );
+      QCOMPARE( mCapabilities->supportedTileLayers()[2].abstract, QString( "A layer without a title and with an abstract" ) );
+      QVERIFY( mCapabilities->supportedTileLayers()[3].abstract.isEmpty() );
+
+      // check bounding box
+      QgsWmsBoundingBoxProperty bb;
+      bb.box = QgsRectangle( 295000, 150000, 785000, 460000 );
+      bb.crs = QString( "EPSG:3059" );
+      QCOMPARE( mCapabilities->supportedTileLayers()[0].boundingBoxes.size(), 1 );
+      QCOMPARE( mCapabilities->supportedTileLayers()[0].boundingBoxes[0].crs, bb.crs );
+      QCOMPARE( mCapabilities->supportedTileLayers()[0].boundingBoxes[0].box, bb.box );
+    }
+
+    // check TileMatrices generated from TileLayers
+    void tileMatrices()
+    {
+      QgsWmtsTileMatrix m;
+
+      QCOMPARE( mCapabilities->supportedTileMatrixSets().size(), 4 );
+      QCOMPARE( mCapabilities->supportedTileMatrixSets()[QStringLiteral( "layerwtwa-wmsc-0" )].tileMatrices.size(), 2 );
+
+      m = mCapabilities->supportedTileMatrixSets()[QStringLiteral( "layerwtwa-wmsc-0" )].tileMatrices[603.400];
+
+      QCOMPARE( m.tileWidth, 256 );
+      QCOMPARE( m.tileHeight, 256 );
+      QCOMPARE( m.tres, 603.400 );
+
+      QCOMPARE( m.matrixWidth, 4 );
+      QCOMPARE( m.matrixHeight, 3 );
+      QCOMPARE( m.topLeft, QgsPointXY( 295000, 613411.2 ) );
+    }
+
+  private:
+    QgsWmsCapabilities *mCapabilities = nullptr;
+};
+
+QGSTEST_MAIN( TestQgsWmscCapabilities )
+#include "testqgswmsccapabilities.moc"

--- a/tests/testdata/provider/wms-c_Capabilities.xml
+++ b/tests/testdata/provider/wms-c_Capabilities.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<WMT_MS_Capabilities version="1.1.1">
+  <Service>
+    <Name>OGC:WMS</Name>
+    <Title>Service title</Title>
+    <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.com/ows?" />
+  </Service>
+  <Capability>
+    <Request>
+      <GetCapabilities>
+        <Format>application/vnd.ogc.wms_xml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.com/ows?" />
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetCapabilities>
+      <GetMap>
+        <Format>image/png</Format>
+        <Format>image/jpeg</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.com/ows?" />
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetMap>
+      <GetFeatureInfo>
+        <Format>text/plain</Format>
+        <Format>application/vnd.ogc.gml</Format>
+        <DCPType>
+          <HTTP>
+            <Get>
+              <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://example.com/ows?" />
+            </Get>
+          </HTTP>
+        </DCPType>
+      </GetFeatureInfo>
+    </Request>
+    <Exception>
+      <Format>text/plain</Format>
+    </Exception>
+    <VendorSpecificCapabilities>
+      <TileSet>
+        <SRS>EPSG:3059</SRS>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <Resolutions>603.400 301.700</Resolutions>
+        <Width>256</Width>
+        <Height>256</Height>
+        <Format>image/png</Format>
+        <Layers>layerwtwa</Layers>
+        <Styles />
+      </TileSet>
+      <TileSet>
+        <SRS>EPSG:3059</SRS>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <Resolutions>603.400 301.700 </Resolutions>
+        <Width>256</Width>
+        <Height>256</Height>
+        <Format>image/png</Format>
+        <Layers>layerwtna</Layers>
+        <Styles />
+      </TileSet>
+      <TileSet>
+        <SRS>EPSG:3059</SRS>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <Resolutions>603.400 301.700 </Resolutions>
+        <Width>256</Width>
+        <Height>256</Height>
+        <Format>image/png</Format>
+        <Layers>layerntwa</Layers>
+        <Styles />
+      </TileSet>
+      <TileSet>
+        <SRS>EPSG:3059</SRS>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <Resolutions>603.400 301.700 </Resolutions>
+        <Width>256</Width>
+        <Height>256</Height>
+        <Format>image/png</Format>
+        <Layers>layerntna</Layers>
+        <Styles />
+      </TileSet>
+    </VendorSpecificCapabilities>
+    <Layer>
+      <Title>Layer set title</Title>
+      <SRS>EPSG:3059</SRS>
+      <Layer cascaded="1" queryable="0">
+        <Name>layerwtwa</Name>
+        <Title>This is a layer title</Title>
+        <Abstract>This is a layer abstract</Abstract>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <SRS>EPSG:3059</SRS>
+      </Layer>
+      <Layer cascaded="1" queryable="0">
+        <Name>layerwtna</Name>
+        <Title>A layer with a title and without an abstract</Title>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <SRS>EPSG:3059</SRS>
+      </Layer>
+      <Layer cascaded="1" queryable="0">
+        <Name>layerntwa</Name>
+        <Abstract>A layer without a title and with an abstract</Abstract>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <SRS>EPSG:3059</SRS>
+      </Layer>
+      <Layer cascaded="1" queryable="0">
+        <Name>layerntna</Name>
+        <BoundingBox SRS="EPSG:3059" minx="295000.0" miny="150000.0" maxx="785000.0" maxy="460000.0" />
+        <SRS>EPSG:3059</SRS>
+      </Layer>
+    </Layer>
+  </Capability>
+</WMT_MS_Capabilities>


### PR DESCRIPTION
…Layer data (fixes #30262)

## Description
WMS-C Capabilities document lists TileSets without layer title or abstract although both could be present in the Layer properties. Copying over from matching layer title / abstract just makes WMS-C tiled layers more user friendly.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
