### PR TITLE
Allow data defined control over line placement options

### DIFF
--- a/python/core/auto_generated/qgspallabeling.sip.in
+++ b/python/core/auto_generated/qgspallabeling.sip.in
@@ -275,6 +275,7 @@ class QgsPalLayerSettings
       RepeatDistanceUnit,
       Priority,
       PredefinedPositionOrder,
+      LinePlacementOptions,
 
       // rendering
       ScaleVisibility,

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -685,6 +685,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/mesh
   ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/locator
+  ${CMAKE_SOURCE_DIR}/src/core/pal
   ${CMAKE_SOURCE_DIR}/src/core/providers/memory
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/scalebar

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -535,6 +535,7 @@ void QgsLabelingGui::populateDataDefinedButtons()
   registerDataDefinedButton( mCentroidDDBtn, QgsPalLayerSettings::CentroidWhole );
   registerDataDefinedButton( mPointQuadOffsetDDBtn, QgsPalLayerSettings::OffsetQuad );
   registerDataDefinedButton( mPointPositionOrderDDBtn, QgsPalLayerSettings::PredefinedPositionOrder );
+  registerDataDefinedButton( mLinePlacementFlagsDDBtn, QgsPalLayerSettings::LinePlacementOptions );
   registerDataDefinedButton( mPointOffsetDDBtn, QgsPalLayerSettings::OffsetXY );
   registerDataDefinedButton( mPointOffsetUnitsDDBtn, QgsPalLayerSettings::OffsetUnits );
   registerDataDefinedButton( mLineDistanceDDBtn, QgsPalLayerSettings::LabelDistance );

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -598,7 +598,7 @@ int FeaturePart::createCandidatesAlongLineNearStraightSegments( QList<LabelPosit
   double labelWidth = getLabelWidth();
   double labelHeight = getLabelHeight();
   double distanceLineToLabel = getLabelDistance();
-  LineArrangementFlags flags = mLF->layer()->arrangementFlags();
+  LineArrangementFlags flags = mLF->arrangementFlags();
   if ( flags == 0 )
     flags = FLAG_ON_LINE; // default flag
 
@@ -823,7 +823,7 @@ int FeaturePart::createCandidatesAlongLineNearMidpoint( QList<LabelPosition *> &
   double angle;
   double cost;
 
-  LineArrangementFlags flags = mLF->layer()->arrangementFlags();
+  LineArrangementFlags flags = mLF->arrangementFlags();
   if ( flags == 0 )
     flags = FLAG_ON_LINE; // default flag
 
@@ -1184,7 +1184,7 @@ int FeaturePart::createCurvedCandidatesAlongLine( QList< LabelPosition * > &lPos
   QLinkedList<LabelPosition *> positions;
   double delta = std::max( li->label_height, total_distance / mLF->layer()->pal->line_p );
 
-  pal::LineArrangementFlags flags = mLF->layer()->arrangementFlags();
+  pal::LineArrangementFlags flags = mLF->arrangementFlags();
   if ( flags == 0 )
     flags = FLAG_ON_LINE; // default flag
 

--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -51,7 +51,6 @@ Layer::Layer( QgsAbstractLabelProvider *provider, const QString &name, QgsPalLay
   , mDisplayAll( displayAll )
   , mCentroidInside( false )
   , mArrangement( arrangement )
-  , mArrangementFlags( nullptr )
   , mMode( LabelPerFeature )
   , mMergeLines( false )
   , mUpsidedownLabels( Upright )

--- a/src/core/pal/layer.h
+++ b/src/core/pal/layer.h
@@ -114,19 +114,6 @@ namespace pal
       void setArrangement( QgsPalLayerSettings::Placement arrangement ) { mArrangement = arrangement; }
 
       /**
-       * Returns the layer's arrangement flags.
-       * \see setArrangementFlags
-       */
-      LineArrangementFlags arrangementFlags() const { return mArrangementFlags; }
-
-      /**
-       * Sets the layer's arrangement flags.
-       * \param flags arrangement flags
-       * \see arrangementFlags
-       */
-      void setArrangementFlags( LineArrangementFlags flags ) { mArrangementFlags = flags; }
-
-      /**
        * \brief Sets whether the layer is currently active.
        *
        * Active means "is currently displayed or used as obstacles". When a layer is
@@ -290,7 +277,7 @@ namespace pal
 
       //! Optional flags used for some placement methods
       QgsPalLayerSettings::Placement mArrangement;
-      LineArrangementFlags mArrangementFlags;
+
       LabelMode mMode;
       bool mMergeLines;
 

--- a/src/core/qgslabelfeature.h
+++ b/src/core/qgslabelfeature.h
@@ -22,6 +22,7 @@
 #include "geos_c.h"
 #include "qgsgeos.h"
 #include "qgsmargins.h"
+#include "pal.h"
 
 namespace pal
 {
@@ -335,6 +336,19 @@ class CORE_EXPORT QgsLabelFeature
     void setObstacleFactor( double factor ) { mObstacleFactor = factor; }
 
     /**
+     * Returns the feature's arrangement flags.
+     * \see setArrangementFlags
+     */
+    pal::LineArrangementFlags arrangementFlags() const { return mArrangementFlags; }
+
+    /**
+     * Sets the feature's arrangement flags.
+     * \param flags arrangement flags
+     * \see arrangementFlags
+     */
+    void setArrangementFlags( pal::LineArrangementFlags flags ) { mArrangementFlags = flags; }
+
+    /**
      * Text of the label
      *
      * Used also if "merge connected lines to avoid duplicate labels" is enabled
@@ -411,6 +425,8 @@ class CORE_EXPORT QgsLabelFeature
     QString mLabelText;
     //! extra information for curved labels (may be NULLPTR)
     pal::LabelInfo *mInfo = nullptr;
+
+    pal::LineArrangementFlags mArrangementFlags = nullptr;
 
   private:
 

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -133,9 +133,6 @@ void QgsLabelingEngine::processProvider( QgsAbstractLabelProvider *provider, Qgs
                               flags.testFlag( QgsAbstractLabelProvider::DrawLabels ),
                               flags.testFlag( QgsAbstractLabelProvider::DrawAllLabels ) );
 
-  // extra flags for placement of labels for linestrings
-  l->setArrangementFlags( static_cast< pal::LineArrangementFlags >( provider->linePlacementFlags() ) );
-
   // set label mode (label per feature is the default)
   l->setLabelMode( flags.testFlag( QgsAbstractLabelProvider::LabelPerFeaturePart ) ? pal::Layer::LabelPerFeaturePart : pal::Layer::LabelPerFeature );
 
@@ -395,7 +392,6 @@ QgsAbstractLabelProvider::QgsAbstractLabelProvider( QgsMapLayer *layer, const QS
   , mProviderId( providerId )
   , mFlags( DrawLabels )
   , mPlacement( QgsPalLayerSettings::AroundPoint )
-  , mLinePlacementFlags( 0 )
   , mPriority( 0.5 )
   , mObstacleType( QgsPalLayerSettings::PolygonInterior )
   , mUpsidedownLabels( QgsPalLayerSettings::Upright )
@@ -453,15 +449,15 @@ QString QgsLabelingUtils::encodePredefinedPositionOrder( const QVector<QgsPalLay
         break;
     }
   }
-  return predefinedOrderString.join( QStringLiteral( "," ) );
+  return predefinedOrderString.join( ',' );
 }
 
 QVector<QgsPalLayerSettings::PredefinedPointPosition> QgsLabelingUtils::decodePredefinedPositionOrder( const QString &positionString )
 {
   QVector<QgsPalLayerSettings::PredefinedPointPosition> result;
-  QStringList predefinedOrderList = positionString.split( ',' );
-  const auto constPredefinedOrderList = predefinedOrderList;
-  for ( const QString &position : constPredefinedOrderList )
+  const QStringList predefinedOrderList = positionString.split( ',' );
+  result.reserve( predefinedOrderList.size() );
+  for ( const QString &position : predefinedOrderList )
   {
     QString cleaned = position.trimmed().toUpper();
     if ( cleaned == QLatin1String( "TL" ) )
@@ -490,4 +486,40 @@ QVector<QgsPalLayerSettings::PredefinedPointPosition> QgsLabelingUtils::decodePr
       result << QgsPalLayerSettings::BottomRight;
   }
   return result;
+}
+
+QString QgsLabelingUtils::encodeLinePlacementFlags( pal::LineArrangementFlags flags )
+{
+  QStringList parts;
+  if ( flags & pal::FLAG_ON_LINE )
+    parts << QStringLiteral( "OL" );
+  if ( flags & pal::FLAG_ABOVE_LINE )
+    parts << QStringLiteral( "AL" );
+  if ( flags & pal::FLAG_BELOW_LINE )
+    parts << QStringLiteral( "BL" );
+  if ( !( flags & pal::FLAG_MAP_ORIENTATION ) )
+    parts << QStringLiteral( "LO" );
+  return parts.join( ',' );
+}
+
+pal::LineArrangementFlags QgsLabelingUtils::decodeLinePlacementFlags( const QString &string )
+{
+  pal::LineArrangementFlags flags = nullptr;
+  const QStringList flagList = string.split( ',' );
+  bool foundLineOrientationFlag = false;
+  for ( const QString &flag : flagList )
+  {
+    QString cleaned = flag.trimmed().toUpper();
+    if ( cleaned == QLatin1String( "OL" ) )
+      flags |= pal::FLAG_ON_LINE;
+    else if ( cleaned == QLatin1String( "AL" ) )
+      flags |= pal::FLAG_ABOVE_LINE;
+    else if ( cleaned == QLatin1String( "BL" ) )
+      flags |= pal::FLAG_BELOW_LINE;
+    else if ( cleaned == QLatin1String( "LO" ) )
+      foundLineOrientationFlag = true;
+  }
+  if ( !foundLineOrientationFlag )
+    flags |= pal::FLAG_MAP_ORIENTATION;
+  return flags;
 }

--- a/src/core/qgslabelingengine.h
+++ b/src/core/qgslabelingengine.h
@@ -23,7 +23,7 @@
 
 #include "qgspallabeling.h"
 #include "qgslabelingenginesettings.h"
-
+#include "pal.h"
 
 class QgsLabelingEngine;
 
@@ -93,9 +93,6 @@ class CORE_EXPORT QgsAbstractLabelProvider
     //! What placement strategy to use for the labels
     QgsPalLayerSettings::Placement placement() const { return mPlacement; }
 
-    //! For layers with linestring geometries - extra placement flags (or-ed combination of QgsPalLayerSettings::LinePlacementFlags)
-    unsigned int linePlacementFlags() const { return mLinePlacementFlags; }
-
     //! Default priority of labels (may be overridden by individual labels)
     double priority() const { return mPriority; }
 
@@ -121,8 +118,6 @@ class CORE_EXPORT QgsAbstractLabelProvider
     Flags mFlags;
     //! Placement strategy
     QgsPalLayerSettings::Placement mPlacement;
-    //! Extra placement flags for linestring geometries
-    unsigned int mLinePlacementFlags;
     //! Default priority of labels
     double mPriority;
     //! Type of the obstacle of feature geometries
@@ -254,6 +249,18 @@ class CORE_EXPORT QgsLabelingUtils
      * \see encodePredefinedPositionOrder()
      */
     static QVector< QgsPalLayerSettings::PredefinedPointPosition > decodePredefinedPositionOrder( const QString &positionString );
+
+    /**
+     * Encodes line placement \a flags to a string.
+     * \see decodeLinePlacementFlags()
+     */
+    static QString encodeLinePlacementFlags( pal::LineArrangementFlags flags );
+
+    /**
+     * Decodes a \a string to set of line placement flags.
+     * \see encodeLinePlacementFlags()
+     */
+    static pal::LineArrangementFlags decodeLinePlacementFlags( const QString &string );
 
 };
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -209,6 +209,11 @@ void QgsPalLayerSettings::initPropertyDefinitions()
                             "<b>BL</b>=Bottom left|<b>BSL</b>=Bottom, slightly left|<b>B</b>=Bottom middle|<br>"
                             "<b>BSR</b>=Bottom, slightly right|<b>BR</b>=Bottom right]" ), origin )
     },
+    {
+      QgsPalLayerSettings::LinePlacementOptions, QgsPropertyDefinition( "LinePlacementFlags", QgsPropertyDefinition::DataTypeString, QObject::tr( "Line placement options" ),  QObject::tr( "Comma separated list of placement options<br>" )
+          + QStringLiteral( "[<b>OL</b>=On line|<b>AL</b>=Above line|<b>BL</b>=Below line|<br>"
+                            "<b>LO</b>=Respect line orientation]" ), origin )
+    },
     { QgsPalLayerSettings::PositionX, QgsPropertyDefinition( "PositionX", QObject::tr( "Position (X)" ), QgsPropertyDefinition::Double, origin ) },
     { QgsPalLayerSettings::PositionY, QgsPropertyDefinition( "PositionY", QObject::tr( "Position (Y)" ), QgsPropertyDefinition::Double, origin ) },
     { QgsPalLayerSettings::Hali, QgsPropertyDefinition( "Hali", QgsPropertyDefinition::DataTypeString, QObject::tr( "Horizontal alignment" ), QObject::tr( "string " ) + "[<b>Left</b>|<b>Center</b>|<b>Right</b>]", origin ) },
@@ -2082,6 +2087,15 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   {
     ( *labelFeature )->setHasFixedQuadrant( true );
   }
+
+  pal::LineArrangementFlags featureArrangementFlags = static_cast< pal::LineArrangementFlags >( placementFlags );
+  context.expressionContext().setOriginalValueVariable( QgsLabelingUtils::encodeLinePlacementFlags( featureArrangementFlags ) );
+  const QString dataDefinedLineArrangement = mDataDefinedProperties.valueAsString( QgsPalLayerSettings::LinePlacementOptions, context.expressionContext() );
+  if ( !dataDefinedLineArrangement.isEmpty() )
+  {
+    featureArrangementFlags = QgsLabelingUtils::decodeLinePlacementFlags( dataDefinedLineArrangement );
+  }
+  ( *labelFeature )->setArrangementFlags( featureArrangementFlags );
 
   // data defined z-index?
   context.expressionContext().setOriginalValueVariable( zIndex );

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -421,6 +421,7 @@ class CORE_EXPORT QgsPalLayerSettings
       RepeatDistanceUnit = 86,
       Priority = 87,
       PredefinedPositionOrder = 91,
+      LinePlacementOptions = 99, //!< Line placement flags
 
       // rendering
       ScaleVisibility = 23,

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -43,7 +43,6 @@ void QgsVectorLayerDiagramProvider::init()
   mName = mLayerId;
   mPriority = 1 - mSettings.priority() / 10.0; // convert 0..10 --> 1..0
   mPlacement = QgsPalLayerSettings::Placement( mSettings.placement() );
-  mLinePlacementFlags = mSettings.linePlacementFlags();
 }
 
 

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -56,7 +56,6 @@ QgsVectorLayerLabelProvider::QgsVectorLayerLabelProvider( QgsVectorLayer *layer,
 void QgsVectorLayerLabelProvider::init()
 {
   mPlacement = mSettings.placement;
-  mLinePlacementFlags = mSettings.placementFlags;
   mFlags = Flags();
   if ( mSettings.drawLabels )
     mFlags |= DrawLabels;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -961,6 +961,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/processing
   ${CMAKE_SOURCE_DIR}/src/core/mesh
+  ${CMAKE_SOURCE_DIR}/src/core/pal
   ${CMAKE_SOURCE_DIR}/src/core/providers/memory
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/scalebar

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -519,7 +519,8 @@ void QgsTextFormatWidget::initWidget()
           << mCheckBoxSubstituteText
           << mGeometryGeneratorGroupBox
           << mGeometryGenerator
-          << mGeometryGeneratorType;
+          << mGeometryGeneratorType
+          << mLinePlacementFlagsDDBtn;
   connectValueChanged( widgets, SLOT( updatePreview() ) );
 
   connect( mQuadrantBtnGrp, static_cast<void ( QButtonGroup::* )( int )>( &QButtonGroup::buttonClicked ), this, &QgsTextFormatWidget::updatePreview );

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/symbology
+  ${CMAKE_SOURCE_DIR}/src/core/pal
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/src/gui/auth
   ${CMAKE_SOURCE_DIR}/external

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -335,7 +335,7 @@
              <enum>QTabWidget::Rounded</enum>
             </property>
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <property name="iconSize">
              <size>
@@ -591,7 +591,7 @@
               <item>
                <widget class="QStackedWidget" name="mLabelStackedWidget">
                 <property name="currentIndex">
-                 <number>5</number>
+                 <number>0</number>
                 </property>
                 <widget class="QWidget" name="mLabelPage_Text">
                  <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4012,6 +4012,13 @@ font-style: italic;</string>
                              </property>
                             </widget>
                            </item>
+                           <item>
+                            <widget class="QgsPropertyOverrideButton" name="mLinePlacementFlagsDDBtn">
+                             <property name="text">
+                              <string>…</string>
+                             </property>
+                            </widget>
+                           </item>
                           </layout>
                          </item>
                          <item row="1" column="1">
@@ -6567,6 +6574,7 @@ font-style: italic;</string>
   <tabstop>chkLineOn</tabstop>
   <tabstop>chkLineBelow</tabstop>
   <tabstop>chkLineOrientationDependent</tabstop>
+  <tabstop>mLinePlacementFlagsDDBtn</tabstop>
   <tabstop>mCentroidRadioVisible</tabstop>
   <tabstop>mCentroidRadioWhole</tabstop>
   <tabstop>mCentroidDDBtn</tabstop>
@@ -6641,6 +6649,9 @@ font-style: italic;</string>
   <tabstop>mObstacleFactorDDBtn</tabstop>
   <tabstop>mObstacleTypeComboBox</tabstop>
   <tabstop>scrollArea_mPreview</tabstop>
+  <tabstop>mGeometryGeneratorGroupBox</tabstop>
+  <tabstop>mGeometryGeneratorExpressionButton</tabstop>
+  <tabstop>mGeometryGeneratorType</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -17,6 +17,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/effects
   ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
+  ${CMAKE_SOURCE_DIR}/src/core/pal
   ${CMAKE_SOURCE_DIR}/src/core/processing
   ${CMAKE_SOURCE_DIR}/src/core/processing/models
   ${CMAKE_SOURCE_DIR}/src/core/raster

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -46,6 +46,7 @@ class TestQgsLabelingEngine : public QObject
     void testRuleBased();
     void zOrder(); //test that labels are stacked correctly
     void testEncodeDecodePositionOrder();
+    void testEncodeDecodeLinePlacement();
     void testSubstitutions();
     void testCapitalization();
     void testParticipatingLayers();
@@ -480,6 +481,21 @@ void TestQgsLabelingEngine::testEncodeDecodePositionOrder()
   expected << QgsPalLayerSettings::TopRight << QgsPalLayerSettings::BottomSlightlyRight
            << QgsPalLayerSettings::MiddleLeft << QgsPalLayerSettings::TopMiddle;
   QCOMPARE( decoded, expected );
+}
+
+void TestQgsLabelingEngine::testEncodeDecodeLinePlacement()
+{
+  QString encoded = QgsLabelingUtils::encodeLinePlacementFlags( pal::FLAG_ABOVE_LINE | pal::FLAG_ON_LINE );
+  QVERIFY( !encoded.isEmpty() );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( encoded ), pal::FLAG_ABOVE_LINE | pal::FLAG_ON_LINE );
+  encoded = QgsLabelingUtils::encodeLinePlacementFlags( pal::FLAG_ON_LINE | pal::FLAG_MAP_ORIENTATION );
+  QVERIFY( !encoded.isEmpty() );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( encoded ), pal::FLAG_ON_LINE | pal::FLAG_MAP_ORIENTATION );
+
+  //test decoding with a messy string
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,," ) ), pal::FLAG_ON_LINE | pal::FLAG_MAP_ORIENTATION );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,BL,  al" ) ), pal::FLAG_ON_LINE | pal::FLAG_ABOVE_LINE | pal::FLAG_BELOW_LINE | pal::FLAG_MAP_ORIENTATION );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,BL, LO,  al" ) ), pal::FLAG_ON_LINE | pal::FLAG_ABOVE_LINE | pal::FLAG_BELOW_LINE );
 }
 
 void TestQgsLabelingEngine::testSubstitutions()

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -11,6 +11,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/mesh
   ${CMAKE_SOURCE_DIR}/src/core/metadata
+  ${CMAKE_SOURCE_DIR}/src/core/pal
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/providers/wms


### PR DESCRIPTION
Allows users to override the line placement settings (e.g. above/below/on line options) on a per-feature basis. Somehow this one was the only(?) setting from labeling which was missing a data defined control...