### PR TITLE
remove constraints if defaultValueClauses on offline editing

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -839,7 +839,8 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
     copySymbology( layer, newLayer );
 
     //remove constrainst of fields that use defaultValueClauses from provider on original
-    for ( const QgsField &field : layer->fields() )
+    const auto fields = layer->fields();
+    for ( const QgsField &field : fields )
     {
       if ( !layer->dataProvider()->defaultValueClause( layer->fields().fieldOriginIndex( layer->fields().indexOf( field.name() ) ) ).isEmpty() )
       {

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -838,6 +838,15 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
     // copy style
     copySymbology( layer, newLayer );
 
+    //remove constrainst of fields that use defaultValueClauses from provider on original
+    for ( const QgsField &field : layer->fields() )
+    {
+      if ( !layer->dataProvider()->defaultValueClause( layer->fields().fieldOriginIndex( layer->fields().indexOf( field.name() ) ) ).isEmpty() )
+      {
+        newLayer->removeFieldConstraint( newLayer->fields().indexOf( field.name() ), QgsFieldConstraints::ConstraintNotNull );
+      }
+    }
+
     QgsLayerTreeGroup *layerTreeRoot = QgsProject::instance()->layerTreeRoot();
     // Find the parent group of the original layer
     QgsLayerTreeLayer *layerTreeLayer = layerTreeRoot->findLayer( layer->id() );


### PR DESCRIPTION
If there is a defaultValue from providerside (eg. "nextval(...")) the offline layer does not contain the `NOT NULL` constraint from now on. Since otherwise the user is pushed to fill it up, what leads to troubles on synchronizing it back.

fixes #28122

- [x] test
