### PR TITLE
Add QLongLong support for literal node expression

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -1170,6 +1170,8 @@ QString QgsExpressionNodeLiteral::dump() const
       return QString::number( mValue.toInt() );
     case QVariant::Double:
       return QString::number( mValue.toDouble() );
+    case QVariant::LongLong:
+      return QString::number( mValue.toLongLong() );
     case QVariant::String:
       return QgsExpression::quotedString( mValue.toString() );
     case QVariant::Bool:

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -56,6 +56,9 @@ class TestQgsOgcUtils : public QObject
     void testExpressionFromOgcFilter();
     void testExpressionFromOgcFilter_data();
 
+    void testExpressionFromOgcFilterWithLongLong();
+    void testExpressionFromOgcFilterWithLongLong_data();
+
     void testExpressionFromOgcFilterWFS20();
     void testExpressionFromOgcFilterWFS20_data();
 
@@ -450,6 +453,56 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter()
   QDomElement rootElem = doc.documentElement();
 
   QgsVectorLayer layer( "Point?crs=epsg:4326&field=LITERAL:string(20)", "temp", "memory" );
+
+  std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
+  QVERIFY( expr.get() );
+
+  qDebug( "OGC XML  : %s", xmlText.toAscii().data() );
+  qDebug( "EXPR-DUMP: %s", expr->expression().toAscii().data() );
+
+  if ( expr->hasParserError() )
+    qDebug( "ERROR: %s ", expr->parserErrorString().toAscii().data() );
+  QVERIFY( !expr->hasParserError() );
+
+  QCOMPARE( dumpText, expr->expression() );
+}
+
+void TestQgsOgcUtils::testExpressionFromOgcFilterWithLongLong_data()
+{
+  QTest::addColumn<QString>( "xmlText" );
+  QTest::addColumn<QString>( "dumpText" );
+  QTest::newRow( "Literal less than" ) << QString(
+                                         "<Filter><And>"
+                                         "<PropertyIsGreaterThan>"
+                                         "<PropertyName>id</PropertyName>"
+                                         "<Literal>1</Literal>"
+                                         "</PropertyIsGreaterThan>"
+                                         "<PropertyIsLessThan>"
+                                         "<PropertyName>id</PropertyName>"
+                                         "<Literal>3</Literal>"
+                                         "</PropertyIsLessThan>"
+                                         "</And></Filter>" )
+                                       << QStringLiteral( "id > 1 AND id < 3" );
+}
+
+void TestQgsOgcUtils::testExpressionFromOgcFilterWithLongLong()
+{
+  QFETCH( QString, xmlText );
+  QFETCH( QString, dumpText );
+
+  QDomDocument doc;
+
+  QVERIFY( doc.setContent( xmlText, true ) );
+  QDomElement rootElem = doc.documentElement();
+
+  QgsVectorLayer layer( "Point?crs=epsg:4326", "temp", "memory" );
+
+  QgsField longlongField( QStringLiteral( "id" ), QVariant::LongLong );
+
+  QList<QgsField> fields;
+  fields.append( longlongField );
+  layer.dataProvider()->addAttributes( fields );
+  layer.updateFields();
 
   std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
   QVERIFY( expr.get() );

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -310,7 +310,7 @@ void TestQgsOgcUtils::testExpressionFromOgcFilterWFS20()
 
   QgsVectorLayer layer( "Point?crs=epsg:4326&field=LITERAL:string(20)", "temp", "memory" );
 
-  std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, QgsOgcUtils::FILTER_FES_2_0, &layer ) );
+  std::unique_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, QgsOgcUtils::FILTER_FES_2_0, &layer ) );
   QVERIFY( expr.get() );
 
   qDebug( "OGC XML  : %s", xmlText.toAscii().data() );
@@ -454,7 +454,7 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter()
 
   QgsVectorLayer layer( "Point?crs=epsg:4326&field=LITERAL:string(20)", "temp", "memory" );
 
-  std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
+  std::unique_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
   QVERIFY( expr.get() );
 
   qDebug( "OGC XML  : %s", xmlText.toAscii().data() );
@@ -504,7 +504,7 @@ void TestQgsOgcUtils::testExpressionFromOgcFilterWithLongLong()
   layer.dataProvider()->addAttributes( fields );
   layer.updateFields();
 
-  std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
+  std::unique_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
   QVERIFY( expr.get() );
 
   qDebug( "OGC XML  : %s", xmlText.toAscii().data() );


### PR DESCRIPTION
## Description

Fixes #30263 issue with QLongLong.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
