### PR TITLE
Bad Layer Handler Improvements

### DIFF
--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -84,6 +84,22 @@ and "/home/user/projects" exists but no "2018" subfolder exists, then the functi
 
 .. versionadded:: 3.2
 %End
+
+    static QStringList findFile( const QString &file, const QString &basepath = QString(), int maxClimbs = 4, int searchCeiling = 4, const QString &currentDir = QString() );
+%Docstring
+Will check ``basepath`` in an outward spiral up to ``maxClimbs`` levels to check if ``file`` exists.
+
+:param file: Name or full path of the file to find
+:param basepath: current basepath of the file, needed if only the name is specified in file
+:param maxClimbs: limit the number of time the search can move up from the basepath
+:param searchCeiling: limits where in the folder hierarchy the search can be performed, 1 = root/drive, 2 = first folder level, 3 = sub folders ( Unix: /usr/bin, Win: C:/Users/Admin ), etc.
+:param currentDir: alternative default directory to override the actual current directory during the search
+
+:return: List of strings of the first matching path in unix format.
+
+.. versionadded:: 3.12
+%End
+
 };
 
 /************************************************************************

--- a/src/app/qgshandlebadlayers.h
+++ b/src/app/qgshandlebadlayers.h
@@ -64,17 +64,36 @@ class APP_EXPORT QgsHandleBadLayers
     void apply();
     void accept() override;
 
+    /**
+     *  Will search for selected (if any) or all files.
+     * Found files will be highlighted in green of approval, otherwise in red.
+     * \since QGIS 3.12
+     */
+    void autoFind();
+
   private:
     QPushButton *mBrowseButton = nullptr;
     QPushButton *mApplyButton = nullptr;
+    QPushButton *mAutoFindButton = nullptr;
     const QList<QDomNode> &mLayers;
     QList<int> mRows;
     QString mVectorFileFilter;
     QString mRasterFileFilter;
-    QHash <QString, QList<QString> > mFileBase;
+    // Registry of the original paths associated with a file as a backup
+    QHash <QString, QString > mOriginalFileBase;
+    // Keeps a registry of valid alternatives for a basepath
+    QHash <QString, QStringList > mAlternativeBasepaths;
 
     QString filename( int row );
     void setFilename( int row, const QString &filename );
+
+    /**
+     * Checks if \a newPath for the provided \a layerId is valid.
+     * Otherwise all other know viable alternative for the original basepath will be tested.
+     * \since QGIS 3.12
+     */
+    QString checkBasepath( const QString &layerId, const QString &newPath, const QString &fileName );
+
 };
 
 #endif

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -87,6 +87,19 @@ class CORE_EXPORT QgsFileUtils
      * \since QGIS 3.2
      */
     static QString findClosestExistingPath( const QString &path );
+
+    /**
+     * Will check \a basepath in an outward spiral up to \a maxClimbs levels to check if \a file exists.
+     * \param file Name or full path of the file to find
+     * \param basepath current basepath of the file, needed if only the name is specified in file
+     * \param maxClimbs limit the number of time the search can move up from the basepath
+     * \param searchCeiling limits where in the folder hierarchy the search can be performed, 1 = root/drive, 2 = first folder level, 3 = sub folders ( Unix: /usr/bin, Win: C:/Users/Admin ), etc.
+     * \param currentDir alternative default directory to override the actual current directory during the search
+     * \returns List of strings of the first matching path in unix format.
+     * \since QGIS 3.12
+     */
+    static QStringList findFile( const QString &file, const QString &basepath = QString(), int maxClimbs = 4, int searchCeiling = 4, const QString &currentDir = QString() );
+
 };
 
 #endif // QGSFILEUTILS_H


### PR DESCRIPTION


## Description
This improves upon the previous work that I did for the bad feature handler.

This aims to add a button that will search for layers in an outward pattern up 4 levels (levels can be changed). The layers found will be highlighted in green. Then the user can hit apply or ok to confirm. If the folder containing the old path, it will move up until it reaches a valid folder and search from there. If the next valid folder is less than 4 levels away, it will also search up 4 levels, otherwise the search will be done only from the valid folder.

The layers in red will have to be changed through some other means.

The way alternative basepath are stored and handled has also changed. I have added existence check when attempting all alternative basepaths for a given original path.

This add a new button to launch the auto finder function. A query could be added to ask for the maximum depth to move up. In our current architecture 4 level is not much but for a user working in local, this might mean that the search could end up near the root and take a long time to find a file. 

Hence why I have added a way to limit vertical movement by ensuring that we are 3 folder away from the drive (by checking the number of system separator).

This is open for discussion.

Feature at work:
![autofinder](https://user-images.githubusercontent.com/12854129/66336231-b0671080-e90a-11e9-9a53-8b1b5edd1579.gif)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
