### PR TITLE
[processing] set correct default for r.stream.extract algorithm (fix #30231)

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.stream.extract.txt
+++ b/python/plugins/processing/algs/grass7/description/r.stream.extract.txt
@@ -4,7 +4,7 @@ Raster (r.*)
 QgsProcessingParameterRasterLayer|elevation|Input map: elevation map|None|False
 QgsProcessingParameterRasterLayer|accumulation|Input map: accumulation map|None|True
 QgsProcessingParameterRasterLayer|depression|Input map: map with real depressions|None|True
-QgsProcessingParameterNumber|threshold|Minimum flow accumulation for streams|QgsProcessingParameterNumber.Double|None|False|0.0|None
+QgsProcessingParameterNumber|threshold|Minimum flow accumulation for streams|QgsProcessingParameterNumber.Double|1.0|False|0.001|None
 QgsProcessingParameterNumber|mexp|Montgomery exponent for slope|QgsProcessingParameterNumber.Double|0.0|True|None|None
 QgsProcessingParameterNumber|stream_length|Delete stream segments shorter than cells|QgsProcessingParameterNumber.Integer|0|True|0|None
 QgsProcessingParameterNumber|d8cut|Use SFD above this threshold|QgsProcessingParameterNumber.Double|None|True|0|None


### PR DESCRIPTION
## Description
In the r.stream.extract algorithm "Minimum flow accumulation for streams"  parameter has incorrect default value of 0. According to the GRASS documentation, this paramer should be greater then 0.

Fixes #30231.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
