### PR TITLE
[processing] assign correct ids to features in the random points in polygons algorithm (fix #26321)

### DIFF
--- a/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
@@ -135,6 +135,7 @@ class RandomPointsPolygons(QgisAlgorithm):
 
         total = 100.0 / source.featureCount() if source.featureCount() else 0
         current_progress = 0
+        pointId = 0
         for current, f in enumerate(source.getFeatures()):
             if feedback.isCanceled():
                 break
@@ -190,12 +191,13 @@ class RandomPointsPolygons(QgisAlgorithm):
                     f = QgsFeature(nPoints)
                     f.initAttributes(1)
                     f.setFields(fields)
-                    f.setAttribute('id', nPoints)
+                    f.setAttribute('id', pointId)
                     f.setGeometry(geom)
                     sink.addFeature(f, QgsFeatureSink.FastInsert)
                     index.addFeature(f)
                     points[nPoints] = p
                     nPoints += 1
+                    pointId += 1
                     feedback.setProgress(current_progress + int(nPoints * feature_total))
                 nIterations += 1
 


### PR DESCRIPTION
## Description
Random point in polygons algorithm assigns points IDs for each polygon individually. This results to duplicate IDs and quite confusing for users.

Fixes #26321

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
