### PR TITLE
[processing] remove trailing semicolon from SQL before creating a layer (fix #30239)

### DIFF
--- a/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
@@ -101,7 +101,7 @@ class PostGISExecuteAndLoadSQL(QgisAlgorithm):
         uri = postgis.uri_from_name(connection)
         sql = self.parameterAsString(parameters, self.SQL, context)
         sql = sql.replace('\n', ' ')
-        uri.setDataSource("", "(" + sql + ")", geom_field, "", id_field)
+        uri.setDataSource("", "(" + sql.rstrip(';') + ")", geom_field, "", id_field)
 
         vlayer = QgsVectorLayer(uri.uri(), "layername", "postgres")
 


### PR DESCRIPTION
## Description
"PostgreSQL execute and load SQL" algorithm uses SQL to create layer datasource URI. If SQL ends with semicolon then generated URI is not valid. This PR fixes issue by removing trailing semicolon when creating an URI.

Fixes #30239.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit