### PR TITLE
[processing] Fix incorrect columns hidden when toggling advanced parameters

### DIFF
--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -111,6 +111,7 @@ class BatchPanel(BASE, WIDGET):
 
         self.context_generator = ContextGenerator(self.processing_context)
 
+        self.parameter_to_column = {}
         self.initWidgets()
 
     def layerRegistryChanged(self):
@@ -136,12 +137,14 @@ class BatchPanel(BASE, WIDGET):
                 column, QTableWidgetItem(param.description()))
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
                 self.tblParameters.setColumnHidden(column, True)
+            self.parameter_to_column[param.name()] = column
             column += 1
 
         for out in self.alg.destinationParameterDefinitions():
             if not out.flags() & QgsProcessingParameterDefinition.FlagHidden:
                 self.tblParameters.setHorizontalHeaderItem(
                     column, QTableWidgetItem(out.description()))
+                self.parameter_to_column[out.name()] = column
                 column += 1
 
         # Add an empty row to begin
@@ -345,6 +348,6 @@ class BatchPanel(BASE, WIDGET):
             self.wrappers[row][column].setParameterValue(wrapper.parameterValue(), context)
 
     def toggleAdvancedMode(self, checked):
-        for column, param in enumerate(self.alg.parameterDefinitions()):
+        for param in self.alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
-                self.tblParameters.setColumnHidden(column, not checked)
+                self.tblParameters.setColumnHidden(self.parameter_to_column[param.name()], not checked)


### PR DESCRIPTION
## Description
Backport 070de69e30d564a4a8b527a58ef0bc4543cbb4bc to the LTR branch.
This commit fixes displaying of the advanced parameters in the bath mode, as reported in #29900.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
