### PR TITLE
[ui] When the color ramp shader widget list of values has been customized, maintain those values when modifying the color ramp

### DIFF
--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -257,7 +257,6 @@ void QgsColorRampShaderWidget::setUnitFromLabels()
   {
     mUnitLineEdit->setText( unit );
   }
-  autoLabel();
 }
 
 
@@ -327,7 +326,7 @@ void QgsColorRampShaderWidget::classify()
     QgsTreeWidgetItemObject *newItem = new QgsTreeWidgetItemObject( mColormapTreeWidget );
     newItem->setText( ValueColumn, QString::number( it->value, 'g', 15 ) );
     newItem->setData( ColorColumn, Qt::EditRole, it->color );
-    newItem->setText( LabelColumn, it->label );
+    newItem->setText( LabelColumn, QString() ); // Labels will be populated in autoLabel()
     newItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsSelectable );
     connect( newItem, &QgsTreeWidgetItemObject::itemEdited,
              this, &QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited );
@@ -409,8 +408,6 @@ void QgsColorRampShaderWidget::populateColormapTreeWidget( const QList<QgsColorR
              this, &QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited );
   }
   setUnitFromLabels();
-
-  autoLabel();
   emit widgetChanged();
 }
 
@@ -671,6 +668,7 @@ void QgsColorRampShaderWidget::setFromShader( const QgsColorRampShader &colorRam
              this, &QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited );
   }
   setUnitFromLabels();
+
   mClipCheckBox->setChecked( colorRampShader.clip() );
   mClassificationModeComboBox->setCurrentIndex( mClassificationModeComboBox->findData( colorRampShader.classificationMode() ) );
   mNumberOfEntriesSpinBox->setValue( colorRampShader.colorRampItemList().count() ); // some default

--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -66,8 +66,7 @@ QgsColorRampShaderWidget::QgsColorRampShaderWidget( QWidget *parent )
   mColormapTreeWidget->setColumnWidth( ColorColumn, Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 6.6 );
   mColormapTreeWidget->setContextMenuPolicy( Qt::CustomContextMenu );
   mColormapTreeWidget->setSelectionMode( QAbstractItemView::ExtendedSelection );
-  connect( mColormapTreeWidget, &QTreeView::customContextMenuRequested, this, [ = ]( QPoint ) { contextMenu->exec( QCursor::pos() ); }
-         );
+  connect( mColormapTreeWidget, &QTreeView::customContextMenuRequested, this, [ = ]( QPoint ) { contextMenu->exec( QCursor::pos() ); } );
 
   QString defaultPalette = settings.value( QStringLiteral( "Raster/defaultPalette" ), "" ).toString();
   btnColorRamp->setColorRampFromName( defaultPalette );
@@ -89,7 +88,7 @@ QgsColorRampShaderWidget::QgsColorRampShaderWidget( QWidget *parent )
   resetClassifyButton();
 
   connect( mClassificationModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsColorRampShaderWidget::classify );
-  connect( mClassifyButton, &QPushButton::clicked, this, &QgsColorRampShaderWidget::applyColorRamp );
+  connect( mClassifyButton, &QPushButton::clicked, this, &QgsColorRampShaderWidget::classify );
   connect( btnColorRamp, &QgsColorRampButton::colorRampChanged, this, &QgsColorRampShaderWidget::applyColorRamp );
   connect( mNumberOfEntriesSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsColorRampShaderWidget::classify );
   connect( mClipCheckBox, &QAbstractButton::toggled, this, &QgsColorRampShaderWidget::widgetChanged );
@@ -319,7 +318,6 @@ void QgsColorRampShaderWidget::classify()
                                       mRasterDataProvider );
   colorRampShader->setClip( mClipCheckBox->isChecked() );
 
-
   mColormapTreeWidget->clear();
 
   const QList<QgsColorRampShader::ColorRampItem> colorRampItemList = colorRampShader->colorRampItemList();
@@ -335,7 +333,6 @@ void QgsColorRampShaderWidget::classify()
              this, &QgsColorRampShaderWidget::mColormapTreeWidget_itemEdited );
   }
   mClipCheckBox->setChecked( colorRampShader->clip() );
-
 
   autoLabel();
   emit widgetChanged();
@@ -371,7 +368,30 @@ void QgsColorRampShaderWidget::applyColorRamp()
     mClassificationModeComboBox->setCurrentIndex( mClassificationModeComboBox->findData( QgsColorRampShader::EqualInterval ) );
   }
 
-  classify();
+  int topLevelItemCount = mColormapTreeWidget->topLevelItemCount();
+  if ( topLevelItemCount > 0 )
+  {
+    // if the list values has been customized, maintain pre-existing values
+    QTreeWidgetItem *currentItem = nullptr;
+    for ( int i = 0; i < topLevelItemCount; ++i )
+    {
+      currentItem = mColormapTreeWidget->topLevelItem( i );
+      if ( !currentItem )
+      {
+        continue;
+      }
+
+      double value = currentItem->text( ValueColumn ).toDouble();
+      double position = ( value - mMin ) / ( mMax - mMin );
+      currentItem->setData( ColorColumn, Qt::EditRole, ramp->color( position ) );
+    }
+
+    emit widgetChanged();
+  }
+  else
+  {
+    classify();
+  }
 }
 
 void QgsColorRampShaderWidget::populateColormapTreeWidget( const QList<QgsColorRampShader::ColorRampItem> &colorRampItems )
@@ -409,7 +429,6 @@ void QgsColorRampShaderWidget::mLoadFromBandButton_clicked()
   {
     QMessageBox::warning( this, tr( "Load Color Map" ), tr( "The color map for band %1 has no entries." ).arg( mBand ) );
   }
-
   loadMinimumMaximumFromTree();
   emit widgetChanged();
 }


### PR DESCRIPTION
## Description
This PR fixes #30345 , whereas a customized list of values in the color ramp shader widget would be overwritten when modifying the color ramp.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
