### PR TITLE
[processing] allow to define model parameters as advanced

### DIFF
--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -356,6 +356,13 @@ class ModelerParameterDefinitionDialog(QDialog):
             self.requiredCheck.setChecked(not self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
         self.verticalLayout.addWidget(self.requiredCheck)
 
+        self.advancedCheck = QCheckBox()
+        self.advancedCheck.setText(self.tr('Advanced'))
+        self.advancedCheck.setChecked(False)
+        if self.param is not None:
+            self.advancedCheck.setChecked(self.param.flags() & QgsProcessingParameterDefinition.FlagAdvanced)
+        self.verticalLayout.addWidget(self.advancedCheck)
+
         # If child algorithm output is mandatory, disable checkbox
         if isinstance(self.param, QgsProcessingDestinationParameter):
             provider_name, child_name, output_name = self.param.name().split(':')
@@ -576,6 +583,11 @@ class ModelerParameterDefinitionDialog(QDialog):
             self.param.setFlags(self.param.flags() | QgsProcessingParameterDefinition.FlagOptional)
         else:
             self.param.setFlags(self.param.flags() & ~QgsProcessingParameterDefinition.FlagOptional)
+
+        if self.advancedCheck.isChecked():
+            self.param.setFlags(self.param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        else:
+            self.param.setFlags(self.param.flags() & ~QgsProcessingParameterDefinition.FlagAdvanced)
 
         settings = QgsSettings()
         settings.setValue("/Processing/modelParametersDefinitionDialogGeometry", self.saveGeometry())

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -373,6 +373,9 @@ class ModelerParameterDefinitionDialog(QDialog):
                 self.requiredCheck.setEnabled(False)
                 self.requiredCheck.setChecked(True)
 
+            self.advancedCheck.setEnabled(False)
+            self.advancedCheck.setChecked(False)
+
         self.buttonBox = QDialogButtonBox(self)
         self.buttonBox.setOrientation(Qt.Horizontal)
         self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel |


### PR DESCRIPTION
## Description
Allow to declare model parameters as advanced (currently only "optional" flag is supported) by checking corresponding checkbox in the parameter definition dialog.

This is one of the missed things in the modeler which make complex models with lot of parameters a bit dfficult to use.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit