### PR TITLE
Add DateTime filter support to QgsFieldProxyModel

### DIFF
--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -85,6 +85,7 @@ bool QgsFieldProxyModel::filterAcceptsRow( int source_row, const QModelIndex &so
        ( mFilters.testFlag( Double ) && type == QVariant::Double ) ||
        ( mFilters.testFlag( Date ) && type == QVariant::Date ) ||
        ( mFilters.testFlag( Date ) && type == QVariant::DateTime ) ||
+       ( mFilters.testFlag( DateTime ) && type == QVariant::DateTime ) ||
        ( mFilters.testFlag( Time ) && type == QVariant::Time ) )
     return true;
 

--- a/src/core/qgsfieldproxymodel.h
+++ b/src/core/qgsfieldproxymodel.h
@@ -46,6 +46,7 @@ class CORE_EXPORT QgsFieldProxyModel : public QSortFilterProxyModel
       Date = 16, //!< Date or datetime fields
       Time = 32, //!< Time fields
       HideReadOnly = 64,  //!< Hide read-only fields
+      DateTime = 128, //!< Datetime fieldss
       AllTypes = Numeric | Date | String | Time, //!< All field types
     };
     Q_DECLARE_FLAGS( Filters, Filter )

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -306,6 +306,10 @@ void TestQgsFieldExpressionWidget::testFilters()
   QCOMPARE( widget->mCombo->count(), 1 );
   QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "timefld" ) );
 
+  widget->setFilters( QgsFieldProxyModel::DateTime );
+  QCOMPARE( widget->mCombo->count(), 1 );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "datetimefld" ) );
+
   QgsProject::instance()->removeMapLayer( layer );
 }
 


### PR DESCRIPTION
Allows filtering for DateTime fields in the various field-model-based widgets.