### PR TITLE
[map canvas] Fix scale change when resizing in locked scale mode

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1538,19 +1538,28 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent *e )
 void QgsMapCanvas::resizeEvent( QResizeEvent *e )
 {
   QGraphicsView::resizeEvent( e );
-  mResizeTimer->start( 500 );
+  mResizeTimer->start( 500 ); // in charge of refreshing canvas
 
+  double oldScale = mSettings.scale();
   QSize lastSize = viewport()->size();
-
   mSettings.setOutputSize( lastSize );
 
   mScene->setSceneRect( QRectF( 0, 0, lastSize.width(), lastSize.height() ) );
 
   moveCanvasContents( true );
 
-  updateScale();
-
-  //refresh();
+  if ( mScaleLocked )
+  {
+    double scaleFactor = oldScale / mSettings.scale();
+    QgsRectangle r = mSettings.extent();
+    QgsPointXY center = r.center();
+    r.scale( scaleFactor, &center );
+    mSettings.setExtent( r );
+  }
+  else
+  {
+    updateScale();
+  }
 
   emit extentsChanged();
 }


### PR DESCRIPTION
## Description
The map canvas didn't respect the locked scale mode when reacting to resize events. This PR fixes that.

@nyalldawson , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
