### PR TITLE
Revert "Hide panels and toolbars on welcome page"

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -843,6 +843,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   connect( mMapCanvas, &QgsMapCanvas::layersChanged, this, &QgisApp::showMapCanvas );
 
+  mCentralContainer->setCurrentIndex( mProjOpen ? 0 : 1 );
+
   // a bar to warn the user with non-blocking messages
   startProfile( QStringLiteral( "Message bar" ) );
   mInfoBar = new QgsMessageBar( centralWidget );
@@ -1491,32 +1493,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   {
     mCentralContainer->setCurrentIndex( 0 );
   } );
-
-  // As the last thing set the welcome page and restore dock and panel visibility
-
-  connect( mCentralContainer, &QStackedWidget::currentChanged, this, [ this ]( int index )
-  {
-    QgsSettings settings;
-
-    if ( index == 1 ) // welcomepage
-    {
-      if ( settings.value( QStringLiteral( "UI/allWidgetsVisible" ), true ).toBool() )
-      {
-        toggleReducedView( false );
-        settings.setValue( QStringLiteral( "UI/widgetsHiddenForWelcomePage" ), true );
-      }
-    }
-    else
-    {
-      if ( settings.value( QStringLiteral( "UI/widgetsHiddenForWelcomePage" ), false ).toBool() && !QgsSettings().value( QStringLiteral( "UI/allWidgetsVisible" ), true ).toBool() )
-      {
-        toggleReducedView( true );
-      }
-      settings.setValue( QStringLiteral( "UI/widgetsHiddenForWelcomePage" ), false );
-    }
-  } );
-
-  mCentralContainer->setCurrentIndex( 1 );
 } // QgisApp ctor
 
 QgisApp::QgisApp()
@@ -6824,8 +6800,8 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
         }
       }
 
-      menuBar()->setVisible( false );
-      statusBar()->setVisible( false );
+      this->menuBar()->setVisible( false );
+      this->statusBar()->setVisible( false );
 
       settings.setValue( QStringLiteral( "UI/hiddenToolBarsActive" ), toolBarsActive );
     }
@@ -6880,8 +6856,8 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
         toolBar->setVisible( true );
       }
     }
-    menuBar()->setVisible( true );
-    statusBar()->setVisible( true );
+    this->menuBar()->setVisible( true );
+    this->statusBar()->setVisible( true );
 
     settings.remove( QStringLiteral( "UI/hiddenToolBarsActive" ) );
     settings.remove( QStringLiteral( "UI/hiddenDocksTitle" ) );


### PR DESCRIPTION
Hiding panels and toolbars on the welcome page had a number of issues. Some of them could be fixed, some of them not.

- The browser as a common initial "point of action" was hidden (not sure how to fix. Treat browser in a special way?)
- New project default setting was broken (fixable)
- Sometimes panels and toolbars were not restored after leaving the welcome page (fixable)

As a first fix I'd propose to show the panels again and at the same time discuss what's actually required.