### PR TITLE
Allow multiple selection of d&d fields in form designer

### DIFF
--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -37,6 +37,7 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   availableWidgetsWidgetLayout->addWidget( mAvailableWidgetsTree );
   availableWidgetsWidgetLayout->setMargin( 0 );
   mAvailableWidgetsWidget->setLayout( availableWidgetsWidgetLayout );
+  mAvailableWidgetsTree->setSelectionMode( QAbstractItemView::SelectionMode::ExtendedSelection );
   mAvailableWidgetsTree->setHeaderLabels( QStringList() << tr( "Available Widgets" ) );
   mAvailableWidgetsTree->setType( DnDTree::Type::Drag );
 
@@ -154,6 +155,7 @@ void QgsAttributesFormProperties::initFormLayoutTree()
   mFormLayoutTree->clear();
   mFormLayoutTree->setSortingEnabled( false );
   mFormLayoutTree->setSelectionBehavior( QAbstractItemView::SelectRows );
+  mFormLayoutTree->setSelectionMode( QAbstractItemView::SelectionMode::ExtendedSelection );
   mFormLayoutTree->setAcceptDrops( true );
   mFormLayoutTree->setDragDropMode( QAbstractItemView::DragDrop );
 


### PR DESCRIPTION
## Description

Fix issue #27705
Backport in 3.6 from dbe8b6c

Allow multiple selection of fields for drag and drop in attributes form designer

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
