### PR TITLE
[testcase] Properly test resizing of locked scale map canvas

### DIFF
--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -304,7 +304,10 @@ void TestQgsMapCanvas::testMagnificationScale()
 void TestQgsMapCanvas::testScaleLockCanvasResize()
 {
   QSize prevSize = mCanvas->size();
+
   mCanvas->resize( 600, 400 );
+  QgsApplication::sendPostedEvents( mCanvas );
+  mCanvas->resizeEvent( nullptr );
   QCOMPARE( mCanvas->width(), 600 );
   QCOMPARE( mCanvas->height(), 400 );
 
@@ -313,6 +316,8 @@ void TestQgsMapCanvas::testScaleLockCanvasResize()
   mCanvas->setScaleLocked( true );
 
   mCanvas->resize( 300, 200 );
+  QgsApplication::sendPostedEvents( mCanvas );
+  mCanvas->resizeEvent( nullptr );
   QCOMPARE( mCanvas->width(), 300 );
   QCOMPARE( mCanvas->height(), 200 );
 
@@ -322,6 +327,8 @@ void TestQgsMapCanvas::testScaleLockCanvasResize()
   mCanvas->setScaleLocked( false );
   mCanvas->setMagnificationFactor( 1.0 );
   mCanvas->resize( prevSize );
+  QgsApplication::sendPostedEvents( mCanvas );
+  mCanvas->resizeEvent( nullptr );
 }
 
 void TestQgsMapCanvas::testZoomByWheel()


### PR DESCRIPTION
## Description
@nyalldawson , @3nids , this commit makes the locked scale map canvas resize test work.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
