### PR TITLE
[raster] Allow raster providers to hint whether resampling is beneficial

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -75,6 +75,7 @@ Base class for raster data providers.
       NoProviderCapabilities,
       ReadLayerMetadata,
       WriteLayerMetadata,
+      ProviderHintBenefitsFromResampling
     };
 
     typedef QFlags<QgsRasterDataProvider::ProviderCapability> ProviderCapabilities;

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -99,6 +99,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
       NoProviderCapabilities = 0,       //!< Provider has no capabilities
       ReadLayerMetadata = 1 << 1, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
       WriteLayerMetadata = 1 << 2, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
+      ProviderHintBenefitsFromResampling = 1 << 3 //!< Provider benefits from resampling and should apply user default resampling settings (since QGIS 3.10)
     };
 
     //! Provider capabilities

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1379,6 +1379,11 @@ QString QgsGdalProvider::description() const
   return PROVIDER_DESCRIPTION;
 }
 
+QgsRasterDataProvider::ProviderCapabilities QgsGdalProvider::providerCapabilities() const
+{
+  return QgsRasterDataProvider::ProviderHintBenefitsFromResampling;
+}
+
 // This is used also by global isValidRasterFileName
 QStringList QgsGdalProvider::subLayers( GDALDatasetH dataset )
 {

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -99,6 +99,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
 
     QString name() const override;
     QString description() const override;
+    QgsRasterDataProvider::ProviderCapabilities providerCapabilities() const override;
     QgsCoordinateReferenceSystem crs() const override;
     QgsRectangle extent() const override;
     bool isValid() const override;


### PR DESCRIPTION
## Description
For some providers, such as tiled WMTS/XYZ/AMS, resampling is not always visually beneficial and can lead to larger downloads. This PR allows raster providers to hint as to whether it benefits from resampling; if the flag is set, default user resampling settings will be applied. 

@nyalldawson , as discussed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
