### PR TITLE
Raise an exception when geometry field autodetection has failed

### DIFF
--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -152,6 +152,9 @@ class ExecuteSQL(QgisAlgorithm):
         if not vLayer.isValid():
             raise QgsProcessingException(vLayer.dataProvider().error().message())
 
+        if vLayer.wkbType() == QgsWkbTypes.Unknown:
+            raise QgsProcessingException(self.tr("Cannot find geometry field"))
+
         (sink, dest_id) = self.parameterAsSink(parameters, self.OUTPUT, context,
                                                vLayer.fields(), vLayer.wkbType() if geometry_type != 1 else 1, vLayer.crs())
         if sink is None:


### PR DESCRIPTION
## Description

When using "execute SQL" and you don't retrieve geom field from your request, if you let `[not selected]` or `autodetect` geom type, an unknow exception occured. 

It's because the geom type is `Unknown` so the virtual layer could not be created. This PR raise an explicit exception to inform user.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
