### PR TITLE
Fix __MAC_OS_X_VERSION_MAX_ALLOWED comparison in dark theme function

### DIFF
--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -121,7 +121,11 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
 
 bool QgsMacNative::hasDarkTheme()
 {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
+#ifdef __MAC_OS_X_VERSION_MAX_ALLOWED
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+  // Version comparison needs to be numeric, in case __MAC_10_10_4 is not defined, e.g. some pre-10.14 SDKs
+  // See: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html
+  //      Section "Conditionally Compiling for Different SDKs"
   if ( [NSApp respondsToSelector:@selector( effectiveAppearance )] )
   {
     // compiled on macos 10.14+ AND running on macos 10.14+
@@ -135,6 +139,7 @@ bool QgsMacNative::hasDarkTheme()
     // DarkTheme was introduced in MacOS 10.14, fallback to light theme
     return false;
   }
+#endif
 #endif
   // compiled on macos 10.13-
   // NSAppearanceNameDarkAqua is not in SDK headers


### PR DESCRIPTION
## Description
Version comparison needs to be numeric, in case `__MAC_10_10_4` is not
defined, e.g. some pre-10.14 SDKs

Forward port of #8938

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
