### PR TITLE
[OGR provider] Handle read-write support for .shz and .shp.zip with GDAL 3.1

### DIFF
--- a/src/core/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/core/providers/gdal/qgsgdaldataitems.cpp
@@ -158,6 +158,12 @@ QgsDataItem *QgsGdalDataItemProvider::createDataItem( const QString &pathIn, Qgs
     scanExtSetting = true;
   }
 
+  if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) )
+  {
+    // .shp.zip are vector datasets
+    return nullptr;
+  }
+
   // get suffix, removing .gz if present
   QString tmpPath = path; //path used for testing, not for layer creation
   if ( is_vsigzip )

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -443,6 +443,14 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
     tmpPath.chop( 3 );
   QFileInfo info( tmpPath );
   QString suffix = info.suffix().toLower();
+
+// GDAL 3.1 Shapefile driver directly handles .shp.zip files
+  if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) &&
+       GDALIdentifyDriver( path.toUtf8().constData(), nullptr ) )
+  {
+    suffix = QStringLiteral( "shp.zip" );
+  }
+
   // extract basename with extension
   info.setFile( path );
   QString name = info.fileName();
@@ -551,7 +559,8 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
   static QStringList sSkipFastTrackExtensions { QStringLiteral( "xlsx" ),
       QStringLiteral( "ods" ),
       QStringLiteral( "csv" ),
-      QStringLiteral( "nc" ) };
+      QStringLiteral( "nc" ),
+      QStringLiteral( "shp.zip" ) };
 
   // Fast track: return item without testing if:
   // scanExtSetting or zipfile and scan zip == "Basic scan"

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -522,6 +522,11 @@ class CORE_EXPORT QgsOgrProviderUtils
 
     //! Whether a driver can share the same dataset handle among different layers
     static bool canDriverShareSameDatasetAmongLayers( const QString &driverName );
+
+    //! Whether a driver can share the same dataset handle among different layers
+    static bool canDriverShareSameDatasetAmongLayers( const QString &driverName,
+        bool updateMode,
+        const QString &dsName );
 };
 
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -29,6 +29,7 @@
 #include "qgslogger.h"
 #include "qgswkbtypes.h"
 
+#include <gdal.h>
 #include <ogr_api.h>
 
 // Version constants
@@ -225,8 +226,16 @@ bool qgsVariantGreaterThan( const QVariant &lhs, const QVariant &rhs )
 
 QString qgsVsiPrefix( const QString &path )
 {
-  if ( path.startsWith( QLatin1String( "/vsizip/" ), Qt::CaseInsensitive ) ||
-       path.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) )
+  if ( path.startsWith( QLatin1String( "/vsizip/" ), Qt::CaseInsensitive ) )
+    return QStringLiteral( "/vsizip/" );
+  else if ( path.endsWith( QLatin1String( ".shp.zip" ), Qt::CaseInsensitive ) )
+  {
+    // GDAL 3.1 Shapefile driver directly handles .shp.zip files
+    if ( GDALIdentifyDriver( path.toUtf8().constData(), nullptr ) )
+      return QString();
+    return QStringLiteral( "/vsizip/" );
+  }
+  else if ( path.endsWith( QLatin1String( ".zip" ), Qt::CaseInsensitive ) )
     return QStringLiteral( "/vsizip/" );
   else if ( path.startsWith( QLatin1String( "/vsitar/" ), Qt::CaseInsensitive ) ||
             path.endsWith( QLatin1String( ".tar" ), Qt::CaseInsensitive ) ||


### PR DESCRIPTION
GDAL 3.1 will bring read-write supprot for single-layer ZIP compressed shape
files (.shz), or multi-layer ones (.shp.zip). Do the few tweaking in QGIS so
that it is handled properly.

Related GDAL PR: https://github.com/OSGeo/gdal/pull/1676
