### PR TITLE
Correctly handle binary (bytea) fields for postgres, other related fixes

### DIFF
--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -37,7 +37,7 @@ QgsBinaryWidgetWrapper::QgsBinaryWidgetWrapper( QgsVectorLayer *layer, int field
 
 QVariant QgsBinaryWidgetWrapper::value() const
 {
-  return mValue.isEmpty() || mValue.isNull() ? QVariant( QVariant::Invalid ) : mValue;
+  return mValue.isEmpty() || mValue.isNull() ? QVariant( QVariant::ByteArray ) : mValue;
 }
 
 void QgsBinaryWidgetWrapper::showIndeterminateState()
@@ -188,6 +188,7 @@ void QgsBinaryWidgetWrapper::clear()
     return;
 
   setValue( QByteArray() );
+  emitValueChanged();
 }
 
 QString QgsBinaryWidgetWrapper::defaultPath()

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -229,6 +229,7 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
       << QgsVectorDataProvider::NativeType( tr( "Text, fixed length (char)" ), QStringLiteral( "char" ), QVariant::String, 1, 255, -1, -1 )
       << QgsVectorDataProvider::NativeType( tr( "Text, limited variable length (varchar)" ), QStringLiteral( "varchar" ), QVariant::String, 1, 255, -1, -1 )
       << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QVariant::String, -1, -1, -1, -1 )
+      << QgsVectorDataProvider::NativeType( tr( "Text, case-insensitive unlimited length (citext)" ), QStringLiteral( "citext" ), QVariant::String, -1, -1, -1, -1 )
 
       // date type
       << QgsVectorDataProvider::NativeType( tr( "Date" ), QStringLiteral( "date" ), QVariant::Date, -1, -1, -1, -1 )
@@ -978,6 +979,7 @@ bool QgsPostgresProvider::loadFields()
         fieldSize = -1;
       }
       else if ( fieldTypeName == QLatin1String( "text" ) ||
+                fieldTypeName == QLatin1String( "citext" ) ||
                 fieldTypeName == QLatin1String( "geometry" ) ||
                 fieldTypeName == QLatin1String( "inet" ) ||
                 fieldTypeName == QLatin1String( "money" ) ||

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -244,6 +244,9 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
 
       // boolean
       << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool, -1, -1, -1, -1 )
+
+      // binary (bytea)
+      << QgsVectorDataProvider::NativeType( tr( "Binary object (bytea)" ), QStringLiteral( "bytea" ), QVariant::ByteArray, -1, -1, -1, -1 )
       ;
 
   if ( connectionRO()->pgVersion() >= 90200 )
@@ -372,6 +375,22 @@ void QgsPostgresProvider::disconnectDb()
     mConnectionRW->unref();
     mConnectionRW = nullptr;
   }
+}
+
+QString QgsPostgresProvider::quotedByteaValue( const QVariant &value )
+{
+  if ( value.isNull() )
+    return QStringLiteral( "NULL" );
+
+  const QByteArray ba = value.toByteArray();
+  const unsigned char *buf = reinterpret_cast< const unsigned char * >( ba.constData() );
+  QString param;
+  param.reserve( ba.length() * 4 );
+  for ( int i = 0; i < ba.length(); ++i )
+  {
+    param += QStringLiteral( "\\%1" ).arg( static_cast< int >( buf[i] ), 3, 8, QChar( '0' ) );
+  }
+  return QStringLiteral( "decode('%1','escape')" ).arg( param );
 }
 
 QString QgsPostgresProvider::storageType() const
@@ -951,6 +970,11 @@ bool QgsPostgresProvider::loadFields()
       else if ( fieldTypeName == QLatin1String( "timestamp" ) )
       {
         fieldType = QVariant::DateTime;
+        fieldSize = -1;
+      }
+      else if ( fieldTypeName == QLatin1String( "bytea" ) )
+      {
+        fieldType = QVariant::ByteArray;
         fieldSize = -1;
       }
       else if ( fieldTypeName == QLatin1String( "text" ) ||
@@ -2191,11 +2215,15 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
         }
         else if ( fieldTypeName == QLatin1String( "jsonb" ) )
         {
-          values += delim + quotedJsonValue( v ) + QLatin1String( "::jsonb" );
+          values += delim + quotedJsonValue( v ) + QStringLiteral( "::jsonb" );
         }
         else if ( fieldTypeName == QLatin1String( "json" ) )
         {
-          values += delim + quotedJsonValue( v ) + QLatin1String( "::json" );
+          values += delim + quotedJsonValue( v ) + QStringLiteral( "::json" );
+        }
+        else if ( fieldTypeName == QLatin1String( "bytea" ) )
+        {
+          values += delim + quotedByteaValue( v );
         }
         //TODO: convert arrays and hstore to native types
         else
@@ -2755,6 +2783,10 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
             sql += QStringLiteral( "%1::json" )
                    .arg( quotedJsonValue( siter.value() ) );
           }
+          else if ( fld.typeName() == QLatin1String( "bytea" ) )
+          {
+            sql += quotedByteaValue( siter.value() );
+          }
           else
           {
             sql += quotedValue( *siter );
@@ -3084,6 +3116,10 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
           {
             sql += QStringLiteral( "st_geographyfromewkt(%1)" )
                    .arg( quotedValue( siter->toString() ) );
+          }
+          else if ( fld.typeName() == QLatin1String( "bytea" ) )
+          {
+            sql += quotedByteaValue( siter.value() );
           }
           else
           {

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -447,6 +447,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     static QString quotedIdentifier( const QString &ident ) { return QgsPostgresConn::quotedIdentifier( ident ); }
     static QString quotedValue( const QVariant &value ) { return QgsPostgresConn::quotedValue( value ); }
     static QString quotedJsonValue( const QVariant &value ) { return QgsPostgresConn::quotedJsonValue( value ); }
+    static QString quotedByteaValue( const QVariant &value );
 
     friend class QgsPostgresFeatureSource;
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -45,7 +45,7 @@ from qgis.core import (
     QgsGeometry
 )
 from qgis.gui import QgsGui, QgsAttributeForm
-from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject
+from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject, QByteArray
 from qgis.PyQt.QtWidgets import QLabel
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtXml import QDomDocument
@@ -164,6 +164,64 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             1: True,
             2: False,
             3: NULL
+        }
+        self.assertEqual(values, expected)
+
+    def testByteaType(self):
+        vl = QgsVectorLayer('{} table="qgis_test"."byte_a_table" sql='.format(self.dbconn), "testbytea", "postgres")
+        self.assertTrue(vl.isValid())
+
+        fields = vl.dataProvider().fields()
+        self.assertEqual(fields.at(fields.indexFromName('fld1')).type(), QVariant.ByteArray)
+
+        values = {feat['id']: feat['fld1'] for feat in vl.getFeatures()}
+        expected = {
+            1: QByteArray(b'YmludmFsdWU='),
+            2: QByteArray()
+        }
+        self.assertEqual(values, expected)
+
+        # editing binary values
+        self.execSQLCommand('DROP TABLE IF EXISTS qgis_test."byte_a_table_edit" CASCADE')
+        self.execSQLCommand(
+            'CREATE TABLE qgis_test."byte_a_table_edit" ( pk SERIAL NOT NULL PRIMARY KEY, blobby bytea)')
+        self.execSQLCommand("INSERT INTO qgis_test.\"byte_a_table_edit\" (pk, blobby) VALUES "
+                            "(1, encode('bbb', 'base64')::bytea)")
+        vl = QgsVectorLayer(
+            self.dbconn + ' sslmode=disable table="qgis_test"."byte_a_table_edit" sql=',
+            'test', 'postgres')
+        self.assertTrue(vl.isValid())
+        values = {feat['pk']: feat['blobby'] for feat in vl.getFeatures()}
+        expected = {
+            1: QByteArray(b'YmJi')
+        }
+        self.assertEqual(values, expected)
+
+        # change attribute value
+        self.assertTrue(vl.dataProvider().changeAttributeValues({1: {1: QByteArray(b'bbbvx')}}))
+        values = {feat['pk']: feat['blobby'] for feat in vl.getFeatures()}
+        expected = {
+            1: QByteArray(b'bbbvx')
+        }
+        self.assertEqual(values, expected)
+
+        # add feature
+        f = QgsFeature()
+        f.setAttributes([2, QByteArray(b'cccc')])
+        self.assertTrue(vl.dataProvider().addFeature(f))
+        values = {feat['pk']: feat['blobby'] for feat in vl.getFeatures()}
+        expected = {
+            1: QByteArray(b'bbbvx'),
+            2: QByteArray(b'cccc')
+        }
+        self.assertEqual(values, expected)
+
+        # change feature
+        self.assertTrue(vl.dataProvider().changeFeatures({2: {1: QByteArray(b'dddd')}}, {}))
+        values = {feat['pk']: feat['blobby'] for feat in vl.getFeatures()}
+        expected = {
+            1: QByteArray(b'bbbvx'),
+            2: QByteArray(b'dddd')
         }
         self.assertEqual(values, expected)
 

--- a/tests/src/python/test_qgsbinarywidget.py
+++ b/tests/src/python/test_qgsbinarywidget.py
@@ -62,7 +62,7 @@ class TestQgsBinaryWidget(unittest.TestCase):
         self.assertEqual(widget.value(), bin_val2)
 
         widget.setValue(NULL)
-        self.assertEqual(widget.value(), NULL)
+        self.assertEqual(widget.value(), QByteArray())
 
 
 if __name__ == '__main__':

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -20,6 +20,8 @@ SET client_min_messages = warning;
 --
 
 CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS citext;
+
 
 --- Create qgis_test schema
 DROP SCHEMA IF EXISTS qgis_test CASCADE;
@@ -514,6 +516,21 @@ INSERT INTO qgis_test.boolean_table VALUES
 (1, TRUE),
 (2, FALSE),
 (3, NULL);
+
+
+--------------------------------------
+-- Table for citext
+--
+
+CREATE TABLE qgis_test.citext_table
+(
+  id int PRIMARY KEY,
+  fld1 citext
+);
+
+INSERT INTO qgis_test.citext_table VALUES
+(1, 'test val'),
+(2, NULL);
 
 
 --------------------------------------

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -515,6 +515,22 @@ INSERT INTO qgis_test.boolean_table VALUES
 (2, FALSE),
 (3, NULL);
 
+
+--------------------------------------
+-- Table for bytea
+--
+
+CREATE TABLE qgis_test.byte_a_table
+(
+  id int PRIMARY KEY,
+  fld1 bytea
+);
+
+INSERT INTO qgis_test.byte_a_table VALUES
+(1, encode('binvalue', 'base64')::bytea),
+(2, NULL);
+
+
 -----------------------------
 -- Table for constraint tests
 --


### PR DESCRIPTION
Previously these would be silently dropped from the layers, but we now have comprehensive support for binary fields and should expose them (Fix sponsored by WhereGroup)

I've also pulled in the citext handling fix from #30102 and added unit tests for it.