### PR TITLE
Fix handling of expression variables when working with multiframe items

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -285,6 +285,42 @@ with the ``variables`` specified.
 .. versionadded:: 3.0
 %End
 
+    static QgsExpressionContextScope *multiFrameScope( const QgsLayoutMultiFrame *frame ) /Factory/;
+%Docstring
+Creates a new scope which contains variables and functions relating to a :py:class:`QgsLayoutMultiFrame`.
+
+.. seealso:: :py:func:`setLayoutMultiFrameVariable`
+
+.. seealso:: :py:func:`setLayoutMultiFrameVariables`
+
+.. versionadded:: 3.10
+%End
+
+    static void setLayoutMultiFrameVariable( QgsLayoutMultiFrame *frame, const QString &name, const QVariant &value );
+%Docstring
+Sets a layout multi ``frame`` context variable, with the given ``name`` and ``value``.
+This variable will be contained within scopes retrieved via
+multiFrameScope().
+
+.. seealso:: :py:func:`setLayoutItemVariables`
+
+.. seealso:: :py:func:`multiFrameScope`
+
+.. versionadded:: 3.10
+%End
+
+    static void setLayoutMultiFrameVariables( QgsLayoutMultiFrame *frame, const QVariantMap &variables );
+%Docstring
+Sets all layout multiframe context variables for an ``frame``. Existing variables will be removed and replaced
+with the ``variables`` specified.
+
+.. seealso:: :py:func:`setLayoutMultiFrameVariable`
+
+.. seealso:: :py:func:`multiFrameScope`
+
+.. versionadded:: 3.10
+%End
+
     static QgsExpressionContext createFeatureBasedContext( const QgsFeature &feature, const QgsFields &fields );
 %Docstring
 Helper function for creating an expression context which contains just a feature and fields

--- a/python/core/auto_generated/layout/qgslayoutmultiframe.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmultiframe.sip.in
@@ -278,6 +278,9 @@ Returns the multiframe display name.
     virtual QgsAbstractLayoutUndoCommand *createCommand( const QString &text, int id, QUndoCommand *parent = 0 ) /Factory/;
 
 
+    virtual QgsExpressionContext createExpressionContext() const;
+
+
     void beginCommand( const QString &commandText, UndoCommand command = UndoNone );
 %Docstring
 Starts new undo command for this item.

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -28,6 +28,7 @@
 #include "qgsexpressionutils.h"
 #include "qgslayoutpagecollection.h"
 #include "qgslayoutatlas.h"
+#include "qgslayoutmultiframe.h"
 
 QgsExpressionContextScope *QgsExpressionContextUtils::globalScope()
 {
@@ -731,6 +732,67 @@ void QgsExpressionContextUtils::setLayoutItemVariables( QgsLayoutItem *item, con
 
   item->setCustomProperty( QStringLiteral( "variableNames" ), variableNames );
   item->setCustomProperty( QStringLiteral( "variableValues" ), variableValues );
+}
+
+QgsExpressionContextScope *QgsExpressionContextUtils::multiFrameScope( const QgsLayoutMultiFrame *frame )
+{
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Multiframe Item" ) );
+  if ( !frame )
+    return scope;
+
+  //add variables defined in layout item properties
+  const QStringList variableNames = frame->customProperty( QStringLiteral( "variableNames" ) ).toStringList();
+  const QStringList variableValues = frame->customProperty( QStringLiteral( "variableValues" ) ).toStringList();
+
+  int varIndex = 0;
+  for ( const QString &variableName : variableNames )
+  {
+    if ( varIndex >= variableValues.length() )
+    {
+      break;
+    }
+
+    QVariant varValue = variableValues.at( varIndex );
+    varIndex++;
+    scope->setVariable( variableName, varValue );
+  }
+
+  return scope;
+}
+
+void QgsExpressionContextUtils::setLayoutMultiFrameVariable( QgsLayoutMultiFrame *frame, const QString &name, const QVariant &value )
+{
+  if ( !frame )
+    return;
+
+  //write variable to layout multiframe
+  QStringList variableNames = frame->customProperty( QStringLiteral( "variableNames" ) ).toStringList();
+  QStringList variableValues = frame->customProperty( QStringLiteral( "variableValues" ) ).toStringList();
+
+  variableNames << name;
+  variableValues << value.toString();
+
+  frame->setCustomProperty( QStringLiteral( "variableNames" ), variableNames );
+  frame->setCustomProperty( QStringLiteral( "variableValues" ), variableValues );
+}
+
+void QgsExpressionContextUtils::setLayoutMultiFrameVariables( QgsLayoutMultiFrame *frame, const QVariantMap &variables )
+{
+  if ( !frame )
+    return;
+
+  QStringList variableNames;
+  QStringList variableValues;
+
+  QVariantMap::const_iterator it = variables.constBegin();
+  for ( ; it != variables.constEnd(); ++it )
+  {
+    variableNames << it.key();
+    variableValues << it.value().toString();
+  }
+
+  frame->setCustomProperty( QStringLiteral( "variableNames" ), variableNames );
+  frame->setCustomProperty( QStringLiteral( "variableValues" ), variableValues );
 }
 
 QgsExpressionContext QgsExpressionContextUtils::createFeatureBasedContext( const QgsFeature &feature, const QgsFields &fields )

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -32,6 +32,7 @@ class QgsLayoutItem;
 class QgsProcessingAlgorithm;
 class QgsProcessingModelAlgorithm;
 class QgsProcessingContext;
+class QgsLayoutMultiFrame;
 
 /**
  * \ingroup core
@@ -250,6 +251,33 @@ class CORE_EXPORT QgsExpressionContextUtils
      * \since QGIS 3.0
      */
     static void setLayoutItemVariables( QgsLayoutItem *item, const QVariantMap &variables );
+
+    /**
+     * Creates a new scope which contains variables and functions relating to a QgsLayoutMultiFrame.
+     * \see setLayoutMultiFrameVariable()
+     * \see setLayoutMultiFrameVariables()
+     * \since QGIS 3.10
+     */
+    static QgsExpressionContextScope *multiFrameScope( const QgsLayoutMultiFrame *frame ) SIP_FACTORY;
+
+    /**
+     * Sets a layout multi \a frame context variable, with the given \a name and \a value.
+     * This variable will be contained within scopes retrieved via
+     * multiFrameScope().
+     * \see setLayoutItemVariables()
+     * \see multiFrameScope()
+     * \since QGIS 3.10
+     */
+    static void setLayoutMultiFrameVariable( QgsLayoutMultiFrame *frame, const QString &name, const QVariant &value );
+
+    /**
+     * Sets all layout multiframe context variables for an \a frame. Existing variables will be removed and replaced
+     * with the \a variables specified.
+     * \see setLayoutMultiFrameVariable()
+     * \see multiFrameScope()
+     * \since QGIS 3.10
+     */
+    static void setLayoutMultiFrameVariables( QgsLayoutMultiFrame *frame, const QVariantMap &variables );
 
     /**
      * Helper function for creating an expression context which contains just a feature and fields

--- a/src/core/layout/qgslayoutmultiframe.cpp
+++ b/src/core/layout/qgslayoutmultiframe.cpp
@@ -19,6 +19,7 @@
 #include "qgslayout.h"
 #include "qgslayoutpagecollection.h"
 #include "qgslayoutundostack.h"
+#include "qgsexpressioncontextutils.h"
 #include <QtCore>
 
 QgsLayoutMultiFrame::QgsLayoutMultiFrame( QgsLayout *layout )
@@ -277,6 +278,13 @@ QString QgsLayoutMultiFrame::displayName() const
 QgsAbstractLayoutUndoCommand *QgsLayoutMultiFrame::createCommand( const QString &text, int id, QUndoCommand *parent )
 {
   return new QgsLayoutMultiFrameUndoCommand( this, text, id, parent );
+}
+
+QgsExpressionContext QgsLayoutMultiFrame::createExpressionContext() const
+{
+  QgsExpressionContext context = QgsLayoutObject::createExpressionContext();
+  context.appendScope( QgsExpressionContextUtils::multiFrameScope( this ) );
+  return context;
 }
 
 void QgsLayoutMultiFrame::beginCommand( const QString &commandText, QgsLayoutMultiFrame::UndoCommand command )

--- a/src/core/layout/qgslayoutmultiframe.h
+++ b/src/core/layout/qgslayoutmultiframe.h
@@ -288,6 +288,8 @@ class CORE_EXPORT QgsLayoutMultiFrame: public QgsLayoutObject, public QgsLayoutU
 
     QgsAbstractLayoutUndoCommand *createCommand( const QString &text, int id, QUndoCommand *parent = nullptr ) override SIP_FACTORY;
 
+    QgsExpressionContext createExpressionContext() const override;
+
     /**
      * Starts new undo command for this item.
      * The \a commandText should be a capitalized, imperative tense description (e.g. "Add Map Item").

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -221,11 +221,13 @@ void QgsLayoutItemPropertiesWidget::updateVariables()
   if ( !mItem )
     return;
 
+  mBlockVariableUpdates = true;
   QgsExpressionContext context = mItem->createExpressionContext();
   mVariableEditor->setContext( &context );
   int editableIndex = context.indexOfScope( tr( "Layout Item" ) );
   if ( editableIndex >= 0 )
     mVariableEditor->setEditableScopeIndex( editableIndex );
+  mBlockVariableUpdates = false;
 }
 
 QgsLayoutItemPropertiesWidget::QgsLayoutItemPropertiesWidget( QWidget *parent, QgsLayoutItem *item )
@@ -304,7 +306,11 @@ QgsLayoutItemPropertiesWidget::QgsLayoutItemPropertiesWidget( QWidget *parent, Q
   connect( mOpacityWidget, &QgsOpacityWidget::opacityChanged, this, &QgsLayoutItemPropertiesWidget::opacityChanged );
 
   updateVariables();
-  connect( mVariableEditor, &QgsVariableEditorWidget::scopeChanged, this, &QgsLayoutItemPropertiesWidget::variablesChanged );
+  connect( mVariableEditor, &QgsVariableEditorWidget::scopeChanged, this, [ = ]
+  {
+    if ( !mBlockVariableUpdates )
+      QgsLayoutItemPropertiesWidget::variablesChanged();
+  } );
   // listen out for variable edits
   connect( QgsApplication::instance(), &QgsApplication::customVariablesChanged, this, &QgsLayoutItemPropertiesWidget::updateVariables );
   connect( item->layout()->project(), &QgsProject::customVariablesChanged, this, &QgsLayoutItemPropertiesWidget::updateVariables );
@@ -707,6 +713,8 @@ void QgsLayoutItemPropertiesWidget::setValuesForGuiElements()
   setValuesForGuiPositionElements();
   setValuesForGuiNonPositionElements();
   populateDataDefinedButtons();
+
+  updateVariables();
 }
 
 void QgsLayoutItemPropertiesWidget::mBlendModeCombo_currentIndexChanged( int index )

--- a/src/gui/layout/qgslayoutitemwidget.h
+++ b/src/gui/layout/qgslayoutitemwidget.h
@@ -299,7 +299,7 @@ class GUI_EXPORT QgsLayoutItemPropertiesWidget: public QWidget, private Ui::QgsL
     bool mFreezeWidthSpin = false;
     bool mFreezeHeightSpin = false;
     bool mFreezePageSpin = false;
-
+    bool mBlockVariableUpdates = false;
 //    void changeItemTransparency( int value );
     void changeItemPosition();
     void changeItemReference( QgsLayoutItem::ReferencePoint point );

--- a/tests/src/core/testqgslayoutmultiframe.cpp
+++ b/tests/src/core/testqgslayoutmultiframe.cpp
@@ -26,6 +26,7 @@
 #include "qgslayoutpagecollection.h"
 #include "qgslayoutundostack.h"
 #include "qgsreadwritecontext.h"
+#include "qgsexpressioncontextutils.h"
 
 #include <QObject>
 #include "qgstest.h"
@@ -51,6 +52,7 @@ class TestQgsLayoutMultiFrame : public QObject
     void deleteFrame();
     void writeReadXml();
     void noPageNoCrash();
+    void variables();
 
   private:
     QgsLayout *mLayout = nullptr;
@@ -649,6 +651,31 @@ void TestQgsLayoutMultiFrame::noPageNoCrash()
   html->setResizeMode( QgsLayoutMultiFrame::RepeatUntilFinished );
   html->recalculateFrameSizes();
   QCOMPARE( html->frameCount(), 1 );
+}
+
+void TestQgsLayoutMultiFrame::variables()
+{
+  QgsLayout l( QgsProject::instance() );
+
+  QgsLayoutItemHtml *html = new QgsLayoutItemHtml( &l );
+  std::unique_ptr< QgsExpressionContextScope > scope( QgsExpressionContextUtils::multiFrameScope( html ) );
+  int before = scope->variableCount();
+
+  QgsExpressionContextUtils::setLayoutMultiFrameVariable( html, QStringLiteral( "var" ), 5 );
+  scope.reset( QgsExpressionContextUtils::multiFrameScope( html ) );
+  QCOMPARE( scope->variableCount(), before + 1 );
+  QCOMPARE( scope->variable( QStringLiteral( "var" ) ).toInt(), 5 );
+
+  QVariantMap vars;
+  vars.insert( QStringLiteral( "var2" ), 7 );
+  QgsExpressionContextUtils::setLayoutMultiFrameVariables( html, vars );
+  scope.reset( QgsExpressionContextUtils::multiFrameScope( html ) );
+  QCOMPARE( scope->variableCount(), before + 1 );
+  QVERIFY( !scope->hasVariable( QStringLiteral( "var" ) ) );
+  QCOMPARE( scope->variable( QStringLiteral( "var2" ) ).toInt(), 7 );
+
+  QgsExpressionContext context = html->createExpressionContext();
+  QCOMPARE( context.variable( QStringLiteral( "var2" ) ).toInt(), 7 );
 }
 
 QGSTEST_MAIN( TestQgsLayoutMultiFrame )


### PR DESCRIPTION
Make sure that changes in the item variable editor when a multiframe item is selected (i.e. HTML items, attribute tables) are saved on a multiframe level, instead of an individual frame level.

In this case we prefer to make the multiframe's scope the main, editable one. That's because most expressions are evaluated on the multiframe subclass level, not on a frame-by-frame basis.

Ideally both would be editable, but for now let's go with the most useful one....