### PR TITLE
Write intermediate memory layer to disk in Execute SQL

### DIFF
--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -136,7 +136,8 @@ class ExecuteSQL(QgisAlgorithm):
             # belongs to temporary QgsMapLayerStore, not project.
             # So, we write them to disk is this is the case.
             if not QgsProject.instance().mapLayer(layer.id()):
-                tf = tempfile.NamedTemporaryFile(suffix=".gpkg")
+                suffix = "." + QgsVectorFileWriter.supportedFormatExtensions()[0]
+                tf = tempfile.NamedTemporaryFile(suffix=suffix)
                 tmp_path = tf.name
                 QgsVectorFileWriter.writeAsVectorFormat(
                     layer, tmp_path, layer.dataProvider().encoding())

--- a/python/plugins/processing/algs/qgis/ExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/ExecuteSQL.py
@@ -21,8 +21,6 @@ __author__ = 'Hugo Mercier'
 __date__ = 'January 2016'
 __copyright__ = '(C) 2016, Hugo Mercier'
 
-import tempfile
-
 from qgis.core import (QgsVirtualLayerDefinition,
                        QgsVectorLayer,
                        QgsWkbTypes,
@@ -30,6 +28,7 @@ from qgis.core import (QgsVirtualLayerDefinition,
                        QgsProcessingParameterMultipleLayers,
                        QgsProcessingParameterDefinition,
                        QgsExpression,
+                       QgsProcessingUtils,
                        QgsProcessingParameterString,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterCrs,
@@ -135,10 +134,9 @@ class ExecuteSQL(QgisAlgorithm):
             # access (thanks the QgsVirtualLayerProvider) to memory layer that
             # belongs to temporary QgsMapLayerStore, not project.
             # So, we write them to disk is this is the case.
-            if not QgsProject.instance().mapLayer(layer.id()):
-                suffix = "." + QgsVectorFileWriter.supportedFormatExtensions()[0]
-                tf = tempfile.NamedTemporaryFile(suffix=suffix)
-                tmp_path = tf.name
+            if not context.project().mapLayer(layer.id()):
+                basename = "memorylayer." + QgsVectorFileWriter.supportedFormatExtensions()[0]
+                tmp_path = QgsProcessingUtils.generateTempFilename(basename)
                 QgsVectorFileWriter.writeAsVectorFormat(
                     layer, tmp_path, layer.dataProvider().encoding())
                 df.addSource('input{}'.format(layerIdx + 1), tmp_path, "ogr")


### PR DESCRIPTION
## Description
Issue https://github.com/qgis/QGIS/issues/24041
When using the Execute SQL algorithm from the graphic modeler, it may try to access (thanks the QgsVirtualLayerProvider) to memory layer that belongs to temporary QgsMapLayerStore, not project.
So, we write them to disk is this is the case.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
