### PR TITLE
[TilesXYZ] Add metatile size parameter

### DIFF
--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -131,6 +131,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
     DPI = 'DPI'
     TILE_FORMAT = 'TILE_FORMAT'
     QUALITY = 'QUALITY'
+    METATILESIZE = 'METATILESIZE'
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT, self.tr('Extent')))
@@ -159,6 +160,11 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
                                                        minValue=1,
                                                        maxValue=100,
                                                        defaultValue=75))
+        self.addParameter(QgsProcessingParameterNumber(self.METATILESIZE,
+                                                       self.tr('Metatile size'),
+                                                       minValue=1,
+                                                       maxValue=20,
+                                                       defaultValue=4))
 
     def prepareAlgorithm(self, parameters, context, feedback):
         project = context.project()
@@ -175,6 +181,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         dpi = self.parameterAsInt(parameters, self.DPI, context)
         self.tile_format = self.formats[self.parameterAsEnum(parameters, self.TILE_FORMAT, context)]
         quality = self.parameterAsInt(parameters, self.QUALITY, context)
+        self.metatilesize = self.parameterAsInt(parameters, self.METATILESIZE, context)
         try:
             tile_width = self.parameterAsInt(parameters, self.TILE_WIDTH, context)
             tile_height = self.parameterAsInt(parameters, self.TILE_HEIGHT, context)
@@ -209,7 +216,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         metatiles_by_zoom = {}
         metatiles_count = 0
         for zoom in range(self.min_zoom, self.max_zoom + 1):
-            metatiles = get_metatiles(self.wgs_extent, zoom, 4)
+            metatiles = get_metatiles(self.wgs_extent, zoom, self.metatilesize)
             metatiles_by_zoom[zoom] = metatiles
             metatiles_count += len(metatiles)
 


### PR DESCRIPTION
Larger values may speed up the rendering and provide better labelling (fewer gaps without labels) at the expense of using more memory.

Ported from XYZ Tiles plugin - originally contributed by @nurenda
