### PR TITLE
[arcgisrest] Fix clipped mapserver legend image

### DIFF
--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #include <cstring>
+#include <QFontMetrics>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkRequest>
@@ -147,7 +148,9 @@ void QgsAmsLegendFetcher::handleFinished()
     int padding = 5;
     int vpadding = 1;
     int imageSize = 20;
-    int textWidth = 175;
+    int textWidth = 0;
+    QFont font;
+    QFontMetrics fm( font );
 
     typedef QPair<QString, QImage> LegendEntry_t;
     QSize maxImageSize( 0, 0 );
@@ -155,6 +158,7 @@ void QgsAmsLegendFetcher::handleFinished()
     {
       maxImageSize.setWidth( std::max( maxImageSize.width(), legendEntry.second.width() ) );
       maxImageSize.setHeight( std::max( maxImageSize.height(), legendEntry.second.height() ) );
+      textWidth = std::max( textWidth, fm.width( legendEntry.first ) + 10 );
     }
     double scaleFactor = maxImageSize.width() == 0 || maxImageSize.height() == 0 ? 1.0 :
                          std::min( 1., std::min( double( imageSize ) / maxImageSize.width(), double( imageSize ) / maxImageSize.height() ) );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -1381,8 +1381,8 @@ void QgsArcGisRestUtils::addLayerItems( const std::function< void( const QString
     }
   }
 
-  // Add root MapServer as layer
-  if ( serviceData.contains( QStringLiteral( "supportedImageFormatTypes" ) ) )
+  // Add root MapServer as layer when multiple layers are listed
+  if ( layerInfoList.count() > 1 && serviceData.contains( QStringLiteral( "supportedImageFormatTypes" ) ) )
   {
     const QString name = QStringLiteral( "(%1)" ).arg( QObject::tr( "All layers" ) );
     const QString description = serviceData.value( QStringLiteral( "Comments" ) ).toString();


### PR DESCRIPTION
## Description
Instead of hardcoding a text width, calculate the width of each legend text string to find out the maximum width value.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
