### PR TITLE
Return NoProxy instead of DefaultProxy when url matches excludes list

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -192,21 +192,39 @@ Returns the proxy exclude list.
 
 This list consists of the beginning of URL strings which will not use the fallback proxy.
 
+.. seealso:: :py:func:`noProxyList`
+
 .. seealso:: :py:func:`fallbackProxy`
 
 .. seealso:: :py:func:`setFallbackProxyAndExcludes`
 %End
 
-    void setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes );
+    QStringList noProxyList() const;
+%Docstring
+Returns the no proxy list.
+
+This list consists of the beginning of URL strings which will not use any proxy at all
+
+.. seealso:: :py:func:`excludeList`
+
+.. seealso:: :py:func:`fallbackProxy`
+
+.. seealso:: :py:func:`setFallbackProxyAndExcludes`
+%End
+
+    void setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes, const QStringList &noProxyURLs );
 %Docstring
 Sets the fallback ``proxy`` and URLs which shouldn't use it.
 
 The fallback proxy is used for URLs which no other proxy factory returned proxies for.
 The ``excludes`` list specifies the beginning of URL strings which will not use this fallback proxy.
+The ``noProxyURLs`` list specifies the beginning of URL strings which will not use any proxy at all
 
 .. seealso:: :py:func:`fallbackProxy`
 
 .. seealso:: :py:func:`excludeList`
+
+.. seealso:: :py:func:`noProxyList`
 %End
 
     static QString cacheLoadControlName( QNetworkRequest::CacheLoadControl control );
@@ -443,7 +461,6 @@ See QgsSslErrorHandler for details on how to handle SSL errors and potentially i
 
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -130,3 +130,8 @@ enable_problem_resolution=false
 [gps]
 # Default for GPS leap seconds correction as of 2019-06-19
 leapSecondsCorrection=18
+
+# [proxy]
+# # URL list for which proxy configuration doesn't apply. In the case of these URLs, systeme configuration
+# # is applied
+# proxyExcludedUrls=http://intranet,http://anotherproxy

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -132,6 +132,6 @@ enable_problem_resolution=false
 leapSecondsCorrection=18
 
 # [proxy]
-# # URL list for which proxy configuration doesn't apply. In the case of these URLs, systeme configuration
+# # URL list for which proxy configuration doesn't apply. In the case of these URLs, the default system proxy configuration
 # # is applied
 # proxyExcludedUrls=http://intranet,http://anotherproxy

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -359,20 +359,20 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QString settingProxyType = mSettings->value( QStringLiteral( "proxy/proxyType" ), QStringLiteral( "DefaultProxy" ) ).toString();
   mProxyTypeComboBox->setCurrentIndex( mProxyTypeComboBox->findText( settingProxyType ) );
 
-  //URLs excluded not going through proxies
-  const QStringList excludedUrlPathList = mSettings->value( QStringLiteral( "proxy/proxyExcludedUrls" ) ).toStringList();
-  for ( const QString &path : excludedUrlPathList )
+  //url with no proxy at all
+  const QStringList noProxyUrlPathList = mSettings->value( QStringLiteral( "proxy/noProxyUrls" ) ).toStringList();
+  for ( const QString &path : noProxyUrlPathList )
   {
     if ( path.trimmed().isEmpty() )
       continue;
 
-    QListWidgetItem *newItem = new QListWidgetItem( mExcludeUrlListWidget );
+    QListWidgetItem *newItem = new QListWidgetItem( mNoProxyUrlListWidget );
     newItem->setText( path );
     newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    mExcludeUrlListWidget->addItem( newItem );
+    mNoProxyUrlListWidget->addItem( newItem );
   }
-  connect( mAddUrlPushButton, &QAbstractButton::clicked, this, &QgsOptions::addExcludedUrl );
-  connect( mRemoveUrlPushButton, &QAbstractButton::clicked, this, &QgsOptions::removeExcludedUrl );
+  connect( mAddUrlPushButton, &QAbstractButton::clicked, this, &QgsOptions::addNoProxyUrl );
+  connect( mRemoveUrlPushButton, &QAbstractButton::clicked, this, &QgsOptions::removeNoProxyUrl );
 
   // cache settings
   mCacheDirectory->setText( mSettings->value( QStringLiteral( "cache/directory" ) ).toString() );
@@ -1426,16 +1426,16 @@ void QgsOptions::saveOptions()
 
   mSettings->setValue( QStringLiteral( "cache/size" ), QVariant::fromValue( mCacheSize->value() * 1024L ) );
 
-  //url to exclude from proxys
-  QStringList excludedUrls;
-  excludedUrls.reserve( mExcludeUrlListWidget->count() );
-  for ( int i = 0; i < mExcludeUrlListWidget->count(); ++i )
+  //url with no proxy at all
+  QStringList noProxyUrls;
+  noProxyUrls.reserve( mNoProxyUrlListWidget->count() );
+  for ( int i = 0; i < mNoProxyUrlListWidget->count(); ++i )
   {
-    const QString host = mExcludeUrlListWidget->item( i )->text();
+    const QString host = mNoProxyUrlListWidget->item( i )->text();
     if ( !host.trimmed().isEmpty() )
-      excludedUrls << host;
+      noProxyUrls << host;
   }
-  mSettings->setValue( QStringLiteral( "proxy/proxyExcludedUrls" ), excludedUrls );
+  mSettings->setValue( QStringLiteral( "proxy/noProxyUrls" ), noProxyUrls );
 
   QgisApp::instance()->namUpdate();
 
@@ -2130,19 +2130,19 @@ void QgsOptions::removeSVGPath()
   delete itemToRemove;
 }
 
-void QgsOptions::addExcludedUrl()
+void QgsOptions::addNoProxyUrl()
 {
-  QListWidgetItem *newItem = new QListWidgetItem( mExcludeUrlListWidget );
+  QListWidgetItem *newItem = new QListWidgetItem( mNoProxyUrlListWidget );
   newItem->setText( QStringLiteral( "URL" ) );
   newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-  mExcludeUrlListWidget->addItem( newItem );
-  mExcludeUrlListWidget->setCurrentItem( newItem );
+  mNoProxyUrlListWidget->addItem( newItem );
+  mNoProxyUrlListWidget->setCurrentItem( newItem );
 }
 
-void QgsOptions::removeExcludedUrl()
+void QgsOptions::removeNoProxyUrl()
 {
-  int currentRow = mExcludeUrlListWidget->currentRow();
-  QListWidgetItem *itemToRemove = mExcludeUrlListWidget->takeItem( currentRow );
+  int currentRow = mNoProxyUrlListWidget->currentRow();
+  QListWidgetItem *itemToRemove = mNoProxyUrlListWidget->takeItem( currentRow );
   delete itemToRemove;
 }
 

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -115,11 +115,11 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
 
     void mProxyTypeComboBox_currentIndexChanged( int idx );
 
-    //! Add a new URL to exclude from Proxy
-    void addExcludedUrl();
+    //! Add a new URL to no proxy URL list
+    void addNoProxyUrl();
 
-    //! Remove an URL to exclude from Proxy
-    void removeExcludedUrl();
+    //! Remove current URL from no proxy URL list
+    void removeNoProxyUrl();
 
     //! Slot to flag restoring/delete window state settings upon restart
     void restoreDefaultWindowState();

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -83,7 +83,7 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
         if ( !exclude.trimmed().isEmpty() && url.startsWith( exclude ) )
         {
           QgsDebugMsgLevel( QStringLiteral( "using default proxy for %1 [exclude %2]" ).arg( url, exclude ), 4 );
-          return QList<QNetworkProxy>() << QNetworkProxy();
+          return QList<QNetworkProxy>() << QNetworkProxy( QNetworkProxy::NoProxy );
         }
       }
 

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -77,13 +77,23 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
 
       QString url = query.url().toString();
 
+      const auto constNoProxyList = nam->noProxyList();
+      for ( const QString &noProxy : constNoProxyList )
+      {
+        if ( !noProxy.trimmed().isEmpty() && url.startsWith( noProxy ) )
+        {
+          QgsDebugMsgLevel( QStringLiteral( "don't using any proxy for %1 [exclude %2]" ).arg( url, noProxy ), 4 );
+          return QList<QNetworkProxy>() << QNetworkProxy( QNetworkProxy::NoProxy );
+        }
+      }
+
       const auto constExcludeList = nam->excludeList();
       for ( const QString &exclude : constExcludeList )
       {
         if ( !exclude.trimmed().isEmpty() && url.startsWith( exclude ) )
         {
           QgsDebugMsgLevel( QStringLiteral( "using default proxy for %1 [exclude %2]" ).arg( url, exclude ), 4 );
-          return QList<QNetworkProxy>() << QNetworkProxy( QNetworkProxy::NoProxy );
+          return QList<QNetworkProxy>() << QNetworkProxy( QNetworkProxy::DefaultProxy );
         }
       }
 
@@ -160,12 +170,17 @@ QStringList QgsNetworkAccessManager::excludeList() const
   return mExcludedURLs;
 }
 
+QStringList QgsNetworkAccessManager::noProxyList() const
+{
+  return mNoProxyURLs;
+}
+
 const QNetworkProxy &QgsNetworkAccessManager::fallbackProxy() const
 {
   return mFallbackProxy;
 }
 
-void QgsNetworkAccessManager::setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes )
+void QgsNetworkAccessManager::setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes, const QStringList &noProxyURLs )
 {
   QgsDebugMsgLevel( QStringLiteral( "proxy settings: (type:%1 host: %2:%3, user:%4, password:%5" )
                     .arg( proxy.type() == QNetworkProxy::DefaultProxy ? QStringLiteral( "DefaultProxy" ) :
@@ -189,6 +204,12 @@ void QgsNetworkAccessManager::setFallbackProxyAndExcludes( const QNetworkProxy &
     return url.trimmed().isEmpty();
   } ), mExcludedURLs.end() ); // clazy:exclude=detaching-member
 
+  mNoProxyURLs = noProxyURLs;
+  mNoProxyURLs.erase( std::remove_if( mNoProxyURLs.begin(), mNoProxyURLs.end(), // clazy:exclude=detaching-member
+                                      []( const QString & url )
+  {
+    return url.trimmed().isEmpty();
+  } ), mNoProxyURLs.end() ); // clazy:exclude=detaching-member
 }
 
 QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData )
@@ -531,11 +552,16 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
   QgsSettings settings;
   QNetworkProxy proxy;
   QStringList excludes;
+  QStringList noProxyURLs;
 
   bool proxyEnabled = settings.value( QStringLiteral( "proxy/proxyEnabled" ), false ).toBool();
   if ( proxyEnabled )
   {
+    // This settings is keep for retrocompatibility, the returned proxy for these URL is the default one,
+    // meaning the system one
     excludes = settings.value( QStringLiteral( "proxy/proxyExcludedUrls" ), QStringList() ).toStringList();
+
+    noProxyURLs = settings.value( QStringLiteral( "proxy/noProxyUrls" ), QStringList() ).toStringList();
 
     //read type, host, port, user, passw from settings
     QString proxyHost = settings.value( QStringLiteral( "proxy/proxyHost" ), "" ).toString();
@@ -594,7 +620,7 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
     }
   }
 
-  setFallbackProxyAndExcludes( proxy, excludes );
+  setFallbackProxyAndExcludes( proxy, excludes, noProxyURLs );
 
   QgsNetworkDiskCache *newcache = qobject_cast<QgsNetworkDiskCache *>( cache() );
   if ( !newcache )

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -356,21 +356,35 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      *
      * This list consists of the beginning of URL strings which will not use the fallback proxy.
      *
+     * \see noProxyList()
      * \see fallbackProxy()
      * \see setFallbackProxyAndExcludes()
      */
     QStringList excludeList() const;
 
     /**
+     * Returns the no proxy list.
+     *
+     * This list consists of the beginning of URL strings which will not use any proxy at all
+     *
+     * \see excludeList()
+     * \see fallbackProxy()
+     * \see setFallbackProxyAndExcludes()
+     */
+    QStringList noProxyList() const;
+
+    /**
      * Sets the fallback \a proxy and URLs which shouldn't use it.
      *
      * The fallback proxy is used for URLs which no other proxy factory returned proxies for.
      * The \a excludes list specifies the beginning of URL strings which will not use this fallback proxy.
+     * The \a noProxyURLs list specifies the beginning of URL strings which will not use any proxy at all
      *
      * \see fallbackProxy()
      * \see excludeList()
+     * \see noProxyList()
      */
-    void setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes );
+    void setFallbackProxyAndExcludes( const QNetworkProxy &proxy, const QStringList &excludes, const QStringList &noProxyURLs );
 
     /**
      * Returns the name for QNetworkRequest::CacheLoadControl.
@@ -637,6 +651,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     QList<QNetworkProxyFactory *> mProxyFactories;
     QNetworkProxy mFallbackProxy;
     QStringList mExcludedURLs;
+    QStringList mNoProxyURLs;
     bool mUseSystemProxy = false;
     bool mInitialized = false;
     static QgsNetworkAccessManager *sMainNAM;
@@ -657,4 +672,3 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H
-

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -362,7 +362,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>843</width>
-                <height>915</height>
+                <height>832</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -1098,8 +1098,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>543</width>
-                <height>1094</height>
+                <width>541</width>
+                <height>1072</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1446,10 +1446,10 @@
                     <property name="title">
                      <string>Current environment variables (read-only - bold indicates modified at startup)</string>
                     </property>
-                    <property name="collapsed" stdset="0">
+                    <property name="collapsed">
                      <bool>false</bool>
                     </property>
-                    <property name="saveCollapsedState" stdset="0">
+                    <property name="saveCollapsedState">
                      <bool>true</bool>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1634,8 +1634,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>555</width>
-                <height>369</height>
+                <width>552</width>
+                <height>398</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1662,7 +1662,7 @@
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leProjectGlobalCrs" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="leProjectGlobalCrs">
                     <property name="minimumSize">
                      <size>
                       <width>0</width>
@@ -1781,7 +1781,7 @@
                    </widget>
                   </item>
                   <item row="3" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs" native="true">
+                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs">
                     <property name="enabled">
                      <bool>false</bool>
                     </property>
@@ -1826,8 +1826,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>500</width>
-                <height>747</height>
+                <width>857</width>
+                <height>830</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2157,7 +2157,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>674</width>
-                <height>1052</height>
+                <height>965</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -2942,8 +2942,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>506</width>
-                <height>314</height>
+                <width>501</width>
+                <height>298</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3253,8 +3253,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>613</width>
-                <height>636</height>
+                <width>604</width>
+                <height>609</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3544,7 +3544,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     <property name="value">
                      <number>200</number>
                     </property>
-                    <property name="showClearButton" stdset="0">
+                    <property name="showClearButton">
                      <bool>true</bool>
                     </property>
                    </widget>
@@ -3697,8 +3697,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>154</width>
-                <height>271</height>
+                <width>157</width>
+                <height>265</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -3865,8 +3865,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>873</height>
+                <width>857</width>
+                <height>830</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4474,8 +4474,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>473</width>
-                <height>606</height>
+                <width>480</width>
+                <height>543</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -4743,8 +4743,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>415</width>
-                <height>392</height>
+                <width>412</width>
+                <height>372</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4912,8 +4912,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>616</width>
-                <height>736</height>
+                <width>857</width>
+                <height>830</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5132,17 +5132,17 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <property name="checkable">
                   <bool>true</bool>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_1">
                   <item row="1" column="0">
                    <widget class="QLabel" name="label_47">
                     <property name="text">
-                     <string>Exclude URLs (starting with)</string>
+                     <string>No proxy for (URLs starting with)</string>
                     </property>
                    </widget>
                   </item>
@@ -5286,7 +5286,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </spacer>
                   </item>
                   <item row="2" column="0" colspan="5">
-                   <widget class="QListWidget" name="mExcludeUrlListWidget"/>
+                   <widget class="QListWidget" name="mNoProxyUrlListWidget"/>
                   </item>
                  </layout>
                 </widget>
@@ -5414,8 +5414,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -5526,28 +5526,21 @@ p, li { white-space: pre-wrap; }
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorSchemeList</class>
-   <extends>QWidget</extends>
-   <header location="global">qgscolorschemelist.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelectionWidget</class>
@@ -5561,6 +5554,18 @@ p, li { white-space: pre-wrap; }
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsColorSchemeList</class>
+   <extends>QWidget</extends>
+   <header location="global">qgscolorschemelist.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsVariableEditorWidget</class>
    <extends>QWidget</extends>
    <header location="global">qgsvariableeditorwidget.h</header>
@@ -5570,11 +5575,6 @@ p, li { white-space: pre-wrap; }
    <class>QgsScaleComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSettingsTree</class>
@@ -5809,7 +5809,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>leProxyPort</tabstop>
   <tabstop>mAddUrlPushButton</tabstop>
   <tabstop>mRemoveUrlPushButton</tabstop>
-  <tabstop>mExcludeUrlListWidget</tabstop>
+  <tabstop>mNoProxyUrlListWidget</tabstop>
   <tabstop>mAdvancedSettingsEnableButton</tabstop>
   <tabstop>mGPUEnableCheckBox</tabstop>
   <tabstop>mOpenClDevicesCombo</tabstop>

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -208,6 +208,12 @@ void TestQgsNetworkAccessManager::testProxyExcludeList()
   manager2.setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << "" );
   // empty strings MUST be filtered from this list - otherwise they match all hosts!
   QCOMPARE( manager2.excludeList(), QStringList() << QStringLiteral( "intranet" ) );
+
+  // check that when we query an exclude URL, the returned proxy is no proxy
+  QgsNetworkAccessManager::instance()->setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << "" );
+  QList<QNetworkProxy> proxies = QgsNetworkAccessManager::instance()->proxyFactory()->queryProxy( QNetworkProxyQuery( QUrl( "intranet/mystuff" ) ) );
+  QCOMPARE( proxies.count(), 1 );
+  QCOMPARE( proxies.at( 0 ).type(),  QNetworkProxy::NoProxy );
 }
 
 void TestQgsNetworkAccessManager::fetchEmptyUrl()

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -200,18 +200,23 @@ void TestQgsNetworkAccessManager::testProxyExcludeList()
 {
   QgsNetworkAccessManager manager;
   QNetworkProxy fallback( QNetworkProxy::HttpProxy, QStringLiteral( "babies_first_proxy" ) );
-  manager.setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << QStringLiteral( "something_else" ) );
+  manager.setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << QStringLiteral( "something_else" ), QStringList() << QStringLiteral( "noProxyUrl" ) );
   QCOMPARE( manager.fallbackProxy().hostName(), QStringLiteral( "babies_first_proxy" ) );
   QCOMPARE( manager.excludeList(), QStringList() << QStringLiteral( "intranet" ) << QStringLiteral( "something_else" ) );
+  QCOMPARE( manager.noProxyList(), QStringList() << QStringLiteral( "noProxyUrl" ) );
 
   QgsNetworkAccessManager manager2;
-  manager2.setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << "" );
+  manager2.setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << "", QStringList() << QStringLiteral( "noProxyUrl" ) << "" );
   // empty strings MUST be filtered from this list - otherwise they match all hosts!
   QCOMPARE( manager2.excludeList(), QStringList() << QStringLiteral( "intranet" ) );
+  QCOMPARE( manager2.noProxyList(), QStringList() << QStringLiteral( "noProxyUrl" ) );
 
   // check that when we query an exclude URL, the returned proxy is no proxy
-  QgsNetworkAccessManager::instance()->setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << "" );
+  QgsNetworkAccessManager::instance()->setFallbackProxyAndExcludes( fallback, QStringList() << QStringLiteral( "intranet" ) << "", QStringList() << QStringLiteral( "noProxy" ) );
   QList<QNetworkProxy> proxies = QgsNetworkAccessManager::instance()->proxyFactory()->queryProxy( QNetworkProxyQuery( QUrl( "intranet/mystuff" ) ) );
+  QCOMPARE( proxies.count(), 1 );
+  QCOMPARE( proxies.at( 0 ).type(),  QNetworkProxy::DefaultProxy );
+  proxies = QgsNetworkAccessManager::instance()->proxyFactory()->queryProxy( QNetworkProxyQuery( QUrl( "noProxy/mystuff" ) ) );
   QCOMPARE( proxies.count(), 1 );
   QCOMPARE( proxies.at( 0 ).type(),  QNetworkProxy::NoProxy );
 }


### PR DESCRIPTION
## Description
Issue https://github.com/qgis/QGIS/issues/28034
When url was matching excludes list, returned proxy was the default one, meaning the one defined in the system. The returned one is now the NoProxy one.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
