### PR TITLE
fix #28761 [mesh] Time slider for non-temporal data should be disabled

### DIFF
--- a/src/app/mesh/qgsmeshrendereractivedatasetwidget.cpp
+++ b/src/app/mesh/qgsmeshrendereractivedatasetwidget.cpp
@@ -116,7 +116,14 @@ void QgsMeshRendererActiveDatasetWidget::setTimeRange()
   mTimeComboBox->blockSignals( false );
 
   // enable/disable time controls depending on whether the data set is time varying
-  bool isTimeVarying = datasetCount > 1;
+  enableTimeControls();
+}
+
+void QgsMeshRendererActiveDatasetWidget::enableTimeControls()
+{
+  const int scalarDatesets = mMeshLayer->dataProvider()->datasetCount( mActiveScalarDatasetGroup );
+  const int vectorDatesets = mMeshLayer->dataProvider()->datasetCount( mActiveVectorDatasetGroup );
+  const bool isTimeVarying = ( scalarDatesets > 1 ) || ( vectorDatesets > 1 );
   mTimeComboBox->setEnabled( isTimeVarying );
   mDatasetSlider->setEnabled( isTimeVarying );
   mTimeFormatButton->setEnabled( isTimeVarying );
@@ -132,6 +139,10 @@ void QgsMeshRendererActiveDatasetWidget::onActiveScalarGroupChanged( int groupIn
     return;
 
   mActiveScalarDatasetGroup = groupIndex;
+
+  // enable/disable time slider controls
+  enableTimeControls();
+
   // keep the same timestep if possible
   onActiveTimeChanged( mTimeComboBox->currentIndex() );
   emit activeScalarGroupChanged( mActiveScalarDatasetGroup );
@@ -143,6 +154,8 @@ void QgsMeshRendererActiveDatasetWidget::onActiveVectorGroupChanged( int groupIn
     return;
 
   mActiveVectorDatasetGroup = groupIndex;
+  // enable/disable time slider controls
+  enableTimeControls();
 
   // keep the same timestep if possible
   onActiveTimeChanged( mTimeComboBox->currentIndex() );

--- a/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
+++ b/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
@@ -28,8 +28,9 @@ class QgsMeshLayer;
  * Widget for selection of active dataset group from tree view.
  * Also selects the active scalar and vector dataset by slider
  *
- * At the moment, it is not possible to select different vector and
- * scalar dataset
+ * User can choose different scalar and vector dataset.
+ * Time slider is deactivated when no dataset is selected or
+ * when all selected datasets are non-temporal.
  */
 class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui::QgsMeshRendererActiveDatasetWidgetBase
 {
@@ -87,6 +88,9 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
   private:
     //! Loops through all dataset groups and finds the maximum number of datasets
     void setTimeRange();
+
+    //! Enables/Disables time controls depending on whether the selected datasets are time varying
+    void enableTimeControls();
 
     void updateMetadata();
 


### PR DESCRIPTION
closes https://github.com/qgis/QGIS/issues/28761

when both scalar and vector datasets are non-temporal, all time control widgets are disabled