### PR TITLE
QgsOgcUtils: The wildcard attribute of PropertyIsLike OGC Filter Element is not well replaced

### DIFF
--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -394,6 +394,21 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
         "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
         "</Filter>" )
       << QStringLiteral( "NAME LIKE '%\\\\%QGIS%*'" );
+
+  QTest::newRow( "ilike wildCard simple" ) << QString(
+        "<Filter>"
+        "<PropertyIsLike matchCase=\"false\" wildCard='*' singleChar='.' escape=\"\\\">"
+        "<PropertyName>NAME</PropertyName><Literal>*QGIS*</Literal></PropertyIsLike>"
+        "</Filter>" )
+      << QStringLiteral( "NAME ILIKE '%QGIS%'" );
+
+  QTest::newRow( "ilike wildCard complex" ) << QString(
+        "<Filter>"
+        "<PropertyIsLike matchCase=\"false\"  wildCard='*' singleChar='.' escape=\"\\\">"
+        "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
+        "</Filter>" )
+      << QStringLiteral( "NAME ILIKE '%\\\\%QGIS%*'" );
+
   // different single chars
   QTest::newRow( "like single char" ) << QString(
                                         "<Filter>"

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -381,12 +381,19 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
                            << QStringLiteral( "NAME ILIKE '*QGIS*'" );
 
   // different wildCards
-  QTest::newRow( "like wildCard" ) << QString(
-                                     "<Filter>"
-                                     "<PropertyIsLike wildCard='*' singleChar='.' escape=\"\\\">"
-                                     "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
-                                     "</Filter>" )
-                                   << QStringLiteral( "NAME LIKE '%\\\\%QGIS%*'" );
+  QTest::newRow( "like wildCard simple" ) << QString(
+      "<Filter>"
+      "<PropertyIsLike wildCard='*' singleChar='.' escape=\"\\\">"
+      "<PropertyName>NAME</PropertyName><Literal>*QGIS*</Literal></PropertyIsLike>"
+      "</Filter>" )
+                                          << QStringLiteral( "NAME LIKE '%QGIS%'" );
+
+  QTest::newRow( "like wildCard complex" ) << QString(
+        "<Filter>"
+        "<PropertyIsLike wildCard='*' singleChar='.' escape=\"\\\">"
+        "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
+        "</Filter>" )
+      << QStringLiteral( "NAME LIKE '%\\\\%QGIS%*'" );
   // different single chars
   QTest::newRow( "like single char" ) << QString(
                                         "<Filter>"


### PR DESCRIPTION
## Description
Fixing  #30465
And firstly add a more simple test for PropertyIsLike wildCard attribute. The test for a different wildcard is to complex and does not test the situation of the wild card at the end.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
