### PR TITLE
Providers PR follow up (postgres, spatialite)

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -18,6 +18,7 @@
 
 #include "qgsinbuiltdataitemproviders.h"
 #include "qgsdataitem.h"
+#include "qgsdataitemguiproviderregistry.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsnative.h"
@@ -344,7 +345,7 @@ QString QgsLayerItemGuiProvider::name()
   return QStringLiteral( "layer_item" );
 }
 
-void QgsLayerItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext )
+void QgsLayerItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context )
 {
   if ( item->type() != QgsDataItem::Layer )
     return;
@@ -412,7 +413,7 @@ void QgsLayerItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
     QAction *deleteAction = new QAction( deleteText, menu );
     connect( deleteAction, &QAction::triggered, this, [ = ]
     {
-      deleteLayers( selectedDeletableItemPaths );
+      deleteLayers( selectedDeletableItemPaths, context );
     } );
     menu->addAction( deleteAction );
   }
@@ -484,7 +485,7 @@ void QgsLayerItemGuiProvider::addLayersFromItems( const QList<QgsDataItem *> &it
     QgisApp::instance()->handleDropUriList( layerUriList );
 }
 
-void QgsLayerItemGuiProvider::deleteLayers( const QStringList &itemPaths )
+void QgsLayerItemGuiProvider::deleteLayers( const QStringList &itemPaths, QgsDataItemGuiContext context )
 {
   for ( const QString &itemPath : itemPaths )
   {
@@ -495,11 +496,28 @@ void QgsLayerItemGuiProvider::deleteLayers( const QStringList &itemPaths )
       QgsMessageLog::logMessage( tr( "Item with path %1 no longer exists." ).arg( itemPath ) );
       return;
     }
-    Q_NOWARN_DEPRECATED_PUSH
-    bool res = item->deleteLayer();
-    Q_NOWARN_DEPRECATED_POP
-    if ( !res )
-      QMessageBox::information( QgisApp::instance(), tr( "Delete Layer" ), tr( "Item Layer %1 cannot be deleted." ).arg( item->name() ) );
+
+    // first try to use the new API - through QgsDataItemGuiProvider. If that fails, try to use the legacy API...
+    bool usedNewApi = false;
+    const QList<QgsDataItemGuiProvider *> providers = QgsGui::dataItemGuiProviderRegistry()->providers();
+    for ( QgsDataItemGuiProvider *provider : providers )
+    {
+      if ( provider->deleteLayer( item, context ) )
+      {
+        usedNewApi = true;
+        break;
+      }
+    }
+
+    if ( !usedNewApi )
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      bool res = item->deleteLayer();
+      Q_NOWARN_DEPRECATED_POP
+
+      if ( !res )
+        QMessageBox::information( QgisApp::instance(), tr( "Delete Layer" ), tr( "Item Layer %1 cannot be deleted." ).arg( item->name() ) );
+    }
   }
 }
 

--- a/src/app/browser/qgsinbuiltdataitemproviders.h
+++ b/src/app/browser/qgsinbuiltdataitemproviders.h
@@ -100,7 +100,7 @@ class QgsLayerItemGuiProvider : public QObject, public QgsDataItemGuiProvider
 
     void addLayersFromItems( const QList<QgsDataItem *> &items );
     void showPropertiesForItem( QgsLayerItem *item );
-    void deleteLayers( const QStringList &itemPath );
+    void deleteLayers( const QStringList &itemPath, QgsDataItemGuiContext context );
 
 };
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -318,14 +318,14 @@ bool QgsGeoPackageItemGuiProvider::deleteLayer( QgsLayerItem *layerItem, QgsData
                                   " do you want to remove it from the project and delete it?" ).arg( item->name(),
                                       layersList.at( 0 )->name() ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
       {
-        return true;
+        return false;
       }
     }
     else if ( QMessageBox::question( nullptr, QObject::tr( "Delete Layer" ),
                                      QObject::tr( "Are you sure you want to delete layer <b>%1</b> from GeoPackage?" ).arg( item->name() ),
                                      QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     {
-      return true;
+      return false;
     }
 
     if ( ! layersList.isEmpty() )
@@ -363,7 +363,7 @@ bool QgsGeoPackageItemGuiProvider::deleteLayer( QgsLayerItem *layerItem, QgsData
   }
   else
   {
-    return true;
+    return false;
   }
 }
 

--- a/src/providers/postgres/CMakeLists.txt
+++ b/src/providers/postgres/CMakeLists.txt
@@ -29,11 +29,13 @@ SET(PG_MOC_HDRS
 IF (WITH_GUI)
   SET(PG_SRCS ${PG_SRCS}
     qgspostgresprovidergui.cpp
+    qgspostgresdataitemguiprovider.cpp
     qgspgsourceselect.cpp
     qgspgnewconnection.cpp
     qgspostgresprojectstoragedialog.cpp
   )
   SET(PG_MOC_HDRS ${PG_MOC_HDRS}
+    qgspostgresdataitemguiprovider.h
     qgspgnewconnection.h
     qgspgsourceselect.h
     qgspostgresprojectstoragedialog.h

--- a/src/providers/postgres/CMakeLists.txt
+++ b/src/providers/postgres/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(PG_MOC_HDRS
 
 IF (WITH_GUI)
   SET(PG_SRCS ${PG_SRCS}
+    qgspostgresprovidergui.cpp
     qgspgsourceselect.cpp
     qgspgnewconnection.cpp
     qgspostgresprojectstoragedialog.cpp

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.cpp
@@ -1,0 +1,413 @@
+/***************************************************************************
+  qgspostgresdataitemguiprovider.cpp
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspostgresdataitemguiprovider.h"
+
+#include "qgspostgresdataitems.h"
+#include "qgspostgresprovider.h"
+#include "qgspgnewconnection.h"
+#include "qgsnewnamedialog.h"
+
+#include <QInputDialog>
+#include <QMessageBox>
+
+
+void QgsPostgresDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
+{
+  if ( QgsPGRootItem *rootItem = qobject_cast< QgsPGRootItem * >( item ) )
+  {
+    QAction *actionNew = new QAction( tr( "New Connection…" ), this );
+    connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
+    menu->addAction( actionNew );
+  }
+
+  if ( QgsPGConnectionItem *connItem = qobject_cast< QgsPGConnectionItem * >( item ) )
+  {
+    QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+    connect( actionRefresh, &QAction::triggered, this, [connItem] { refreshConnection( connItem ); } );
+    menu->addAction( actionRefresh );
+
+    menu->addSeparator();
+
+    QAction *actionEdit = new QAction( tr( "Edit Connection…" ), this );
+    connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
+    menu->addAction( actionEdit );
+
+    QAction *actionDelete = new QAction( tr( "Delete Connection" ), this );
+    connect( actionDelete, &QAction::triggered, this, [connItem] { deleteConnection( connItem ); } );
+    menu->addAction( actionDelete );
+
+    menu->addSeparator();
+
+    QAction *actionCreateSchema = new QAction( tr( "Create Schema…" ), this );
+    connect( actionCreateSchema, &QAction::triggered, this, [connItem] { createSchema( connItem ); } );
+    menu->addAction( actionCreateSchema );
+  }
+
+  if ( QgsPGSchemaItem *schemaItem = qobject_cast< QgsPGSchemaItem * >( item ) )
+  {
+    QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+    connect( actionRefresh, &QAction::triggered, this, [schemaItem] { schemaItem->refresh(); } );
+    menu->addAction( actionRefresh );
+
+    menu->addSeparator();
+
+    QAction *actionRename = new QAction( tr( "Rename Schema…" ), this );
+    connect( actionRename, &QAction::triggered, this, [schemaItem] { renameSchema( schemaItem ); } );
+    menu->addAction( actionRename );
+
+    QAction *actionDelete = new QAction( tr( "Delete Schema" ), this );
+    connect( actionDelete, &QAction::triggered, this, [schemaItem] { deleteSchema( schemaItem ); } );
+    menu->addAction( actionDelete );
+  }
+
+  if ( QgsPGLayerItem *layerItem = qobject_cast< QgsPGLayerItem * >( item ) )
+  {
+    const QgsPostgresLayerProperty &layerInfo = layerItem->layerInfo();
+    QString typeName = layerInfo.isView ? tr( "View" ) : tr( "Table" );
+
+    QAction *actionRenameLayer = new QAction( tr( "Rename %1…" ).arg( typeName ), this );
+    connect( actionRenameLayer, &QAction::triggered, this, [layerItem] { renameLayer( layerItem ); } );
+    menu->addAction( actionRenameLayer );
+
+    if ( !layerInfo.isView )
+    {
+      QAction *actionTruncateLayer = new QAction( tr( "Truncate %1" ).arg( typeName ), this );
+      connect( actionTruncateLayer, &QAction::triggered, this, [layerItem] { truncateTable( layerItem ); } );
+      menu->addAction( actionTruncateLayer );
+    }
+
+    if ( layerInfo.isMaterializedView )
+    {
+      QAction *actionRefreshMaterializedView = new QAction( tr( "Refresh Materialized View" ), this );
+      connect( actionRefreshMaterializedView, &QAction::triggered, this, [layerItem] { refreshMaterializedView( layerItem ); } );
+      menu->addAction( actionRefreshMaterializedView );
+    }
+  }
+}
+
+void QgsPostgresDataItemGuiProvider::newConnection( QgsDataItem *item )
+{
+  QgsPgNewConnection nc( nullptr );
+  if ( nc.exec() )
+  {
+    item->refresh();
+  }
+}
+
+void QgsPostgresDataItemGuiProvider::editConnection( QgsDataItem *item )
+{
+  QgsPgNewConnection nc( nullptr, item->name() );
+  if ( nc.exec() )
+  {
+    // the parent should be updated
+    if ( item->parent() )
+      item->parent()->refreshConnections();
+  }
+}
+
+void QgsPostgresDataItemGuiProvider::deleteConnection( QgsDataItem *item )
+{
+  if ( QMessageBox::question( nullptr, QObject::tr( "Delete Connection" ),
+                              QObject::tr( "Are you sure you want to delete the connection to %1?" ).arg( item->name() ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  QgsPostgresConn::deleteConnection( item->name() );
+  // the parent should be updated
+  if ( item->parent() )
+    item->parent()->refreshConnections();
+}
+
+void QgsPostgresDataItemGuiProvider::refreshConnection( QgsDataItem *item )
+{
+  item->refresh();
+  // the parent should be updated
+  if ( item->parent() )
+    item->parent()->refreshConnections();
+}
+
+void QgsPostgresDataItemGuiProvider::createSchema( QgsDataItem *item )
+{
+  QString schemaName = QInputDialog::getText( nullptr, tr( "Create Schema" ), tr( "Schema name:" ) );
+  if ( schemaName.isEmpty() )
+    return;
+
+  QgsDataSourceUri uri = QgsPostgresConn::connUri( item->name() );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    QMessageBox::warning( nullptr, tr( "Create Schema" ), tr( "Unable to create schema." ) );
+    return;
+  }
+
+  //create the schema
+  QString sql = QStringLiteral( "CREATE SCHEMA %1" ).arg( QgsPostgresConn::quotedIdentifier( schemaName ) );
+
+  QgsPostgresResult result( conn->PQexec( sql ) );
+  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    QMessageBox::warning( nullptr, tr( "Create Schema" ), tr( "Unable to create schema %1\n%2" ).arg( schemaName,
+                          result.PQresultErrorMessage() ) );
+    conn->unref();
+    return;
+  }
+
+  conn->unref();
+
+  item->refresh();
+  // the parent should be updated
+  if ( item->parent() )
+    item->parent()->refreshConnections();
+}
+
+
+void QgsPostgresDataItemGuiProvider::deleteSchema( QgsPGSchemaItem *schemaItem )
+{
+  // check if schema contains tables/views
+  QgsDataSourceUri uri = QgsPostgresConn::connUri( schemaItem->connectionName() );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    QMessageBox::warning( nullptr, tr( "Delete Schema" ), tr( "Unable to delete schema." ) );
+    return;
+  }
+
+  QString sql = QStringLiteral( "SELECT table_name FROM information_schema.tables WHERE table_schema='%1'" ).arg( schemaItem->name() );
+  QgsPostgresResult result( conn->PQexec( sql ) );
+  if ( result.PQresultStatus() != PGRES_TUPLES_OK )
+  {
+    QMessageBox::warning( nullptr, tr( "Delete Schema" ), tr( "Unable to delete schema." ) );
+    conn->unref();
+    return;
+  }
+
+  QStringList childObjects;
+  int maxListed = 10;
+  for ( int idx = 0; idx < result.PQntuples(); idx++ )
+  {
+    childObjects << result.PQgetvalue( idx, 0 );
+    QgsPostgresSchemaProperty schema;
+    if ( idx == maxListed - 1 )
+      break;
+  }
+
+  int count = result.PQntuples();
+  if ( count > 0 )
+  {
+    QString objects = childObjects.join( QStringLiteral( "\n" ) );
+    if ( count > maxListed )
+    {
+      objects += QStringLiteral( "\n[%1 additional objects not listed]" ).arg( count - maxListed );
+    }
+    if ( QMessageBox::question( nullptr, QObject::tr( "Delete Schema" ),
+                                QObject::tr( "Schema '%1' contains objects:\n\n%2\n\nAre you sure you want to delete the schema and all these objects?" ).arg( schemaItem->name(), objects ),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    {
+      conn->unref();
+      return;
+    }
+  }
+  else
+  {
+    if ( QMessageBox::question( nullptr, QObject::tr( "Delete Schema" ),
+                                QObject::tr( "Are you sure you want to delete the schema '%1'?" ).arg( schemaItem->name() ),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+      return;
+  }
+
+  QString errCause;
+  bool res = QgsPostgresUtils::deleteSchema( schemaItem->name(), uri, errCause, count > 0 );
+  if ( !res )
+  {
+    QMessageBox::warning( nullptr, tr( "Delete Schema" ), errCause );
+  }
+  else
+  {
+    QMessageBox::information( nullptr, tr( "Delete Schema" ), tr( "Schema deleted successfully." ) );
+    if ( schemaItem->parent() )
+      schemaItem->parent()->refreshConnections();
+  }
+}
+
+void QgsPostgresDataItemGuiProvider::renameSchema( QgsPGSchemaItem *schemaItem )
+{
+  QgsNewNameDialog dlg( tr( "schema '%1'" ).arg( schemaItem->name() ), schemaItem->name() );
+  dlg.setWindowTitle( tr( "Rename Schema" ) );
+  if ( dlg.exec() != QDialog::Accepted || dlg.name() == schemaItem->name() )
+    return;
+
+  QString schemaName = QgsPostgresConn::quotedIdentifier( schemaItem->name() );
+  QgsDataSourceUri uri = QgsPostgresConn::connUri( schemaItem->connectionName() );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    QMessageBox::warning( nullptr, tr( "Rename Schema" ), tr( "Unable to rename schema." ) );
+    return;
+  }
+
+  //rename the schema
+  QString sql = QStringLiteral( "ALTER SCHEMA %1 RENAME TO %2" )
+                .arg( schemaName, QgsPostgresConn::quotedIdentifier( dlg.name() ) );
+
+  QgsPostgresResult result( conn->PQexec( sql ) );
+  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    QMessageBox::warning( nullptr, tr( "Rename Schema" ), tr( "Unable to rename schema %1\n%2" ).arg( schemaName,
+                          result.PQresultErrorMessage() ) );
+    conn->unref();
+    return;
+  }
+
+  conn->unref();
+  QMessageBox::information( nullptr, tr( "Rename Schema" ), tr( "Schema renamed successfully." ) );
+  if ( schemaItem->parent() )
+    schemaItem->parent()->refreshConnections();
+}
+
+void QgsPostgresDataItemGuiProvider::renameLayer( QgsPGLayerItem *layerItem )
+{
+  const QgsPostgresLayerProperty &layerInfo = layerItem->layerInfo();
+  QString typeName = layerInfo.isView ? tr( "View" ) : tr( "Table" );
+  QString lowerTypeName = layerInfo.isView ? tr( "view" ) : tr( "table" );
+
+  QgsNewNameDialog dlg( tr( "%1 %2.%3" ).arg( lowerTypeName, layerInfo.schemaName, layerInfo.tableName ), layerInfo.tableName );
+  dlg.setWindowTitle( tr( "Rename %1" ).arg( typeName ) );
+  if ( dlg.exec() != QDialog::Accepted || dlg.name() == layerInfo.tableName )
+    return;
+
+  QString schemaName = layerInfo.schemaName;
+  QString tableName = layerInfo.tableName;
+  QString schemaTableName;
+  if ( !schemaName.isEmpty() )
+  {
+    schemaTableName = QgsPostgresConn::quotedIdentifier( schemaName ) + '.';
+  }
+  QString oldName = schemaTableName + QgsPostgresConn::quotedIdentifier( tableName );
+  QString newName = QgsPostgresConn::quotedIdentifier( dlg.name() );
+
+  QgsDataSourceUri dsUri( layerItem->uri() );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    QMessageBox::warning( nullptr, tr( "Rename %1" ).arg( typeName ), tr( "Unable to rename %1." ).arg( lowerTypeName ) );
+    return;
+  }
+
+  //rename the layer
+  QString sql;
+  if ( layerInfo.isView )
+  {
+    sql = QStringLiteral( "ALTER %1 VIEW %2 RENAME TO %3" ).arg( layerInfo.relKind == QLatin1String( "m" ) ? QStringLiteral( "MATERIALIZED" ) : QString(),
+          oldName, newName );
+  }
+  else
+  {
+    sql = QStringLiteral( "ALTER TABLE %1 RENAME TO %2" ).arg( oldName, newName );
+  }
+
+  QgsPostgresResult result( conn->PQexec( sql ) );
+  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    QMessageBox::warning( nullptr, tr( "Rename %1" ).arg( typeName ), tr( "Unable to rename %1 %2\n%3" ).arg( lowerTypeName, layerItem->name(),
+                          result.PQresultErrorMessage() ) );
+    conn->unref();
+    return;
+  }
+
+  conn->unref();
+  if ( layerItem->parent() )
+    layerItem->parent()->refreshConnections();
+}
+
+void QgsPostgresDataItemGuiProvider::truncateTable( QgsPGLayerItem *layerItem )
+{
+  const QgsPostgresLayerProperty &layerInfo = layerItem->layerInfo();
+  if ( QMessageBox::question( nullptr, QObject::tr( "Truncate Table" ),
+                              QObject::tr( "Are you sure you want to truncate %1.%2?\n\nThis will delete all data within the table." ).arg( layerInfo.schemaName, layerInfo.tableName ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  QgsDataSourceUri dsUri( layerItem->uri() );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    QMessageBox::warning( nullptr, tr( "Truncate Table" ), tr( "Unable to truncate table." ) );
+    return;
+  }
+
+  QString schemaName = layerInfo.schemaName;
+  QString tableName = layerInfo.tableName;
+  QString schemaTableName;
+  if ( !schemaName.isEmpty() )
+  {
+    schemaTableName = QgsPostgresConn::quotedIdentifier( schemaName ) + '.';
+  }
+  QString tableRef = schemaTableName + QgsPostgresConn::quotedIdentifier( tableName );
+
+  QString sql = QStringLiteral( "TRUNCATE TABLE %1" ).arg( tableRef );
+
+  QgsPostgresResult result( conn->PQexec( sql ) );
+  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    QMessageBox::warning( nullptr, tr( "Truncate Table" ), tr( "Unable to truncate %1\n%2" ).arg( layerItem->name(),
+                          result.PQresultErrorMessage() ) );
+    conn->unref();
+    return;
+  }
+
+  conn->unref();
+  QMessageBox::information( nullptr, tr( "Truncate Table" ), tr( "Table truncated successfully." ) );
+}
+
+void QgsPostgresDataItemGuiProvider::refreshMaterializedView( QgsPGLayerItem *layerItem )
+{
+  const QgsPostgresLayerProperty &layerInfo = layerItem->layerInfo();
+  if ( QMessageBox::question( nullptr, QObject::tr( "Refresh Materialized View" ),
+                              QObject::tr( "Are you sure you want to refresh the materialized view %1.%2?\n\nThis will update all data within the table." ).arg( layerInfo.schemaName, layerInfo.tableName ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  QgsDataSourceUri dsUri( layerItem->uri() );
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    QMessageBox::warning( nullptr, tr( "Refresh View" ), tr( "Unable to refresh the view." ) );
+    return;
+  }
+
+  QString schemaName = layerInfo.schemaName;
+  QString tableName = layerInfo.tableName;
+  QString schemaTableName;
+  if ( !schemaName.isEmpty() )
+  {
+    schemaTableName = QgsPostgresConn::quotedIdentifier( schemaName ) + '.';
+  }
+  QString tableRef = schemaTableName + QgsPostgresConn::quotedIdentifier( tableName );
+
+  QString sql = QStringLiteral( "REFRESH MATERIALIZED VIEW CONCURRENTLY %1" ).arg( tableRef );
+
+  QgsPostgresResult result( conn->PQexec( sql ) );
+  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    QMessageBox::warning( nullptr, tr( "Refresh View" ), tr( "Unable to refresh view %1\n%2" ).arg( layerItem->name(),
+                          result.PQresultErrorMessage() ) );
+    conn->unref();
+    return;
+  }
+
+  conn->unref();
+  QMessageBox::information( nullptr, tr( "Refresh View" ), tr( "Materialized view refreshed successfully." ) );
+}

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -31,6 +31,11 @@ class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProv
     void populateContextMenu( QgsDataItem *item, QMenu *menu,
                               const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
 
+    bool deleteLayer( QgsLayerItem *item, QgsDataItemGuiContext context ) override;
+
+    bool acceptDrop( QgsDataItem *item, QgsDataItemGuiContext context ) override;
+    bool handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction action ) override;
+
   private:
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );

--- a/src/providers/postgres/qgspostgresdataitemguiprovider.h
+++ b/src/providers/postgres/qgspostgresdataitemguiprovider.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+  qgspostgresdataitemguiprovider.h
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPOSTGRESDATAITEMGUIPROVIDER_H
+#define QGSPOSTGRESDATAITEMGUIPROVIDER_H
+
+#include "qgsdataitemguiprovider.h"
+
+class QgsPGSchemaItem;
+class QgsPGLayerItem;
+
+class QgsPostgresDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
+{
+    Q_OBJECT
+  public:
+
+    QString name() override { return QStringLiteral( "PostGIS" ); }
+
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+
+  private:
+    static void newConnection( QgsDataItem *item );
+    static void editConnection( QgsDataItem *item );
+    static void deleteConnection( QgsDataItem *item );
+    static void refreshConnection( QgsDataItem *item );
+    static void createSchema( QgsDataItem *item );
+    static void deleteSchema( QgsPGSchemaItem *schemaItem );
+    static void renameSchema( QgsPGSchemaItem *schemaItem );
+    static void renameLayer( QgsPGLayerItem *layerItem );
+    static void truncateTable( QgsPGLayerItem *layerItem );
+    static void refreshMaterializedView( QgsPGLayerItem *layerItem );
+
+};
+
+#endif // QGSPOSTGRESDATAITEMGUIPROVIDER_H

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -17,6 +17,7 @@
 #include "qgspostgresconn.h"
 #include "qgspostgresconnpool.h"
 #include "qgspostgresprojectstorage.h"
+#include "qgspostgresprovider.h"
 #include "qgscolumntypethread.h"
 #include "qgslogger.h"
 #include "qgsdatasourceuri.h"
@@ -27,17 +28,13 @@
 #include "qgssettings.h"
 
 #ifdef HAVE_GUI
-#include "qgspgnewconnection.h"
-#include "qgsnewnamedialog.h"
 #include "qgspgsourceselect.h"
 #endif
 
 #include <QMessageBox>
-#include <QInputDialog>
-#include <QProgressDialog>
 #include <climits>
 
-static bool deleteLayer( const QString &uri, QString &errCause )
+bool QgsPostgresUtils::deleteLayer( const QString &uri, QString &errCause )
 {
   QgsDebugMsg( "deleting layer " + uri );
 
@@ -132,7 +129,7 @@ static bool deleteLayer( const QString &uri, QString &errCause )
   return true;
 }
 
-static bool deleteSchema( const QString &schema, const QgsDataSourceUri &uri, QString &errCause, bool cascade = false )
+bool QgsPostgresUtils::deleteSchema( const QString &schema, const QgsDataSourceUri &uri, QString &errCause, bool cascade )
 {
   QgsDebugMsg( "deleting schema " + schema );
 
@@ -225,103 +222,6 @@ bool QgsPGConnectionItem::equal( const QgsDataItem *other )
   return ( mPath == o->mPath && mName == o->mName );
 }
 
-#ifdef HAVE_GUI
-QList<QAction *> QgsPGConnectionItem::actions( QWidget *parent )
-{
-  QList<QAction *> lst;
-
-  QAction *actionRefresh = new QAction( tr( "Refresh" ), parent );
-  connect( actionRefresh, &QAction::triggered, this, &QgsPGConnectionItem::refreshConnection );
-  lst.append( actionRefresh );
-
-  QAction *separator = new QAction( parent );
-  separator->setSeparator( true );
-  lst.append( separator );
-
-  QAction *actionEdit = new QAction( tr( "Edit Connection…" ), parent );
-  connect( actionEdit, &QAction::triggered, this, &QgsPGConnectionItem::editConnection );
-  lst.append( actionEdit );
-
-  QAction *actionDelete = new QAction( tr( "Delete Connection" ), this );
-  connect( actionDelete, &QAction::triggered, this, &QgsPGConnectionItem::deleteConnection );
-  lst.append( actionDelete );
-
-  QAction *separator2 = new QAction( parent );
-  separator2->setSeparator( true );
-  lst.append( separator2 );
-
-  QAction *actionCreateSchema = new QAction( tr( "Create Schema…" ), parent );
-  connect( actionCreateSchema, &QAction::triggered, this, &QgsPGConnectionItem::createSchema );
-  lst.append( actionCreateSchema );
-
-  return lst;
-}
-
-void QgsPGConnectionItem::editConnection()
-{
-  QgsPgNewConnection nc( nullptr, mName );
-  if ( nc.exec() )
-  {
-    // the parent should be updated
-    if ( mParent )
-      mParent->refreshConnections();
-  }
-}
-
-void QgsPGConnectionItem::deleteConnection()
-{
-  if ( QMessageBox::question( nullptr, QObject::tr( "Delete Connection" ),
-                              QObject::tr( "Are you sure you want to delete the connection to %1?" ).arg( mName ),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-    return;
-
-  QgsPostgresConn::deleteConnection( mName );
-  // the parent should be updated
-  if ( mParent )
-    mParent->refreshConnections();
-}
-
-void QgsPGConnectionItem::refreshConnection()
-{
-  refresh();
-  // the parent should be updated
-  if ( mParent )
-    mParent->refreshConnections();
-}
-
-void QgsPGConnectionItem::createSchema()
-{
-  QString schemaName = QInputDialog::getText( nullptr, tr( "Create Schema" ), tr( "Schema name:" ) );
-  if ( schemaName.isEmpty() )
-    return;
-
-  QgsDataSourceUri uri = QgsPostgresConn::connUri( mName );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
-  if ( !conn )
-  {
-    QMessageBox::warning( nullptr, tr( "Create Schema" ), tr( "Unable to create schema." ) );
-    return;
-  }
-
-  //create the schema
-  QString sql = QStringLiteral( "CREATE SCHEMA %1" ).arg( QgsPostgresConn::quotedIdentifier( schemaName ) );
-
-  QgsPostgresResult result( conn->PQexec( sql ) );
-  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
-  {
-    QMessageBox::warning( nullptr, tr( "Create Schema" ), tr( "Unable to create schema %1\n%2" ).arg( schemaName,
-                          result.PQresultErrorMessage() ) );
-    conn->unref();
-    return;
-  }
-
-  conn->unref();
-  refresh();
-  // the parent should be updated
-  if ( mParent )
-    mParent->refreshConnections();
-}
-#endif
 
 void QgsPGConnectionItem::refreshSchema( const QString &schema )
 {
@@ -438,32 +338,6 @@ QString QgsPGLayerItem::comments() const
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsPGLayerItem::actions( QWidget *parent )
-{
-  QList<QAction *> lst;
-
-  QString typeName = mLayerProperty.isView ? tr( "View" ) : tr( "Table" );
-
-  QAction *actionRenameLayer = new QAction( tr( "Rename %1…" ).arg( typeName ), parent );
-  connect( actionRenameLayer, &QAction::triggered, this, &QgsPGLayerItem::renameLayer );
-  lst.append( actionRenameLayer );
-
-  if ( !mLayerProperty.isView )
-  {
-    QAction *actionTruncateLayer = new QAction( tr( "Truncate %1" ).arg( typeName ), parent );
-    connect( actionTruncateLayer, &QAction::triggered, this, &QgsPGLayerItem::truncateTable );
-    lst.append( actionTruncateLayer );
-  }
-
-  if ( mLayerProperty.isMaterializedView )
-  {
-    QAction *actionRefreshMaterializedView = new QAction( tr( "Refresh Materialized View" ), parent );
-    connect( actionRefreshMaterializedView, &QAction::triggered, this, &QgsPGLayerItem::refreshMaterializedView );
-    lst.append( actionRefreshMaterializedView );
-  }
-
-  return lst;
-}
 
 bool QgsPGLayerItem::deleteLayer()
 {
@@ -475,7 +349,7 @@ bool QgsPGLayerItem::deleteLayer()
     return true;
 
   QString errCause;
-  bool res = ::deleteLayer( mUri, errCause );
+  bool res = QgsPostgresUtils::deleteLayer( mUri, errCause );
   if ( !res )
   {
     QMessageBox::warning( nullptr, tr( "Delete %1" ).arg( typeName ), errCause );
@@ -489,137 +363,6 @@ bool QgsPGLayerItem::deleteLayer()
   return true;
 }
 
-void QgsPGLayerItem::renameLayer()
-{
-  QString typeName = mLayerProperty.isView ? tr( "View" ) : tr( "Table" );
-  QString lowerTypeName = mLayerProperty.isView ? tr( "view" ) : tr( "table" );
-
-  QgsNewNameDialog dlg( tr( "%1 %2.%3" ).arg( lowerTypeName, mLayerProperty.schemaName, mLayerProperty.tableName ), mLayerProperty.tableName );
-  dlg.setWindowTitle( tr( "Rename %1" ).arg( typeName ) );
-  if ( dlg.exec() != QDialog::Accepted || dlg.name() == mLayerProperty.tableName )
-    return;
-
-  QString schemaName = mLayerProperty.schemaName;
-  QString tableName = mLayerProperty.tableName;
-  QString schemaTableName;
-  if ( !schemaName.isEmpty() )
-  {
-    schemaTableName = QgsPostgresConn::quotedIdentifier( schemaName ) + '.';
-  }
-  QString oldName = schemaTableName + QgsPostgresConn::quotedIdentifier( tableName );
-  QString newName = QgsPostgresConn::quotedIdentifier( dlg.name() );
-
-  QgsDataSourceUri dsUri( mUri );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
-  if ( !conn )
-  {
-    QMessageBox::warning( nullptr, tr( "Rename %1" ).arg( typeName ), tr( "Unable to rename %1." ).arg( lowerTypeName ) );
-    return;
-  }
-
-  //rename the layer
-  QString sql;
-  if ( mLayerProperty.isView )
-  {
-    sql = QStringLiteral( "ALTER %1 VIEW %2 RENAME TO %3" ).arg( mLayerProperty.relKind == QLatin1String( "m" ) ? QStringLiteral( "MATERIALIZED" ) : QString(),
-          oldName, newName );
-  }
-  else
-  {
-    sql = QStringLiteral( "ALTER TABLE %1 RENAME TO %2" ).arg( oldName, newName );
-  }
-
-  QgsPostgresResult result( conn->PQexec( sql ) );
-  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
-  {
-    QMessageBox::warning( nullptr, tr( "Rename %1" ).arg( typeName ), tr( "Unable to rename %1 %2\n%3" ).arg( lowerTypeName, mName,
-                          result.PQresultErrorMessage() ) );
-    conn->unref();
-    return;
-  }
-
-  conn->unref();
-  if ( mParent )
-    mParent->refresh();
-}
-
-void QgsPGLayerItem::truncateTable()
-{
-  if ( QMessageBox::question( nullptr, QObject::tr( "Truncate Table" ),
-                              QObject::tr( "Are you sure you want to truncate %1.%2?\n\nThis will delete all data within the table." ).arg( mLayerProperty.schemaName, mLayerProperty.tableName ),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-    return;
-
-  QgsDataSourceUri dsUri( mUri );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
-  if ( !conn )
-  {
-    QMessageBox::warning( nullptr, tr( "Truncate Table" ), tr( "Unable to truncate table." ) );
-    return;
-  }
-
-  QString schemaName = mLayerProperty.schemaName;
-  QString tableName = mLayerProperty.tableName;
-  QString schemaTableName;
-  if ( !schemaName.isEmpty() )
-  {
-    schemaTableName = QgsPostgresConn::quotedIdentifier( schemaName ) + '.';
-  }
-  QString tableRef = schemaTableName + QgsPostgresConn::quotedIdentifier( tableName );
-
-  QString sql = QStringLiteral( "TRUNCATE TABLE %1" ).arg( tableRef );
-
-  QgsPostgresResult result( conn->PQexec( sql ) );
-  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
-  {
-    QMessageBox::warning( nullptr, tr( "Truncate Table" ), tr( "Unable to truncate %1\n%2" ).arg( mName,
-                          result.PQresultErrorMessage() ) );
-    conn->unref();
-    return;
-  }
-
-  conn->unref();
-  QMessageBox::information( nullptr, tr( "Truncate Table" ), tr( "Table truncated successfully." ) );
-}
-
-void QgsPGLayerItem::refreshMaterializedView()
-{
-  if ( QMessageBox::question( nullptr, QObject::tr( "Refresh Materialized View" ),
-                              QObject::tr( "Are you sure you want to refresh the materialized view %1.%2?\n\nThis will update all data within the table." ).arg( mLayerProperty.schemaName, mLayerProperty.tableName ),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-    return;
-
-  QgsDataSourceUri dsUri( mUri );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
-  if ( !conn )
-  {
-    QMessageBox::warning( nullptr, tr( "Refresh View" ), tr( "Unable to refresh the view." ) );
-    return;
-  }
-
-  QString schemaName = mLayerProperty.schemaName;
-  QString tableName = mLayerProperty.tableName;
-  QString schemaTableName;
-  if ( !schemaName.isEmpty() )
-  {
-    schemaTableName = QgsPostgresConn::quotedIdentifier( schemaName ) + '.';
-  }
-  QString tableRef = schemaTableName + QgsPostgresConn::quotedIdentifier( tableName );
-
-  QString sql = QStringLiteral( "REFRESH MATERIALIZED VIEW CONCURRENTLY %1" ).arg( tableRef );
-
-  QgsPostgresResult result( conn->PQexec( sql ) );
-  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
-  {
-    QMessageBox::warning( nullptr, tr( "Refresh View" ), tr( "Unable to refresh view %1\n%2" ).arg( mName,
-                          result.PQresultErrorMessage() ) );
-    conn->unref();
-    return;
-  }
-
-  conn->unref();
-  QMessageBox::information( nullptr, tr( "Refresh View" ), tr( "Materialized view refreshed successfully." ) );
-}
 #endif
 
 QString QgsPGLayerItem::createUri()
@@ -737,133 +480,6 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   return items;
 }
 
-#ifdef HAVE_GUI
-QList<QAction *> QgsPGSchemaItem::actions( QWidget *parent )
-{
-  QList<QAction *> lst;
-
-  QAction *actionRefresh = new QAction( tr( "Refresh" ), parent );
-  connect( actionRefresh, &QAction::triggered, this, static_cast<void ( QgsDataItem::* )()>( &QgsDataItem::refresh ) );
-  lst.append( actionRefresh );
-
-  QAction *separator = new QAction( parent );
-  separator->setSeparator( true );
-  lst.append( separator );
-
-  QAction *actionRename = new QAction( tr( "Rename Schema…" ), parent );
-  connect( actionRename, &QAction::triggered, this, &QgsPGSchemaItem::renameSchema );
-  lst.append( actionRename );
-
-  QAction *actionDelete = new QAction( tr( "Delete Schema" ), parent );
-  connect( actionDelete, &QAction::triggered, this, &QgsPGSchemaItem::deleteSchema );
-  lst.append( actionDelete );
-
-  return lst;
-}
-
-void QgsPGSchemaItem::deleteSchema()
-{
-  // check if schema contains tables/views
-  QgsDataSourceUri uri = QgsPostgresConn::connUri( mConnectionName );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
-  if ( !conn )
-  {
-    QMessageBox::warning( nullptr, tr( "Delete Schema" ), tr( "Unable to delete schema." ) );
-    return;
-  }
-
-  QString sql = QStringLiteral( "SELECT table_name FROM information_schema.tables WHERE table_schema='%1'" ).arg( mName );
-  QgsPostgresResult result( conn->PQexec( sql ) );
-  if ( result.PQresultStatus() != PGRES_TUPLES_OK )
-  {
-    QMessageBox::warning( nullptr, tr( "Delete Schema" ), tr( "Unable to delete schema." ) );
-    conn->unref();
-    return;
-  }
-
-  QStringList childObjects;
-  int maxListed = 10;
-  for ( int idx = 0; idx < result.PQntuples(); idx++ )
-  {
-    childObjects << result.PQgetvalue( idx, 0 );
-    QgsPostgresSchemaProperty schema;
-    if ( idx == maxListed - 1 )
-      break;
-  }
-
-  int count = result.PQntuples();
-  if ( count > 0 )
-  {
-    QString objects = childObjects.join( QStringLiteral( "\n" ) );
-    if ( count > maxListed )
-    {
-      objects += QStringLiteral( "\n[%1 additional objects not listed]" ).arg( count - maxListed );
-    }
-    if ( QMessageBox::question( nullptr, QObject::tr( "Delete Schema" ),
-                                QObject::tr( "Schema '%1' contains objects:\n\n%2\n\nAre you sure you want to delete the schema and all these objects?" ).arg( mName, objects ),
-                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-    {
-      conn->unref();
-      return;
-    }
-  }
-  else
-  {
-    if ( QMessageBox::question( nullptr, QObject::tr( "Delete Schema" ),
-                                QObject::tr( "Are you sure you want to delete the schema '%1'?" ).arg( mName ),
-                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-      return;
-  }
-
-  QString errCause;
-  bool res = ::deleteSchema( mName, uri, errCause, count > 0 );
-  if ( !res )
-  {
-    QMessageBox::warning( nullptr, tr( "Delete Schema" ), errCause );
-  }
-  else
-  {
-    QMessageBox::information( nullptr, tr( "Delete Schema" ), tr( "Schema deleted successfully." ) );
-    if ( mParent )
-      mParent->refresh();
-  }
-}
-
-void QgsPGSchemaItem::renameSchema()
-{
-  QgsNewNameDialog dlg( tr( "schema '%1'" ).arg( mName ), mName );
-  dlg.setWindowTitle( tr( "Rename Schema" ) );
-  if ( dlg.exec() != QDialog::Accepted || dlg.name() == mName )
-    return;
-
-  QString schemaName = QgsPostgresConn::quotedIdentifier( mName );
-  QgsDataSourceUri uri = QgsPostgresConn::connUri( mConnectionName );
-  QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
-  if ( !conn )
-  {
-    QMessageBox::warning( nullptr, tr( "Rename Schema" ), tr( "Unable to rename schema." ) );
-    return;
-  }
-
-  //rename the schema
-  QString sql = QStringLiteral( "ALTER SCHEMA %1 RENAME TO %2" )
-                .arg( schemaName, QgsPostgresConn::quotedIdentifier( dlg.name() ) );
-
-  QgsPostgresResult result( conn->PQexec( sql ) );
-  if ( result.PQresultStatus() != PGRES_COMMAND_OK )
-  {
-    QMessageBox::warning( nullptr, tr( "Rename Schema" ), tr( "Unable to rename schema %1\n%2" ).arg( schemaName,
-                          result.PQresultErrorMessage() ) );
-    conn->unref();
-    return;
-  }
-
-  conn->unref();
-  QMessageBox::information( nullptr, tr( "Rename Schema" ), tr( "Schema renamed successfully." ) );
-  if ( mParent )
-    mParent->refresh();
-}
-#endif
 
 QgsPGLayerItem *QgsPGSchemaItem::createLayer( QgsPostgresLayerProperty layerProperty )
 {
@@ -952,17 +568,6 @@ QVector<QgsDataItem *> QgsPGRootItem::createChildren()
 }
 
 #ifdef HAVE_GUI
-QList<QAction *> QgsPGRootItem::actions( QWidget *parent )
-{
-  QList<QAction *> lst;
-
-  QAction *actionNew = new QAction( tr( "New Connection…" ), parent );
-  connect( actionNew, &QAction::triggered, this, &QgsPGRootItem::newConnection );
-  lst.append( actionNew );
-
-  return lst;
-}
-
 QWidget *QgsPGRootItem::paramWidget()
 {
   QgsPgSourceSelect *select = new QgsPgSourceSelect( nullptr, nullptr, QgsProviderRegistry::WidgetMode::Manager );
@@ -973,15 +578,6 @@ QWidget *QgsPGRootItem::paramWidget()
 void QgsPGRootItem::onConnectionsChanged()
 {
   refresh();
-}
-
-void QgsPGRootItem::newConnection()
-{
-  QgsPgNewConnection nc( nullptr );
-  if ( nc.exec() )
-  {
-    refresh();
-  }
 }
 #endif
 

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -235,11 +235,6 @@ void QgsPGConnectionItem::refreshSchema( const QString &schema )
   }
 }
 
-bool QgsPGConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction )
-{
-  return handleDrop( data, QString() );
-}
-
 bool QgsPGConnectionItem::handleDrop( const QMimeData *data, const QString &toSchema )
 {
   if ( !QgsMimeDataUtils::isUriList( data ) )
@@ -336,34 +331,6 @@ QString QgsPGLayerItem::comments() const
 {
   return mLayerProperty.tableComment;
 }
-
-#ifdef HAVE_GUI
-
-bool QgsPGLayerItem::deleteLayer()
-{
-  QString typeName = mLayerProperty.isView ? tr( "View" ) : tr( "Table" );
-
-  if ( QMessageBox::question( nullptr, tr( "Delete %1" ).arg( typeName ),
-                              QObject::tr( "Are you sure you want to delete %1.%2?" ).arg( mLayerProperty.schemaName, mLayerProperty.tableName ),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
-    return true;
-
-  QString errCause;
-  bool res = QgsPostgresUtils::deleteLayer( mUri, errCause );
-  if ( !res )
-  {
-    QMessageBox::warning( nullptr, tr( "Delete %1" ).arg( typeName ), errCause );
-  }
-  else
-  {
-    QMessageBox::information( nullptr, tr( "Delete %1" ).arg( typeName ), tr( "%1 deleted successfully." ).arg( typeName ) );
-    if ( mParent )
-      mParent->refresh();
-  }
-  return true;
-}
-
-#endif
 
 QString QgsPGLayerItem::createUri()
 {

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -42,8 +42,6 @@ class QgsPGRootItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
-
-    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
     static QMainWindow *sMainWindow;
@@ -51,7 +49,6 @@ class QgsPGRootItem : public QgsDataCollectionItem
   public slots:
 #ifdef HAVE_GUI
     void onConnectionsChanged();
-    void newConnection();
 #endif
 };
 
@@ -63,9 +60,6 @@ class QgsPGConnectionItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
-#ifdef HAVE_GUI
-    QList<QAction *> actions( QWidget *parent ) override;
-#endif
 
     bool acceptDrop() override { return true; }
     bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
@@ -76,12 +70,6 @@ class QgsPGConnectionItem : public QgsDataCollectionItem
     void addGeometryColumn( const QgsPostgresLayerProperty & );
 
   public slots:
-#ifdef HAVE_GUI
-    void editConnection();
-    void deleteConnection();
-    void refreshConnection();
-    void createSchema();
-#endif
 
     // refresh specified schema or all schemas if schema name is empty
     void refreshSchema( const QString &schema );
@@ -95,18 +83,11 @@ class QgsPGSchemaItem : public QgsDataCollectionItem
     QgsPGSchemaItem( QgsDataItem *parent, const QString &connectionName, const QString &name, const QString &path );
 
     QVector<QgsDataItem *> createChildren() override;
-#ifdef HAVE_GUI
-    QList<QAction *> actions( QWidget *parent ) override;
-#endif
 
     bool acceptDrop() override { return true; }
     bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
 
-  public slots:
-#ifdef HAVE_GUI
-    void deleteSchema();
-    void renameSchema();
-#endif
+    QString connectionName() const { return mConnectionName; }
 
   private:
     QgsPGLayerItem *createLayer( QgsPostgresLayerProperty layerProperty );
@@ -123,17 +104,13 @@ class QgsPGLayerItem : public QgsLayerItem
 
     QString createUri();
 
-#ifdef HAVE_GUI
-    QList<QAction *> actions( QWidget *parent ) override;
-#endif
     QString comments() const override;
+
+    const QgsPostgresLayerProperty &layerInfo() const { return mLayerProperty; }
 
   public slots:
 #ifdef HAVE_GUI
     bool deleteLayer() override;
-    void renameLayer();
-    void truncateTable();
-    void refreshMaterializedView();
 #endif
 
   private:

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -61,9 +61,6 @@ class QgsPGConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
-    bool acceptDrop() override { return true; }
-    bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
-
     bool handleDrop( const QMimeData *data, const QString &toSchema );
 
   signals:
@@ -107,11 +104,6 @@ class QgsPGLayerItem : public QgsLayerItem
     QString comments() const override;
 
     const QgsPostgresLayerProperty &layerInfo() const { return mLayerProperty; }
-
-  public slots:
-#ifdef HAVE_GUI
-    bool deleteLayer() override;
-#endif
 
   private:
     QgsPostgresLayerProperty mLayerProperty;

--- a/src/providers/postgres/qgspostgresprojectstorage.cpp
+++ b/src/providers/postgres/qgspostgresprojectstorage.cpp
@@ -254,36 +254,6 @@ bool QgsPostgresProjectStorage::readProjectStorageMetadata( const QString &uri, 
 }
 
 
-#ifdef HAVE_GUI
-
-#include "qgspostgresprojectstoragedialog.h"
-
-QString QgsPostgresProjectStorageGuiProvider::visibleName()
-{
-  return QObject::tr( "PostgreSQL" );
-}
-
-QString QgsPostgresProjectStorageGuiProvider::showLoadGui()
-{
-  QgsPostgresProjectStorageDialog dlg( false );
-  if ( !dlg.exec() )
-    return QString();
-
-  return dlg.currentProjectUri();
-}
-
-QString QgsPostgresProjectStorageGuiProvider::showSaveGui()
-{
-  QgsPostgresProjectStorageDialog dlg( true );
-  if ( !dlg.exec() )
-    return QString();
-
-  return dlg.currentProjectUri();
-}
-
-#endif
-
-
 QString QgsPostgresProjectStorage::encodeUri( const QgsPostgresProjectUri &postUri )
 {
   QUrl u;

--- a/src/providers/postgres/qgspostgresprojectstorage.h
+++ b/src/providers/postgres/qgspostgresprojectstorage.h
@@ -20,9 +20,6 @@
 
 #include "qgsdatasourceuri.h"
 
-#ifdef HAVE_GUI
-#include "qgsprojectstorageguiprovider.h"
-#endif
 
 //! Stores information parsed from postgres project URI
 typedef struct
@@ -58,16 +55,5 @@ class QgsPostgresProjectStorage : public QgsProjectStorage
     static QgsPostgresProjectUri decodeUri( const QString &uri );
 };
 
-
-#ifdef HAVE_GUI
-class QgsPostgresProjectStorageGuiProvider : public QgsProjectStorageGuiProvider
-{
-  public:
-    QString type() override { return QStringLiteral( "postgresql" ); }
-    QString visibleName() override;
-    QString showLoadGui() override;
-    QString showSaveGui() override;
-};
-#endif
 
 #endif // QGSPOSTGRESPROJECTSTORAGE_H

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -45,14 +45,11 @@
 
 #include "qgspostgresprovider.h"
 #include "qgsprovidermetadata.h"
-#ifdef HAVE_GUI
-#include "qgsproviderguimetadata.h"
-#include "qgspgsourceselect.h"
-#include "qgssourceselectprovider.h"
-#endif
 
-const QString POSTGRES_KEY = QStringLiteral( "postgres" );
-const QString POSTGRES_DESCRIPTION = QStringLiteral( "PostgreSQL/PostGIS data provider" );
+
+const QString QgsPostgresProvider::POSTGRES_KEY = QStringLiteral( "postgres" );
+const QString QgsPostgresProvider::POSTGRES_DESCRIPTION = QStringLiteral( "PostgreSQL/PostGIS data provider" );
+
 static const QString EDITOR_WIDGET_STYLES_TABLE = QStringLiteral( "qgis_editor_widget_styles" );
 
 inline qint64 PKINT2FID( qint32 x )
@@ -5015,49 +5012,6 @@ void QgsPostgresProviderMetadata::cleanupProvider()
 }
 
 
-#ifdef HAVE_GUI
-
-//! Provider for postgres source select
-class QgsPostgresSourceSelectProvider : public QgsSourceSelectProvider  //#spellok
-{
-  public:
-
-    QString providerKey() const override { return QStringLiteral( "postgres" ); }
-    QString text() const override { return QObject::tr( "PostgreSQL" ); }
-    int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 20; }
-    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPostgisLayer.svg" ) ); }
-    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
-    {
-      return new QgsPgSourceSelect( parent, fl, widgetMode );
-    }
-};
-
-class QgsPostgresProviderGuiMetadata: public QgsProviderGuiMetadata
-{
-  public:
-    QgsPostgresProviderGuiMetadata():
-      QgsProviderGuiMetadata( POSTGRES_KEY )
-    {
-    }
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
-    {
-      QList<QgsSourceSelectProvider *> providers;
-      providers << new QgsPostgresSourceSelectProvider;  //#spellok
-      return providers;
-    }
-    QList<QgsProjectStorageGuiProvider *> projectStorageGuiProviders() override
-    {
-      QList<QgsProjectStorageGuiProvider *> providers;
-      providers << new QgsPostgresProjectStorageGuiProvider;
-      return providers;
-    }
-    void registerGui( QMainWindow *mainWindow ) override
-    {
-      QgsPGRootItem::sMainWindow = mainWindow;
-    }
-};
-#endif
-
 // ----------
 
 void QgsPostgresSharedData::addFeaturesCounted( long diff )
@@ -5175,17 +5129,13 @@ void QgsPostgresSharedData::setFieldSupportsEnumValues( int index, bool isSuppor
   mFieldSupportsEnumValues[ index ] = isSupported;
 }
 
-QgsPostgresProviderMetadata::QgsPostgresProviderMetadata():
-  QgsProviderMetadata( POSTGRES_KEY, POSTGRES_DESCRIPTION ) {}
+
+QgsPostgresProviderMetadata::QgsPostgresProviderMetadata()
+  : QgsProviderMetadata( QgsPostgresProvider::POSTGRES_KEY, QgsPostgresProvider::POSTGRES_DESCRIPTION )
+{
+}
 
 QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsPostgresProviderMetadata();
 }
-
-#ifdef HAVE_GUI
-QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
-{
-  return new QgsPostgresProviderGuiMetadata();
-}
-#endif

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -50,6 +50,10 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
+
+    static const QString POSTGRES_KEY;
+    static const QString POSTGRES_DESCRIPTION;
+
     enum Relkind
     {
       Unknown,

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -472,6 +472,9 @@ class QgsPostgresProvider : public QgsVectorDataProvider
 class QgsPostgresUtils
 {
   public:
+    static bool deleteLayer( const QString &uri, QString &errCause );
+    static bool deleteSchema( const QString &schema, const QgsDataSourceUri &uri, QString &errCause, bool cascade = false );
+
     static QString whereClause( QgsFeatureId featureId,
                                 const QgsFields &fields,
                                 QgsPostgresConn *conn,

--- a/src/providers/postgres/qgspostgresprovidergui.cpp
+++ b/src/providers/postgres/qgspostgresprovidergui.cpp
@@ -1,0 +1,110 @@
+/***************************************************************************
+  qgspostgresprovidergui.cpp
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsapplication.h"
+#include "qgsproviderguimetadata.h"
+#include "qgspgsourceselect.h"
+#include "qgssourceselectprovider.h"
+#include "qgspostgresprovider.h"
+#include "qgspostgresdataitems.h"
+#include "qgsprojectstorageguiprovider.h"
+#include "qgspostgresprojectstoragedialog.h"
+
+
+//! Provider for postgres source select
+class QgsPostgresSourceSelectProvider : public QgsSourceSelectProvider  //#spellok
+{
+  public:
+
+    QString providerKey() const override { return QStringLiteral( "postgres" ); }
+    QString text() const override { return QObject::tr( "PostgreSQL" ); }
+    int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 20; }
+    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddPostgisLayer.svg" ) ); }
+    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsPgSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+class QgsPostgresProjectStorageGuiProvider : public QgsProjectStorageGuiProvider
+{
+  public:
+    QString type() override { return QStringLiteral( "postgresql" ); }
+    QString visibleName() override
+    {
+      return QObject::tr( "PostgreSQL" );
+    }
+
+    QString showLoadGui() override
+    {
+      QgsPostgresProjectStorageDialog dlg( false );
+      if ( !dlg.exec() )
+        return QString();
+
+      return dlg.currentProjectUri();
+    }
+
+    QString showSaveGui() override
+    {
+      QgsPostgresProjectStorageDialog dlg( true );
+      if ( !dlg.exec() )
+        return QString();
+
+      return dlg.currentProjectUri();
+    }
+
+};
+
+
+
+class QgsPostgresProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsPostgresProviderGuiMetadata():
+      QgsProviderGuiMetadata( QgsPostgresProvider::POSTGRES_KEY )
+    {
+    }
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
+    {
+      QList<QgsSourceSelectProvider *> providers;
+      providers << new QgsPostgresSourceSelectProvider;  //#spellok
+      return providers;
+    }
+
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
+    {
+      return QList<QgsDataItemGuiProvider *>();
+    }
+
+    QList<QgsProjectStorageGuiProvider *> projectStorageGuiProviders() override
+    {
+      QList<QgsProjectStorageGuiProvider *> providers;
+      providers << new QgsPostgresProjectStorageGuiProvider;
+      return providers;
+    }
+
+    void registerGui( QMainWindow *mainWindow ) override
+    {
+      QgsPGRootItem::sMainWindow = mainWindow;
+    }
+};
+
+
+QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
+{
+  return new QgsPostgresProviderGuiMetadata();
+}

--- a/src/providers/postgres/qgspostgresprovidergui.cpp
+++ b/src/providers/postgres/qgspostgresprovidergui.cpp
@@ -21,6 +21,7 @@
 #include "qgspostgresdataitems.h"
 #include "qgsprojectstorageguiprovider.h"
 #include "qgspostgresprojectstoragedialog.h"
+#include "qgspostgresdataitemguiprovider.h"
 
 
 //! Provider for postgres source select
@@ -87,7 +88,8 @@ class QgsPostgresProviderGuiMetadata: public QgsProviderGuiMetadata
 
     QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
     {
-      return QList<QgsDataItemGuiProvider *>();
+      return QList<QgsDataItemGuiProvider *>()
+             << new QgsPostgresDataItemGuiProvider;
     }
 
     QList<QgsProjectStorageGuiProvider *> projectStorageGuiProviders() override

--- a/src/providers/spatialite/CMakeLists.txt
+++ b/src/providers/spatialite/CMakeLists.txt
@@ -25,9 +25,11 @@ SET(SPATIALITE_MOC_HDRS
 IF (WITH_GUI)
   SET(SPATIALITE_SRCS ${SPATIALITE_SRCS}
     qgsspatialiteprovidergui.cpp
+    qgsspatialitedataitemguiprovider.cpp
     qgsspatialitesourceselect.cpp
   )
   SET(SPATIALITE_MOC_HDRS ${SPATIALITE_MOC_HDRS}
+    qgsspatialitedataitemguiprovider.h
     qgsspatialitesourceselect.h
   )
 ENDIF ()

--- a/src/providers/spatialite/CMakeLists.txt
+++ b/src/providers/spatialite/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(SPATIALITE_MOC_HDRS
 
 IF (WITH_GUI)
   SET(SPATIALITE_SRCS ${SPATIALITE_SRCS}
+    qgsspatialiteprovidergui.cpp
     qgsspatialitesourceselect.cpp
   )
   SET(SPATIALITE_MOC_HDRS ${SPATIALITE_MOC_HDRS}

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.cpp
@@ -1,0 +1,214 @@
+/***************************************************************************
+  qgsspatialitedataitemguiprovider.cpp
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsspatialitedataitemguiprovider.h"
+#include "qgsspatialiteconnection.h"
+#include "qgsspatialitedataitems.h"
+#include "qgsspatialitesourceselect.h"
+
+#include "qgsapplication.h"
+#include "qgsmessageoutput.h"
+#include "qgsmimedatautils.h"
+#include "qgssettings.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+
+void QgsSpatiaLiteDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
+{
+  if ( QgsSLRootItem *rootItem = qobject_cast< QgsSLRootItem * >( item ) )
+  {
+    QAction *actionNew = new QAction( tr( "New Connection…" ), this );
+    connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
+    menu->addAction( actionNew );
+
+    QAction *actionCreateDatabase = new QAction( tr( "Create Database…" ), this );
+    connect( actionCreateDatabase, &QAction::triggered, this, [rootItem] { createDatabase( rootItem ); } );
+    menu->addAction( actionCreateDatabase );
+  }
+
+  if ( QgsSLConnectionItem *connItem = qobject_cast< QgsSLConnectionItem * >( item ) )
+  {
+    QAction *actionDelete = new QAction( tr( "Delete" ), this );
+    connect( actionDelete, &QAction::triggered, this, [connItem] { deleteConnection( connItem ); } );
+    menu->addAction( actionDelete );
+  }
+}
+
+bool QgsSpatiaLiteDataItemGuiProvider::deleteLayer( QgsLayerItem *item, QgsDataItemGuiContext )
+{
+  if ( QgsSLLayerItem *layerItem = qobject_cast< QgsSLLayerItem * >( item ) )
+  {
+    if ( QMessageBox::question( nullptr, QObject::tr( "Delete Object" ),
+                                QObject::tr( "Are you sure you want to delete %1?" ).arg( layerItem->name() ),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+      return false;
+
+    QgsDataSourceUri uri( layerItem->uri() );
+    QString errCause;
+    if ( !SpatiaLiteUtils::deleteLayer( uri.database(), uri.table(), errCause ) )
+    {
+      QMessageBox::warning( nullptr, tr( "Delete Layer" ), errCause );
+      return false;
+    }
+    else
+    {
+      QMessageBox::information( nullptr, tr( "Delete Layer" ), tr( "Layer deleted successfully." ) );
+      layerItem->parent()->refresh();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool QgsSpatiaLiteDataItemGuiProvider::acceptDrop( QgsDataItem *item, QgsDataItemGuiContext )
+{
+  if ( qobject_cast< QgsSLConnectionItem * >( item ) )
+    return true;
+
+  return false;
+}
+
+bool QgsSpatiaLiteDataItemGuiProvider::handleDrop( QgsDataItem *item, QgsDataItemGuiContext, const QMimeData *data, Qt::DropAction action )
+{
+  if ( QgsSLConnectionItem *connItem = qobject_cast< QgsSLConnectionItem * >( item ) )
+  {
+    return handleDropConnectionItem( connItem, data, action );
+  }
+  return false;
+}
+
+
+void QgsSpatiaLiteDataItemGuiProvider::newConnection( QgsDataItem *item )
+{
+  if ( QgsSpatiaLiteSourceSelect::newConnection( nullptr ) )
+  {
+    item->refreshConnections();
+  }
+}
+
+void QgsSpatiaLiteDataItemGuiProvider::createDatabase( QgsDataItem *item )
+{
+  QgsSettings settings;
+  QString lastUsedDir = settings.value( QStringLiteral( "UI/lastSpatiaLiteDir" ), QDir::homePath() ).toString();
+
+  QString filename = QFileDialog::getSaveFileName( nullptr, tr( "New SpatiaLite Database File" ),
+                     lastUsedDir,
+                     tr( "SpatiaLite" ) + " (*.sqlite *.db *.sqlite3 *.db3 *.s3db)" );
+  if ( filename.isEmpty() )
+    return;
+
+  QString errCause;
+  if ( SpatiaLiteUtils::createDb( filename, errCause ) )
+  {
+    // add connection
+    settings.setValue( "/SpatiaLite/connections/" + QFileInfo( filename ).fileName() + "/sqlitepath", filename );
+
+    item->refresh();
+  }
+  else
+  {
+    QMessageBox::critical( nullptr, tr( "Create SpatiaLite database" ), tr( "Failed to create the database:\n" ) + errCause );
+  }
+}
+
+void QgsSpatiaLiteDataItemGuiProvider::deleteConnection( QgsDataItem *item )
+{
+  if ( QMessageBox::question( nullptr, QObject::tr( "Delete Connection" ),
+                              QObject::tr( "Are you sure you want to delete the connection to %1?" ).arg( item->name() ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  QgsSpatiaLiteConnection::deleteConnection( item->name() );
+  // the parent should be updated
+  item->parent()->refreshConnections();
+}
+
+bool QgsSpatiaLiteDataItemGuiProvider::handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction )
+{
+  if ( !QgsMimeDataUtils::isUriList( data ) )
+    return false;
+
+  // TODO: probably should show a GUI with settings etc
+
+  QgsDataSourceUri destUri;
+  destUri.setDatabase( connItem->databasePath() );
+
+  QStringList importResults;
+  bool hasError = false;
+
+  QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
+  const auto constLst = lst;
+  for ( const QgsMimeDataUtils::Uri &u : constLst )
+  {
+    // open the source layer
+    bool owner;
+    QString error;
+    QgsVectorLayer *srcLayer = u.vectorLayer( owner, error );
+    if ( !srcLayer )
+    {
+      importResults.append( tr( "%1: %2" ).arg( u.name, error ) );
+      hasError = true;
+      continue;
+    }
+
+    if ( srcLayer->isValid() )
+    {
+      destUri.setDataSource( QString(), u.name, srcLayer->geometryType() != QgsWkbTypes::NullGeometry ? QStringLiteral( "geom" ) : QString() );
+      QgsDebugMsg( "URI " + destUri.uri() );
+
+      std::unique_ptr< QgsVectorLayerExporterTask > exportTask( new QgsVectorLayerExporterTask( srcLayer, destUri.uri(), QStringLiteral( "spatialite" ), srcLayer->crs(), QVariantMap(), owner ) );
+
+      // when export is successful:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::exportComplete, connItem, [ = ]()
+      {
+        // this is gross - TODO - find a way to get access to messageBar from data items
+        QMessageBox::information( nullptr, tr( "Import to SpatiaLite database" ), tr( "Import was successful." ) );
+        connItem->refresh();
+      } );
+
+      // when an error occurs:
+      connect( exportTask.get(), &QgsVectorLayerExporterTask::errorOccurred, connItem, [ = ]( int error, const QString & errorMessage )
+      {
+        if ( error != QgsVectorLayerExporter::ErrUserCanceled )
+        {
+          QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+          output->setTitle( tr( "Import to SpatiaLite database" ) );
+          output->setMessage( tr( "Failed to import layer!\n\n" ) + errorMessage, QgsMessageOutput::MessageText );
+          output->showMessage();
+        }
+        connItem->refresh();
+      } );
+
+      QgsApplication::taskManager()->addTask( exportTask.release() );
+    }
+    else
+    {
+      importResults.append( tr( "%1: Not a valid layer!" ).arg( u.name ) );
+      hasError = true;
+    }
+  }
+
+  if ( hasError )
+  {
+    QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
+    output->setTitle( tr( "Import to SpatiaLite database" ) );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( QStringLiteral( "\n" ) ), QgsMessageOutput::MessageText );
+    output->showMessage();
+  }
+
+  return true;
+}

--- a/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
+++ b/src/providers/spatialite/qgsspatialitedataitemguiprovider.h
@@ -1,0 +1,46 @@
+/***************************************************************************
+  qgsspatialitedataitemguiprovider.h
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSPATIALITEDATAITEMGUIPROVIDER_H
+#define QGSSPATIALITEDATAITEMGUIPROVIDER_H
+
+#include "qgsdataitemguiprovider.h"
+
+class QgsSLConnectionItem;
+
+
+class QgsSpatiaLiteDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
+{
+    Q_OBJECT
+  public:
+
+    QString name() override { return QStringLiteral( "SPATIALITE" ); }
+
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+
+    bool deleteLayer( QgsLayerItem *item, QgsDataItemGuiContext context ) override;
+
+    bool acceptDrop( QgsDataItem *item, QgsDataItemGuiContext context ) override;
+    bool handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction action ) override;
+
+  private:
+    static void newConnection( QgsDataItem *item );
+    static void createDatabase( QgsDataItem *item );
+    static void deleteConnection( QgsDataItem *item );
+    static bool handleDropConnectionItem( QgsSLConnectionItem *connItem, const QMimeData *data, Qt::DropAction );
+};
+
+#endif // QGSSPATIALITEDATAITEMGUIPROVIDER_H

--- a/src/providers/spatialite/qgsspatialitedataitems.h
+++ b/src/providers/spatialite/qgsspatialitedataitems.h
@@ -24,9 +24,6 @@ class QgsSLLayerItem : public QgsLayerItem
   public:
     QgsSLLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &uri, LayerType layerType );
 
-#ifdef HAVE_GUI
-    bool deleteLayer() override;
-#endif
 };
 
 class QgsSLConnectionItem : public QgsDataCollectionItem
@@ -38,18 +35,7 @@ class QgsSLConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
-#ifdef HAVE_GUI
-    QList<QAction *> actions( QWidget *parent ) override;
-#endif
-
-    bool acceptDrop() override { return true; }
-    bool handleDrop( const QMimeData *data, Qt::DropAction action ) override;
-
-  public slots:
-#ifdef HAVE_GUI
-    void editConnection();
-    void deleteConnection();
-#endif
+    QString databasePath() const { return mDbPath; }
 
   protected:
     QString mDbPath;
@@ -67,20 +53,18 @@ class QgsSLRootItem : public QgsDataCollectionItem
 
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
-    QList<QAction *> actions( QWidget *parent ) override;
 #endif
 
   public slots:
 #ifdef HAVE_GUI
     void onConnectionsChanged();
-    void newConnection();
 #endif
-    void createDatabase();
 };
 
 namespace SpatiaLiteUtils
 {
   bool createDb( const QString &dbPath, QString &errCause );
+  bool deleteLayer( const QString &dbPath, const QString &tableName, QString &errCause );
 }
 
 //! Provider for SpatiaLite root data item

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -15,7 +15,6 @@ email                : a.furieri@lqt.it
  ***************************************************************************/
 
 #include "qgis.h"
-#include "qgsapplication.h"
 #include "qgsfeature.h"
 #include "qgsfields.h"
 #include "qgsgeometry.h"
@@ -37,12 +36,6 @@ email                : a.furieri@lqt.it
 
 #include "qgsprovidermetadata.h"
 
-#ifdef HAVE_GUI
-#include "qgssourceselectprovider.h"
-#include "qgsspatialitesourceselect.h"
-#include "qgsproviderguimetadata.h"
-#endif
-
 #include <QMessageBox>
 #include <QFileInfo>
 #include <QDir>
@@ -52,8 +45,8 @@ email                : a.furieri@lqt.it
 using json = nlohmann::json;
 
 
-const QString SPATIALITE_KEY = QStringLiteral( "spatialite" );
-const QString SPATIALITE_DESCRIPTION = QStringLiteral( "SpatiaLite data provider" );
+const QString QgsSpatiaLiteProvider::SPATIALITE_KEY = QStringLiteral( "spatialite" );
+const QString QgsSpatiaLiteProvider::SPATIALITE_DESCRIPTION = QStringLiteral( "SpatiaLite data provider" );
 static const QString SPATIALITE_ARRAY_PREFIX = QStringLiteral( "json" );
 static const QString SPATIALITE_ARRAY_SUFFIX = QStringLiteral( "list" );
 
@@ -6047,38 +6040,10 @@ void QgsSpatiaLiteProviderMetadata::cleanupProvider()
   QgsSqliteHandle::closeAll();
 }
 
-#ifdef HAVE_GUI
 
-//! Provider for spatialite source select
-class QgsSpatialiteSourceSelectProvider : public QgsSourceSelectProvider
-{
-  public:
-
-    QString providerKey() const override { return QStringLiteral( "spatialite" ); }
-    QString text() const override { return QObject::tr( "SpatiaLite" ); }
-    int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 10; }
-    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddSpatiaLiteLayer.svg" ) ); }
-    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
-    {
-      return new QgsSpatiaLiteSourceSelect( parent, fl, widgetMode );
-    }
-};
-
-QgsSpatiaLiteProviderGuiMetadata::QgsSpatiaLiteProviderGuiMetadata():
-  QgsProviderGuiMetadata( SPATIALITE_KEY )
-{
-}
-
-QList<QgsSourceSelectProvider *> QgsSpatiaLiteProviderGuiMetadata::sourceSelectProviders()
-{
-  QList<QgsSourceSelectProvider *> providers;
-  providers << new QgsSpatialiteSourceSelectProvider;
-  return providers;
-}
-#endif
 
 QgsSpatiaLiteProviderMetadata::QgsSpatiaLiteProviderMetadata():
-  QgsProviderMetadata( SPATIALITE_KEY, SPATIALITE_DESCRIPTION )
+  QgsProviderMetadata( QgsSpatiaLiteProvider::SPATIALITE_KEY, QgsSpatiaLiteProvider::SPATIALITE_DESCRIPTION )
 {
 }
 
@@ -6093,10 +6058,3 @@ QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
 {
   return new QgsSpatiaLiteProviderMetadata();
 }
-
-#ifdef HAVE_GUI
-QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
-{
-  return new QgsSpatiaLiteProviderGuiMetadata();
-}
-#endif

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -37,9 +37,6 @@ extern "C"
 #include <set>
 
 #include "qgsprovidermetadata.h"
-#ifdef HAVE_GUI
-#include "qgsproviderguimetadata.h"
-#endif
 
 class QgsFeature;
 class QgsField;
@@ -62,6 +59,10 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     Q_OBJECT
 
   public:
+
+    static const QString SPATIALITE_KEY;
+    static const QString SPATIALITE_DESCRIPTION;
+
     //! Import a vector layer into the database
     static QgsVectorLayerExporter::ExportError createEmptyLayer(
       const QString &uri,
@@ -406,15 +407,6 @@ class QgsSpatiaLiteProviderMetadata: public QgsProviderMetadata
     bool createDb( const QString &dbPath, QString &errCause ) override;
     QList< QgsDataItemProvider * > dataItemProviders() const override;
 };
-
-#ifdef HAVE_GUI
-class QgsSpatiaLiteProviderGuiMetadata: public QgsProviderGuiMetadata
-{
-  public:
-    QgsSpatiaLiteProviderGuiMetadata();
-    QList<QgsSourceSelectProvider *> sourceSelectProviders() override;
-};
-#endif
 
 // clazy:excludeall=qstring-allocations
 

--- a/src/providers/spatialite/qgsspatialiteprovidergui.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovidergui.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+  qgsspatialiteprovidergui.cpp
+  --------------------------------------
+  Date                 : June 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsapplication.h"
+#include "qgsproviderguimetadata.h"
+#include "qgssourceselectprovider.h"
+
+#include "qgsspatialitesourceselect.h"
+#include "qgsspatialiteprovider.h"
+
+
+//! Provider for spatialite source select
+class QgsSpatialiteSourceSelectProvider : public QgsSourceSelectProvider
+{
+  public:
+
+    QString providerKey() const override { return QStringLiteral( "spatialite" ); }
+    QString text() const override { return QObject::tr( "SpatiaLite" ); }
+    int ordering() const override { return QgsSourceSelectProvider::OrderDatabaseProvider + 10; }
+    QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddSpatiaLiteLayer.svg" ) ); }
+    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
+    {
+      return new QgsSpatiaLiteSourceSelect( parent, fl, widgetMode );
+    }
+};
+
+
+class QgsSpatiaLiteProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsSpatiaLiteProviderGuiMetadata()
+      : QgsProviderGuiMetadata( QgsSpatiaLiteProvider::SPATIALITE_KEY )
+    {
+    }
+
+    QList<QgsSourceSelectProvider *> sourceSelectProviders() override
+    {
+      QList<QgsSourceSelectProvider *> providers;
+      providers << new QgsSpatialiteSourceSelectProvider;
+      return providers;
+    }
+
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
+    {
+      return QList<QgsDataItemGuiProvider *>();
+    }
+};
+
+
+QGISEXTERN QgsProviderGuiMetadata *providerGuiMetadataFactory()
+{
+  return new QgsSpatiaLiteProviderGuiMetadata();
+}

--- a/src/providers/spatialite/qgsspatialiteprovidergui.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovidergui.cpp
@@ -17,6 +17,7 @@
 #include "qgsproviderguimetadata.h"
 #include "qgssourceselectprovider.h"
 
+#include "qgsspatialitedataitemguiprovider.h"
 #include "qgsspatialitesourceselect.h"
 #include "qgsspatialiteprovider.h"
 
@@ -54,7 +55,8 @@ class QgsSpatiaLiteProviderGuiMetadata: public QgsProviderGuiMetadata
 
     QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override
     {
-      return QList<QgsDataItemGuiProvider *>();
+      return QList<QgsDataItemGuiProvider *>()
+             << new QgsSpatiaLiteDataItemGuiProvider;
     }
 };
 


### PR DESCRIPTION
Migration of data items of providers to the new APIs - this time postgres and spatialite providers. There should be no actual functionality changes, just moving code around. To be continued...

This PR also fixes handling of layer deletion through the new API (QgsDataItemGuiProvider) which wasn't properly wired yet.