### PR TITLE
[processing] fix inputs handling in the batch mode

### DIFF
--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -85,8 +85,14 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 if param.flags() & QgsProcessingParameterDefinition.FlagHidden or param.isDestination():
                     continue
                 wrapper = self.mainWidget().wrappers[row][col]
-                parameters[param.name()] = wrapper.parameterValue()
-                if not param.checkValueIsAcceptable(wrapper.parameterValue()):
+                if wrapper is None:
+                    widget = self.mainWidget().tblParameters.cellWidget(row, col)
+                    value = widget.value()
+                else:
+                    value = wrapper.parameterValue()
+
+                parameters[param.name()] = value
+                if not param.checkValueIsAcceptable(value):
                     self.messageBar().pushMessage("", self.tr('Wrong or missing parameter value: {0} (row {1})').format(
                         param.description(), row + 1),
                         level=Qgis.Warning, duration=5)


### PR DESCRIPTION
## Description
In batch mode we use custom widget for inputs and getting parameter value from it need to be handled differently from wrappers. Only affects 3.4.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit