### PR TITLE
API for creation of parameter definition widgets

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingguiregistry.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingguiregistry.sip.in
@@ -125,6 +125,33 @@ handles the given ``parameter``, ``None`` will be returned.
 .. versionadded:: 3.4
 %End
 
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget( const QString &type,
+        QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = 0,
+        const QgsProcessingAlgorithm *algorithm = 0 ) /Factory/;
+%Docstring
+Creates a new parameter definition widget allowing for configuration of an instance of
+a specific parameter ``type``.
+
+The ``context`` argument must specify a Processing context, which will be used
+by the widget to evaluate existing ``definition`` properties such as default values. Similarly,
+the ``widgetContext`` argument specifies the wider GUI context in which the widget
+will be used.
+
+The optional ``definition`` argument may specify an existing parameter definition which
+will be reflected in the initial state of the returned widget. If ``definition`` is ``None``,
+then the returned widget will use default settings instead.
+
+Additionally, the optional ``algorithm`` parameter may be used to specify the algorithm or model
+associated with the parameter.
+
+If ``None`` is returned for a particular parameter ``type``,
+it indicates that the parameter type cannot be configured via GUI.
+
+.. versionadded:: 3.10
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
@@ -142,6 +142,10 @@ Returns a new instance of a parameter definition, using the current settings def
 The ``name`` parameter specifies the name for the newly created parameter.
 %End
 
+  public slots:
+    virtual void accept();
+
+
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
@@ -1,0 +1,154 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/processing/qgsprocessingparameterdefinitionwidget.h          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+class QgsProcessingAbstractParameterDefinitionWidget : QWidget
+{
+%Docstring
+Abstract base class for widgets which allow users to specify the properties of a
+Processing parameter.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingparameterdefinitionwidget.h"
+%End
+  public:
+
+    QgsProcessingAbstractParameterDefinitionWidget( QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = 0,
+        const QgsProcessingAlgorithm *algorithm = 0, QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Creates a new QgsProcessingAbstractParameterDefinitionWidget, with the specified ``parent`` widget.
+
+The ``context`` argument must specify a Processing context, which will be used
+by the widget to evaluate existing ``definition`` properties such as default values. Similarly,
+the ``widgetContext`` argument specifies the wider GUI context in which the widget
+will be used.
+
+The optional ``definition`` argument may be used to provide a parameter definition to use
+to initially populate the widget's state.
+
+Additionally, the optional ``algorithm`` parameter may be used to specify the algorithm or model
+associated with the parameter.
+%End
+
+    virtual QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const = 0 /Factory/;
+%Docstring
+Returns a new instance of a parameter definition, using the current settings defined in the dialog.
+
+Common properties for parameters, including the ``name``, ``description``, and parameter ``flags`` are passed to the
+method. Subclass implementations must use these properties when crafting a parameter definition which
+also respects the additional properties specific to the parameter type handled by the widget sublass.
+%End
+};
+
+
+class QgsProcessingParameterDefinitionWidget: QWidget
+{
+%Docstring
+A widget which allow users to specify the properties of a Processing parameter.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingparameterdefinitionwidget.h"
+%End
+  public:
+
+    QgsProcessingParameterDefinitionWidget( const QString &type,
+                                            QgsProcessingContext &context,
+                                            const QgsProcessingParameterWidgetContext &widgetContext,
+                                            const QgsProcessingParameterDefinition *definition = 0,
+                                            const QgsProcessingAlgorithm *algorithm = 0,
+                                            QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsProcessingParameterDefinitionWidget, for a parameter of the
+specified ``type``.
+
+The ``context`` argument must specify a Processing context, which will be used
+by the widget to evaluate existing ``definition`` properties such as default values. Similarly,
+the ``widgetContext`` argument specifies the wider GUI context in which the widget
+will be used.
+
+The optional ``definition`` argument may be used to provide a parameter definition to use
+to initially populate the widget's state.
+
+Additionally, the optional ``algorithm`` parameter may be used to specify the algorithm or model
+associated with the parameter.
+%End
+
+    QgsProcessingParameterDefinition *createParameter( const QString &name = QString() ) const /Factory/;
+%Docstring
+Returns a new instance of a parameter definition, using the current settings defined in the dialog.
+
+The ``name`` parameter specifies the name for the newly created parameter.
+%End
+
+};
+
+class QgsProcessingParameterDefinitionDialog: QDialog
+{
+%Docstring
+A dialog which allow users to specify the properties of a Processing parameter.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingparameterdefinitionwidget.h"
+%End
+  public:
+
+    QgsProcessingParameterDefinitionDialog( const QString &type,
+                                            QgsProcessingContext &context,
+                                            const QgsProcessingParameterWidgetContext &widgetContext,
+                                            const QgsProcessingParameterDefinition *definition = 0,
+                                            const QgsProcessingAlgorithm *algorithm = 0,
+                                            QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsProcessingParameterDefinitionDialog, for a parameter of the
+specified ``type``.
+
+The ``context`` argument must specify a Processing context, which will be used
+by the widget to evaluate existing ``definition`` properties such as default values. Similarly,
+the ``widgetContext`` argument specifies the wider GUI context in which the widget
+will be used.
+
+The optional ``definition`` argument may be used to provide a parameter definition to use
+to initially populate the dialog's state.
+
+Additionally, the optional ``algorithm`` parameter may be used to specify the algorithm or model
+associated with the parameter.
+%End
+
+    QgsProcessingParameterDefinition *createParameter( const QString &name = QString() ) const /Factory/;
+%Docstring
+Returns a new instance of a parameter definition, using the current settings defined in the dialog.
+
+The ``name`` parameter specifies the name for the newly created parameter.
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/processing/qgsprocessingparameterdefinitionwidget.h          *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -414,7 +414,7 @@ be shown in the returned widget).
 Additionally, the optional ``algorithm`` parameter may be used to specify the algorithm or model
 associated with the parameter.
 
-If a factory subclass returns ``None`` for this method (i.e. as the base class implemention does),
+If a factory subclass returns ``None`` for this method (i.e. as the base class implementation does),
 it indicates that the parameter type cannot be configured via GUI. In this case the parameter
 type will not be configurable when users add it as an input to their graphical models.
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -391,6 +391,36 @@ last for the lifetime of the widget.
 .. seealso:: :py:func:`createWidgetWrapper`
 %End
 
+    virtual QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = 0,
+      const QgsProcessingAlgorithm *algorithm = 0 ) /Factory/;
+%Docstring
+Creates a new parameter definition widget allowing for configuration of an instance of
+the parameter type handled by this factory.
+
+The ``context`` argument must specify a Processing context, which will be used
+by the widget to evaluate existing ``definition`` properties such as default values. Similarly,
+the ``widgetContext`` argument specifies the wider GUI context in which the widget
+will be used.
+
+The optional ``definition`` argument may specify a parameter definition which
+should be reflected in the initial state of the returned widget. Subclasses must
+ensure that they correctly handle both the case when a initial ``definition`` is
+passed, or when ``definition`` is ``None`` (in which case sensible defaults should
+be shown in the returned widget).
+
+Additionally, the optional ``algorithm`` parameter may be used to specify the algorithm or model
+associated with the parameter.
+
+If a factory subclass returns ``None`` for this method (i.e. as the base class implemention does),
+it indicates that the parameter type cannot be configured via GUI. In this case the parameter
+type will not be configurable when users add it as an input to their graphical models.
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
     virtual QStringList compatibleParameterTypes() const = 0;

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -340,6 +340,7 @@
 %Include auto_generated/processing/qgsprocessingmaplayercombobox.sip
 %Include auto_generated/processing/qgsprocessingmodelerparameterwidget.sip
 %Include auto_generated/processing/qgsprocessingmultipleselectiondialog.sip
+%Include auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip
 %Include auto_generated/processing/qgsprocessingrecentalgorithmlog.sip
 %Include auto_generated/processing/qgsprocessingtoolboxmodel.sip
 %Include auto_generated/processing/qgsprocessingtoolboxtreeview.sip

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -41,7 +41,6 @@ from qgis.core import (QgsApplication,
                        QgsProcessing,
                        QgsCoordinateReferenceSystem,
                        QgsProcessingParameterDefinition,
-                       QgsProcessingParameterBoolean,
                        QgsProcessingParameterCrs,
                        QgsProcessingParameterMapLayer,
                        QgsProcessingParameterExtent,
@@ -81,8 +80,7 @@ class ModelerParameterDefinitionDialog(QDialog):
 
     @staticmethod
     def use_legacy_dialog(param=None, paramType=None):
-        if paramType in (parameters.PARAMETER_BOOLEAN,
-                         parameters.PARAMETER_TABLE_FIELD,
+        if paramType in (parameters.PARAMETER_TABLE_FIELD,
                          parameters.PARAMETER_BAND,
                          parameters.PARAMETER_LAYOUTITEM,
                          parameters.PARAMETER_VECTOR,
@@ -99,8 +97,7 @@ class ModelerParameterDefinitionDialog(QDialog):
                          parameters.PARAMETER_ENUM,
                          parameters.PARAMETER_MATRIX):
             return True
-        elif isinstance(param, (QgsProcessingParameterBoolean,
-                                QgsProcessingParameterField,
+        elif isinstance(param, (QgsProcessingParameterField,
                                 QgsProcessingParameterBand,
                                 QgsProcessingParameterLayoutItem,
                                 QgsProcessingParameterFeatureSource,
@@ -153,15 +150,7 @@ class ModelerParameterDefinitionDialog(QDialog):
         if isinstance(self.param, QgsProcessingParameterDefinition):
             self.nameTextBox.setText(self.param.description())
 
-        if self.paramType == parameters.PARAMETER_BOOLEAN or \
-                isinstance(self.param, QgsProcessingParameterBoolean):
-            self.state = QCheckBox()
-            self.state.setText(self.tr('Checked'))
-            self.state.setChecked(False)
-            if self.param is not None:
-                self.state.setChecked(bool(self.param.defaultValue()))
-            self.verticalLayout.addWidget(self.state)
-        elif self.paramType == parameters.PARAMETER_TABLE_FIELD or \
+        if self.paramType == parameters.PARAMETER_TABLE_FIELD or \
                 isinstance(self.param, QgsProcessingParameterField):
             self.verticalLayout.addWidget(QLabel(self.tr('Parent layer')))
             self.parentCombo = QComboBox()
@@ -449,11 +438,8 @@ class ModelerParameterDefinitionDialog(QDialog):
                 i += 1
         else:
             name = self.param.name()
-        if (self.paramType == parameters.PARAMETER_BOOLEAN or
-                isinstance(self.param, QgsProcessingParameterBoolean)):
-            self.param = QgsProcessingParameterBoolean(name, description, self.state.isChecked())
-        elif (self.paramType == parameters.PARAMETER_TABLE_FIELD or
-              isinstance(self.param, QgsProcessingParameterField)):
+        if (self.paramType == parameters.PARAMETER_TABLE_FIELD or
+                isinstance(self.param, QgsProcessingParameterField)):
             if self.parentCombo.currentIndex() < 0:
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
                                     self.tr('Wrong or missing parameter values'))

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -79,6 +79,49 @@ from processing.modeler.exceptions import UndefinedParameterException
 
 class ModelerParameterDefinitionDialog(QDialog):
 
+    @staticmethod
+    def use_legacy_dialog(param=None, paramType=None):
+        if paramType in (parameters.PARAMETER_BOOLEAN,
+                         parameters.PARAMETER_TABLE_FIELD,
+                         parameters.PARAMETER_BAND,
+                         parameters.PARAMETER_LAYOUTITEM,
+                         parameters.PARAMETER_VECTOR,
+                         parameters.PARAMETER_TABLE,
+                         parameters.PARAMETER_MULTIPLE,
+                         parameters.PARAMETER_NUMBER,
+                         parameters.PARAMETER_DISTANCE,
+                         parameters.PARAMETER_SCALE,
+                         parameters.PARAMETER_EXPRESSION,
+                         parameters.PARAMETER_STRING,
+                         parameters.PARAMETER_FILE,
+                         parameters.PARAMETER_POINT,
+                         parameters.PARAMETER_CRS,
+                         parameters.PARAMETER_ENUM,
+                         parameters.PARAMETER_MATRIX):
+            return True
+        elif isinstance(param, (QgsProcessingParameterBoolean,
+                                QgsProcessingParameterField,
+                                QgsProcessingParameterBand,
+                                QgsProcessingParameterLayoutItem,
+                                QgsProcessingParameterFeatureSource,
+                                QgsProcessingParameterVectorLayer,
+                                QgsProcessingParameterMultipleLayers,
+                                QgsProcessingParameterNumber,
+                                QgsProcessingParameterDistance,
+                                QgsProcessingParameterScale,
+                                QgsProcessingParameterExpression,
+                                QgsProcessingParameterString,
+                                QgsProcessingParameterFile,
+                                QgsProcessingParameterPoint,
+                                QgsProcessingParameterCrs,
+                                QgsProcessingParameterEnum,
+                                QgsProcessingParameterMatrix,
+                                QgsProcessingDestinationParameter)):
+            return True
+
+        # yay, use new API!
+        return False
+
     def __init__(self, alg, paramType=None, param=None):
         self.alg = alg
         self.paramType = paramType

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -90,7 +90,6 @@ class ModelerParameterDefinitionDialog(QDialog):
                          parameters.PARAMETER_DISTANCE,
                          parameters.PARAMETER_SCALE,
                          parameters.PARAMETER_EXPRESSION,
-                         parameters.PARAMETER_STRING,
                          parameters.PARAMETER_FILE,
                          parameters.PARAMETER_POINT,
                          parameters.PARAMETER_CRS,
@@ -107,7 +106,6 @@ class ModelerParameterDefinitionDialog(QDialog):
                                 QgsProcessingParameterDistance,
                                 QgsProcessingParameterScale,
                                 QgsProcessingParameterExpression,
-                                QgsProcessingParameterString,
                                 QgsProcessingParameterFile,
                                 QgsProcessingParameterPoint,
                                 QgsProcessingParameterCrs,
@@ -326,13 +324,6 @@ class ModelerParameterDefinitionDialog(QDialog):
                             self.parentCombo.setCurrentIndex(idx)
                     idx += 1
             self.verticalLayout.addWidget(self.parentCombo)
-        elif (self.paramType == parameters.PARAMETER_STRING or
-              isinstance(self.param, QgsProcessingParameterString)):
-            self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
-            self.defaultTextBox = QLineEdit()
-            if self.param is not None:
-                self.defaultTextBox.setText(self.param.defaultValue())
-            self.verticalLayout.addWidget(self.defaultTextBox)
         elif (self.paramType == parameters.PARAMETER_FILE or
               isinstance(self.param, QgsProcessingParameterFile)):
             self.verticalLayout.addWidget(QLabel(self.tr('Type')))
@@ -541,10 +532,6 @@ class ModelerParameterDefinitionDialog(QDialog):
             self.param = QgsProcessingParameterExpression(name, description,
                                                           str(self.defaultEdit.expression()),
                                                           parent)
-        elif (self.paramType == parameters.PARAMETER_STRING or
-              isinstance(self.param, QgsProcessingParameterString)):
-            self.param = QgsProcessingParameterString(name, description,
-                                                      str(self.defaultTextBox.text()))
         elif (self.paramType == parameters.PARAMETER_EXTENT or
               isinstance(self.param, QgsProcessingParameterExtent)):
             self.param = QgsProcessingParameterExtent(name, description)

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -54,14 +54,11 @@ from qgis.core import (QgsApplication,
                        QgsProcessingParameterRange,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterEnum,
-                       QgsProcessingParameterString,
                        QgsProcessingParameterExpression,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterBand,
-                       QgsProcessingParameterLayout,
-                       QgsProcessingParameterLayoutItem,
                        QgsProcessingDestinationParameter,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterFileDestination,
@@ -82,7 +79,6 @@ class ModelerParameterDefinitionDialog(QDialog):
     def use_legacy_dialog(param=None, paramType=None):
         if paramType in (parameters.PARAMETER_TABLE_FIELD,
                          parameters.PARAMETER_BAND,
-                         parameters.PARAMETER_LAYOUTITEM,
                          parameters.PARAMETER_VECTOR,
                          parameters.PARAMETER_TABLE,
                          parameters.PARAMETER_MULTIPLE,
@@ -98,7 +94,6 @@ class ModelerParameterDefinitionDialog(QDialog):
             return True
         elif isinstance(param, (QgsProcessingParameterField,
                                 QgsProcessingParameterBand,
-                                QgsProcessingParameterLayoutItem,
                                 QgsProcessingParameterFeatureSource,
                                 QgsProcessingParameterVectorLayer,
                                 QgsProcessingParameterMultipleLayers,
@@ -206,20 +201,6 @@ class ModelerParameterDefinitionDialog(QDialog):
                     self.parentCombo.addItem(definition.description(), definition.name())
                     if self.param is not None:
                         if self.param.parentLayerParameterName() == definition.name():
-                            self.parentCombo.setCurrentIndex(idx)
-                    idx += 1
-            self.verticalLayout.addWidget(self.parentCombo)
-        elif self.paramType == parameters.PARAMETER_LAYOUTITEM or \
-                isinstance(self.param, QgsProcessingParameterLayoutItem):
-            self.verticalLayout.addWidget(QLabel(self.tr('Parent layout')))
-            self.parentCombo = QComboBox()
-            idx = 0
-            for param in list(self.alg.parameterComponents().values()):
-                definition = self.alg.parameterDefinition(param.parameterName())
-                if isinstance(definition, (QgsProcessingParameterLayout)):
-                    self.parentCombo.addItem(definition.description(), definition.name())
-                    if self.param is not None:
-                        if self.param.parentLayoutParameterName() == definition.name():
                             self.parentCombo.setCurrentIndex(idx)
                     idx += 1
             self.verticalLayout.addWidget(self.parentCombo)
@@ -451,14 +432,6 @@ class ModelerParameterDefinitionDialog(QDialog):
                 return
             parent = self.parentCombo.currentData()
             self.param = QgsProcessingParameterBand(name, description, None, parent)
-        elif (self.paramType == parameters.PARAMETER_LAYOUTITEM or
-              isinstance(self.param, QgsProcessingParameterLayoutItem)):
-            if self.parentCombo.currentIndex() < 0:
-                QMessageBox.warning(self, self.tr('Unable to define parameter'),
-                                    self.tr('Wrong or missing parameter values'))
-                return
-            parent = self.parentCombo.currentData()
-            self.param = QgsProcessingParameterLayoutItem(name, description, None, parent)
         elif (self.paramType == parameters.PARAMETER_MAP_LAYER or
               isinstance(self.param, QgsProcessingParameterMapLayer)):
             self.param = QgsProcessingParameterMapLayer(

--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -102,6 +102,8 @@ class ModelerScene(QGraphicsScene):
             parent_name = None
             if hasattr(parameter_def, 'parentLayerParameterName') and parameter_def.parentLayerParameterName():
                 parent_name = parameter_def.parentLayerParameterName()
+            if hasattr(parameter_def, 'parentLayoutParameterName') and parameter_def.parentLayoutParameterName():
+                parent_name = parameter_def.parentLayoutParameterName()
             elif hasattr(parameter_def, 'parentParameterName') and parameter_def.parentParameterName():
                 parent_name = parameter_def.parentParameterName()
             if parent_name:

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgsrectangle.h"
 #include "qgsproperty.h"
+#include "qgssymbollayerutils.h"
 
 QgsUnitTypes::DistanceUnit QgsXmlUtils::readMapUnits( const QDomElement &element )
 {
@@ -164,6 +165,11 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
       element.setAttribute( QStringLiteral( "value" ), value.toString() );
       break;
 
+    case QVariant::Color:
+      element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "color" ) );
+      element.setAttribute( QStringLiteral( "value" ), value.value< QColor >().isValid() ? QgsSymbolLayerUtils::encodeColor( value.value< QColor >() ) : QString() );
+      break;
+
     case QVariant::UserType:
     {
       if ( value.canConvert< QgsProperty >() )
@@ -233,6 +239,10 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
   else if ( type == QLatin1String( "bool" ) )
   {
     return element.attribute( QStringLiteral( "value" ) ) == QLatin1String( "true" );
+  }
+  else if ( type == QLatin1String( "color" ) )
+  {
+    return element.attribute( QStringLiteral( "value" ) ).isEmpty() ? QColor() : QgsSymbolLayerUtils::decodeColor( element.attribute( QStringLiteral( "value" ) ) );
   }
   else if ( type == QLatin1String( "Map" ) )
   {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -205,6 +205,7 @@ SET(QGIS_GUI_SRCS
   processing/qgsprocessingmatrixparameterdialog.cpp
   processing/qgsprocessingmodelerparameterwidget.cpp
   processing/qgsprocessingmultipleselectiondialog.cpp
+  processing/qgsprocessingparameterdefinitionwidget.cpp
   processing/qgsprocessingrecentalgorithmlog.cpp
   processing/qgsprocessingtoolboxmodel.cpp
   processing/qgsprocessingtoolboxtreeview.cpp
@@ -780,6 +781,7 @@ SET(QGIS_GUI_MOC_HDRS
   processing/qgsprocessingmatrixparameterdialog.h
   processing/qgsprocessingmodelerparameterwidget.h
   processing/qgsprocessingmultipleselectiondialog.h
+  processing/qgsprocessingparameterdefinitionwidget.h
   processing/qgsprocessingrecentalgorithmlog.h
   processing/qgsprocessingtoolboxmodel.h
   processing/qgsprocessingtoolboxtreeview.h

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -130,3 +130,15 @@ QgsProcessingModelerParameterWidget *QgsProcessingGuiRegistry::createModelerPara
   return mParameterWidgetFactories.value( parameterType )->createModelerWidgetWrapper( model, childId, parameter, context );
 }
 
+QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingGuiRegistry::createParameterDefinitionWidget( const QString &type,
+    QgsProcessingContext &context,
+    const QgsProcessingParameterWidgetContext &widgetContext,
+    const QgsProcessingParameterDefinition *definition,
+    const QgsProcessingAlgorithm *algorithm )
+{
+  if ( !mParameterWidgetFactories.contains( type ) )
+    return nullptr;
+
+  return mParameterWidgetFactories.value( type )->createParameterDefinitionWidget( context, widgetContext, definition, algorithm );
+}
+

--- a/src/gui/processing/qgsprocessingguiregistry.h
+++ b/src/gui/processing/qgsprocessingguiregistry.h
@@ -29,6 +29,7 @@ class QgsProcessingAlgorithm;
 class QgsProcessingAlgorithmConfigurationWidget;
 class QgsProcessingAlgorithmConfigurationWidgetFactory;
 class QgsProcessingModelerParameterWidget;
+class QgsProcessingParameterWidgetContext;
 
 /**
  * The QgsProcessingGuiRegistry is a home for widgets for processing
@@ -137,6 +138,33 @@ class GUI_EXPORT QgsProcessingGuiRegistry
     QgsProcessingModelerParameterWidget *createModelerParameterWidget( QgsProcessingModelAlgorithm *model,
         const QString &childId,
         const QgsProcessingParameterDefinition *parameter, QgsProcessingContext &context ) SIP_FACTORY;
+
+    /**
+     * Creates a new parameter definition widget allowing for configuration of an instance of
+     * a specific parameter \a type.
+     *
+     * The \a context argument must specify a Processing context, which will be used
+     * by the widget to evaluate existing \a definition properties such as default values. Similarly,
+     * the \a widgetContext argument specifies the wider GUI context in which the widget
+     * will be used.
+     *
+     * The optional \a definition argument may specify an existing parameter definition which
+     * will be reflected in the initial state of the returned widget. If \a definition is NULLPTR,
+     * then the returned widget will use default settings instead.
+     *
+     * Additionally, the optional \a algorithm parameter may be used to specify the algorithm or model
+     * associated with the parameter.
+     *
+     * If NULLPTR is returned for a particular parameter \a type,
+     * it indicates that the parameter type cannot be configured via GUI.
+     *
+     * \since QGIS 3.10
+     */
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget( const QString &type,
+        QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = nullptr,
+        const QgsProcessingAlgorithm *algorithm = nullptr ) SIP_FACTORY;
 
   private:
 

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
@@ -28,6 +28,7 @@
 #include <QCheckBox>
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QMessageBox>
 
 QgsProcessingAbstractParameterDefinitionWidget::QgsProcessingAbstractParameterDefinitionWidget( QgsProcessingContext &,
     const QgsProcessingParameterWidgetContext &,
@@ -146,4 +147,15 @@ QgsProcessingParameterDefinitionDialog::QgsProcessingParameterDefinitionDialog( 
 QgsProcessingParameterDefinition *QgsProcessingParameterDefinitionDialog::createParameter( const QString &name ) const
 {
   return mWidget->createParameter( name );
+}
+
+void QgsProcessingParameterDefinitionDialog::accept()
+{
+  if ( mWidget->mDescriptionLineEdit->text().isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Unable to define parameter" ),
+                          tr( "Invalid parameter name" ) );
+    return;
+  }
+  QDialog::accept();
 }

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
@@ -1,0 +1,149 @@
+/***************************************************************************
+                         qgsprocessingparameterdefinitionwidget.cpp
+                         ------------------------------------------
+    begin                : July 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgsprocessingparameterdefinitionwidget.h"
+#include "qgsgui.h"
+#include "qgsprocessingguiregistry.h"
+#include "qgsapplication.h"
+#include "qgsprocessingregistry.h"
+#include "qgsprocessingparametertype.h"
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+
+QgsProcessingAbstractParameterDefinitionWidget::QgsProcessingAbstractParameterDefinitionWidget( QgsProcessingContext &,
+    const QgsProcessingParameterWidgetContext &,
+    const QgsProcessingParameterDefinition *,
+    const QgsProcessingAlgorithm *, QWidget *parent )
+  : QWidget( parent )
+{
+
+}
+
+//
+// QgsProcessingParameterDefinitionWidget
+//
+
+QgsProcessingParameterDefinitionWidget::QgsProcessingParameterDefinitionWidget( const QString &type,
+    QgsProcessingContext &context,
+    const QgsProcessingParameterWidgetContext &widgetContext,
+    const QgsProcessingParameterDefinition *definition,
+    const QgsProcessingAlgorithm *algorithm, QWidget *parent )
+  : QWidget( parent )
+  , mType( type )
+{
+  mDefinitionWidget = QgsGui::instance()->processingGuiRegistry()->createParameterDefinitionWidget( type, context, widgetContext, definition, algorithm );
+
+  QVBoxLayout *vlayout = new QVBoxLayout();
+
+  QLabel *label = new QLabel( tr( "Description" ) );
+  vlayout->addWidget( label );
+  mDescriptionLineEdit = new QLineEdit();
+  vlayout->addWidget( mDescriptionLineEdit );
+
+  if ( definition )
+  {
+    mDescriptionLineEdit->setText( definition->description() );
+  }
+
+  if ( mDefinitionWidget )
+    vlayout->addWidget( mDefinitionWidget );
+
+  vlayout->addSpacing( 20 );
+  mRequiredCheckBox = new QCheckBox( tr( "Mandatory" ) );
+  if ( definition )
+    mRequiredCheckBox->setChecked( !( definition->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
+  else
+    mRequiredCheckBox->setChecked( true );
+  vlayout->addWidget( mRequiredCheckBox );
+
+  mAdvancedCheckBox = new QCheckBox( tr( "Advanced" ) );
+  if ( definition )
+    mAdvancedCheckBox->setChecked( definition->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
+  else
+    mAdvancedCheckBox->setChecked( false );
+  vlayout->addWidget( mAdvancedCheckBox );
+
+  vlayout->addStretch();
+  setLayout( vlayout );
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterDefinitionWidget::createParameter( const QString &name ) const
+{
+  std::unique_ptr< QgsProcessingParameterDefinition > param;
+  QgsProcessingParameterDefinition::Flags flags = nullptr;
+
+  if ( !mRequiredCheckBox->isChecked() )
+    flags |= QgsProcessingParameterDefinition::FlagOptional;
+  if ( mAdvancedCheckBox->isChecked() )
+    flags |= QgsProcessingParameterDefinition::FlagAdvanced;
+
+  if ( mDefinitionWidget )
+  {
+    // if a specific definition widget exists, get it to create the parameter (since it will know
+    // how to set all the additional properties of that parameter, which we don't)
+    param.reset( mDefinitionWidget->createParameter( name, mDescriptionLineEdit->text(), flags ) );
+  }
+  else if ( QgsApplication::processingRegistry()->parameterType( mType ) )
+  {
+    // otherwise, just create a default version of the parameter
+    param.reset( QgsApplication::processingRegistry()->parameterType( mType )->create( name ) );
+    if ( param )
+    {
+      param->setDescription( mDescriptionLineEdit->text() );
+      param->setFlags( flags );
+    }
+  }
+
+  return param.release();
+}
+
+//
+// QgsProcessingParameterDefinitionDialog
+//
+
+QgsProcessingParameterDefinitionDialog::QgsProcessingParameterDefinitionDialog( const QString &type,
+    QgsProcessingContext &context,
+    const QgsProcessingParameterWidgetContext &widgetContext,
+    const QgsProcessingParameterDefinition *definition,
+    const QgsProcessingAlgorithm *algorithm,
+    QWidget *parent )
+  : QDialog( parent )
+{
+  QVBoxLayout *vLayout = new QVBoxLayout();
+  mWidget = new QgsProcessingParameterDefinitionWidget( type, context, widgetContext, definition, algorithm );
+  vLayout->addWidget( mWidget );
+  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok );
+  connect( bbox, &QDialogButtonBox::accepted, this, &QgsProcessingParameterDefinitionDialog::accept );
+  connect( bbox, &QDialogButtonBox::rejected, this, &QgsProcessingParameterDefinitionDialog::reject );
+  vLayout->addWidget( bbox );
+  setLayout( vLayout );
+  setWindowTitle( definition ? tr( "%1 Parameter Definition" ).arg( definition->description() )
+                  : QgsApplication::processingRegistry()->parameterType( type ) ? tr( "%1 Parameter Definition" ).arg( QgsApplication::processingRegistry()->parameterType( type )->name() ) :
+                  tr( "Parameter Definition" ) );
+  setObjectName( QStringLiteral( "QgsProcessingParameterDefinitionDialog" ) );
+  QgsGui::enableAutoGeometryRestore( this );
+}
+
+QgsProcessingParameterDefinition *QgsProcessingParameterDefinitionDialog::createParameter( const QString &name ) const
+{
+  return mWidget->createParameter( name );
+}

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
@@ -122,6 +122,8 @@ class GUI_EXPORT QgsProcessingParameterDefinitionWidget: public QWidget
     QCheckBox *mRequiredCheckBox = nullptr;
     QCheckBox *mAdvancedCheckBox = nullptr;
 
+    friend class QgsProcessingParameterDefinitionDialog;
+
 };
 
 /**
@@ -164,6 +166,9 @@ class GUI_EXPORT QgsProcessingParameterDefinitionDialog: public QDialog
      * The \a name parameter specifies the name for the newly created parameter.
      */
     QgsProcessingParameterDefinition *createParameter( const QString &name = QString() ) const SIP_FACTORY;
+
+  public slots:
+    void accept() override;
 
   private:
 

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
@@ -1,0 +1,175 @@
+/***************************************************************************
+                         qgsprocessingparameterdefinitionwidget.h
+                         ----------------------------------------
+    begin                : July 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSPROCESSINGPARAMETERDEFINITIONWIDGET_H
+#define QGSPROCESSINGPARAMETERDEFINITIONWIDGET_H
+
+#include <QWidget>
+#include <QDialog>
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsprocessingparameters.h"
+
+class QgsProcessingParameterWidgetContext;
+class QLineEdit;
+class QCheckBox;
+
+/**
+ * Abstract base class for widgets which allow users to specify the properties of a
+ * Processing parameter.
+ *
+ * \ingroup gui
+ * \since QGIS 3.10
+ */
+class GUI_EXPORT QgsProcessingAbstractParameterDefinitionWidget : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Creates a new QgsProcessingAbstractParameterDefinitionWidget, with the specified \a parent widget.
+     *
+     * The \a context argument must specify a Processing context, which will be used
+     * by the widget to evaluate existing \a definition properties such as default values. Similarly,
+     * the \a widgetContext argument specifies the wider GUI context in which the widget
+     * will be used.
+     *
+     * The optional \a definition argument may be used to provide a parameter definition to use
+     * to initially populate the widget's state.
+     *
+     * Additionally, the optional \a algorithm parameter may be used to specify the algorithm or model
+     * associated with the parameter.
+     */
+    QgsProcessingAbstractParameterDefinitionWidget( QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = nullptr,
+        const QgsProcessingAlgorithm *algorithm = nullptr, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns a new instance of a parameter definition, using the current settings defined in the dialog.
+     *
+     * Common properties for parameters, including the \a name, \a description, and parameter \a flags are passed to the
+     * method. Subclass implementations must use these properties when crafting a parameter definition which
+     * also respects the additional properties specific to the parameter type handled by the widget sublass.
+     */
+    virtual QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const = 0 SIP_FACTORY;
+};
+
+
+/**
+ * A widget which allow users to specify the properties of a Processing parameter.
+ *
+ * \ingroup gui
+ * \since QGIS 3.10
+ */
+class GUI_EXPORT QgsProcessingParameterDefinitionWidget: public QWidget
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for QgsProcessingParameterDefinitionWidget, for a parameter of the
+     * specified \a type.
+     *
+     * The \a context argument must specify a Processing context, which will be used
+     * by the widget to evaluate existing \a definition properties such as default values. Similarly,
+     * the \a widgetContext argument specifies the wider GUI context in which the widget
+     * will be used.
+     *
+     * The optional \a definition argument may be used to provide a parameter definition to use
+     * to initially populate the widget's state.
+     *
+     * Additionally, the optional \a algorithm parameter may be used to specify the algorithm or model
+     * associated with the parameter.
+     *
+     */
+    QgsProcessingParameterDefinitionWidget( const QString &type,
+                                            QgsProcessingContext &context,
+                                            const QgsProcessingParameterWidgetContext &widgetContext,
+                                            const QgsProcessingParameterDefinition *definition = nullptr,
+                                            const QgsProcessingAlgorithm *algorithm = nullptr,
+                                            QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns a new instance of a parameter definition, using the current settings defined in the dialog.
+     *
+     * The \a name parameter specifies the name for the newly created parameter.
+     */
+    QgsProcessingParameterDefinition *createParameter( const QString &name = QString() ) const SIP_FACTORY;
+
+  private:
+
+    QString mType;
+    QgsProcessingAbstractParameterDefinitionWidget *mDefinitionWidget = nullptr;
+    QLineEdit *mDescriptionLineEdit = nullptr;
+    QCheckBox *mRequiredCheckBox = nullptr;
+    QCheckBox *mAdvancedCheckBox = nullptr;
+
+};
+
+/**
+ * A dialog which allow users to specify the properties of a Processing parameter.
+ *
+ * \ingroup gui
+ * \since QGIS 3.10
+ */
+class GUI_EXPORT QgsProcessingParameterDefinitionDialog: public QDialog
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for QgsProcessingParameterDefinitionDialog, for a parameter of the
+     * specified \a type.
+     *
+     * The \a context argument must specify a Processing context, which will be used
+     * by the widget to evaluate existing \a definition properties such as default values. Similarly,
+     * the \a widgetContext argument specifies the wider GUI context in which the widget
+     * will be used.
+     *
+     * The optional \a definition argument may be used to provide a parameter definition to use
+     * to initially populate the dialog's state.
+     *
+     * Additionally, the optional \a algorithm parameter may be used to specify the algorithm or model
+     * associated with the parameter.
+     *
+     */
+    QgsProcessingParameterDefinitionDialog( const QString &type,
+                                            QgsProcessingContext &context,
+                                            const QgsProcessingParameterWidgetContext &widgetContext,
+                                            const QgsProcessingParameterDefinition *definition = nullptr,
+                                            const QgsProcessingAlgorithm *algorithm = nullptr,
+                                            QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns a new instance of a parameter definition, using the current settings defined in the dialog.
+     *
+     * The \a name parameter specifies the name for the newly created parameter.
+     */
+    QgsProcessingParameterDefinition *createParameter( const QString &name = QString() ) const SIP_FACTORY;
+
+  private:
+
+    QgsProcessingParameterDefinitionWidget *mWidget = nullptr;
+
+};
+
+
+#endif // QGSPROCESSINGPARAMETERDEFINITIONWIDGET_H

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -315,6 +315,13 @@ QgsProcessingModelerParameterWidget *QgsProcessingParameterWidgetFactoryInterfac
   return widget.release();
 }
 
+QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingParameterWidgetFactoryInterface::createParameterDefinitionWidget( QgsProcessingContext &,
+    const QgsProcessingParameterWidgetContext &, const QgsProcessingParameterDefinition *,
+    const QgsProcessingAlgorithm * )
+{
+  return nullptr;
+}
+
 QString QgsProcessingParameterWidgetFactoryInterface::modelerExpressionFormatString() const
 {
   return QString();

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -37,6 +37,7 @@ class QgsVectorLayer;
 class QgsProcessingModelAlgorithm;
 class QgsMapCanvas;
 class QgsProcessingAlgorithm;
+class QgsProcessingAbstractParameterDefinitionWidget;
 
 /**
  * \class QgsProcessingContextGenerator
@@ -451,6 +452,36 @@ class GUI_EXPORT QgsProcessingParameterWidgetFactoryInterface
         const QString &childId,
         const QgsProcessingParameterDefinition *parameter,
         QgsProcessingContext &context );
+
+    /**
+     * Creates a new parameter definition widget allowing for configuration of an instance of
+     * the parameter type handled by this factory.
+     *
+     * The \a context argument must specify a Processing context, which will be used
+     * by the widget to evaluate existing \a definition properties such as default values. Similarly,
+     * the \a widgetContext argument specifies the wider GUI context in which the widget
+     * will be used.
+     *
+     * The optional \a definition argument may specify a parameter definition which
+     * should be reflected in the initial state of the returned widget. Subclasses must
+     * ensure that they correctly handle both the case when a initial \a definition is
+     * passed, or when \a definition is NULLPTR (in which case sensible defaults should
+     * be shown in the returned widget).
+     *
+     * Additionally, the optional \a algorithm parameter may be used to specify the algorithm or model
+     * associated with the parameter.
+     *
+     * If a factory subclass returns NULLPTR for this method (i.e. as the base class implemention does),
+     * it indicates that the parameter type cannot be configured via GUI. In this case the parameter
+     * type will not be configurable when users add it as an input to their graphical models.
+     *
+     * \since QGIS 3.10
+     */
+    virtual QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = nullptr,
+      const QgsProcessingAlgorithm *algorithm = nullptr ) SIP_FACTORY;
 
   protected:
 

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -471,7 +471,7 @@ class GUI_EXPORT QgsProcessingParameterWidgetFactoryInterface
      * Additionally, the optional \a algorithm parameter may be used to specify the algorithm or model
      * associated with the parameter.
      *
-     * If a factory subclass returns NULLPTR for this method (i.e. as the base class implemention does),
+     * If a factory subclass returns NULLPTR for this method (i.e. as the base class implementation does),
      * it indicates that the parameter type cannot be configured via GUI. In this case the parameter
      * type will not be configurable when users add it as an input to their graphical models.
      *

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -359,6 +359,32 @@ QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingCrsWidgetWrapper::crea
 // QgsProcessingStringWidgetWrapper
 //
 
+
+QgsProcessingStringParameterDefinitionWidget::QgsProcessingStringParameterDefinitionWidget( QgsProcessingContext &context, const QgsProcessingParameterWidgetContext &widgetContext, const QgsProcessingParameterDefinition *definition, const QgsProcessingAlgorithm *algorithm, QWidget *parent )
+  : QgsProcessingAbstractParameterDefinitionWidget( context, widgetContext, definition, algorithm, parent )
+{
+  QVBoxLayout *vlayout = new QVBoxLayout();
+  vlayout->setMargin( 0 );
+  vlayout->setContentsMargins( 0, 0, 0, 0 );
+
+  vlayout->addWidget( new QLabel( tr( "Default value" ) ) );
+
+  mDefaultLineEdit = new QLineEdit();
+  if ( const QgsProcessingParameterString *stringParam = dynamic_cast<const QgsProcessingParameterString *>( definition ) )
+    mDefaultLineEdit->setText( QgsProcessingParameters::parameterAsString( stringParam, stringParam->defaultValue(), context ) );
+  vlayout->addWidget( mDefaultLineEdit );
+  setLayout( vlayout );
+}
+
+QgsProcessingParameterDefinition *QgsProcessingStringParameterDefinitionWidget::createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const
+{
+  auto param = qgis::make_unique< QgsProcessingParameterString >( name, description, mDefaultLineEdit->text() );
+  param->setFlags( flags );
+  return param.release();
+}
+
+
+
 QgsProcessingStringWidgetWrapper::QgsProcessingStringWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
 {
@@ -463,6 +489,11 @@ QString QgsProcessingStringWidgetWrapper::parameterType() const
 QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingStringWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
 {
   return new QgsProcessingStringWidgetWrapper( parameter, type );
+}
+
+QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingStringWidgetWrapper::createParameterDefinitionWidget( QgsProcessingContext &context, const QgsProcessingParameterWidgetContext &widgetContext, const QgsProcessingParameterDefinition *definition, const QgsProcessingAlgorithm *algorithm )
+{
+  return new QgsProcessingStringParameterDefinitionWidget( context, widgetContext, definition, algorithm );
 }
 
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -1888,8 +1888,6 @@ QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingEnumWidgetWrapper::cre
   return new QgsProcessingEnumWidgetWrapper( parameter, type );
 }
 
-
-
 //
 // QgsProcessingLayoutWidgetWrapper
 //

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -44,6 +44,7 @@
 #include <QToolButton>
 #include <QLabel>
 #include <QHBoxLayout>
+#include <QVBoxLayout>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLineEdit>
@@ -57,6 +58,31 @@
 //
 // QgsProcessingBooleanWidgetWrapper
 //
+
+
+QgsProcessingBooleanParameterDefinitionWidget::QgsProcessingBooleanParameterDefinitionWidget( QgsProcessingContext &context, const QgsProcessingParameterWidgetContext &widgetContext, const QgsProcessingParameterDefinition *definition, const QgsProcessingAlgorithm *algorithm, QWidget *parent )
+  : QgsProcessingAbstractParameterDefinitionWidget( context, widgetContext, definition, algorithm, parent )
+{
+  QVBoxLayout *vlayout = new QVBoxLayout();
+  vlayout->setMargin( 0 );
+  vlayout->setContentsMargins( 0, 0, 0, 0 );
+
+  mDefaultCheckBox = new QCheckBox( tr( "Checked" ) );
+  if ( const QgsProcessingParameterBoolean *boolParam = dynamic_cast<const QgsProcessingParameterBoolean *>( definition ) )
+    mDefaultCheckBox->setChecked( QgsProcessingParameters::parameterAsBool( boolParam, boolParam->defaultValue(), context ) );
+  else
+    mDefaultCheckBox->setChecked( false );
+  vlayout->addWidget( mDefaultCheckBox );
+  setLayout( vlayout );
+}
+
+QgsProcessingParameterDefinition *QgsProcessingBooleanParameterDefinitionWidget::createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const
+{
+  auto param = qgis::make_unique< QgsProcessingParameterBoolean >( name, description, mDefaultCheckBox->isChecked() );
+  param->setFlags( flags );
+  return param.release();
+}
+
 
 QgsProcessingBooleanWidgetWrapper::QgsProcessingBooleanWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
   : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
@@ -189,6 +215,11 @@ QString QgsProcessingBooleanWidgetWrapper::parameterType() const
 QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingBooleanWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
 {
   return new QgsProcessingBooleanWidgetWrapper( parameter, type );
+}
+
+QgsProcessingAbstractParameterDefinitionWidget *QgsProcessingBooleanWidgetWrapper::createParameterDefinitionWidget( QgsProcessingContext &context, const QgsProcessingParameterWidgetContext &widgetContext, const QgsProcessingParameterDefinition *definition, const QgsProcessingAlgorithm *algorithm )
+{
+  return new QgsProcessingBooleanParameterDefinitionWidget( context, widgetContext, definition, algorithm );
 }
 
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -788,6 +788,25 @@ class GUI_EXPORT QgsProcessingPointWidgetWrapper : public QgsAbstractProcessingP
     friend class TestProcessingGui;
 };
 
+
+class GUI_EXPORT QgsProcessingColorParameterDefinitionWidget : public QgsProcessingAbstractParameterDefinitionWidget
+{
+    Q_OBJECT
+  public:
+
+    QgsProcessingColorParameterDefinitionWidget( QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = nullptr,
+        const QgsProcessingAlgorithm *algorithm = nullptr, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const override;
+
+  private:
+
+    QgsColorButton *mDefaultColorButton = nullptr;
+    QCheckBox *mAllowOpacity = nullptr;
+
+};
+
 class GUI_EXPORT QgsProcessingColorWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
 {
     Q_OBJECT
@@ -800,6 +819,11 @@ class GUI_EXPORT QgsProcessingColorWidgetWrapper : public QgsAbstractProcessingP
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
     QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = nullptr,
+      const QgsProcessingAlgorithm *algorithm = nullptr ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -51,6 +51,23 @@ class QgsColorButton;
 
 ///@cond PRIVATE
 
+class GUI_EXPORT QgsProcessingBooleanParameterDefinitionWidget : public QgsProcessingAbstractParameterDefinitionWidget
+{
+    Q_OBJECT
+  public:
+
+    QgsProcessingBooleanParameterDefinitionWidget( QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = nullptr,
+        const QgsProcessingAlgorithm *algorithm = nullptr, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const override;
+
+  private:
+
+    QCheckBox *mDefaultCheckBox = nullptr;
+
+};
+
 class GUI_EXPORT QgsProcessingBooleanWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
 {
     Q_OBJECT
@@ -63,6 +80,11 @@ class GUI_EXPORT QgsProcessingBooleanWidgetWrapper : public QgsAbstractProcessin
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
     QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = nullptr,
+      const QgsProcessingAlgorithm *algorithm = nullptr ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -143,6 +143,25 @@ class GUI_EXPORT QgsProcessingCrsWidgetWrapper : public QgsAbstractProcessingPar
     friend class TestProcessingGui;
 };
 
+
+
+class GUI_EXPORT QgsProcessingStringParameterDefinitionWidget : public QgsProcessingAbstractParameterDefinitionWidget
+{
+    Q_OBJECT
+  public:
+
+    QgsProcessingStringParameterDefinitionWidget( QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = nullptr,
+        const QgsProcessingAlgorithm *algorithm = nullptr, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const override;
+
+  private:
+
+    QLineEdit *mDefaultLineEdit = nullptr;
+
+};
+
 class GUI_EXPORT QgsProcessingStringWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
 {
     Q_OBJECT
@@ -155,6 +174,11 @@ class GUI_EXPORT QgsProcessingStringWidgetWrapper : public QgsAbstractProcessing
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
     QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = nullptr,
+      const QgsProcessingAlgorithm *algorithm = nullptr ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -21,6 +21,7 @@
 
 #define SIP_NO_FILE
 #include "qgsprocessingwidgetwrapper.h"
+#include "qgsprocessingparameterdefinitionwidget.h"
 #include "qgsmaptool.h"
 
 #include <QAbstractButton>

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -627,6 +627,24 @@ class GUI_EXPORT QgsProcessingLayoutWidgetWrapper : public QgsAbstractProcessing
 };
 
 
+
+class GUI_EXPORT QgsProcessingLayoutItemParameterDefinitionWidget : public QgsProcessingAbstractParameterDefinitionWidget
+{
+    Q_OBJECT
+  public:
+
+    QgsProcessingLayoutItemParameterDefinitionWidget( QgsProcessingContext &context,
+        const QgsProcessingParameterWidgetContext &widgetContext,
+        const QgsProcessingParameterDefinition *definition = nullptr,
+        const QgsProcessingAlgorithm *algorithm = nullptr, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    QgsProcessingParameterDefinition *createParameter( const QString &name, const QString &description, QgsProcessingParameterDefinition::Flags flags ) const override;
+
+  private:
+
+    QComboBox *mParentLayoutComboBox = nullptr;
+
+};
+
 class GUI_EXPORT QgsProcessingLayoutItemWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
 {
     Q_OBJECT
@@ -639,6 +657,11 @@ class GUI_EXPORT QgsProcessingLayoutItemWidgetWrapper : public QgsAbstractProces
     // QgsProcessingParameterWidgetFactoryInterface
     QString parameterType() const override;
     QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+    QgsProcessingAbstractParameterDefinitionWidget *createParameterDefinitionWidget(
+      QgsProcessingContext &context,
+      const QgsProcessingParameterWidgetContext &widgetContext,
+      const QgsProcessingParameterDefinition *definition = nullptr,
+      const QgsProcessingAlgorithm *algorithm = nullptr ) override;
 
     // QgsProcessingParameterWidgetWrapper interface
     QWidget *createWidget() override SIP_FACTORY;

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -2889,6 +2889,34 @@ void TestProcessingGui::testLayoutItemWrapper()
   // modeler wrapper
   testWrapper( QgsProcessingGui::Modeler );
 
+
+  // config widget
+  QgsProcessingParameterWidgetContext widgetContext;
+  QgsProcessingContext context;
+  std::unique_ptr< QgsProcessingParameterDefinitionWidget > widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "layoutitem" ), context, widgetContext );
+  std::unique_ptr< QgsProcessingParameterDefinition > def( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) ); // should default to mandatory
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+
+  // using a parameter definition as initial values
+  QgsProcessingParameterLayoutItem itemParam( QStringLiteral( "n" ), QStringLiteral( "test desc" ), QVariant(), QStringLiteral( "parent" ) );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "layoutitem" ), context, widgetContext, &itemParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+  QCOMPARE( static_cast< QgsProcessingParameterLayoutItem * >( def.get() )->parentLayoutParameterName(), QStringLiteral( "parent" ) );
+  itemParam.setFlags( QgsProcessingParameterDefinition::FlagAdvanced | QgsProcessingParameterDefinition::FlagOptional );
+  itemParam.setParentLayoutParameterName( QString() );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "layoutitem" ), context, widgetContext, &itemParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
+  QVERIFY( static_cast< QgsProcessingParameterLayoutItem * >( def.get() )->parentLayoutParameterName().isEmpty() );
 }
 
 void TestProcessingGui::testPointPanel()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -912,6 +912,34 @@ void TestProcessingGui::testStringWrapper()
   QCOMPARE( l->toolTip(), param.toolTip() );
   delete w;
   delete l;
+
+
+  // config widget
+  QgsProcessingParameterWidgetContext widgetContext;
+  std::unique_ptr< QgsProcessingParameterDefinitionWidget > widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "string" ), context, widgetContext );
+  std::unique_ptr< QgsProcessingParameterDefinition > def( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) ); // should default to mandatory
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+
+  // using a parameter definition as initial values
+  QgsProcessingParameterString stringParam( QStringLiteral( "n" ), QStringLiteral( "test desc" ), QStringLiteral( "aaa" ), false );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "string" ), context, widgetContext, &stringParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+  QCOMPARE( static_cast< QgsProcessingParameterString * >( def.get() )->defaultValue().toString(), QStringLiteral( "aaa" ) );
+  stringParam.setFlags( QgsProcessingParameterDefinition::FlagAdvanced | QgsProcessingParameterDefinition::FlagOptional );
+  stringParam.setDefaultValue( QString() );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "string" ), context, widgetContext, &stringParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
+  QVERIFY( static_cast< QgsProcessingParameterString * >( def.get() )->defaultValue().toString().isEmpty() );
 }
 
 void TestProcessingGui::testFileWrapper()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -3177,6 +3177,37 @@ void TestProcessingGui::testColorWrapper()
 
   // modeler wrapper
   testWrapper( QgsProcessingGui::Modeler );
+
+  // config widget
+  QgsProcessingParameterWidgetContext widgetContext;
+  QgsProcessingContext context;
+  std::unique_ptr< QgsProcessingParameterDefinitionWidget > widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "color" ), context, widgetContext );
+  std::unique_ptr< QgsProcessingParameterDefinition > def( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) ); // should default to mandatory
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+  QVERIFY( static_cast< QgsProcessingParameterColor * >( def.get() )->opacityEnabled() ); // should default to true
+
+  // using a parameter definition as initial values
+  QgsProcessingParameterColor colorParam( QStringLiteral( "n" ), QStringLiteral( "test desc" ), QColor( 255, 0, 0, 100 ), true );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "color" ), context, widgetContext, &colorParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+  QCOMPARE( static_cast< QgsProcessingParameterColor * >( def.get() )->defaultValue().value< QColor >(), QColor( 255, 0, 0, 100 ) );
+  QVERIFY( static_cast< QgsProcessingParameterColor * >( def.get() )->opacityEnabled() );
+  colorParam.setFlags( QgsProcessingParameterDefinition::FlagAdvanced | QgsProcessingParameterDefinition::FlagOptional );
+  colorParam.setOpacityEnabled( false );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "color" ), context, widgetContext, &colorParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
+  QCOMPARE( static_cast< QgsProcessingParameterColor * >( def.get() )->defaultValue().value< QColor >(), QColor( 255, 0, 0 ) );
+  QVERIFY( !static_cast< QgsProcessingParameterColor * >( def.get() )->opacityEnabled() );
 }
 
 void TestProcessingGui::mapLayerComboBox()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -3206,7 +3206,7 @@ void TestProcessingGui::testColorWrapper()
   QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
   QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
   QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
-  QCOMPARE( static_cast< QgsProcessingParameterColor * >( def.get() )->defaultValue().value< QColor >(), QColor( 255, 0, 0 ) );
+  QCOMPARE( static_cast< QgsProcessingParameterColor * >( def.get() )->defaultValue().value< QColor >(), QColor( 255, 0, 0 ) ); // (no opacity!)
   QVERIFY( !static_cast< QgsProcessingParameterColor * >( def.get() )->opacityEnabled() );
 }
 

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -712,6 +712,33 @@ void TestProcessingGui::testBooleanWrapper()
   QCOMPARE( l->toolTip(), param.toolTip() );
   delete w;
   delete l;
+
+  // config widget
+  QgsProcessingParameterWidgetContext widgetContext;
+  std::unique_ptr< QgsProcessingParameterDefinitionWidget > widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "boolean" ), context, widgetContext );
+  std::unique_ptr< QgsProcessingParameterDefinition > def( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) ); // should default to mandatory
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+
+  // using a parameter definition as initial values
+  QgsProcessingParameterBoolean boolParam( QStringLiteral( "n" ), QStringLiteral( "test desc" ), true, false );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "boolean" ), context, widgetContext, &boolParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) );
+  QVERIFY( !( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced ) );
+  QVERIFY( static_cast< QgsProcessingParameterBoolean * >( def.get() )->defaultValue().toBool() );
+  boolParam.setFlags( QgsProcessingParameterDefinition::FlagAdvanced | QgsProcessingParameterDefinition::FlagOptional );
+  boolParam.setDefaultValue( false );
+  widget = qgis::make_unique< QgsProcessingParameterDefinitionWidget >( QStringLiteral( "boolean" ), context, widgetContext, &boolParam );
+  def.reset( widget->createParameter( QStringLiteral( "param_name" ) ) );
+  QCOMPARE( def->name(), QStringLiteral( "param_name" ) );
+  QCOMPARE( def->description(), QStringLiteral( "test desc" ) );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagOptional );
+  QVERIFY( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced );
+  QVERIFY( !static_cast< QgsProcessingParameterBoolean * >( def.get() )->defaultValue().toBool() );
 }
 
 void TestProcessingGui::testStringWrapper()

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -17,6 +17,7 @@ from qgis.core import (QgsXmlUtils,
                        QgsCoordinateReferenceSystem)
 
 from qgis.PyQt.QtXml import QDomDocument
+from qgis.PyQt.QtGui import QColor
 
 from qgis.testing import start_app, unittest
 
@@ -182,6 +183,22 @@ class TestQgsXmlUtils(unittest.TestCase):
 
         g2 = QgsXmlUtils.readVariant(elem)
         self.assertEqual(g2.asWkt(), 'Point (3 4)')
+
+    def test_color(self):
+        """
+        Test that QColor values are correctly loaded and written
+        """
+        doc = QDomDocument("properties")
+
+        elem = QgsXmlUtils.writeVariant(QColor(100, 200, 210), doc)
+        c = QgsXmlUtils.readVariant(elem)
+        self.assertEqual(c, QColor(100, 200, 210))
+        elem = QgsXmlUtils.writeVariant(QColor(100, 200, 210, 50), doc)
+        c = QgsXmlUtils.readVariant(elem)
+        self.assertEqual(c, QColor(100, 200, 210, 50))
+        elem = QgsXmlUtils.writeVariant(QColor(), doc)
+        c = QgsXmlUtils.readVariant(elem)
+        self.assertFalse(c.isValid())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, these configuration widgets were all hardcoded into the Python modeler dialog. This prevented 3rd party, plugin provided, parameters from ever being full first class citizens in QGIS, as there was no way to allow their use as inputs to user created models to be customised.

Now, the registry is responsible for creating the configuration widget, allowing for 3rd party parameter types to provide their own customised configuration widgets.

I've ported a handful of the existing parameters to the new api - boolean, color, string and layout item, to give good examples of how the remainder can be ported.

