### PR TITLE
When building on proj >= 6.2, show the full scope and remarks for coordinate operations

### DIFF
--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -82,6 +82,13 @@ and ``destinationTransformId`` transforms.
       bool isAvailable;
     };
 
+    struct SingleOperationDetails
+    {
+      QString scope;
+
+      QString remarks;
+    };
+
     struct TransformDetails
     {
       QString proj;
@@ -91,6 +98,8 @@ and ``destinationTransformId`` transforms.
       bool isAvailable;
 
       QList< QgsDatumTransform::GridDetails > grids;
+
+      QList< QgsDatumTransform::SingleOperationDetails > operationDetails;
     };
 
     static QList< QgsDatumTransform::TransformDetails > operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -344,6 +344,21 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
 
     details.grids.append( gridDetails );
   }
+
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
+  for ( int j = 0; j < proj_concatoperation_get_step_count( pjContext, op ); ++j )
+  {
+    QgsProjUtils::proj_pj_unique_ptr step( proj_concatoperation_get_step( pjContext, op, j ) );
+    if ( step )
+    {
+      SingleOperationDetails singleOpDetails;
+      singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
+      singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
+      details.operationDetails.append( singleOpDetails );
+    }
+  }
+#endif
+
   return details;
 }
 #endif

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -148,6 +148,21 @@ class CORE_EXPORT QgsDatumTransform
     };
 
     /**
+     * Contains information about a single coordinate operation.
+     *
+     * \note Only used in builds based on on Proj >= 6.2
+     * \since QGIS 3.10
+     */
+    struct SingleOperationDetails
+    {
+      //! Scope of operation, from EPSG registry database
+      QString scope;
+
+      //! Remarks for operation, from EPSG registry database
+      QString remarks;
+    };
+
+    /**
      * Contains information about a coordinate transformation operation.
      *
      * \note Only used in builds based on on Proj >= 6.0
@@ -174,6 +189,14 @@ class CORE_EXPORT QgsDatumTransform
        * Contains a list of transform grids used by the operation.
        */
       QList< QgsDatumTransform::GridDetails > grids;
+
+      /**
+       * Contains information about the single operation steps used in the transform operation.
+       *
+       * \note Only used in builds based on on Proj >= 6.2
+       * \since QGIS 3.10
+       */
+      QList< QgsDatumTransform::SingleOperationDetails > operationDetails;
     };
 
     /**

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1031,6 +1031,7 @@ INCLUDE_DIRECTORIES(SYSTEM
   ${SQLITE3_INCLUDE_DIR}
   ${QSCINTILLA_INCLUDE_DIR}
   ${GDAL_INCLUDE_DIR}
+  ${PROJ_INCLUDE_DIR}
 )
 
 # disable deprecation warnings for classes re-exporting deprecated methods

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -29,6 +29,7 @@
 
 #if PROJ_VERSION_MAJOR>=6
 #include "qgsprojutils.h"
+#include <proj.h>
 #endif
 
 bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, QWidget *parent )
@@ -113,6 +114,8 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
 #if PROJ_VERSION_MAJOR>=6
   // proj 6 doesn't provide deprecated operations
   mHideDeprecatedCheckBox->setVisible( false );
+
+  mLabelDstDescription->hide();
 #else
   QgsSettings settings;
   mHideDeprecatedCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/hideDeprecated" ), true ).toBool() );
@@ -172,7 +175,41 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms, con
       preferredInitialRow = row;
     }
 
-    const QString toolTipString = QStringLiteral( "<b>%1</b><p>%2</p>" ).arg( transform.name, transform.proj );
+
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
+    QStringList opText;
+    for ( const QgsDatumTransform::SingleOperationDetails &singleOpDetails : transform.operationDetails )
+    {
+      QString text;
+      if ( !singleOpDetails.scope.isEmpty() )
+      {
+        text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Scope" ), singleOpDetails.scope );
+      }
+      if ( !singleOpDetails.remarks.isEmpty() )
+      {
+        if ( !text.isEmpty() )
+          text += QStringLiteral( "<br>" );
+        text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Remarks" ), singleOpDetails.remarks );
+      }
+
+      if ( !text.isEmpty() )
+      {
+        opText.append( text );
+      }
+    }
+
+    if ( opText.count() > 1 )
+    {
+      for ( int k = 0; k < opText.count(); ++k )
+        opText[k] = QStringLiteral( "<li>%1</li>" ).arg( opText.at( k ) );
+    }
+
+    const QString toolTipString = QStringLiteral( "<b>%1</b>" ).arg( transform.name )
+                                  + ( !opText.empty() ? ( opText.count() == 1 ? QStringLiteral( "<p>%1</p>" ).arg( opText.at( 0 ) ) : QStringLiteral( "<ul>%1</ul>" ).arg( opText.join( QString() ) ) ) : QString() ) +
+                                  QStringLiteral( "<p><code>%2</code></p>" ).arg( transform.proj );
+#else
+    const QString toolTipString = QStringLiteral( "<b>%1</b><p><code>%2</code></p>" ).arg( transform.name, transform.proj );
+#endif
     item->setToolTip( toolTipString );
     if ( itemDisabled )
     {

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -210,9 +210,15 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms, con
         opText[k] = QStringLiteral( "<li>%1</li>" ).arg( opText.at( k ) );
     }
 
+    const QColor disabled = palette().color( QPalette::Disabled, QPalette::Text );
+    const QColor active = palette().color( QPalette::Active, QPalette::Text );
+
+    const QColor codeColor( static_cast< int >( active.red() * 0.6 + disabled.red() * 0.4 ),
+                            static_cast< int >( active.green() * 0.6 + disabled.green() * 0.4 ),
+                            static_cast< int >( active.blue() * 0.6 + disabled.blue() * 0.4 ) );
     const QString toolTipString = QStringLiteral( "<b>%1</b>" ).arg( transform.name )
                                   + ( !opText.empty() ? ( opText.count() == 1 ? QStringLiteral( "<p>%1</p>" ).arg( opText.at( 0 ) ) : QStringLiteral( "<ul>%1</ul>" ).arg( opText.join( QString() ) ) ) : QString() ) +
-                                  QStringLiteral( "<p><code>%2</code></p>" ).arg( transform.proj );
+                                  QStringLiteral( "<p><code style=\"color: %1\">%2</code></p>" ).arg( codeColor.name(), transform.proj );
 #else
     const QString toolTipString = QStringLiteral( "<b>%1</b><p><code>%2</code></p>" ).arg( transform.name, transform.proj );
 #endif

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgsguiutils.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 
 #include <QDir>
 #include <QPushButton>
@@ -139,6 +140,11 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
 #endif
   mLabelSrcDescription->clear();
   mLabelDstDescription->clear();
+
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_projections/working_with_projections.html" ) );
+  } );
 
   load( selectedDatumTransforms, selectedProj );
 }

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -13,30 +13,7 @@
   <property name="windowTitle">
    <string>Select Datum Transformations</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,3,1,0,0">
-   <item row="2" column="0">
-    <widget class="QLabel" name="mLabelSrcDescription">
-     <property name="text">
-      <string notr="true">Description</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,3,1,0,0,0">
    <item row="0" column="0" colspan="2">
     <widget class="QStackedWidget" name="mCrsStackedWidget">
      <property name="currentIndex">
@@ -132,7 +109,7 @@
      </widget>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="mMakeDefaultCheckBox">
@@ -176,18 +153,57 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="mLabelDstDescription">
-     <property name="text">
-      <string notr="true">Description</string>
+   <item row="5" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="mLabelSrcDescription">
+       <property name="cursor">
+        <cursorShape>IBeamCursor</cursorShape>
+       </property>
+       <property name="text">
+        <string notr="true">Description</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="mLabelDstDescription">
+       <property name="cursor">
+        <cursorShape>IBeamCursor</cursorShape>
+       </property>
+       <property name="text">
+        <string notr="true">Description</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -112,12 +112,9 @@
    <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
-       <property name="toolTip">
-        <string>If checked, the selected transformation will become the default choice in all new projects</string>
-       </property>
+      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
        <property name="text">
-        <string>Make default</string>
+        <string>Hide deprecated transformations</string>
        </property>
       </widget>
      </item>
@@ -135,9 +132,12 @@
       </spacer>
      </item>
      <item>
-      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
+      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
+       <property name="toolTip">
+        <string>If checked, the selected transformation will become the default choice in all new projects</string>
+       </property>
        <property name="text">
-        <string>Hide deprecated transformations</string>
+        <string>Make default</string>
        </property>
       </widget>
      </item>
@@ -217,8 +217,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>mDatumTransformTableWidget</tabstop>
-  <tabstop>mMakeDefaultCheckBox</tabstop>
   <tabstop>mHideDeprecatedCheckBox</tabstop>
+  <tabstop>mMakeDefaultCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -159,7 +159,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Gives much more useful information to users to allow them to make informed choices about suitable operations.

Depends on https://github.com/OSGeo/PROJ/pull/1537
