### PR TITLE
[Tests] Add to PyQgsOgcUtils some tests to interpret specific text as decimal in scientific notation

### DIFF
--- a/tests/src/python/test_qgsogcutils.py
+++ b/tests/src/python/test_qgsogcutils.py
@@ -98,6 +98,27 @@ class TestQgsOgcUtils(unittest.TestCase):
         e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
         self.assertEqual(e.expression(), 'id > 2 AND id < 4')
 
+        # Literals are Scientific notation 15e-01 and 35e-01
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:And>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>15e-01</ogc:Literal>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsLessThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>35e-01</ogc:Literal>
+                </ogc:PropertyIsLessThan>
+              </ogc:And>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'id > 2 AND id < 4')
+
     def test_expressionFromOgcFilterWithLonglong(self):
         """
         Test expressionFromOgcFilter with LongLong type field
@@ -158,6 +179,27 @@ class TestQgsOgcUtils(unittest.TestCase):
                 <ogc:PropertyIsLessThan>
                   <ogc:PropertyName>id</ogc:PropertyName>
                   <ogc:Literal>3.5</ogc:Literal>
+                </ogc:PropertyIsLessThan>
+              </ogc:And>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'id > 2 AND id < 4')
+
+        # Literals are Scientific notation 15e-01 and 35e-01
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:And>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>15e-01</ogc:Literal>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsLessThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>35e-01</ogc:Literal>
                 </ogc:PropertyIsLessThan>
               </ogc:And>
             </ogc:Filter>
@@ -239,6 +281,27 @@ class TestQgsOgcUtils(unittest.TestCase):
         e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
         self.assertEqual(e.expression(), 'id > 1.5 AND id < 3.5')
 
+        # Literals are Scientific notation 15e-01 and 35e-01
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:And>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>15e-01</ogc:Literal>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsLessThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>35e-01</ogc:Literal>
+                </ogc:PropertyIsLessThan>
+              </ogc:And>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'id > 1.5 AND id < 3.5')
+
     def test_expressionFromOgcFilterWithString(self):
         """
         Test expressionFromOgcFilter with String type field
@@ -309,6 +372,27 @@ class TestQgsOgcUtils(unittest.TestCase):
 
         e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
         self.assertEqual(e.expression(), 'id > \'1.5\' AND id < \'3.5\'')
+
+        # Literals are Scientific notation 15e-01 and 35e-01
+        f = '''<?xml version="1.0" encoding="UTF-8"?>
+            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+              <ogc:And>
+                <ogc:PropertyIsGreaterThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>15e-01</ogc:Literal>
+                </ogc:PropertyIsGreaterThan>
+                <ogc:PropertyIsLessThan>
+                  <ogc:PropertyName>id</ogc:PropertyName>
+                  <ogc:Literal>35e-01</ogc:Literal>
+                </ogc:PropertyIsLessThan>
+              </ogc:And>
+            </ogc:Filter>
+        '''
+        d = QDomDocument('filter')
+        d.setContent(f, True)
+
+        e = QgsOgcUtils.expressionFromOgcFilter(d.documentElement(), vl)
+        self.assertEqual(e.expression(), 'id > \'15e-01\' AND id < \'35e-01\'')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Fixed #27262 by adding test to avoid regression

Needs backports of #30378 before merging

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
