### PR TITLE
[WMTS] Fixing the WMTS GetCapabilities Get element children

### DIFF
--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -281,6 +281,15 @@ namespace QgsWmts
     //ows:Get
     QDomElement getElement = doc.createElement( QStringLiteral( "ows:Get" )/*ows:Get*/ );
     getElement.setAttribute( QStringLiteral( "xlink:href" ), hrefString );
+    QDomElement constraintElement = doc.createElement( QStringLiteral( "ows:Constraint" )/*ows:Constraint*/ );
+    constraintElement.setAttribute( QStringLiteral( "name" ), QStringLiteral( "GetEncoding" ) );
+    QDomElement allowedValuesElement = doc.createElement( QStringLiteral( "ows:AllowedValues" )/*ows:AllowedValues*/ );
+    QDomElement valueElement = doc.createElement( QStringLiteral( "ows:Value" )/*ows:Value*/ );
+    QDomText valueText = doc.createTextNode( QStringLiteral( "KVP" ) );
+    valueElement.appendChild( valueText );
+    allowedValuesElement.appendChild( valueElement );
+    constraintElement.appendChild( allowedValuesElement );
+    getElement.appendChild( constraintElement );
     httpElement.appendChild( getElement );
 
     //ows:Operation element with name GetTile

--- a/tests/testdata/qgis_server/wmts_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities.txt
@@ -20,21 +20,39 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetCapabilities">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_groups.qgs&amp;"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_groups.qgs&amp;">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetTile">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_groups.qgs&amp;"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_groups.qgs&amp;">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetFeatureInfo">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_groups.qgs&amp;"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server_accesscontrol/project_groups.qgs&amp;">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
@@ -20,21 +20,39 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetCapabilities">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/?"/>
+     <ows:Get xlink:href="https://www.qgis.org/?">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetTile">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/?"/>
+     <ows:Get xlink:href="https://www.qgis.org/?">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetFeatureInfo">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/?"/>
+     <ows:Get xlink:href="https://www.qgis.org/?">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
@@ -20,21 +20,39 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetCapabilities">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/?"/>
+     <ows:Get xlink:href="https://www.qgis.org/?">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetTile">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/?"/>
+     <ows:Get xlink:href="https://www.qgis.org/?">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetFeatureInfo">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/?"/>
+     <ows:Get xlink:href="https://www.qgis.org/?">
+      <ows:Constraint name="GetEncoding">
+       <ows:AllowedValues>
+        <ows:Value>KVP</ows:Value>
+       </ows:AllowedValues>
+      </ows:Constraint>
+     </ows:Get>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>


### PR DESCRIPTION
## Description
The ows Get element has a Constraint child that describe the way to do request to the service. In the case of WMTS, all are KVP.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
