### PR TITLE
Visitor API for style entities

### DIFF
--- a/python/core/auto_additions/qgsprovidermetadata.py
+++ b/python/core/auto_additions/qgsprovidermetadata.py
@@ -1,0 +1,8 @@
+# The following has been generated automatically from src/core/qgsprovidermetadata.h
+# monkey patching scoped based enum
+QgsProviderMetadata.FilterType.FilterVector.__doc__ = ""
+QgsProviderMetadata.FilterType.FilterRaster.__doc__ = ""
+QgsProviderMetadata.FilterType.FilterMesh.__doc__ = ""
+QgsProviderMetadata.FilterType.FilterMeshDataset.__doc__ = ""
+QgsProviderMetadata.FilterType.__doc__ = 'Type of file filters\n\n.. versionadded:: 3.10\n\n' + '* ``FilterVector``: ' + QgsProviderMetadata.FilterType.FilterVector.__doc__ + '\n' + '* ``FilterRaster``: ' + QgsProviderMetadata.FilterType.FilterRaster.__doc__ + '\n' + '* ``FilterMesh``: ' + QgsProviderMetadata.FilterType.FilterMesh.__doc__ + '\n' + '* ``FilterMeshDataset``: ' + QgsProviderMetadata.FilterType.FilterMeshDataset.__doc__
+# --

--- a/python/core/auto_additions/qgsstyleentityvisitor.py
+++ b/python/core/auto_additions/qgsstyleentityvisitor.py
@@ -1,4 +1,16 @@
 # The following has been generated automatically from src/core/symbology/qgsstyleentityvisitor.h
 # monkey patching scoped based enum
-QgsStyleEntityVisitorInterface.NodeType.__doc__ = 'Describes the types of nodes which may be visited by the visitor.\n\n' + 
+QgsStyleEntityVisitorInterface.NodeType.Project.__doc__ = "QGIS Project node"
+QgsStyleEntityVisitorInterface.NodeType.Layer.__doc__ = "Map layer"
+QgsStyleEntityVisitorInterface.NodeType.SymbolRule.__doc__ = "Rule based symbology or label child rule"
+QgsStyleEntityVisitorInterface.NodeType.Layouts.__doc__ = "Layout collection"
+QgsStyleEntityVisitorInterface.NodeType.PrintLayout.__doc__ = "An individual print layout"
+QgsStyleEntityVisitorInterface.NodeType.LayoutItem.__doc__ = "Individual item in a print layout"
+QgsStyleEntityVisitorInterface.NodeType.Report.__doc__ = "A QGIS print report"
+QgsStyleEntityVisitorInterface.NodeType.ReportHeader.__doc__ = "Report header section"
+QgsStyleEntityVisitorInterface.NodeType.ReportFooter.__doc__ = "Report footer section"
+QgsStyleEntityVisitorInterface.NodeType.ReportSection.__doc__ = "Report sub section"
+QgsStyleEntityVisitorInterface.NodeType.Annotations.__doc__ = "Annotations collection"
+QgsStyleEntityVisitorInterface.NodeType.Annotation.__doc__ = "An individual annotation"
+QgsStyleEntityVisitorInterface.NodeType.__doc__ = 'Describes the types of nodes which may be visited by the visitor.\n\n' + '* ``Project``: ' + QgsStyleEntityVisitorInterface.NodeType.Project.__doc__ + '\n' + '* ``Layer``: ' + QgsStyleEntityVisitorInterface.NodeType.Layer.__doc__ + '\n' + '* ``SymbolRule``: ' + QgsStyleEntityVisitorInterface.NodeType.SymbolRule.__doc__ + '\n' + '* ``Layouts``: ' + QgsStyleEntityVisitorInterface.NodeType.Layouts.__doc__ + '\n' + '* ``PrintLayout``: ' + QgsStyleEntityVisitorInterface.NodeType.PrintLayout.__doc__ + '\n' + '* ``LayoutItem``: ' + QgsStyleEntityVisitorInterface.NodeType.LayoutItem.__doc__ + '\n' + '* ``Report``: ' + QgsStyleEntityVisitorInterface.NodeType.Report.__doc__ + '\n' + '* ``ReportHeader``: ' + QgsStyleEntityVisitorInterface.NodeType.ReportHeader.__doc__ + '\n' + '* ``ReportFooter``: ' + QgsStyleEntityVisitorInterface.NodeType.ReportFooter.__doc__ + '\n' + '* ``ReportSection``: ' + QgsStyleEntityVisitorInterface.NodeType.ReportSection.__doc__ + '\n' + '* ``Annotations``: ' + QgsStyleEntityVisitorInterface.NodeType.Annotations.__doc__ + '\n' + '* ``Annotation``: ' + QgsStyleEntityVisitorInterface.NodeType.Annotation.__doc__
 # --

--- a/python/core/auto_additions/qgsstyleentityvisitor.py
+++ b/python/core/auto_additions/qgsstyleentityvisitor.py
@@ -1,0 +1,4 @@
+# The following has been generated automatically from src/core/symbology/qgsstyleentityvisitor.h
+# monkey patching scoped based enum
+QgsStyleEntityVisitorInterface.NodeType.__doc__ = 'Describes the types of nodes which may be visited by the visitor.\n\n' + 
+# --

--- a/python/core/auto_generated/annotations/qgsannotation.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotation.sip.in
@@ -323,6 +323,17 @@ Sets the feature associated with the annotation.
 .. seealso:: :py:func:`associatedFeature`
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+within the annotation.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void appearanceChanged();

--- a/python/core/auto_generated/annotations/qgsannotationmanager.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotationmanager.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsAnnotationManager : QObject
 {
 %Docstring
@@ -100,6 +99,17 @@ present in the XML document.
 Returns a DOM element representing the state of the manager.
 
 .. seealso:: :py:func:`readXml`
+%End
+
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+within the contained annotations.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
 %End
 
   signals:

--- a/python/core/auto_generated/layout/qgsabstractreportsection.sip.in
+++ b/python/core/auto_generated/layout/qgsabstractreportsection.sip.in
@@ -344,6 +344,17 @@ Sets the item state from a DOM element.
 Refreshes the section when global layout related options change.
 %End
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+with the report.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
     enum SubSection

--- a/python/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/core/auto_generated/layout/qgslayout.sip.in
@@ -603,6 +603,17 @@ was not successful.
 .. seealso:: :py:func:`groupItems`
 %End
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+with the layout.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   public slots:
 
     void refresh();

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsLayoutItemRenderContext
 {
 %Docstring
@@ -931,6 +930,17 @@ Returns whether the item should be drawn in the current context.
 
     virtual QgsExpressionContext createExpressionContext() const;
 
+
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+with the layout item.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
 
   public slots:
 

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -576,6 +576,9 @@ Returns map rendering errors
 :return: list of errors
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   protected:
 
     virtual void draw( QgsLayoutItemRenderContext &context );

--- a/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -862,6 +862,8 @@ Retrieves the second fill color for the grid frame.
 
     virtual QgsExpressionContext createExpressionContext() const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
       public:
 };

--- a/python/core/auto_generated/layout/qgslayoutitemmapitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapitem.sip.in
@@ -176,6 +176,17 @@ StackAboveMapLayer.
 .. versionadded:: 3.6
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+with the map item.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
 
@@ -258,6 +269,11 @@ Returns whether any items within the stack contain advanced effects,
 such as blending modes.
 %End
 
+    QgsLayoutItemMapItem *item( int index ) const;
+%Docstring
+Returns a reference to the item at the specified ``index`` within the stack.
+%End
+
   protected:
 
     void addItem( QgsLayoutItemMapItem *item /Transfer/ );
@@ -313,11 +329,6 @@ Moves an item which matching ``itemId`` up the stack, causing it to be rendered 
     QgsLayoutItemMapItem *item( const QString &itemId ) const;
 %Docstring
 Returns a reference to an item which matching ``itemId`` within the stack.
-%End
-
-    QgsLayoutItemMapItem *item( int index ) const;
-%Docstring
-Returns a reference to the item at the specified ``index`` within the stack.
 %End
 
 

--- a/python/core/auto_generated/layout/qgslayoutitemmapoverview.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapoverview.sip.in
@@ -238,6 +238,9 @@ Ownership of the layer remain with the overview item.
 .. versionadded:: 3.6
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   public slots:
 
     void overviewExtentChanged();

--- a/python/core/auto_generated/layout/qgslayoutitempolygon.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolygon.sip.in
@@ -47,6 +47,8 @@ The caller takes responsibility for deleting the returned object.
 
     virtual QString displayName() const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     QgsFillSymbol *symbol();
 %Docstring

--- a/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -211,6 +211,9 @@ Returns the pen width in millimeters for the stroke of the arrow head.
 .. seealso:: :py:func:`arrowHeadStrokeColor`
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   protected:
 
     virtual bool _addNode( int indexPoint, QPointF newPoint, double radius );

--- a/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
@@ -509,6 +509,9 @@ Adjusts the scale bar box size and updates the item.
 
     virtual void finalizeRestoreFromXml();
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   protected:
 
     virtual void draw( QgsLayoutItemRenderContext &context );

--- a/python/core/auto_generated/layout/qgslayoutitemshape.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemshape.sip.in
@@ -99,6 +99,9 @@ Returns the corner radius for rounded rectangle corners.
     virtual double estimatedFrameBleed() const;
 
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   protected:
 
     virtual void draw( QgsLayoutItemRenderContext &context );

--- a/python/core/auto_generated/layout/qgslayoutmanager.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmanager.sip.in
@@ -115,6 +115,17 @@ Generates a unique title for a new layout of the specified ``type``, which does 
 clash with any already contained by the manager.
 %End
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+within the contained layouts.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void layoutAboutToBeAdded( const QString &name );

--- a/python/core/auto_generated/layout/qgsmasterlayoutinterface.sip.in
+++ b/python/core/auto_generated/layout/qgsmasterlayoutinterface.sip.in
@@ -103,6 +103,18 @@ Sets the layout's state from a DOM element. ``layoutElement`` is the DOM node co
 %Docstring
 Refreshes the layout when global layout related options change.
 %End
+
+    virtual bool layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+with the layout.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
 };
 
 

--- a/python/core/auto_generated/layout/qgsprintlayout.sip.in
+++ b/python/core/auto_generated/layout/qgsprintlayout.sip.in
@@ -58,6 +58,9 @@ Returns the print layout's atlas.
     virtual void updateSettings();
 
 
+    virtual bool layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   signals:
 
     void nameChanged( const QString &name );

--- a/python/core/auto_generated/layout/qgsreport.sip.in
+++ b/python/core/auto_generated/layout/qgsreport.sip.in
@@ -56,6 +56,8 @@ Note that ownership is not transferred to ``project``.
 
     virtual void updateSettings();
 
+    virtual bool layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
   signals:
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1267,6 +1267,16 @@ Generates an unique identifier for this layer, the generate ID is prefixed by ``
 .. versionadded:: 3.8
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified symbology ``visitor``, causing it to visit all symbols associated
+with the layer.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
 
   public slots:
 

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -1055,6 +1055,17 @@ Translates the project with QTranslator and qm file
 .. versionadded:: 3.4
 %End
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified style entity ``visitor``, causing it to visit all style entities associated
+with the project.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void cleared();

--- a/python/core/auto_generated/qgsrulebasedlabeling.sip.in
+++ b/python/core/auto_generated/qgsrulebasedlabeling.sip.in
@@ -257,6 +257,17 @@ Returns ``True`` if this rule or any of its children requires advanced compositi
 to render.
 %End
 
+        bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified symbology ``visitor``, causing it to visit all child rules associated
+with the rule.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
       private:
         Rule( const QgsRuleBasedLabeling::Rule &rh );
     };
@@ -285,6 +296,8 @@ Create the instance from a DOM element with saved configuration
     virtual QStringList subProviders() const;
 
     virtual QgsPalLayerSettings settings( const QString &providerId = QString() ) const;
+
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
     virtual void setSettings( QgsPalLayerSettings *settings /Transfer/, const QString &providerId = QString() );

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2357,6 +2357,9 @@ Sets the coordinate transform context to ``transformContext``
 .. versionadded:: 3.8
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
+
   signals:
 
     void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );

--- a/python/core/auto_generated/qgsvectorlayerlabeling.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerlabeling.sip.in
@@ -94,6 +94,17 @@ Try to create instance of an implementation based on the XML data
 Writes the SE 1.1 TextSymbolizer element based on the current layer labeling settings
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified symbology ``visitor``, causing it to visit all symbols associated
+with the labeling.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
     virtual void writeTextSymbolizer( QDomNode &parent, QgsPalLayerSettings &settings, const QgsStringMap &props ) const;
@@ -135,6 +146,8 @@ Constructs simple labeling configuration with given initial settings
     virtual QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) const;
 
     virtual QgsPalLayerSettings settings( const QString &providerId = QString() ) const;
+
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
     virtual void setSettings( QgsPalLayerSettings *settings /Transfer/, const QString &providerId = QString() );

--- a/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgspalettedrasterrenderer.sip.in
@@ -86,14 +86,13 @@ Returns the raster band used for rendering the raster.
 
     virtual void writeXml( QDomDocument &doc, QDomElement &parentElem ) const;
 
-
     virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems /Out/ ) const;
-
 
     virtual QList<int> usesBands() const;
 
-
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const;
+
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
     void setSourceColorRamp( QgsColorRamp *ramp /Transfer/ );

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -365,6 +365,8 @@ Draws a preview of the rasterlayer into a QImage
 
     virtual QDateTime timestamp() const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     bool writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsStringMap &props = QgsStringMap() ) const;
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterrenderer.sip.in
@@ -120,6 +120,17 @@ Used from subclasses to create SLD Rule elements following SLD v1.0 specs
 .. versionadded:: 3.6
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified symbology ``visitor``, causing it to visit all symbols associated
+with the renderer.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
     void _writeXml( QDomDocument &doc, QDomElement &rasterRendererElem ) const;

--- a/python/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
+++ b/python/core/auto_generated/raster/qgssinglebandpseudocolorrenderer.sip.in
@@ -75,14 +75,13 @@ Creates a color ramp shader
 
     virtual void writeXml( QDomDocument &doc, QDomElement &parentElem ) const;
 
-
     virtual void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems /Out/ ) const;
-
 
     virtual QList<int> usesBands() const;
 
-
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const;
+
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
     int band() const;

--- a/python/core/auto_generated/symbology/qgs25drenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgs25drenderer.sip.in
@@ -41,6 +41,8 @@ Create a new 2.5D renderer from XML
 
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     QColor roofColor() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -170,6 +170,8 @@ can be added later by calling addCategory().
 
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     void updateSymbols( QgsSymbol *sym );
 %Docstring

--- a/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -141,6 +141,8 @@ class QgsGraduatedSymbolRenderer : QgsFeatureRenderer
     virtual QgsFeatureRenderer::Capabilities capabilities();
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     QString classAttribute() const;
     void setClassAttribute( const QString &attr );

--- a/python/core/auto_generated/symbology/qgsheatmaprenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsheatmaprenderer.sip.in
@@ -60,6 +60,8 @@ Creates a new heatmap renderer instance from XML
     virtual QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context );
 
     static QgsHeatmapRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) /Factory/;
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     virtual void modifyRequestExtent( QgsRectangle &extent, QgsRenderContext &context );
 

--- a/python/core/auto_generated/symbology/qgsinvertedpolygonrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsinvertedpolygonrenderer.sip.in
@@ -70,61 +70,26 @@ Features collected during renderFeature() are rendered using the embedded featur
 
     virtual QString dump() const;
 
-
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
     virtual bool filterNeedsGeometry() const;
 
     virtual QgsFeatureRenderer::Capabilities capabilities();
 
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
-
     virtual QgsSymbolList symbols( QgsRenderContext &context ) const;
-
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
 
     virtual QgsSymbol *symbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
 
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
-
     virtual QgsSymbol *originalSymbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
-
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
 
     virtual QgsSymbolList symbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
 
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
-
     virtual QgsSymbolList originalSymbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
-
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
 
     virtual QgsLegendSymbolList legendSymbolItems() const;
 
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
-
     virtual bool willRenderFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
 
-%Docstring
-Proxy that will call this method on the embedded renderer.
-%End
 
     static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
 %Docstring
@@ -147,6 +112,8 @@ Creates a renderer out of an XML, for loading
     virtual bool legendSymbolItemChecked( const QString &key );
 
     virtual void checkLegendSymbolItem( const QString &key, bool state = true );
+
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 
     bool preprocessingEnabled() const;

--- a/python/core/auto_generated/symbology/qgspointclusterrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgspointclusterrenderer.sip.in
@@ -34,6 +34,8 @@ A renderer that automatically clusters points with the same geographic position.
 
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) /Factory/;
 %Docstring

--- a/python/core/auto_generated/symbology/qgspointdisplacementrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgspointdisplacementrenderer.sip.in
@@ -44,6 +44,8 @@ Constructor for QgsPointDisplacementRenderer.
 
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) /Factory/;
 %Docstring

--- a/python/core/auto_generated/symbology/qgspointdistancerenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgspointdistancerenderer.sip.in
@@ -107,6 +107,8 @@ Constructor for QgsPointDistanceRenderer.
 
     virtual QString filter( const QgsFields &fields = QgsFields() );
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     void setLabelAttributeName( const QString &name );
 %Docstring

--- a/python/core/auto_generated/symbology/qgsrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsrenderer.sip.in
@@ -473,6 +473,17 @@ implementation does not use subrenderers and will always return ``None``.
 .. versionadded:: 2.16
 %End
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified symbology ``visitor``, causing it to visit all symbols associated
+with the renderer.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
   protected:
     QgsFeatureRenderer( const QString &type );
 

--- a/python/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsrulebasedrenderer.sip.in
@@ -423,6 +423,17 @@ Check if this rule is an ELSE rule
 :return: ``True`` if this rule is an else rule
 %End
 
+        bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+%Docstring
+Accepts the specified symbology ``visitor``, causing it to visit all child rules associated
+with the rule.
+
+Returns ``True`` if the visitor should continue visiting other objects, or ``False`` if visiting
+should be canceled.
+
+.. versionadded:: 3.10
+%End
+
       protected:
         void initFilter();
 
@@ -506,6 +517,8 @@ Returns symbol for current feature. Should not be used individually: there could
     virtual QSet<QString> legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
 
     virtual QgsFeatureRenderer::Capabilities capabilities();
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
 
     QgsRuleBasedRenderer::Rule *rootRule();

--- a/python/core/auto_generated/symbology/qgssinglesymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgssinglesymbolrenderer.sip.in
@@ -33,6 +33,8 @@ of ``symbol`` is transferred to the renderer.
 
     virtual QSet<QString> usedAttributes( const QgsRenderContext &context ) const;
 
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
     QgsSymbol *symbol() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -98,6 +98,21 @@ Constructor for QgsStyle.
       LabelSettingsEntity,
     };
 
+    bool addEntity( const QString &name, const QgsStyleEntityInterface *entity, bool update = false );
+%Docstring
+Adds an ``entity`` to the style, with the specified ``name``. Ownership is not transferred.
+
+If ``update`` is ``True`` then the style database is updated automatically as a result.
+
+Returns ``True`` if the add operation was successful.
+
+.. note::
+
+   Adding an entity with the name of existing one replaces the existing one automatically.
+
+.. versionadded:: 3.10
+%End
+
     bool addSymbol( const QString &name, QgsSymbol *symbol /Transfer/, bool update = false );
 %Docstring
 Adds a symbol to style and takes symbol's ownership

--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -884,6 +884,170 @@ name or tag changes.
 
 };
 
+class QgsStyleEntityInterface
+{
+%Docstring
+An interface for entities which can be placed in a QgsStyle database.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsstyle.h"
+%End
+%ConvertToSubClassCode
+    switch ( sipCpp->type() )
+    {
+      case QgsStyle::SymbolEntity:
+        sipType = sipType_QgsStyleSymbolEntity;
+        break;
+
+      case QgsStyle::ColorrampEntity:
+        sipType = sipType_QgsStyleColorRampEntity;
+        break;
+
+      case QgsStyle::TextFormatEntity:
+        sipType = sipType_QgsStyleTextFormatEntity;
+        break;
+
+      case QgsStyle::LabelSettingsEntity:
+        sipType = sipType_QgsStyleLabelSettingsEntity;
+        break;
+
+      case QgsStyle::SmartgroupEntity:
+      case QgsStyle::TagEntity:
+        sipType = 0;
+        break;
+    }
+%End
+  public:
+
+    virtual ~QgsStyleEntityInterface();
+
+    virtual QgsStyle::StyleEntity type() const = 0;
+%Docstring
+Returns the type of style entity.
+%End
+
+};
+
+class QgsStyleSymbolEntity : QgsStyleEntityInterface
+{
+%Docstring
+A symbol entity for QgsStyle databases.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsstyle.h"
+%End
+  public:
+
+    QgsStyleSymbolEntity( const QgsSymbol *symbol );
+%Docstring
+Constructor for QgsStyleSymbolEntity, with the specified ``symbol``.
+
+Ownership of ``symbol`` is NOT transferred.
+%End
+
+    virtual QgsStyle::StyleEntity type() const;
+
+
+    const QgsSymbol *symbol() const;
+%Docstring
+Returns the entity's symbol.
+%End
+
+};
+
+class QgsStyleColorRampEntity : QgsStyleEntityInterface
+{
+%Docstring
+A color ramp entity for QgsStyle databases.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsstyle.h"
+%End
+  public:
+
+    QgsStyleColorRampEntity( const QgsColorRamp *ramp );
+%Docstring
+Constructor for QgsStyleColorRampEntity, with the specified color ``ramp``.
+
+Ownership of ``ramp`` is NOT transferred.
+%End
+
+    virtual QgsStyle::StyleEntity type() const;
+
+
+    const QgsColorRamp *ramp() const;
+%Docstring
+Returns the entity's color ramp.
+%End
+
+};
+
+class QgsStyleTextFormatEntity : QgsStyleEntityInterface
+{
+%Docstring
+A text format entity for QgsStyle databases.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsstyle.h"
+%End
+  public:
+
+    QgsStyleTextFormatEntity( const QgsTextFormat &format );
+%Docstring
+Constructor for QgsStyleTextFormatEntity, with the specified text ``format``.
+%End
+
+    virtual QgsStyle::StyleEntity type() const;
+
+
+    QgsTextFormat format() const;
+%Docstring
+Returns the entity's text format.
+%End
+
+};
+
+class QgsStyleLabelSettingsEntity : QgsStyleEntityInterface
+{
+%Docstring
+A label settings entity for QgsStyle databases.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsstyle.h"
+%End
+  public:
+
+    QgsStyleLabelSettingsEntity( const QgsPalLayerSettings &settings );
+%Docstring
+Constructor for QgsStyleLabelSettingsEntity, with the specified label ``settings``.
+%End
+
+    virtual QgsStyle::StyleEntity type() const;
+
+
+
+    const QgsPalLayerSettings &settings() const;
+%Docstring
+Returns the entity's label settings.
+%End
+
+};
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/symbology/qgsstyleentityvisitor.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyleentityvisitor.sip.in
@@ -91,6 +91,8 @@ Subclasses should return ``False`` if they do NOT want to visit this particular 
 if the node type is QgsStyleEntityVisitorInterface.NodeType.Layouts and they do not wish to visit
 layout objects. In this case the visitor will not process the node, and will move to the next available
 node instead. Return ``True`` to proceed with visiting the node.
+
+The default implementation returns ``True``.
 %End
 
     virtual bool visitExit( const QgsStyleEntityVisitorInterface::Node &node );
@@ -99,6 +101,8 @@ Called when the visitor stops visiting a ``node``.
 
 Subclasses should return ``False`` to abort further visitations, or ``True`` to continue
 visiting other nodes.
+
+The default implementation returns ``True``.
 %End
 
 };

--- a/python/core/auto_generated/symbology/qgsstyleentityvisitor.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyleentityvisitor.sip.in
@@ -1,0 +1,112 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/symbology/qgsstyleentityvisitor.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsStyleEntityVisitorInterface
+{
+%Docstring
+
+An interface for classes which can visit style entity (e.g. symbol) nodes (using the visitor pattern).
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsstyleentityvisitor.h"
+%End
+  public:
+
+    enum class NodeType
+    {
+      Project,
+      Layer,
+      SymbolRule,
+      Layouts,
+      PrintLayout,
+      LayoutItem,
+      Report,
+      ReportHeader,
+      ReportFooter,
+      ReportSection,
+      Annotations,
+      Annotation,
+    };
+
+    struct StyleLeaf
+    {
+
+      StyleLeaf( const QgsStyleEntityInterface *entity, const QString &identifier = QString(), const QString &description = QString() );
+%Docstring
+Constructor for StyleLeaf, visiting the given style ``entity`` with the specified ``identifier`` and ``description``.
+
+Ownership of ``entity`` is not transferred.
+%End
+
+      QString identifier;
+
+      QString description;
+
+      const QgsStyleEntityInterface *entity;
+    };
+
+    struct Node
+    {
+
+      Node( QgsStyleEntityVisitorInterface::NodeType type, const QString &identifier, const QString &description );
+%Docstring
+Constructor for Node, visiting the node with the specified ``identifier`` and ``description``.
+%End
+
+      QgsStyleEntityVisitorInterface::NodeType type;
+
+      QString identifier;
+
+      QString description;
+
+    };
+
+    virtual ~QgsStyleEntityVisitorInterface();
+
+    virtual bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &entity );
+%Docstring
+Called when the visitor will visit a style ``entity``.
+
+Subclasses should return ``False`` to abort further visitations, or ``True`` to continue
+visiting after processing this entity.
+%End
+
+    virtual bool visitEnter( const QgsStyleEntityVisitorInterface::Node &node );
+%Docstring
+Called when the visitor starts visiting a ``node``.
+
+Subclasses should return ``False`` if they do NOT want to visit this particular node - e.g.
+if the node type is QgsStyleEntityVisitorInterface.NodeType.Layouts and they do not wish to visit
+layout objects. In this case the visitor will not process the node, and will move to the next available
+node instead. Return ``True`` to proceed with visiting the node.
+%End
+
+    virtual bool visitExit( const QgsStyleEntityVisitorInterface::Node &node );
+%Docstring
+Called when the visitor stops visiting a ``node``.
+
+Subclasses should return ``False`` to abort further visitations, or ``True`` to continue
+visiting other nodes.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/symbology/qgsstyleentityvisitor.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -268,6 +268,7 @@
 %Include auto_generated/symbology/qgsheatmaprenderer.sip
 %Include auto_generated/symbology/qgsinvertedpolygonrenderer.sip
 %Include auto_generated/symbology/qgsnullsymbolrenderer.sip
+%Include auto_generated/symbology/qgsstyleentityvisitor.sip
 %Include auto_generated/symbology/qgssymbollayer.sip
 %Include auto_generated/symbology/qgssymbollayerregistry.sip
 %Include auto_generated/symbology/qgssymbollayerutils.sip

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -990,17 +990,18 @@ while ($LINE_IDX < $LINE_COUNT){
                     my $enum_member = $+{em};
                     my $comment = $+{co};
                     dbg_info("is_scope_based:$is_scope_based enum_mk_base:$enum_mk_base monkeypatch:$monkeypatch");
-                    if ($is_scope_based eq "1") {
-                        if ( $monkeypatch eq 1 and $enum_member ne "" ){
-                            if ($enum_mk_base ne "") {
-                                push @OUTPUT_PYTHON, "$enum_mk_base.$enum_member = $enum_qualname.$enum_member\n";
-                                push @OUTPUT_PYTHON, "$enum_mk_base.$enum_member.__doc__ = \"$comment\"\n" ;
-                                push @enum_members_doc, "'* ``$enum_member``: ' + $enum_qualname.$enum_member.__doc__";
-                            } else {
+                    if ($is_scope_based eq "1" and $enum_member ne "") {
+                        if ( $monkeypatch eq 1 and $enum_mk_base ne ""){
+		                    push @OUTPUT_PYTHON, "$enum_mk_base.$enum_member = $enum_qualname.$enum_member\n";
+		                    push @OUTPUT_PYTHON, "$enum_mk_base.$enum_member.__doc__ = \"$comment\"\n" ;
+		                    push @enum_members_doc, "'* ``$enum_member``: ' + $enum_qualname.$enum_member.__doc__";
+                        } else {
+                            if ( $monkeypatch eq 1 )
+                            {
                                 push @OUTPUT_PYTHON, "$ACTUAL_CLASS.$enum_member = $ACTUAL_CLASS.$enum_qualname.$enum_member\n";
-                                push @OUTPUT_PYTHON, "$ACTUAL_CLASS.$enum_qualname.$enum_member.__doc__ = \"$comment\"\n";
-                                push @enum_members_doc, "'* ``$enum_member``: ' + $ACTUAL_CLASS.$enum_qualname.$enum_member.__doc__";
                             }
+                            push @OUTPUT_PYTHON, "$ACTUAL_CLASS.$enum_qualname.$enum_member.__doc__ = \"$comment\"\n";
+                            push @enum_members_doc, "'* ``$enum_member``: ' + $ACTUAL_CLASS.$enum_qualname.$enum_member.__doc__";
                         }
                     }
                     $enum_decl = fix_annotations($enum_decl);

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -6393,8 +6393,8 @@ singsog:singsong
 sinse:since
 Sionist:Zionist
 Sionists:Zionists
-sitation:situation
-sitations:situations
+sitation:situation:*
+sitations:situations:*
 Sixtin:Sistine
 Skagerak:Skagerrak
 skateing:skating

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1183,6 +1183,7 @@ SET(QGIS_CORE_HDRS
   symbology/qgsheatmaprenderer.h
   symbology/qgsinvertedpolygonrenderer.h
   symbology/qgsnullsymbolrenderer.h
+  symbology/qgsstyleentityvisitor.h
   symbology/qgssymbollayer.h
   symbology/qgssymbollayerregistry.h
   symbology/qgssymbollayerutils.h

--- a/src/core/annotations/qgsannotation.cpp
+++ b/src/core/annotations/qgsannotation.cpp
@@ -20,6 +20,8 @@
 #include "qgsmaplayer.h"
 #include "qgsproject.h"
 #include "qgsgeometryutils.h"
+#include "qgsstyleentityvisitor.h"
+
 #include <QPen>
 #include <QPainter>
 
@@ -178,6 +180,31 @@ void QgsAnnotation::setMapLayer( QgsMapLayer *layer )
 void QgsAnnotation::setAssociatedFeature( const QgsFeature &feature )
 {
   mFeature = feature;
+}
+
+bool QgsAnnotation::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Annotation, QStringLiteral( "annotation" ), tr( "Annotation" ) ) ) )
+    return true;
+
+  if ( mMarkerSymbol )
+  {
+    QgsStyleSymbolEntity entity( mMarkerSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "marker" ), QObject::tr( "Marker" ) ) ) )
+      return false;
+  }
+
+  if ( mFillSymbol )
+  {
+    QgsStyleSymbolEntity entity( mFillSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "fill" ), QObject::tr( "Fill" ) ) ) )
+      return false;
+  }
+
+  if ( !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Annotation, QStringLiteral( "annotation" ), tr( "Annotation" ) ) ) )
+    return false;
+
+  return true;
 }
 
 QSizeF QgsAnnotation::minimumFrameSize() const

--- a/src/core/annotations/qgsannotation.cpp
+++ b/src/core/annotations/qgsannotation.cpp
@@ -184,6 +184,7 @@ void QgsAnnotation::setAssociatedFeature( const QgsFeature &feature )
 
 bool QgsAnnotation::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
+  // NOTE: if visitEnter returns false it means "don't visit the annotation", not "abort all further visitations"
   if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Annotation, QStringLiteral( "annotation" ), tr( "Annotation" ) ) ) )
     return true;
 

--- a/src/core/annotations/qgsannotation.h
+++ b/src/core/annotations/qgsannotation.h
@@ -306,6 +306,17 @@ class CORE_EXPORT QgsAnnotation : public QObject
      */
     virtual void setAssociatedFeature( const QgsFeature &feature );
 
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * within the annotation.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
   signals:
 
     //! Emitted whenever the annotation's appearance changes

--- a/src/core/annotations/qgsannotationmanager.cpp
+++ b/src/core/annotations/qgsannotationmanager.cpp
@@ -149,6 +149,7 @@ bool QgsAnnotationManager::accept( QgsStyleEntityVisitorInterface *visitor ) con
   if ( mAnnotations.empty() )
     return true;
 
+  // NOTE: if visitEnter returns false it means "don't visit any annotations", not "abort all further visitations"
   if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Annotations, QStringLiteral( "annotations" ), tr( "Annotations" ) ) ) )
     return true;
 

--- a/src/core/annotations/qgsannotationmanager.h
+++ b/src/core/annotations/qgsannotationmanager.h
@@ -24,7 +24,7 @@
 class QgsReadWriteContext;
 class QgsProject;
 class QgsAnnotation;
-
+class QgsStyleEntityVisitorInterface;
 
 /**
  * \ingroup core
@@ -106,6 +106,17 @@ class CORE_EXPORT QgsAnnotationManager : public QObject
      * \see readXml()
      */
     QDomElement writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const;
+
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * within the contained annotations.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
   signals:
 

--- a/src/core/layout/qgsabstractreportsection.cpp
+++ b/src/core/layout/qgsabstractreportsection.cpp
@@ -173,11 +173,13 @@ void QgsAbstractReportSection::reloadSettings()
 
 bool QgsAbstractReportSection::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
+  // NOTE: if visitEnter returns false it means "don't visit the report section", not "abort all further visitations"
   if ( mParent && !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::ReportSection, QStringLiteral( "reportsection" ), QObject::tr( "Report Section" ) ) ) )
     return true;
 
   if ( mHeader )
   {
+    // NOTE: if visitEnter returns false it means "don't visit the header", not "abort all further visitations"
     if ( visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::ReportHeader, QStringLiteral( "reportheader" ), QObject::tr( "Report Header" ) ) ) )
     {
       if ( !mHeader->accept( visitor ) )
@@ -196,9 +198,9 @@ bool QgsAbstractReportSection::accept( QgsStyleEntityVisitorInterface *visitor )
 
   if ( mFooter )
   {
+    // NOTE: if visitEnter returns false it means "don't visit the footer", not "abort all further visitations"
     if ( visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::ReportFooter, QStringLiteral( "reportfooter" ), QObject::tr( "Report Footer" ) ) ) )
     {
-
       if ( !mFooter->accept( visitor ) )
         return false;
 

--- a/src/core/layout/qgsabstractreportsection.h
+++ b/src/core/layout/qgsabstractreportsection.h
@@ -312,6 +312,17 @@ class CORE_EXPORT QgsAbstractReportSection : public QgsAbstractLayoutIterator
      */
     virtual void reloadSettings();
 
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * with the report.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
   protected:
 
     //! Report sub-sections

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -646,6 +646,17 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      */
     QList<QgsLayoutItem *> ungroupItems( QgsLayoutItemGroup *group );
 
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * with the layout.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
   public slots:
 
     /**

--- a/src/core/layout/qgslayoutitem.cpp
+++ b/src/core/layout/qgslayoutitem.cpp
@@ -1125,6 +1125,11 @@ QgsExpressionContext QgsLayoutItem::createExpressionContext() const
   return context;
 }
 
+bool QgsLayoutItem::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  Q_UNUSED( visitor );
+  return true;
+}
 
 void QgsLayoutItem::refresh()
 {

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -33,7 +33,7 @@ class QgsLayout;
 class QPainter;
 class QgsLayoutItemGroup;
 class QgsLayoutEffect;
-
+class QgsStyleEntityVisitorInterface;
 
 /**
  * \ingroup core
@@ -862,6 +862,17 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     bool shouldDrawItem() const;
 
     QgsExpressionContext createExpressionContext() const override;
+
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * with the layout item.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
   public slots:
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1345,6 +1345,7 @@ bool QgsLayoutItemMap::isLabelBlockingItem( QgsLayoutItem *item ) const
 
 bool QgsLayoutItemMap::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
+  // NOTE: if visitEnter returns false it means "don't visit the item", not "abort all further visitations"
   if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::LayoutItem, uuid(), displayName() ) ) )
     return true;
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -32,6 +32,7 @@
 #include "qgsexpressioncontext.h"
 #include "qgsapplication.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
@@ -1340,6 +1341,35 @@ void QgsLayoutItemMap::removeLabelBlockingItem( QgsLayoutItem *item )
 bool QgsLayoutItemMap::isLabelBlockingItem( QgsLayoutItem *item ) const
 {
   return mBlockingLabelItems.contains( item );
+}
+
+bool QgsLayoutItemMap::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::LayoutItem, uuid(), displayName() ) ) )
+    return true;
+
+  if ( mOverviewStack )
+  {
+    for ( int i = 0; i < mOverviewStack->size(); ++i )
+    {
+      if ( mOverviewStack->item( i )->accept( visitor ) )
+        return false;
+    }
+  }
+
+  if ( mGridStack )
+  {
+    for ( int i = 0; i < mGridStack->size(); ++i )
+    {
+      if ( mGridStack->item( i )->accept( visitor ) )
+        return false;
+    }
+  }
+
+  if ( !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::LayoutItem, uuid(), displayName() ) ) )
+    return false;
+
+  return true;
 }
 
 QPointF QgsLayoutItemMap::mapToItemCoords( QPointF mapCoords ) const

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -517,6 +517,8 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
      */
     QgsMapRendererJob::Errors renderingErrors() const { return mRenderingErrors; }
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
+
   protected:
 
     void draw( QgsLayoutItemRenderContext &context ) override;

--- a/src/core/layout/qgslayoutitemmapgrid.cpp
+++ b/src/core/layout/qgslayoutitemmapgrid.cpp
@@ -34,6 +34,7 @@
 #include "qgsexception.h"
 #include "qgssettings.h"
 #include "qgscoordinateformatter.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QPainter>
 #include <QPen>
@@ -2222,6 +2223,24 @@ QgsExpressionContext QgsLayoutItemMapGrid::createExpressionContext() const
   context.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "grid_axis" ), "x", true ) );
   context.setHighlightedVariables( QStringList() << QStringLiteral( "grid_number" ) << QStringLiteral( "grid_axis" ) );
   return context;
+}
+
+bool QgsLayoutItemMapGrid::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mGridLineSymbol )
+  {
+    QgsStyleSymbolEntity entity( mGridLineSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "grid" ), QObject::tr( "Grid" ) ) ) )
+      return false;
+  }
+  if ( mGridMarkerSymbol )
+  {
+    QgsStyleSymbolEntity entity( mGridMarkerSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "grid" ), QObject::tr( "Grid" ) ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 bool QgsLayoutItemMapGrid::testFrameSideFlag( QgsLayoutItemMapGrid::FrameSideFlag flag ) const

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -806,6 +806,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
     QColor frameFillColor2() const { return mGridFrameFillColor2; }
 
     QgsExpressionContext createExpressionContext() const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
   private:
 

--- a/src/core/layout/qgslayoutitemmapitem.cpp
+++ b/src/core/layout/qgslayoutitemmapitem.cpp
@@ -117,6 +117,11 @@ void QgsLayoutItemMapItem::setStackingLayer( QgsMapLayer *layer )
   mStackingLayer.setLayer( layer );
 }
 
+bool QgsLayoutItemMapItem::accept( QgsStyleEntityVisitorInterface * ) const
+{
+  return true;
+}
+
 //
 // QgsLayoutItemMapItemStack
 //

--- a/src/core/layout/qgslayoutitemmapitem.h
+++ b/src/core/layout/qgslayoutitemmapitem.h
@@ -178,6 +178,17 @@ class CORE_EXPORT QgsLayoutItemMapItem : public QgsLayoutObject
      */
     void setStackingLayer( QgsMapLayer *layer );
 
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * with the map item.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
   protected:
 
     //! Friendly display name
@@ -263,6 +274,11 @@ class CORE_EXPORT QgsLayoutItemMapItemStack
      */
     bool containsAdvancedEffects() const;
 
+    /**
+     * Returns a reference to the item at the specified \a index within the stack.
+     */
+    QgsLayoutItemMapItem *item( int index ) const;
+
   protected:
 
     /**
@@ -303,11 +319,6 @@ class CORE_EXPORT QgsLayoutItemMapItemStack
      * Returns a reference to an item which matching \a itemId within the stack.
      */
     QgsLayoutItemMapItem *item( const QString &itemId ) const;
-
-    /**
-     * Returns a reference to the item at the specified \a index within the stack.
-     */
-    QgsLayoutItemMapItem *item( int index ) const;
 
     /**
      * Returns a reference to an item at the specified \a index within the stack.

--- a/src/core/layout/qgslayoutitemmapoverview.cpp
+++ b/src/core/layout/qgslayoutitemmapoverview.cpp
@@ -28,6 +28,7 @@
 #include "qgsexception.h"
 #include "qgsvectorlayer.h"
 #include "qgssinglesymbolrenderer.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QPainter>
 
@@ -306,6 +307,18 @@ QgsVectorLayer *QgsLayoutItemMapOverview::asMapLayer()
   mExtentLayer->dataProvider()->addFeature( f );
 
   return mExtentLayer.get();
+}
+
+bool QgsLayoutItemMapOverview::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mFrameSymbol )
+  {
+    QgsStyleSymbolEntity entity( mFrameSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "overview" ), QObject::tr( "Overview" ) ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsLayoutItemMapOverview::setFrameSymbol( QgsFillSymbol *symbol )

--- a/src/core/layout/qgslayoutitemmapoverview.h
+++ b/src/core/layout/qgslayoutitemmapoverview.h
@@ -230,6 +230,8 @@ class CORE_EXPORT QgsLayoutItemMapOverview : public QgsLayoutItemMapItem
      */
     QgsVectorLayer *asMapLayer();
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
+
   public slots:
 
     /**

--- a/src/core/layout/qgslayoutitempolygon.cpp
+++ b/src/core/layout/qgslayoutitempolygon.cpp
@@ -23,6 +23,8 @@
 #include "qgssymbollayerutils.h"
 #include "qgssymbol.h"
 #include "qgsmapsettings.h"
+#include "qgsstyleentityvisitor.h"
+
 #include <limits>
 
 QgsLayoutItemPolygon::QgsLayoutItemPolygon( QgsLayout *layout )
@@ -95,6 +97,18 @@ QString QgsLayoutItemPolygon::displayName() const
     return id();
 
   return tr( "<Polygon>" );
+}
+
+bool QgsLayoutItemPolygon::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mPolygonStyleSymbol )
+  {
+    QgsStyleSymbolEntity entity( mPolygonStyleSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, uuid(), displayName() ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsLayoutItemPolygon::_draw( QgsLayoutItemRenderContext &context, const QStyleOptionGraphicsItem * )

--- a/src/core/layout/qgslayoutitempolygon.h
+++ b/src/core/layout/qgslayoutitempolygon.h
@@ -54,6 +54,7 @@ class CORE_EXPORT QgsLayoutItemPolygon: public QgsLayoutNodesItem
     int type() const override;
     QIcon icon() const override;
     QString displayName() const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Returns the fill symbol used to draw the shape.

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -23,6 +23,7 @@
 #include "qgslayoututils.h"
 #include "qgsreadwritecontext.h"
 #include "qgssvgcache.h"
+#include "qgsstyleentityvisitor.h"
 #include <QSvgRenderer>
 #include <limits>
 #include <QGraphicsPathItem>
@@ -386,6 +387,18 @@ void QgsLayoutItemPolyline::setArrowHeadStrokeWidth( double width )
   mArrowHeadStrokeWidth = width;
   updateBoundingRect();
   update();
+}
+
+bool QgsLayoutItemPolyline::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mPolylineStyleSymbol )
+  {
+    QgsStyleSymbolEntity entity( mPolylineStyleSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, uuid(), displayName() ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsLayoutItemPolyline::_writeXmlStyle( QDomDocument &doc, QDomElement &elmt, const QgsReadWriteContext &context ) const

--- a/src/core/layout/qgslayoutitempolyline.h
+++ b/src/core/layout/qgslayoutitempolyline.h
@@ -189,6 +189,8 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
      */
     double arrowHeadStrokeWidth() const { return mArrowHeadStrokeWidth; }
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
+
   protected:
 
     bool _addNode( int indexPoint, QPointF newPoint, double radius ) override;

--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -32,6 +32,7 @@
 #include "qgsfontutils.h"
 #include "qgsunittypes.h"
 #include "qgssettings.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -851,4 +852,13 @@ void QgsLayoutItemScaleBar::finalizeRestoreFromXml()
   }
 
   updateScale();
+}
+
+bool QgsLayoutItemScaleBar::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  QgsStyleTextFormatEntity entity( mSettings.textFormat() );
+  if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, uuid(), displayName() ) ) )
+    return false;
+
+  return true;
 }

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -438,6 +438,8 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
 
     void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
     void finalizeRestoreFromXml() override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
+
   protected:
 
     void draw( QgsLayoutItemRenderContext &context ) override;

--- a/src/core/layout/qgslayoutitemshape.cpp
+++ b/src/core/layout/qgslayoutitemshape.cpp
@@ -19,6 +19,7 @@
 #include "qgslayoututils.h"
 #include "qgssymbollayerutils.h"
 #include "qgslayoutmodel.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QPainter>
 
@@ -148,6 +149,18 @@ QRectF QgsLayoutItemShape::boundingRect() const
 double QgsLayoutItemShape::estimatedFrameBleed() const
 {
   return mMaxSymbolBleed;
+}
+
+bool QgsLayoutItemShape::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mShapeStyleSymbol )
+  {
+    QgsStyleSymbolEntity entity( mShapeStyleSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, uuid(), displayName() ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsLayoutItemShape::draw( QgsLayoutItemRenderContext &context )

--- a/src/core/layout/qgslayoutitemshape.h
+++ b/src/core/layout/qgslayoutitemshape.h
@@ -107,6 +107,8 @@ class CORE_EXPORT QgsLayoutItemShape : public QgsLayoutItem
     // rather than the item's pen
     double estimatedFrameBleed() const override;
 
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
+
   protected:
 
     void draw( QgsLayoutItemRenderContext &context ) override;

--- a/src/core/layout/qgslayoutmanager.cpp
+++ b/src/core/layout/qgslayoutmanager.cpp
@@ -22,6 +22,7 @@
 #include "qgsreport.h"
 #include "qgscompositionconverter.h"
 #include "qgsreadwritecontext.h"
+#include "qgsstyleentityvisitor.h"
 #include <QMessageBox>
 
 QgsLayoutManager::QgsLayoutManager( QgsProject *project )
@@ -301,6 +302,26 @@ QString QgsLayoutManager::generateUniqueTitle( QgsMasterLayoutInterface::Type ty
     id++;
   }
   return name;
+}
+
+bool QgsLayoutManager::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mLayouts.empty() )
+    return true;
+
+  if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Layouts, QStringLiteral( "layouts" ), tr( "Layouts" ) ) ) )
+    return true;
+
+  for ( QgsMasterLayoutInterface *l : mLayouts )
+  {
+    if ( !l->layoutAccept( visitor ) )
+      return false;
+  }
+
+  if ( !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Layouts, QStringLiteral( "layouts" ), tr( "Layouts" ) ) ) )
+    return false;
+
+  return true;
 }
 
 

--- a/src/core/layout/qgslayoutmanager.cpp
+++ b/src/core/layout/qgslayoutmanager.cpp
@@ -309,6 +309,7 @@ bool QgsLayoutManager::accept( QgsStyleEntityVisitorInterface *visitor ) const
   if ( mLayouts.empty() )
     return true;
 
+  // NOTE: if visitEnter returns false it means "don't visit the layouts", not "abort all further visitations"
   if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Layouts, QStringLiteral( "layouts" ), tr( "Layouts" ) ) ) )
     return true;
 

--- a/src/core/layout/qgslayoutmanager.h
+++ b/src/core/layout/qgslayoutmanager.h
@@ -25,6 +25,7 @@
 
 class QgsProject;
 class QgsPrintLayout;
+class QgsStyleEntityVisitorInterface;
 
 /**
  * \ingroup core
@@ -121,6 +122,17 @@ class CORE_EXPORT QgsLayoutManager : public QObject
      * clash with any already contained by the manager.
      */
     QString generateUniqueTitle( QgsMasterLayoutInterface::Type type = QgsMasterLayoutInterface::PrintLayout ) const;
+
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * within the contained layouts.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
   signals:
 

--- a/src/core/layout/qgsmasterlayoutinterface.h
+++ b/src/core/layout/qgsmasterlayoutinterface.h
@@ -24,6 +24,7 @@
 
 class QgsProject;
 class QgsReadWriteContext;
+class QgsStyleEntityVisitorInterface;
 
 #ifdef SIP_RUN
 % ModuleHeaderCode
@@ -120,6 +121,18 @@ class CORE_EXPORT QgsMasterLayoutInterface
      * Refreshes the layout when global layout related options change.
      */
     virtual void updateSettings() = 0;
+
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * with the layout.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const { Q_UNUSED( visitor ); return true; }
+
 };
 
 #endif //QGSLAYOUTINTERFACE_H

--- a/src/core/layout/qgsprintlayout.cpp
+++ b/src/core/layout/qgsprintlayout.cpp
@@ -116,8 +116,10 @@ void QgsPrintLayout::updateSettings()
 
 bool QgsPrintLayout::layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const
 {
+  // NOTE: if visitEnter returns false it means "don't visit the layout", not "abort all further visitations"
   if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::PrintLayout, QStringLiteral( "layout" ), mName ) ) )
     return true;
+
   if ( !accept( visitor ) )
     return false;
   if ( !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::PrintLayout, QStringLiteral( "layout" ), mName ) ) )

--- a/src/core/layout/qgsprintlayout.cpp
+++ b/src/core/layout/qgsprintlayout.cpp
@@ -18,6 +18,7 @@
 #include "qgslayoutatlas.h"
 #include "qgsreadwritecontext.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsstyleentityvisitor.h"
 
 QgsPrintLayout::QgsPrintLayout( QgsProject *project )
   : QgsLayout( project )
@@ -111,6 +112,17 @@ QgsExpressionContext QgsPrintLayout::createExpressionContext() const
 void QgsPrintLayout::updateSettings()
 {
   reloadSettings();
+}
+
+bool QgsPrintLayout::layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::PrintLayout, QStringLiteral( "layout" ), mName ) ) )
+    return true;
+  if ( !accept( visitor ) )
+    return false;
+  if ( !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::PrintLayout, QStringLiteral( "layout" ), mName ) ) )
+    return false;
+  return true;
 }
 
 QgsMasterLayoutInterface::Type QgsPrintLayout::layoutType() const

--- a/src/core/layout/qgsprintlayout.h
+++ b/src/core/layout/qgsprintlayout.h
@@ -61,6 +61,8 @@ class CORE_EXPORT QgsPrintLayout : public QgsLayout, public QgsMasterLayoutInter
     QgsExpressionContext createExpressionContext() const override;
     void updateSettings() override;
 
+    bool layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const override;
+
   signals:
 
     /**

--- a/src/core/layout/qgsreport.cpp
+++ b/src/core/layout/qgsreport.cpp
@@ -66,6 +66,11 @@ void QgsReport::updateSettings()
   reloadSettings();
 }
 
+bool QgsReport::layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  return accept( visitor );
+}
+
 QgsMasterLayoutInterface::Type QgsReport::layoutType() const
 {
   return QgsMasterLayoutInterface::Report;

--- a/src/core/layout/qgsreport.h
+++ b/src/core/layout/qgsreport.h
@@ -63,6 +63,7 @@ class CORE_EXPORT QgsReport : public QObject, public QgsAbstractReportSection, p
     QDomElement writeLayoutXml( QDomDocument &document, const QgsReadWriteContext &context ) const override;
     bool readLayoutXml( const QDomElement &layoutElement, const QDomDocument &document, const QgsReadWriteContext &context ) override;
     void updateSettings() override;
+    bool layoutAccept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
   signals:
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1877,6 +1877,11 @@ QString QgsMapLayer::generateId( const QString &layerName )
   return id;
 }
 
+bool QgsMapLayer::accept( QgsStyleEntityVisitorInterface * ) const
+{
+  return true;
+}
+
 void QgsMapLayer::setProviderType( const QString &providerType )
 {
   mProviderKey = providerType;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -46,6 +46,7 @@ class QgsMapLayerLegend;
 class QgsMapLayerRenderer;
 class QgsMapLayerStyleManager;
 class QgsProject;
+class QgsStyleEntityVisitorInterface;
 
 class QDomDocument;
 class QKeyEvent;
@@ -1139,6 +1140,16 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     static QString generateId( const QString &layerName );
 
+    /**
+     * Accepts the specified symbology \a visitor, causing it to visit all symbols associated
+     * with the layer.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
   public slots:
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -3078,6 +3078,7 @@ bool QgsProject::accept( QgsStyleEntityVisitorInterface *visitor ) const
   {
     for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
     {
+      // NOTE: if visitEnter returns false it means "don't visit this layer", not "abort all further visitations"
       if ( visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Layer, ( *it )->id(), ( *it )->name() ) ) )
       {
         if ( !( ( *it )->accept( visitor ) ) )

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -55,6 +55,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsapplication.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QApplication>
 #include <QFileInfo>
@@ -3068,4 +3069,31 @@ QString QgsProject::translate( const QString &context, const QString &sourceText
     return sourceText;
   }
   return result;
+}
+
+bool QgsProject::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  const QMap<QString, QgsMapLayer *> layers = mapLayers();
+  if ( !layers.empty() )
+  {
+    for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
+    {
+      if ( visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Layer, ( *it )->id(), ( *it )->name() ) ) )
+      {
+        if ( !( ( *it )->accept( visitor ) ) )
+          return false;
+
+        if ( !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::Layer, ( *it )->id(), ( *it )->name() ) ) )
+          return false;
+      }
+    }
+  }
+
+  if ( !mLayoutManager->accept( visitor ) )
+    return false;
+
+  if ( !mAnnotationManager->accept( visitor ) )
+    return false;
+
+  return true;
 }

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -1049,6 +1049,17 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     QString translate( const QString &context, const QString &sourceText, const char *disambiguation = nullptr, int n = -1 ) const override;
 
+    /**
+     * Accepts the specified style entity \a visitor, causing it to visit all style entities associated
+     * with the project.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
   signals:
 
     /**

--- a/src/core/qgsrulebasedlabeling.cpp
+++ b/src/core/qgsrulebasedlabeling.cpp
@@ -135,6 +135,7 @@ bool QgsRuleBasedLabeling::Rule::requiresAdvancedEffects() const
 
 bool QgsRuleBasedLabeling::Rule::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
+  // NOTE: if visitEnter returns false it means "don't visit the rule", not "abort all further visitations"
   if ( mParent && !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::SymbolRule, mRuleKey, mDescription ) ) )
     return true;
 

--- a/src/core/qgsrulebasedlabeling.h
+++ b/src/core/qgsrulebasedlabeling.h
@@ -290,6 +290,17 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
          */
         bool requiresAdvancedEffects() const;
 
+        /**
+         * Accepts the specified symbology \a visitor, causing it to visit all child rules associated
+         * with the rule.
+         *
+         * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+         * should be canceled.
+         *
+         * \since QGIS 3.10
+         */
+        bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
       private:
 #ifdef SIP_RUN
         Rule( const QgsRuleBasedLabeling::Rule &rh );
@@ -361,6 +372,7 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
     QgsVectorLayerLabelProvider *provider( QgsVectorLayer *layer ) const override SIP_SKIP;
     QStringList subProviders() const override;
     QgsPalLayerSettings settings( const QString &providerId = QString() ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Set pal settings for a specific provider (takes ownership).

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1390,6 +1390,19 @@ void QgsVectorLayer::setTransformContext( const QgsCoordinateTransformContext &t
     mDataProvider->setTransformContext( transformContext );
 }
 
+bool QgsVectorLayer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mRenderer )
+    if ( !mRenderer->accept( visitor ) )
+      return false;
+
+  if ( mLabeling )
+    if ( !mLabeling->accept( visitor ) )
+      return false;
+
+  return true;
+}
+
 bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &context )
 {
   QgsDebugMsgLevel( QStringLiteral( "Datasource in QgsVectorLayer::readXml: %1" ).arg( mDataSource.toLocal8Bit().data() ), 3 );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -73,6 +73,7 @@ class QgsFeedback;
 class QgsAuxiliaryStorage;
 class QgsAuxiliaryLayer;
 class QgsGeometryOptions;
+class QgsStyleEntityVisitorInterface;
 
 typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
@@ -2194,6 +2195,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \since QGIS 3.8
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
+
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
   signals:
 

--- a/src/core/qgsvectorlayerlabeling.cpp
+++ b/src/core/qgsvectorlayerlabeling.cpp
@@ -21,6 +21,7 @@
 #include "qgssymbollayer.h"
 #include "qgsmarkersymbollayer.h"
 #include "qgis.h"
+#include "qgsstyleentityvisitor.h"
 
 
 QgsAbstractVectorLayerLabeling *QgsAbstractVectorLayerLabeling::create( const QDomElement &element, const QgsReadWriteContext &context )
@@ -38,6 +39,11 @@ QgsAbstractVectorLayerLabeling *QgsAbstractVectorLayerLabeling::create( const QD
   {
     return nullptr;
   }
+}
+
+bool QgsAbstractVectorLayerLabeling::accept( QgsStyleEntityVisitorInterface * ) const
+{
+  return true;
 }
 
 QgsVectorLayerLabelProvider *QgsVectorLayerSimpleLabeling::provider( QgsVectorLayer *layer ) const
@@ -73,6 +79,17 @@ QgsPalLayerSettings QgsVectorLayerSimpleLabeling::settings( const QString &provi
 {
   Q_UNUSED( providerId )
   return *mSettings;
+}
+
+bool QgsVectorLayerSimpleLabeling::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mSettings )
+  {
+    QgsStyleLabelSettingsEntity entity( *mSettings );
+    if ( !visitor->visit( &entity ) )
+      return false;
+  }
+  return true;
 }
 
 bool QgsVectorLayerSimpleLabeling::requiresAdvancedEffects() const

--- a/src/core/qgsvectorlayerlabeling.h
+++ b/src/core/qgsvectorlayerlabeling.h
@@ -30,6 +30,7 @@ class QgsPalLayerSettings;
 class QgsReadWriteContext;
 class QgsVectorLayer;
 class QgsVectorLayerLabelProvider;
+class QgsStyleEntityVisitorInterface;
 
 /**
  * \ingroup core
@@ -114,6 +115,17 @@ class CORE_EXPORT QgsAbstractVectorLayerLabeling
       parent.appendChild( doc.createComment( QStringLiteral( "SE Export for %1 not implemented yet" ).arg( type() ) ) );
     }
 
+    /**
+     * Accepts the specified symbology \a visitor, causing it to visit all symbols associated
+     * with the labeling.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
   protected:
 
     /**
@@ -153,6 +165,7 @@ class CORE_EXPORT QgsVectorLayerSimpleLabeling : public QgsAbstractVectorLayerLa
     QgsVectorLayerLabelProvider *provider( QgsVectorLayer *layer ) const override SIP_SKIP;
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     QgsPalLayerSettings settings( const QString &providerId = QString() ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Set pal settings (takes ownership).

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -19,6 +19,7 @@
 #include "qgsrastertransparency.h"
 #include "qgsrasterviewport.h"
 #include "qgssymbollayerutils.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QColor>
 #include <QDomDocument>
@@ -297,6 +298,18 @@ void QgsPalettedRasterRenderer::toSld( QDomDocument &doc, QDomElement &element, 
       colorMapEntryElem.setAttribute( QStringLiteral( "opacity" ), QString::number( classDataIt->color.alphaF() ) );
     }
   }
+}
+
+bool QgsPalettedRasterRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mSourceColorRamp )
+  {
+    QgsStyleColorRampEntity entity( mSourceColorRamp.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsPalettedRasterRenderer::legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems ) const

--- a/src/core/raster/qgspalettedrasterrenderer.h
+++ b/src/core/raster/qgspalettedrasterrenderer.h
@@ -98,12 +98,10 @@ class CORE_EXPORT QgsPalettedRasterRenderer: public QgsRasterRenderer
     int band() const { return mBand; }
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
-
     void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const override;
-
     QList<int> usesBands() const override;
-
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Set the source color \a ramp. Ownership is transferred to the renderer.

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1301,6 +1301,16 @@ QDateTime QgsRasterLayer::timestamp() const
   return mDataProvider->timestamp();
 }
 
+bool QgsRasterLayer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mPipe.renderer() )
+  {
+    if ( !mPipe.renderer()->accept( visitor ) )
+      return false;
+  }
+  return true;
+}
+
 
 bool QgsRasterLayer::writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsStringMap &props ) const
 {

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -421,6 +421,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     void setLayerOrder( const QStringList &layers ) override;
     void setSubLayerVisibility( const QString &name, bool vis ) override;
     QDateTime timestamp() const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Writes the symbology of the layer into the document provided in SLD 1.0.0 format

--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -168,3 +168,8 @@ void QgsRasterRenderer::toSld( QDomDocument &doc, QDomElement &element, const Qg
     rasterSymbolizerElem.appendChild( opacityElem );
   }
 }
+
+bool QgsRasterRenderer::accept( QgsStyleEntityVisitorInterface * ) const
+{
+  return true;
+}

--- a/src/core/raster/qgsrasterrenderer.h
+++ b/src/core/raster/qgsrasterrenderer.h
@@ -29,6 +29,7 @@ class QDomElement;
 
 class QPainter;
 class QgsRasterTransparency;
+class QgsStyleEntityVisitorInterface;
 
 /**
  * \ingroup core
@@ -117,6 +118,17 @@ class CORE_EXPORT QgsRasterRenderer : public QgsRasterInterface
      * Used from subclasses to create SLD Rule elements following SLD v1.0 specs
      * \since QGIS 3.6  */
     virtual void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const;
+
+    /**
+     * Accepts the specified symbology \a visitor, causing it to visit all symbols associated
+     * with the renderer.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
   protected:
 

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -21,6 +21,7 @@
 #include "qgsrastershader.h"
 #include "qgsrastertransparency.h"
 #include "qgsrasterviewport.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -401,4 +402,16 @@ void QgsSingleBandPseudoColorRenderer::toSld( QDomDocument &doc, QDomElement &el
       colorMapEntryElem.setAttribute( QStringLiteral( "opacity" ), QString::number( classDataIt->color.alphaF() ) );
     }
   }
+}
+
+bool QgsSingleBandPseudoColorRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( const QgsColorRampShader *shader = dynamic_cast< const QgsColorRampShader * >( mShader->rasterShaderFunction() ) )
+  {
+    QgsStyleColorRampEntity entity( shader->sourceColorRamp() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
+      return false;
+  }
+
+  return true;
 }

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -77,12 +77,10 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
                        const QgsRectangle &extent = QgsRectangle() );
 
     void writeXml( QDomDocument &doc, QDomElement &parentElem ) const override;
-
     void legendSymbologyItems( QList< QPair< QString, QColor > > &symbolItems SIP_OUT ) const override;
-
     QList<int> usesBands() const override;
-
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Returns the band used by the renderer

--- a/src/core/symbology/qgs25drenderer.cpp
+++ b/src/core/symbology/qgs25drenderer.cpp
@@ -22,6 +22,7 @@
 #include "qgsproperty.h"
 #include "qgssymbollayerutils.h"
 #include "qgsdatadefinedsizelegend.h"
+#include "qgsstyleentityvisitor.h"
 
 #define ROOF_EXPRESSION \
   "translate(" \
@@ -177,6 +178,16 @@ QgsSymbolList Qgs25DRenderer::symbols( QgsRenderContext &context ) const
   QgsSymbolList lst;
   lst.append( mSymbol.get() );
   return lst;
+}
+
+bool Qgs25DRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mSymbol )
+  {
+    QgsStyleSymbolEntity entity( mSymbol.get() );
+    return visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) );
+  }
+  return true;
 }
 
 QgsFillSymbolLayer *Qgs25DRenderer::roofLayer() const

--- a/src/core/symbology/qgs25drenderer.h
+++ b/src/core/symbology/qgs25drenderer.h
@@ -47,6 +47,7 @@ class CORE_EXPORT Qgs25DRenderer : public QgsFeatureRenderer
 
     QgsSymbol *symbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
     QgsSymbolList symbols( QgsRenderContext &context ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Gets the roof color

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -34,6 +34,7 @@
 #include "qgsfieldformatterregistry.h"
 #include "qgsapplication.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -627,6 +628,25 @@ QgsSymbolList QgsCategorizedSymbolRenderer::symbols( QgsRenderContext &context )
     lst.append( cat.symbol() );
   }
   return lst;
+}
+
+bool QgsCategorizedSymbolRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  for ( const QgsRendererCategory &cat : mCategories )
+  {
+    QgsStyleSymbolEntity entity( cat.symbol() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, cat.value().toString(), cat.label() ) ) )
+      return false;
+  }
+
+  if ( mSourceColorRamp )
+  {
+    QgsStyleColorRampEntity entity( mSourceColorRamp.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, const QgsReadWriteContext &context )

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -174,6 +174,7 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     QgsFeatureRenderer::Capabilities capabilities() override { return SymbolLevels | Filter; }
     QString filter( const QgsFields &fields = QgsFields() ) override;
     QgsSymbolList symbols( QgsRenderContext &context ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Update all the symbols but leave categories and colors. This method also sets the source

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -34,6 +34,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -547,6 +548,25 @@ QgsSymbolList QgsGraduatedSymbolRenderer::symbols( QgsRenderContext &context ) c
     lst.append( range.symbol() );
   }
   return lst;
+}
+
+bool QgsGraduatedSymbolRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  for ( const QgsRendererRange &range : mRanges )
+  {
+    QgsStyleSymbolEntity entity( range.symbol() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "%1 - %2" ).arg( range.lowerValue() ).arg( range.upperValue() ), range.label() ) ) )
+      return false;
+  }
+
+  if ( mSourceColorRamp )
+  {
+    QgsStyleColorRampEntity entity( mSourceColorRamp.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsGraduatedSymbolRenderer::makeBreaksSymmetric( QList<double> &breaks, double symmetryPoint, bool astride )

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -158,6 +158,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
     void toSld( QDomDocument &doc, QDomElement &element, const QgsStringMap &props = QgsStringMap() ) const override;
     QgsFeatureRenderer::Capabilities capabilities() override { return SymbolLevels | Filter; }
     QgsSymbolList symbols( QgsRenderContext &context ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     QString classAttribute() const { return mAttrName; }
     void setClassAttribute( const QString &attr ) { mAttrName = attr; }

--- a/src/core/symbology/qgsheatmaprenderer.cpp
+++ b/src/core/symbology/qgsheatmaprenderer.cpp
@@ -27,6 +27,7 @@
 #include "qgsrendercontext.h"
 #include "qgspainteffect.h"
 #include "qgspainteffectregistry.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -393,6 +394,17 @@ QgsHeatmapRenderer *QgsHeatmapRenderer::convertFromRenderer( const QgsFeatureRen
   {
     return new QgsHeatmapRenderer();
   }
+}
+
+bool QgsHeatmapRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mGradientRamp )
+  {
+    QgsStyleColorRampEntity entity( mGradientRamp );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
+      return false;
+  }
+  return true;
 }
 
 void QgsHeatmapRenderer::setColorRamp( QgsColorRamp *ramp )

--- a/src/core/symbology/qgsheatmaprenderer.h
+++ b/src/core/symbology/qgsheatmaprenderer.h
@@ -57,6 +57,7 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRenderer
     static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     static QgsHeatmapRenderer *convertFromRenderer( const QgsFeatureRenderer *renderer ) SIP_FACTORY;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     //reimplemented to extent the request so that points up to heatmap's radius distance outside
     //visible area are included

--- a/src/core/symbology/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.cpp
@@ -25,6 +25,7 @@
 #include "qgsogcutils.h"
 #include "qgspainteffect.h"
 #include "qgspainteffectregistry.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -89,6 +90,14 @@ void QgsInvertedPolygonRenderer::checkLegendSymbolItem( const QString &key, bool
     return;
 
   mSubRenderer->checkLegendSymbolItem( key, state );
+}
+
+bool QgsInvertedPolygonRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( !mSubRenderer )
+    return true;
+
+  return mSubRenderer->accept( visitor );
 }
 
 void QgsInvertedPolygonRenderer::startRender( QgsRenderContext &context, const QgsFields &fields )

--- a/src/core/symbology/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.h
@@ -76,46 +76,15 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRenderer
     void stopRender( QgsRenderContext &context ) override;
 
     QString dump() const override;
-
-    //! Proxy that will call this method on the embedded renderer.
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
     bool filterNeedsGeometry() const override;
-    //! Proxy that will call this method on the embedded renderer.
     QgsFeatureRenderer::Capabilities capabilities() override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     QgsSymbolList symbols( QgsRenderContext &context ) const override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     QgsSymbol *symbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     QgsSymbol *originalSymbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     QgsSymbolList symbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     QgsSymbolList originalSymbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     QgsLegendSymbolList legendSymbolItems() const override;
-
-    /**
-     * Proxy that will call this method on the embedded renderer.
-     */
     bool willRenderFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
 
     //! Creates a renderer out of an XML, for loading
@@ -131,6 +100,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRenderer
     bool legendSymbolItemsCheckable() const override;
     bool legendSymbolItemChecked( const QString &key ) override;
     void checkLegendSymbolItem( const QString &key, bool state = true ) override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     //! \returns TRUE if the geometries are to be preprocessed (merged with an union) before rendering.
     bool preprocessingEnabled() const { return mPreprocessingEnabled; }

--- a/src/core/symbology/qgspointclusterrenderer.cpp
+++ b/src/core/symbology/qgspointclusterrenderer.cpp
@@ -22,6 +22,7 @@
 #include "qgspainteffect.h"
 #include "qgsmarkersymbollayer.h"
 #include "qgsproperty.h"
+#include "qgsstyleentityvisitor.h"
 #include <cmath>
 
 QgsPointClusterRenderer::QgsPointClusterRenderer()
@@ -161,6 +162,21 @@ QSet<QString> QgsPointClusterRenderer::usedAttributes( const QgsRenderContext &c
   if ( mClusterSymbol )
     attr.unite( mClusterSymbol->usedAttributes( context ) );
   return attr;
+}
+
+bool QgsPointClusterRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( !QgsPointDistanceRenderer::accept( visitor ) )
+    return false;
+
+  if ( mClusterSymbol )
+  {
+    QgsStyleSymbolEntity entity( mClusterSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "cluster" ), QObject::tr( "Cluster Symbol" ) ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsPointClusterRenderer::setClusterSymbol( QgsMarkerSymbol *symbol )

--- a/src/core/symbology/qgspointclusterrenderer.h
+++ b/src/core/symbology/qgspointclusterrenderer.h
@@ -39,6 +39,7 @@ class CORE_EXPORT QgsPointClusterRenderer: public QgsPointDistanceRenderer
     void stopRender( QgsRenderContext &context ) override;
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     //! Creates a renderer from XML element
     static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) SIP_FACTORY;

--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -21,6 +21,7 @@
 #include "qgspainteffectregistry.h"
 #include "qgspainteffect.h"
 #include "qgspointclusterrenderer.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QPainter>
 #include <cmath>
@@ -237,6 +238,21 @@ QSet<QString> QgsPointDisplacementRenderer::usedAttributes( const QgsRenderConte
   if ( mCenterSymbol )
     attr.unite( mCenterSymbol->usedAttributes( context ) );
   return attr;
+}
+
+bool QgsPointDisplacementRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( !QgsPointDistanceRenderer::accept( visitor ) )
+    return false;
+
+  if ( mCenterSymbol )
+  {
+    QgsStyleSymbolEntity entity( mCenterSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity, QStringLiteral( "center" ), QObject::tr( "Center Symbol" ) ) ) )
+      return false;
+  }
+
+  return true;
 }
 
 void QgsPointDisplacementRenderer::setCenterSymbol( QgsMarkerSymbol *symbol )

--- a/src/core/symbology/qgspointdisplacementrenderer.h
+++ b/src/core/symbology/qgspointdisplacementrenderer.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsPointDistanceRenderer
     void stopRender( QgsRenderContext &context ) override;
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     //! Create a renderer from XML element
     static QgsFeatureRenderer *create( QDomElement &symbologyElem, const QgsReadWriteContext &context ) SIP_FACTORY;

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -21,6 +21,7 @@
 #include "qgsspatialindex.h"
 #include "qgsmultipoint.h"
 #include "qgslogger.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomElement>
 #include <QPainter>
@@ -203,6 +204,15 @@ QString QgsPointDistanceRenderer::filter( const QgsFields &fields )
     return QgsFeatureRenderer::filter( fields );
   else
     return mRenderer->filter( fields );
+}
+
+bool QgsPointDistanceRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mRenderer )
+    if ( !mRenderer->accept( visitor ) )
+      return false;
+
+  return true;
 }
 
 QSet<QString> QgsPointDistanceRenderer::usedAttributes( const QgsRenderContext &context ) const

--- a/src/core/symbology/qgspointdistancerenderer.h
+++ b/src/core/symbology/qgspointdistancerenderer.h
@@ -105,6 +105,7 @@ class CORE_EXPORT QgsPointDistanceRenderer: public QgsFeatureRenderer
     bool legendSymbolItemChecked( const QString &key ) override;
     void checkLegendSymbolItem( const QString &key, bool state ) override;
     QString filter( const QgsFields &fields = QgsFields() ) override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Sets the attribute name for labeling points.

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -444,6 +444,11 @@ const QgsFeatureRenderer *QgsFeatureRenderer::embeddedRenderer() const
   return nullptr;
 }
 
+bool QgsFeatureRenderer::accept( QgsStyleEntityVisitorInterface * ) const
+{
+  return true;
+}
+
 void QgsFeatureRenderer::convertSymbolSizeScale( QgsSymbol *symbol, QgsSymbol::ScaleMethod method, const QString &field )
 {
   if ( symbol->type() == QgsSymbol::Marker )

--- a/src/core/symbology/qgsrenderer.h
+++ b/src/core/symbology/qgsrenderer.h
@@ -37,6 +37,7 @@ class QgsFeature;
 class QgsVectorLayer;
 class QgsPaintEffect;
 class QgsReadWriteContext;
+class QgsStyleEntityVisitorInterface;
 
 typedef QMap<QString, QString> QgsStringMap SIP_SKIP;
 
@@ -458,6 +459,17 @@ class CORE_EXPORT QgsFeatureRenderer
      * \since QGIS 2.16
      */
     virtual const QgsFeatureRenderer *embeddedRenderer() const;
+
+    /**
+     * Accepts the specified symbology \a visitor, causing it to visit all symbols associated
+     * with the renderer.
+     *
+     * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+     * should be canceled.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
   protected:
     QgsFeatureRenderer( const QString &type );

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -158,6 +158,7 @@ void QgsRuleBasedRenderer::Rule::setIsElse( bool iselse )
 
 bool QgsRuleBasedRenderer::Rule::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
+  // NOTE: if visitEnter returns false it means "don't visit the rule", not "abort all further visitations"
   if ( mParent && !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::SymbolRule, mRuleKey, mLabel ) ) )
     return true;
 

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -27,6 +27,7 @@
 #include "qgspainteffect.h"
 #include "qgspainteffectregistry.h"
 #include "qgsproperty.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QSet>
 
@@ -155,6 +156,33 @@ void QgsRuleBasedRenderer::Rule::setIsElse( bool iselse )
   mFilter.reset();
 }
 
+bool QgsRuleBasedRenderer::Rule::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mParent && !visitor->visitEnter( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::SymbolRule, mRuleKey, mLabel ) ) )
+    return true;
+
+  if ( mSymbol )
+  {
+    QgsStyleSymbolEntity entity( mSymbol.get() );
+    if ( !visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) ) )
+      return false;
+  }
+
+  if ( !mChildren.empty() )
+  {
+    for ( const Rule *rule : mChildren )
+    {
+
+      if ( !rule->accept( visitor ) )
+        return false;
+    }
+  }
+
+  if ( mParent && !visitor->visitExit( QgsStyleEntityVisitorInterface::Node( QgsStyleEntityVisitorInterface::NodeType::SymbolRule, mRuleKey, mLabel ) ) )
+    return false;
+
+  return true;
+}
 
 QString QgsRuleBasedRenderer::Rule::dump( int indent ) const
 {
@@ -1262,6 +1290,11 @@ QgsSymbolList QgsRuleBasedRenderer::originalSymbolsForFeature( const QgsFeature 
 QSet< QString > QgsRuleBasedRenderer::legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const
 {
   return mRootRule->legendKeysForFeature( feature, &context );
+}
+
+bool QgsRuleBasedRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  return mRootRule->accept( visitor );
 }
 
 QgsRuleBasedRenderer *QgsRuleBasedRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -428,6 +428,17 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
          */
         bool isElse() const { return mElseRule; }
 
+        /**
+         * Accepts the specified symbology \a visitor, causing it to visit all child rules associated
+         * with the rule.
+         *
+         * Returns TRUE if the visitor should continue visiting other objects, or FALSE if visiting
+         * should be canceled.
+         *
+         * \since QGIS 3.10
+         */
+        bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
       protected:
         void initFilter();
 
@@ -509,6 +520,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
     QgsSymbolList originalSymbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
     QSet<QString> legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
     QgsFeatureRenderer::Capabilities capabilities() override { return MoreSymbolsPerFeature | Filter | ScaleDependent; }
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /////
 

--- a/src/core/symbology/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology/qgssinglesymbolrenderer.cpp
@@ -29,6 +29,7 @@
 #include "qgspainteffect.h"
 #include "qgspainteffectregistry.h"
 #include "qgsproperty.h"
+#include "qgsstyleentityvisitor.h"
 
 #include <QDomDocument>
 #include <QDomElement>
@@ -78,6 +79,16 @@ QSet<QString> QgsSingleSymbolRenderer::usedAttributes( const QgsRenderContext &c
   if ( mSymbol )
     attributes.unite( mSymbol->usedAttributes( context ) );
   return attributes;
+}
+
+bool QgsSingleSymbolRenderer::accept( QgsStyleEntityVisitorInterface *visitor ) const
+{
+  if ( mSymbol )
+  {
+    QgsStyleSymbolEntity entity( mSymbol.get() );
+    return visitor->visit( QgsStyleEntityVisitorInterface::StyleLeaf( &entity ) );
+  }
+  return true;
 }
 
 QgsSymbol *QgsSingleSymbolRenderer::symbol() const

--- a/src/core/symbology/qgssinglesymbolrenderer.h
+++ b/src/core/symbology/qgssinglesymbolrenderer.h
@@ -43,6 +43,7 @@ class CORE_EXPORT QgsSingleSymbolRenderer : public QgsFeatureRenderer
     void startRender( QgsRenderContext &context, const QgsFields &fields ) override;
     void stopRender( QgsRenderContext &context ) override;
     QSet<QString> usedAttributes( const QgsRenderContext &context ) const override;
+    bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
     /**
      * Returns the symbol which will be rendered for every feature.

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -2853,3 +2853,23 @@ void QgsStyle::clearCachedTags( QgsStyle::StyleEntity type, const QString &name 
       break;
   }
 }
+
+QgsStyle::StyleEntity QgsStyleSymbolEntity::type() const
+{
+  return QgsStyle::SymbolEntity;
+}
+
+QgsStyle::StyleEntity QgsStyleColorRampEntity::type() const
+{
+  return QgsStyle::ColorrampEntity;
+}
+
+QgsStyle::StyleEntity QgsStyleTextFormatEntity::type() const
+{
+  return QgsStyle::TextFormatEntity;
+}
+
+QgsStyle::StyleEntity QgsStyleLabelSettingsEntity::type() const
+{
+  return QgsStyle::LabelSettingsEntity;
+}

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -43,6 +43,34 @@ QgsStyle::~QgsStyle()
   clear();
 }
 
+bool QgsStyle::addEntity( const QString &name, const QgsStyleEntityInterface *entity, bool update )
+{
+  switch ( entity->type() )
+  {
+    case SymbolEntity:
+      if ( !static_cast< const QgsStyleSymbolEntity * >( entity )->symbol() )
+        return false;
+      return addSymbol( name, static_cast< const QgsStyleSymbolEntity * >( entity )->symbol()->clone(), update );
+
+    case ColorrampEntity:
+      if ( !static_cast< const QgsStyleColorRampEntity * >( entity )->ramp() )
+        return false;
+      return addColorRamp( name, static_cast< const QgsStyleColorRampEntity * >( entity )->ramp()->clone(), update );
+
+    case TextFormatEntity:
+      return addTextFormat( name, static_cast< const QgsStyleTextFormatEntity * >( entity )->format(), update );
+
+    case LabelSettingsEntity:
+      return addLabelSettings( name, static_cast< const QgsStyleLabelSettingsEntity * >( entity )->settings(), update );
+
+    case TagEntity:
+    case SmartgroupEntity:
+      break;
+
+  }
+  return false;
+}
+
 QgsStyle *QgsStyle::defaultStyle() // static
 {
   if ( !sDefaultStyle )

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -900,4 +900,175 @@ class CORE_EXPORT QgsStyle : public QObject
     Q_DISABLE_COPY( QgsStyle )
 };
 
+/**
+ * \class QgsStyleEntityInterface
+ * \ingroup core
+ * An interface for entities which can be placed in a QgsStyle database.
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsStyleEntityInterface
+{
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    switch ( sipCpp->type() )
+    {
+      case QgsStyle::SymbolEntity:
+        sipType = sipType_QgsStyleSymbolEntity;
+        break;
+
+      case QgsStyle::ColorrampEntity:
+        sipType = sipType_QgsStyleColorRampEntity;
+        break;
+
+      case QgsStyle::TextFormatEntity:
+        sipType = sipType_QgsStyleTextFormatEntity;
+        break;
+
+      case QgsStyle::LabelSettingsEntity:
+        sipType = sipType_QgsStyleLabelSettingsEntity;
+        break;
+
+      case QgsStyle::SmartgroupEntity:
+      case QgsStyle::TagEntity:
+        sipType = 0;
+        break;
+    }
+    SIP_END
+#endif
+
+  public:
+
+    virtual ~QgsStyleEntityInterface() = default;
+
+    /**
+     * Returns the type of style entity.
+     */
+    virtual QgsStyle::StyleEntity type() const = 0;
+
+};
+
+/**
+ * \class QgsStyleSymbolEntity
+ * \ingroup core
+ * A symbol entity for QgsStyle databases.
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsStyleSymbolEntity : public QgsStyleEntityInterface
+{
+  public:
+
+    /**
+     * Constructor for QgsStyleSymbolEntity, with the specified \a symbol.
+     *
+     * Ownership of \a symbol is NOT transferred.
+     */
+    QgsStyleSymbolEntity( const QgsSymbol *symbol )
+      : mSymbol( symbol )
+    {}
+
+    QgsStyle::StyleEntity type() const override;
+
+    /**
+     * Returns the entity's symbol.
+     */
+    const QgsSymbol *symbol() const { return mSymbol; }
+
+  private:
+
+    const QgsSymbol *mSymbol = nullptr;
+
+};
+
+/**
+ * \class QgsStyleColorRampEntity
+ * \ingroup core
+ * A color ramp entity for QgsStyle databases.
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsStyleColorRampEntity : public QgsStyleEntityInterface
+{
+  public:
+
+    /**
+     * Constructor for QgsStyleColorRampEntity, with the specified color \a ramp.
+     *
+     * Ownership of \a ramp is NOT transferred.
+     */
+    QgsStyleColorRampEntity( const QgsColorRamp *ramp )
+      : mRamp( ramp )
+    {}
+
+    QgsStyle::StyleEntity type() const override;
+
+    /**
+     * Returns the entity's color ramp.
+     */
+    const QgsColorRamp *ramp() const { return mRamp; }
+
+  private:
+
+    const QgsColorRamp *mRamp = nullptr;
+};
+
+/**
+ * \class QgsStyleTextFormatEntity
+ * \ingroup core
+ * A text format entity for QgsStyle databases.
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsStyleTextFormatEntity : public QgsStyleEntityInterface
+{
+  public:
+
+    /**
+     * Constructor for QgsStyleTextFormatEntity, with the specified text \a format.
+     */
+    QgsStyleTextFormatEntity( const QgsTextFormat &format )
+      : mFormat( format )
+    {}
+
+    QgsStyle::StyleEntity type() const override;
+
+    /**
+     * Returns the entity's text format.
+     */
+    QgsTextFormat format() const { return mFormat; }
+
+  private:
+
+    QgsTextFormat mFormat;
+
+};
+
+/**
+ * \class QgsStyleLabelSettingsEntity
+ * \ingroup core
+ * A label settings entity for QgsStyle databases.
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsStyleLabelSettingsEntity : public QgsStyleEntityInterface
+{
+  public:
+
+    /**
+     * Constructor for QgsStyleLabelSettingsEntity, with the specified label \a settings.
+     */
+    QgsStyleLabelSettingsEntity( const QgsPalLayerSettings &settings )
+      : mSettings( settings )
+    {}
+
+    QgsStyle::StyleEntity type() const override;
+
+
+    /**
+     * Returns the entity's label settings.
+     */
+    const QgsPalLayerSettings &settings() const { return mSettings; }
+
+  private:
+
+    QgsPalLayerSettings mSettings;
+};
+
 #endif

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -32,6 +32,7 @@
 class QgsSymbol;
 class QgsSymbolLayer;
 class QgsColorRamp;
+class QgsStyleEntityInterface;
 
 class QDomDocument;
 class QDomElement;
@@ -182,6 +183,19 @@ class CORE_EXPORT QgsStyle : public QObject
       TextFormatEntity, //!< Text formats
       LabelSettingsEntity, //!< Label settings
     };
+
+    /**
+     * Adds an \a entity to the style, with the specified \a name. Ownership is not transferred.
+     *
+     * If \a update is TRUE then the style database is updated automatically as a result.
+     *
+     * Returns TRUE if the add operation was successful.
+     *
+     * \note Adding an entity with the name of existing one replaces the existing one automatically.
+     *
+     * \since QGIS 3.10
+     */
+    bool addEntity( const QString &name, const QgsStyleEntityInterface *entity, bool update = false );
 
     /**
      * Adds a symbol to style and takes symbol's ownership

--- a/src/core/symbology/qgsstyleentityvisitor.h
+++ b/src/core/symbology/qgsstyleentityvisitor.h
@@ -38,7 +38,7 @@ class CORE_EXPORT QgsStyleEntityVisitorInterface
     /**
      * Describes the types of nodes which may be visited by the visitor.
      */
-    enum class NodeType
+    enum class NodeType : int
     {
       Project, //!< QGIS Project node
       Layer, //!< Map layer

--- a/src/core/symbology/qgsstyleentityvisitor.h
+++ b/src/core/symbology/qgsstyleentityvisitor.h
@@ -78,16 +78,22 @@ class CORE_EXPORT QgsStyleEntityVisitorInterface
        *
        * This may be blank if no identifier is required, e.g. when a renderer has a single
        * symbol only.
+       *
+       * Note that in some cases where a specific identifier is not available, a generic, untranslated
+       * one may be used (e.g. "overview", "grid").
        */
       QString identifier;
 
       /**
        * A string describing the style entity. The actual value of \a description will vary
        * depending on the class being visited. E.g for a categorized renderer, the
-       * description will be the category label associated with the symbol.
+       * description will be the category label associated with the symbol, for a print layout, it will
+       * be the name of the layout in the project.
        *
        * This may be blank if no description is associated with a style entity, e.g. when a renderer has a single
        * symbol only.
+       *
+       * This value may be a generic, translated value in some cases, e.g. "Grid" or "Overview".
        */
       QString description;
 
@@ -144,7 +150,11 @@ class CORE_EXPORT QgsStyleEntityVisitorInterface
      * Subclasses should return FALSE to abort further visitations, or TRUE to continue
      * visiting after processing this entity.
      */
-    virtual bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &entity ) { Q_UNUSED( entity ); return true; }
+    virtual bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &entity )
+    {
+      Q_UNUSED( entity )
+      return true;
+    }
 
     /**
      * Called when the visitor starts visiting a \a node.
@@ -153,16 +163,28 @@ class CORE_EXPORT QgsStyleEntityVisitorInterface
      * if the node type is QgsStyleEntityVisitorInterface::NodeType::Layouts and they do not wish to visit
      * layout objects. In this case the visitor will not process the node, and will move to the next available
      * node instead. Return TRUE to proceed with visiting the node.
+     *
+     * The default implementation returns TRUE.
      */
-    virtual bool visitEnter( const QgsStyleEntityVisitorInterface::Node &node ) { Q_UNUSED( node ); return true; }
+    virtual bool visitEnter( const QgsStyleEntityVisitorInterface::Node &node )
+    {
+      Q_UNUSED( node )
+      return true;
+    }
 
     /**
      * Called when the visitor stops visiting a \a node.
      *
      * Subclasses should return FALSE to abort further visitations, or TRUE to continue
      * visiting other nodes.
+     *
+     * The default implementation returns TRUE.
      */
-    virtual bool visitExit( const QgsStyleEntityVisitorInterface::Node &node ) { Q_UNUSED( node ); return true; }
+    virtual bool visitExit( const QgsStyleEntityVisitorInterface::Node &node )
+    {
+      Q_UNUSED( node )
+      return true;
+    }
 
 };
 

--- a/src/core/symbology/qgsstyleentityvisitor.h
+++ b/src/core/symbology/qgsstyleentityvisitor.h
@@ -1,0 +1,169 @@
+/***************************************************************************
+                         qgsstyleentityvisitor.h
+                         ---------------
+    begin                : July 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSTYLEENTITYVISITOR_H
+#define QGSSTYLEENTITYVISITOR_H
+
+#include "qgis_core.h"
+#include "qgsstyle.h"
+
+/**
+ * \class QgsStyleEntityVisitorInterface
+ * \ingroup core
+ *
+ * An interface for classes which can visit style entity (e.g. symbol) nodes (using the visitor pattern).
+ *
+ * \since QGIS 3.10
+ */
+
+class CORE_EXPORT QgsStyleEntityVisitorInterface
+{
+
+  public:
+
+    /**
+     * Describes the types of nodes which may be visited by the visitor.
+     */
+    enum class NodeType
+    {
+      Project, //!< QGIS Project node
+      Layer, //!< Map layer
+      SymbolRule, //!< Rule based symbology or label child rule
+      Layouts, //!< Layout collection
+      PrintLayout, //!< An individual print layout
+      LayoutItem, //!< Individual item in a print layout
+      Report, //!< A QGIS print report
+      ReportHeader, //!< Report header section
+      ReportFooter, //!< Report footer section
+      ReportSection, //!< Report sub section
+      Annotations, //!< Annotations collection
+      Annotation, //!< An individual annotation
+    };
+
+    /**
+     * Contains information relating to the style entity currently being visited.
+     */
+    struct StyleLeaf
+    {
+
+      /**
+       * Constructor for StyleLeaf, visiting the given style \a entity with the specified \a identifier and \a description.
+       *
+       * Ownership of \a entity is not transferred.
+       */
+      StyleLeaf( const QgsStyleEntityInterface *entity, const QString &identifier = QString(), const QString &description = QString() )
+        : identifier( identifier )
+        , description( description )
+        , entity( entity )
+      {}
+
+      /**
+       * A string identifying the style entity. The actual value of \a identifier will vary
+       * depending on the class being visited. E.g for a categorized renderer, the
+       * identifier will be the category ID associated with the symbol.
+       *
+       * This may be blank if no identifier is required, e.g. when a renderer has a single
+       * symbol only.
+       */
+      QString identifier;
+
+      /**
+       * A string describing the style entity. The actual value of \a description will vary
+       * depending on the class being visited. E.g for a categorized renderer, the
+       * description will be the category label associated with the symbol.
+       *
+       * This may be blank if no description is associated with a style entity, e.g. when a renderer has a single
+       * symbol only.
+       */
+      QString description;
+
+      /**
+       * Reference to style entity being visited.
+       */
+      const QgsStyleEntityInterface *entity = nullptr;
+    };
+
+    /**
+     * Contains information relating to a node (i.e. a group of symbols or other nodes)
+     * being visited.
+     */
+    struct Node
+    {
+
+      /**
+       * Constructor for Node, visiting the node with the specified \a identifier and \a description.
+       */
+      Node( QgsStyleEntityVisitorInterface::NodeType type, const QString &identifier, const QString &description )
+        : type( type )
+        , identifier( identifier )
+        , description( description )
+      {}
+
+      /**
+       * Node type.
+       */
+      QgsStyleEntityVisitorInterface::NodeType type = QgsStyleEntityVisitorInterface::NodeType::Project;
+
+      /**
+       * A string identifying the node. The actual value of \a identifier will vary
+       * depending on the node being visited. E.g for a rule based renderer, the
+       * identifier will be a rule ID. For a project, node identifiers will be
+       * layer IDs.
+       */
+      QString identifier;
+
+      /**
+       * A string describing the node. The actual value of \a description will vary
+       * depending on the node being visited. E.g for a rule based renderer, the
+       * identifier will be a rule label. For a project, node identifiers will be
+       * layer names.
+       */
+      QString description;
+
+    };
+
+    virtual ~QgsStyleEntityVisitorInterface() = default;
+
+    /**
+     * Called when the visitor will visit a style \a entity.
+     *
+     * Subclasses should return FALSE to abort further visitations, or TRUE to continue
+     * visiting after processing this entity.
+     */
+    virtual bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &entity ) { Q_UNUSED( entity ); return true; }
+
+    /**
+     * Called when the visitor starts visiting a \a node.
+     *
+     * Subclasses should return FALSE if they do NOT want to visit this particular node - e.g.
+     * if the node type is QgsStyleEntityVisitorInterface::NodeType::Layouts and they do not wish to visit
+     * layout objects. In this case the visitor will not process the node, and will move to the next available
+     * node instead. Return TRUE to proceed with visiting the node.
+     */
+    virtual bool visitEnter( const QgsStyleEntityVisitorInterface::Node &node ) { Q_UNUSED( node ); return true; }
+
+    /**
+     * Called when the visitor stops visiting a \a node.
+     *
+     * Subclasses should return FALSE to abort further visitations, or TRUE to continue
+     * visiting other nodes.
+     */
+    virtual bool visitExit( const QgsStyleEntityVisitorInterface::Node &node ) { Q_UNUSED( node ); return true; }
+
+};
+
+#endif // QGSSTYLEENTITYVISITOR_H

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -6,7 +6,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/external
   ${CMAKE_SOURCE_DIR}/external/kdbush/include
   ${CMAKE_SOURCE_DIR}/src/core
-  ${CMAKE_SOURCE_DIR}/src/annotations
+  ${CMAKE_SOURCE_DIR}/src/core/annotations
   ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/dxf
   ${CMAKE_SOURCE_DIR}/src/core/expression

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -29,8 +29,21 @@
 #include "qgslinesymbollayer.h"
 #include "qgsfillsymbollayer.h"
 #include "qgssinglesymbolrenderer.h"
-
+#include "qgsmarkersymbollayer.h"
+#include "qgsrulebasedrenderer.h"
+#include "qgsvectorlayerlabeling.h"
 #include "qgsstyle.h"
+#include "qgsproject.h"
+#include "qgsstyleentityvisitor.h"
+#include "qgsrasterlayer.h"
+#include "qgsrastershader.h"
+#include "qgssinglebandpseudocolorrenderer.h"
+#include "qgsprintlayout.h"
+#include "qgslayoutitemscalebar.h"
+#include "qgsfontutils.h"
+#include "qgslayoutmanager.h"
+#include "qgsannotationmanager.h"
+#include "qgstextannotation.h"
 
 /**
  * \ingroup UnitTests
@@ -72,6 +85,7 @@ class TestStyle : public QObject
     void testTags();
     void testSmartGroup();
     void testIsStyleXml();
+    void testVisitor();
 
 };
 
@@ -1010,6 +1024,218 @@ void TestStyle::testIsStyleXml()
   QVERIFY( !QgsStyle::isXmlStyleFile( QStringLiteral( "blah" ) ) );
   QVERIFY( QgsStyle::isXmlStyleFile( mTestDataDir + QStringLiteral( "categorized.xml" ) ) );
   QVERIFY( !QgsStyle::isXmlStyleFile( mTestDataDir + QStringLiteral( "openstreetmap/testdata.xml" ) ) );
+}
+
+
+class TestVisitor : public QgsStyleEntityVisitorInterface
+{
+  public:
+
+    TestVisitor( QStringList &found )
+      : mFound( found )
+    {}
+
+    bool visitEnter( const QgsStyleEntityVisitorInterface::Node &node ) override
+    {
+      mFound << QStringLiteral( "enter: %1 %2" ).arg( node.identifier, node.description );
+      return true;
+    }
+
+    bool visitExit( const QgsStyleEntityVisitorInterface::Node &node ) override
+    {
+      mFound << QStringLiteral( "exit: %1 %2" ).arg( node.identifier, node.description );
+      return true;
+    }
+
+    bool visit( const QgsStyleEntityVisitorInterface::StyleLeaf &entity ) override
+    {
+      switch ( entity.entity->type() )
+      {
+        case QgsStyle::SymbolEntity:
+        {
+          mFound << QStringLiteral( "symbol: %1 %2 %3" ).arg( entity.description, entity.identifier, static_cast< const QgsStyleSymbolEntity * >( entity.entity )->symbol()->color().name() );
+          break;
+        }
+        case QgsStyle::ColorrampEntity:
+          mFound << QStringLiteral( "ramp: %1 %2 %3" ).arg( entity.description, entity.identifier, static_cast< const QgsStyleColorRampEntity * >( entity.entity )->ramp()->color( 0 ).name() );
+          break;
+
+        case QgsStyle::TextFormatEntity:
+          mFound << QStringLiteral( "text format: %1 %2 %3" ).arg( entity.description, entity.identifier, static_cast< const QgsStyleTextFormatEntity * >( entity.entity )->format().font().family() );
+          break;
+
+        case QgsStyle::LabelSettingsEntity:
+          mFound << QStringLiteral( "labels: %1 %2 %3" ).arg( entity.description, entity.identifier, static_cast< const QgsStyleLabelSettingsEntity * >( entity.entity )->settings().fieldName );
+          break;
+
+        case QgsStyle::TagEntity:
+        case QgsStyle::SmartgroupEntity:
+          break;
+      }
+      return true;
+    }
+
+    QStringList &mFound;
+};
+
+void TestStyle::testVisitor()
+{
+  // test style visitor
+  QgsProject p;
+
+  QStringList found;
+  TestVisitor visitor( found );
+  QVERIFY( p.accept( &visitor ) );
+  QVERIFY( found.isEmpty() );
+
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+  p.addMapLayer( vl );
+
+  // with renderer
+  QgsSimpleMarkerSymbolLayer *simpleMarkerLayer = new QgsSimpleMarkerSymbolLayer();
+  QgsMarkerSymbol *markerSymbol = new QgsMarkerSymbol();
+  markerSymbol->changeSymbolLayer( 0, simpleMarkerLayer );
+  vl->setRenderer( new QgsSingleSymbolRenderer( markerSymbol ) );
+
+  QVERIFY( p.accept( &visitor ) );
+  QCOMPARE( found, QStringList() << QStringLiteral( "enter: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "symbol:   #ff0000" )
+            << QStringLiteral( "exit: %1 vl" ).arg( vl->id() ) );
+
+  // rule based renderer
+  QgsVectorLayer *vl2 = new QgsVectorLayer( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=col1:string" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) );
+  QVERIFY( vl2->isValid() );
+  p.addMapLayer( vl2 );
+  QgsSymbol *s1 = QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry );
+  s1->setColor( QColor( 0, 255, 0 ) );
+  QgsSymbol *s2 = QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry );
+  s2->setColor( QColor( 0, 255, 255 ) );
+  QgsRuleBasedRenderer::Rule *rootRule = new QgsRuleBasedRenderer::Rule( nullptr );
+  QgsRuleBasedRenderer::Rule *rule2 = new QgsRuleBasedRenderer::Rule( s1, 0, 0, QStringLiteral( "fld >= 5 and fld <= 20" ) );
+  rootRule->appendChild( rule2 );
+  QgsRuleBasedRenderer::Rule *rule3 = new QgsRuleBasedRenderer::Rule( s2, 0, 0, QStringLiteral( "fld <= 10" ) );
+  rule2->appendChild( rule3 );
+  vl2->setRenderer( new QgsRuleBasedRenderer( rootRule ) );
+
+  found.clear();
+  QVERIFY( p.accept( &visitor ) );
+  QCOMPARE( found, QStringList()
+            << QStringLiteral( "enter: %1 vl2" ).arg( vl2->id() )
+            << QStringLiteral( "enter: %1 " ).arg( rule2->ruleKey() )
+            << QStringLiteral( "symbol:   #00ff00" )
+            << QStringLiteral( "enter: %1 " ).arg( rule3->ruleKey() )
+            << QStringLiteral( "symbol:   #00ffff" )
+            << QStringLiteral( "exit: %1 " ).arg( rule3->ruleKey() )
+            << QStringLiteral( "exit: %1 " ).arg( rule2->ruleKey() )
+            << QStringLiteral( "exit: %1 vl2" ).arg( vl2->id() )
+            << QStringLiteral( "enter: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "symbol:   #ff0000" )
+            << QStringLiteral( "exit: %1 vl" ).arg( vl->id() ) );
+
+  p.removeMapLayer( vl2 );
+
+  // labeling
+  QgsPalLayerSettings settings;
+  settings.fieldName = QStringLiteral( "Class" );
+  vl->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );  // TODO: this should not be necessary!
+
+  found.clear();
+  QVERIFY( p.accept( &visitor ) );
+
+  QCOMPARE( found, QStringList() << QStringLiteral( "enter: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "symbol:   #ff0000" )
+            << QStringLiteral( "labels:   Class" )
+            << QStringLiteral( "exit: %1 vl" ).arg( vl->id() ) );
+
+  // raster layer
+  QgsRasterLayer *rl = new QgsRasterLayer( QStringLiteral( TEST_DATA_DIR ) + "/tenbytenraster.asc",
+      QStringLiteral( "rl" ) );
+  QVERIFY( rl->isValid() );
+  p.addMapLayer( rl );
+
+  QgsRasterShader *rasterShader = new QgsRasterShader();
+  QgsColorRampShader *colorRampShader = new QgsColorRampShader();
+  colorRampShader->setColorRampType( QgsColorRampShader::Interpolated );
+  colorRampShader->setSourceColorRamp( new QgsGradientColorRamp( QColor( 255, 255, 0 ), QColor( 255, 0, 255 ) ) );
+  rasterShader->setRasterShaderFunction( colorRampShader );
+  QgsSingleBandPseudoColorRenderer *r = new QgsSingleBandPseudoColorRenderer( rl->dataProvider(), 1, rasterShader );
+  rl->setRenderer( r );
+
+  found.clear();
+  QVERIFY( p.accept( &visitor ) );
+
+  QCOMPARE( found, QStringList()
+            << QStringLiteral( "enter: %1 rl" ).arg( rl->id() )
+            << QStringLiteral( "ramp:   #ffff00" )
+            << QStringLiteral( "exit: %1 rl" ).arg( rl->id() )
+            << QStringLiteral( "enter: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "symbol:   #ff0000" )
+            << QStringLiteral( "labels:   Class" )
+            << QStringLiteral( "exit: %1 vl" ).arg( vl->id() ) );
+
+  // with layout
+  QgsPrintLayout *l = new QgsPrintLayout( &p );
+  l->setName( QStringLiteral( "test layout" ) );
+  l->initializeDefaults();
+  QgsLayoutItemScaleBar *scalebar = new QgsLayoutItemScaleBar( l );
+  scalebar->attemptSetSceneRect( QRectF( 20, 180, 50, 20 ) );
+  l->addLayoutItem( scalebar );
+  scalebar->setTextFormat( QgsTextFormat::fromQFont( QgsFontUtils::getStandardTestFont() ) );
+
+  p.layoutManager()->addLayout( l );
+
+  found.clear();
+  QVERIFY( p.accept( &visitor ) );
+
+  QCOMPARE( found, QStringList()
+            << QStringLiteral( "enter: %1 rl" ).arg( rl->id() )
+            << QStringLiteral( "ramp:   #ffff00" )
+            << QStringLiteral( "exit: %1 rl" ).arg( rl->id() )
+            << QStringLiteral( "enter: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "symbol:   #ff0000" )
+            << QStringLiteral( "labels:   Class" )
+            << QStringLiteral( "exit: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "enter: layouts Layouts" )
+            << QStringLiteral( "enter: layout test layout" )
+            << QStringLiteral( "text format: <Scalebar> %1 QGIS Vera Sans" ).arg( scalebar->uuid() )
+            << QStringLiteral( "symbol: Page page #ffffff" )
+            << QStringLiteral( "exit: layout test layout" )
+            << QStringLiteral( "exit: layouts Layouts" ) );
+
+  // with annotations
+  QgsTextAnnotation *annotation = new QgsTextAnnotation();
+  QgsSymbol *a1 = QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry );
+  a1->setColor( QColor( 0, 200, 0 ) );
+  annotation->setMarkerSymbol( static_cast< QgsMarkerSymbol * >( a1 ) );
+  QgsSymbol *a2 = QgsSymbol::defaultSymbol( QgsWkbTypes::PolygonGeometry );
+  a2->setColor( QColor( 200, 200, 0 ) );
+  annotation->setFillSymbol( static_cast< QgsFillSymbol * >( a2 ) );
+  p.annotationManager()->addAnnotation( annotation );
+
+  found.clear();
+  QVERIFY( p.accept( &visitor ) );
+
+  QCOMPARE( found, QStringList()
+            << QStringLiteral( "enter: %1 rl" ).arg( rl->id() )
+            << QStringLiteral( "ramp:   #ffff00" )
+            << QStringLiteral( "exit: %1 rl" ).arg( rl->id() )
+            << QStringLiteral( "enter: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "symbol:   #ff0000" )
+            << QStringLiteral( "labels:   Class" )
+            << QStringLiteral( "exit: %1 vl" ).arg( vl->id() )
+            << QStringLiteral( "enter: layouts Layouts" )
+            << QStringLiteral( "enter: layout test layout" )
+            << QStringLiteral( "text format: <Scalebar> %1 QGIS Vera Sans" ).arg( scalebar->uuid() )
+            << QStringLiteral( "symbol: Page page #ffffff" )
+            << QStringLiteral( "exit: layout test layout" )
+            << QStringLiteral( "exit: layouts Layouts" )
+            << QStringLiteral( "enter: annotations Annotations" )
+            << QStringLiteral( "enter: annotation Annotation" )
+            << QStringLiteral( "symbol: Marker marker #00c800" )
+            << QStringLiteral( "symbol: Fill fill #c8c800" )
+            << QStringLiteral( "exit: annotation Annotation" )
+            << QStringLiteral( "exit: annotations Annotations" ) );
 }
 
 QGSTEST_MAIN( TestStyle )


### PR DESCRIPTION
Adds a new visitor pattern API for creation of visitors which visit all the style entities (symbols, color ramps, text formats, and label styles) associated with different objects. Can be used on a renderer, map layer, or project wide level.

E.g. on a project wide level, allows collection of ALL the style symbols/color ramps/text settings inside a project, including those in layouts or annotations!

This opens up lots of possibilities. E.g. scripts (or processing algorithms!) which:
- check for broken file references in symbols (e.g. missing svgs)
- list all expressions from data defined properties in symbols, and check their validity
- extract all symbols, color ramps, label settings from a project and saves them to a style database
- extracts the unique colors from a project, and builds an automatic "project color scheme" from them
- finds wherever you've used crappy fonts in a project (ms shell dlg anyone?)

...etc etc

(a nice follow up would be a visitor which allows symbols to be modified, but that's an order of magnitude more complex). 

