### PR TITLE
[processing] adjust color widget wrapper size policy to be consistent with others

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2577,6 +2577,7 @@ QWidget *QgsProcessingColorWidgetWrapper::createWidget()
     case QgsProcessingGui::Modeler:
     {
       mColorButton = new QgsColorButton( nullptr );
+      mColorButton->setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
 
       if ( colorParam->flags() & QgsProcessingParameterDefinition::FlagOptional )
         mColorButton->setShowNull( true );


### PR DESCRIPTION
## Description
Set horizontal size policy to `Preffered` allowing color button to expand to full width of the algorithm dialog as all other wrappers do.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
