### PR TITLE
[processing] allow to set tiles background in the TilesXZY algorithms (fix #30490)

### DIFF
--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -35,6 +35,7 @@ from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterString,
                        QgsProcessingParameterExtent,
+                       QgsProcessingParameterColor,
                        QgsProcessingOutputFile,
                        QgsProcessingParameterFileDestination,
                        QgsProcessingParameterFolderDestination,
@@ -129,6 +130,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
     ZOOM_MIN = 'ZOOM_MIN'
     ZOOM_MAX = 'ZOOM_MAX'
     DPI = 'DPI'
+    BACKGROUND_COLOR = 'BACKGROUND_COLOR'
     TILE_FORMAT = 'TILE_FORMAT'
     QUALITY = 'QUALITY'
     METATILESIZE = 'METATILESIZE'
@@ -150,6 +152,10 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
                                                        minValue=48,
                                                        maxValue=600,
                                                        defaultValue=96))
+        self.addParameter(QgsProcessingParameterColor(self.BACKGROUND_COLOR,
+                                                      self.tr('Background color'),
+                                                      defaultValue=QColor(Qt.transparent),
+                                                      optional=True))
         self.formats = ['PNG', 'JPG']
         self.addParameter(QgsProcessingParameterEnum(self.TILE_FORMAT,
                                                      self.tr('Tile format'),
@@ -179,6 +185,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         self.min_zoom = self.parameterAsInt(parameters, self.ZOOM_MIN, context)
         self.max_zoom = self.parameterAsInt(parameters, self.ZOOM_MAX, context)
         dpi = self.parameterAsInt(parameters, self.DPI, context)
+        color = self.parameterAsColor(parameters, self.BACKGROUND_COLOR, context)
         self.tile_format = self.formats[self.parameterAsEnum(parameters, self.TILE_FORMAT, context)]
         quality = self.parameterAsInt(parameters, self.QUALITY, context)
         self.metatilesize = self.parameterAsInt(parameters, self.METATILESIZE, context)
@@ -202,7 +209,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         settings.setLayers(self.layers)
         settings.setOutputDpi(dpi)
         if self.tile_format == 'PNG':
-            settings.setBackgroundColor(QColor(Qt.transparent))
+            settings.setBackgroundColor(color)
 
         # disable partial labels (they would be cut at the edge of tiles)
         labeling_engine_settings = settings.labelingEngineSettings()
@@ -247,7 +254,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
                 settings.setOutputSize(size)
 
                 image = QImage(size, QImage.Format_ARGB32_Premultiplied)
-                image.fill(Qt.transparent)
+                image.fill(color)
                 dpm = settings.outputDpi() / 25.4 * 1000
                 image.setDotsPerMeterX(dpm)
                 image.setDotsPerMeterY(dpm)


### PR DESCRIPTION
## Description
Adds new optional parameter allowing to set different background color for generated tiles. Defaults to transparent background to maintain backward compatibility.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit