### PR TITLE
Add useful PyQGIS additions to QgsSymbol

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -83,19 +83,28 @@ Returns the list of symbol layers contained in the symbol.
 .. versionadded:: 2.7
 %End
 
-    QgsSymbolLayer *symbolLayer( int layer );
+
+    SIP_PYOBJECT symbolLayer( int layer ) /TypeHint="QgsSymbolLayer"/;
 %Docstring
-Returns a specific symbol layer contained in the symbol.
-
-:param layer: layer number
-
-:return: corresponding symbol layer
+Returns the symbol layer at the specified index. An IndexError will be raised if no layer with the specified index exists.
 
 .. seealso:: :py:func:`symbolLayers`
 
 .. seealso:: :py:func:`symbolLayerCount`
 
 .. versionadded:: 2.7
+%End
+%MethodCode
+    const int count = sipCpp->symbolLayerCount();
+    if ( a0 < 0 || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipRes = sipConvertFromType( sipCpp->symbolLayer( a0 ), sipType_QgsSymbolLayer, NULL );
+    }
 %End
 
     int symbolLayerCount() const;
@@ -109,6 +118,69 @@ Returns the total number of symbol layers contained in the symbol.
 .. seealso:: :py:func:`symbolLayer`
 
 .. versionadded:: 2.7
+%End
+
+
+    int __len__() const;
+%Docstring
+Returns the number of symbol layers contained in the symbol.
+%End
+%MethodCode
+    sipRes = sipCpp->symbolLayerCount();
+%End
+
+    //! Ensures that bool(obj) returns ``True`` (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
+    SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsSymbolLayer"/;
+%Docstring
+Returns the symbol layer at the specified ``index``. An IndexError will be raised if no layer with the specified ``index`` exists.
+
+Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
+corresponds to the last layer in the symbol.
+
+.. versionadded:: 3.10
+%End
+%MethodCode
+    const int count = sipCpp->symbolLayerCount();
+    if ( a0 < -count || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else if ( a0 >= 0 )
+    {
+      return sipConvertFromType( sipCpp->symbolLayer( a0 ), sipType_QgsSymbolLayer, NULL );
+    }
+    else
+    {
+      return sipConvertFromType( sipCpp->symbolLayer( count + a0 ), sipType_QgsSymbolLayer, NULL );
+    }
+%End
+
+    void __delitem__( int index );
+%Docstring
+Deletes the layer at the specified ``index``. A layer at the ``index`` must already exist or an IndexError will be raised.
+
+Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
+corresponds to the last layer in the symbol.
+
+.. versionadded:: 3.10
+%End
+%MethodCode
+    const int count = sipCpp->symbolLayerCount();
+    if ( a0 >= 0 && a0 < count )
+      sipCpp->deleteSymbolLayer( a0 );
+    else if ( a0 < 0 && a0 >= -count )
+      sipCpp->deleteSymbolLayer( count + a0 );
+    else
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
 %End
 
     bool insertSymbolLayer( int index, QgsSymbolLayer *layer /Transfer/ );

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -130,15 +130,38 @@ class CORE_EXPORT QgsSymbol
      */
     QgsSymbolLayerList symbolLayers() { return mLayers; }
 
+#ifndef SIP_RUN
+
     /**
-     * Returns a specific symbol layer contained in the symbol.
-     * \param layer layer number
-     * \returns corresponding symbol layer
+     * Returns the symbol layer at the specified index
      * \see symbolLayers
      * \see symbolLayerCount
      * \since QGIS 2.7
      */
     QgsSymbolLayer *symbolLayer( int layer );
+#else
+
+    /**
+     * Returns the symbol layer at the specified index. An IndexError will be raised if no layer with the specified index exists.
+     *
+     * \see symbolLayers
+     * \see symbolLayerCount
+     * \since QGIS 2.7
+     */
+    SIP_PYOBJECT symbolLayer( int layer ) SIP_TYPEHINT( QgsSymbolLayer );
+    % MethodCode
+    const int count = sipCpp->symbolLayerCount();
+    if ( a0 < 0 || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipRes = sipConvertFromType( sipCpp->symbolLayer( a0 ), sipType_QgsSymbolLayer, NULL );
+    }
+    % End
+#endif
 
     /**
      * Returns the total number of symbol layers contained in the symbol.
@@ -148,6 +171,71 @@ class CORE_EXPORT QgsSymbol
      * \since QGIS 2.7
      */
     int symbolLayerCount() const { return mLayers.count(); }
+
+#ifdef SIP_RUN
+
+    /**
+     * Returns the number of symbol layers contained in the symbol.
+     */
+    int __len__() const;
+    % MethodCode
+    sipRes = sipCpp->symbolLayerCount();
+    % End
+
+    //! Ensures that bool(obj) returns TRUE (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
+
+    /**
+    * Returns the symbol layer at the specified ``index``. An IndexError will be raised if no layer with the specified ``index`` exists.
+    *
+    * Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
+    * corresponds to the last layer in the symbol.
+    *
+    * \since QGIS 3.10
+    */
+    SIP_PYOBJECT __getitem__( int index ) SIP_TYPEHINT( QgsSymbolLayer );
+    % MethodCode
+    const int count = sipCpp->symbolLayerCount();
+    if ( a0 < -count || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else if ( a0 >= 0 )
+    {
+      return sipConvertFromType( sipCpp->symbolLayer( a0 ), sipType_QgsSymbolLayer, NULL );
+    }
+    else
+    {
+      return sipConvertFromType( sipCpp->symbolLayer( count + a0 ), sipType_QgsSymbolLayer, NULL );
+    }
+    % End
+
+    /**
+     * Deletes the layer at the specified ``index``. A layer at the ``index`` must already exist or an IndexError will be raised.
+     *
+     * Indexes can be less than 0, in which case they correspond to layers from the end of the symbol. E.g. an index of -1
+     * corresponds to the last layer in the symbol.
+     *
+     * \since QGIS 3.10
+     */
+    void __delitem__( int index );
+    % MethodCode
+    const int count = sipCpp->symbolLayerCount();
+    if ( a0 >= 0 && a0 < count )
+      sipCpp->deleteSymbolLayer( a0 );
+    else if ( a0 < 0 && a0 >= -count )
+      sipCpp->deleteSymbolLayer( count + a0 );
+    else
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    % End
+#endif
 
     /**
      * Inserts a symbol \a layer to specified \a index.

--- a/tests/src/python/test_qgssymbol.py
+++ b/tests/src/python/test_qgssymbol.py
@@ -76,6 +76,77 @@ class TestQgsSymbol(unittest.TestCase):
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
 
+    def testPythonAdditions(self):
+        """
+        Test PyQGIS additions to QgsSymbol
+        """
+        markerSymbol = QgsMarkerSymbol()
+        markerSymbol.symbolLayer(0).setColor(QColor(255, 255, 0))
+        self.assertEqual(len(markerSymbol), 1)
+        layers = [l.color().name() for l in markerSymbol]
+        self.assertEqual(layers, ['#ffff00'])
+        self.assertEqual(markerSymbol[0].color().name(), '#ffff00')
+        self.assertEqual(markerSymbol[-1].color().name(), '#ffff00')
+        with self.assertRaises(IndexError):
+            _ = markerSymbol[1]
+        with self.assertRaises(IndexError):
+            _ = markerSymbol[-2]
+        with self.assertRaises(IndexError):
+            _ = markerSymbol.symbolLayer(1)
+        with self.assertRaises(IndexError):
+            _ = markerSymbol.symbolLayer(-1) # negative index only supported by []
+
+        with self.assertRaises(IndexError):
+            del markerSymbol[1]
+        with self.assertRaises(IndexError):
+            del markerSymbol[-2]
+
+        del markerSymbol[0]
+        self.assertEqual(len(markerSymbol), 0)
+        self.assertTrue(markerSymbol)
+
+        with self.assertRaises(IndexError):
+            _ = markerSymbol[0]
+        with self.assertRaises(IndexError):
+            _ = markerSymbol[-1]
+
+        with self.assertRaises(IndexError):
+            del markerSymbol[0]
+        with self.assertRaises(IndexError):
+            del markerSymbol[-1]
+
+        markerSymbol.appendSymbolLayer(
+            QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayerBase.Star, color=QColor(255, 0, 0),
+                                       strokeColor=QColor(0, 255, 0), size=10))
+        markerSymbol.appendSymbolLayer(
+            QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayerBase.Star, color=QColor(255, 255, 0),
+                                       strokeColor=QColor(0, 255, 255), size=10))
+
+        self.assertEqual(len(markerSymbol), 2)
+        layers = [l.color().name() for l in markerSymbol]
+        self.assertEqual(layers, ['#ff0000', '#ffff00'])
+        self.assertEqual(markerSymbol[0].color().name(), '#ff0000')
+        self.assertEqual(markerSymbol[-1].color().name(), '#ffff00')
+        self.assertEqual(markerSymbol[1].color().name(), '#ffff00')
+        self.assertEqual(markerSymbol[-2].color().name(), '#ff0000')
+        with self.assertRaises(IndexError):
+            _ = markerSymbol[2]
+        with self.assertRaises(IndexError):
+            _ = markerSymbol[-3]
+        with self.assertRaises(IndexError):
+            _ = markerSymbol.symbolLayer(2)
+        with self.assertRaises(IndexError):
+            _ = markerSymbol.symbolLayer(-1) # negative index only supported by []
+
+        with self.assertRaises(IndexError):
+            del markerSymbol[2]
+        with self.assertRaises(IndexError):
+            del markerSymbol[-3]
+
+        del markerSymbol[1]
+        layers = [l.color().name() for l in markerSymbol]
+        self.assertEqual(layers, ['#ff0000'])
+
     def testGeometryRendering(self):
         '''Tests rendering a bunch of different geometries, including bad/odd geometries.'''
 


### PR DESCRIPTION
Adds:
- __len__ : returns number of symbol layers in symbol
- [ ] getter: returns a specific symbol layer, also allows negative indices to retrieve from end of symbol
- del [ ]: removes a specific symbol layer, also allows negative indices
- raise IndexError when an invalid symbol layer is requested
- allow iteration over symbol layers using
  for layer in symbol:
     print(layer.color())
