### PR TITLE
Further tweaks and fixes for transformation selection dialog

### DIFF
--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -87,6 +87,8 @@ and ``destinationTransformId`` transforms.
       QString scope;
 
       QString remarks;
+
+      QString areaOfUse;
     };
 
     struct TransformDetails
@@ -95,7 +97,13 @@ and ``destinationTransformId`` transforms.
       QString name;
       double accuracy;
 
+      QString scope;
+
+      QString remarks;
+
       bool isAvailable;
+
+      QString areaOfUse;
 
       QList< QgsDatumTransform::GridDetails > grids;
 

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -323,6 +323,17 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
   details.accuracy = proj_coordoperation_get_accuracy( pjContext, op );
   details.isAvailable = proj_coordoperation_is_instantiable( pjContext, op );
 
+  const char *areaOfUseName = nullptr;
+  if ( proj_get_area_of_use( pjContext, op, nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+  {
+    details.areaOfUse = QString( areaOfUseName );
+  }
+
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
+  details.remarks = QString( proj_get_remarks( op ) );
+  details.scope = QString( proj_get_scope( op ) );
+#endif
+
   for ( int j = 0; j < proj_coordoperation_get_grid_used_count( pjContext, op ); ++j )
   {
     const char *shortName = nullptr;
@@ -354,6 +365,12 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
       SingleOperationDetails singleOpDetails;
       singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
       singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
+
+      const char *areaOfUseName = nullptr;
+      if ( proj_get_area_of_use( pjContext, step.get(), nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+      {
+        singleOpDetails.areaOfUse = QString( areaOfUseName );
+      }
       details.operationDetails.append( singleOpDetails );
     }
   }

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -160,6 +160,9 @@ class CORE_EXPORT QgsDatumTransform
 
       //! Remarks for operation, from EPSG registry database
       QString remarks;
+
+      //! Area of use, from EPSG registry database
+      QString areaOfUse;
     };
 
     /**
@@ -178,12 +181,36 @@ class CORE_EXPORT QgsDatumTransform
       double accuracy = 0;
 
       /**
+       * Scope of operation, from EPSG registry database.
+       *
+       * This is only available for single step coordinate operations. For multi-step operations, check
+       * \a operationDetails instead.
+       */
+      QString scope;
+
+      /**
+      * Remarks for operation, from EPSG registry database.
+      *
+      * This is only available for single step coordinate operations. For multi-step operations, check
+      * \a operationDetails instead.
+      */
+      QString remarks;
+
+      /**
        * TRUE if operation is available.
        *
        * If FALSE, it likely means a transform grid is required which is not
        * available.
        */
       bool isAvailable = false;
+
+      /**
+       * Area of use string.
+       *
+       * This is only available for single step coordinate operations. For multi-step operations, check
+       * \a operationDetails instead.
+       */
+      QString areaOfUse;
 
       /**
        * Contains a list of transform grids used by the operation.

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -204,8 +204,7 @@ QList<QgsDatumTransform::GridDetails> QgsProjUtils::gridsUsed( const QString &pr
     const QString gridName = match.captured( 1 );
     QgsDatumTransform::GridDetails grid;
     grid.shortName = gridName;
-#if PROJ_VERSION_MAJOR >= 6
-#if PROJ_VERSION_MINOR >= 2
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
     const char *fullName = nullptr;
     const char *packageName = nullptr;
     const char *url = nullptr;
@@ -219,7 +218,6 @@ QList<QgsDatumTransform::GridDetails> QgsProjUtils::gridsUsed( const QString &pr
     grid.directDownload = directDownload;
     grid.openLicense = openLicense;
     grid.isAvailable = available;
-#endif
 #endif
     grids.append( grid );
   }

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -108,6 +108,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     {
       TransformIdRole = Qt::UserRole + 1,
       ProjRole,
+      AvailableRole,
     };
 
     bool gridShiftTransformation( const QString &itemText ) const;

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -95,8 +95,15 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
   mRecentProjections = QgsCoordinateReferenceSystem::recentProjections();
 
   mCheckBoxNoProjection->setHidden( true );
+  mCheckBoxNoProjection->setEnabled( false );
   connect( mCheckBoxNoProjection, &QCheckBox::toggled, this, &QgsProjectionSelectionTreeWidget::crsSelected );
-  connect( mCheckBoxNoProjection, &QCheckBox::toggled, mFrameProjections, &QFrame::setDisabled );
+  connect( mCheckBoxNoProjection, &QCheckBox::toggled, this, [ = ]( bool checked )
+  {
+    if ( mCheckBoxNoProjection->isEnabled() )
+    {
+      mFrameProjections->setDisabled( checked );
+    }
+  } );
 }
 
 QgsProjectionSelectionTreeWidget::~QgsProjectionSelectionTreeWidget()
@@ -472,7 +479,7 @@ QString QgsProjectionSelectionTreeWidget::getSelectedExpression( const QString &
 
 QgsCoordinateReferenceSystem QgsProjectionSelectionTreeWidget::crs() const
 {
-  if ( mCheckBoxNoProjection->isChecked() )
+  if ( mCheckBoxNoProjection->isEnabled() && mCheckBoxNoProjection->isChecked() )
     return QgsCoordinateReferenceSystem();
 
   int srid = getSelectedExpression( QStringLiteral( "srs_id" ) ).toLong();
@@ -484,7 +491,12 @@ QgsCoordinateReferenceSystem QgsProjectionSelectionTreeWidget::crs() const
 
 void QgsProjectionSelectionTreeWidget::setShowNoProjection( bool show )
 {
-  mCheckBoxNoProjection->setHidden( !show );
+  mCheckBoxNoProjection->setVisible( show );
+  mCheckBoxNoProjection->setEnabled( show );
+  if ( show )
+  {
+    mFrameProjections->setDisabled( mCheckBoxNoProjection->isChecked() );
+  }
 }
 
 void QgsProjectionSelectionTreeWidget::setShowBoundsMap( bool show )


### PR DESCRIPTION
- Show area of use information, which gives users much more context and clues for selecting the right transform from the list
- Fix missing scope and remarks for single operations

Previously:

![image](https://user-images.githubusercontent.com/1829991/60634083-eb136580-9e50-11e9-9297-244464e26cbd.png)

Now:

![image](https://user-images.githubusercontent.com/1829991/60634074-e2bb2a80-9e50-11e9-8185-1a359734d7ac.png)


![image](https://user-images.githubusercontent.com/1829991/60634131-26159900-9e51-11e9-87ce-71a6b8e13caf.png)


