### PR TITLE
Label engine API tweaks

### DIFF
--- a/python/core/auto_generated/qgspallabeling.sip.in
+++ b/python/core/auto_generated/qgspallabeling.sip.in
@@ -309,6 +309,25 @@ names which the labeling requires for the rendering.
 .. versionadded:: 3.8
 %End
 
+    void startRender( QgsRenderContext &context );
+%Docstring
+Prepares the label settings for rendering.
+
+This should be called before rendering any labels, and must be
+followed by a call to stopRender() in order to gracefully clean up symbols.
+
+.. versionadded:: 3.10
+%End
+
+    void stopRender( QgsRenderContext &context );
+%Docstring
+Finalises the label settings after use.
+
+This must be called after a call to startRender(), in order to gracefully clean up symbols.
+
+.. versionadded:: 3.10
+%End
+
     static const QgsPropertiesDefinition &propertyDefinitions();
 %Docstring
 Returns the labeling property definitions.

--- a/python/core/auto_generated/qgspallabeling.sip.in
+++ b/python/core/auto_generated/qgspallabeling.sip.in
@@ -296,7 +296,7 @@ class QgsPalLayerSettings
     };
 
 
-    bool prepare( const QgsRenderContext &context, QSet<QString> &attributeNames /In,Out/, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs );
+    bool prepare( QgsRenderContext &context, QSet<QString> &attributeNames /In,Out/, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs );
 %Docstring
 Prepare for registration of features.
 The ``context``, ``mapSettings`` and ``fields`` parameters give more

--- a/src/core/qgslabelfeature.cpp
+++ b/src/core/qgslabelfeature.cpp
@@ -72,3 +72,13 @@ void QgsLabelFeature::setPermissibleZone( const QgsGeometry &geometry )
 
   mPermissibleZoneGeosPrepared.reset( GEOSPrepare_r( QgsGeos::getGEOSHandler(), mPermissibleZoneGeos.get() ) );
 }
+
+QgsFeature QgsLabelFeature::feature() const
+{
+  return mFeature;
+}
+
+void QgsLabelFeature::setFeature( const QgsFeature &feature )
+{
+  mFeature = feature;
+}

--- a/src/core/qgslabelfeature.h
+++ b/src/core/qgslabelfeature.h
@@ -371,6 +371,22 @@ class CORE_EXPORT QgsLabelFeature
     //! Returns provider of this instance
     QgsAbstractLabelProvider *provider() const;
 
+    /**
+     * Returns the original feature associated with this label.
+     * \see setFeature()
+     *
+     * \since QGIS 3.10
+     */
+    QgsFeature feature() const;
+
+    /**
+     * Sets the original \a feature associated with this label.
+     * \see feature()
+     *
+     * \since QGIS 3.10
+     */
+    void setFeature( const QgsFeature &feature );
+
   protected:
     //! Pointer to PAL layer (assigned when registered to PAL)
     pal::Layer *mLayer = nullptr;
@@ -435,6 +451,8 @@ class CORE_EXPORT QgsLabelFeature
 
     // TODO - not required when QgsGeometry caches geos preparedness
     geos::prepared_unique_ptr mPermissibleZoneGeosPrepared;
+
+    QgsFeature mFeature;
 
 };
 

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -351,6 +351,12 @@ void QgsLabelingEngine::run( QgsRenderContext &context )
   // sort labels
   std::sort( labels.begin(), labels.end(), QgsLabelSorter( mMapSettings ) );
 
+  // prepare for rendering
+  for ( QgsAbstractLabelProvider *provider : qgis::as_const( mProviders ) )
+  {
+    provider->startRender( context );
+  }
+
   // draw the labels
   for ( pal::LabelPosition *label : qgis::as_const( labels ) )
   {
@@ -365,6 +371,12 @@ void QgsLabelingEngine::run( QgsRenderContext &context )
 
     context.expressionContext().setFeature( lf->feature() );
     lf->provider()->drawLabel( context, label );
+  }
+
+  // cleanup
+  for ( QgsAbstractLabelProvider *provider : qgis::as_const( mProviders ) )
+  {
+    provider->stopRender( context );
   }
 
   // Reset composition mode for further drawing operations
@@ -399,6 +411,23 @@ QgsAbstractLabelProvider::QgsAbstractLabelProvider( QgsMapLayer *layer, const QS
 {
 }
 
+void QgsAbstractLabelProvider::startRender( QgsRenderContext &context )
+{
+  const auto subproviders = subProviders();
+  for ( QgsAbstractLabelProvider *subProvider : subproviders )
+  {
+    subProvider->startRender( context );
+  }
+}
+
+void QgsAbstractLabelProvider::stopRender( QgsRenderContext &context )
+{
+  const auto subproviders = subProviders();
+  for ( QgsAbstractLabelProvider *subProvider : subproviders )
+  {
+    subProvider->stopRender( context );
+  }
+}
 
 //
 // QgsLabelingUtils

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -363,6 +363,7 @@ void QgsLabelingEngine::run( QgsRenderContext &context )
       continue;
     }
 
+    context.expressionContext().setFeature( lf->feature() );
     lf->provider()->drawLabel( context, label );
   }
 

--- a/src/core/qgslabelingengine.h
+++ b/src/core/qgslabelingengine.h
@@ -65,8 +65,27 @@ class CORE_EXPORT QgsAbstractLabelProvider
     //! Returns list of label features (they are owned by the provider and thus deleted on its destruction)
     virtual QList<QgsLabelFeature *> labelFeatures( QgsRenderContext &context ) = 0;
 
-    //! draw this label at the position determined by the labeling engine
+    /**
+     * Draw this label at the position determined by the labeling engine.
+     *
+     * Before any calls to drawLabel(), a provider should be prepared for rendering by a call to
+     * startRender() and a corresponding call to stopRender().
+     */
     virtual void drawLabel( QgsRenderContext &context, pal::LabelPosition *label ) const = 0;
+
+    /**
+     * To be called before rendering of labels begins. Must be accompanied by
+     * a corresponding call to stopRender()
+     * \since QGIS 3.10
+     */
+    virtual void startRender( QgsRenderContext &context );
+
+    /**
+     * To be called after rendering is complete.
+     * \see startRender()
+     * \since QGIS 3.10
+     */
+    virtual void stopRender( QgsRenderContext &context );
 
     //! Returns list of child providers - useful if the provider needs to put labels into more layers with different configuration
     virtual QList<QgsAbstractLabelProvider *> subProviders() { return QList<QgsAbstractLabelProvider *>(); }

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -403,7 +403,7 @@ QgsPalLayerSettings &QgsPalLayerSettings::operator=( const QgsPalLayerSettings &
   return *this;
 }
 
-bool QgsPalLayerSettings::prepare( const QgsRenderContext &context, QSet<QString> &attributeNames, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs )
+bool QgsPalLayerSettings::prepare( QgsRenderContext &context, QSet<QString> &attributeNames, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs )
 {
   if ( drawLabels )
   {

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2121,6 +2121,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
   //  feature to the layer
   QgsTextLabelFeature *lf = new QgsTextLabelFeature( feature.id(), std::move( geos_geom_clone ), QSizeF( labelX, labelY ) );
+  lf->setFeature( feature );
   mFeatsRegPal++;
 
   *labelFeature = lf;
@@ -2317,6 +2318,7 @@ void QgsPalLayerSettings::registerObstacleFeature( const QgsFeature &f, QgsRende
   //  feature to the layer
   *obstacleFeature = new QgsLabelFeature( f.id(), std::move( geos_geom_clone ), QSizeF( 0, 0 ) );
   ( *obstacleFeature )->setIsObstacle( true );
+  ( *obstacleFeature )->setFeature( f );
   mFeatsRegPal++;
 }
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -515,9 +515,35 @@ bool QgsPalLayerSettings::prepare( QgsRenderContext &context, QSet<QString> &att
   return true;
 }
 
+void QgsPalLayerSettings::startRender( QgsRenderContext & )
+{
+  if ( mRenderStarted )
+  {
+    qWarning( "Start render called for when a previous render was already underway!!" );
+    return;
+  }
+
+  mRenderStarted = true;
+}
+
+void QgsPalLayerSettings::stopRender( QgsRenderContext & )
+{
+  if ( !mRenderStarted )
+  {
+    qWarning( "Stop render called for QgsPalLayerSettings without a startRender call!" );
+    return;
+  }
+
+  mRenderStarted = false;
+}
 
 QgsPalLayerSettings::~QgsPalLayerSettings()
 {
+  if ( mRenderStarted )
+  {
+    qWarning( "stopRender was not called on QgsPalLayerSettings object!" );
+  }
+
   // pal layer is deleted internally in PAL
 
   delete expression;

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -456,6 +456,25 @@ class CORE_EXPORT QgsPalLayerSettings
     bool prepare( QgsRenderContext &context, QSet<QString> &attributeNames SIP_INOUT, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs );
 
     /**
+     * Prepares the label settings for rendering.
+     *
+     * This should be called before rendering any labels, and must be
+     * followed by a call to stopRender() in order to gracefully clean up symbols.
+     *
+     * \since QGIS 3.10
+     */
+    void startRender( QgsRenderContext &context );
+
+    /**
+     * Finalises the label settings after use.
+     *
+     * This must be called after a call to startRender(), in order to gracefully clean up symbols.
+     *
+     * \since QGIS 3.10
+     */
+    void stopRender( QgsRenderContext &context );
+
+    /**
      * Returns the labeling property definitions.
      * \since QGIS 3.0
      */
@@ -1032,6 +1051,8 @@ class CORE_EXPORT QgsPalLayerSettings
     QgsTextFormat mFormat;
 
     QgsExpression mGeometryGeneratorExpression;
+
+    bool mRenderStarted = false;
 
     static const QVector< PredefinedPointPosition > DEFAULT_PLACEMENT_ORDER;
 

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -453,7 +453,7 @@ class CORE_EXPORT QgsPalLayerSettings
      *
      * \since QGIS 3.8
      */
-    bool prepare( const QgsRenderContext &context, QSet<QString> &attributeNames SIP_INOUT, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs );
+    bool prepare( QgsRenderContext &context, QSet<QString> &attributeNames SIP_INOUT, const QgsFields &fields, const QgsMapSettings &mapSettings, const QgsCoordinateReferenceSystem &crs );
 
     /**
      * Returns the labeling property definitions.

--- a/src/core/qgsrulebasedlabeling.cpp
+++ b/src/core/qgsrulebasedlabeling.cpp
@@ -28,7 +28,7 @@ QgsVectorLayerLabelProvider *QgsRuleBasedLabelProvider::createProvider( QgsVecto
   return new QgsVectorLayerLabelProvider( layer, providerId, withFeatureLoop, settings );
 }
 
-bool QgsRuleBasedLabelProvider::prepare( const QgsRenderContext &context, QSet<QString> &attributeNames )
+bool QgsRuleBasedLabelProvider::prepare( QgsRenderContext &context, QSet<QString> &attributeNames )
 {
   for ( QgsVectorLayerLabelProvider *provider : qgis::as_const( mSubProviders ) )
     provider->setEngine( mEngine );
@@ -320,7 +320,7 @@ void QgsRuleBasedLabeling::Rule::createSubProviders( QgsVectorLayer *layer, QgsR
   }
 }
 
-void QgsRuleBasedLabeling::Rule::prepare( const QgsRenderContext &context, QSet<QString> &attributeNames, QgsRuleBasedLabeling::RuleToProviderMap &subProviders )
+void QgsRuleBasedLabeling::Rule::prepare( QgsRenderContext &context, QSet<QString> &attributeNames, QgsRuleBasedLabeling::RuleToProviderMap &subProviders )
 {
   if ( mSettings )
   {

--- a/src/core/qgsrulebasedlabeling.h
+++ b/src/core/qgsrulebasedlabeling.h
@@ -276,7 +276,7 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
          * call prepare() on sub-providers and populate attributeNames
          * \note not available in Python bindings
          */
-        void prepare( const QgsRenderContext &context, QSet<QString> &attributeNames, RuleToProviderMap &subProviders ) SIP_SKIP;
+        void prepare( QgsRenderContext &context, QSet<QString> &attributeNames, RuleToProviderMap &subProviders ) SIP_SKIP;
 
         /**
          * register individual features
@@ -405,7 +405,7 @@ class CORE_EXPORT QgsRuleBasedLabelProvider : public QgsVectorLayerLabelProvider
 
     // reimplemented
 
-    bool prepare( const QgsRenderContext &context, QSet<QString> &attributeNames ) override;
+    bool prepare( QgsRenderContext &context, QSet<QString> &attributeNames ) override;
 
     void registerFeature( const QgsFeature &feature, QgsRenderContext &context, const QgsGeometry &obstacleGeometry = QgsGeometry() ) override;
 

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -97,6 +97,18 @@ bool QgsVectorLayerLabelProvider::prepare( QgsRenderContext &context, QSet<QStri
   return mSettings.prepare( context, attributeNames, mFields, mapSettings, mCrs );
 }
 
+void QgsVectorLayerLabelProvider::startRender( QgsRenderContext &context )
+{
+  QgsAbstractLabelProvider::startRender( context );
+  mSettings.startRender( context );
+}
+
+void QgsVectorLayerLabelProvider::stopRender( QgsRenderContext &context )
+{
+  QgsAbstractLabelProvider::stopRender( context );
+  mSettings.stopRender( context );
+}
+
 QList<QgsLabelFeature *> QgsVectorLayerLabelProvider::labelFeatures( QgsRenderContext &ctx )
 {
   if ( !mSource )

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -90,7 +90,7 @@ QgsVectorLayerLabelProvider::~QgsVectorLayerLabelProvider()
 }
 
 
-bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext &context, QSet<QString> &attributeNames )
+bool QgsVectorLayerLabelProvider::prepare( QgsRenderContext &context, QSet<QString> &attributeNames )
 {
   const QgsMapSettings &mapSettings = mEngine->mapSettings();
 

--- a/src/core/qgsvectorlayerlabelprovider.h
+++ b/src/core/qgsvectorlayerlabelprovider.h
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
      * \param attributeNames list of attribute names to which additional required attributes shall be added
      * \returns Whether the preparation was successful - if not, the provider shall not be used
      */
-    virtual bool prepare( const QgsRenderContext &context, QSet<QString> &attributeNames );
+    virtual bool prepare( QgsRenderContext &context, QSet<QString> &attributeNames );
 
     /**
      * Register a feature for labeling as one or more QgsLabelFeature objects stored into mLabels

--- a/src/core/qgsvectorlayerlabelprovider.h
+++ b/src/core/qgsvectorlayerlabelprovider.h
@@ -52,6 +52,8 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
     QList<QgsLabelFeature *> labelFeatures( QgsRenderContext &context ) override;
 
     void drawLabel( QgsRenderContext &context, pal::LabelPosition *label ) const override;
+    void startRender( QgsRenderContext &context ) override;
+    void stopRender( QgsRenderContext &context ) override;
 
     // new virtual methods
 
@@ -112,6 +114,8 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
 
     //! List of generated
     QList<QgsLabelFeature *> mLabels;
+
+  private:
 
     friend class TestQgsLabelingEngine;
 };


### PR DESCRIPTION
Some API refactoring required to allow symbols to be correctly utilised as components of QgsPalLayerSettings. This is required to allow us to correctly call startRender/stopRender on those symbols before and after the label rendering job, allowing them to be correctly cleaned up after a rendering operation.