### PR TITLE
[xyz] Don't crash on empty tilesets, instead return empty images

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -652,7 +652,11 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
     {
       Q_ASSERT( mTileLayer );
       Q_ASSERT( mTileMatrixSet );
-      Q_ASSERT( !mTileMatrixSet->tileMatrices.isEmpty() );
+      if ( mTileMatrixSet->tileMatrices.isEmpty() )
+      {
+        QgsDebugMsg( QStringLiteral( "WMTS tile set is empty!" ) );
+        return image;
+      }
 
       // if we know both source and output DPI, let's scale the tiles
       if ( mDpi != -1 && mTileLayer->dpi != -1 )

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -16,6 +16,7 @@
 #include "qgsxyzconnectiondialog.h"
 #include "qgsxyzconnection.h"
 #include "qgsgui.h"
+#include <QMessageBox>
 
 QgsXyzConnectionDialog::QgsXyzConnectionDialog( QWidget *parent )
   : QDialog( parent )
@@ -68,4 +69,14 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
     conn.tilePixelRatio = 0;  // unknown
   conn.authCfg = mAuthSettings->configId( );
   return conn;
+}
+
+void QgsXyzConnectionDialog::accept()
+{
+  if ( mCheckBoxZMin->isChecked() && mCheckBoxZMax->isChecked() && mSpinZMax->value() < mSpinZMin->value() )
+  {
+    QMessageBox::warning( this, tr( "Connection Properties" ), tr( "The maximum zoom level (%1) cannot be lower than the minimum zoom level (%2)." ).arg( mSpinZMax->value() ).arg( mSpinZMin->value() ) );
+    return;
+  }
+  QDialog::accept();
 }

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -34,6 +34,8 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
 
     QgsXyzConnection connection() const;
 
+    void accept() override;
+
   private:
 
     QString mBaseKey;


### PR DESCRIPTION
Also show a warning when bad settings are set in the connection properties (e.g. min zoom > max zoom)