### PR TITLE
Always enable 3d model material for non 3D model shape.

### DIFF
--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -229,6 +229,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
              << labelLength << spinLength
              << labelModel << lineEditModel << btnModel << cbOverwriteMaterial;
 
+  widgetMaterial->setEnabled( true );
   QList<QWidget *> activeWidgets;
   switch ( cboShape->currentIndex() )
   {
@@ -252,6 +253,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
       break;
     case 6:  // 3d model
       activeWidgets << labelModel << lineEditModel << btnModel << cbOverwriteMaterial;
+      widgetMaterial->setEnabled( cbOverwriteMaterial->isChecked() );
       break;
   }
 


### PR DESCRIPTION
## Description
Previously, on 3D Point Layer style dialog, when you choose Shape = 3D Model, then disable the (overwrite model material), then change another shape, the material widget (diffuse, ambient, specular, shininess) are still disabled. This PR makes it always enabled for non-3D model shape. See the preview below:
![always_enabled_material](https://user-images.githubusercontent.com/1421861/60767427-5448e200-a0b8-11e9-830e-05240e4bb683.gif)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
