### PR TITLE
Fix totally inaccurate message always shows at the top of CRS

### DIFF
--- a/src/gui/qgsprojectionselectiondialog.cpp
+++ b/src/gui/qgsprojectionselectiondialog.cpp
@@ -46,12 +46,10 @@ void QgsProjectionSelectionDialog::setMessage( const QString &message )
   if ( m.isEmpty() )
   {
     // Set up text edit pane
-    QString format( QStringLiteral( "<h1>%1</h1>%2 %3" ) );
-    QString header = tr( "Define this layer's coordinate reference system:" );
     QString sentence1 = tr( "This layer appears to have no projection specification." );
     QString sentence2 = tr( "By default, this layer will now have its projection set to that of the project, "
                             "but you may override this by selecting a different projection below." );
-    m = format.arg( header, sentence1, sentence2 );
+    m = QStringLiteral( "%1 %2" ).arg( sentence1, sentence2 );
   }
 
   QString myStyle = QgsApplication::reportStyleSheet();

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -170,7 +170,8 @@ void QgsProjectionSelectionWidget::selectCrs()
 {
   //find out crs id of current proj4 string
   QgsProjectionSelectionDialog dlg( this );
-  dlg.setMessage( mMessage );
+  if ( !mMessage.isEmpty() )
+    dlg.setMessage( mMessage );
   dlg.setCrs( mCrs );
 
   if ( optionVisible( QgsProjectionSelectionWidget::CrsOption::CrsNotSet ) )


### PR DESCRIPTION
selector dialogs in totally inappropriate occasions.

E.g. run the "reproject layer" algorithm, click the globe icon next the the CRS choice, and you see this misleading message:

![image](https://user-images.githubusercontent.com/1829991/60776045-5bc9c300-a16c-11e9-9b48-ea9bd9923d6d.png)


