### PR TITLE
Fix crash when using rotation tool with selected feature(s) (fixes #30592)

### DIFF
--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -233,6 +233,12 @@ void QgsMapToolRotateFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
     QgsRectangle selectRect( layerCoords.x() - searchRadius, layerCoords.y() - searchRadius,
                              layerCoords.x() + searchRadius, layerCoords.y() + searchRadius );
 
+    if ( !mAnchorPoint )
+    {
+      mAnchorPoint = qgis::make_unique<QgsVertexMarker>( mCanvas );
+      mAnchorPoint->setIconType( QgsVertexMarker::ICON_CROSS );
+    }
+
     if ( vlayer->selectedFeatureCount() == 0 )
     {
       QgsFeatureIterator fit = vlayer->getFeatures( QgsFeatureRequest().setFilterRect( selectRect ).setNoAttributes() );
@@ -269,12 +275,6 @@ void QgsMapToolRotateFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
 
       QgsRectangle bound = cf.geometry().boundingBox();
       mStartPointMapCoords = toMapCoordinates( vlayer, bound.center() );
-
-      if ( !mAnchorPoint )
-      {
-        mAnchorPoint = qgis::make_unique<QgsVertexMarker>( mCanvas );
-      }
-      mAnchorPoint->setIconType( QgsVertexMarker::ICON_CROSS );
       mAnchorPoint->setCenter( mStartPointMapCoords );
 
       mStPoint = toCanvasCoordinates( mStartPointMapCoords );
@@ -326,7 +326,11 @@ void QgsMapToolRotateFeature::cancel()
 {
   deleteRotationWidget();
   deleteRubberband();
-  mAnchorPoint.reset();
+  QgsVectorLayer *vlayer = currentVectorLayer();
+  if ( vlayer->selectedFeatureCount() == 0 )
+  {
+    mAnchorPoint.reset();
+  }
   mRotationActive = false;
 }
 
@@ -465,8 +469,8 @@ void QgsMapToolRotateFeature::deactivate()
 {
   deleteRotationWidget();
   mRotationActive = false;
-  mAnchorPoint.reset();
   mRotationOffset = 0;
+  mAnchorPoint.reset();
   deleteRubberband();
   QgsMapTool::deactivate();
 }


### PR DESCRIPTION
## Description
Fix calling a null anchor point pointer when rotating selected feature(s) for the second time.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
