### PR TITLE
[Backport release-3_8] QgsOgcUtils: The wildcard attribute of PropertyIsLike OGC Filter Element is not well replaced

### DIFF
--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -394,6 +394,21 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
         "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
         "</Filter>" )
       << QStringLiteral( "NAME LIKE '%\\\\%QGIS%*'" );
+
+  QTest::newRow( "ilike wildCard simple" ) << QString(
+        "<Filter>"
+        "<PropertyIsLike matchCase=\"false\" wildCard='*' singleChar='.' escape=\"\\\">"
+        "<PropertyName>NAME</PropertyName><Literal>*QGIS*</Literal></PropertyIsLike>"
+        "</Filter>" )
+      << QStringLiteral( "NAME ILIKE '%QGIS%'" );
+
+  QTest::newRow( "ilike wildCard complex" ) << QString(
+        "<Filter>"
+        "<PropertyIsLike matchCase=\"false\"  wildCard='*' singleChar='.' escape=\"\\\">"
+        "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
+        "</Filter>" )
+      << QStringLiteral( "NAME ILIKE '%\\\\%QGIS%*'" );
+
   // different single chars
   QTest::newRow( "like single char" ) << QString(
                                         "<Filter>"

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -381,12 +381,19 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
                            << QStringLiteral( "NAME ILIKE '*QGIS*'" );
 
   // different wildCards
-  QTest::newRow( "like wildCard" ) << QString(
-                                     "<Filter>"
-                                     "<PropertyIsLike wildCard='*' singleChar='.' escape=\"\\\">"
-                                     "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
-                                     "</Filter>" )
-                                   << QStringLiteral( "NAME LIKE '%\\\\%QGIS%*'" );
+  QTest::newRow( "like wildCard simple" ) << QString(
+      "<Filter>"
+      "<PropertyIsLike wildCard='*' singleChar='.' escape=\"\\\">"
+      "<PropertyName>NAME</PropertyName><Literal>*QGIS*</Literal></PropertyIsLike>"
+      "</Filter>" )
+                                          << QStringLiteral( "NAME LIKE '%QGIS%'" );
+
+  QTest::newRow( "like wildCard complex" ) << QString(
+        "<Filter>"
+        "<PropertyIsLike wildCard='*' singleChar='.' escape=\"\\\">"
+        "<PropertyName>NAME</PropertyName><Literal>*%QGIS*\\*</Literal></PropertyIsLike>"
+        "</Filter>" )
+      << QStringLiteral( "NAME LIKE '%\\\\%QGIS%*'" );
   // different single chars
   QTest::newRow( "like single char" ) << QString(
                                         "<Filter>"


### PR DESCRIPTION
Manually Backport #30467