### PR TITLE
Backport transformation selection dialog improvements to 3.8

### DIFF
--- a/cmake/FindSpatiaLite.cmake
+++ b/cmake/FindSpatiaLite.cmake
@@ -70,11 +70,6 @@ IF (SPATIALITE_FOUND)
      SET(CMAKE_REQUIRED_LIBRARIES "-F/Library/Frameworks" ${CMAKE_REQUIRED_LIBRARIES})
    ENDIF(APPLE)
 
-   check_library_exists("${SPATIALITE_LIBRARY}" gaiaStatisticsInvalidate "" SPATIALITE_VERSION_GE_4_2_0)
-   IF (NOT SPATIALITE_VERSION_GE_4_2_0)
-     MESSAGE(FATAL_ERROR "Found SpatiaLite, but version is too old. Requires at least version 4.2.0")
-   ENDIF (NOT SPATIALITE_VERSION_GE_4_2_0)
-
 ELSE (SPATIALITE_FOUND)
 
    IF (SPATIALITE_FIND_REQUIRED)

--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -82,6 +82,13 @@ and ``destinationTransformId`` transforms.
       bool isAvailable;
     };
 
+    struct SingleOperationDetails
+    {
+      QString scope;
+
+      QString remarks;
+    };
+
     struct TransformDetails
     {
       QString proj;
@@ -91,6 +98,8 @@ and ``destinationTransformId`` transforms.
       bool isAvailable;
 
       QList< QgsDatumTransform::GridDetails > grids;
+
+      QList< QgsDatumTransform::SingleOperationDetails > operationDetails;
     };
 
     static QList< QgsDatumTransform::TransformDetails > operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );

--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -113,6 +113,8 @@ and ``destinationTransformId`` transforms.
 
       QString areaOfUse;
 
+      QgsRectangle bounds;
+
       QList< QgsDatumTransform::GridDetails > grids;
 
       QList< QgsDatumTransform::SingleOperationDetails > operationDetails;

--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -89,6 +89,10 @@ and ``destinationTransformId`` transforms.
       QString remarks;
 
       QString areaOfUse;
+
+      QString authority;
+
+      QString code;
     };
 
     struct TransformDetails
@@ -96,6 +100,10 @@ and ``destinationTransformId`` transforms.
       QString proj;
       QString name;
       double accuracy;
+
+      QString authority;
+
+      QString code;
 
       QString scope;
 

--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -87,6 +87,8 @@ and ``destinationTransformId`` transforms.
       QString scope;
 
       QString remarks;
+
+      QString areaOfUse;
     };
 
     struct TransformDetails
@@ -95,7 +97,13 @@ and ``destinationTransformId`` transforms.
       QString name;
       double accuracy;
 
+      QString scope;
+
+      QString remarks;
+
       bool isAvailable;
+
+      QString areaOfUse;
 
       QList< QgsDatumTransform::GridDetails > grids;
 

--- a/python/gui/auto_generated/qgscoordinateboundspreviewmapwidget.sip.in
+++ b/python/gui/auto_generated/qgscoordinateboundspreviewmapwidget.sip.in
@@ -1,0 +1,64 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscoordinateboundspreviewmapwidget.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsCoordinateBoundsPreviewMapWidget : QgsMapCanvas
+{
+%Docstring
+A widget for showing the bounds of a rectangular region on an interactive map.
+
+.. versionadded:: 3.8.1
+%End
+
+%TypeHeaderCode
+#include "qgscoordinateboundspreviewmapwidget.h"
+%End
+  public:
+
+    QgsCoordinateBoundsPreviewMapWidget( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsCoordinateBoundsPreviewMapWidget.
+%End
+
+    ~QgsCoordinateBoundsPreviewMapWidget();
+
+    void setCanvasRect( const QgsRectangle &rect );
+%Docstring
+Sets the canvas bounds rectangle for the bounds overview map.
+
+Must be in EPSG:4326 coordinate reference system.
+
+.. seealso:: :py:func:`canvasRect`
+%End
+
+    QgsRectangle canvasRect() const;
+%Docstring
+Returns the current canvas bounds rectangle shown in the map.
+
+.. seealso:: :py:func:`setCanvasRect`
+%End
+
+    void setPreviewRect( const QgsRectangle &rect );
+%Docstring
+Sets the "preview" rectangle for the bounds overview map.
+Must be in EPSG:4326 coordinate reference system.
+
+.. seealso:: :py:func:`previewRect`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscoordinateboundspreviewmapwidget.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgscoordinateboundspreviewmapwidget.sip.in
+++ b/python/gui/auto_generated/qgscoordinateboundspreviewmapwidget.sip.in
@@ -49,8 +49,6 @@ Returns the current canvas bounds rectangle shown in the map.
 %Docstring
 Sets the "preview" rectangle for the bounds overview map.
 Must be in EPSG:4326 coordinate reference system.
-
-.. seealso:: :py:func:`previewRect`
 %End
 
 };

--- a/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsProjectionSelectionTreeWidget : QWidget
 {
 %Docstring

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -94,6 +94,7 @@
 %Include auto_generated/qgscolorwidgets.sip
 %Include auto_generated/qgscompoundcolorwidget.sip
 %Include auto_generated/qgsconfigureshortcutsdialog.sip
+%Include auto_generated/qgscoordinateboundspreviewmapwidget.sip
 %Include auto_generated/qgscredentialdialog.sip
 %Include auto_generated/qgscurveeditorwidget.sip
 %Include auto_generated/qgscustomdrophandler.sip

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7864,7 +7864,7 @@ QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbology
 
     if ( destCRS.isValid() )
     {
-      QgsDatumTransformDialog::run( vlayer->crs(), destCRS, this );
+      QgsDatumTransformDialog::run( vlayer->crs(), destCRS, this, mMapCanvas );
       ct = QgsCoordinateTransform( vlayer->crs(), destCRS, QgsProject::instance() );
     }
 
@@ -13712,7 +13712,7 @@ bool QgisApp::askUserForDatumTransform( const QgsCoordinateReferenceSystem &sour
 {
   Q_ASSERT( qApp->thread() == QThread::currentThread() );
 
-  return QgsDatumTransformDialog::run( sourceCrs, destinationCrs, this );
+  return QgsDatumTransformDialog::run( sourceCrs, destinationCrs, this, mMapCanvas );
 }
 
 void QgisApp::readDockWidgetSettings( QDockWidget *dockWidget, const QDomElement &elem )

--- a/src/app/qgsdatumtransformtablewidget.cpp
+++ b/src/app/qgsdatumtransformtablewidget.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscoordinatetransform.h"
 #include "qgsdatumtransformdialog.h"
+#include "qgisapp.h"
 
 
 QgsDatumTransformTableModel::QgsDatumTransformTableModel( QObject *parent )
@@ -228,7 +229,7 @@ QgsDatumTransformTableWidget::QgsDatumTransformTableWidget( QWidget *parent )
 
 void QgsDatumTransformTableWidget::addDatumTransform()
 {
-  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true, false, false );
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true, false, false, QPair< int, int >(), nullptr, nullptr, QString(), QgisApp::instance()->mapCanvas() );
   if ( dlg.exec() )
   {
     const QgsDatumTransformDialog::TransformInfo dt = dlg.selectedDatumTransform();
@@ -296,7 +297,7 @@ void QgsDatumTransformTableWidget::editDatumTransform()
          ( sourceTransform != -1 || destinationTransform != -1 ) )
 #endif
     {
-      QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, false, qMakePair( sourceTransform, destinationTransform ), nullptr, nullptr, proj );
+      QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, false, qMakePair( sourceTransform, destinationTransform ), nullptr, nullptr, proj, QgisApp::instance()->mapCanvas() );
       if ( dlg.exec() )
       {
         const QgsDatumTransformDialog::TransformInfo dt = dlg.selectedDatumTransform();

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -323,6 +323,17 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
   details.accuracy = proj_coordoperation_get_accuracy( pjContext, op );
   details.isAvailable = proj_coordoperation_is_instantiable( pjContext, op );
 
+  const char *areaOfUseName = nullptr;
+  if ( proj_get_area_of_use( pjContext, op, nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+  {
+    details.areaOfUse = QString( areaOfUseName );
+  }
+
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
+  details.remarks = QString( proj_get_remarks( op ) );
+  details.scope = QString( proj_get_scope( op ) );
+#endif
+
   for ( int j = 0; j < proj_coordoperation_get_grid_used_count( pjContext, op ); ++j )
   {
     const char *shortName = nullptr;
@@ -354,6 +365,12 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
       SingleOperationDetails singleOpDetails;
       singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
       singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
+
+      const char *areaOfUseName = nullptr;
+      if ( proj_get_area_of_use( pjContext, step.get(), nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+      {
+        singleOpDetails.areaOfUse = QString( areaOfUseName );
+      }
       details.operationDetails.append( singleOpDetails );
     }
   }

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -344,6 +344,21 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
 
     details.grids.append( gridDetails );
   }
+
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
+  for ( int j = 0; j < proj_concatoperation_get_step_count( pjContext, op ); ++j )
+  {
+    QgsProjUtils::proj_pj_unique_ptr step( proj_concatoperation_get_step( pjContext, op, j ) );
+    if ( step )
+    {
+      SingleOperationDetails singleOpDetails;
+      singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
+      singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
+      details.operationDetails.append( singleOpDetails );
+    }
+  }
+#endif
+
   return details;
 }
 #endif

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -327,9 +327,18 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
   details.code = QString( proj_get_id_code( op, 0 ) );
 
   const char *areaOfUseName = nullptr;
-  if ( proj_get_area_of_use( pjContext, op, nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
+  double westLon = 0;
+  double southLat = 0;
+  double eastLon = 0;
+  double northLat = 0;
+  if ( proj_get_area_of_use( pjContext, op, &westLon, &southLat, &eastLon, &northLat, &areaOfUseName ) )
   {
     details.areaOfUse = QString( areaOfUseName );
+    // don't use the constructor which normalizes!
+    details.bounds.setXMinimum( westLon );
+    details.bounds.setYMinimum( southLat );
+    details.bounds.setXMaximum( eastLon );
+    details.bounds.setYMaximum( northLat );
   }
 
 #if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -323,6 +323,9 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
   details.accuracy = proj_coordoperation_get_accuracy( pjContext, op );
   details.isAvailable = proj_coordoperation_is_instantiable( pjContext, op );
 
+  details.authority = QString( proj_get_id_auth_name( op, 0 ) );
+  details.code = QString( proj_get_id_code( op, 0 ) );
+
   const char *areaOfUseName = nullptr;
   if ( proj_get_area_of_use( pjContext, op, nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )
   {
@@ -365,6 +368,8 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
       SingleOperationDetails singleOpDetails;
       singleOpDetails.remarks = QString( proj_get_remarks( step.get() ) );
       singleOpDetails.scope = QString( proj_get_scope( step.get() ) );
+      singleOpDetails.authority = QString( proj_get_id_auth_name( step.get(), 0 ) );
+      singleOpDetails.code = QString( proj_get_id_code( step.get(), 0 ) );
 
       const char *areaOfUseName = nullptr;
       if ( proj_get_area_of_use( pjContext, step.get(), nullptr, nullptr, nullptr, nullptr, &areaOfUseName ) )

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -19,6 +19,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsrectangle.h"
 #include <QString>
 #include <QList>
 
@@ -231,8 +232,16 @@ class CORE_EXPORT QgsDatumTransform
        *
        * This is only available for single step coordinate operations. For multi-step operations, check
        * \a operationDetails instead.
+       *
+       * \see bounds
        */
       QString areaOfUse;
+
+      /**
+       * Valid bounds for the coordinate operation.
+       * \see areaOfUse
+       */
+      QgsRectangle bounds;
 
       /**
        * Contains a list of transform grids used by the operation.

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -148,6 +148,21 @@ class CORE_EXPORT QgsDatumTransform
     };
 
     /**
+     * Contains information about a single coordinate operation.
+     *
+     * \note Only used in builds based on on Proj >= 6.2
+     * \since QGIS 3.10
+     */
+    struct SingleOperationDetails
+    {
+      //! Scope of operation, from EPSG registry database
+      QString scope;
+
+      //! Remarks for operation, from EPSG registry database
+      QString remarks;
+    };
+
+    /**
      * Contains information about a coordinate transformation operation.
      *
      * \note Only used in builds based on on Proj >= 6.0
@@ -174,6 +189,14 @@ class CORE_EXPORT QgsDatumTransform
        * Contains a list of transform grids used by the operation.
        */
       QList< QgsDatumTransform::GridDetails > grids;
+
+      /**
+       * Contains information about the single operation steps used in the transform operation.
+       *
+       * \note Only used in builds based on on Proj >= 6.2
+       * \since QGIS 3.10
+       */
+      QList< QgsDatumTransform::SingleOperationDetails > operationDetails;
     };
 
     /**

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -160,6 +160,9 @@ class CORE_EXPORT QgsDatumTransform
 
       //! Remarks for operation, from EPSG registry database
       QString remarks;
+
+      //! Area of use, from EPSG registry database
+      QString areaOfUse;
     };
 
     /**
@@ -178,12 +181,36 @@ class CORE_EXPORT QgsDatumTransform
       double accuracy = 0;
 
       /**
+       * Scope of operation, from EPSG registry database.
+       *
+       * This is only available for single step coordinate operations. For multi-step operations, check
+       * \a operationDetails instead.
+       */
+      QString scope;
+
+      /**
+      * Remarks for operation, from EPSG registry database.
+      *
+      * This is only available for single step coordinate operations. For multi-step operations, check
+      * \a operationDetails instead.
+      */
+      QString remarks;
+
+      /**
        * TRUE if operation is available.
        *
        * If FALSE, it likely means a transform grid is required which is not
        * available.
        */
       bool isAvailable = false;
+
+      /**
+       * Area of use string.
+       *
+       * This is only available for single step coordinate operations. For multi-step operations, check
+       * \a operationDetails instead.
+       */
+      QString areaOfUse;
 
       /**
        * Contains a list of transform grids used by the operation.

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -163,6 +163,12 @@ class CORE_EXPORT QgsDatumTransform
 
       //! Area of use, from EPSG registry database
       QString areaOfUse;
+
+      //! Authority name, e.g. EPSG.
+      QString authority;
+
+      //! Authority code, e.g. "8447" (for EPSG:8447).
+      QString code;
     };
 
     /**
@@ -179,6 +185,22 @@ class CORE_EXPORT QgsDatumTransform
       QString name;
       //! Transformation accuracy (in meters)
       double accuracy = 0;
+
+      /**
+       * Authority name, e.g. EPSG.
+       *
+       * This is only available for single step coordinate operations. For multi-step operations, check
+       * \a operationDetails instead.
+       */
+      QString authority;
+
+      /**
+       * Identification code, e.g. "8447" (For EPSG:8447).
+       *
+       * This is only available for single step coordinate operations. For multi-step operations, check
+       * \a operationDetails instead.
+       */
+      QString code;
 
       /**
        * Scope of operation, from EPSG registry database.

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -204,8 +204,7 @@ QList<QgsDatumTransform::GridDetails> QgsProjUtils::gridsUsed( const QString &pr
     const QString gridName = match.captured( 1 );
     QgsDatumTransform::GridDetails grid;
     grid.shortName = gridName;
-#if PROJ_VERSION_MAJOR >= 6
-#if PROJ_VERSION_MINOR >= 2
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
     const char *fullName = nullptr;
     const char *packageName = nullptr;
     const char *url = nullptr;
@@ -219,7 +218,6 @@ QList<QgsDatumTransform::GridDetails> QgsProjUtils::gridsUsed( const QString &pr
     grid.directDownload = directDownload;
     grid.openLicense = openLicense;
     grid.isAvailable = available;
-#endif
 #endif
     grids.append( grid );
   }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -248,6 +248,7 @@ SET(QGIS_GUI_SRCS
   qgscolorwidgets.cpp
   qgscompoundcolorwidget.cpp
   qgsconfigureshortcutsdialog.cpp
+  qgscoordinateboundspreviewmapwidget.cpp
   qgscredentialdialog.cpp
   qgscustomdrophandler.cpp
   qgscurveeditorwidget.cpp
@@ -432,6 +433,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgscolorwidgets.h
   qgscompoundcolorwidget.h
   qgsconfigureshortcutsdialog.h
+  qgscoordinateboundspreviewmapwidget.h
   qgscredentialdialog.h
   qgscurveeditorwidget.h
   qgscustomdrophandler.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -985,6 +985,7 @@ INCLUDE_DIRECTORIES(SYSTEM
   ${SQLITE3_INCLUDE_DIR}
   ${QSCINTILLA_INCLUDE_DIR}
   ${GDAL_INCLUDE_DIR}
+  ${PROJ_INCLUDE_DIR}
 )
 
 # disable deprecation warnings for classes re-exporting deprecated methods

--- a/src/gui/qgscoordinateboundspreviewmapwidget.cpp
+++ b/src/gui/qgscoordinateboundspreviewmapwidget.cpp
@@ -1,0 +1,95 @@
+/***************************************************************************
+ *   qgscoordinateboundspreviewmapwidget.h                                 *
+ *   Copyright (C) 2019 by Nyall Dawson                                    *
+ *   nyall dot dawson at gmail dot com                                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+#include "qgscoordinateboundspreviewmapwidget.h"
+#include "qgsrubberband.h"
+#include "qgsvertexmarker.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayer.h"
+#include "qgsmaptoolpan.h"
+
+QgsCoordinateBoundsPreviewMapWidget::QgsCoordinateBoundsPreviewMapWidget( QWidget *parent )
+  : QgsMapCanvas( parent )
+{
+  mPreviewBand = new QgsRubberBand( this, QgsWkbTypes::PolygonGeometry );
+  mPreviewBand->setWidth( 4 );
+
+  mCanvasPreviewBand = new QgsRubberBand( this, QgsWkbTypes::PolygonGeometry );
+  mCanvasPreviewBand->setWidth( 4 );
+  QColor rectColor = QColor( 185, 84, 210, 60 );
+  mCanvasPreviewBand->setColor( rectColor );
+
+  mCanvasCenterMarker = new QgsVertexMarker( this );
+  mCanvasCenterMarker->setIconType( QgsVertexMarker::ICON_CROSS );
+  mCanvasCenterMarker->setColor( QColor( 185, 84, 210 ) );
+  mCanvasCenterMarker->setPenWidth( 3 );
+
+  QgsCoordinateReferenceSystem srs( 4326, QgsCoordinateReferenceSystem::EpsgCrsId );
+  setDestinationCrs( srs );
+
+  QString layerPath = QgsApplication::pkgDataPath() + QStringLiteral( "/resources/data/world_map.shp" );
+  mLayers << new QgsVectorLayer( layerPath );
+  setLayers( mLayers );
+  setMapTool( new QgsMapToolPan( this ) );
+  setPreviewJobsEnabled( true );
+}
+
+QgsCoordinateBoundsPreviewMapWidget::~QgsCoordinateBoundsPreviewMapWidget()
+{
+  qDeleteAll( mLayers );
+  delete mPreviewBand;
+  delete mCanvasPreviewBand;
+  delete mCanvasCenterMarker;
+}
+
+void QgsCoordinateBoundsPreviewMapWidget::setPreviewRect( const QgsRectangle &rect )
+{
+  if ( !qgsDoubleNear( rect.area(), 0.0 ) )
+  {
+    QgsGeometry geom;
+    if ( rect.xMinimum() > rect.xMaximum() )
+    {
+      QgsRectangle rect1 = QgsRectangle( -180, rect.yMinimum(), rect.xMaximum(), rect.yMaximum() );
+      QgsRectangle rect2 = QgsRectangle( rect.xMinimum(), rect.yMinimum(), 180, rect.yMaximum() );
+      geom = QgsGeometry::fromRect( rect1 );
+      geom.addPart( QgsGeometry::fromRect( rect2 ) );
+    }
+    else
+    {
+      geom = QgsGeometry::fromRect( rect );
+    }
+    mPreviewBand->setToGeometry( geom, nullptr );
+    mPreviewBand->setColor( QColor( 255, 0, 0, 65 ) );
+    QgsRectangle extent = geom.boundingBox();
+    extent.scale( 1.1 );
+    setExtent( extent );
+    refresh();
+    mPreviewBand->show();
+  }
+  else
+  {
+    mPreviewBand->hide();
+    zoomToFullExtent();
+  }
+}
+
+QgsRectangle QgsCoordinateBoundsPreviewMapWidget::canvasRect() const
+{
+  return mCanvasRect;
+}
+
+void QgsCoordinateBoundsPreviewMapWidget::setCanvasRect( const QgsRectangle &rect )
+{
+  mCanvasRect = rect;
+  mCanvasPreviewBand->setToGeometry( QgsGeometry::fromRect( mCanvasRect ), nullptr );
+  mCanvasPreviewBand->show();
+  mCanvasCenterMarker->setCenter( rect.center() );
+  mCanvasCenterMarker->show();
+}

--- a/src/gui/qgscoordinateboundspreviewmapwidget.h
+++ b/src/gui/qgscoordinateboundspreviewmapwidget.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *   qgscoordinateboundspreviewmapwidget.h                                 *
+ *   Copyright (C) 2019 by Nyall Dawson                                    *
+ *   nyall dot dawson at gmail dot com                                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+#ifndef QGSCOORDINATEBOUNDSPREVIEWWIDGET_H
+#define QGSCOORDINATEBOUNDSPREVIEWWIDGET_H
+
+#include "qgsmapcanvas.h"
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+
+class QgsVertexMarker;
+
+/**
+ * \class QgsCoordinateBoundsPreviewMapWidget
+ * \ingroup gui
+ * A widget for showing the bounds of a rectangular region on an interactive map.
+ * \since QGIS 3.8.1
+ */
+
+class GUI_EXPORT QgsCoordinateBoundsPreviewMapWidget : public QgsMapCanvas
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsCoordinateBoundsPreviewMapWidget.
+     */
+    QgsCoordinateBoundsPreviewMapWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    ~QgsCoordinateBoundsPreviewMapWidget() override;
+
+    /**
+     * Sets the canvas bounds rectangle for the bounds overview map.
+     *
+     * Must be in EPSG:4326 coordinate reference system.
+     * \see canvasRect()
+     */
+    void setCanvasRect( const QgsRectangle &rect );
+
+    /**
+     * Returns the current canvas bounds rectangle shown in the map.
+     * \see setCanvasRect()
+     */
+    QgsRectangle canvasRect() const;
+
+    /**
+     * Sets the "preview" rectangle for the bounds overview map.
+     * Must be in EPSG:4326 coordinate reference system.
+     * \see previewRect()
+     */
+    void setPreviewRect( const QgsRectangle &rect );
+
+  private:
+
+    QgsRubberBand *mPreviewBand = nullptr;
+    QgsRubberBand *mCanvasPreviewBand = nullptr;
+    QgsVertexMarker *mCanvasCenterMarker = nullptr;
+
+    QList<QgsMapLayer *> mLayers;
+
+    QgsRectangle mCanvasRect;
+
+};
+
+#endif // QGSCOORDINATEBOUNDSPREVIEWWIDGET_H

--- a/src/gui/qgscoordinateboundspreviewmapwidget.h
+++ b/src/gui/qgscoordinateboundspreviewmapwidget.h
@@ -54,7 +54,6 @@ class GUI_EXPORT QgsCoordinateBoundsPreviewMapWidget : public QgsMapCanvas
     /**
      * Sets the "preview" rectangle for the bounds overview map.
      * Must be in EPSG:4326 coordinate reference system.
-     * \see previewRect()
      */
     void setPreviewRect( const QgsRectangle &rect );
 

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -29,6 +29,7 @@
 
 #if PROJ_VERSION_MAJOR>=6
 #include "qgsprojutils.h"
+#include <proj.h>
 #endif
 
 bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, QWidget *parent )
@@ -113,6 +114,8 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
 #if PROJ_VERSION_MAJOR>=6
   // proj 6 doesn't provide deprecated operations
   mHideDeprecatedCheckBox->setVisible( false );
+
+  mLabelDstDescription->hide();
 #else
   QgsSettings settings;
   mHideDeprecatedCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/hideDeprecated" ), true ).toBool() );
@@ -172,7 +175,41 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms, con
       preferredInitialRow = row;
     }
 
-    const QString toolTipString = QStringLiteral( "<b>%1</b><p>%2</p>" ).arg( transform.name, transform.proj );
+
+#if PROJ_VERSION_MAJOR > 6 or PROJ_VERSION_MINOR >= 2
+    QStringList opText;
+    for ( const QgsDatumTransform::SingleOperationDetails &singleOpDetails : transform.operationDetails )
+    {
+      QString text;
+      if ( !singleOpDetails.scope.isEmpty() )
+      {
+        text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Scope" ), singleOpDetails.scope );
+      }
+      if ( !singleOpDetails.remarks.isEmpty() )
+      {
+        if ( !text.isEmpty() )
+          text += QStringLiteral( "<br>" );
+        text += QStringLiteral( "<b>%1</b>: %2" ).arg( tr( "Remarks" ), singleOpDetails.remarks );
+      }
+
+      if ( !text.isEmpty() )
+      {
+        opText.append( text );
+      }
+    }
+
+    if ( opText.count() > 1 )
+    {
+      for ( int k = 0; k < opText.count(); ++k )
+        opText[k] = QStringLiteral( "<li>%1</li>" ).arg( opText.at( k ) );
+    }
+
+    const QString toolTipString = QStringLiteral( "<b>%1</b>" ).arg( transform.name )
+                                  + ( !opText.empty() ? ( opText.count() == 1 ? QStringLiteral( "<p>%1</p>" ).arg( opText.at( 0 ) ) : QStringLiteral( "<ul>%1</ul>" ).arg( opText.join( QString() ) ) ) : QString() ) +
+                                  QStringLiteral( "<p><code>%2</code></p>" ).arg( transform.proj );
+#else
+    const QString toolTipString = QStringLiteral( "<b>%1</b><p><code>%2</code></p>" ).arg( transform.name, transform.proj );
+#endif
     item->setToolTip( toolTipString );
     if ( itemDisabled )
     {

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -70,8 +70,8 @@ bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs
   }
 }
 
-QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSystem &sourceCrs,
-    const QgsCoordinateReferenceSystem &destinationCrs, const bool allowCrsChanges, const bool showMakeDefault, const bool forceChoice,
+QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSystem &sCrs,
+    const QgsCoordinateReferenceSystem &dCrs, const bool allowCrsChanges, const bool showMakeDefault, const bool forceChoice,
     QPair<int, int> selectedDatumTransforms,
     QWidget *parent,
     Qt::WindowFlags f, const QString &selectedProj, QgsMapCanvas *mapCanvas )
@@ -79,6 +79,9 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
   , mPreviousCursorOverride( qgis::make_unique< QgsTemporaryCursorRestoreOverride >() ) // this dialog is often shown while cursor overrides are in place, so temporarily remove them
 {
   setupUi( this );
+
+  QgsCoordinateReferenceSystem sourceCrs = sCrs;
+  QgsCoordinateReferenceSystem destinationCrs = dCrs;
 
   QgsGui::enableAutoGeometryRestore( this );
 
@@ -108,6 +111,20 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
   headers << tr( "Source Transform" ) << tr( "Destination Transform" ) ;
 #endif
   mDatumTransformTableWidget->setHorizontalHeaderLabels( headers );
+
+#if PROJ_VERSION_MAJOR>=6
+  if ( !sourceCrs.isValid() )
+    sourceCrs = QgsProject::instance()->crs();
+  if ( !sourceCrs.isValid() )
+    sourceCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  if ( !destinationCrs.isValid() )
+    destinationCrs = QgsProject::instance()->crs();
+  if ( !destinationCrs.isValid() )
+    destinationCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+
+  mSourceProjectionSelectionWidget->setOptionVisible( QgsProjectionSelectionWidget::CrsNotSet, false );
+  mDestinationProjectionSelectionWidget->setOptionVisible( QgsProjectionSelectionWidget::CrsNotSet, false );
+#endif
 
   mSourceProjectionSelectionWidget->setCrs( sourceCrs );
   mDestinationProjectionSelectionWidget->setCrs( destinationCrs );

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -210,9 +210,15 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms, con
         opText[k] = QStringLiteral( "<li>%1</li>" ).arg( opText.at( k ) );
     }
 
+    const QColor disabled = palette().color( QPalette::Disabled, QPalette::Text );
+    const QColor active = palette().color( QPalette::Active, QPalette::Text );
+
+    const QColor codeColor( static_cast< int >( active.red() * 0.6 + disabled.red() * 0.4 ),
+                            static_cast< int >( active.green() * 0.6 + disabled.green() * 0.4 ),
+                            static_cast< int >( active.blue() * 0.6 + disabled.blue() * 0.4 ) );
     const QString toolTipString = QStringLiteral( "<b>%1</b>" ).arg( transform.name )
                                   + ( !opText.empty() ? ( opText.count() == 1 ? QStringLiteral( "<p>%1</p>" ).arg( opText.at( 0 ) ) : QStringLiteral( "<ul>%1</ul>" ).arg( opText.join( QString() ) ) ) : QString() ) +
-                                  QStringLiteral( "<p><code>%2</code></p>" ).arg( transform.proj );
+                                  QStringLiteral( "<p><code style=\"color: %1\">%2</code></p>" ).arg( codeColor.name(), transform.proj );
 #else
     const QString toolTipString = QStringLiteral( "<b>%1</b><p><code>%2</code></p>" ).arg( transform.name, transform.proj );
 #endif

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgsguiutils.h"
 #include "qgsgui.h"
+#include "qgshelp.h"
 
 #include <QDir>
 #include <QPushButton>
@@ -139,6 +140,11 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
 #endif
   mLabelSrcDescription->clear();
   mLabelDstDescription->clear();
+
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, [ = ]
+  {
+    QgsHelp::openHelp( QStringLiteral( "working_with_projections/working_with_projections.html" ) );
+  } );
 
   load( selectedDatumTransforms, selectedProj );
 }

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -749,20 +749,28 @@ void QgsDatumTransformDialog::tableCurrentItemChanged( QTableWidgetItem *, QTabl
   {
     mLabelSrcDescription->clear();
     mLabelDstDescription->clear();
+#if PROJ_VERSION_MAJOR>=6
+    mAreaCanvas->hide();
+#endif
   }
   else
   {
-
     QTableWidgetItem *srcItem = mDatumTransformTableWidget->item( row, 0 );
     mLabelSrcDescription->setText( srcItem ? srcItem->toolTip() : QString() );
     if ( srcItem )
     {
       QgsRectangle rect = srcItem->data( BoundsRole ).value< QgsRectangle >();
       mAreaCanvas->setPreviewRect( rect );
+#if PROJ_VERSION_MAJOR>=6
+      mAreaCanvas->show();
+#endif
     }
     else
     {
       mAreaCanvas->setPreviewRect( QgsRectangle() );
+#if PROJ_VERSION_MAJOR>=6
+      mAreaCanvas->hide();
+#endif
     }
     QTableWidgetItem *destItem = mDatumTransformTableWidget->item( row, 1 );
     mLabelDstDescription->setText( destItem ? destItem->toolTip() : QString() );

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -776,7 +776,14 @@ void QgsDatumTransformDialog::tableCurrentItemChanged( QTableWidgetItem *, QTabl
     mLabelSrcDescription->setText( srcItem ? srcItem->toolTip() : QString() );
     if ( srcItem )
     {
-      QgsRectangle rect = srcItem->data( BoundsRole ).value< QgsRectangle >();
+      // find area of intersection of operation, source and dest bounding boxes
+      // see https://github.com/OSGeo/PROJ/issues/1549 for justification
+      const QgsRectangle operationRect = srcItem->data( BoundsRole ).value< QgsRectangle >();
+      const QgsRectangle sourceRect = mSourceCrs.bounds();
+      const QgsRectangle destRect = mDestinationCrs.bounds();
+      QgsRectangle rect = operationRect.intersect( sourceRect );
+      rect = rect.intersect( destRect );
+
       mAreaCanvas->setPreviewRect( rect );
 #if PROJ_VERSION_MAJOR>=6
       mAreaCanvas->show();

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -108,6 +108,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     {
       TransformIdRole = Qt::UserRole + 1,
       ProjRole,
+      AvailableRole,
     };
 
     bool gridShiftTransformation( const QString &itemText ) const;

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -65,11 +65,15 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
      * and the user has asked to be prompted, not re-adding transforms already in the current project
      * context, etc.
      *
+     * The optional \a mapCanvas argument can be used to refine the dialog's display based on the current
+     * map canvas extent.
+     *
      * \since QGIS 3.8
      */
     static bool run( const QgsCoordinateReferenceSystem &sourceCrs = QgsCoordinateReferenceSystem(),
                      const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem(),
-                     QWidget *parent = nullptr );
+                     QWidget *parent = nullptr,
+                     QgsMapCanvas *mapCanvas = nullptr );
 
     // TODO QGIS 4.0 - remove selectedDatumTransform
 
@@ -84,7 +88,8 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
                              QPair<int, int> selectedDatumTransforms = qMakePair( -1, -1 ),
                              QWidget *parent = nullptr,
                              Qt::WindowFlags f = nullptr,
-                             const QString &selectedProj = QString() );
+                             const QString &selectedProj = QString(),
+                             QgsMapCanvas *mapCanvas = nullptr );
     ~QgsDatumTransformDialog() override;
 
     void accept() override;
@@ -109,6 +114,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
       TransformIdRole = Qt::UserRole + 1,
       ProjRole,
       AvailableRole,
+      BoundsRole
     };
 
     bool gridShiftTransformation( const QString &itemText ) const;

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -95,8 +95,15 @@ QgsProjectionSelectionTreeWidget::QgsProjectionSelectionTreeWidget( QWidget *par
   mRecentProjections = QgsCoordinateReferenceSystem::recentProjections();
 
   mCheckBoxNoProjection->setHidden( true );
+  mCheckBoxNoProjection->setEnabled( false );
   connect( mCheckBoxNoProjection, &QCheckBox::toggled, this, &QgsProjectionSelectionTreeWidget::crsSelected );
-  connect( mCheckBoxNoProjection, &QCheckBox::toggled, mFrameProjections, &QFrame::setDisabled );
+  connect( mCheckBoxNoProjection, &QCheckBox::toggled, this, [ = ]( bool checked )
+  {
+    if ( mCheckBoxNoProjection->isEnabled() )
+    {
+      mFrameProjections->setDisabled( checked );
+    }
+  } );
 }
 
 QgsProjectionSelectionTreeWidget::~QgsProjectionSelectionTreeWidget()
@@ -472,7 +479,7 @@ QString QgsProjectionSelectionTreeWidget::getSelectedExpression( const QString &
 
 QgsCoordinateReferenceSystem QgsProjectionSelectionTreeWidget::crs() const
 {
-  if ( mCheckBoxNoProjection->isChecked() )
+  if ( mCheckBoxNoProjection->isEnabled() && mCheckBoxNoProjection->isChecked() )
     return QgsCoordinateReferenceSystem();
 
   int srid = getSelectedExpression( QStringLiteral( "srs_id" ) ).toLong();
@@ -484,7 +491,12 @@ QgsCoordinateReferenceSystem QgsProjectionSelectionTreeWidget::crs() const
 
 void QgsProjectionSelectionTreeWidget::setShowNoProjection( bool show )
 {
-  mCheckBoxNoProjection->setHidden( !show );
+  mCheckBoxNoProjection->setVisible( show );
+  mCheckBoxNoProjection->setEnabled( show );
+  if ( show )
+  {
+    mFrameProjections->setDisabled( mCheckBoxNoProjection->isChecked() );
+  }
 }
 
 void QgsProjectionSelectionTreeWidget::setShowBoundsMap( bool show )

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -20,8 +20,6 @@
 #include "qgis_gui.h"
 #include "qgscoordinatereferencesystem.h"
 
-
-class QgsVertexMarker;
 class QResizeEvent;
 
 /**
@@ -287,16 +285,7 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     //! Hide deprecated CRSes
     void hideDeprecated( QTreeWidgetItem *item );
 
-    QgsRubberBand *mPreviewBand;
-    QgsRubberBand *mPreviewBand2;
-    QgsVertexMarker *mVertexMarker;
-
     bool mShowMap = true;
-
-    QList<QgsMapLayer *> mLayers;
-
-    QgsRectangle mPreviewRect;
-
 
   private slots:
     //! Gets list of authorities

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -13,30 +13,7 @@
   <property name="windowTitle">
    <string>Select Datum Transformations</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,3,1,0,0">
-   <item row="2" column="0">
-    <widget class="QLabel" name="mLabelSrcDescription">
-     <property name="text">
-      <string notr="true">Description</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,3,1,0,0,0">
    <item row="0" column="0" colspan="2">
     <widget class="QStackedWidget" name="mCrsStackedWidget">
      <property name="currentIndex">
@@ -132,7 +109,7 @@
      </widget>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="mMakeDefaultCheckBox">
@@ -176,18 +153,57 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="mLabelDstDescription">
-     <property name="text">
-      <string notr="true">Description</string>
+   <item row="5" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="mLabelSrcDescription">
+       <property name="cursor">
+        <cursorShape>IBeamCursor</cursorShape>
+       </property>
+       <property name="text">
+        <string notr="true">Description</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="mLabelDstDescription">
+       <property name="cursor">
+        <cursorShape>IBeamCursor</cursorShape>
+       </property>
+       <property name="text">
+        <string notr="true">Description</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -112,12 +112,9 @@
    <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
-       <property name="toolTip">
-        <string>If checked, the selected transformation will become the default choice in all new projects</string>
-       </property>
+      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
        <property name="text">
-        <string>Make default</string>
+        <string>Hide deprecated transformations</string>
        </property>
       </widget>
      </item>
@@ -135,9 +132,12 @@
       </spacer>
      </item>
      <item>
-      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
+      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
+       <property name="toolTip">
+        <string>If checked, the selected transformation will become the default choice in all new projects</string>
+       </property>
        <property name="text">
-        <string>Hide deprecated transformations</string>
+        <string>Make default</string>
        </property>
       </widget>
      </item>
@@ -217,8 +217,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>mDatumTransformTableWidget</tabstop>
-  <tabstop>mMakeDefaultCheckBox</tabstop>
   <tabstop>mHideDeprecatedCheckBox</tabstop>
+  <tabstop>mMakeDefaultCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -13,8 +13,42 @@
   <property name="windowTitle">
    <string>Select Datum Transformations</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,3,1,0,0,0">
-   <item row="0" column="0" colspan="2">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,1,0,0,0,0">
+   <item row="5" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
+       <property name="text">
+        <string>Hide deprecated transformations</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
+       <property name="toolTip">
+        <string>If checked, the selected transformation will become the default choice in all new projects</string>
+       </property>
+       <property name="text">
+        <string>Make default</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0" colspan="2">
     <widget class="QStackedWidget" name="mCrsStackedWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -109,51 +143,7 @@
      </widget>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
-       <property name="text">
-        <string>Hide deprecated transformations</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
-       <property name="toolTip">
-        <string>If checked, the selected transformation will become the default choice in all new projects</string>
-       </property>
-       <property name="text">
-        <string>Make default</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QTableWidget" name="mDatumTransformTableWidget">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -163,7 +153,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="mLabelSrcDescription">
@@ -204,6 +194,26 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QTableWidget" name="mDatumTransformTableWidget">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Multiple operations are possible for converting coordinates between these two Coordinate Reference Systems. Please select the appropriate conversion operation, given the desired area of use, origins of your data, and any other constraints which may alter the &quot;fit for purpose&quot; for particular transformation operations.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -159,7 +159,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -13,41 +13,7 @@
   <property name="windowTitle">
    <string>Select Datum Transformations</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,1,0,0,0,0">
-   <item row="5" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
-       <property name="text">
-        <string>Hide deprecated transformations</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
-       <property name="toolTip">
-        <string>If checked, the selected transformation will become the default choice in all new projects</string>
-       </property>
-       <property name="text">
-        <string>Make default</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,2,1,0,0,0">
    <item row="1" column="0" colspan="2">
     <widget class="QStackedWidget" name="mCrsStackedWidget">
      <property name="currentIndex">
@@ -143,6 +109,50 @@
      </widget>
     </widget>
    </item>
+   <item row="5" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="mHideDeprecatedCheckBox">
+       <property name="text">
+        <string>Hide deprecated transformations</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
+       <property name="toolTip">
+        <string>If checked, the selected transformation will become the default choice in all new projects</string>
+       </property>
+       <property name="text">
+        <string>Make default</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QTableWidget" name="mDatumTransformTableWidget">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+    </widget>
+   </item>
    <item row="6" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="mButtonBox">
      <property name="orientation">
@@ -154,7 +164,7 @@
     </widget>
    </item>
    <item row="3" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,1,0">
      <item>
       <widget class="QLabel" name="mLabelSrcDescription">
        <property name="cursor">
@@ -193,17 +203,29 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QgsCoordinateBoundsPreviewMapWidget" name="mAreaCanvas" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>117</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777214</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
+     </item>
     </layout>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QTableWidget" name="mDatumTransformTableWidget">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-    </widget>
    </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="label_5">
@@ -222,6 +244,12 @@
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCoordinateBoundsPreviewMapWidget</class>
+   <extends>QWidget</extends>
+   <header>qgscoordinateboundspreviewmapwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -7,108 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>620</width>
-    <height>508</height>
+    <height>433</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Select Datum Transformations</string>
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,2,1,0,0,0">
-   <item row="1" column="0" colspan="2">
-    <widget class="QStackedWidget" name="mCrsStackedWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Source CRS</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QgsProjectionSelectionWidget" name="mSourceProjectionSelectionWidget" native="true"/>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Destination CRS</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QgsProjectionSelectionWidget" name="mDestinationProjectionSelectionWidget" native="true"/>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="page_2">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,1">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Source CRS</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Destination CRS</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="mDestCrsLabel">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="mSourceCrsLabel">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
    <item row="5" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -213,7 +118,7 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>117</width>
+         <width>230</width>
          <height>117</height>
         </size>
        </property>
@@ -227,13 +132,138 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Multiple operations are possible for converting coordinates between these two Coordinate Reference Systems. Please select the appropriate conversion operation, given the desired area of use, origins of your data, and any other constraints which may alter the &quot;fit for purpose&quot; for particular transformation operations.</string>
+   <item row="1" column="0" colspan="2">
+    <widget class="QStackedWidget" name="mCrsStackedWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="wordWrap">
+     <widget class="QWidget" name="page">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Source CRS</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QgsProjectionSelectionWidget" name="mSourceProjectionSelectionWidget" native="true"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Destination CRS</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QgsProjectionSelectionWidget" name="mDestinationProjectionSelectionWidget" native="true"/>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,1">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Source CRS</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Destination CRS</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="mDestCrsLabel">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="mSourceCrsLabel">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTextEdit" name="textEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="acceptDrops">
+      <bool>false</bool>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="readOnly">
       <bool>true</bool>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Multiple operations are possible for converting coordinates between these two Coordinate Reference Systems.&lt;/span&gt; Please select the appropriate conversion operation, given the desired area of use, origins of your data, and any other constraints which may alter the &amp;quot;fit for purpose&amp;quot; for particular transformation operations.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -262,7 +262,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QgsMapCanvas" name="mAreaCanvas" native="true">
+           <widget class="QgsCoordinateBoundsPreviewMapWidget" name="mAreaCanvas" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -300,9 +300,9 @@
    <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsMapCanvas</class>
+   <class>QgsCoordinateBoundsPreviewMapWidget</class>
    <extends>QWidget</extends>
-   <header>qgsmapcanvas.h</header>
+   <header>qgscoordinateboundspreviewmapwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Backports all the recent transformation selection dialog improvements and ui tweaks to 3.8. We need these in place in 3.8 prior to any official packages updating to proj 6.