### PR TITLE
[layouts] Default to right alignment when adding a label item for right-to-left locale

### DIFF
--- a/src/app/layout/qgslayoutapputils.cpp
+++ b/src/app/layout/qgslayoutapputils.cpp
@@ -168,6 +168,10 @@ void QgsLayoutAppUtils::registerGuiForKnownItemTypes()
     Q_ASSERT( label );
 
     label->setText( QObject::tr( "Lorem ipsum" ) );
+    if ( QApplication::isRightToLeft() )
+    {
+      label->setHAlign( Qt::AlignRight );
+    }
     QSizeF minSize = label->sizeForText();
     QSizeF currentSize = label->rect().size();
 


### PR DESCRIPTION
## Description
@nyalldawson , here's a little extra right-to-left UX fix following your legend work.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
