### PR TITLE
[processing] make color parameter available to description-based algs

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -56,7 +56,8 @@ from qgis.core import (QgsRasterLayer,
                        QgsProcessingParameterMapLayer,
                        QgsProcessingParameterMultipleLayers,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterNumber)
+                       QgsProcessingParameterNumber,
+                       QgsProcessingParameterColor)
 
 from qgis.PyQt.QtCore import QCoreApplication
 
@@ -210,6 +211,11 @@ def getParameterFromString(s, context=''):
                 if len(params) > 6:
                     params[6] = float(params[6].strip()) if params[6] is not None else sys.float_info.max - 1
             elif clazz == QgsProcessingParameterString:
+                if len(params) > 3:
+                    params[3] = True if params[3].lower() == 'true' else False
+                if len(params) > 4:
+                    params[4] = True if params[4].lower() == 'true' else False
+            elif clazz == QgsProcessingParameterColor:
                 if len(params) > 3:
                     params[3] = True if params[3].lower() == 'true' else False
                 if len(params) > 4:


### PR DESCRIPTION
## Description
Add `QgsProcessingParameterColor` handling to the `getParameterFromString()` function used by description-based providers.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit