### PR TITLE
Add api to allow reading a QgsProject file without loading any layers

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -526,6 +526,7 @@ Sets state from DOM document
 
 :param layerElement: The DOM element corresponding to ``maplayer'' tag
 :param context: writing context (e.g. for conversion between relative and absolute paths)
+:param flags: optional argument which can be used to control layer reading behavior.
 \note
 
 The DOM node corresponds to a DOM document project file XML element read
@@ -535,8 +536,6 @@ This, in turn, calls readXml() (and then readSymbology()), which is overridable
 by sub-classes so that they can read their own specific state from the given DOM node.
 
 Invoked by :py:func:`QgsProject.read()`
-
-The optional ``flags`` argument can be used to control layer reading behavior.
 
 :return: ``True`` if successful
 %End

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -513,7 +513,14 @@ Returns ``True`` if the layer is considered a spatial layer, ie it has some form
 .. versionadded:: 2.16
 %End
 
-    bool readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context );
+    enum ReadFlag
+    {
+      FlagDontResolveLayers,
+    };
+    typedef QFlags<QgsMapLayer::ReadFlag> ReadFlags;
+
+
+    bool readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context, QgsMapLayer::ReadFlags flags = 0 );
 %Docstring
 Sets state from DOM document
 
@@ -528,6 +535,8 @@ This, in turn, calls readXml() (and then readSymbology()), which is overridable
 by sub-classes so that they can read their own specific state from the given DOM node.
 
 Invoked by :py:func:`QgsProject.read()`
+
+The optional ``flags`` argument can be used to control layer reading behavior.
 
 :return: ``True`` if successful
 %End
@@ -1653,11 +1662,14 @@ Checks whether a new set of dependencies will introduce a cycle
 
 
 
+
 };
 
 QFlags<QgsMapLayer::LayerFlag> operator|(QgsMapLayer::LayerFlag f1, QFlags<QgsMapLayer::LayerFlag> f2);
 
 QFlags<QgsMapLayer::StyleCategory> operator|(QgsMapLayer::StyleCategory f1, QFlags<QgsMapLayer::StyleCategory> f2);
+
+QFlags<QgsMapLayer::ReadFlag> operator|(QgsMapLayer::ReadFlag f1, QFlags<QgsMapLayer::ReadFlag> f2);
 
 
 

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -233,18 +233,29 @@ Clears the project, removing all settings and resetting it back to an empty, def
 .. versionadded:: 2.4
 %End
 
-    bool read( const QString &filename );
+    enum ReadFlag
+    {
+      FlagDontResolveLayers,
+    };
+    typedef QFlags<QgsProject::ReadFlag> ReadFlags;
+
+
+    bool read( const QString &filename, QgsProject::ReadFlags flags = 0 );
 %Docstring
 Reads given project file from the given file.
 
 :param filename: name of project file to read
+:param flags: optional flags which control the read behavior of projects
 
 :return: ``True`` if project file has been read successfully
 %End
 
-    bool read();
+    bool read( QgsProject::ReadFlags flags = 0 );
 %Docstring
 Reads the project from its currently associated file (see fileName() ).
+
+The ``flags`` argument can be used to specify optional flags which control
+the read behavior of projects.
 
 :return: ``True`` if project file has been read successfully
 %End
@@ -438,9 +449,11 @@ Returns project file path if layer is embedded from other project file. Returns 
 %End
 
 
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers );
+    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, QgsProject::ReadFlags flags = 0 );
 %Docstring
 Create layer group instance defined in an arbitrary project file.
+
+The optional ``flags`` argument can be used to control layer reading behavior.
 
 .. versionadded:: 2.4
 %End
@@ -1463,6 +1476,9 @@ So there can be created a ts file with these values.
 %End
 
 };
+
+QFlags<QgsProject::ReadFlag> operator|(QgsProject::ReadFlag f1, QFlags<QgsProject::ReadFlag> f2);
+
 
 class QgsProjectDirtyBlocker
 {

--- a/src/analysis/mesh/qgsmeshcalculator.cpp
+++ b/src/analysis/mesh/qgsmeshcalculator.cpp
@@ -87,7 +87,7 @@ QgsMeshCalculator::Result QgsMeshCalculator::processCalculation( QgsFeedback *fe
 
   if ( !mMeshLayer ||
        !mMeshLayer->dataProvider() ||
-       mMeshLayer->dataProvider()->name() != QStringLiteral( "mdal" )
+       mMeshLayer->providerType() != QStringLiteral( "mdal" )
      )
   {
     return CreateOutputError;

--- a/src/analysis/processing/qgsprojectstylealgorithms.cpp
+++ b/src/analysis/processing/qgsprojectstylealgorithms.cpp
@@ -203,7 +203,7 @@ QVariantMap QgsStyleFromProjectAlgorithm::processAlgorithm( const QVariantMap &p
   {
     // load project from path
     QgsProject p;
-    if ( !p.read( mProjectPath ) )
+    if ( !p.read( mProjectPath, QgsProject::FlagDontResolveLayers ) )
     {
       throw QgsProcessingException( QObject::tr( "Could not read project %1" ).arg( mProjectPath ) );
     }

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -693,7 +693,7 @@ QVector<QgsRasterCalculatorEntry> QgsRasterCalculatorEntry::rasterEntries()
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
     QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( layerIt.value() );
-    if ( rlayer && rlayer->dataProvider() && rlayer->dataProvider()->name() == QLatin1String( "gdal" ) )
+    if ( rlayer && rlayer->dataProvider() && rlayer->providerType() == QLatin1String( "gdal" ) )
     {
       //get number of bands
       for ( int i = 0; i < rlayer->bandCount(); ++i )

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -568,7 +568,7 @@ void QgsProjectItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
       QgsProject p;
       QgsTemporaryCursorOverride override( Qt::WaitCursor );
-      if ( p.read( projectPath ) )
+      if ( p.read( projectPath, QgsProject::FlagDontResolveLayers ) )
       {
         p.accept( &visitor );
         override.release();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5148,7 +5148,7 @@ QList<QgsMapLayer *> QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
   if ( !layer )
   {
     layer = qobject_cast<QgsVectorLayer *>( activeLayer() );
-    if ( !layer || layer->dataProvider()->name() != QLatin1String( "ogr" ) )
+    if ( !layer || layer->providerType() != QLatin1String( "ogr" ) )
       return result;
   }
 
@@ -11418,7 +11418,7 @@ bool QgisApp::saveDirty()
       QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( it.value() );
       // note that we skip the unsaved edits check for memory layers -- it's misleading, because their contents aren't actually
       // saved if this is part of a project close operation. Instead we let these get picked up by checkMemoryLayers().
-      if ( !vl || vl->dataProvider()->name() == QLatin1String( "memory" ) )
+      if ( !vl || vl->providerType() == QLatin1String( "memory" ) )
       {
         continue;
       }
@@ -11481,7 +11481,7 @@ bool QgisApp::saveDirty()
   {
     if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( it.value() ) )
     {
-      if ( vl->dataProvider()->name() == QLatin1String( "memory" ) && vl->isEditable() && vl->isModified() )
+      if ( vl->providerType() == QLatin1String( "memory" ) && vl->isEditable() && vl->isModified() )
       {
         vl->rollBack();
       }
@@ -11504,7 +11504,7 @@ bool QgisApp::checkUnsavedLayerEdits()
       {
         // note that we skip the unsaved edits check for memory layers -- it's misleading, because their contents aren't actually
         // saved if this is part of a project close operation. Instead we let these get picked up by checkMemoryLayers()
-        if ( ! vl->dataProvider() || vl->dataProvider()->name() == QLatin1String( "memory" ) )
+        if ( ! vl->dataProvider() || vl->providerType() == QLatin1String( "memory" ) )
           continue;
 
         const bool hasUnsavedEdits = ( vl->isEditable() && vl->isModified() );
@@ -11530,7 +11530,7 @@ bool QgisApp::checkMemoryLayers()
   const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
   for ( auto it = layers.begin(); it != layers.end(); ++it )
   {
-    if ( it.value() && it.value()->dataProvider()->name() == QLatin1String( "memory" ) )
+    if ( it.value() && it.value()->providerType() == QLatin1String( "memory" ) )
     {
       QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( it.value() );
       if ( vl && vl->featureCount() != 0 && !vl->customProperty( QStringLiteral( "skipMemoryLayersCheck" ) ).toInt() )

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -457,7 +457,7 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
                 layer ? layer->source() : QString(),
                 layer ? layer->source() : QString(),
                 layer ? QgsLayerItem::typeFromMapLayer( layer ) : QgsLayerItem::NoType,
-                layer ? layer->dataProvider()->name() : QString() );
+                layer ? layer->providerType() : QString() );
             layerItem->setState( Populated ); // children are not expected
             layerItem->setToolTip( layer ? layer->source() : QString() );
             if ( parentItem == this )

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -420,7 +420,7 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
   QVector<QgsDataItem *> childItems;
 
   QgsProject p;
-  if ( !p.read( mPath ) )
+  if ( !p.read( mPath, QgsProject::FlagDontResolveLayers ) )
   {
     childItems.append( new QgsErrorItem( nullptr, p.error(), mPath + "/error" ) );
     return childItems;

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -294,7 +294,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( vlayer )
       {
-        if ( vlayer->dataProvider()->name() == QLatin1String( "memory" ) )
+        if ( vlayer->providerType() == QLatin1String( "memory" ) )
         {
           QAction *actionMakePermanent = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
           connect( actionMakePermanent, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );

--- a/src/app/qgslayertreeviewmemoryindicator.cpp
+++ b/src/app/qgslayertreeviewmemoryindicator.cpp
@@ -45,7 +45,7 @@ bool QgsLayerTreeViewMemoryIndicatorProvider::acceptLayer( QgsMapLayer *layer )
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !( vlayer && vlayer->isValid() ) )
     return false;
-  return  vlayer->dataProvider()->name() == QLatin1String( "memory" );
+  return  vlayer->providerType() == QLatin1String( "memory" );
 }
 
 QString QgsLayerTreeViewMemoryIndicatorProvider::iconName( QgsMapLayer *layer )

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -72,7 +72,7 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QgsRasterLayer *rasterLayer, QWidget *
   connect( mOrButton, &QPushButton::clicked, this, &QgsRasterCalcDialog::mOrButton_clicked );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsRasterCalcDialog::showHelp );
 
-  if ( rasterLayer && rasterLayer->dataProvider() && rasterLayer->dataProvider()->name() == QLatin1String( "gdal" ) )
+  if ( rasterLayer && rasterLayer->dataProvider() && rasterLayer->providerType() == QLatin1String( "gdal" ) )
   {
     setExtentSize( rasterLayer->width(), rasterLayer->height(), rasterLayer->extent() );
     mCrsSelector->setCrs( rasterLayer->crs() );
@@ -180,7 +180,7 @@ void QgsRasterCalcDialog::insertAvailableRasterBands()
   for ( const auto &entry : qgis::as_const( mAvailableRasterBands ) )
   {
     QgsRasterLayer *rlayer = entry.raster;
-    if ( rlayer && rlayer->dataProvider() && rlayer->dataProvider()->name() == QLatin1String( "gdal" ) )
+    if ( rlayer && rlayer->dataProvider() && rlayer->providerType() == QLatin1String( "gdal" ) )
     {
       if ( !mExtentSizeSet ) //set bounding box / resolution of output to the values of the first possible input layer
       {

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -251,7 +251,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
       }
       cboProviderEncoding->setCurrentIndex( encindex );
     }
-    else if ( mLayer->dataProvider()->name() == QLatin1String( "ogr" ) )
+    else if ( mLayer->providerType() == QLatin1String( "ogr" ) )
     {
       // if OGR_L_TestCapability(OLCStringsAsUTF8) returns true, OGR provider encoding can be set to only UTF-8
       // so make encoding box grayed out

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -389,7 +389,7 @@ bool QgsLayoutItemMap::containsWmsLayer() const
   const QList< QgsMapLayer * > layers = layersToRender();
   for ( QgsMapLayer *layer : layers )
   {
-    if ( layer->dataProvider() && layer->dataProvider()->name() == QLatin1String( "wms" ) )
+    if ( layer->dataProvider() && layer->providerType() == QLatin1String( "wms" ) )
     {
       return true;
     }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -388,6 +388,11 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     mProviderKey = pkeyElt.text();
   }
 
+  if ( mReadFlags & QgsMapLayer::FlagDontResolveLayers )
+  {
+    return false;
+  }
+
   QgsDataProvider::ProviderOptions providerOptions;
   if ( !setDataProvider( mProviderKey, providerOptions ) )
   {

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -789,7 +789,7 @@ QString QgsProcessingUtils::convertToCompatibleFormat( const QgsVectorLayer *vl,
   // if the data provider is NOT ogr, then we HAVE to convert. Otherwise we run into
   // issues with data providers like spatialite, delimited text where the format can be
   // opened outside of QGIS, but with potentially very different behavior!
-  requiresTranslation = requiresTranslation || vl->dataProvider()->name() != QLatin1String( "ogr" );
+  requiresTranslation = requiresTranslation || vl->providerType() != QLatin1String( "ogr" );
 
   // if the layer has a feature filter set, then we HAVE to convert. Feature filters are
   // a purely QGIS concept.
@@ -799,7 +799,7 @@ QString QgsProcessingUtils::convertToCompatibleFormat( const QgsVectorLayer *vl,
   QString diskPath;
   if ( !requiresTranslation )
   {
-    const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( vl->dataProvider()->name(), vl->source() );
+    const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( vl->providerType(), vl->source() );
     if ( parts.contains( QStringLiteral( "path" ) ) )
     {
       diskPath = parts.value( QStringLiteral( "path" ) ).toString();

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -208,9 +208,10 @@ QPainter::CompositionMode QgsMapLayer::blendMode() const
 }
 
 
-bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context )
+bool QgsMapLayer::readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context, QgsMapLayer::ReadFlags flags )
 {
   bool layerError;
+  mReadFlags = flags;
 
   QDomNode mnl;
   QDomElement mne;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -523,6 +523,16 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual bool isSpatial() const;
 
     /**
+     * Flags which control project read behavior.
+     * \since QGIS 3.10
+     */
+    enum ReadFlag
+    {
+      FlagDontResolveLayers = 1 << 1, //!< Don't resolve layer paths or create data providers for layers.
+    };
+    Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
+
+    /**
      * Sets state from DOM document
      * \param layerElement The DOM element corresponding to ``maplayer'' tag
      * \param context writing context (e.g. for conversion between relative and absolute paths)
@@ -536,9 +546,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
      *
      * Invoked by QgsProject::read().
      *
+     * The optional \a flags argument can be used to control layer reading behavior.
+     *
      * \returns TRUE if successful
      */
-    bool readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context );
+    bool readLayerXml( const QDomElement &layerElement, QgsReadWriteContext &context, QgsMapLayer::ReadFlags flags = nullptr );
 
     /**
      * Stores state in DOM node
@@ -1497,6 +1509,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Data provider key (name of the data provider)
     QString mProviderKey;
 
+    //TODO QGIS 4 - move to readXml as a new argument (breaks API)
+
+    //! Read flags. It's up to the subclass to respect these when restoring state from XML
+    QgsMapLayer::ReadFlags mReadFlags = nullptr;
 
   private:
 
@@ -1570,11 +1586,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     QString mOriginalXmlProperties;
 
+
 };
 
 Q_DECLARE_METATYPE( QgsMapLayer * )
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapLayer::LayerFlags )
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapLayer::StyleCategories )
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapLayer::ReadFlags )
 
 
 #ifndef SIP_RUN

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -536,6 +536,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * Sets state from DOM document
      * \param layerElement The DOM element corresponding to ``maplayer'' tag
      * \param context writing context (e.g. for conversion between relative and absolute paths)
+     * \param flags optional argument which can be used to control layer reading behavior.
      * \note
      *
      * The DOM node corresponds to a DOM document project file XML element read
@@ -545,8 +546,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * by sub-classes so that they can read their own specific state from the given DOM node.
      *
      * Invoked by QgsProject::read().
-     *
-     * The optional \a flags argument can be used to control layer reading behavior.
      *
      * \returns TRUE if successful
      */

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -103,7 +103,7 @@ bool QgsMapLayerProxyModel::acceptsLayer( QgsMapLayer *layer ) const
   if ( mExceptList.contains( layer ) )
     return false;
 
-  if ( layer->dataProvider() && mExcludedProviders.contains( layer->dataProvider()->name() ) )
+  if ( layer->dataProvider() && mExcludedProviders.contains( layer->providerType() ) )
     return false;
 
   if ( mFilters.testFlag( WritableLayer ) && layer->readOnly() )

--- a/src/core/qgsmaplayerref.h
+++ b/src/core/qgsmaplayerref.h
@@ -120,7 +120,7 @@ struct _LayerRef
          layer->name() != name )
       return false;
 
-    if ( layer->dataProvider()->name() != provider )
+    if ( layer->providerType() != provider )
       return false;
 
     return true;

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -65,7 +65,7 @@ QgsMimeDataUtils::Uri::Uri( QString &encData )
 }
 
 QgsMimeDataUtils::Uri::Uri( QgsMapLayer *layer )
-  : providerKey( layer->dataProvider()->name() )
+  : providerKey( layer->providerType() )
   , name( layer->name() )
   , uri( layer->dataProvider()->dataSourceUri() )
   , layerId( layer->id() )

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -240,7 +240,7 @@ void QgsOfflineEditing::synchronize()
     if ( remoteLayer->isValid() )
     {
       // Rebuild WFS cache to get feature id<->GML fid mapping
-      if ( remoteLayer->dataProvider()->name().contains( QLatin1String( "WFS" ), Qt::CaseInsensitive ) )
+      if ( remoteLayer->providerType().contains( QLatin1String( "WFS" ), Qt::CaseInsensitive ) )
       {
         QgsFeatureIterator fit = remoteLayer->getFeatures();
         QgsFeature f;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -889,7 +889,7 @@ void QgsProject::setSnappingConfig( const QgsSnappingConfig &snappingConfig )
   emit snappingConfigChanged( mSnappingConfig );
 }
 
-bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &brokenNodes )
+bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &brokenNodes, QgsProject::ReadFlags flags )
 {
   // Layer order is set by the restoring the legend settings from project file.
   // This is done on the 'readProject( ... )' signal
@@ -930,7 +930,7 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
 
     if ( element.attribute( QStringLiteral( "embedded" ) ) == QLatin1String( "1" ) )
     {
-      createEmbeddedLayer( element.attribute( QStringLiteral( "id" ) ), readPath( element.attribute( QStringLiteral( "project" ) ) ), brokenNodes );
+      createEmbeddedLayer( element.attribute( QStringLiteral( "id" ) ), readPath( element.attribute( QStringLiteral( "project" ) ) ), brokenNodes, flags );
     }
     else
     {
@@ -939,7 +939,7 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
       context.setProjectTranslator( this );
       context.setTransformContext( transformContext() );
 
-      if ( !addLayer( element, brokenNodes, context ) )
+      if ( !addLayer( element, brokenNodes, context, flags ) )
       {
         returnStatus = false;
       }
@@ -956,7 +956,7 @@ bool QgsProject::_getMapLayers( const QDomDocument &doc, QList<QDomNode> &broken
   return returnStatus;
 }
 
-bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &brokenNodes, QgsReadWriteContext &context )
+bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &brokenNodes, QgsReadWriteContext &context, QgsProject::ReadFlags flags )
 {
   QString type = layerElem.attribute( QStringLiteral( "type" ) );
   QgsDebugMsgLevel( "Layer type is " + type, 4 );
@@ -1000,10 +1000,13 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   const bool layerWasStored { layerStore()->mapLayer( layerId ) != nullptr };
 
   // have the layer restore state that is stored in Dom node
-  bool layerIsValid = mapLayer->readLayerXml( layerElem, context ) && mapLayer->isValid();
+  QgsMapLayer::ReadFlags layerFlags = nullptr;
+  if ( flags & QgsProject::FlagDontResolveLayers )
+    layerFlags |= QgsMapLayer::FlagDontResolveLayers;
+  bool layerIsValid = mapLayer->readLayerXml( layerElem, context, layerFlags ) && mapLayer->isValid();
   QList<QgsMapLayer *> newLayers;
   newLayers << mapLayer.get();
-  if ( layerIsValid )
+  if ( layerIsValid || flags & QgsProject::FlagDontResolveLayers )
   {
     emit readMapLayer( mapLayer.get(), layerElem );
     addMapLayers( newLayers );
@@ -1027,14 +1030,14 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
   return layerIsValid;
 }
 
-bool QgsProject::read( const QString &filename )
+bool QgsProject::read( const QString &filename, QgsProject::ReadFlags flags )
 {
   mFile.setFileName( filename );
 
-  return read();
+  return read( flags );
 }
 
-bool QgsProject::read()
+bool QgsProject::read( QgsProject::ReadFlags flags )
 {
   QString filename = mFile.fileName();
   bool returnValue;
@@ -1059,18 +1062,18 @@ bool QgsProject::read()
       setError( err );
       return false;
     }
-    returnValue = unzip( inDevice.fileName() );  // calls setError() if returning false
+    returnValue = unzip( inDevice.fileName(), flags );  // calls setError() if returning false
   }
   else
   {
     if ( QgsZipUtils::isZipFile( mFile.fileName() ) )
     {
-      returnValue = unzip( mFile.fileName() );
+      returnValue = unzip( mFile.fileName(), flags );
     }
     else
     {
       mAuxiliaryStorage.reset( new QgsAuxiliaryStorage( *this ) );
-      returnValue = readProjectFile( mFile.fileName() );
+      returnValue = readProjectFile( mFile.fileName(), flags );
     }
 
     //on translation we should not change the filename back
@@ -1088,7 +1091,7 @@ bool QgsProject::read()
   return returnValue;
 }
 
-bool QgsProject::readProjectFile( const QString &filename )
+bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags flags )
 {
   QFile projectFile( filename );
   clearError();
@@ -1301,7 +1304,7 @@ bool QgsProject::readProjectFile( const QString &filename )
 
   // get the map layers
   QList<QDomNode> brokenNodes;
-  bool clean = _getMapLayers( *doc, brokenNodes );
+  bool clean = _getMapLayers( *doc, brokenNodes, flags );
 
   // review the integrity of the retrieved map layers
   if ( !clean )
@@ -1329,7 +1332,7 @@ bool QgsProject::readProjectFile( const QString &filename )
   mLayerTreeRegistryBridge->setEnabled( true );
 
   // load embedded groups and layers
-  loadEmbeddedNodes( mRootGroup );
+  loadEmbeddedNodes( mRootGroup, flags );
 
   // now that layers are loaded, we can resolve layer tree's references to the layers
   mRootGroup->resolveReferences( this );
@@ -1448,7 +1451,7 @@ bool QgsProject::readProjectFile( const QString &filename )
 }
 
 
-void QgsProject::loadEmbeddedNodes( QgsLayerTreeGroup *group )
+void QgsProject::loadEmbeddedNodes( QgsLayerTreeGroup *group, QgsProject::ReadFlags flags )
 {
 
   const auto constChildren = group->children();
@@ -1462,7 +1465,7 @@ void QgsProject::loadEmbeddedNodes( QgsLayerTreeGroup *group )
         // make sure to convert the path from relative to absolute
         QString projectPath = readPath( childGroup->customProperty( QStringLiteral( "embedded_project" ) ).toString() );
         childGroup->setCustomProperty( QStringLiteral( "embedded_project" ), projectPath );
-        QgsLayerTreeGroup *newGroup = createEmbeddedGroup( childGroup->name(), projectPath, childGroup->customProperty( QStringLiteral( "embedded-invisible-layers" ) ).toStringList() );
+        QgsLayerTreeGroup *newGroup = createEmbeddedGroup( childGroup->name(), projectPath, childGroup->customProperty( QStringLiteral( "embedded-invisible-layers" ) ).toStringList(), flags );
         if ( newGroup )
         {
           QList<QgsLayerTreeNode *> clonedChildren;
@@ -1476,7 +1479,7 @@ void QgsProject::loadEmbeddedNodes( QgsLayerTreeGroup *group )
       }
       else
       {
-        loadEmbeddedNodes( childGroup );
+        loadEmbeddedNodes( childGroup, flags );
       }
     }
     else if ( QgsLayerTree::isLayer( child ) )
@@ -1484,7 +1487,7 @@ void QgsProject::loadEmbeddedNodes( QgsLayerTreeGroup *group )
       if ( child->customProperty( QStringLiteral( "embedded" ) ).toInt() )
       {
         QList<QDomNode> brokenNodes;
-        createEmbeddedLayer( QgsLayerTree::toLayer( child )->layerId(), child->customProperty( QStringLiteral( "embedded_project" ) ).toString(), brokenNodes );
+        createEmbeddedLayer( QgsLayerTree::toLayer( child )->layerId(), child->customProperty( QStringLiteral( "embedded_project" ) ).toString(), brokenNodes, flags );
       }
     }
 
@@ -2298,7 +2301,7 @@ QString QgsProject::layerIsEmbedded( const QString &id ) const
 }
 
 bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &projectFilePath, QList<QDomNode> &brokenNodes,
-                                      bool saveFlag )
+                                      bool saveFlag, QgsProject::ReadFlags flags )
 {
   QgsDebugCall;
 
@@ -2368,7 +2371,7 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
 
       mEmbeddedLayers.insert( layerId, qMakePair( projectFilePath, saveFlag ) );
 
-      if ( addLayer( mapLayerElem, brokenNodes, embeddedContext ) )
+      if ( addLayer( mapLayerElem, brokenNodes, embeddedContext, flags ) )
       {
         return true;
       }
@@ -2384,7 +2387,7 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
 }
 
 
-QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers )
+QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, QgsProject::ReadFlags flags )
 {
   // open project file, get layer ids in group, add the layers
   QFile projectFile( projectFilePath );
@@ -2434,7 +2437,7 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
 
   // set "embedded" to all children + load embedded layers
   mLayerTreeRegistryBridge->setEnabled( false );
-  initializeEmbeddedSubtree( projectFilePath, newGroup );
+  initializeEmbeddedSubtree( projectFilePath, newGroup, flags );
   mLayerTreeRegistryBridge->setEnabled( true );
 
   // consider the layers might be identify disabled in its project
@@ -2452,7 +2455,7 @@ QgsLayerTreeGroup *QgsProject::createEmbeddedGroup( const QString &groupName, co
   return newGroup;
 }
 
-void QgsProject::initializeEmbeddedSubtree( const QString &projectFilePath, QgsLayerTreeGroup *group )
+void QgsProject::initializeEmbeddedSubtree( const QString &projectFilePath, QgsLayerTreeGroup *group, QgsProject::ReadFlags flags )
 {
   const auto constChildren = group->children();
   for ( QgsLayerTreeNode *child : constChildren )
@@ -2462,13 +2465,13 @@ void QgsProject::initializeEmbeddedSubtree( const QString &projectFilePath, QgsL
 
     if ( QgsLayerTree::isGroup( child ) )
     {
-      initializeEmbeddedSubtree( projectFilePath, QgsLayerTree::toGroup( child ) );
+      initializeEmbeddedSubtree( projectFilePath, QgsLayerTree::toGroup( child ), flags );
     }
     else if ( QgsLayerTree::isLayer( child ) )
     {
       // load the layer into our project
       QList<QDomNode> brokenNodes;
-      createEmbeddedLayer( QgsLayerTree::toLayer( child )->layerId(), projectFilePath, brokenNodes, false );
+      createEmbeddedLayer( QgsLayerTree::toLayer( child )->layerId(), projectFilePath, brokenNodes, false, flags );
     }
   }
 }
@@ -2706,7 +2709,7 @@ QList<QgsMapLayer *> QgsProject::mapLayersByName( const QString &layerName ) con
   return mLayerStore->mapLayersByName( layerName );
 }
 
-bool QgsProject::unzip( const QString &filename )
+bool QgsProject::unzip( const QString &filename, QgsProject::ReadFlags flags )
 {
   clearError();
   std::unique_ptr<QgsProjectArchive> archive( new QgsProjectArchive() );
@@ -2738,7 +2741,7 @@ bool QgsProject::unzip( const QString &filename )
   }
 
   // read the project file
-  if ( ! readProjectFile( archive->projectFile() ) )
+  if ( ! readProjectFile( archive->projectFile(), flags ) )
   {
     setError( tr( "Cannot read unzipped qgs project file" ) );
     return false;
@@ -3073,7 +3076,7 @@ QString QgsProject::translate( const QString &context, const QString &sourceText
 
 bool QgsProject::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
-  const QMap<QString, QgsMapLayer *> layers = mapLayers();
+  const QMap<QString, QgsMapLayer *> layers = mapLayers( false );
   if ( !layers.empty() )
   {
     for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -269,7 +269,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     enum ReadFlag
     {
-      FlagDontResolveLayers = 1 << 1, //!< Don't resolve layer paths. Dramatically improves project read time if the actual data from the layers is not required.
+      FlagDontResolveLayers = 1 << 1, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -264,17 +264,32 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     void clear();
 
     /**
+     * Flags which control project read behavior.
+     * \since QGIS 3.10
+     */
+    enum ReadFlag
+    {
+      FlagDontResolveLayers = 1 << 1, //!< Don't resolve layer paths. Dramatically improves project read time if the actual data from the layers is not required.
+    };
+    Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
+
+    /**
      * Reads given project file from the given file.
      * \param filename name of project file to read
+     * \param flags optional flags which control the read behavior of projects
      * \returns TRUE if project file has been read successfully
      */
-    bool read( const QString &filename );
+    bool read( const QString &filename, QgsProject::ReadFlags flags = nullptr );
 
     /**
      * Reads the project from its currently associated file (see fileName() ).
+     *
+     * The \a flags argument can be used to specify optional flags which control
+     * the read behavior of projects.
+     *
      * \returns TRUE if project file has been read successfully
      */
-    bool read();
+    bool read( QgsProject::ReadFlags flags = nullptr );
 
     /**
      * Reads the layer described in the associated DOM node.
@@ -426,18 +441,24 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QString layerIsEmbedded( const QString &id ) const;
 
     /**
-     * Creates a maplayer instance defined in an arbitrary project file. Caller takes ownership
+     * Creates a maplayer instance defined in an arbitrary project file. Caller takes ownership.
+     *
+     * The optional \a flags argument can be used to specify flags which control layer reading.
+     *
      * \returns the layer or 0 in case of error
      * \note not available in Python bindings
      */
     bool createEmbeddedLayer( const QString &layerId, const QString &projectFilePath, QList<QDomNode> &brokenNodes,
-                              bool saveFlag = true ) SIP_SKIP;
+                              bool saveFlag = true, QgsProject::ReadFlags flags = nullptr ) SIP_SKIP;
 
     /**
      * Create layer group instance defined in an arbitrary project file.
+     *
+     * The optional \a flags argument can be used to control layer reading behavior.
+     *
      * \since QGIS 2.4
      */
-    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers );
+    QgsLayerTreeGroup *createEmbeddedGroup( const QString &groupName, const QString &projectFilePath, const QStringList &invisibleLayers, QgsProject::ReadFlags flags = nullptr );
 
     //! Convenience function to set topological editing
     void setTopologicalEditing( bool enabled );
@@ -1449,9 +1470,10 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \param doc DOM document to parse
      * \param brokenNodes a list of DOM nodes corresponding to layers that we were unable to load; this could be
      * because the layers were removed or re-located after the project was last saved
+     * \param flags optional project reading flags
      * \returns TRUE if function worked; else is FALSE
     */
-    bool _getMapLayers( const QDomDocument &doc, QList<QDomNode> &brokenNodes );
+    bool _getMapLayers( const QDomDocument &doc, QList<QDomNode> &brokenNodes, QgsProject::ReadFlags flags = nullptr );
 
     /**
      * Set error message from read/write operation
@@ -1466,25 +1488,35 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     void clearError() SIP_SKIP;
 
     /**
-     * Creates layer and adds it to maplayer registry
+     * Creates layer and adds it to maplayer registry.
+     *
+     * The optional \a flags argument can be used to control layer reading behavior.
+     *
      * \note not available in Python bindings
      */
-    bool addLayer( const QDomElement &layerElem, QList<QDomNode> &brokenNodes, QgsReadWriteContext &context ) SIP_SKIP;
+    bool addLayer( const QDomElement &layerElem, QList<QDomNode> &brokenNodes, QgsReadWriteContext &context, QgsProject::ReadFlags flags = nullptr ) SIP_SKIP;
 
-    //! \note not available in Python bindings
-    void initializeEmbeddedSubtree( const QString &projectFilePath, QgsLayerTreeGroup *group ) SIP_SKIP;
+    /**
+     * The optional \a flags argument can be used to control layer reading behavior.
+     *
+     * \note not available in Python bindings
+    */
+    void initializeEmbeddedSubtree( const QString &projectFilePath, QgsLayerTreeGroup *group, QgsProject::ReadFlags flags = nullptr ) SIP_SKIP;
 
-    //! \note not available in Python bindings
-    void loadEmbeddedNodes( QgsLayerTreeGroup *group ) SIP_SKIP;
+    /**
+     * The optional \a flags argument can be used to control layer reading behavior.
+     * \note not available in Python bindings
+     */
+    void loadEmbeddedNodes( QgsLayerTreeGroup *group, QgsProject::ReadFlags flags = nullptr ) SIP_SKIP;
 
     //! Read .qgs file
-    bool readProjectFile( const QString &filename );
+    bool readProjectFile( const QString &filename, QgsProject::ReadFlags flags = nullptr );
 
     //! Write .qgs file
     bool writeProjectFile( const QString &filename );
 
     //! Unzip .qgz file then read embedded .qgs file
-    bool unzip( const QString &filename );
+    bool unzip( const QString &filename, QgsProject::ReadFlags flags = nullptr );
 
     //! Zip project
     bool zip( const QString &filename );
@@ -1560,6 +1592,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     // Required by QGIS Server for switching the current project instance
     friend class QgsConfigCache;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProject::ReadFlags )
 
 /**
  * Temporarily blocks QgsProject "dirtying" for the lifetime of the object.

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -37,7 +37,7 @@ QgsTransaction *QgsTransaction::create( const QSet<QgsVectorLayer *> &layers )
   QgsVectorLayer *firstLayer = *layers.constBegin();
 
   QString connStr = connectionString( firstLayer->source() );
-  QString providerKey = firstLayer->dataProvider()->name();
+  QString providerKey = firstLayer->providerType();
   std::unique_ptr<QgsTransaction> transaction( QgsTransaction::create( connStr, providerKey ) );
   if ( transaction )
   {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1438,7 +1438,10 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
   QgsDataProvider::ProviderOptions options { context.transformContext() };
   if ( ( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) || !setDataProvider( mProviderKey, options ) )
   {
-    QgsDebugMsg( QStringLiteral( "Could not set data provider for layer %1" ).arg( publicSource() ) );
+    if ( !( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) )
+    {
+      QgsDebugMsg( QStringLiteral( "Could not set data provider for layer %1" ).arg( publicSource() ) );
+    }
     const QDomElement elem = layer_node.toElement();
 
     // for invalid layer sources, we fallback to stored wkbType if available

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2133,7 +2133,10 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage,
   bool result = true;
   emit readCustomSymbology( node.toElement(), errorMessage );
 
-  if ( isSpatial() )
+  // we must try to restore a renderer if our geometry type is unknown
+  // as this allows the renderer to be correctly restored even for layers
+  // with broken sources
+  if ( isSpatial() || mWkbType == QgsWkbTypes::Unknown )
   {
     // try renderer v2 first
     if ( categories.testFlag( Symbology ) )
@@ -2152,7 +2155,7 @@ bool QgsVectorLayer::readStyle( const QDomNode &node, QString &errorMessage,
         }
       }
       // make sure layer has a renderer - if none exists, fallback to a default renderer
-      if ( !renderer() )
+      if ( isSpatial() && !renderer() )
       {
         setRenderer( QgsFeatureRenderer::defaultRenderer( geometryType() ) );
       }
@@ -3253,7 +3256,10 @@ bool QgsVectorLayer::isAuxiliaryField( int index, int &srcIndex ) const
 
 void QgsVectorLayer::setRenderer( QgsFeatureRenderer *r )
 {
-  if ( !isSpatial() )
+  // we must allow setting a renderer if our geometry type is unknown
+  // as this allows the renderer to be correctly set even for layers
+  // with broken sources
+  if ( !isSpatial() && mWkbType != QgsWkbTypes::Unknown )
     return;
 
   if ( r != mRenderer )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1436,7 +1436,7 @@ bool QgsVectorLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
   }
 
   QgsDataProvider::ProviderOptions options { context.transformContext() };
-  if ( !setDataProvider( mProviderKey, options ) )
+  if ( ( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) || !setDataProvider( mProviderKey, options ) )
   {
     QgsDebugMsg( QStringLiteral( "Could not set data provider for layer %1" ).arg( publicSource() ) );
     const QDomElement elem = layer_node.toElement();

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1777,8 +1777,11 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     // <<< BACKWARD COMPATIBILITY < 1.9
   }
 
-  QgsDataProvider::ProviderOptions providerOptions { context.transformContext() };
-  setDataProvider( mProviderKey, providerOptions );
+  if ( !( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) )
+  {
+    QgsDataProvider::ProviderOptions providerOptions { context.transformContext() };
+    setDataProvider( mProviderKey, providerOptions );
+  }
 
   if ( ! mDataProvider )
   {

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1785,7 +1785,10 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
 
   if ( ! mDataProvider )
   {
-    QgsDebugMsg( QStringLiteral( "Raster data provider could not be created for %1" ).arg( mDataSource ) );
+    if ( !( mReadFlags & QgsMapLayer::FlagDontResolveLayers ) )
+    {
+      QgsDebugMsg( QStringLiteral( "Raster data provider could not be created for %1" ).arg( mDataSource ) );
+    }
     return false;
   }
 

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -59,7 +59,7 @@ QVariantMap QgsValueRelationConfigDlg::config()
   cfg.insert( QStringLiteral( "LayerName" ), mLayerName->currentLayer() ? mLayerName->currentLayer()->name() : QString() );
   cfg.insert( QStringLiteral( "LayerSource" ), mLayerName->currentLayer() ? mLayerName->currentLayer()->publicSource() : QString() );
   cfg.insert( QStringLiteral( "LayerProviderName" ), ( mLayerName->currentLayer() && mLayerName->currentLayer()->dataProvider() ) ?
-              mLayerName->currentLayer()->dataProvider()->name() :
+              mLayerName->currentLayer()->providerType() :
               QString() );
   cfg.insert( QStringLiteral( "Key" ), mKeyColumn->currentField() );
   cfg.insert( QStringLiteral( "Value" ), mValueColumn->currentField() );

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -136,7 +136,7 @@ void QgsGeoPackageItemGuiProvider::deleteGpkg()
     const auto mapLayers = QgsProject::instance()->mapLayers();
     for ( auto it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
     {
-      const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( it.value()->dataProvider()->name(), it.value()->source() );
+      const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( it.value()->providerType(), it.value()->source() );
       if ( parts.value( QStringLiteral( "path" ) ).toString() == path )
       {
         projectLayer = it.value();

--- a/src/gui/providers/ogr/qgsogritemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsogritemguiprovider.cpp
@@ -138,7 +138,7 @@ void QgsOgrItemGuiProvider::deleteCollection()
   const auto mapLayers = QgsProject::instance()->mapLayers();
   for ( auto it = mapLayers.constBegin(); it != mapLayers.constEnd(); ++it )
   {
-    const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( it.value()->dataProvider()->name(), it.value()->source() );
+    const QVariantMap parts = QgsProviderRegistry::instance()->decodeUri( it.value()->providerType(), it.value()->source() );
     if ( parts.value( QStringLiteral( "path" ) ).toString() == path )
     {
       projectLayer = it.value();

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -73,7 +73,7 @@ QVariant QgsSelectLayerTreeModel::data( const QModelIndex &index, int role ) con
     if ( QgsLayerTree::isLayer( node ) && index.column() > 0 )
     {
       QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
-      if ( nodeLayer->layer()->dataProvider()->name() == QStringLiteral( "WFS" ) )
+      if ( nodeLayer->layer()->providerType() == QStringLiteral( "WFS" ) )
       {
         switch ( role )
         {

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -1372,7 +1372,9 @@ void TestQgsProcessingAlgs::styleFromProject()
   results = alg->run( parameters, *context, &feedback, &ok );
   QVERIFY( ok );
   QCOMPARE( results.value( QStringLiteral( "SYMBOLS" ) ).toInt(), 6 );
-  QCOMPARE( results.value( QStringLiteral( "COLORRAMPS" ) ).toInt(), 1 );
+  // this should be 1, but currently raster layers aren't supported -
+  // we first need to allow raster renderers to be read and restored for invalid layer sources
+  QCOMPARE( results.value( QStringLiteral( "COLORRAMPS" ) ).toInt(), 0 );
   QCOMPARE( results.value( QStringLiteral( "TEXTFORMATS" ) ).toInt(), 1 );
   QCOMPARE( results.value( QStringLiteral( "LABELSETTINGS" ) ).toInt(), 1 );
 }

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -43,6 +43,7 @@ class TestQgsProject : public QObject
     void testLayerFlags();
     void testLocalFiles();
     void testLocalUrlFiles();
+    void testReadFlags();
 };
 
 void TestQgsProject::init()
@@ -425,6 +426,36 @@ void TestQgsProject::testLocalUrlFiles()
   QgsPathResolver resolver( f.fileName( ) );
   QCOMPARE( resolver.writePath( layerPath ), QString( "./" + info.baseName() + ".shp" + extraStuff ) ) ;
 
+}
+
+void TestQgsProject::testReadFlags()
+{
+  QString project1Path = QString( TEST_DATA_DIR ) + QStringLiteral( "/embedded_groups/project1.qgs" );
+  QgsProject p;
+  QVERIFY( p.read( project1Path, QgsProject::FlagDontResolveLayers ) );
+  auto layers = p.mapLayers();
+  QCOMPARE( layers.count(), 3 );
+  // layers should be invalid - we skipped loading them!
+  QVERIFY( !layers.value( QStringLiteral( "points20170310142652246" ) )->isValid() );
+  QVERIFY( !layers.value( QStringLiteral( "lines20170310142652255" ) )->isValid() );
+  QVERIFY( !layers.value( QStringLiteral( "polys20170310142652234" ) )->isValid() );
+
+  // but they should have renderers (and other stuff!)
+  QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "points20170310142652246" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
+  QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "lines20170310142652255" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
+  QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "polys20170310142652234" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
+
+  // project with embedded groups
+  QString project2Path = QString( TEST_DATA_DIR ) + QStringLiteral( "/embedded_groups/project2.qgs" );
+  QgsProject p2;
+  QVERIFY( p2.read( project2Path, QgsProject::FlagDontResolveLayers ) );
+  // layers should be invalid - we skipped loading them!
+  layers = p2.mapLayers();
+  QCOMPARE( layers.count(), 2 );
+  QVERIFY( !layers.value( QStringLiteral( "lines20170310142652255" ) )->isValid() );
+  QVERIFY( !layers.value( QStringLiteral( "polys20170310142652234" ) )->isValid() );
+  QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "lines20170310142652255" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
+  QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "polys20170310142652234" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
 }
 
 


### PR DESCRIPTION
This causes the project to be read, but no data providers created for
layers (i.e. the same result as loading a project in the app and
choosing to leave bad layers in the project).

It's intended for occasions when you want to efficiently access properties
of a project without the (often very expensive) cost of actually
loading layers. E.g. to just read project metadata, parse the
layer tree structure, extract print layouts or renderer properties, etc.
