### PR TITLE
Fixing db_manager so that it can run sql with inline comments

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -59,6 +59,35 @@ from .ui.ui_DlgSqlWindow import Ui_DbManagerDlgSqlWindow as Ui_Dialog
 
 import re
 
+def check_comments_in_sql(raw_sql_input):
+    lines = []
+    for line in raw_sql_input.split('\n'):
+        if not line.strip().startswith('--'):
+            if '--' in line:
+                comment_positions = []
+                comments = re.finditer(r'--', line)
+                for match in comments:
+                    comment_positions.append(match.start())
+                quote_positions = []
+                identifiers = re.finditer(r'"(?:[^"]|"")*"', line)
+                quotes = re.finditer(r"'(?:[^']|'')*'", line)
+                for match in identifiers:
+                    quote_positions.append((match.start(), match.end()))
+                for match in quotes:
+                    quote_positions.append((match.start(), match.end()))
+                unquoted_comments = comment_positions.copy()
+                for comment in comment_positions:
+                    for quote_position in quote_positions:
+                        if comment >= quote_position[0] and comment < quote_position[1]:
+                            unquoted_comments.remove(comment)
+                if len(unquoted_comments) > 0:
+                    lines.append(line[:unquoted_comments[0]])
+                else:
+                    lines.append(line)
+            else:
+                lines.append(line)
+    sql = ' '.join(lines)
+    return sql.strip()
 
 class DlgSqlWindow(QWidget, Ui_Dialog):
     nameChanged = pyqtSignal(str)
@@ -605,35 +634,8 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
     def _getExecutableSqlQuery(self):
         sql = self._getSqlQuery()
 
-        # Clean it up!
-        lines = []
-        for line in sql.split('\n'):
-            if not line.strip().startswith('--'):
-                if '--' in line:
-                    comment_positions = []
-                    comments = re.finditer(r'--', line)
-                    for match in comments:
-                        comment_positions.append(match.start())
-                    quote_positions = []
-                    identifiers = re.finditer(r'"(?:[^"]|"")*"', line)
-                    quotes = re.finditer(r"'(?:[^']|'')*'", line)
-                    for match in identifiers:
-                        quote_positions.append((match.start(), match.end()))
-                    for match in quotes:
-                        quote_positions.append((match.start(), match.end()))
-                    unquoted_comments = comment_positions.copy()
-                    for comment in comment_positions:
-                        for quote_position in quote_positions:
-                            if comment >= quote_position[0] and comment < quote_position[1]:
-                                unquoted_comments.remove(comment)
-                    if len(unquoted_comments) > 0:
-                        lines.append(line[:unquoted_comments[0]])
-                    else:
-                        lines.append(line)
-                else:
-                    lines.append(line)
-        sql = ' '.join(lines)
-        return sql.strip()
+        uncommented_sql = check_comments_in_sql(sql)
+        return uncommented_sql
 
     def uniqueChanged(self):
         # when an item is (un)checked, simply trigger an update of the combobox text

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -612,16 +612,16 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             if not line.strip().startswith('--'):
                 if '--' in line:
                     comment_positions = []
-                    comments = re.finditer(r'--',line)
+                    comments = re.finditer(r'--', line)
                     for match in comments:
                         comment_positions.append(match.start())
                     quote_positions = []
-                    identifiers = re.finditer(r'"(?:[^"]|"")*"',line)
-                    quotes = re.finditer(r"'(?:[^']|'')*'",line)
+                    identifiers = re.finditer(r'"(?:[^"]|"")*"', line)
+                    quotes = re.finditer(r"'(?:[^']|'')*'", line)
                     for match in identifiers:
-                        quote_positions.append((match.start(),match.end()))
+                        quote_positions.append((match.start(), match.end()))
                     for match in quotes:
-                        quote_positions.append((match.start(),match.end()))
+                        quote_positions.append((match.start(), match.end()))
                     unquoted_comments = copy.deepcopy(comment_positions)
                     for comment in comment_positions:
                         for quote_position in quote_positions:

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -609,6 +609,9 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         lines = []
         for line in sql.split('\n'):
             if not line.strip().startswith('--'):
+                comment_idx = line.find('--')
+                if comment_idx > 1:
+                    line = line[:comment_idx]
                 lines.append(line)
         sql = ' '.join(lines)
         return sql.strip()

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -89,6 +89,7 @@ def check_comments_in_sql(raw_sql_input):
     sql = ' '.join(lines)
     return sql.strip()
 
+
 class DlgSqlWindow(QWidget, Ui_Dialog):
     nameChanged = pyqtSignal(str)
     QUERY_HISTORY_LIMIT = 20

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -59,6 +59,7 @@ from .ui.ui_DlgSqlWindow import Ui_DbManagerDlgSqlWindow as Ui_Dialog
 
 import re
 
+
 def check_comments_in_sql(raw_sql_input):
     lines = []
     for line in raw_sql_input.split('\n'):

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -58,7 +58,6 @@ except:
 from .ui.ui_DlgSqlWindow import Ui_DbManagerDlgSqlWindow as Ui_Dialog
 
 import re
-import copy
 
 
 class DlgSqlWindow(QWidget, Ui_Dialog):
@@ -622,7 +621,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
                         quote_positions.append((match.start(), match.end()))
                     for match in quotes:
                         quote_positions.append((match.start(), match.end()))
-                    unquoted_comments = copy.deepcopy(comment_positions)
+                    unquoted_comments = comment_positions.copy()
                     for comment in comment_positions:
                         for quote_position in quote_positions:
                             if comment >= quote_position[0] and comment < quote_position[1]:

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -252,6 +252,7 @@ ADD_PYTHON_TEST(PyQgsAuxiliaryStorage test_qgsauxiliarystorage.py)
 ADD_PYTHON_TEST(PyQgsAuthManagerOgr test_authmanager_ogr.py)
 ADD_PYTHON_TEST(PyQgsFieldValidator test_qgsfieldvalidator.py)
 ADD_PYTHON_TEST(PyQgsPluginDependencies test_plugindependencies.py)
+ADD_PYTHON_TEST(PyQgsDBManagerSQLWindow test_db_manager_sql_window.py)
 
 IF (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_db_manager_sql_window.py
+++ b/tests/src/python/test_db_manager_sql_window.py
@@ -15,24 +15,31 @@ from plugins.db_manager.dlg_sql_window import check_comments_in_sql
 
 
 class TestPyQgsDBManagerSQLWindow(unittest.TestCase):
+
     def test_no_comment_parsing(self):
         query = "SELECT * FROM test"
         self.assertEqual(check_comments_in_sql(query), query)
+
     def test_comment_parsing(self):
         query = "SELECT * FROM test -- WHERE a = 1 "
         self.assertEqual(check_comments_in_sql(query), "SELECT * FROM test")
+
     def test_comment_parsing_newline(self):
         query = "SELECT * FROM test -- WHERE a = 1 \n ORDER BY b"
         self.assertEqual(check_comments_in_sql(query), "SELECT * FROM test   ORDER BY b")
+
     def test_comment_parsing_newline2(self):
         query = "SELECT * FROM test \n-- WHERE a = 1 \n ORDER BY b"
         self.assertEqual(check_comments_in_sql(query), "SELECT * FROM test   ORDER BY b")
+
     def test_comment_parsing_nothing(self):
         query = "--SELECT * FROM test"
         self.assertEqual(check_comments_in_sql(query), "")
+
     def test_comment_parsing_quote(self):
         query = "SELECT * FROM test WHERE a = '--sdf'"
         self.assertEqual(check_comments_in_sql(query), query)
+        
     def test_comment_parsing_identifier(self):
         query = 'SELECT * FROM "test--1" WHERE a = 1'
         self.assertEqual(check_comments_in_sql(query), query)

--- a/tests/src/python/test_db_manager_sql_window.py
+++ b/tests/src/python/test_db_manager_sql_window.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for the DBManager SQL Window
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Stephen Knox'
+__date__ = '2019-08-27'
+__copyright__ = 'Copyright 2019, Stephen Knox'
+
+from qgis.testing import unittest
+from plugins.db_manager.dlg_sql_window import check_comments_in_sql
+
+
+class TestPyQgsDBManagerSQLWindow(unittest.TestCase):
+    def test_no_comment_parsing(self):
+        query = "SELECT * FROM test"
+        self.assertEqual(check_comments_in_sql(query), query)
+    def test_comment_parsing(self):
+        query = "SELECT * FROM test -- WHERE a = 1 "
+        self.assertEqual(check_comments_in_sql(query), "SELECT * FROM test")
+    def test_comment_parsing_newline(self):
+        query = "SELECT * FROM test -- WHERE a = 1 \n ORDER BY b"
+        self.assertEqual(check_comments_in_sql(query), "SELECT * FROM test   ORDER BY b")
+    def test_comment_parsing_newline2(self):
+        query = "SELECT * FROM test \n-- WHERE a = 1 \n ORDER BY b"
+        self.assertEqual(check_comments_in_sql(query), "SELECT * FROM test   ORDER BY b")
+    def test_comment_parsing_nothing(self):
+        query = "--SELECT * FROM test"
+        self.assertEqual(check_comments_in_sql(query), "")
+    def test_comment_parsing_quote(self):
+        query = "SELECT * FROM test WHERE a = '--sdf'"
+        self.assertEqual(check_comments_in_sql(query), query)
+    def test_comment_parsing_identifier(self):
+        query = 'SELECT * FROM "test--1" WHERE a = 1'
+        self.assertEqual(check_comments_in_sql(query), query)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/src/python/test_db_manager_sql_window.py
+++ b/tests/src/python/test_db_manager_sql_window.py
@@ -44,5 +44,6 @@ class TestPyQgsDBManagerSQLWindow(unittest.TestCase):
         query = 'SELECT * FROM "test--1" WHERE a = 1'
         self.assertEqual(check_comments_in_sql(query), query)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_db_manager_sql_window.py
+++ b/tests/src/python/test_db_manager_sql_window.py
@@ -39,7 +39,7 @@ class TestPyQgsDBManagerSQLWindow(unittest.TestCase):
     def test_comment_parsing_quote(self):
         query = "SELECT * FROM test WHERE a = '--sdf'"
         self.assertEqual(check_comments_in_sql(query), query)
-        
+
     def test_comment_parsing_identifier(self):
         query = 'SELECT * FROM "test--1" WHERE a = 1'
         self.assertEqual(check_comments_in_sql(query), query)


### PR DESCRIPTION
Fixes #29089

## Description
Allows the execution of SQL in db_manager with comments of the -- variety which are inline (not just at the beginning of a newline as before).

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
