### PR TITLE
Faster map rendering when using null symbol renderer

### DIFF
--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -124,6 +124,14 @@ bool QgsVectorLayerRenderer::render()
     return false;
   }
 
+  if ( mRenderer->type() == QStringLiteral( "nullSymbol" ) )
+  {
+    // a little shortcut for the null symbol renderer - most of the time it is not going to render anything
+    // so we can even skip the whole loop to fetch features
+    if ( !mDrawVertexMarkers && !mLabelProvider && !mDiagramProvider && mSelectedFeatureIds.isEmpty() )
+      return true;
+  }
+
   bool usingEffect = false;
   if ( mRenderer->paintEffect() && mRenderer->paintEffect()->enabled() )
   {


### PR DESCRIPTION
If we can skip the loop which fetches features altogether, let's do that and save some time which would be otherwise spent getting geometries only to delete them immediately afterwards.

This is practical especially for 3D scenes where it is useful to set 2D renderer to null if 3D renderer is set.
