### PR TITLE
[layouts] Avoid crash when layout map references a project layer with a bad path

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1683,6 +1683,12 @@ QList<QgsMapLayer *> QgsLayoutItemMap::layersToRender( const QgsExpressionContex
     }
   }
 
+  // remove any invalid layers
+  renderLayers.erase( std::remove_if( renderLayers.begin(), renderLayers.end(), []( QgsMapLayer * layer )
+  {
+    return !layer || !layer->isValid();
+  } ), renderLayers.end() );
+
   return renderLayers;
 }
 


### PR DESCRIPTION
Can happen on loading a project with print layout maps, when layers in the map have a broken path and the user chooses to leave the broken layers in the project