### PR TITLE
Fix exit crash in the plugin layer registry deconstructor (fixes #30681)

### DIFF
--- a/src/core/qgspluginlayerregistry.cpp
+++ b/src/core/qgspluginlayerregistry.cpp
@@ -57,10 +57,10 @@ QgsPluginLayerRegistry::~QgsPluginLayerRegistry()
   if ( !mPluginLayerTypes.isEmpty() )
   {
     QgsDebugMsg( QStringLiteral( "QgsPluginLayerRegistry::~QgsPluginLayerRegistry(): creator list not empty" ) );
-    PluginLayerTypes::const_iterator it = mPluginLayerTypes.constBegin();
-    for ( ; it != mPluginLayerTypes.constEnd(); ++it )
+    const QStringList keys = mPluginLayerTypes.keys();
+    for ( const QString &key : keys )
     {
-      removePluginLayerType( it.key() );
+      removePluginLayerType( key );
     }
   }
 }


### PR DESCRIPTION
Deleting map items while tterating through that map == crasher. 