### PR TITLE
Browsing features in attribute table does not require edit mode

### DIFF
--- a/src/ui/qgsdualviewbase.ui
+++ b/src/ui/qgsdualviewbase.ui
@@ -261,7 +261,7 @@
            <item>
             <widget class="QToolButton" name="mFlashButton">
              <property name="toolTip">
-              <string>Highlight currently edited feature on map</string>
+              <string>Highlight current feature on map</string>
              </property>
              <property name="text">
               <string/>
@@ -294,7 +294,7 @@
            <item>
             <widget class="QToolButton" name="mAutoPanButton">
              <property name="toolTip">
-              <string>Automatically pan to currently edited feature</string>
+              <string>Automatically pan to the current feature</string>
              </property>
              <property name="text">
               <string/>
@@ -314,7 +314,7 @@
            <item>
             <widget class="QToolButton" name="mAutoZoomButton">
              <property name="toolTip">
-              <string>Automatically zoom to currently edited feature</string>
+              <string>Automatically zoom to the current feature</string>
              </property>
              <property name="text">
               <string/>


### PR DESCRIPTION
In attribute table form view, since the buttons to pan to, zoom to and highlight the active feature are available regardless the layer edit mode, their tooltip should not refer to "currently edited feature".

Also I didn't notice these were push buttons at first and was surprised that my map canvas was changing with each "selection". Wonder if the tooltip should be more verbose, sthg like :"Push it to automatically zoom to the current _(active instead?)_ feature". Don't know if the rewording is better but...


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
