### PR TITLE
[processing] add createByDefault argument to directory output constructor

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -2865,7 +2865,8 @@ A folder output parameter.
 
     QgsProcessingParameterFolderDestination( const QString &name, const QString &description = QString(),
         const QVariant &defaultValue = QVariant(),
-        bool optional = false );
+        bool optional = false,
+        bool createByDefault = true );
 %Docstring
 Constructor for QgsProcessingParameterFolderDestination.
 %End

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -228,6 +228,8 @@ def getParameterFromString(s, context=''):
             elif clazz == QgsProcessingParameterFolderDestination:
                 if len(params) > 3:
                     params[3] = True if params[3].lower() == 'true' else False
+                if len(params) > 4:
+                    params[4] = True if params[4].lower() == 'true' else False
             elif clazz == QgsProcessingParameterRasterDestination:
                 if len(params) > 3:
                     params[3] = True if params[3].lower() == 'true' else False

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -102,56 +102,61 @@ class DestinationSelectionPanel(BASE, WIDGET):
         self.destinationChanged.emit()
 
     def selectOutput(self):
-        if isinstance(self.parameter, QgsProcessingParameterFolderDestination):
-            self.selectDirectory()
-        else:
-            popupMenu = QMenu()
+        popupMenu = QMenu()
 
-            if not self.default_selection:
-                if self.parameter.flags() & QgsProcessingParameterDefinition.FlagOptional:
-                    actionSkipOutput = QAction(
-                        self.tr('Skip Output'), self.btnSelect)
-                    actionSkipOutput.triggered.connect(self.skipOutput)
-                    popupMenu.addAction(actionSkipOutput)
-
-                if isinstance(self.parameter, QgsProcessingParameterFeatureSink) \
-                        and self.parameter.supportsNonFileBasedOutput():
-                    # use memory layers for temporary layers if supported
-                    actionSaveToTemp = QAction(
-                        self.tr('Create Temporary Layer'), self.btnSelect)
-                else:
-                    actionSaveToTemp = QAction(
-                        self.tr('Save to a Temporary File'), self.btnSelect)
-                actionSaveToTemp.triggered.connect(self.saveToTemporary)
-                popupMenu.addAction(actionSaveToTemp)
-
-            actionSaveToFile = QAction(
-                QCoreApplication.translate('DestinationSelectionPanel', 'Save to File…'), self.btnSelect)
-            actionSaveToFile.triggered.connect(self.selectFile)
-            popupMenu.addAction(actionSaveToFile)
+        if not self.default_selection:
+            if self.parameter.flags() & QgsProcessingParameterDefinition.FlagOptional:
+                actionSkipOutput = QAction(
+                    self.tr('Skip Output'), self.btnSelect)
+                actionSkipOutput.triggered.connect(self.skipOutput)
+                popupMenu.addAction(actionSkipOutput)
 
             if isinstance(self.parameter, QgsProcessingParameterFeatureSink) \
                     and self.parameter.supportsNonFileBasedOutput():
-                actionSaveToGpkg = QAction(
-                    QCoreApplication.translate('DestinationSelectionPanel', 'Save to GeoPackage…'), self.btnSelect)
-                actionSaveToGpkg.triggered.connect(self.saveToGeopackage)
-                popupMenu.addAction(actionSaveToGpkg)
-                actionSaveToPostGIS = QAction(
-                    QCoreApplication.translate('DestinationSelectionPanel', 'Save to PostGIS Table…'), self.btnSelect)
-                actionSaveToPostGIS.triggered.connect(self.saveToPostGIS)
-                settings = QgsSettings()
-                settings.beginGroup('/PostgreSQL/connections/')
-                names = settings.childGroups()
-                settings.endGroup()
-                actionSaveToPostGIS.setEnabled(bool(names))
-                popupMenu.addAction(actionSaveToPostGIS)
+                # use memory layers for temporary layers if supported
+                actionSaveToTemp = QAction(
+                    self.tr('Create Temporary Layer'), self.btnSelect)
+            elif isinstance(self.parameter, QgsProcessingParameterFolderDestination):
+                actionSaveToTemp = QAction(
+                    self.tr('Save to a Temporary Directory'), self.btnSelect)
+            else:
+                actionSaveToTemp = QAction(
+                    self.tr('Save to a Temporary File'), self.btnSelect)
+            actionSaveToTemp.triggered.connect(self.saveToTemporary)
+            popupMenu.addAction(actionSaveToTemp)
 
-            actionSetEncoding = QAction(
-                QCoreApplication.translate('DestinationSelectionPanel', 'Change File Encoding ({})…').format(self.encoding), self.btnSelect)
-            actionSetEncoding.triggered.connect(self.selectEncoding)
-            popupMenu.addAction(actionSetEncoding)
+        if isinstance(self.parameter, QgsProcessingParameterFolderDestination):
+            actionSaveToFile = QAction(
+                QCoreApplication.translate('DestinationSelectionPanel', 'Save to Directory…'), self.btnSelect)
+            actionSaveToFile.triggered.connect(self.selectDirectory)
+        else:
+            actionSaveToFile = QAction(
+                QCoreApplication.translate('DestinationSelectionPanel', 'Save to File…'), self.btnSelect)
+            actionSaveToFile.triggered.connect(self.selectFile)
+        popupMenu.addAction(actionSaveToFile)
 
-            popupMenu.exec_(QCursor.pos())
+        if isinstance(self.parameter, QgsProcessingParameterFeatureSink) \
+                and self.parameter.supportsNonFileBasedOutput():
+            actionSaveToGpkg = QAction(
+                QCoreApplication.translate('DestinationSelectionPanel', 'Save to GeoPackage…'), self.btnSelect)
+            actionSaveToGpkg.triggered.connect(self.saveToGeopackage)
+            popupMenu.addAction(actionSaveToGpkg)
+            actionSaveToPostGIS = QAction(
+                QCoreApplication.translate('DestinationSelectionPanel', 'Save to PostGIS Table…'), self.btnSelect)
+            actionSaveToPostGIS.triggered.connect(self.saveToPostGIS)
+            settings = QgsSettings()
+            settings.beginGroup('/PostgreSQL/connections/')
+            names = settings.childGroups()
+            settings.endGroup()
+            actionSaveToPostGIS.setEnabled(bool(names))
+            popupMenu.addAction(actionSaveToPostGIS)
+
+        actionSetEncoding = QAction(
+            QCoreApplication.translate('DestinationSelectionPanel', 'Change File Encoding ({})…').format(self.encoding), self.btnSelect)
+        actionSetEncoding.triggered.connect(self.selectEncoding)
+        popupMenu.addAction(actionSetEncoding)
+
+        popupMenu.exec_(QCursor.pos())
 
     def saveToTemporary(self):
         if isinstance(self.parameter, QgsProcessingParameterFeatureSink) and self.parameter.supportsNonFileBasedOutput():

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -4889,8 +4889,8 @@ QgsProcessingParameterFileDestination *QgsProcessingParameterFileDestination::fr
   return new QgsProcessingParameterFileDestination( name, description, QString(), definition.isEmpty() ? QVariant() : definition, isOptional );
 }
 
-QgsProcessingParameterFolderDestination::QgsProcessingParameterFolderDestination( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )
-  : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
+QgsProcessingParameterFolderDestination::QgsProcessingParameterFolderDestination( const QString &name, const QString &description, const QVariant &defaultValue, bool optional, bool createByDefault )
+  : QgsProcessingDestinationParameter( name, description, defaultValue, optional, createByDefault )
 {}
 
 QgsProcessingParameterDefinition *QgsProcessingParameterFolderDestination::clone() const

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -2699,7 +2699,8 @@ class CORE_EXPORT QgsProcessingParameterFolderDestination : public QgsProcessing
      */
     QgsProcessingParameterFolderDestination( const QString &name, const QString &description = QString(),
         const QVariant &defaultValue = QVariant(),
-        bool optional = false );
+        bool optional = false,
+        bool createByDefault = true );
 
     /**
      * Returns the type name for the parameter class.


### PR DESCRIPTION
## Description
In  #6873 `createByDefault` argument was added to all destination parameters except directory. But in some cases directory outputs should not be created by default and having such options is useful.

Follow up #6873.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
