### PR TITLE
[processing] ignore hidden parameters when generating GDAL command (fix #30669)

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
@@ -127,6 +127,9 @@ class GdalParametersPanel(ParametersPanel):
                 if not output.name() in parameters or parameters[output.name()] is None:
                     parameters[output.name()] = self.tr("[temporary file]")
             for p in self.alg.parameterDefinitions():
+                if p.flags() & QgsProcessingParameterDefinition.FlagHidden:
+                    continue
+
                 if (not p.name() in parameters and not p.flags() & QgsProcessingParameterDefinition.FlagOptional) \
                         or (not p.checkValueIsAcceptable(parameters[p.name()])):
                     # not ready yet


### PR DESCRIPTION
## Description
Hidden parameters should not be used for constructing "helper" GDAL command.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
