### PR TITLE
[Bugfix] DB Mananger: Fix in Oracle plugin the way to strip uniqueCol

### DIFF
--- a/python/plugins/db_manager/db_plugins/oracle/plugin.py
+++ b/python/plugins/db_manager/db_plugins/oracle/plugin.py
@@ -203,8 +203,12 @@ class ORDatabase(Database):
         uri = self.uri()
         con = self.database().connector
 
+        if uniqueCol is not None:
+            uniqueCol = uniqueCol.strip('"').replace('""', '"')
+
         uri.setDataSource(u"", u"({}\n)".format(
-            sql), geomCol, filter, uniqueCol.strip(u'"'))
+            sql), geomCol, filter, uniqueCol)
+
         if avoidSelectById:
             uri.disableSelectAtId(True)
         provider = self.dbplugin().providerName()


### PR DESCRIPTION
## Description
For an Oracle layer based on an SQL request, the contextual menu provides "Update SQL Layer". If the unique column is not defined for the layer, the update failed.

```
WARNING    Traceback (most recent call last):
              File "/home/dhont/3liz_dev/QGIS/qgis_rldhont/apps/share/qgis/python/plugins/db_manager/dlg_sql_layer_window.py", line 343, in updateSqlLayer
              layer = self._getSqlLayer(self.filter)
              File "/home/dhont/3liz_dev/QGIS/qgis_rldhont/apps/share/qgis/python/plugins/db_manager/dlg_sql_layer_window.py", line 327, in _getSqlLayer
              self.avoidSelectById.isChecked(), _filter)
              File "/home/dhont/3liz_dev/QGIS/qgis_rldhont/apps/share/qgis/python/plugins/db_manager/db_plugins/oracle/plugin.py", line 207, in toSqlLayer
              sql), geomCol, filter, uniqueCol.strip(u'"'))
             AttributeError: 'NoneType' object has no attribute 'strip'
```

This PR fixed it.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
