### PR TITLE
[processing] pass layer name to the gdalwarp to avoid issues with multi-layer datasources (fix #30292)

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -217,6 +217,8 @@ class ClipRasterByMask(GdalAlgorithm):
 
         arguments.append('-cutline')
         arguments.append(maskLayer)
+        arguments.append('-cl')
+        arguments.append(maskLayerName)
 
         if self.parameterAsBoolean(parameters, self.CROP_TO_CUTLINE, context):
             arguments.append('-crop_to_cutline')

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -343,7 +343,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-of JPEG -cutline ' +
-                 mask + ' -crop_to_cutline ' + source + ' ' +
+                 mask + ' -cl polys2 -crop_to_cutline ' + source + ' ' +
                  outdir + '/check.jpg'])
             # with NODATA value
             self.assertEqual(
@@ -353,7 +353,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-of JPEG -cutline ' +
-                 mask + ' -crop_to_cutline -dstnodata 9999.0 ' + source + ' ' +
+                 mask + ' -cl polys2 -crop_to_cutline -dstnodata 9999.0 ' + source + ' ' +
                  outdir + '/check.jpg'])
             # with "0" NODATA value
             self.assertEqual(
@@ -363,7 +363,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-of JPEG -cutline ' +
-                 mask + ' -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
+                 mask + ' -cl polys2 -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
                  outdir + '/check.jpg'])
             # with "0" NODATA value and custom data type
             self.assertEqual(
@@ -374,7 +374,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-ot Float32 -of JPEG -cutline ' +
-                 mask + ' -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
+                 mask + ' -cl polys2 -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
                  outdir + '/check.jpg'])
             # with creation options
             self.assertEqual(
@@ -384,7 +384,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-of JPEG -cutline ' +
-                 mask + ' -crop_to_cutline -co COMPRESS=DEFLATE -co PREDICTOR=2 -co ZLEVEL=9 ' +
+                 mask + ' -cl polys2 -crop_to_cutline -co COMPRESS=DEFLATE -co PREDICTOR=2 -co ZLEVEL=9 ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
             # with multothreading and additional parameters
@@ -396,7 +396,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-of JPEG -cutline ' +
-                 mask + ' -crop_to_cutline -multi -nosrcalpha -wm 2048 -nomd ' +
+                 mask + ' -cl polys2 -crop_to_cutline -multi -nosrcalpha -wm 2048 -nomd ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
 


### PR DESCRIPTION
## Description
When multi-layer datasource is used in the `gdalwarp` we should pass not only path to the file, but also layer name. Fixes #30292.

Tests updated accordingly.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit