### PR TITLE
Change to cdash 2.6

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -8,6 +8,6 @@ set(CTEST_PROJECT_NAME "QGIS")
 set(CTEST_NIGHTLY_START_TIME "20:00:00 CEST")
 
 set(CTEST_DROP_METHOD "https")
-set(CTEST_DROP_SITE "dash.orfeo-toolbox.org")
+set(CTEST_DROP_SITE "cdash.orfeo-toolbox.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=QGIS")
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/INSTALL
+++ b/INSTALL
@@ -357,7 +357,7 @@ using dpkg -r libqgis1-dev.  Otherwise dpkg-buildpackage will complain about a
 build conflict.
 
 /!\ Note: By default tests are run in the process of building and their
-results are uploaded to http://dash.orfeo-toolbox.org/index.php?project=QGIS.
+results are uploaded to http://cdash.orfeo-toolbox.org/index.php?project=QGIS.
 You can turn the tests off using DEB_BUILD_OPTIONS=nocheck in front of the
 build command. The upload of results can be avoided with DEB_TEST_TARGET=test.
 
@@ -2197,7 +2197,7 @@ Then run all tests from build directory:
   cd build
   make test
 
-To run all tests and report to http://dash.orfeo-toolbox.org/index.php?project=QGIS
+To run all tests and report to http://cdash.orfeo-toolbox.org/index.php?project=QGIS
 
   cd build
   make Experimental

--- a/doc/INSTALL.html
+++ b/doc/INSTALL.html
@@ -592,7 +592,7 @@ build conflict.
 </P>
 <P>
 /!\ <B>Note:</B> By default tests are run in the process of building and their
-results are uploaded to <A HREF="http://dash.orfeo-toolbox.org/index.php?project=QGIS.">http://dash.orfeo-toolbox.org/index.php?project=QGIS.</A>
+results are uploaded to <A HREF="http://cdash.orfeo-toolbox.org/index.php?project=QGIS.">http://cdash.orfeo-toolbox.org/index.php?project=QGIS.</A>
 You can turn the tests off using DEB_BUILD_OPTIONS=nocheck in front of the
 build command. The upload of results can be avoided with DEB_TEST_TARGET=test.
 </P>
@@ -3034,7 +3034,7 @@ make test
 </PRE></div>
 
 <P>
-To run all tests and report to <A HREF="http://dash.orfeo-toolbox.org/index.php?project=QGIS">http://dash.orfeo-toolbox.org/index.php?project=QGIS</A>
+To run all tests and report to <A HREF="http://cdash.orfeo-toolbox.org/index.php?project=QGIS">http://cdash.orfeo-toolbox.org/index.php?project=QGIS</A>
 </P>
 
 <div class="code"><PRE>

--- a/doc/debug-tests.t2t
+++ b/doc/debug-tests.t2t
@@ -26,7 +26,7 @@ cd build
 make test
 ```
 
-To run all tests and report to http://dash.orfeo-toolbox.org/index.php?project=QGIS
+To run all tests and report to http://cdash.orfeo-toolbox.org/index.php?project=QGIS
 
 ```
 cd build

--- a/doc/linux.t2t
+++ b/doc/linux.t2t
@@ -251,7 +251,7 @@ using ``dpkg -r libqgis1-dev``.  Otherwise ``dpkg-buildpackage`` will complain a
 build conflict.
 
 /!\ **Note:** By default tests are run in the process of building and their
-results are uploaded to http://dash.orfeo-toolbox.org/index.php?project=QGIS.
+results are uploaded to http://cdash.orfeo-toolbox.org/index.php?project=QGIS.
 You can turn the tests off using DEB_BUILD_OPTIONS=nocheck in front of the
 build command. The upload of results can be avoided with DEB_TEST_TARGET=test.
 

--- a/scripts/parse_dash_results.py
+++ b/scripts/parse_dash_results.py
@@ -50,7 +50,7 @@ from PyQt5.QtWidgets import (QDialog,
 import struct
 import glob
 
-dash_url = 'https://dash.orfeo-toolbox.org'
+dash_url = 'https://cdash.orfeo-toolbox.org'
 
 
 def error(msg):


### PR DESCRIPTION
## Description
Change the CDash URL to use the new CDash 2.6 instance.

Orfeo-ToolBox is now using this new instance as well. The migration from old dashboard was not possible, hence the new dashboard URL. I already created a QGIS project on this dashboard. 

https://cdash.orfeo-toolbox.org/index.php?project=QGIS

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
