### PR TITLE
Preserve snapping settings for offline editing

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -222,6 +222,9 @@ void QgsOfflineEditing::synchronize()
 
   emit progressStarted();
 
+  //copy snapping settings
+  QgsSnappingConfig snappingConfig = QgsProject::instance()->snappingConfig();
+
   // restore and sync remote layers
   QList<QgsMapLayer *> offlineLayers;
   QMap<QString, QgsMapLayer *> mapLayers = QgsProject::instance()->mapLayers();
@@ -270,6 +273,10 @@ void QgsOfflineEditing::synchronize()
       updateRelations( offlineLayer, remoteLayer );
       updateMapThemes( offlineLayer, remoteLayer );
       updateLayerOrder( offlineLayer, remoteLayer );
+
+      //append snapping setting on remote layer
+      snappingConfig.setIndividualLayerSettings( remoteLayer, QgsProject::instance()->snappingConfig().individualLayerSettings( offlineLayer ) );
+      snappingConfig.removeLayers( QList<QgsMapLayer *>() << offlineLayer );
 
       //set QgsLayerTreeNode properties back
       QgsLayerTreeLayer *layerTreeLayer = QgsProject::instance()->layerTreeRoot()->findLayer( offlineLayer->id() );
@@ -348,6 +355,9 @@ void QgsOfflineEditing::synchronize()
   // reset commitNo
   QString sql = QStringLiteral( "UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'" );
   sqlExec( database.get(), sql );
+
+  //set snapping config
+  QgsProject::instance()->setSnappingConfig( snappingConfig );
 
   emit progressStopped();
 }

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -89,7 +89,13 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
 
   //preserve individual snapping settings
   QgsSnappingConfig snappingConfig = QgsProject::instance()->snappingConfig();
+  QHash<QString, QgsSnappingConfig::IndividualLayerSettings> preservedIndividualLayerSettings;
   const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> individualLayerSettings = snappingConfig.individualLayerSettings();
+  for ( const QgsSnappingConfig::IndividualLayerSettings &individualSetting : individualLayerSettings )
+  {
+    preservedIndividualLayerSettings.insert( individualLayerSettings.key( individualSetting )->id(), individualSetting );
+  }
+
   snappingConfig.removeLayers( QgsProject::instance()->mapLayers().values() );
 
   QString dbPath = QDir( offlineDataPath ).absoluteFilePath( offlineDbFile );
@@ -196,9 +202,9 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
       QgsProject::instance()->writeEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH, QgsProject::instance()->writePath( dbPath ) );
 
       //preserve individual snapping settings
-      for ( const QgsSnappingConfig::IndividualLayerSettings &individualSetting : individualLayerSettings )
+      for ( const QgsSnappingConfig::IndividualLayerSettings &preservedIndividualSetting : preservedIndividualLayerSettings )
       {
-        snappingConfig.setIndividualLayerSettings( layerIdMapping.value( individualLayerSettings.key( individualSetting )->id() ), individualSetting );
+        snappingConfig.setIndividualLayerSettings( layerIdMapping.value( preservedIndividualLayerSettings.key( preservedIndividualSetting ) ), preservedIndividualSetting );
       }
       QgsProject::instance()->setSnappingConfig( snappingConfig );
 

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -133,7 +133,6 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
         joinInfoBuffer.insert( vl->id(), joins );
       }
 
-      //preserve individual snapping settings
       QgsSnappingConfig snappingConfig = QgsProject::instance()->snappingConfig();
 
       // copy selected vector layers to SpatiaLite
@@ -150,8 +149,8 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
           if ( newLayer )
           {
             layerIdMapping.insert( origLayerId, newLayer );
-            //append snapping setting on new layer
-            snappingConfig.setIndividualLayerSettings( newLayer, QgsProject::instance()->snappingConfig().individualLayerSettings( vl ) );
+            //append individual layer setting on snapping settings
+            snappingConfig.setIndividualLayerSettings( newLayer, snappingConfig.individualLayerSettings( vl ) );
             snappingConfig.removeLayers( QList<QgsMapLayer *>() << vl );
 
             // remove remote layer
@@ -161,7 +160,6 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
         }
       }
 
-      //set snapping config
       QgsProject::instance()->setSnappingConfig( snappingConfig );
 
       // restore join info on new SpatiaLite layer
@@ -222,7 +220,6 @@ void QgsOfflineEditing::synchronize()
 
   emit progressStarted();
 
-  //copy snapping settings
   QgsSnappingConfig snappingConfig = QgsProject::instance()->snappingConfig();
 
   // restore and sync remote layers
@@ -274,8 +271,8 @@ void QgsOfflineEditing::synchronize()
       updateMapThemes( offlineLayer, remoteLayer );
       updateLayerOrder( offlineLayer, remoteLayer );
 
-      //append snapping setting on remote layer
-      snappingConfig.setIndividualLayerSettings( remoteLayer, QgsProject::instance()->snappingConfig().individualLayerSettings( offlineLayer ) );
+      //append individual layer setting on snapping settings
+      snappingConfig.setIndividualLayerSettings( remoteLayer, snappingConfig.individualLayerSettings( offlineLayer ) );
       snappingConfig.removeLayers( QList<QgsMapLayer *>() << offlineLayer );
 
       //set QgsLayerTreeNode properties back
@@ -356,7 +353,6 @@ void QgsOfflineEditing::synchronize()
   QString sql = QStringLiteral( "UPDATE 'log_indices' SET 'last_index' = 0 WHERE \"name\" = 'commit_no'" );
   sqlExec( database.get(), sql );
 
-  //set snapping config
   QgsProject::instance()->setSnappingConfig( snappingConfig );
 
   emit progressStopped();


### PR DESCRIPTION
Preserve the settings on advanced configuration made for the individual layers, when layers are converted to "offline"-layers.