### PR TITLE
Some ports from Kadas

### DIFF
--- a/python/core/auto_generated/qgsmimedatautils.sip.in
+++ b/python/core/auto_generated/qgsmimedatautils.sip.in
@@ -23,7 +23,7 @@ class QgsMimeDataUtils
 %Docstring
 Constructs invalid URI
 %End
-      explicit Uri( QString &encData );
+      explicit Uri( const QString &encData );
 %Docstring
 Constructs URI from encoded data
 %End

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -107,7 +107,7 @@ Returns the project translator
 
     void setProjectTranslator( QgsProjectTranslator *projectTranslator );
 %Docstring
-Sets the project translator. Means it shouldn't conform mDefaultTranslator anymore.
+Sets the project translator.
 It's usually the QgsProject where the function with the context is made and won't be changed anymore.
 
 .. versionadded:: 3.4

--- a/python/core/auto_generated/qgsreadwritecontext.sip.in
+++ b/python/core/auto_generated/qgsreadwritecontext.sip.in
@@ -131,7 +131,6 @@ Sets data coordinate transform context to ``transformContext``
 .. versionadded:: 3.8
 %End
 
-      public:
 };
 
 

--- a/python/core/auto_generated/qgsscalecalculator.sip.in
+++ b/python/core/auto_generated/qgsscalecalculator.sip.in
@@ -57,7 +57,7 @@ Set the map units
 Returns current map units
 %End
 
-    double calculate( const QgsRectangle &mapExtent, double canvasWidth );
+    double calculate( const QgsRectangle &mapExtent, double canvasWidth ) const;
 %Docstring
 Calculate the scale denominator
 
@@ -67,7 +67,7 @@ Calculate the scale denominator
 :return: scale denominator of current map view, e.g. 1000.0 for a 1:1000 map.
 %End
 
-    double calculateGeographicDistance( const QgsRectangle &mapExtent );
+    double calculateGeographicDistance( const QgsRectangle &mapExtent ) const;
 %Docstring
 Calculate the distance between two points in geographic coordinates.
 Used to calculate scale for map views with geographic (decimal degree)

--- a/python/core/auto_generated/qgsunittypes.sip.in
+++ b/python/core/auto_generated/qgsunittypes.sip.in
@@ -79,6 +79,7 @@ Helper functions for various unit types.
       AngleMinutesOfArc,
       AngleSecondsOfArc,
       AngleTurn,
+      AngleMil,
       AngleUnknownUnit,
     };
 

--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -156,7 +156,7 @@ called when map tool is being deactivated
 convenient method to clean members
 %End
 
-    QgsMapCanvas *canvas();
+    QgsMapCanvas *canvas() const;
 %Docstring
 returns pointer to the tool's map canvas
 %End
@@ -255,7 +255,7 @@ transformation from layer's coordinates to map coordinates (which is different i
 trnasformation of the rect from map coordinates to layer's coordinates
 %End
 
-    QPoint toCanvasCoordinates( const QgsPointXY &point );
+    QPoint toCanvasCoordinates( const QgsPointXY &point ) const;
 %Docstring
 transformation from map coordinates to screen coordinates
 %End

--- a/python/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/gui/auto_generated/qgsrubberband.sip.in
@@ -43,6 +43,8 @@ for tracking the mouse while drawing polylines or polygons.
       ICON_DIAMOND,
 
       ICON_FULL_DIAMOND,
+
+      ICON_SVG
     };
 
     QgsRubberBand( QgsMapCanvas *mapCanvas /TransferThis/, QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
@@ -55,6 +57,8 @@ Creates a new RubberBand.
 :param geometryType: Defines how the data should be drawn onto the screen.
                      QgsWkbTypes.LineGeometry, QgsWkbTypes.PolygonGeometry or QgsWkbTypes.PointGeometry
 %End
+
+    ~QgsRubberBand();
 
     void setColor( const QColor &color );
 %Docstring
@@ -124,6 +128,17 @@ Returns the current width of the line or stroke width for polygon.
 Sets the icon type to highlight point geometries.
 
 :param icon: The icon to visualize point geometries
+%End
+
+    void setSvgIcon( const QString &path, const QPoint &drawOffset );
+%Docstring
+Set the path to the svg file to use to draw points.
+Calling this function automatically calls setIcon(ICON_SVG)
+
+:param path: The path to the svg
+:param drawOffset: The offset where to draw the image origin
+
+.. versionadded:: 3.10
 %End
 
 

--- a/python/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/gui/auto_generated/qgsrubberband.sip.in
@@ -58,8 +58,6 @@ Creates a new RubberBand.
                      QgsWkbTypes.LineGeometry, QgsWkbTypes.PolygonGeometry or QgsWkbTypes.PointGeometry
 %End
 
-    ~QgsRubberBand();
-
     void setColor( const QColor &color );
 %Docstring
 Sets the color for the rubberband.

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -28,7 +28,7 @@
 
 static const char *QGIS_URILIST_MIMETYPE = "application/x-vnd.qgis.qgis.uri";
 
-QgsMimeDataUtils::Uri::Uri( QString &encData )
+QgsMimeDataUtils::Uri::Uri( const QString &encData )
 {
   QgsDebugMsg( "encData: " + encData );
   const QStringList decoded = decode( encData );

--- a/src/core/qgsmimedatautils.h
+++ b/src/core/qgsmimedatautils.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsMimeDataUtils
       //! Constructs invalid URI
       Uri() = default;
       //! Constructs URI from encoded data
-      explicit Uri( QString &encData );
+      explicit Uri( const QString &encData );
 
       /**
        * Constructs a URI corresponding to the specified \a layer.

--- a/src/core/qgsreadwritecontext.cpp
+++ b/src/core/qgsreadwritecontext.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 #include "qgsreadwritecontext.h"
 
+///@cond PRIVATE
 class DefaultTranslator : public QgsProjectTranslator
 {
     // QgsProjectTranslator interface
@@ -26,6 +27,8 @@ class DefaultTranslator : public QgsProjectTranslator
       return sourceText;
     }
 };
+
+///@endcond PRIVATE
 
 static DefaultTranslator sDefaultTranslator;
 

--- a/src/core/qgsreadwritecontext.cpp
+++ b/src/core/qgsreadwritecontext.cpp
@@ -14,8 +14,23 @@
  ***************************************************************************/
 #include "qgsreadwritecontext.h"
 
+class DefaultTranslator : public QgsProjectTranslator
+{
+    // QgsProjectTranslator interface
+  public:
+    QString translate( const QString &context, const QString &sourceText, const char *disambiguation, int n ) const override
+    {
+      Q_UNUSED( context );
+      Q_UNUSED( disambiguation );
+      Q_UNUSED( n );
+      return sourceText;
+    }
+};
+
+static DefaultTranslator sDefaultTranslator;
+
 QgsReadWriteContext::QgsReadWriteContext()
-  : mProjectTranslator( &mDefaultTranslator )
+  : mProjectTranslator( &sDefaultTranslator )
 {
 
 }
@@ -77,12 +92,4 @@ QList<QgsReadWriteContext::ReadWriteMessage > QgsReadWriteContext::takeMessages(
   QList<QgsReadWriteContext::ReadWriteMessage > messages = mMessages;
   mMessages.clear();
   return messages;
-}
-
-QString QgsReadWriteContext::DefaultTranslator::translate( const QString &context, const QString &sourceText, const char *disambiguation, int n ) const
-{
-  Q_UNUSED( context )
-  Q_UNUSED( disambiguation )
-  Q_UNUSED( n )
-  return sourceText;
 }

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -135,13 +135,6 @@ class CORE_EXPORT QgsReadWriteContext
 
   private:
 
-    class DefaultTranslator : public QgsProjectTranslator
-    {
-        // QgsProjectTranslator interface
-      public:
-        QString translate( const QString &context, const QString &sourceText, const char *disambiguation, int n ) const;
-    };
-
     //! Pop the last category
     void leaveCategory();
 
@@ -150,7 +143,6 @@ class CORE_EXPORT QgsReadWriteContext
     QStringList mCategories = QStringList();
     QgsProjectTranslator *mProjectTranslator = nullptr;
     friend class QgsReadWriteContextCategoryPopper;
-    DefaultTranslator mDefaultTranslator;
     QgsCoordinateTransformContext mCoordinateTransformContext = QgsCoordinateTransformContext();
 };
 

--- a/src/core/qgsreadwritecontext.h
+++ b/src/core/qgsreadwritecontext.h
@@ -108,7 +108,7 @@ class CORE_EXPORT QgsReadWriteContext
     const QgsProjectTranslator *projectTranslator( ) const { return mProjectTranslator; }
 
     /**
-     * Sets the project translator. Means it shouldn't conform mDefaultTranslator anymore.
+     * Sets the project translator.
      * It's usually the QgsProject where the function with the context is made and won't be changed anymore.
      *
      * \since QGIS 3.4

--- a/src/core/qgsscalecalculator.cpp
+++ b/src/core/qgsscalecalculator.cpp
@@ -47,7 +47,7 @@ QgsUnitTypes::DistanceUnit QgsScaleCalculator::mapUnits() const
   return mMapUnits;
 }
 
-double QgsScaleCalculator::calculate( const QgsRectangle &mapExtent, double canvasWidth )
+double QgsScaleCalculator::calculate( const QgsRectangle &mapExtent, double canvasWidth )  const
 {
   double conversionFactor = 0;
   double delta = 0;
@@ -88,7 +88,7 @@ double QgsScaleCalculator::calculate( const QgsRectangle &mapExtent, double canv
 }
 
 
-double QgsScaleCalculator::calculateGeographicDistance( const QgsRectangle &mapExtent )
+double QgsScaleCalculator::calculateGeographicDistance( const QgsRectangle &mapExtent ) const
 {
   // need to calculate the x distance in meters
   // We'll use the middle latitude for the calculation

--- a/src/core/qgsscalecalculator.h
+++ b/src/core/qgsscalecalculator.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsScaleCalculator
      * \param canvasWidth Width of the map canvas in pixel (physical) units
      * \returns scale denominator of current map view, e.g. 1000.0 for a 1:1000 map.
      */
-    double calculate( const QgsRectangle &mapExtent, double canvasWidth );
+    double calculate( const QgsRectangle &mapExtent, double canvasWidth ) const;
 
     /**
      * Calculate the distance between two points in geographic coordinates.
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsScaleCalculator
      * data.
      * \param mapExtent QgsRectangle containing the current map extent
      */
-    double calculateGeographicDistance( const QgsRectangle &mapExtent );
+    double calculateGeographicDistance( const QgsRectangle &mapExtent ) const;
 
   private:
 

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -1256,6 +1256,8 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::AngleUnit fromUnit, Qgs
           return 3600;
         case AngleTurn:
           return 1.0 / 360.0;
+        case AngleMil:
+          return M_PI / 180.0 * 3200 / M_PI;
         case AngleUnknownUnit:
           break;
       }
@@ -1277,6 +1279,8 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::AngleUnit fromUnit, Qgs
           return 3600 * 180.0 / M_PI;
         case AngleTurn:
           return 0.5 / M_PI;
+        case AngleMil:
+          return 3200 / M_PI;
         case AngleUnknownUnit:
           break;
       }
@@ -1298,6 +1302,8 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::AngleUnit fromUnit, Qgs
           return 3600 * 360.0 / 400.0;
         case AngleTurn:
           return 1.0 / 400.0;
+        case AngleMil:
+          return M_PI / 200.0 * 3200 / M_PI;
         case AngleUnknownUnit:
           break;
       }
@@ -1319,6 +1325,8 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::AngleUnit fromUnit, Qgs
           return 60.0;
         case AngleTurn:
           return 1.0 / 360.0 / 60.0;
+        case AngleMil:
+          return M_PI / 180.0 / 60.0 * 3200 / M_PI;
         case AngleUnknownUnit:
           break;
       }
@@ -1340,6 +1348,8 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::AngleUnit fromUnit, Qgs
           return 1.0;
         case AngleTurn:
           return 1.0 / 360.0 / 3600.0;
+        case AngleMil:
+          return M_PI / 180.0 / 3600.0 * 3200 / M_PI;
         case AngleUnknownUnit:
           break;
       }
@@ -1361,11 +1371,37 @@ double QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::AngleUnit fromUnit, Qgs
           return 360.0 * 3600.0;
         case AngleTurn:
           return 1.0;
+        case AngleMil:
+          return 2 * M_PI * 3200 / M_PI;
         case AngleUnknownUnit:
           break;
       }
       break;
     }
+    case AngleMil:
+    {
+      switch ( toUnit )
+      {
+        case AngleDegrees:
+          return 180.0 / M_PI * M_PI / 3200;
+        case AngleRadians:
+          return M_PI / 3200;
+        case AngleGon:
+          return 200.0 / M_PI * M_PI / 3200;
+        case AngleMinutesOfArc:
+          return 180.0 * 60.0 / M_PI * M_PI / 3200;
+        case AngleSecondsOfArc:
+          return 180.0 * 3600.0 / M_PI * M_PI / 3200;
+        case AngleTurn:
+          return M_PI / 2 * M_PI / 3200;
+        case AngleMil:
+          return 1.0;
+        case AngleUnknownUnit:
+          break;
+      }
+      break;
+    }
+
     case AngleUnknownUnit:
       break;
   }
@@ -1396,6 +1432,8 @@ QString QgsUnitTypes::formatAngle( double angle, int decimals, QgsUnitTypes::Ang
     case AngleTurn:
       unitLabel = QObject::tr( " tr", "angle turn" );
       break;
+    case AngleMil:
+      unitLabel = QObject::tr( " mil", "angular mil" );
     case AngleUnknownUnit:
       break;
   }

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -520,7 +520,7 @@ double QgsUnitTypes::fromUnitToUnitFactor( DistanceUnit fromUnit, DistanceUnit t
         case DistanceMeters:
           return CENTIMETERS_TO_METER;
         case DistanceKilometers:
-          return CENTIMETERS_TO_METER / KILOMETERS_TO_METER;;
+          return CENTIMETERS_TO_METER / KILOMETERS_TO_METER;
         case DistanceCentimeters:
           return 1.0;
         case DistanceMillimeters:

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -1233,6 +1233,8 @@ QString QgsUnitTypes::toString( QgsUnitTypes::AngleUnit unit )
       return QObject::tr( "seconds of arc", "angle" );
     case AngleTurn:
       return QObject::tr( "turns", "angle" );
+    case AngleMil:
+      return QObject::tr( "mil", "angle" );
     case AngleUnknownUnit:
       return QObject::tr( "<unknown>", "angle" );
   }

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -1180,6 +1180,8 @@ QString QgsUnitTypes::encodeUnit( QgsUnitTypes::AngleUnit unit )
       return QStringLiteral( "soa" );
     case AngleTurn:
       return QStringLiteral( "tr" );
+    case AngleMil:
+      return QStringLiteral( "mil" );
     case AngleUnknownUnit:
       return QStringLiteral( "<unknown>" );
   }
@@ -1205,6 +1207,8 @@ QgsUnitTypes::AngleUnit QgsUnitTypes::decodeAngleUnit( const QString &string, bo
     return AngleSecondsOfArc;
   if ( normalized == encodeUnit( AngleTurn ) )
     return AngleTurn;
+  if ( normalized == encodeUnit( AngleMil ) )
+    return AngleMil;
   if ( normalized == encodeUnit( AngleUnknownUnit ) )
     return AngleUnknownUnit;
   if ( ok )
@@ -1434,6 +1438,7 @@ QString QgsUnitTypes::formatAngle( double angle, int decimals, QgsUnitTypes::Ang
       break;
     case AngleMil:
       unitLabel = QObject::tr( " mil", "angular mil" );
+      break;
     case AngleUnknownUnit:
       break;
   }

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -103,6 +103,7 @@ class CORE_EXPORT QgsUnitTypes
       AngleMinutesOfArc, //!< Minutes of arc
       AngleSecondsOfArc, //!< Seconds of arc
       AngleTurn, //!< Turn/revolutions
+      AngleMil, //!< Angular mil
       AngleUnknownUnit, //!< Unknown angle unit
     };
     Q_ENUM( AngleUnit )

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -72,7 +72,7 @@ QgsRectangle QgsMapTool::toLayerCoordinates( const QgsMapLayer *layer, const Qgs
   return mCanvas->mapSettings().mapToLayerCoordinates( layer, rect );
 }
 
-QPoint QgsMapTool::toCanvasCoordinates( const QgsPointXY &point )
+QPoint QgsMapTool::toCanvasCoordinates( const QgsPointXY &point ) const
 {
   qreal x = point.x(), y = point.y();
   mCanvas->getCoordinateTransform()->transformInPlace( x, y );
@@ -195,7 +195,7 @@ bool QgsMapTool::gestureEvent( QGestureEvent *e )
   return true;
 }
 
-QgsMapCanvas *QgsMapTool::canvas()
+QgsMapCanvas *QgsMapTool::canvas() const
 {
   return mCanvas;
 }

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -164,7 +164,7 @@ class GUI_EXPORT QgsMapTool : public QObject
     virtual void clean();
 
     //! returns pointer to the tool's map canvas
-    QgsMapCanvas *canvas();
+    QgsMapCanvas *canvas() const;
 
     /**
      * Emit map tool changed with the old tool
@@ -235,7 +235,7 @@ class GUI_EXPORT QgsMapTool : public QObject
     QgsRectangle toLayerCoordinates( const QgsMapLayer *layer, const QgsRectangle &rect );
 
     //! transformation from map coordinates to screen coordinates
-    QPoint toCanvasCoordinates( const QgsPointXY &point );
+    QPoint toCanvasCoordinates( const QgsPointXY &point ) const;
 
     //! pointer to map canvas
     QgsMapCanvas *mCanvas = nullptr;

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -536,7 +536,7 @@ void QgsRubberBand::updateRect()
   if ( mSvgRenderer )
   {
     QRectF viewBox = mSvgRenderer->viewBoxF();
-    iconSize = qMax( qAbs( mSvgOffset.x() ) + .5 * viewBox.width(), qAbs( mSvgOffset.y() ) + .5 * viewBox.height() );
+    iconSize = qMax( std::fabs( mSvgOffset.x() ) + .5 * viewBox.width(), std::fabs( mSvgOffset.y() ) + .5 * viewBox.height() );
   }
 
   qreal w = ( ( mIconSize - 1 ) / 2 + mPen.width() ); // in canvas units

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -536,7 +536,7 @@ void QgsRubberBand::updateRect()
   if ( mSvgRenderer )
   {
     QRectF viewBox = mSvgRenderer->viewBoxF();
-    iconSize = qMax( std::fabs( mSvgOffset.x() ) + .5 * viewBox.width(), std::fabs( mSvgOffset.y() ) + .5 * viewBox.height() );
+    iconSize = std::max( std::fabs( mSvgOffset.x() ) + .5 * viewBox.width(), std::fabs( mSvgOffset.y() ) + .5 * viewBox.height() );
   }
 
   qreal w = ( ( mIconSize - 1 ) / 2 + mPen.width() ); // in canvas units

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -21,7 +21,6 @@
 #include "qgsproject.h"
 #include "qgsrectangle.h"
 #include <QPainter>
-#include <QSvgRenderer>
 
 QgsRubberBand::QgsRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geometryType )
   : QObject( nullptr )

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -44,11 +44,6 @@ QgsRubberBand::QgsRubberBand()
 {
 }
 
-QgsRubberBand::~QgsRubberBand()
-{
-  delete mSvgRenderer;
-}
-
 void QgsRubberBand::setColor( const QColor &color )
 {
   setStrokeColor( color );
@@ -80,15 +75,13 @@ void QgsRubberBand::setWidth( int width )
 
 void QgsRubberBand::setIcon( IconType icon )
 {
-  delete mSvgRenderer;
-  mSvgRenderer = 0;
   mIconType = icon;
 }
 
 void QgsRubberBand::setSvgIcon( const QString &path, const QPoint &drawOffset )
 {
   setIcon( ICON_SVG );
-  mSvgRenderer = new QSvgRenderer( path );;
+  mSvgRenderer = qgis::make_unique<QSvgRenderer>( path );
   mSvgOffset = drawOffset;
 }
 

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -112,8 +112,6 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
      */
     QgsRubberBand( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS, QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
 
-    ~QgsRubberBand();
-
     /**
      * Sets the color for the rubberband.
      * Shorthand method to set fill and stroke color with a single call.
@@ -380,7 +378,7 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
 
     //! Icon to be shown.
     IconType mIconType = ICON_CIRCLE;
-    QSvgRenderer *mSvgRenderer = nullptr;
+    std::unque_ptr<QSvgRenderer> mSvgRenderer;
     QPoint mSvgOffset;
 
     /**

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -29,6 +29,7 @@
 
 class QgsVectorLayer;
 class QPaintEvent;
+class QSvgRenderer;
 
 /**
  * \ingroup gui
@@ -93,6 +94,12 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
        * \since QGIS 3.0
        */
       ICON_FULL_DIAMOND,
+
+      /**
+       * An svg image is used to highlight points
+       * \since QGIS 3.10
+       */
+      ICON_SVG
     };
 
     /**
@@ -104,6 +111,8 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
      *         QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry or QgsWkbTypes::PointGeometry
      */
     QgsRubberBand( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS, QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::LineGeometry );
+
+    ~QgsRubberBand();
 
     /**
      * Sets the color for the rubberband.
@@ -165,6 +174,15 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
      *  \param icon The icon to visualize point geometries
      */
     void setIcon( IconType icon );
+
+    /**
+     * Set the path to the svg file to use to draw points.
+     * Calling this function automatically calls setIcon(ICON_SVG)
+     * \param path The path to the svg
+     * \param drawOffset The offset where to draw the image origin
+     * \since QGIS 3.10
+     */
+    void setSvgIcon( const QString &path, const QPoint &drawOffset );
 
 
     /**
@@ -362,6 +380,8 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
 
     //! Icon to be shown.
     IconType mIconType = ICON_CIRCLE;
+    QSvgRenderer *mSvgRenderer = nullptr;
+    QPoint mSvgOffset;
 
     /**
      * Nested lists used for multitypes

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -24,12 +24,12 @@
 #include <QPen>
 #include <QPolygon>
 #include <QObject>
+#include <QSvgRenderer>
 
 #include "qgis_gui.h"
 
 class QgsVectorLayer;
 class QPaintEvent;
-class QSvgRenderer;
 
 /**
  * \ingroup gui
@@ -378,7 +378,7 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
 
     //! Icon to be shown.
     IconType mIconType = ICON_CIRCLE;
-    std::unque_ptr<QSvgRenderer> mSvgRenderer;
+    std::unique_ptr<QSvgRenderer> mSvgRenderer;
     QPoint mSvgOffset;
 
     /**

--- a/tests/src/python/test_qgsunittypes.py
+++ b/tests/src/python/test_qgsunittypes.py
@@ -558,6 +558,7 @@ class TestQgsUnitTypes(unittest.TestCase):
                  QgsUnitTypes.AngleMinutesOfArc,
                  QgsUnitTypes.AngleSecondsOfArc,
                  QgsUnitTypes.AngleTurn,
+                 QgsUnitTypes.AngleMil,
                  QgsUnitTypes.AngleUnknownUnit]
 
         for u in units:
@@ -583,6 +584,7 @@ class TestQgsUnitTypes(unittest.TestCase):
                  QgsUnitTypes.AngleMinutesOfArc,
                  QgsUnitTypes.AngleSecondsOfArc,
                  QgsUnitTypes.AngleTurn,
+                 QgsUnitTypes.AngleMil,
                  QgsUnitTypes.AngleUnknownUnit]
 
         dupes = set()
@@ -629,6 +631,7 @@ class TestQgsUnitTypes(unittest.TestCase):
         self.assertEqual(QgsUnitTypes.formatAngle(1.11111111, 4, QgsUnitTypes.AngleMinutesOfArc), '1.1111′')
         self.assertEqual(QgsUnitTypes.formatAngle(1.99999999, 2, QgsUnitTypes.AngleSecondsOfArc), '2.00″')
         self.assertEqual(QgsUnitTypes.formatAngle(1, 2, QgsUnitTypes.AngleTurn), '1.00 tr')
+        self.assertEqual(QgsUnitTypes.formatAngle(1, 2, QgsUnitTypes.AngleMil), '1.00 mil')
         self.assertEqual(QgsUnitTypes.formatAngle(1, 2, QgsUnitTypes.AngleUnknownUnit), '1.00')
 
     def testEncodeDecodeLayoutUnits(self):


### PR DESCRIPTION
**Code cleanups**

- Hide away *default translator* implementation
- Rubberband loops (not from Kadas)
- Const correctness
- ~Add inline keyword to declarations to match definitions and avoid "redeclared without dllimport" warnings~ Removed again at least for now, see https://isocpp.org/wiki/faq/inline-functions#where-to-put-inline-keyword

**Feature**

- Add the possibility to use an SVG as rubberband marker
- Add [mil](https://en.wikipedia.org/wiki/Milliradian) units