### PR TITLE
Fix addEntry for reference relation widget 

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -208,7 +208,6 @@ void QgsRelationReferenceWidget::setRelation( const QgsRelation &relation, bool 
       mComboBox->setIdentifierField( mReferencedField );
 
     mReferencedFieldIdx = mReferencedLayer->fields().lookupField( relation.fieldPairs().at( 0 ).second );
-    mReferencingFieldIdx = mReferencingLayer->fields().lookupField( relation.fieldPairs().at( 0 ).first );
     mAttributeEditorFrame->setObjectName( QStringLiteral( "referencing/" ) + relation.name() );
 
 
@@ -897,7 +896,7 @@ void QgsRelationReferenceWidget::addEntry()
 
   if ( mEditorContext.vectorLayerTools()->addFeature( mReferencedLayer, attributes, QgsGeometry(), &f ) )
   {
-    mComboBox->setIdentifierValue( f.attribute( mReferencingFieldIdx ) );
+    mComboBox->setIdentifierValue( f.attribute( mReferencedFieldIdx ) );
     mAddEntryButton->setEnabled( false );
   }
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -205,7 +205,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     // Index of the referenced layer key
     int mReferencedFieldIdx = -1;
     QString mReferencedField;
-    int mReferencingFieldIdx = -1;
     bool mAllowNull = true;
     QgsHighlight *mHighlight = nullptr;
     QgsMapToolIdentifyFeature *mMapTool = nullptr;

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -29,6 +29,7 @@
 #include "qgsfeaturefiltermodel.h"
 #include "qgsgui.h"
 #include "qgsmapcanvas.h"
+#include "qgsvectorlayertools.h"
 
 class TestQgsRelationReferenceWidget : public QObject
 {
@@ -48,6 +49,7 @@ class TestQgsRelationReferenceWidget : public QObject
     void testInvalidRelation();
     void testSetGetForeignKey();
     void testIdentifyOnMap();
+    void testAddEntry();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -373,6 +375,49 @@ void TestQgsRelationReferenceWidget::testIdentifyOnMap()
 
   mLayer1->rollBack();
 }
+
+
+void TestQgsRelationReferenceWidget::testAddEntry()
+{
+  // check that a new added entry in referenced layer populate correctly the
+  // referencing combobox
+  QWidget parentWidget;
+  QgsRelationReferenceWidget w( &parentWidget );
+  QVERIFY( mLayer1->startEditing() );
+  w.setRelation( *mRelation, true );
+  w.init();
+
+  // Monkey patch gui vector layer tool in order to simple add a new feature in
+  // referenced layer
+  class DummyVectorLayerTools : public QgsVectorLayerTools
+  {
+      bool addFeature( QgsVectorLayer *layer, const QgsAttributeMap &, const QgsGeometry &, QgsFeature *feat = nullptr ) const override
+      {
+        feat->setAttribute( QStringLiteral( "pk" ), 13 );
+        feat->setAttribute( QStringLiteral( "material" ), "steel" );
+        feat->setAttribute( QStringLiteral( "diameter" ), 140 );
+        feat->setAttribute( QStringLiteral( "raccord" ), "collar" );
+        layer->addFeature( *feat );
+        return true;
+      }
+
+      bool startEditing( QgsVectorLayer * ) const override {return true;}
+
+      bool stopEditing( QgsVectorLayer *, bool = true ) const override {return true;};
+
+      bool saveEdits( QgsVectorLayer * ) const override {return true;};
+  };
+
+  QgsAttributeEditorContext context;
+  DummyVectorLayerTools tools;
+  context.setVectorLayerTools( &tools );
+  w.setEditorContext( context, nullptr, nullptr );
+  w.addEntry();
+
+  QCOMPARE( w.mComboBox->identifierValue(), 13 );
+}
+
+
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )
 #include "testqgsrelationreferencewidget.moc"

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -414,7 +414,7 @@ void TestQgsRelationReferenceWidget::testAddEntry()
   w.setEditorContext( context, nullptr, nullptr );
   w.addEntry();
 
-  QCOMPARE( w.mComboBox->identifierValue(), 13 );
+  QCOMPARE( w.mComboBox->identifierValue().toInt(), 13 );
 }
 
 


### PR DESCRIPTION
## Description

When adding an entry from the reference relation widget, the widget was using the referencing field index and not the referenced one, so it fails to update correctly the combo box after the form pop up. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
