### PR TITLE
[Tests] Creating tests about usedAttributes method

### DIFF
--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """QGIS Unit tests for QgsCategorizedSymbolRenderer
 
+From build dir, run: ctest -R PyQgsCategorizedSymbolRenderer -V
+
 .. note:: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
@@ -11,6 +13,8 @@ __date__ = '2/12/2015'
 __copyright__ = 'Copyright 2015, The QGIS Project'
 
 import qgis  # NOQA
+
+import os
 
 from qgis.testing import unittest, start_app
 from qgis.core import (QgsCategorizedSymbolRenderer,
@@ -26,13 +30,24 @@ from qgis.core import (QgsCategorizedSymbolRenderer,
                        QgsStyle,
                        QgsVectorLayer,
                        QgsEditorWidgetSetup,
-                       QgsReadWriteContext
+                       QgsReadWriteContext,
+                       QgsProject,
+                       QgsSimpleMarkerSymbolLayer,
+                       QgsSymbolLayer,
+                       QgsProperty,
+                       QgsMapSettings,
+                       QgsRectangle,
+                       QgsRenderContext
                        )
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import Qt, QVariant, QSize
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 
+from utilities import unitTestDataPath
+
 start_app()
+
+TEST_DATA_DIR = unitTestDataPath()
 
 
 def createMarkerSymbol():
@@ -573,6 +588,56 @@ class TestQgsCategorizedSymbolRenderer(unittest.TestCase):
         self.assertEqual(renderer.usedAttributes(ctx), {"value", "value - 1"})
         renderer.setClassAttribute("valuea - valueb")
         self.assertEqual(renderer.usedAttributes(ctx), {"valuea", "valuea - valueb", "valueb"})
+
+    def testPointsUsedAttributes(self):
+        points_shp = os.path.join(TEST_DATA_DIR, 'points.shp')
+        points_layer = QgsVectorLayer(points_shp, 'Points', 'ogr')
+        QgsProject.instance().addMapLayer(points_layer)
+
+        cats = []
+        sym1 = QgsMarkerSymbol()
+        l1 = QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayer.Triangle, 5)
+        l1.setColor(QColor(255, 0, 0))
+        l1.setStrokeStyle(Qt.NoPen)
+        l1.setDataDefinedProperty(QgsSymbolLayer.PropertyAngle, QgsProperty.fromField("Heading"))
+        sym1.changeSymbolLayer(0, l1)
+        cats.append(QgsRendererCategory("B52", sym1, "B52"))
+        sym2 = QgsMarkerSymbol()
+        l2 = QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayer.Triangle, 5)
+        l2.setColor(QColor(0, 255, 0))
+        l2.setStrokeStyle(Qt.NoPen)
+        l2.setDataDefinedProperty(QgsSymbolLayer.PropertyAngle, QgsProperty.fromField("Heading"))
+        sym2.changeSymbolLayer(0, l2)
+        cats.append(QgsRendererCategory("Biplane", sym2, "Biplane"))
+        sym3 = QgsMarkerSymbol()
+        l3 = QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayer.Triangle, 5)
+        l3.setColor(QColor(0, 0, 255))
+        l3.setStrokeStyle(Qt.NoPen)
+        l3.setDataDefinedProperty(QgsSymbolLayer.PropertyAngle, QgsProperty.fromField("Heading"))
+        sym3.changeSymbolLayer(0, l3)
+        cats.append(QgsRendererCategory("Jet", sym3, "Jet"))
+
+        renderer = QgsCategorizedSymbolRenderer("Class", cats)
+
+        points_layer.setRenderer(renderer)
+
+        ms = QgsMapSettings()
+        ms.setOutputSize(QSize(400, 400))
+        ms.setOutputDpi(96)
+        ms.setExtent(QgsRectangle(-133, 22, -70, 52))
+        ms.setLayers([points_layer])
+
+        ctx = QgsRenderContext.fromMapSettings(ms)
+        ctx.expressionContext().appendScope(points_layer.createExpressionContextScope())
+
+        # for symbol layer
+        self.assertCountEqual(l1.usedAttributes(ctx), {'Heading'})
+        # for symbol
+        self.assertCountEqual(sym1.usedAttributes(ctx), {'Heading'})
+        # for symbol renderer
+        self.assertCountEqual(renderer.usedAttributes(ctx), {'Class', 'Heading'})
+
+        QgsProject.instance().removeMapLayer(points_layer)
 
     def testFilterNeedsGeometry(self):
         renderer = QgsCategorizedSymbolRenderer()

--- a/tests/src/python/test_qgspointclusterrenderer.py
+++ b/tests/src/python/test_qgspointclusterrenderer.py
@@ -15,6 +15,9 @@
 *   (at your option) any later version.                                   *
 *                                                                         *
 ***************************************************************************
+
+From build dir, run: ctest -R PyQgsPointClusterRenderer -V
+
 """
 
 __author__ = 'Nyall Dawson'
@@ -40,7 +43,8 @@ from qgis.core import (QgsVectorLayer,
                        QgsPointDisplacementRenderer,
                        QgsMapSettings,
                        QgsProperty,
-                       QgsSymbolLayer
+                       QgsSymbolLayer,
+                       QgsRenderContext
                        )
 from qgis.testing import start_app, unittest
 from utilities import (unitTestDataPath)
@@ -179,6 +183,11 @@ class TestQgsPointClusterRenderer(unittest.TestCase):
         result = renderchecker.runTest('expected_cluster_variables')
         self.layer.renderer().setClusterSymbol(old_marker)
         self.assertTrue(result)
+
+    def testUsedAttributes(self):
+        ctx = QgsRenderContext.fromMapSettings(self.mapsettings)
+
+        self.assertCountEqual(self.renderer.usedAttributes(ctx), {})
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -15,6 +15,9 @@
 *   (at your option) any later version.                                   *
 *                                                                         *
 ***************************************************************************
+
+From build dir, run: ctest -R PyQgsPointDisplacementRenderer -V
+
 """
 
 __author__ = 'Nyall Dawson'
@@ -45,7 +48,8 @@ from qgis.core import (QgsVectorLayer,
                        QgsMapSettings,
                        QgsProperty,
                        QgsReadWriteContext,
-                       QgsSymbolLayer
+                       QgsSymbolLayer,
+                       QgsRenderContext
                        )
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -427,6 +431,12 @@ class TestQgsPointDisplacementRenderer(unittest.TestCase):
         self.report += renderchecker.report()
         self.assertTrue(res)
         self._tearDown(layer)
+
+    def testUsedAttributes(self):
+        layer, renderer, mapsettings = self._setUp()
+        ctx = QgsRenderContext.fromMapSettings(mapsettings)
+
+        self.assertCountEqual(renderer.usedAttributes(ctx), {})
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -15,6 +15,9 @@
 *   (at your option) any later version.                                   *
 *                                                                         *
 ***************************************************************************
+
+From build dir, run: ctest -R PyQgsRulebasedRenderer -V
+
 """
 
 __author__ = 'Matthias Kuhn'
@@ -369,6 +372,24 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         self.assertEqual(len(rootrule.rulesForFeature(ft, ctx)), 1)
         self.assertEqual(rootrule.rulesForFeature(ft, ctx)[0], self.rx3)
         renderer.stopRender(ctx)
+
+    def testUsedAttributes(self):
+        ctx = QgsRenderContext.fromMapSettings(self.mapsettings)
+
+        # Create rulebased style
+        sym2 = QgsFillSymbol.createSimple({'color': '#71bd6c', 'outline_color': 'black'})
+        sym3 = QgsFillSymbol.createSimple({'color': '#1f78b4', 'outline_color': 'black'})
+
+        self.rx2 = QgsRuleBasedRenderer.Rule(sym2, 0, 0, '"id" = 200')
+        self.rx3 = QgsRuleBasedRenderer.Rule(sym3, 1000, 100000000, 'ELSE')
+
+        rootrule = QgsRuleBasedRenderer.Rule(None)
+        rootrule.appendChild(self.rx2)
+        rootrule.appendChild(self.rx3)
+
+        renderer = QgsRuleBasedRenderer(rootrule)
+
+        self.assertCountEqual(renderer.usedAttributes(ctx), {'id'})
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -446,14 +446,10 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
 
         # for symbol layer
         self.assertCountEqual(l1.usedAttributes(ctx), {'Heading'})
-        self.assertIn('Heading', l1.usedAttributes(ctx))
         # for symbol
         self.assertCountEqual(sym1.usedAttributes(ctx), {'Heading'})
-        self.assertIn('Heading', sym1.usedAttributes(ctx))
         # for symbol renderer
         self.assertCountEqual(renderer.usedAttributes(ctx), {'Class', 'Heading'})
-        self.assertIn('Class', renderer.usedAttributes(ctx))
-        self.assertIn('Heading', renderer.usedAttributes(ctx))
 
         QgsProject.instance().removeMapLayer(points_layer)
 

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -28,7 +28,8 @@ import qgis  # NOQA
 
 import os
 
-from qgis.PyQt.QtCore import QSize
+from qgis.PyQt.QtCore import Qt, QSize
+from qgis.PyQt.QtGui import QColor
 
 from qgis.core import (QgsVectorLayer,
                        QgsMapSettings,
@@ -42,7 +43,10 @@ from qgis.core import (QgsVectorLayer,
                        QgsCategorizedSymbolRenderer,
                        QgsGraduatedSymbolRenderer,
                        QgsRendererRange,
-                       QgsRenderContext
+                       QgsRenderContext,
+                       QgsSymbolLayer,
+                       QgsSimpleMarkerSymbolLayer,
+                       QgsProperty
                        )
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -57,7 +61,7 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
 
     def setUp(self):
         myShpFile = os.path.join(TEST_DATA_DIR, 'rectangles.shp')
-        layer = QgsVectorLayer(myShpFile, 'Points', 'ogr')
+        layer = QgsVectorLayer(myShpFile, 'Rectangles', 'ogr')
         QgsProject.instance().addMapLayer(layer)
 
         # Create rulebased style
@@ -390,6 +394,68 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         renderer = QgsRuleBasedRenderer(rootrule)
 
         self.assertCountEqual(renderer.usedAttributes(ctx), {'id'})
+
+    def testPointsUsedAttributes(self):
+        points_shp = os.path.join(TEST_DATA_DIR, 'points.shp')
+        points_layer = QgsVectorLayer(points_shp, 'Points', 'ogr')
+        QgsProject.instance().addMapLayer(points_layer)
+
+        # Create rulebased style
+        sym1 = QgsMarkerSymbol()
+        l1 = QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayer.Triangle, 5)
+        l1.setColor(QColor(255, 0, 0))
+        l1.setStrokeStyle(Qt.NoPen)
+        l1.setDataDefinedProperty(QgsSymbolLayer.PropertyAngle, QgsProperty.fromField("Heading"))
+        sym1.changeSymbolLayer(0, l1)
+
+        sym2 = QgsMarkerSymbol()
+        l2 = QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayer.Triangle, 5)
+        l2.setColor(QColor(0, 255, 0))
+        l2.setStrokeStyle(Qt.NoPen)
+        l2.setDataDefinedProperty(QgsSymbolLayer.PropertyAngle, QgsProperty.fromField("Heading"))
+        sym2.changeSymbolLayer(0, l2)
+
+        sym3 = QgsMarkerSymbol()
+        l3 = QgsSimpleMarkerSymbolLayer(QgsSimpleMarkerSymbolLayer.Triangle, 5)
+        l3.setColor(QColor(0, 0, 255))
+        l3.setStrokeStyle(Qt.NoPen)
+        l3.setDataDefinedProperty(QgsSymbolLayer.PropertyAngle, QgsProperty.fromField("Heading"))
+        sym3.changeSymbolLayer(0, l3)
+
+        r1 = QgsRuleBasedRenderer.Rule(sym1, 0, 0, '"Class" = \'B52\'')
+        r2 = QgsRuleBasedRenderer.Rule(sym2, 0, 0, '"Class" = \'Biplane\'')
+        r3 = QgsRuleBasedRenderer.Rule(sym3, 0, 0, '"Class" = \'Jet\'')
+
+        rootrule = QgsRuleBasedRenderer.Rule(None)
+        rootrule.appendChild(r1)
+        rootrule.appendChild(r2)
+        rootrule.appendChild(r3)
+
+        renderer = QgsRuleBasedRenderer(rootrule)
+
+        points_layer.setRenderer(renderer)
+
+        ms = QgsMapSettings()
+        ms.setOutputSize(QSize(400, 400))
+        ms.setOutputDpi(96)
+        ms.setExtent(QgsRectangle(-133, 22, -70, 52))
+        ms.setLayers([points_layer])
+
+        ctx = QgsRenderContext.fromMapSettings(ms)
+        ctx.expressionContext().appendScope(points_layer.createExpressionContextScope())
+
+        # for symbol layer
+        self.assertCountEqual(l1.usedAttributes(ctx), {'Heading'})
+        self.assertIn('Heading', l1.usedAttributes(ctx))
+        # for symbol
+        self.assertCountEqual(sym1.usedAttributes(ctx), {'Heading'})
+        self.assertIn('Heading', sym1.usedAttributes(ctx))
+        # for symbol renderer
+        self.assertCountEqual(renderer.usedAttributes(ctx), {'Class', 'Heading'})
+        self.assertIn('Class', renderer.usedAttributes(ctx))
+        self.assertIn('Heading', renderer.usedAttributes(ctx))
+
+        QgsProject.instance().removeMapLayer(points_layer)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssinglesymbolrenderer.py
+++ b/tests/src/python/test_qgssinglesymbolrenderer.py
@@ -15,6 +15,9 @@
 *   (at your option) any later version.                                   *
 *                                                                         *
 ***************************************************************************
+
+From build dir, run: ctest -R PyQgsSingleSymbolRenderer -V
+
 """
 
 __author__ = 'Matthias Kuhn'
@@ -33,7 +36,8 @@ from qgis.core import (QgsVectorLayer,
                        QgsMultiRenderChecker,
                        QgsSingleSymbolRenderer,
                        QgsFillSymbol,
-                       QgsFeatureRequest
+                       QgsFeatureRequest,
+                       QgsRenderContext
                        )
 from qgis.testing import unittest
 from qgis.testing.mocked import get_iface
@@ -76,6 +80,11 @@ class TestQgsSingleSymbolRenderer(unittest.TestCase):
         # disable order by and retest
         self.renderer.setOrderByEnabled(False)
         self.assertTrue(renderchecker.runTest('single'))
+
+    def testUsedAttributes(self):
+        ctx = QgsRenderContext.fromMapSettings(self.mapsettings)
+
+        self.assertCountEqual(self.renderer.usedAttributes(ctx), {})
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssymbollayer.py
+++ b/tests/src/python/test_qgssymbollayer.py
@@ -15,6 +15,9 @@
 *   (at your option) any later version.                                   *
 *                                                                         *
 ***************************************************************************
+
+From build dir, run: ctest -R PyQgsSymbolLayer -V
+
 """
 
 __author__ = 'Massimo Endrighi'
@@ -70,7 +73,9 @@ from qgis.core import (QgsCentroidFillSymbolLayer,
                        QgsProject,
                        QgsMultiRenderChecker,
                        QgsSingleSymbolRenderer,
-                       QgsProperty
+                       QgsProperty,
+                       QgsExpressionContext,
+                       QgsExpressionContextUtils
                        )
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -404,11 +409,23 @@ class TestQgsSymbolLayer(unittest.TestCase):
         ms.setExtent(QgsRectangle(-133, 22, -70, 52))
         ms.setLayers([polys_layer])
 
+        # Test usedAttributes
+        ctx = QgsRenderContext.fromMapSettings(ms)
+        ctx.expressionContext().appendScope(polys_layer.createExpressionContextScope())
+        # for symbol layer
+        self.assertCountEqual(layer.usedAttributes(ctx), {'Name'})
+        # for symbol
+        self.assertCountEqual(symbol.usedAttributes(ctx), {'Name'})
+        # for symbol renderer
+        self.assertCountEqual(polys_layer.renderer().usedAttributes(ctx), {'Name'})
+
+        # Test rendering
         renderchecker = QgsMultiRenderChecker()
         renderchecker.setMapSettings(ms)
         renderchecker.setControlPathPrefix('symbol_layer')
         renderchecker.setControlName('expected_filllayer_ddenabled')
         self.assertTrue(renderchecker.runTest('filllayer_ddenabled'))
+
         QgsProject.instance().removeMapLayer(polys_layer)
 
     def testRenderLineLayerDisabled(self):
@@ -469,11 +486,23 @@ class TestQgsSymbolLayer(unittest.TestCase):
         ms.setExtent(QgsRectangle(-133, 22, -70, 52))
         ms.setLayers([lines_layer])
 
+        # Test usedAttributes
+        ctx = QgsRenderContext.fromMapSettings(ms)
+        ctx.expressionContext().appendScope(lines_layer.createExpressionContextScope())
+        # for symbol layer
+        self.assertCountEqual(layer.usedAttributes(ctx), {'Name'})
+        # for symbol
+        self.assertCountEqual(symbol.usedAttributes(ctx), {'Name'})
+        # for symbol renderer
+        self.assertCountEqual(lines_layer.renderer().usedAttributes(ctx), {'Name'})
+
+        # Test rendering
         renderchecker = QgsMultiRenderChecker()
         renderchecker.setMapSettings(ms)
         renderchecker.setControlPathPrefix('symbol_layer')
         renderchecker.setControlName('expected_linelayer_ddenabled')
         self.assertTrue(renderchecker.runTest('linelayer_ddenabled'))
+
         QgsProject.instance().removeMapLayer(lines_layer)
 
     def testRenderMarkerLayerDisabled(self):
@@ -533,11 +562,23 @@ class TestQgsSymbolLayer(unittest.TestCase):
         ms.setExtent(QgsRectangle(-133, 22, -70, 52))
         ms.setLayers([points_layer])
 
+        # Test usedAttributes
+        ctx = QgsRenderContext.fromMapSettings(ms)
+        ctx.expressionContext().appendScope(points_layer.createExpressionContextScope())
+        # for symbol layer
+        self.assertCountEqual(layer.usedAttributes(ctx), {'Class'})
+        # for symbol
+        self.assertCountEqual(symbol.usedAttributes(ctx), {'Class'})
+        # for symbol renderer
+        self.assertCountEqual(points_layer.renderer().usedAttributes(ctx), {'Class'})
+
+        # Test rendering
         renderchecker = QgsMultiRenderChecker()
         renderchecker.setMapSettings(ms)
         renderchecker.setControlPathPrefix('symbol_layer')
         renderchecker.setControlName('expected_markerlayer_ddenabled')
         self.assertTrue(renderchecker.runTest('markerlayer_ddenabled'))
+
         QgsProject.instance().removeMapLayer(points_layer)
 
     def testQgsSimpleFillSymbolLayer(self):
@@ -578,6 +619,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mValue = mSymbolLayer.strokeWidth()
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
+
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
 
     def testQgsGradientFillSymbolLayer(self):
         """Test setting and getting QgsGradientFillSymbolLayer properties.
@@ -661,6 +705,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mGradientLayer.usedAttributes(ctx), {})
+
     def testQgsCentroidFillSymbolLayer(self):
         """
         Create a new style from a .sld file and match test
@@ -700,6 +747,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mValue = mSymbolLayer.pointOnAllParts()
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
+
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
 
         # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
@@ -748,6 +798,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mValue = mSymbolLayer.lineAngle()
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
+
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
 
         # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
@@ -805,13 +858,19 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
     def testQgsPointPatternFillSymbolLayer(self):
         """
         Test point pattern fill
         """
-        # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer = QgsPointPatternFillSymbolLayer.create()
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
+        # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.color(), QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.subSymbol().color(), QColor(150, 50, 100))
@@ -848,6 +907,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mValue = mSymbolLayer.patternWidth()
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
+
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
 
     def testQgsMarkerLineSymbolLayer(self):
         """
@@ -888,6 +950,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mValue = mSymbolLayer.subSymbol().symbolLayer(0).color().name()
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
+
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
 
         # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
@@ -947,6 +1012,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
     def testQgsEllipseSymbolLayer(self):
         """
         Create a new style from a .sld file and match test
@@ -992,6 +1060,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
     def testQgsFontMarkerSymbolLayer(self):
         """
         Create a new style from a .sld file and match test
@@ -1032,6 +1103,9 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
     def testQgsSvgMarkerSymbolLayer(self):
         """
         Create a new style from a .sld file and match test
@@ -1067,13 +1141,19 @@ class TestQgsSymbolLayer(unittest.TestCase):
         mMessage = 'Expected "%s" got "%s"' % (mExpectedValue, mValue)
         assert mExpectedValue == mValue, mMessage
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
     def testQgsFilledMarkerSymbolLayer(self):
         """
         Test QgsFilledMarkerSymbolLayer
         """
-        # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer = QgsFilledMarkerSymbolLayer.create()
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
+        # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.color(), QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.subSymbol().color(), QColor(150, 50, 100))
@@ -1085,9 +1165,12 @@ class TestQgsSymbolLayer(unittest.TestCase):
         """
         Test QgsVectorFieldSymbolLayer
         """
-        # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer = QgsVectorFieldSymbolLayer.create()
 
+        ctx = QgsRenderContext()
+        self.assertCountEqual(mSymbolLayer.usedAttributes(ctx), {})
+
+        # test colors, need to make sure colors are passed/retrieved from subsymbol
         mSymbolLayer.setColor(QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.color(), QColor(150, 50, 100))
         self.assertEqual(mSymbolLayer.subSymbol().color(), QColor(150, 50, 100))


### PR DESCRIPTION
## Description
QgsFeatureRenderer usedAttributes method Returns a list of attributes required by this renderer. Attributes not listed in here may not have been requested from the provider at rendering time.

QgsSymbol usedAttributes method returns a list of attributes required to render this feature. This should include any attributes required by the symbology including the ones required by expressions. 

QgsSymbolLayer usedAttributes method returns the set of attributes referenced by the symbol layer. This includes attributes required by any data defined properties associated with the symbol layer (QgsPropertyCollection referencedFields).

QgsPropertyCollection referencedFields method returns the set of any fields referenced by the active properties from the collection

This methods are useful to speed up the rendering by requesting only needed attributes, but if one fail and do not return all the needed attributes, the rendering could be broken. Tests are needed.

The already existing tests are available for:
* QgsProperty
* QgsPropertyCollection
* QgsCategorizedSymbolRenderer
* QgsGraduatedSymbolRenderer

New tests has to be added to avoid regression in rendering.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
