### PR TITLE
Always show 'clear' action in property override button

### DIFF
--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -529,12 +529,17 @@ void QgsPropertyOverrideButton::aboutToShowMenu()
     mDefineMenu->addAction( mActionExpDialog );
     mDefineMenu->addAction( mActionCopyExpr );
     mDefineMenu->addAction( mActionPasteExpr );
-    mDefineMenu->addAction( mActionClearExpr );
   }
   else
   {
     mDefineMenu->addAction( mActionExpDialog );
     mDefineMenu->addAction( mActionPasteExpr );
+  }
+
+  if ( hasExp || !mFieldName.isEmpty() )
+  {
+    mDefineMenu->addSeparator();
+    mDefineMenu->addAction( mActionClearExpr );
   }
 
   if ( !mDefinition.name().isEmpty() && mDefinition.supportsAssistant() )


### PR DESCRIPTION
Previously this was only shown if the button was set to an expression
value, but there's also a need to clear when a property is set
to a field value. Otherwise it's impossible (well, annoyingly
fiddly) to clear the 'red' status when a bound field is deleted
or no longer available.
