### PR TITLE
Read-only style manager dialog UX improvement

### DIFF
--- a/python/gui/auto_generated/qgscolorbrewercolorrampdialog.sip.in
+++ b/python/gui/auto_generated/qgscolorbrewercolorrampdialog.sip.in
@@ -92,6 +92,13 @@ Sets the color ramp to show in the dialog.
 .. seealso:: :py:func:`ramp`
 %End
 
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void changed();

--- a/python/gui/auto_generated/qgsgradientcolorrampdialog.sip.in
+++ b/python/gui/auto_generated/qgsgradientcolorrampdialog.sip.in
@@ -48,6 +48,13 @@ Sets the color ramp to show in the dialog.
 .. seealso:: :py:func:`ramp`
 %End
 
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void changed();

--- a/python/gui/auto_generated/qgslimitedrandomcolorrampdialog.sip.in
+++ b/python/gui/auto_generated/qgslimitedrandomcolorrampdialog.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsLimitedRandomColorRampWidget : QgsPanelWidget
 {
 %Docstring
@@ -121,6 +122,13 @@ Sets the color ramp to show in the dialog.
 :param ramp: color ramp
 
 .. seealso:: :py:func:`ramp`
+%End
+
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
 %End
 
   signals:

--- a/python/gui/auto_generated/qgspresetcolorrampdialog.sip.in
+++ b/python/gui/auto_generated/qgspresetcolorrampdialog.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsPresetColorRampWidget : QgsPanelWidget
 {
 %Docstring
@@ -89,6 +90,13 @@ Sets the color ramp to show in the dialog.
 :param ramp: color ramp
 
 .. seealso:: :py:func:`ramp`
+%End
+
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
 %End
 
   signals:

--- a/python/gui/auto_generated/qgstextformatwidget.sip.in
+++ b/python/gui/auto_generated/qgstextformatwidget.sip.in
@@ -202,6 +202,13 @@ Constructor for QgsTextFormatDialog.
 Returns the current formatting settings defined by the widget.
 %End
 
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
+%End
+
 };
 
 

--- a/python/gui/auto_generated/symbology/qgscptcitycolorrampdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgscptcitycolorrampdialog.sip.in
@@ -59,6 +59,13 @@ Returns the name of the ramp currently selected in the dialog.
 Returns ``True`` if the ramp should be converted to a :py:class:`QgsGradientColorRamp`.
 %End
 
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
+%End
+
     virtual bool eventFilter( QObject *obj, QEvent *event );
 
 

--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -236,6 +236,13 @@ Returns the symbol that is currently active in the widget. Can be ``None``.
 :return: The active symbol.
 %End
 
+    QDialogButtonBox *buttonBox() const;
+%Docstring
+Returns a reference to the dialog's button box.
+
+.. versionadded:: 3.10
+%End
+
   protected:
     virtual void keyPressEvent( QKeyEvent *e );
 

--- a/src/gui/qgscolorbrewercolorrampdialog.cpp
+++ b/src/gui/qgscolorbrewercolorrampdialog.cpp
@@ -128,14 +128,19 @@ QgsColorBrewerColorRampDialog::QgsColorBrewerColorRampDialog( const QgsColorBrew
   QVBoxLayout *vLayout = new QVBoxLayout();
   mWidget = new QgsColorBrewerColorRampWidget( ramp );
   vLayout->addWidget( mWidget );
-  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, Qt::Horizontal );
-  connect( bbox, &QDialogButtonBox::accepted, this, &QDialog::accept );
-  connect( bbox, &QDialogButtonBox::rejected, this, &QDialog::reject );
-  connect( bbox, &QDialogButtonBox::helpRequested, this, &QgsColorBrewerColorRampDialog::showHelp );
-  vLayout->addWidget( bbox );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, Qt::Horizontal );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsColorBrewerColorRampDialog::showHelp );
+  vLayout->addWidget( mButtonBox );
   setLayout( vLayout );
   setWindowTitle( tr( "ColorBrewer Ramp" ) );
   connect( mWidget, &QgsColorBrewerColorRampWidget::changed, this, &QgsColorBrewerColorRampDialog::changed );
+}
+
+QDialogButtonBox *QgsColorBrewerColorRampDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 void QgsColorBrewerColorRampDialog::showHelp()

--- a/src/gui/qgscolorbrewercolorrampdialog.h
+++ b/src/gui/qgscolorbrewercolorrampdialog.h
@@ -24,6 +24,7 @@
 #include "qgis_sip.h"
 
 class QgsColorBrewerColorRamp;
+class QDialogButtonBox;
 
 /**
  * \ingroup gui
@@ -109,6 +110,12 @@ class GUI_EXPORT QgsColorBrewerColorRampDialog : public QDialog
      */
     void setRamp( const QgsColorBrewerColorRamp &ramp ) { mWidget->setRamp( ramp ); }
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
   signals:
 
     //! Emitted when the dialog settings change
@@ -117,6 +124,7 @@ class GUI_EXPORT QgsColorBrewerColorRampDialog : public QDialog
   private:
 
     QgsColorBrewerColorRampWidget *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
 
   private slots:
 

--- a/src/gui/qgsgradientcolorrampdialog.cpp
+++ b/src/gui/qgsgradientcolorrampdialog.cpp
@@ -155,7 +155,7 @@ QgsGradientColorRampDialog::QgsGradientColorRampDialog( const QgsGradientColorRa
   connect( mStopEditor, &QgsGradientStopEditor::selectedStopChanged, this, &QgsGradientColorRampDialog::selectedStopChanged );
   mStopEditor->selectStop( 0 );
 
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsGradientColorRampDialog::showHelp );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsGradientColorRampDialog::showHelp );
 }
 
 QgsGradientColorRampDialog::~QgsGradientColorRampDialog()
@@ -177,6 +177,11 @@ void QgsGradientColorRampDialog::setRamp( const QgsGradientColorRamp &ramp )
   updatePlot();
 
   emit changed();
+}
+
+QDialogButtonBox *QgsGradientColorRampDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 void QgsGradientColorRampDialog::cboType_currentIndexChanged( int index )

--- a/src/gui/qgsgradientcolorrampdialog.h
+++ b/src/gui/qgsgradientcolorrampdialog.h
@@ -63,6 +63,12 @@ class GUI_EXPORT QgsGradientColorRampDialog : public QDialog, private Ui::QgsGra
      */
     void setRamp( const QgsGradientColorRamp &ramp );
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
   signals:
 
     //! Emitted when the dialog settings change

--- a/src/gui/qgslabelinggui.cpp
+++ b/src/gui/qgslabelinggui.cpp
@@ -1070,12 +1070,17 @@ QgsLabelSettingsDialog::QgsLabelSettingsDialog( const QgsPalLayerSettings &setti
   QVBoxLayout *vLayout = new QVBoxLayout();
   mWidget = new QgsLabelingGui( layer, mapCanvas, settings, nullptr, geomType );
   vLayout->addWidget( mWidget );
-  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok, Qt::Horizontal );
-  connect( bbox, &QDialogButtonBox::accepted, this, &QDialog::accept );
-  connect( bbox, &QDialogButtonBox::rejected, this, &QDialog::reject );
-  vLayout->addWidget( bbox );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok, Qt::Horizontal );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  vLayout->addWidget( mButtonBox );
   setLayout( vLayout );
   setWindowTitle( tr( "Label Settings" ) );
+}
+
+QDialogButtonBox *QgsLabelSettingsDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 

--- a/src/gui/qgslabelinggui.h
+++ b/src/gui/qgslabelinggui.h
@@ -23,6 +23,8 @@
 #include "qgspropertyoverridebutton.h"
 #include "qgis_gui.h"
 
+class QDialogButtonBox;
+
 #define SIP_NO_FILE
 
 ///@cond PRIVATE
@@ -132,9 +134,15 @@ class GUI_EXPORT QgsLabelSettingsDialog : public QDialog
 
     QgsPalLayerSettings settings() const { return mWidget->layerSettings(); }
 
+    /**
+     * Returns a reference to the dialog's button box.
+     */
+    QDialogButtonBox *buttonBox() const;
+
   private:
 
     QgsLabelingGui *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
 
 };
 

--- a/src/gui/qgslimitedrandomcolorrampdialog.cpp
+++ b/src/gui/qgslimitedrandomcolorrampdialog.cpp
@@ -122,14 +122,19 @@ QgsLimitedRandomColorRampDialog::QgsLimitedRandomColorRampDialog( const QgsLimit
   QVBoxLayout *vLayout = new QVBoxLayout();
   mWidget = new QgsLimitedRandomColorRampWidget( ramp );
   vLayout->addWidget( mWidget );
-  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, Qt::Horizontal );
-  connect( bbox, &QDialogButtonBox::accepted, this, &QDialog::accept );
-  connect( bbox, &QDialogButtonBox::rejected, this, &QDialog::reject );
-  connect( bbox, &QDialogButtonBox::helpRequested, this, &QgsLimitedRandomColorRampDialog::showHelp );
-  vLayout->addWidget( bbox );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, Qt::Horizontal );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLimitedRandomColorRampDialog::showHelp );
+  vLayout->addWidget( mButtonBox );
   setLayout( vLayout );
   setWindowTitle( tr( "Random Color Ramp" ) );
   connect( mWidget, &QgsLimitedRandomColorRampWidget::changed, this, &QgsLimitedRandomColorRampDialog::changed );
+}
+
+QDialogButtonBox *QgsLimitedRandomColorRampDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 void QgsLimitedRandomColorRampDialog::showHelp()

--- a/src/gui/qgslimitedrandomcolorrampdialog.h
+++ b/src/gui/qgslimitedrandomcolorrampdialog.h
@@ -23,6 +23,8 @@
 #include "ui_qgslimitedrandomcolorrampwidgetbase.h"
 #include "qgis_gui.h"
 
+class QDialogButtonBox;
+
 /**
  * \ingroup gui
  * \class QgsLimitedRandomColorRampWidget
@@ -120,6 +122,12 @@ class GUI_EXPORT QgsLimitedRandomColorRampDialog : public QDialog
      */
     void setRamp( const QgsLimitedRandomColorRamp &ramp ) { mWidget->setRamp( ramp ); }
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
   signals:
 
     //! Emitted when the dialog settings change
@@ -128,6 +136,7 @@ class GUI_EXPORT QgsLimitedRandomColorRampDialog : public QDialog
   private:
 
     QgsLimitedRandomColorRampWidget *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
 
   private slots:
 

--- a/src/gui/qgspresetcolorrampdialog.cpp
+++ b/src/gui/qgspresetcolorrampdialog.cpp
@@ -112,14 +112,19 @@ QgsPresetColorRampDialog::QgsPresetColorRampDialog( const QgsPresetSchemeColorRa
   QVBoxLayout *vLayout = new QVBoxLayout();
   mWidget = new QgsPresetColorRampWidget( ramp );
   vLayout->addWidget( mWidget );
-  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, Qt::Horizontal );
-  connect( bbox, &QDialogButtonBox::accepted, this, &QDialog::accept );
-  connect( bbox, &QDialogButtonBox::rejected, this, &QDialog::reject );
-  connect( bbox, &QDialogButtonBox::helpRequested, this, &QgsPresetColorRampDialog::showHelp );
-  vLayout->addWidget( bbox );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Help | QDialogButtonBox::Ok, Qt::Horizontal );
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsPresetColorRampDialog::showHelp );
+  vLayout->addWidget( mButtonBox );
   setLayout( vLayout );
   setWindowTitle( tr( "Color Presets Ramp" ) );
   connect( mWidget, &QgsPresetColorRampWidget::changed, this, &QgsPresetColorRampDialog::changed );
+}
+
+QDialogButtonBox *QgsPresetColorRampDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 void QgsPresetColorRampDialog::showHelp()

--- a/src/gui/qgspresetcolorrampdialog.h
+++ b/src/gui/qgspresetcolorrampdialog.h
@@ -23,6 +23,8 @@
 #include "ui_qgspresetcolorrampwidgetbase.h"
 #include "qgis_gui.h"
 
+class QDialogButtonBox;
+
 /**
  * \ingroup gui
  * \class QgsPresetColorRampWidget
@@ -108,6 +110,12 @@ class GUI_EXPORT QgsPresetColorRampDialog : public QDialog
      */
     void setRamp( const QgsPresetSchemeColorRamp &ramp ) { mWidget->setRamp( ramp ); }
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
   signals:
 
     //! Emitted when the dialog settings change
@@ -116,6 +124,7 @@ class GUI_EXPORT QgsPresetColorRampDialog : public QDialog
   private:
 
     QgsPresetColorRampWidget *mWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
 
   private slots:
 

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1686,19 +1686,24 @@ QgsTextFormatDialog::QgsTextFormatDialog( const QgsTextFormat &format, QgsMapCan
   QVBoxLayout *layout = new QVBoxLayout( this );
   layout->addWidget( mFormatWidget );
 
-  QDialogButtonBox *buttonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this );
-  layout->addWidget( buttonBox );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, this );
+  layout->addWidget( mButtonBox );
 
   setLayout( layout );
   QgsGui::instance()->enableAutoGeometryRestore( this );
 
-  connect( buttonBox->button( QDialogButtonBox::Ok ), &QAbstractButton::clicked, this, &QDialog::accept );
-  connect( buttonBox->button( QDialogButtonBox::Cancel ), &QAbstractButton::clicked, this, &QDialog::reject );
+  connect( mButtonBox->button( QDialogButtonBox::Ok ), &QAbstractButton::clicked, this, &QDialog::accept );
+  connect( mButtonBox->button( QDialogButtonBox::Cancel ), &QAbstractButton::clicked, this, &QDialog::reject );
 }
 
 QgsTextFormat QgsTextFormatDialog::format() const
 {
   return mFormatWidget->format();
+}
+
+QDialogButtonBox *QgsTextFormatDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 QgsTextFormatPanelWidget::QgsTextFormatPanelWidget( const QgsTextFormat &format, QgsMapCanvas *mapCanvas, QWidget *parent )

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -287,9 +287,16 @@ class GUI_EXPORT QgsTextFormatDialog : public QDialog
      */
     QgsTextFormat format() const;
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
   private:
 
     QgsTextFormatWidget *mFormatWidget = nullptr;
+    QDialogButtonBox *mButtonBox = nullptr;
 };
 
 /**

--- a/src/gui/symbology/qgscptcitycolorrampdialog.cpp
+++ b/src/gui/symbology/qgscptcitycolorrampdialog.cpp
@@ -50,9 +50,9 @@ QgsCptCityColorRampDialog::QgsCptCityColorRampDialog( const QgsCptCityColorRamp 
   connect( tabBar, &QTabBar::currentChanged, this, &QgsCptCityColorRampDialog::tabBar_currentChanged );
   connect( pbtnLicenseDetails, &QToolButton::pressed, this, &QgsCptCityColorRampDialog::pbtnLicenseDetails_pressed );
   connect( cboVariantName, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsCptCityColorRampDialog::cboVariantName_currentIndexChanged );
-  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsCptCityColorRampDialog::showHelp );
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsCptCityColorRampDialog::showHelp );
 
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 
   QgsSettings settings;
   mSplitter->setSizes( QList<int>() << 250 << 550 );
@@ -216,7 +216,7 @@ void QgsCptCityColorRampDialog::mTreeView_clicked( const QModelIndex &index )
   if ( ! item )
     return;
   QgsDebugMsg( QStringLiteral( "item %1 clicked" ).arg( item->name() ) );
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
   updateTreeView( item );
 }
 
@@ -266,7 +266,7 @@ void QgsCptCityColorRampDialog::mListWidget_itemClicked( QListWidgetItem *item )
   QgsCptCityColorRampItem *rampItem = mListRamps.at( item->data( Qt::UserRole ).toInt() );
   if ( rampItem )
   {
-    buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
+    mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
     lblSchemeName->setText( QFileInfo( rampItem->name() ).fileName() );
     mRamp.copy( &rampItem->ramp() );
     QgsDebugMsg( QStringLiteral( "variant= %1 - %2 variants" ).arg( mRamp.variantName() ).arg( mRamp.variantList().count() ) );
@@ -490,7 +490,7 @@ void QgsCptCityColorRampDialog::updateUi()
       }
     }
     if ( found )
-      buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
+      mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
   }
   else
   {
@@ -503,6 +503,11 @@ bool QgsCptCityColorRampDialog::saveAsGradientRamp() const
   QgsDebugMsg( QStringLiteral( "result: %1 checked: %2" ).arg( result() ).arg( cboConvertStandard->isChecked() ) );
   // if "save as standard gradient" is checked, convert to QgsVectorGradientColorRamp
   return ( result() == Accepted && cboConvertStandard->isChecked() );
+}
+
+QDialogButtonBox *QgsCptCityColorRampDialog::buttonBox() const
+{
+  return mButtonBox;
 }
 
 void QgsCptCityColorRampDialog::updateListWidget( QgsCptCityDataItem *item )
@@ -577,7 +582,7 @@ bool QgsCptCityColorRampDialog::updateRamp()
   clearCopyingInfo();
   lblCollectionInfo->clear();
 
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
   updatePreview( true );
 
   QgsDebugMsg( "schemeName= " + mRamp.schemeName() );
@@ -628,7 +633,7 @@ bool QgsCptCityColorRampDialog::updateRamp()
       populateVariants();
       mListWidget->scrollToItem( listItem, QAbstractItemView::EnsureVisible );
       // mListView->selectionModel()->select( childIndex, QItemSelectionModel::Select );
-      buttonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
+      mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( true );
       emit changed();
       return true;
     }

--- a/src/gui/symbology/qgscptcitycolorrampdialog.h
+++ b/src/gui/symbology/qgscptcitycolorrampdialog.h
@@ -79,6 +79,12 @@ class GUI_EXPORT QgsCptCityColorRampDialog : public QDialog, private Ui::QgsCptC
      */
     bool saveAsGradientRamp() const;
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
     bool eventFilter( QObject *obj, QEvent *event ) override;
 
   signals:

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -177,17 +177,17 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
   searchBox->setPlaceholderText( tr( "Filter symbols…" ) );
 
   connect( this, &QDialog::finished, this, &QgsStyleManagerDialog::onFinished );
+  connect( listItems, &QAbstractItemView::doubleClicked, this, &QgsStyleManagerDialog::editItem );
+  connect( btnEditItem, &QPushButton::clicked, this, [ = ]( bool ) { editItem(); }
+         );
+  connect( actnEditItem, &QAction::triggered, this, [ = ]( bool ) { editItem(); }
+         );
 
   if ( !mReadOnly )
   {
-    connect( listItems, &QAbstractItemView::doubleClicked, this, &QgsStyleManagerDialog::editItem );
-
     connect( btnAddItem, &QPushButton::clicked, this, [ = ]( bool ) { addItem(); }
            );
-    connect( btnEditItem, &QPushButton::clicked, this, [ = ]( bool ) { editItem(); }
-           );
-    connect( actnEditItem, &QAction::triggered, this, [ = ]( bool ) { editItem(); }
-           );
+
     connect( btnRemoveItem, &QPushButton::clicked, this, [ = ]( bool ) { removeItem(); }
            );
     connect( actnRemoveItem, &QAction::triggered, this, [ = ]( bool ) { removeItem(); }
@@ -1264,10 +1264,11 @@ bool QgsStyleManagerDialog::editSymbol()
 
   // let the user edit the symbol and update list when done
   QgsSymbolSelectorDialog dlg( symbol.get(), mStyle, nullptr, this );
-  if ( dlg.exec() == 0 )
-  {
+  if ( mReadOnly )
+    dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
+  if ( !dlg.exec() )
     return false;
-  }
 
   // by adding symbol to style with the same name the old effectively gets overwritten
   mStyle->addSymbol( symbolName, symbol.release(), true );
@@ -1287,6 +1288,9 @@ bool QgsStyleManagerDialog::editColorRamp()
   {
     QgsGradientColorRamp *gradRamp = static_cast<QgsGradientColorRamp *>( ramp.get() );
     QgsGradientColorRampDialog dlg( *gradRamp, this );
+    if ( mReadOnly )
+      dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
     if ( !dlg.exec() )
     {
       return false;
@@ -1297,6 +1301,9 @@ bool QgsStyleManagerDialog::editColorRamp()
   {
     QgsLimitedRandomColorRamp *randRamp = static_cast<QgsLimitedRandomColorRamp *>( ramp.get() );
     QgsLimitedRandomColorRampDialog dlg( *randRamp, this );
+    if ( mReadOnly )
+      dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
     if ( !dlg.exec() )
     {
       return false;
@@ -1307,6 +1314,9 @@ bool QgsStyleManagerDialog::editColorRamp()
   {
     QgsColorBrewerColorRamp *brewerRamp = static_cast<QgsColorBrewerColorRamp *>( ramp.get() );
     QgsColorBrewerColorRampDialog dlg( *brewerRamp, this );
+    if ( mReadOnly )
+      dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
     if ( !dlg.exec() )
     {
       return false;
@@ -1317,6 +1327,9 @@ bool QgsStyleManagerDialog::editColorRamp()
   {
     QgsPresetSchemeColorRamp *presetRamp = static_cast<QgsPresetSchemeColorRamp *>( ramp.get() );
     QgsPresetColorRampDialog dlg( *presetRamp, this );
+    if ( mReadOnly )
+      dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
     if ( !dlg.exec() )
     {
       return false;
@@ -1327,6 +1340,9 @@ bool QgsStyleManagerDialog::editColorRamp()
   {
     QgsCptCityColorRamp *cptCityRamp = static_cast<QgsCptCityColorRamp *>( ramp.get() );
     QgsCptCityColorRampDialog dlg( *cptCityRamp, this );
+    if ( mReadOnly )
+      dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
     if ( !dlg.exec() )
     {
       return false;
@@ -1360,6 +1376,9 @@ bool QgsStyleManagerDialog::editTextFormat()
 
   // let the user edit the format and update list when done
   QgsTextFormatDialog dlg( format, nullptr, this );
+  if ( mReadOnly )
+    dlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
   if ( !dlg.exec() )
     return false;
 
@@ -1373,6 +1392,9 @@ bool QgsStyleManagerDialog::addLabelSettings( QgsWkbTypes::GeometryType type )
 {
   QgsPalLayerSettings settings;
   QgsLabelSettingsDialog settingsDlg( settings, nullptr, nullptr, this, type );
+  if ( mReadOnly )
+    settingsDlg.buttonBox()->button( QDialogButtonBox::Ok )->setEnabled( false );
+
   if ( !settingsDlg.exec() )
     return false;
 

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -912,6 +912,11 @@ void QgsSymbolSelectorDialog::changeLayer( QgsSymbolLayer *layer )
   mSelectorWidget->changeLayer( layer );
 }
 
+QDialogButtonBox *QgsSymbolSelectorDialog::buttonBox() const
+{
+  return mButtonBox;
+}
+
 void QgsSymbolSelectorDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "working_with_vector/style_library.html#the-symbol-selector" ) );

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -302,6 +302,12 @@ class GUI_EXPORT QgsSymbolSelectorDialog : public QDialog
      */
     QgsSymbol *symbol();
 
+    /**
+     * Returns a reference to the dialog's button box.
+     * \since QGIS 3.10
+     */
+    QDialogButtonBox *buttonBox() const;
+
   protected:
     // Reimplements dialog keyPress event so we can ignore it
     void keyPressEvent( QKeyEvent *e ) override;

--- a/src/ui/qgscptcitycolorrampdialogbase.ui
+++ b/src/ui/qgscptcitycolorrampdialogbase.ui
@@ -36,7 +36,16 @@
      </property>
      <widget class="QWidget" name="page">
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -508,7 +517,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
+      <widget class="QDialogButtonBox" name="mButtonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -539,13 +548,13 @@
   <tabstop>lblLicenseName</tabstop>
   <tabstop>pbtnLicenseDetails</tabstop>
   <tabstop>cboConvertStandard</tabstop>
-  <tabstop>buttonBox</tabstop>
+  <tabstop>mButtonBox</tabstop>
   <tabstop>mBrowserView</tabstop>
  </tabstops>
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>mButtonBox</sender>
    <signal>accepted()</signal>
    <receiver>QgsCptCityColorRampDialogBase</receiver>
    <slot>accept()</slot>
@@ -561,7 +570,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>mButtonBox</sender>
    <signal>rejected()</signal>
    <receiver>QgsCptCityColorRampDialogBase</receiver>
    <slot>reject()</slot>

--- a/src/ui/qgsgradientcolorrampdialogbase.ui
+++ b/src/ui/qgsgradientcolorrampdialogbase.ui
@@ -148,7 +148,7 @@
         <x>0</x>
         <y>0</y>
         <width>850</width>
-        <height>492</height>
+        <height>494</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -316,7 +316,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
+      <widget class="QDialogButtonBox" name="mButtonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -331,15 +331,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -392,7 +392,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>mButtonBox</sender>
    <signal>accepted()</signal>
    <receiver>QgsGradientColorRampDialogBase</receiver>
    <slot>accept()</slot>
@@ -408,7 +408,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonBox</sender>
+   <sender>mButtonBox</sender>
    <signal>rejected()</signal>
    <receiver>QgsGradientColorRampDialogBase</receiver>
    <slot>reject()</slot>


### PR DESCRIPTION
When a style manager dialog is opened in read only mode, still allow symbols to be double clicked to view their properties. Just disable actually saving any edited symbols instead.
