### PR TITLE
Fix lengthy delay when clicking change label tool on a label for the first time

### DIFF
--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -767,6 +767,7 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexe
     return false;
 
   QgsTemporaryCursorOverride cursor( Qt::WaitCursor );
+  bool changed = false;
   for ( const QgsPalLayerSettings::Property &p : qgis::as_const( mPalProperties ) )
   {
     int index = -1;
@@ -780,10 +781,13 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexe
     else
     {
       index = QgsAuxiliaryLayer::createProperty( p, vlayer );
+      changed = true;
     }
 
     indexes[p] = index;
   }
+  if ( changed )
+    emit vlayer->styleChanged();
 
   details.settings = vlayer->labeling()->settings( providerId );
 
@@ -815,6 +819,7 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsDiagramIn
     return false;
 
   QgsTemporaryCursorOverride cursor( Qt::WaitCursor );
+  bool changed = false;
   for ( const QgsDiagramLayerSettings::Property &p : qgis::as_const( mDiagramProperties ) )
   {
     int index = -1;
@@ -828,10 +833,13 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsDiagramIn
     else
     {
       index = QgsAuxiliaryLayer::createProperty( p, vlayer );
+      changed = true;
     }
 
     indexes[p] = index;
   }
+  if ( changed )
+    emit vlayer->styleChanged();
 
   return newAuxiliaryLayer;
 }

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -244,8 +244,6 @@ int QgsAuxiliaryLayer::createProperty( QgsPalLayerSettings::Property property, Q
 
         layer->labeling()->setSettings( settings, providerId );
       }
-
-      emit layer->styleChanged();
     }
 
     index = layer->fields().lookupField( fieldName );
@@ -274,8 +272,6 @@ int QgsAuxiliaryLayer::createProperty( QgsDiagramLayerSettings::Property propert
       settings.setDataDefinedProperties( c );
 
       layer->setDiagramLayerSettings( settings );
-      emit layer->styleChanged();
-
       index = layer->fields().lookupField( fieldName );
     }
   }


### PR DESCRIPTION
Previously this was firing off the styleChanged for every new auxiliary
field created, which is a very expensive call to process (as it involves
rebuilding GUI widgets). Instead, delay the call and only it fire it
once, if we actually changed something in the style.
