### PR TITLE
[Backport release-3_4] [oauth2] Various backports

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -33,6 +33,7 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QEventLoop>
+#include <QPointer>
 #include <QString>
 #include <QMutexLocker>
 
@@ -433,8 +434,8 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
 {
   QMutexLocker locker( &mNetworkRequestMutex );
   QString msg;
-  QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
-  if ( !reply )
+  QPointer<QNetworkReply> reply = qobject_cast<QNetworkReply *>( sender() );
+  if ( reply.isNull() )
   {
 #ifdef QGISDEBUG
     msg = tr( "Network error but no reply object accessible" );
@@ -442,16 +443,19 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
 #endif
     return;
   }
+
+  // Grab some reply properties before object is deleted elsewhere
+  QVariant replyStatus = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
+  QVariant replyAuthProp = reply->property( "authcfg" );
+  const QString replyErrString = reply->errorString();
+
   if ( err != QNetworkReply::NoError && err != QNetworkReply::OperationCanceledError )
   {
-    msg = tr( "Network error: %1" ).arg( reply->errorString() );
+    msg = tr( "Network error: %1" ).arg( replyErrString );
     QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
   }
 
-  // TODO: update debug messages to output to QGIS
-
-  QVariant status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-  if ( !status.isValid() )
+  if ( !replyStatus.isValid() )
   {
     if ( err != QNetworkReply::OperationCanceledError )
     {
@@ -460,23 +464,20 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
     }
     return;
   }
-  QVariant phrase = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
-  if ( phrase.isValid() )
-  {
-    if ( err != QNetworkReply::OperationCanceledError )
-    {
-      msg = tr( "Network error, HTTP status: %1" ).arg( phrase.toString() );
-      QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
-    }
-  }
 
-
-  if ( status.toInt() == 401 )
+  if ( replyStatus.toInt() == 401 )
   {
     msg = tr( "Attempting token refresh..." );
     QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
 
-    QString authcfg = reply->property( "authcfg" ).toString();
+
+    if ( !replyAuthProp.isValid() )
+    {
+      msg = tr( "Token refresh FAILED: authcfg property invalid" );
+      QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+      return;
+    }
+    QString authcfg = replyAuthProp.toString();
     if ( authcfg.isEmpty() )
     {
       msg = tr( "Token refresh FAILED: authcfg empty" );

--- a/src/auth/oauth2/qgsauthoauth2method.cpp
+++ b/src/auth/oauth2/qgsauthoauth2method.cpp
@@ -436,8 +436,10 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
   QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
   if ( !reply )
   {
+#ifdef QGISDEBUG
     msg = tr( "Network error but no reply object accessible" );
-    QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Warning );
+    QgsDebugMsg( msg );
+#endif
     return;
   }
   if ( err != QNetworkReply::NoError && err != QNetworkReply::OperationCanceledError )
@@ -461,8 +463,11 @@ void QgsAuthOAuth2Method::onNetworkError( QNetworkReply::NetworkError err )
   QVariant phrase = reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
   if ( phrase.isValid() )
   {
-    msg = tr( "Network error, HTTP status: %1" ).arg( phrase.toString() );
-    QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
+    if ( err != QNetworkReply::OperationCanceledError )
+    {
+      msg = tr( "Network error, HTTP status: %1" ).arg( phrase.toString() );
+      QgsMessageLog::logMessage( msg, AUTH_METHOD_KEY, Qgis::MessageLevel::Info );
+    }
   }
 
 


### PR DESCRIPTION
## Description
Backports of 75c720a659 ff365abe29 (partial) and 4b228435b9 for OAuth2 auth method plugin.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
