### PR TITLE
Disable CRS and transform cache permenantly when exiting Qgis

### DIFF
--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -705,14 +705,12 @@ Returns a list of recently used projections
 .. versionadded:: 2.7
 %End
 
-    static void invalidateCache( bool disableCache = false );
+
+    static void invalidateCache();
 %Docstring
 Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
 This should be called whenever the srs database has been modified in order to ensure
 that outdated CRS objects are not created.
-
-If ``disableCache`` is ``True`` then the inbuilt cache will be completely disabled. This
-argument is for internal use only.
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -705,11 +705,14 @@ Returns a list of recently used projections
 .. versionadded:: 2.7
 %End
 
-    static void invalidateCache();
+    static void invalidateCache( bool disableCache = false );
 %Docstring
 Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
 This should be called whenever the srs database has been modified in order to ensure
 that outdated CRS objects are not created.
+
+If ``disableCache`` is ``True`` then the inbuilt cache will be completely disabled. This
+argument is for internal use only.
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -392,14 +392,12 @@ Calling this method will overwrite any automatically calculated datum transform.
 .. deprecated:: Unused on builds based on Proj 6.0 or later
 %End
 
-    static void invalidateCache( bool disableCache = false );
+
+    static void invalidateCache();
 %Docstring
 Clears the internal cache used to initialize QgsCoordinateTransform objects.
 This should be called whenever the srs database has
 been modified in order to ensure that outdated CRS transforms are not created.
-
-If ``disableCache`` is ``True`` then the inbuilt cache will be completely disabled. This
-argument is for internal use only.
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -392,11 +392,14 @@ Calling this method will overwrite any automatically calculated datum transform.
 .. deprecated:: Unused on builds based on Proj 6.0 or later
 %End
 
-    static void invalidateCache();
+    static void invalidateCache( bool disableCache = false );
 %Docstring
 Clears the internal cache used to initialize QgsCoordinateTransform objects.
 This should be called whenever the srs database has
 been modified in order to ensure that outdated CRS transforms are not created.
+
+If ``disableCache`` is ``True`` then the inbuilt cache will be completely disabled. This
+argument is for internal use only.
 
 .. versionadded:: 3.0
 %End

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -350,10 +350,10 @@ QgsApplication::~QgsApplication()
   // is destroyed before the static variables of the cache, we might use freed memory.
 
   // we do this here as well as in exitQgis() -- it's safe to call as often as we want,
-  // and there's just a *chance* that in between an exitQgis call and this destructor
-  // something else's destructor has caused a new entry in the caches...
-  QgsCoordinateTransform::invalidateCache();
-  QgsCoordinateReferenceSystem::invalidateCache();
+  // and there's just a *chance* that someone hasn't properly called exitQgis prior to
+  // this destructor...
+  QgsCoordinateTransform::invalidateCache( true );
+  QgsCoordinateReferenceSystem::invalidateCache( true );
 }
 
 QgsApplication *QgsApplication::instance()
@@ -1248,11 +1248,11 @@ void QgsApplication::exitQgis()
   if ( QgsProviderRegistry::exists() )
     delete QgsProviderRegistry::instance();
 
-  // invalidate coordinate cache while the PROJ context held by the thread-locale
+  // invalidate coordinate cache AND DISABLE THEM! while the PROJ context held by the thread-locale
   // QgsProjContextStore object is still alive. Otherwise if this later object
   // is destroyed before the static variables of the cache, we might use freed memory.
-  QgsCoordinateTransform::invalidateCache();
-  QgsCoordinateReferenceSystem::invalidateCache();
+  QgsCoordinateTransform::invalidateCache( true );
+  QgsCoordinateReferenceSystem::invalidateCache( true );
 
   QgsStyle::cleanDefaultStyle();
 

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -671,6 +671,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     static QStringList recentProjections();
 
+#ifndef SIP_RUN
+
     /**
      * Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
      * This should be called whenever the srs database has been modified in order to ensure
@@ -682,6 +684,17 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \since QGIS 3.0
      */
     static void invalidateCache( bool disableCache = false );
+#else
+
+    /**
+     * Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
+     * This should be called whenever the srs database has been modified in order to ensure
+     * that outdated CRS objects are not created.
+     *
+     * \since QGIS 3.0
+     */
+    static void invalidateCache( bool disableCache SIP_PYARGREMOVE = false );
+#endif
 
     // Mutators -----------------------------------
     // We don't want to expose these to the public api since they won't create

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -675,9 +675,13 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
      * This should be called whenever the srs database has been modified in order to ensure
      * that outdated CRS objects are not created.
+     *
+     * If \a disableCache is TRUE then the inbuilt cache will be completely disabled. This
+     * argument is for internal use only.
+     *
      * \since QGIS 3.0
      */
-    static void invalidateCache();
+    static void invalidateCache( bool disableCache = false );
 
     // Mutators -----------------------------------
     // We don't want to expose these to the public api since they won't create
@@ -809,16 +813,27 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     static QReadWriteLock sSrIdCacheLock;
     static QHash< long, QgsCoordinateReferenceSystem > sSrIdCache;
+    static bool sDisableSrIdCache;
+
     static QReadWriteLock sOgcLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sOgcCache;
+    static bool sDisableOgcCache;
+
     static QReadWriteLock sProj4CacheLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sProj4Cache;
+    static bool sDisableProj4Cache;
+
     static QReadWriteLock sCRSWktLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sWktCache;
+    static bool sDisableWktCache;
+
     static QReadWriteLock sCRSSrsIdLock;
     static QHash< long, QgsCoordinateReferenceSystem > sSrsIdCache;
+    static bool sDisableSrsIdCache;
+
     static QReadWriteLock sCrsStringLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sStringCache;
+    static bool sDisableStringCache;
 
     friend class TestQgsCoordinateReferenceSystem;
 };

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -419,6 +419,8 @@ class CORE_EXPORT QgsCoordinateTransform
      */
     Q_DECL_DEPRECATED void setDestinationDatumTransformId( int datumId ) SIP_DEPRECATED;
 
+#ifndef SIP_RUN
+
     /**
      * Clears the internal cache used to initialize QgsCoordinateTransform objects.
      * This should be called whenever the srs database has
@@ -430,6 +432,17 @@ class CORE_EXPORT QgsCoordinateTransform
      * \since QGIS 3.0
      */
     static void invalidateCache( bool disableCache = false );
+#else
+
+    /**
+     * Clears the internal cache used to initialize QgsCoordinateTransform objects.
+     * This should be called whenever the srs database has
+     * been modified in order to ensure that outdated CRS transforms are not created.
+     *
+     * \since QGIS 3.0
+     */
+    static void invalidateCache( bool disableCache SIP_PYARGREMOVE = false );
+#endif
 
     /**
      * Computes an *estimated* conversion factor between source and destination units:

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -423,9 +423,13 @@ class CORE_EXPORT QgsCoordinateTransform
      * Clears the internal cache used to initialize QgsCoordinateTransform objects.
      * This should be called whenever the srs database has
      * been modified in order to ensure that outdated CRS transforms are not created.
+     *
+     * If \a disableCache is TRUE then the inbuilt cache will be completely disabled. This
+     * argument is for internal use only.
+     *
      * \since QGIS 3.0
      */
-    static void invalidateCache();
+    static void invalidateCache( bool disableCache = false );
 
     /**
      * Computes an *estimated* conversion factor between source and destination units:
@@ -536,6 +540,7 @@ class CORE_EXPORT QgsCoordinateTransform
     // cache
     static QReadWriteLock sCacheLock;
     static QMultiHash< QPair< QString, QString >, QgsCoordinateTransform > sTransforms; //same auth_id pairs might have different datum transformations
+    static bool sDisableCache;
 
 };
 


### PR DESCRIPTION
Hopefully this will prevent additional items being added to the cache after we've gracefully finalised proj operations, which results in the infamous crash-on-exit fiasco...