### PR TITLE
Append additional "QgsCalloutContext" member to callout rendering virtual methods

### DIFF
--- a/python/core/auto_generated/callouts/qgscallout.sip.in
+++ b/python/core/auto_generated/callouts/qgscallout.sip.in
@@ -156,7 +156,12 @@ Returns the desired drawing order (stacking) to use while rendering this callout
 The default order is QgsCallout.OrderBelowIndividualLabels.
 %End
 
-    void render( QgsRenderContext &context, QRectF rect, const double angle, const QgsGeometry &anchor );
+    struct QgsCalloutContext
+    {
+      bool temporary;
+    };
+
+    void render( QgsRenderContext &context, QRectF rect, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext );
 %Docstring
 Renders the callout onto the specified render ``context``.
 
@@ -171,6 +176,9 @@ E.g. a subclass may prefer to attach to the centroid of the ``anchor``, while an
 prefer to attach to the closest point on ``anchor`` instead.
 
 Both ``rect`` and ``anchor`` must be specified in painter coordinates (i.e. pixels).
+
+The ``calloutContext`` argument is used to specify additional contextual information about
+how a callout is being rendered.
 
 .. warning::
 
@@ -218,7 +226,7 @@ Returns the definitions for data defined properties available for use in callout
 
   protected:
 
-    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor ) = 0;
+    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext ) = 0;
 %Docstring
 Performs the actual rendering of the callout implementation onto the specified render ``context``.
 
@@ -233,6 +241,9 @@ E.g. a subclass may prefer to attach to the centroid of the ``anchor``, while an
 prefer to attach to the closest point on ``anchor`` instead.
 
 Both ``rect`` and ``anchor`` are specified in painter coordinates (i.e. pixels).
+
+The ``calloutContext`` argument is used to specify additional contextual information about
+how a callout is being rendered.
 %End
 
 };
@@ -352,7 +363,7 @@ Returns the map unit scale for the minimum callout length.
 %End
 
   protected:
-    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor );
+    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor, QgsCallout::QgsCalloutContext &calloutContext );
 
 
   private:
@@ -390,7 +401,7 @@ QgsManhattanLineCallout.properties() ).
 
 
   protected:
-    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor );
+    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor, QgsCallout::QgsCalloutContext &calloutContext );
 
 
   private:

--- a/src/core/callouts/qgscallout.cpp
+++ b/src/core/callouts/qgscallout.cpp
@@ -99,7 +99,7 @@ QgsCallout::DrawOrder QgsCallout::drawOrder() const
   return OrderBelowAllLabels;
 }
 
-void QgsCallout::render( QgsRenderContext &context, QRectF rect, const double angle, const QgsGeometry &anchor )
+void QgsCallout::render( QgsRenderContext &context, QRectF rect, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext )
 {
   if ( !mEnabled )
     return;
@@ -123,7 +123,7 @@ void QgsCallout::render( QgsRenderContext &context, QRectF rect, const double an
   painter->drawRect( anchor.boundingBox( ).buffered( 30 ).toRectF() );
 #endif
 
-  draw( context, rect, angle, anchor );
+  draw( context, rect, angle, anchor, calloutContext );
 }
 
 void QgsCallout::setEnabled( bool enabled )
@@ -245,7 +245,7 @@ void QgsSimpleLineCallout::setLineSymbol( QgsLineSymbol *symbol )
   mLineSymbol.reset( symbol );
 }
 
-void QgsSimpleLineCallout::draw( QgsRenderContext &context, QRectF rect, const double, const QgsGeometry &anchor )
+void QgsSimpleLineCallout::draw( QgsRenderContext &context, QRectF rect, const double, const QgsGeometry &anchor, QgsCalloutContext & )
 {
   QgsGeometry label( QgsGeometry::fromRect( rect ) );
   QgsGeometry line;
@@ -320,7 +320,7 @@ QgsManhattanLineCallout *QgsManhattanLineCallout::clone() const
   return new QgsManhattanLineCallout( *this );
 }
 
-void QgsManhattanLineCallout::draw( QgsRenderContext &context, QRectF rect, const double, const QgsGeometry &anchor )
+void QgsManhattanLineCallout::draw( QgsRenderContext &context, QRectF rect, const double, const QgsGeometry &anchor, QgsCalloutContext & )
 {
   QgsGeometry label( QgsGeometry::fromRect( rect ) );
   QgsGeometry line;

--- a/src/core/callouts/qgscallout.h
+++ b/src/core/callouts/qgscallout.h
@@ -174,6 +174,19 @@ class CORE_EXPORT QgsCallout
     virtual DrawOrder drawOrder() const;
 
     /**
+     * Contains additional contextual information about the context in which a callout is
+     * being rendered.
+     * \ingroup core
+     * \since QGIS 3.10
+     */
+    struct CORE_EXPORT QgsCalloutContext
+    {
+      ///@cond PRIVATE
+      bool temporary = false; // Temporary member only, required for building on some platforms
+      ///@endcond
+    };
+
+    /**
      * Renders the callout onto the specified render \a context.
      *
      * The \a rect argument gives the desired size and position of the body of the callout (e.g. the
@@ -188,10 +201,13 @@ class CORE_EXPORT QgsCallout
      *
      * Both \a rect and \a anchor must be specified in painter coordinates (i.e. pixels).
      *
+     * The \a calloutContext argument is used to specify additional contextual information about
+     * how a callout is being rendered.
+     *
      * \warning A prior call to startRender() must have been made before calling this method, and
      * after all render() operations are complete a call to stopRender() must be made.
      */
-    void render( QgsRenderContext &context, QRectF rect, const double angle, const QgsGeometry &anchor );
+    void render( QgsRenderContext &context, QRectF rect, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext );
 
     /**
      * Returns TRUE if the the callout is enabled.
@@ -250,8 +266,11 @@ class CORE_EXPORT QgsCallout
      * prefer to attach to the closest point on \a anchor instead.
      *
      * Both \a rect and \a anchor are specified in painter coordinates (i.e. pixels).
+     *
+     * The \a calloutContext argument is used to specify additional contextual information about
+     * how a callout is being rendered.
      */
-    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor ) = 0;
+    virtual void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor, QgsCalloutContext &calloutContext ) = 0;
 
   private:
 
@@ -365,7 +384,7 @@ class CORE_EXPORT QgsSimpleLineCallout : public QgsCallout
     const QgsMapUnitScale &minimumLengthMapUnitScale() const { return mMinCalloutLengthScale; }
 
   protected:
-    void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor ) override;
+    void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor, QgsCallout::QgsCalloutContext &calloutContext ) override;
 
   private:
 
@@ -414,7 +433,7 @@ class CORE_EXPORT QgsManhattanLineCallout : public QgsSimpleLineCallout
     QgsManhattanLineCallout *clone() const override;
 
   protected:
-    void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor ) override;
+    void draw( QgsRenderContext &context, QRectF bodyBoundingBox, const double angle, const QgsGeometry &anchor, QgsCallout::QgsCalloutContext &calloutContext ) override;
 
   private:
 #ifdef SIP_RUN

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -306,7 +306,8 @@ void QgsVectorLayerLabelProvider::drawCallout( QgsRenderContext &context, pal::L
 
     QgsGeometry g( QgsGeos::fromGeos( label->getFeaturePart()->feature()->geometry() ) );
     g.transform( xform.transform() );
-    mSettings.callout()->render( context, rect, label->getAlpha() * 180 / M_PI, g );
+    QgsCallout::QgsCalloutContext calloutContext;
+    mSettings.callout()->render( context, rect, label->getAlpha() * 180 / M_PI, g, calloutContext );
   }
 }
 

--- a/tests/src/core/testqgscallout.cpp
+++ b/tests/src/core/testqgscallout.cpp
@@ -76,7 +76,7 @@ class DummyCallout : public QgsCallout
 
   protected:
 
-    void draw( QgsRenderContext &, QRectF, const double, const QgsGeometry & ) override { }
+    void draw( QgsRenderContext &, QRectF, const double, const QgsGeometry &, QgsCallout::QgsCalloutContext & ) override { }
 
   private:
     QString mProp1;

--- a/tests/src/core/testqgscalloutregistry.cpp
+++ b/tests/src/core/testqgscalloutregistry.cpp
@@ -31,7 +31,7 @@ class DummyCallout : public QgsCallout
     QgsCallout *clone() const override { return new DummyCallout(); }
     static QgsCallout *create( const QVariantMap &, const QgsReadWriteContext & ) { return new DummyCallout(); }
   protected:
-    void draw( QgsRenderContext &, QRectF, const double, const QgsGeometry & ) override {}
+    void draw( QgsRenderContext &, QRectF, const double, const QgsGeometry &, QgsCallout::QgsCalloutContext & ) override {}
 
 };
 


### PR DESCRIPTION
While unused for now, this gives us flexibility in future to specify additional useful contextual information about how a callout should be rendered without breaking API (e.g. label text alignment, label font settings, etc)
