### PR TITLE
[attribute table] Fix several issues with form view's feature navigation

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -447,24 +447,27 @@ void QgsDualView::updateEditSelectionProgress( int progress, int count )
 void QgsDualView::panOrZoomToFeature( const QgsFeatureIds &featureset )
 {
   QgsMapCanvas *canvas = mFilterModel->mapCanvas();
-  if ( canvas )
+  if ( canvas && view() == AttributeEditor && featureset != mLastFeatureSet )
   {
-    if ( mAutoPanButton->isChecked() )
-      QTimer::singleShot( 0, this, [ = ]()
+    if ( filterMode() != QgsAttributeTableFilterModel::ShowVisible )
     {
-      canvas->panToFeatureIds( mLayer, featureset, false );
-    } );
-    else if ( mAutoZoomButton->isChecked() )
-      QTimer::singleShot( 0, this, [ = ]()
-    {
-      canvas->zoomToFeatureIds( mLayer, featureset );
-    } );
-
+      if ( mAutoPanButton->isChecked() )
+        QTimer::singleShot( 0, this, [ = ]()
+      {
+        canvas->panToFeatureIds( mLayer, featureset, false );
+      } );
+      else if ( mAutoZoomButton->isChecked() )
+        QTimer::singleShot( 0, this, [ = ]()
+      {
+        canvas->zoomToFeatureIds( mLayer, featureset );
+      } );
+    }
     if ( mFlashButton->isChecked() )
       QTimer::singleShot( 0, this, [ = ]()
     {
       canvas->flashFeatureIds( mLayer, featureset );
     } );
+    mLastFeatureSet = featureset;
   }
 }
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -406,6 +406,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     // If the current feature is set, while the form is still not initialized
     // we will temporarily save it in here and set it on init
     QgsFeature mTempAttributeFormFeature;
+    QgsFeatureIds mLastFeatureSet;
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeTable;


### PR DESCRIPTION
## Description
This PR improves the form view's feature browsing feature added in QGIS 3.8 in a few ways:
- Disable zoom / pan when filtering by visible features (fixes #30763)
- Disable flash / zoom / pan when not set to form view
- Do not trigger flash / zoom / pan when selection hasn't actually changed

Hoping this'll make it for 3.8.1; the one regression described in #30763 is pretty bad.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
