### PR TITLE
Disable CRS and transform cache permenantly when exiting Qgis

### DIFF
--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -703,6 +703,7 @@ Returns a list of recently used projections
 .. versionadded:: 2.7
 %End
 
+
     static void invalidateCache();
 %Docstring
 Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -349,6 +349,7 @@ Calling this method will overwrite any automatically calculated datum transform.
 .. seealso:: :py:func:`setSourceDatumTransformId`
 %End
 
+
     static void invalidateCache();
 %Docstring
 Clears the internal cache used to initialize QgsCoordinateTransform objects.

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -312,10 +312,10 @@ QgsApplication::~QgsApplication()
   // is destroyed before the static variables of the cache, we might use freed memory.
 
   // we do this here as well as in exitQgis() -- it's safe to call as often as we want,
-  // and there's just a *chance* that in between an exitQgis call and this destructor
-  // something else's destructor has caused a new entry in the caches...
-  QgsCoordinateTransform::invalidateCache();
-  QgsCoordinateReferenceSystem::invalidateCache();
+  // and there's just a *chance* that someone hasn't properly called exitQgis prior to
+  // this destructor...
+  QgsCoordinateTransform::invalidateCache( true );
+  QgsCoordinateReferenceSystem::invalidateCache( true );
 }
 
 QgsApplication *QgsApplication::instance()
@@ -1196,11 +1196,11 @@ void QgsApplication::exitQgis()
 
   delete QgsProviderRegistry::instance();
 
-  // invalidate coordinate cache while the PROJ context held by the thread-locale
+  // invalidate coordinate cache AND DISABLE THEM! while the PROJ context held by the thread-locale
   // QgsProjContextStore object is still alive. Otherwise if this later object
   // is destroyed before the static variables of the cache, we might use freed memory.
-  QgsCoordinateTransform::invalidateCache();
-  QgsCoordinateReferenceSystem::invalidateCache();
+  QgsCoordinateTransform::invalidateCache( true );
+  QgsCoordinateReferenceSystem::invalidateCache( true );
 
   QgsStyle::cleanDefaultStyle();
 

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -631,13 +631,30 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     static QStringList recentProjections();
 
+#ifndef SIP_RUN
+
     /**
      * Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
      * This should be called whenever the srs database has been modified in order to ensure
      * that outdated CRS objects are not created.
+     *
+     * If \a disableCache is TRUE then the inbuilt cache will be completely disabled. This
+     * argument is for internal use only.
+     *
      * \since QGIS 3.0
      */
-    static void invalidateCache();
+    static void invalidateCache( bool disableCache = false );
+#else
+
+    /**
+     * Clears the internal cache used to initialize QgsCoordinateReferenceSystem objects.
+     * This should be called whenever the srs database has been modified in order to ensure
+     * that outdated CRS objects are not created.
+     *
+     * \since QGIS 3.0
+     */
+    static void invalidateCache( bool disableCache SIP_PYARGREMOVE = false );
+#endif
 
     // Mutators -----------------------------------
     // We don't want to expose these to the public api since they won't create
@@ -762,16 +779,27 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     static QReadWriteLock sSrIdCacheLock;
     static QHash< long, QgsCoordinateReferenceSystem > sSrIdCache;
+    static bool sDisableSrIdCache;
+
     static QReadWriteLock sOgcLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sOgcCache;
+    static bool sDisableOgcCache;
+
     static QReadWriteLock sProj4CacheLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sProj4Cache;
+    static bool sDisableProj4Cache;
+
     static QReadWriteLock sCRSWktLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sWktCache;
+    static bool sDisableWktCache;
+
     static QReadWriteLock sCRSSrsIdLock;
     static QHash< long, QgsCoordinateReferenceSystem > sSrsIdCache;
+    static bool sDisableSrsIdCache;
+
     static QReadWriteLock sCrsStringLock;
     static QHash< QString, QgsCoordinateReferenceSystem > sStringCache;
+    static bool sDisableStringCache;
 
     friend class TestQgsCoordinateReferenceSystem;
 };

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -397,13 +397,30 @@ class CORE_EXPORT QgsCoordinateTransform
      */
     void setDestinationDatumTransformId( int datumId );
 
+#ifndef SIP_RUN
+
     /**
      * Clears the internal cache used to initialize QgsCoordinateTransform objects.
      * This should be called whenever the srs database has
      * been modified in order to ensure that outdated CRS transforms are not created.
+     *
+     * If \a disableCache is TRUE then the inbuilt cache will be completely disabled. This
+     * argument is for internal use only.
+     *
      * \since QGIS 3.0
      */
-    static void invalidateCache();
+    static void invalidateCache( bool disableCache = false );
+#else
+
+    /**
+     * Clears the internal cache used to initialize QgsCoordinateTransform objects.
+     * This should be called whenever the srs database has
+     * been modified in order to ensure that outdated CRS transforms are not created.
+     *
+     * \since QGIS 3.0
+     */
+    static void invalidateCache( bool disableCache SIP_PYARGREMOVE = false );
+#endif
 
     /**
      * Computes an *estimated* conversion factor between source and destination units:
@@ -436,6 +453,7 @@ class CORE_EXPORT QgsCoordinateTransform
     // cache
     static QReadWriteLock sCacheLock;
     static QMultiHash< QPair< QString, QString >, QgsCoordinateTransform > sTransforms; //same auth_id pairs might have different datum transformations
+    static bool sDisableCache;
 
 };
 


### PR DESCRIPTION
Hopefully this will prevent additional items being added to the cache
after we've gracefully finalised proj operations, which results
in the infamous crash-on-exit fiasco...

(cherry picked from commit db0e5e807c20db56341bc35579cffc30e20d555b)
