### PR TITLE
[FEATURE][labels] Add multiline alignment property to the change label tool

### DIFF
--- a/src/app/qgslabelpropertydialog.h
+++ b/src/app/qgslabelpropertydialog.h
@@ -66,6 +66,7 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
     void mRotationSpinBox_valueChanged( double d );
     void mFontColorButton_colorChanged( const QColor &color );
     void mBufferColorButton_colorChanged( const QColor &color );
+    void mMultiLineAlignComboBox_currentIndexChanged( int index );
     void mHaliComboBox_currentIndexChanged( int index );
     void mValiComboBox_currentIndexChanged( int index );
     void mLabelTextLineEdit_textChanged( const QString &text );
@@ -86,6 +87,7 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
     //! Updates combobox with named styles of font
     void populateFontStyleComboBox();
 
+    void fillMultiLineAlignComboBox();
     void fillHaliComboBox();
     void fillValiComboBox();
 

--- a/src/app/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/qgsmaptoolchangelabelproperties.cpp
@@ -38,6 +38,7 @@ QgsMapToolChangeLabelProperties::QgsMapToolChangeLabelProperties( QgsMapCanvas *
   mPalProperties << QgsPalLayerSettings::Underline;
   mPalProperties << QgsPalLayerSettings::Color;
   mPalProperties << QgsPalLayerSettings::Strikeout;
+  mPalProperties << QgsPalLayerSettings::MultiLineAlignment;
   mPalProperties << QgsPalLayerSettings::BufferSize;
   mPalProperties << QgsPalLayerSettings::BufferColor;
   mPalProperties << QgsPalLayerSettings::LabelDistance;

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -45,6 +45,7 @@ const QVector<QgsPalLayerSettings::Property> palHiddenProperties
   QgsPalLayerSettings::Underline,
   QgsPalLayerSettings::Color,
   QgsPalLayerSettings::Strikeout,
+  QgsPalLayerSettings::MultiLineAlignment,
   QgsPalLayerSettings::BufferSize,
   QgsPalLayerSettings::BufferColor,
   QgsPalLayerSettings::LabelDistance,
@@ -53,7 +54,8 @@ const QVector<QgsPalLayerSettings::Property> palHiddenProperties
   QgsPalLayerSettings::ScaleVisibility,
   QgsPalLayerSettings::MinScale,
   QgsPalLayerSettings::MaxScale,
-  QgsPalLayerSettings::AlwaysShow
+  QgsPalLayerSettings::AlwaysShow,
+  QgsPalLayerSettings::CalloutDraw
 };
 
 //

--- a/src/ui/qgslabelpropertydialogbase.ui
+++ b/src/ui/qgslabelpropertydialogbase.ui
@@ -347,6 +347,26 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="0" colspan="3">
+           <layout class="QHBoxLayout" name="horizontalLayout_22">
+            <item>
+             <widget class="QLabel" name="mMultiLineAlignLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Multiline alignment</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mMultiLineAlignComboBox"/>
+            </item>
+           </layout>
+          </item>
           <item row="1" column="1" colspan="2">
            <widget class="QComboBox" name="mFontStyleCmbBx">
             <property name="toolTip">


### PR DESCRIPTION
## Description
This PR adds the multiline alignment property to the change label map tool, which allows us to do some nice setups alongside callouts:
![image](https://user-images.githubusercontent.com/1728657/61527438-a0940a80-aa46-11e9-9d8a-698a6f0bce79.png)



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
