### PR TITLE
For "gap" geometry check errors, allow showing the context

### DIFF
--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerror.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckerror.sip.in
@@ -79,6 +79,16 @@ The id of the feature on which this error has been detected.
 The geometry of the error in map units.
 %End
 
+    virtual QgsRectangle contextBoundingBox() const;
+%Docstring
+The context of the error.
+For topology checks like gap checks this returns the context of an error
+and the involved features.
+May be a NULL rectangle.
+
+.. versionadded:: 3.10
+%End
+
     virtual QgsRectangle affectedAreaBBox() const;
 %Docstring
 The bounding box of the affected area of the error.

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerror.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerror.cpp
@@ -85,6 +85,11 @@ QgsGeometry QgsGeometryCheckError::geometry() const
   return mGeometry;
 }
 
+QgsRectangle QgsGeometryCheckError::contextBoundingBox() const
+{
+  return QgsRectangle();
+}
+
 QgsRectangle QgsGeometryCheckError::affectedAreaBBox() const
 {
   return mGeometry.boundingBox();

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerror.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerror.h
@@ -95,6 +95,16 @@ class ANALYSIS_EXPORT QgsGeometryCheckError
     QgsGeometry geometry() const;
 
     /**
+     * The context of the error.
+     * For topology checks like gap checks this returns the context of an error
+     * and the involved features.
+     * May be a NULL rectangle.
+     *
+     * \since QGIS 3.10
+     */
+    virtual QgsRectangle contextBoundingBox() const;
+
+    /**
      * The bounding box of the affected area of the error.
      */
     virtual QgsRectangle affectedAreaBBox() const;

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -135,7 +135,8 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
 
     // Add error
     double area = gapGeom->area();
-    errors.append( new QgsGeometryGapCheckError( this, QString(), QgsGeometry( gapGeom.release() ), neighboringIds, area, gapAreaBBox ) );
+    QgsRectangle gapBbox = gapGeom->boundingBox();
+    errors.append( new QgsGeometryGapCheckError( this, QString(), QgsGeometry( gapGeom.release() ), neighboringIds, area, gapBbox, gapAreaBBox ) );
   }
 }
 
@@ -293,6 +294,11 @@ QgsGeometryCheck::CheckType QgsGeometryGapCheck::factoryCheckType()
   return QgsGeometryCheck::LayerCheck;
 }
 ///@endcond private
+
+QgsRectangle QgsGeometryGapCheckError::contextBoundingBox() const
+{
+  return mContextBoundingBox;
+}
 
 bool QgsGeometryGapCheckError::isEqual( QgsGeometryCheckError *other ) const
 {

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
@@ -43,12 +43,16 @@ class ANALYSIS_EXPORT QgsGeometryGapCheckError : public QgsGeometryCheckError
                               const QgsGeometry &geometry,
                               const QMap<QString, QgsFeatureIds> &neighbors,
                               double area,
-                              const QgsRectangle &gapAreaBBox )
+                              const QgsRectangle &gapAreaBBox,
+                              const QgsRectangle &contextArea )
       : QgsGeometryCheckError( check, layerId, FID_NULL, geometry, geometry.constGet()->centroid(), QgsVertexId(), area, ValueArea )
       , mNeighbors( neighbors )
       , mGapAreaBBox( gapAreaBBox )
+      , mContextBoundingBox( contextArea )
     {
     }
+
+    QgsRectangle contextBoundingBox() const override;
 
     /**
      * A map of layers and feature ids of the neighbors of the gap.
@@ -72,6 +76,7 @@ class ANALYSIS_EXPORT QgsGeometryGapCheckError : public QgsGeometryCheckError
   private:
     QMap<QString, QgsFeatureIds> mNeighbors;
     QgsRectangle mGapAreaBBox;
+    QgsRectangle mContextBoundingBox;
 };
 
 

--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -242,8 +242,8 @@ void QgsGeometryValidationDock::onCurrentErrorChanged( const QModelIndex &curren
     }
   }
 
-  bool hasFeature = !FID_IS_NULL( current.data( QgsGeometryValidationModel::ErrorFeatureIdRole ) );
-  mZoomToFeatureButton->setEnabled( hasFeature );
+  bool hasContextRectangle = !current.data( QgsGeometryValidationModel::FeatureExtentRole ).isNull();
+  mZoomToFeatureButton->setEnabled( hasContextRectangle );
 }
 
 void QgsGeometryValidationDock::updateMapCanvasExtent()

--- a/src/app/qgsgeometryvalidationmodel.cpp
+++ b/src/app/qgsgeometryvalidationmodel.cpp
@@ -94,11 +94,19 @@ QVariant QgsGeometryValidationModel::data( const QModelIndex &index, int role ) 
 
       case FeatureExtentRole:
       {
-        const QgsFeatureId fid = topologyError->featureId();
-        if ( FID_IS_NULL( fid ) )
-          return QgsRectangle();
-        const QgsFeature feature = getFeature( fid );
-        return feature.geometry().boundingBox();
+        const QgsRectangle contextBoundingBox = topologyError->contextBoundingBox();
+        if ( !contextBoundingBox.isNull() )
+        {
+          return contextBoundingBox;
+        }
+        else
+        {
+          const QgsFeatureId fid = topologyError->featureId();
+          if ( FID_IS_NULL( fid ) )
+            return QgsRectangle();
+          const QgsFeature feature = getFeature( fid );
+          return feature.geometry().boundingBox();
+        }
       }
 
       case ProblemExtentRole:

--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -17,6 +17,7 @@
 #define QGSTEST_H
 
 #include <QtTest/QtTest>
+#include "qgsrectangle.h"
 #include "qgsapplication.h"
 
 #define QGSTEST_MAIN(TestObject) \
@@ -89,5 +90,14 @@ namespace QgsTest
     return qgetenv( "RUN_FLAKY_TESTS" ) == QStringLiteral( "true" );
   }
 }
+
+/**
+ * Formatting QgsRectangle for QCOMPARE pretty printing
+ */
+char *toString( const QgsRectangle &r )
+{
+  return QTest::toString( QStringLiteral( "QgsRectangle(%1, %2, %3, %4)" ).arg( QString::number( r.xMinimum() ), QString::number( r.yMinimum() ), QString::number( r.xMaximum() ), QString::number( r.yMaximum() ) ) );
+}
+
 
 #endif // QGSTEST_H

--- a/src/ui/qgsgeometryvalidationdockbase.ui
+++ b/src/ui/qgsgeometryvalidationdockbase.ui
@@ -31,7 +31,7 @@
     <item row="0" column="3">
      <widget class="QToolButton" name="mZoomToFeatureButton">
       <property name="text">
-       <string>Zoom To Feature</string>
+       <string>Zoom To Feature(s)</string>
       </property>
       <property name="icon">
        <iconset resource="../../images/images.qrc">

--- a/tests/src/geometry_checker/testqgsgeometrychecks.cpp
+++ b/tests/src/geometry_checker/testqgsgeometrychecks.cpp
@@ -47,7 +47,6 @@
 
 #include "qgsgeometrytypecheck.h"
 
-
 class TestQgsGeometryChecks: public QObject
 {
     Q_OBJECT
@@ -536,6 +535,12 @@ void TestQgsGeometryChecks::testGapCheck()
   QVERIFY( searchCheckErrors( checkErrors, "", -1, QgsPointXY( 0.0094, -0.4448 ), QgsVertexId(), 0.0033 ).size() == 1 );
   QVERIFY( ( errs1 = searchCheckErrors( checkErrors, "", -1, QgsPointXY( 0.2939, -0.4694 ), QgsVertexId(), 0.0053 ) ).size() == 1 );
   QVERIFY( searchCheckErrors( checkErrors, "", -1, QgsPointXY( 0.6284, -0.3641 ), QgsVertexId(), 0.0018 ).size() == 1 );
+
+  //  TestQgsGeometryChecks::testGapCheck()
+  QgsGeometryCheckError *error = searchCheckErrors( checkErrors, "", -1, QgsPointXY( 0.2924, -0.8798 ), QgsVertexId(), 0.0027 ).first();
+
+  QCOMPARE( error->contextBoundingBox().snappedToGrid( 0.0001 ), QgsRectangle( -0.0259, -1.0198, 0.6178, -0.4481 ) );
+  QCOMPARE( error->affectedAreaBBox().snappedToGrid( 0.0001 ), QgsRectangle( 0.246, -0.9998, 0.3939, -0.77 ) );
 
   // Test fixes
   QgsFeature f;


### PR DESCRIPTION
When a topological check returns a gap, it's sometimes better to zoom to the gap,
sometimes to show the gap in the context of the surrounding polygons. There is no
one-size-suits-all solution.
Therefore it's now possible to zoom to one by enabling the "zoom to feature(s)" button
also for topological errors.