### PR TITLE
Fix option dialog crash when searching in tree widget

### DIFF
--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp
@@ -25,6 +25,7 @@
 
 #include "qgsoptionsdialoghighlightwidget.h"
 #include "qgsmessagebaritem.h"
+#include "qgslogger.h"
 
 #include "qgsoptionsdialoghighlightwidgetsimpl.h"
 
@@ -235,13 +236,11 @@ bool QgsOptionsDialogHighlightTree::highlightText( const QString &text )
 
     QList<QTreeWidgetItem *> items = treeWidget->findItems( text, Qt::MatchContains | Qt::MatchRecursive, 0 );
     success = !items.empty();
-    mTreeInitialStyle.clear();
     mTreeInitialExpand.clear();
+    QBrush highlightBackground( QColor( HIGHLIGHT_BACKGROUND_RED, HIGHLIGHT_BACKGROUND_GREEN, HIGHLIGHT_BACKGROUND_BLUE ) );
+    QBrush highlightText( QColor( HIGHLIGHT_TEXT_RED, HIGHLIGHT_TEXT_GREEN, HIGHLIGHT_TEXT_BLUE ) );
     for ( QTreeWidgetItem *item : items )
     {
-      mTreeInitialStyle.insert( item, qMakePair( item->background( 0 ), item->foreground( 0 ) ) );
-      item->setBackground( 0, QBrush( QColor( HIGHLIGHT_BACKGROUND_RED, HIGHLIGHT_BACKGROUND_GREEN, HIGHLIGHT_BACKGROUND_BLUE ) ) );
-      item->setForeground( 0, QBrush( QColor( HIGHLIGHT_TEXT_RED, HIGHLIGHT_TEXT_GREEN, HIGHLIGHT_TEXT_BLUE ) ) );
       setChildrenVisible( item, true );
 
       QTreeWidgetItem *parent = item;
@@ -284,15 +283,6 @@ void QgsOptionsDialogHighlightTree::reset()
         item->setExpanded( mTreeInitialExpand.value( item ) );
       }
     }
-    for ( QTreeWidgetItem *item : mTreeInitialStyle.keys() )
-    {
-      if ( item )
-      {
-        item->setBackground( 0, mTreeInitialStyle.value( item ).first );
-        item->setForeground( 0, mTreeInitialStyle.value( item ).second );
-      }
-    }
-    mTreeInitialStyle.clear();
     mTreeInitialExpand.clear();
   }
 }

--- a/src/gui/qgsoptionsdialoghighlightwidgetsimpl.h
+++ b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.h
@@ -138,7 +138,6 @@ class GUI_EXPORT QgsOptionsDialogHighlightTree : public QgsOptionsDialogHighligh
     void reset() override;
     QPointer<QTreeView> mTreeView;
     // a map to save the tree state (backouground, font, expanded) before highlighting items
-    QMap<QTreeWidgetItem *, QPair<QBrush, QBrush>> mTreeInitialStyle = QMap<QTreeWidgetItem *, QPair<QBrush, QBrush>>();
     QMap<QTreeWidgetItem *, bool> mTreeInitialExpand = QMap<QTreeWidgetItem *, bool>();
     QMap<QTreeWidgetItem *, bool> mTreeInitialVisible = QMap<QTreeWidgetItem *, bool>();
 };


### PR DESCRIPTION
## Description
For a while now, using the search bar in the options dialog crashes QGIS if the advanced panel's tree widget is open. For some reason, recent Qt 5 versions don't like the setForeground / setBackground calls. This PR fixes the crash by removing those custom styling. It's not ideal but we're not losing much, and we save QGIS from sudden death.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
