### PR TITLE
Fix change label map tool overwritting pre-existing non-field expressions

### DIFF
--- a/src/app/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/qgsmaptoolchangelabelproperties.cpp
@@ -73,7 +73,7 @@ void QgsMapToolChangeLabelProperties::canvasPressEvent( QgsMapMouseEvent *e )
   if ( !mCurrentLabel.layer->isEditable() )
   {
     QgsPalIndexes indexes;
-    bool newAuxiliaryLayer = createAuxiliaryFields( indexes );
+    bool newAuxiliaryLayer = createAuxiliaryFields( indexes, false );
 
     if ( !newAuxiliaryLayer && !mCurrentLabel.layer->auxiliaryLayer() )
     {

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -742,12 +742,12 @@ QgsMapToolLabel::LabelDetails::LabelDetails( const QgsLabelPosition &p )
   }
 }
 
-bool QgsMapToolLabel::createAuxiliaryFields( QgsPalIndexes &indexes )
+bool QgsMapToolLabel::createAuxiliaryFields( QgsPalIndexes &indexes, bool overwriteExpression )
 {
-  return createAuxiliaryFields( mCurrentLabel, indexes );
+  return createAuxiliaryFields( mCurrentLabel, indexes, overwriteExpression );
 }
 
-bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexes &indexes ) const
+bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexes &indexes, bool overwriteExpression ) const
 {
   bool newAuxiliaryLayer = false;
   QgsVectorLayer *vlayer = details.layer;
@@ -778,7 +778,7 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexe
     {
       index = vlayer->fields().lookupField( prop.field() );
     }
-    else
+    else if ( prop.propertyType() != QgsProperty::ExpressionBasedProperty || ( prop.propertyType() == QgsProperty::ExpressionBasedProperty && overwriteExpression ) )
     {
       index = QgsAuxiliaryLayer::createProperty( p, vlayer );
       changed = true;
@@ -794,13 +794,13 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsPalIndexe
   return newAuxiliaryLayer;
 }
 
-bool QgsMapToolLabel::createAuxiliaryFields( QgsDiagramIndexes &indexes )
+bool QgsMapToolLabel::createAuxiliaryFields( QgsDiagramIndexes &indexes, bool overwriteExpression )
 {
-  return createAuxiliaryFields( mCurrentLabel, indexes );
+  return createAuxiliaryFields( mCurrentLabel, indexes, overwriteExpression );
 }
 
 
-bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsDiagramIndexes &indexes )
+bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsDiagramIndexes &indexes, bool overwriteExpression )
 {
   bool newAuxiliaryLayer = false;
   QgsVectorLayer *vlayer = details.layer;
@@ -830,7 +830,7 @@ bool QgsMapToolLabel::createAuxiliaryFields( LabelDetails &details, QgsDiagramIn
     {
       index = vlayer->fields().lookupField( prop.field() );
     }
-    else
+    else if ( prop.propertyType() != QgsProperty::ExpressionBasedProperty || ( prop.propertyType() == QgsProperty::ExpressionBasedProperty && overwriteExpression ) )
     {
       index = QgsAuxiliaryLayer::createProperty( p, vlayer );
       changed = true;

--- a/src/app/qgsmaptoollabel.h
+++ b/src/app/qgsmaptoollabel.h
@@ -186,10 +186,10 @@ class APP_EXPORT QgsMapToolLabel: public QgsMapTool
       */
     bool isPinned();
 
-    bool createAuxiliaryFields( QgsPalIndexes &palIndexes );
-    bool createAuxiliaryFields( LabelDetails &details, QgsPalIndexes &palIndexes ) const;
-    bool createAuxiliaryFields( QgsDiagramIndexes &diagIndexes );
-    bool createAuxiliaryFields( LabelDetails &details, QgsDiagramIndexes &diagIndexes );
+    bool createAuxiliaryFields( QgsPalIndexes &palIndexes, bool overwriteExpression = true );
+    bool createAuxiliaryFields( LabelDetails &details, QgsPalIndexes &palIndexes, bool overwriteExpression = true ) const;
+    bool createAuxiliaryFields( QgsDiagramIndexes &diagIndexes, bool overwriteExpression = true );
+    bool createAuxiliaryFields( LabelDetails &details, QgsDiagramIndexes &diagIndexes, bool overwriteExpression = true );
 
     QList<QgsPalLayerSettings::Property> mPalProperties;
     QList<QgsDiagramLayerSettings::Property> mDiagramProperties;


### PR DESCRIPTION
## Description
This PR fixes a regression-like that was introduced alongside the fantastic auxiliary field feature whereas preexisting non-field expressions would be overwritten with a newly-created auxiliary field. 

While this might be acceptable for the move label map tool, it's undesirable for the change label map tool, whereas it's not unlikely that non-field expressions are set (e.g., a multilingual project that sets a label font family via an expression looking for a variable that sets the currently displayed language, font color set on basis on a list of conditions, etc.) and should _not_ be overwritten by a new auxiliary field. 

With this PR applied, the change label tool plays nicely with preexisting non-field expression by simply disabling such properties. Any properties not field by such an expression will get an auxiliary field (or index reference to an existing field).

@nyalldawson , took me losing three long, long expressions while testing out callouts and multiline alignments to realize how important this is.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
