### PR TITLE
Followup callouts

### DIFF
--- a/src/core/callouts/qgscalloutsregistry.cpp
+++ b/src/core/callouts/qgscalloutsregistry.cpp
@@ -84,7 +84,7 @@ QgsCalloutAbstractMetadata *QgsCalloutRegistry::calloutMetadata( const QString &
 
 QgsCallout *QgsCalloutRegistry::defaultCallout()
 {
-  return new QgsManhattanLineCallout();
+  return new QgsSimpleLineCallout();
 }
 
 QgsCallout *QgsCalloutRegistry::createCallout( const QString &name, const QVariantMap &properties, const QgsReadWriteContext &context ) const

--- a/src/ui/callouts/widget_simplelinecallout.ui
+++ b/src/ui/callouts/widget_simplelinecallout.ui
@@ -89,9 +89,6 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="specialValueText">
-        <string>Hairline</string>
-       </property>
        <property name="decimals">
         <number>6</number>
        </property>


### PR DESCRIPTION
- Default to straight line callout, not manhattan
- Fix incorrect clear text for min callout distance