### PR TITLE
[FEATURE] Allow rendering raster layers outside the reported extent

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -479,6 +479,14 @@ Resolutions are calculated in the provider's crs().
 .. versionadded:: 3.8.0
 %End
 
+    virtual bool ignoreExtents() const;
+%Docstring
+Returns true if the extents reported by the data provider are not reliable
+and it's possible that there is renderable content outside of these extents.
+
+.. versionadded:: 3.10.0
+%End
+
   signals:
 
     void statusChanged( const QString & ) const;

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -382,7 +382,7 @@ Writes the symbology of the layer into the document provided in SLD 1.0.0 format
 .. versionadded:: 3.6
 %End
 
-    bool ignoreExtent() const;
+    bool ignoreExtents() const;
 %Docstring
 If the ignoreExtent flag is set, the layer will also render outside the
 bounding box reported by the data provider.
@@ -391,17 +391,6 @@ to be drawn outside the data extent.
 
 .. versionadded:: 3.10
 %End
-
-    void setIgnoreExtent( bool ignoreExtent );
-%Docstring
-If the ignoreExtent flag is set, the layer will also render outside the
-bounding box reported by the data provider.
-To be used for example for WMS layers with labels or symbology that happens
-to be drawn outside the data extent.
-
-.. versionadded:: 3.10
-%End
-
 
   public slots:
     void showStatusMessage( const QString &message );

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -382,6 +382,26 @@ Writes the symbology of the layer into the document provided in SLD 1.0.0 format
 .. versionadded:: 3.6
 %End
 
+    bool ignoreExtent() const;
+%Docstring
+If the ignoreExtent flag is set, the layer will also render outside the
+bounding box reported by the data provider.
+To be used for example for WMS layers with labels or symbology that happens
+to be drawn outside the data extent.
+
+.. versionadded:: 3.10
+%End
+
+    void setIgnoreExtent( bool ignoreExtent );
+%Docstring
+If the ignoreExtent flag is set, the layer will also render outside the
+bounding box reported by the data provider.
+To be used for example for WMS layers with labels or symbology that happens
+to be drawn outside the data extent.
+
+.. versionadded:: 3.10
+%End
+
 
   public slots:
     void showStatusMessage( const QString &message );

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -127,6 +127,10 @@ QgsDataSourceUri &QgsOwsConnection::addWmsWcsConnectionSettings( QgsDataSourceUr
   {
     uri.setParam( QStringLiteral( "SmoothPixmapTransform" ), QStringLiteral( "1" ) );
   }
+  if ( settings.value( settingsKey + QStringLiteral( "/ignoreReportedLayerExtents" ), false ).toBool() )
+  {
+    uri.setParam( QStringLiteral( "IgnoreReportedLayerExtents" ), QStringLiteral( "1" ) );
+  }
   QString dpiMode = settings.value( settingsKey + QStringLiteral( "/dpiMode" ), QStringLiteral( "all" ) ).toString();
   if ( !dpiMode.isEmpty() )
   {

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -492,6 +492,11 @@ QList<double> QgsRasterDataProvider::nativeResolutions() const
   return QList< double >();
 }
 
+bool QgsRasterDataProvider::ignoreExtents() const
+{
+  return false;
+}
+
 bool QgsRasterDataProvider::userNoDataValuesContains( int bandNo, double value ) const
 {
   QgsRasterRangeList rangeList = mUserNoDataValue.value( bandNo - 1 );

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -60,7 +60,7 @@ QgsRasterBlock *QgsRasterDataProvider::block( int bandNo, QgsRectangle  const &b
   }
 
   // Read necessary extent only
-  QgsRectangle tmpExtent = extent().intersect( boundingBox );
+  QgsRectangle tmpExtent = boundingBox;
 
   if ( tmpExtent.isEmpty() )
   {

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -538,6 +538,14 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      */
     virtual QList< double > nativeResolutions() const;
 
+    /**
+     * Returns true if the extents reported by the data provider are not reliable
+     * and it's possible that there is renderable content outside of these extents.
+     *
+     * \since QGIS 3.10.0
+     */
+    virtual bool ignoreExtents() const;
+
   signals:
 
     /**

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -922,16 +922,10 @@ void QgsRasterLayer::computeMinMax( int band,
 
 }
 
-bool QgsRasterLayer::ignoreExtent() const
+bool QgsRasterLayer::ignoreExtents() const
 {
-  return mIgnoreExtent;
+  return mDataProvider ? mDataProvider->ignoreExtents() : false;
 }
-
-void QgsRasterLayer::setIgnoreExtent( bool ignoreExtent )
-{
-  mIgnoreExtent = ignoreExtent;
-}
-
 
 void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm, QgsRasterMinMaxOrigin::Limits limits, const QgsRectangle &extent, int sampleSize, bool generateLookupTableFlag )
 {
@@ -1712,9 +1706,6 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     setBlendMode( QgsPainting::getCompositionMode( static_cast< QgsPainting::BlendMode >( e.text().toInt() ) ) );
   }
 
-  QDomElement ignoreExtentElement = layer_node.namedItem( QStringLiteral( "ignoreExtent" ) ).toElement();
-  mIgnoreExtent = ignoreExtentElement.text() == QStringLiteral( "1" );
-
   readCustomProperties( layer_node );
 
   return true;
@@ -1905,10 +1896,6 @@ bool QgsRasterLayer::writeSymbology( QDomNode &layer_node, QDomDocument &documen
   QDomText blendModeText = document.createTextNode( QString::number( QgsPainting::getBlendModeEnum( blendMode() ) ) );
   blendModeElement.appendChild( blendModeText );
   layer_node.appendChild( blendModeElement );
-  QDomElement ignoreExtentElement = document.createElement( QStringLiteral( "ignoreExtent" ) );
-  ignoreExtentElement.appendChild( document.createTextNode( mIgnoreExtent ? QStringLiteral( "1" ) : QStringLiteral( "0" ) ) );
-  layer_node.appendChild( ignoreExtentElement );
-
   return true;
 }
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -922,6 +922,16 @@ void QgsRasterLayer::computeMinMax( int band,
 
 }
 
+bool QgsRasterLayer::ignoreExtent() const
+{
+  return mIgnoreExtent;
+}
+
+void QgsRasterLayer::setIgnoreExtent( bool ignoreExtent )
+{
+  mIgnoreExtent = ignoreExtent;
+}
+
 
 void QgsRasterLayer::setContrastEnhancement( QgsContrastEnhancement::ContrastEnhancementAlgorithm algorithm, QgsRasterMinMaxOrigin::Limits limits, const QgsRectangle &extent, int sampleSize, bool generateLookupTableFlag )
 {
@@ -1702,6 +1712,9 @@ bool QgsRasterLayer::readSymbology( const QDomNode &layer_node, QString &errorMe
     setBlendMode( QgsPainting::getCompositionMode( static_cast< QgsPainting::BlendMode >( e.text().toInt() ) ) );
   }
 
+  QDomElement ignoreExtentElement = layer_node.namedItem( QStringLiteral( "ignoreExtent" ) ).toElement();
+  mIgnoreExtent = ignoreExtentElement.text() == QStringLiteral( "1" );
+
   readCustomProperties( layer_node );
 
   return true;
@@ -1892,6 +1905,9 @@ bool QgsRasterLayer::writeSymbology( QDomNode &layer_node, QDomDocument &documen
   QDomText blendModeText = document.createTextNode( QString::number( QgsPainting::getBlendModeEnum( blendMode() ) ) );
   blendModeElement.appendChild( blendModeText );
   layer_node.appendChild( blendModeElement );
+  QDomElement ignoreExtentElement = document.createElement( QStringLiteral( "ignoreExtent" ) );
+  ignoreExtentElement.appendChild( document.createTextNode( mIgnoreExtent ? QStringLiteral( "1" ) : QStringLiteral( "0" ) ) );
+  layer_node.appendChild( ignoreExtentElement );
 
   return true;
 }

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -434,6 +434,26 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      */
     bool writeSld( QDomNode &node, QDomDocument &doc, QString &errorMessage, const QgsStringMap &props = QgsStringMap() ) const;
 
+    /**
+     * If the ignoreExtent flag is set, the layer will also render outside the
+     * bounding box reported by the data provider.
+     * To be used for example for WMS layers with labels or symbology that happens
+     * to be drawn outside the data extent.
+     *
+     * \since QGIS 3.10
+     */
+    bool ignoreExtent() const;
+
+    /**
+     * If the ignoreExtent flag is set, the layer will also render outside the
+     * bounding box reported by the data provider.
+     * To be used for example for WMS layers with labels or symbology that happens
+     * to be drawn outside the data extent.
+     *
+     * \since QGIS 3.10
+     */
+    void setIgnoreExtent( bool ignoreExtent );
+
 
   public slots:
     void showStatusMessage( const QString &message );
@@ -501,6 +521,8 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     //! To save computations and possible infinite cycle of notifications
     QgsRectangle mLastRectangleUsedByRefreshContrastEnhancementIfNeeded;
+
+    bool mIgnoreExtent = false;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -442,18 +442,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      *
      * \since QGIS 3.10
      */
-    bool ignoreExtent() const;
-
-    /**
-     * If the ignoreExtent flag is set, the layer will also render outside the
-     * bounding box reported by the data provider.
-     * To be used for example for WMS layers with labels or symbology that happens
-     * to be drawn outside the data extent.
-     *
-     * \since QGIS 3.10
-     */
-    void setIgnoreExtent( bool ignoreExtent );
-
+    bool ignoreExtents() const;
 
   public slots:
     void showStatusMessage( const QString &message );
@@ -521,8 +510,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
 
     //! To save computations and possible infinite cycle of notifications
     QgsRectangle mLastRectangleUsedByRefreshContrastEnhancementIfNeeded;
-
-    bool mIgnoreExtent = false;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -134,7 +134,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   }
 
   // clip raster extent to view extent
-  QgsRectangle myRasterExtent = layer->ignoreExtent() ? myProjectedViewExtent : myProjectedViewExtent.intersect( myProjectedLayerExtent );
+  QgsRectangle myRasterExtent = layer->ignoreExtents() ? myProjectedViewExtent : myProjectedViewExtent.intersect( myProjectedLayerExtent );
   if ( myRasterExtent.isEmpty() )
   {
     QgsDebugMsg( QStringLiteral( "draw request outside view extent." ) );

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -134,7 +134,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   }
 
   // clip raster extent to view extent
-  QgsRectangle myRasterExtent = myProjectedViewExtent.intersect( myProjectedLayerExtent );
+  QgsRectangle myRasterExtent = layer->ignoreExtent() ? myProjectedViewExtent : myProjectedViewExtent.intersect( myProjectedLayerExtent );
   if ( myRasterExtent.isEmpty() )
   {
     QgsDebugMsg( QStringLiteral( "draw request outside view extent." ) );

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -282,6 +282,7 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   QString wmsKey = wmsSettingsKey( mBaseKey, mOriginalConnName );
 
   cbxIgnoreGetMapURI->setChecked( settings.value( wmsKey + "/ignoreGetMapURI", false ).toBool() );
+  cbxWmsIgnoreReportedLayerExtents->setChecked( settings.value( wmsKey + QStringLiteral( "/ignoreReportedLayerExtents" ), false ).toBool() );
   cbxWfsIgnoreAxisOrientation->setChecked( settings.value( wfsKey + "/ignoreAxisOrientation", false ).toBool() );
   cbxWfsInvertAxisOrientation->setChecked( settings.value( wfsKey + "/invertAxisOrientation", false ).toBool() );
   cbxWmsIgnoreAxisOrientation->setChecked( settings.value( wmsKey + "/ignoreAxisOrientation", false ).toBool() );
@@ -396,6 +397,7 @@ void QgsNewHttpConnection::accept()
     settings.setValue( wmsKey + "/ignoreAxisOrientation", cbxWmsIgnoreAxisOrientation->isChecked() );
     settings.setValue( wmsKey + "/invertAxisOrientation", cbxWmsInvertAxisOrientation->isChecked() );
 
+    settings.setValue( wmsKey + QStringLiteral( "/ignoreReportedLayerExtents" ), cbxWmsIgnoreReportedLayerExtents->isChecked() );
     settings.setValue( wmsKey + "/ignoreGetMapURI", cbxIgnoreGetMapURI->isChecked() );
     settings.setValue( wmsKey + "/smoothPixmapTransform", cbxSmoothPixmapTransform->isChecked() );
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -87,6 +87,7 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
 
   mIgnoreGetMapUrl = uri.hasParam( QStringLiteral( "IgnoreGetMapUrl" ) );
   mIgnoreGetFeatureInfoUrl = uri.hasParam( QStringLiteral( "IgnoreGetFeatureInfoUrl" ) );
+  mIgnoreReportedLayerExtents = uri.hasParam( QStringLiteral( "IgnoreReportedLayerExtents" ) );
   mParserSettings.ignoreAxisOrientation = uri.hasParam( QStringLiteral( "IgnoreAxisOrientation" ) ); // must be before parsing!
   mParserSettings.invertAxisOrientation = uri.hasParam( QStringLiteral( "InvertAxisOrientation" ) ); // must be before parsing!
   mSmoothPixmapTransform = uri.hasParam( QStringLiteral( "SmoothPixmapTransform" ) );

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -593,6 +593,7 @@ class QgsWmsSettings
 
     bool mIgnoreGetMapUrl;
     bool mIgnoreGetFeatureInfoUrl;
+    bool mIgnoreReportedLayerExtents = false;
     bool mSmoothPixmapTransform;
     enum QgsWmsDpiMode mDpiMode;
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4075,6 +4075,11 @@ void QgsWmsProvider::setSRSQueryItem( QUrl &url )
   setQueryItem( url, crsKey, mImageCrs );
 }
 
+bool QgsWmsProvider::ignoreExtents() const
+{
+  return mSettings.mIgnoreReportedLayerExtents;
+}
+
 // ----------
 
 QgsWmsLegendDownloadHandler::QgsWmsLegendDownloadHandler( QgsNetworkAccessManager &networkAccessManager, const QgsWmsSettings &settings, const QUrl &url )

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -330,6 +330,8 @@ class QgsWmsProvider : public QgsRasterDataProvider
     /* \brief add SRS or CRS parameter */
     void setSRSQueryItem( QUrl &url );
 
+    bool ignoreExtents() const override;
+
   private:
 
     QUrl createRequestUrlWMS( const QgsRectangle &viewExtent, int pixelWidth, int pixelHeight );

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -102,13 +102,6 @@
          <string>WMS/WMTS Options</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="5" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsInvertAxisOrientation">
-           <property name="text">
-            <string>Invert axis orientation</string>
-           </property>
-          </widget>
-         </item>
          <item row="3" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
            <property name="text">
@@ -123,18 +116,26 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="2">
+         <item row="4" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
+           <property name="text">
+            <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
            <property name="text">
             <string>Smooth pixmap transform</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="txtReferer"/>
-         </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="cmbDpiMode"/>
+         <item row="6" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsInvertAxisOrientation">
+           <property name="text">
+            <string>Invert axis orientation</string>
+           </property>
+          </widget>
          </item>
          <item row="1" column="0">
           <widget class="QLabel" name="lblDpiMode">
@@ -146,6 +147,9 @@
            </property>
           </widget>
          </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtReferer"/>
+         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="lblReferer">
            <property name="text">
@@ -156,10 +160,13 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
+         <item row="1" column="1">
+          <widget class="QComboBox" name="cmbDpiMode"/>
+         </item>
+         <item row="5" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxWmsIgnoreReportedLayerExtents">
            <property name="text">
-            <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
+            <string>Ignore reported layer extents</string>
            </property>
           </widget>
          </item>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1440,16 +1440,6 @@ border-radius: 2px;</string>
             </layout>
            </item>
            <item>
-            <widget class="QCheckBox" name="mIgnoreProviderExtent">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Always render full canvas extent and ignore extent reported by provider&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Activating this option will always request the complete canvas extent when rendering. Even when the extent announced by the provider is smaller than the canvas extent or outside the canvas extent.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This is useful if a WMS server announes the extent of the data, but the symbology or labeling takes additional space outside the bounding box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Always render full canvas extent</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <spacer name="verticalSpacer_6">
              <property name="orientation">
               <enum>Qt::Vertical</enum>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1442,7 +1442,7 @@ border-radius: 2px;</string>
            <item>
             <widget class="QCheckBox" name="mIgnoreProviderExtent">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Always render full canvas extent and ignore extent reported by provider&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Activating this option will always request the complete canvas extent when rendering. Even when the extent announced by the provider is smaller than the canvas extent or outside the canvas extent.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This is useful if a WMS server announes the extent of the data, but the symbology or labelling takes additional space outside the bounding box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Always render full canvas extent and ignore extent reported by provider&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Activating this option will always request the complete canvas extent when rendering. Even when the extent announced by the provider is smaller than the canvas extent or outside the canvas extent.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This is useful if a WMS server announes the extent of the data, but the symbology or labeling takes additional space outside the bounding box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string>Always render full canvas extent</string>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -239,7 +239,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>2</number>
+          <number>5</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -275,8 +275,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>729</height>
+                <width>652</width>
+                <height>723</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -381,8 +381,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>729</height>
+                <width>679</width>
+                <height>709</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -969,8 +969,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>348</width>
-                <height>446</height>
+                <width>652</width>
+                <height>723</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1316,8 +1316,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>86</width>
-                <height>42</height>
+                <width>652</width>
+                <height>723</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1440,6 +1440,16 @@ border-radius: 2px;</string>
             </layout>
            </item>
            <item>
+            <widget class="QCheckBox" name="mIgnoreProviderExtent">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Always render full canvas extent and ignore extent reported by provider&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Activating this option will always request the complete canvas extent when rendering. Even when the extent announced by the provider is smaller than the canvas extent or outside the canvas extent.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This is useful if a WMS server announes the extent of the data, but the symbology or labelling takes additional space outside the bounding box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Always render full canvas extent</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_6">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -1481,8 +1491,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>553</width>
-                <height>193</height>
+                <width>658</width>
+                <height>709</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1545,8 +1555,8 @@ border-radius: 2px;</string>
                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                      </widget>
                     </item>
@@ -1681,8 +1691,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>729</height>
+                <width>638</width>
+                <height>759</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_12">
@@ -2244,34 +2254,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mBackgroundLayerCheckBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
The extent reported by raster layers may be smaller than the area which can be rendered.
Notably for WMS with symbology that takes more space than the data.

For reference / visual changelog: this is a screenshot of the final implementation

![Screenshot from 2019-07-25 10-25-17](https://user-images.githubusercontent.com/588407/61858547-92bb0b00-aec6-11e9-9bb2-7d6e51edad32.png)


Fix #30251
