### PR TITLE
Improve appearance of multiline tooltips

### DIFF
--- a/src/gui/qgsshortcutsmanager.cpp
+++ b/src/gui/qgsshortcutsmanager.cpp
@@ -101,8 +101,19 @@ bool QgsShortcutsManager::registerAction( QAction *action, const QString &defaul
   QString sequence = settings.value( mSettingsPath + actionText, defaultSequence ).toString();
 
   action->setShortcut( sequence );
-  action->setToolTip( "<b>" + action->toolTip() + "</b>" );
-  updateActionToolTip( action, sequence );
+  if ( !action->toolTip().isEmpty() )
+  {
+    const QStringList parts = action->toolTip().split( '\n' );
+    QString formatted = QStringLiteral( "<b>%1</b>" ).arg( parts.at( 0 ) );
+    if ( parts.count() > 1 )
+    {
+      for ( int i = 1; i < parts.count(); ++i )
+        formatted += QStringLiteral( "<p>%1</p>" ).arg( parts.at( i ) );
+    }
+
+    action->setToolTip( formatted );
+    updateActionToolTip( action, sequence );
+  }
 
   return true;
 }

--- a/tests/src/python/test_qgsshortcutsmanager.py
+++ b/tests/src/python/test_qgsshortcutsmanager.py
@@ -447,6 +447,24 @@ class TestQgsShortcutsManager(unittest.TestCase):
         self.assertFalse(s.actionByName('shortcut2'))
         self.assertEqual(s.actionByName('action2'), action2)
 
+    def testTooltip(self):
+        """" test action tooltips """
+        action1 = QAction('action1', None)
+        action1.setToolTip('my tooltip')
+        action2 = QAction('action2', None)
+        action2.setToolTip('my multiline\ntooltip')
+        action3 = QAction('action3', None)
+        action3.setToolTip('my tooltip (Ctrl+S)')
+
+        s = QgsShortcutsManager(None)
+        s.registerAction(action1)
+        s.registerAction(action2)
+        s.registerAction(action3, 'Ctrl+S')
+
+        self.assertEqual(action1.toolTip(), '<b>my tooltip</b>')
+        self.assertEqual(action2.toolTip(), '<b>my multiline</b><p>tooltip</p>')
+        self.assertEqual(action3.toolTip(), '<b>my tooltip </b> (Ctrl+S)')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Avoids multiline tooltips being crammed up into a single block of text