### PR TITLE
When using the Show/Hide Label tool, a single click on a label toggles this label

### DIFF
--- a/src/app/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/qgsmaptoolshowhidelabels.cpp
@@ -220,7 +220,15 @@ bool QgsMapToolShowHideLabels::selectedFeatures( QgsVectorLayer *vlayer,
 {
   // culled from QgsMapToolSelectUtils::setSelectFeatures()
 
-  QgsGeometry selectGeometry = mRubberBand->asGeometry();
+  QgsGeometry selectGeometry;
+  if ( mDragging )
+  {
+    selectGeometry = mRubberBand->asGeometry();
+  }
+  else
+  {
+    selectGeometry = QgsGeometry::fromRect( QgsMapToolSelectUtils::expandSelectRectangle( mRubberBand->asGeometry().centroid().asPoint(), canvas(), vlayer ) );
+  }
 
   // toLayerCoordinates will throw an exception for any 'invalid' points in
   // the rubber band.

--- a/src/app/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/qgsmaptoolshowhidelabels.cpp
@@ -136,7 +136,39 @@ void QgsMapToolShowHideLabels::showHideLabels( QMouseEvent *e )
   vlayer->beginEditCommand( editTxt );
 
   bool labelChanged = false;
-  if ( doHide )
+  if ( !mDragging )
+  {
+    // if single click only, clicking on an existing label hides it, while clicking on a feature shows it
+    QList<QgsLabelPosition> positions;
+    if ( selectedLabelFeatures( vlayer, positions ) )
+    {
+      // clicked on a label
+      if ( showHide( positions.at( 0 ), false ) )
+        labelChanged = true;
+    }
+    else
+    {
+      // clicked on a feature
+      QgsFeatureIds fids;
+      if ( selectedFeatures( vlayer, fids ) )
+      {
+        QgsLabelPosition pos;
+        pos.featureId = *fids.constBegin();
+        pos.layerID = vlayer->id();
+
+        // we want to show labels...
+        pos.isDiagram = false;
+        if ( showHide( pos, true ) )
+          labelChanged = true;
+
+        // ... and diagrams
+        pos.isDiagram = true;
+        if ( showHide( pos, true ) )
+          labelChanged = true;
+      }
+    }
+  }
+  else if ( doHide )
   {
     QList<QgsLabelPosition> positions;
     if ( selectedLabelFeatures( vlayer, positions ) )
@@ -228,7 +260,7 @@ bool QgsMapToolShowHideLabels::selectedFeatures( QgsVectorLayer *vlayer,
 
   QApplication::restoreOverrideCursor();
 
-  return true;
+  return !selectedFeatIds.empty();
 }
 
 bool QgsMapToolShowHideLabels::selectedLabelFeatures( QgsVectorLayer *vlayer,
@@ -265,7 +297,7 @@ bool QgsMapToolShowHideLabels::selectedLabelFeatures( QgsVectorLayer *vlayer,
 
   QApplication::restoreOverrideCursor();
 
-  return true;
+  return !listPos.empty();
 }
 
 bool QgsMapToolShowHideLabels::showHide( const QgsLabelPosition &pos, bool show )


### PR DESCRIPTION
Unlike in marquee mode, where users must hold ctrl while dragging
over labels to hide them, when only a click on an existing label
is made we trigger a toggle of the label. It's a more intuitive
UX.