### PR TITLE
Backport End feature setting mode before notifying attribute form interfaces to release 3 4

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -265,7 +265,6 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
       // Settings of feature is done when we trigger the attribute form interface
       // Issue https://github.com/qgis/QGIS/issues/29667
       mIsSettingFeature = false;
-      const auto constMInterfaces = mInterfaces;
       Q_FOREACH ( QgsAttributeFormInterface *iface, mInterfaces )
       {
         iface->featureChanged();

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -262,6 +262,10 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
 
       synchronizeEnabledState();
 
+      // Settings of feature is done when we trigger the attribute form interface
+      // Issue https://github.com/qgis/QGIS/issues/29667
+      mIsSettingFeature = false;
+      const auto constMInterfaces = mInterfaces;
       Q_FOREACH ( QgsAttributeFormInterface *iface, mInterfaces )
       {
         iface->featureChanged();

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -16,6 +16,7 @@
 
 #include "qgstest.h"
 #include <QPushButton>
+#include <QLineEdit>
 
 #include <editorwidgets/core/qgseditorwidgetregistry.h>
 #include "qgsattributeform.h"
@@ -27,6 +28,7 @@
 #include <qgsvectorlayerjoininfo.h>
 #include "qgsgui.h"
 #include "qgsattributeformeditorwidget.h"
+#include "qgsattributeforminterface.h"
 
 class TestQgsAttributeForm : public QObject
 {
@@ -47,6 +49,7 @@ class TestQgsAttributeForm : public QObject
     void testConstraintsOnJoinedFields();
     void testEditableJoin();
     void testUpsertOnEdit();
+    void testAttributeFormInterface();
 
   private:
     QLabel *constraintsLabel( QgsAttributeForm *form, QgsEditorWidgetWrapper *ww )
@@ -850,6 +853,58 @@ void TestQgsAttributeForm::testUpsertOnEdit()
   delete layerB;
   delete layerC;
 }
+
+void TestQgsAttributeForm::testAttributeFormInterface()
+{
+  // Issue https://github.com/qgis/QGIS/issues/29667
+  // we simulate a python code execution that would be triggered
+  // at form opening and that would modify the value of a widget.
+  // We want to check that emitted signal widgetValueChanged is
+  // correctly emitted with correct parameters
+
+  // make a temporary vector layer
+  QString def = QStringLiteral( "Point?field=col0:integer" );
+  QgsVectorLayer *layer = new QgsVectorLayer( def, QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+  layer->setEditorWidgetSetup( 0, QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() ) );
+
+  // add a feature to the vector layer
+  QgsFeature ft( layer->dataProvider()->fields(), 1 );
+  ft.setAttribute( QStringLiteral( "col0" ), 10 );
+
+  class MyInterface : public QgsAttributeFormInterface
+  {
+    public:
+      MyInterface( QgsAttributeForm *form )
+        : QgsAttributeFormInterface( form ) {}
+
+      virtual void featureChanged()
+      {
+        QgsAttributeForm *f = form();
+        QLineEdit *le = f->findChild<QLineEdit *>( "col0" );
+        le->setText( "100" );
+      }
+  };
+
+  // build a form for this feature
+  QgsAttributeForm form( layer );
+  form.addInterface( new MyInterface( &form ) );
+
+  bool setted = false;
+  connect( &form, &QgsAttributeForm::widgetValueChanged, this,
+           [&setted]( const QString & attribute, const QVariant & newValue, bool attributeChanged )
+  {
+
+    // Check that our value setted by the QgsAttributeFormInterface has correct parameters.
+    // attributeChanged has to be true because it won't be taken into account by others
+    // (QgsValueRelationWidgetWrapper for instance)
+    if ( attribute == "col0" && newValue.toInt() == 100 && attributeChanged )
+      setted = true;
+  } );
+
+  form.setFeature( ft );
+  QVERIFY( setted );
+}
+
 
 
 QGSTEST_MAIN( TestQgsAttributeForm )

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -889,20 +889,20 @@ void TestQgsAttributeForm::testAttributeFormInterface()
   QgsAttributeForm form( layer );
   form.addInterface( new MyInterface( &form ) );
 
-  bool setted = false;
+  bool set = false;
   connect( &form, &QgsAttributeForm::widgetValueChanged, this,
-           [&setted]( const QString & attribute, const QVariant & newValue, bool attributeChanged )
+           [&set]( const QString & attribute, const QVariant & newValue, bool attributeChanged )
   {
 
-    // Check that our value setted by the QgsAttributeFormInterface has correct parameters.
+    // Check that our value set by the QgsAttributeFormInterface has correct parameters.
     // attributeChanged has to be true because it won't be taken into account by others
     // (QgsValueRelationWidgetWrapper for instance)
     if ( attribute == "col0" && newValue.toInt() == 100 && attributeChanged )
-      setted = true;
+      set = true;
   } );
 
   form.setFeature( ft );
-  QVERIFY( setted );
+  QVERIFY( set );
 }
 
 


### PR DESCRIPTION
## Description

Backport #30554 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
