### PR TITLE
Cache painter path for font marker when it doesn't change

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -978,6 +978,9 @@ class CORE_EXPORT QgsFontMarkerSymbolLayer : public QgsMarkerSymbolLayer
     QPen mPen;
     QBrush mBrush;
 
+    bool mUseCachedPath = false;
+    QPainterPath mCachedPath;
+
     QString characterToRender( QgsSymbolRenderContext &context, QPointF &charOffset, double &charWidth );
     void calculateOffsetAndRotation( QgsSymbolRenderContext &context, double scaledSize, bool &hasDataDefinedRotation, QPointF &offset, double &angle ) const;
     double calculateSize( QgsSymbolRenderContext &context );


### PR DESCRIPTION
Speeds up font marker rendering by around 2x

Sponsored by QGIS grant program, identified by KDAB's hotspot