### PR TITLE
SVG/raster cache optimizations

### DIFF
--- a/src/core/qgsabstractcontentcache.cpp
+++ b/src/core/qgsabstractcontentcache.cpp
@@ -23,9 +23,7 @@
 
 QgsAbstractContentCacheEntry::QgsAbstractContentCacheEntry( const QString &path )
   : path( path )
-  , fileModified( path.startsWith( QStringLiteral( "base64:" ) ) ? QDateTime() : QFileInfo( path ).lastModified() )
 {
-  fileModifiedLastCheckTimer.start();
 }
 
 //

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -420,6 +420,8 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
 
             if ( cacheEntry->fileModified != modified )
               continue;
+            else
+              cacheEntry->fileModifiedLastCheckTimer.restart();
           }
           currentEntry = cacheEntry;
           break;

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -88,11 +88,7 @@ class CORE_EXPORT QgsAbstractContentCacheEntry
 
     bool operator==( const QgsAbstractContentCacheEntry &other ) const
     {
-      bool equal = other.path == path;
-      if ( equal && ( mFileModifiedCheckTimeout <= 0 || fileModifiedLastCheckTimer.hasExpired( mFileModifiedCheckTimeout ) ) )
-        equal = other.fileModified == fileModified;
-
-      return equal;
+      return other.path == path;
     }
 
     /**
@@ -477,6 +473,12 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
     T *insertCacheEntry( T *entry )
     {
       entry->mFileModifiedCheckTimeout = mFileModifiedCheckTimeout;
+
+      if ( !entry->path.startsWith( QStringLiteral( "base64:" ) ) )
+      {
+        entry->fileModified = QFileInfo( entry->path ).lastModified();
+        entry->fileModifiedLastCheckTimer.start();
+      }
 
       mEntryLookup.insert( entry->path, entry );
 


### PR DESCRIPTION
Optimisations to avoid expensive file modified time checks in svg/raster image cache

Sponsored by QGIS grant program, identified by KDAB's hotspot