### PR TITLE
Optimise reading of multipoints from OGR

### DIFF
--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -19,6 +19,7 @@
 #include "qgsgeometry.h"
 #include "qgsfields.h"
 #include "qgslinestring.h"
+#include "qgsmultipoint.h"
 #include <QTextCodec>
 #include <QUuid>
 #include <cpl_error.h>
@@ -342,6 +343,19 @@ std::unique_ptr< QgsPoint > ogrGeometryToQgsPoint( OGRGeometryH geom )
   return qgis::make_unique< QgsPoint >( wkbType, x, y, z, m );
 }
 
+std::unique_ptr< QgsMultiPoint > ogrGeometryToQgsMultiPoint( OGRGeometryH geom )
+{
+  std::unique_ptr< QgsMultiPoint > mp = qgis::make_unique< QgsMultiPoint >();
+
+  const int count = OGR_G_GetGeometryCount( geom );
+  for ( int i = 0; i < count; ++i )
+  {
+    mp->addGeometry( ogrGeometryToQgsPoint( OGR_G_GetGeometryRef( geom, i ) ).release() );
+  }
+
+  return mp;
+}
+
 std::unique_ptr< QgsLineString > ogrGeometryToQgsLineString( OGRGeometryH geom )
 {
   QgsWkbTypes::Type wkbType = static_cast<QgsWkbTypes::Type>( OGR_G_GetGeometryType( geom ) );
@@ -469,6 +483,11 @@ QgsGeometry QgsOgrUtils::ogrGeometryToQgsGeometry( OGRGeometryH geom )
     case QgsWkbTypes::Point:
     {
       return QgsGeometry( ogrGeometryToQgsPoint( geom ) );
+    }
+
+    case QgsWkbTypes::MultiPoint:
+    {
+      return QgsGeometry( ogrGeometryToQgsMultiPoint( geom ) );
     }
 
     case QgsWkbTypes::LineString:

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -112,6 +112,54 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry()
   geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
   QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "Point (1.1 2.2)" ) );
 
+  ogrGeom = nullptr;
+  wkt = QByteArray( "point z ( 1.1 2.2 3)" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "PointZ (1.1 2.2 3)" ) );
+
+  ogrGeom = nullptr;
+  wkt = QByteArray( "point m ( 1.1 2.2 3)" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "PointM (1.1 2.2 3)" ) );
+
+  ogrGeom = nullptr;
+  wkt = QByteArray( "point zm ( 1.1 2.2 3 4)" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "PointZM (1.1 2.2 3 4)" ) );
+
+  ogrGeom = nullptr;
+  wkt = QByteArray( "multipoint( 1.1 2.2, 3.3 4.4)" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "MultiPoint ((1.1 2.2),(3.3 4.4))" ) );
+
+  ogrGeom = nullptr;
+  wkt = QByteArray( "multipoint z ((1.1 2.2 3), (3.3 4.4 4))" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "MultiPointZ ((1.1 2.2 3),(3.3 4.4 4))" ) );
+
+  ogrGeom = nullptr;
+  wkt = QByteArray( "multipoint m ((1.1 2.2 3), (3.3 4.4 4))" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "MultiPointM ((1.1 2.2 3),(3.3 4.4 4))" ) );
+
+  ogrGeom = nullptr;
+  wkt = QByteArray( "multipoint zm ((1.1 2.2 3 4), (3.3 4.4 4 5))" );
+  wktChar = wkt.data();
+  OGR_G_CreateFromWkt( &wktChar, nullptr, &ogrGeom );
+  geom = QgsOgrUtils::ogrGeometryToQgsGeometry( ogrGeom );
+  QCOMPARE( geom.asWkt( 3 ), QStringLiteral( "MultiPointZM ((1.1 2.2 3 4),(3.3 4.4 4 5))" ) );
 }
 
 void TestQgsOgrUtils::ogrGeometryToQgsGeometry2_data()


### PR DESCRIPTION
Avoid WKB conversion on OGR side, and parsing on QGIS side, and just handle the direct conversion of OGR geometries instead

Sponsored by QGIS grant program, identified by KDAB's hotspot