### PR TITLE
Fix unnecessary calculation of marker symbol bounds

### DIFF
--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -390,7 +390,7 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureIterator &fit )
     features[sym].append( fet );
 
     // new labeling engine
-    if ( mContext.labelingEngine() )
+    if ( mContext.labelingEngine() && ( mLabelProvider || mDiagramProvider ) )
     {
       QgsGeometry obstacleGeometry;
       QgsSymbolList symbols = mRenderer->originalSymbolsForFeature( fet, mContext );


### PR DESCRIPTION
... when labeling is not required for a layer and symbols layers are in place

Speeds up rendering of simple marker points matching this situation by ~3x

Sponsored by QGIS grant program, identified by KDAB's hotspot