### PR TITLE
Add move operators to QgsEffectStack

### DIFF
--- a/python/core/auto_generated/effects/qgseffectstack.sip.in
+++ b/python/core/auto_generated/effects/qgseffectstack.sip.in
@@ -51,6 +51,7 @@ Constructor for empty QgsEffectStack.
 
     QgsEffectStack( const QgsEffectStack &other );
 
+
     explicit QgsEffectStack( const QgsPaintEffect &effect );
 %Docstring
 Creates a new QgsEffectStack effect from a single initial effect.
@@ -143,6 +144,8 @@ Returns a pointer to the effect at a specified index within the stack
 
 :return: QgsPaintEffect at specified position
 %End
+
+
 
 
   protected:

--- a/src/core/effects/qgseffectstack.cpp
+++ b/src/core/effects/qgseffectstack.cpp
@@ -31,6 +31,12 @@ QgsEffectStack::QgsEffectStack( const QgsEffectStack &other )
   }
 }
 
+QgsEffectStack::QgsEffectStack( QgsEffectStack &&other )
+  : QgsPaintEffect( other )
+{
+  std::swap( mEffectList, other.mEffectList );
+}
+
 QgsEffectStack::QgsEffectStack( const QgsPaintEffect &effect )
 {
   appendEffect( effect.clone() );
@@ -53,6 +59,13 @@ QgsEffectStack &QgsEffectStack::operator=( const QgsEffectStack &rhs )
     appendEffect( rhs.effect( i )->clone() );
   }
   mEnabled = rhs.enabled();
+  return *this;
+}
+
+QgsEffectStack &QgsEffectStack::operator=( QgsEffectStack &&other )
+{
+  std::swap( mEffectList, other.mEffectList );
+  mEnabled = other.enabled();
   return *this;
 }
 

--- a/src/core/effects/qgseffectstack.h
+++ b/src/core/effects/qgseffectstack.h
@@ -62,6 +62,11 @@ class CORE_EXPORT QgsEffectStack : public QgsPaintEffect
     QgsEffectStack( const QgsEffectStack &other );
 
     /**
+     * Move constructor.
+     */
+    QgsEffectStack( QgsEffectStack &&other ) SIP_SKIP;
+
+    /**
      * Creates a new QgsEffectStack effect from a single initial effect.
      * \param effect initial effect to add to the stack. The effect will
      * be cloned, so ownership is not transferred to the stack.
@@ -138,6 +143,9 @@ class CORE_EXPORT QgsEffectStack : public QgsPaintEffect
     QgsPaintEffect *effect( int index ) const;
 
     QgsEffectStack &operator=( const QgsEffectStack &rhs );
+
+    QgsEffectStack &operator=( QgsEffectStack &&other ) SIP_SKIP;
+
 
   protected:
 


### PR DESCRIPTION
Results in a (very slight) performance boost with symbol copies

Sponsored by QGIS grant program, identified by KDAB's hotspot