### PR TITLE
Moves MapTip away from the mouse cursor Fixes #28337

### DIFF
--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -146,7 +146,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   QgsDebugMsg( tipHtml );
 
-  mWidget->move( pixelPosition.x(),
+  mWidget->move( pixelPosition.x() + 20,
                  pixelPosition.y() );
 
   mWebView->setHtml( tipHtml );

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -146,7 +146,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   QgsDebugMsg( tipHtml );
 
-  mWidget->move( pixelPosition.x() + 20,
+  mWidget->move( pixelPosition.x() + Qgis::UI_SCALE_FACTOR * 15,
                  pixelPosition.y() );
 
   mWebView->setHtml( tipHtml );


### PR DESCRIPTION
## Description

This aims to fix the problem with MapTips showing under the mouse cursors, something that makes them hard to read, especially when the tip text is small.

![Selection_030](https://user-images.githubusercontent.com/3607161/61698459-104d1280-ad31-11e9-852a-d7672b6b0394.png)

By moving the MapTip 20 pixels the you can now read the all tip without problems>

![Selection_032](https://user-images.githubusercontent.com/3607161/61698587-3d012a00-ad31-11e9-94a5-5490fefbd4bd.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
