### PR TITLE
 Add a reserve method to QgsGeometryCollection

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -97,6 +97,16 @@ Returns a geometry from within the collection.
     virtual int vertexNumberFromVertexId( QgsVertexId id ) const;
 
 
+    void reserve( int size );
+%Docstring
+Attempts to allocate memory for at least ``size`` geometries.
+
+If the number of geometries is known in advance, calling this function prior to adding geometries will prevent
+reallocations and memory fragmentation.
+
+.. versionadded:: 3.10
+%End
+
     virtual bool addGeometry( QgsAbstractGeometry *g /Transfer/ );
 %Docstring
 Adds a geometry and takes ownership. Returns ``True`` in case of success.

--- a/src/analysis/processing/qgsalgorithmpolygonstolines.cpp
+++ b/src/analysis/processing/qgsalgorithmpolygonstolines.cpp
@@ -121,6 +121,7 @@ QgsGeometry QgsPolygonsToLinesAlgorithm::convertToLines( const QgsGeometry &geom
   else
     lineGeometry = qgis::make_unique<QgsMultiCurve>();
 
+  lineGeometry->reserve( rings.size() );
   for ( auto ring : qgis::as_const( rings ) )
     lineGeometry->addGeometry( ring );
 

--- a/src/analysis/processing/qgsalgorithmprojectpointcartesian.cpp
+++ b/src/analysis/processing/qgsalgorithmprojectpointcartesian.cpp
@@ -123,6 +123,7 @@ QgsFeatureList QgsProjectPointCartesianAlgorithm::processFeature( const QgsFeatu
     {
       const QgsMultiPoint *mp = static_cast< const QgsMultiPoint * >( g.constGet() );
       std::unique_ptr< QgsMultiPoint > result = qgis::make_unique< QgsMultiPoint >();
+      result->reserve( mp->numGeometries() );
       for ( int i = 0; i < mp->numGeometries(); ++i )
       {
         const QgsPoint *p = static_cast< const QgsPoint * >( mp->geometryN( i ) );

--- a/src/analysis/processing/qgsalgorithmreverselinedirection.cpp
+++ b/src/analysis/processing/qgsalgorithmreverselinedirection.cpp
@@ -108,6 +108,7 @@ QgsFeatureList QgsReverseLineDirectionAlgorithm ::processFeature( const QgsFeatu
       std::unique_ptr< QgsAbstractGeometry > dest( geom.constGet()->createEmptyWithSameType() );
       const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( geom.constGet() );
       QgsGeometryCollection *destCollection = qgsgeometry_cast< QgsGeometryCollection * >( dest.get() );
+      destCollection->reserve( collection->numGeometries() );
       for ( int i = 0; i < collection->numGeometries(); ++i )
       {
         const QgsCurve *curve = qgsgeometry_cast< const QgsCurve *>( collection->geometryN( i ) );

--- a/src/analysis/processing/qgsalgorithmwedgebuffers.cpp
+++ b/src/analysis/processing/qgsalgorithmwedgebuffers.cpp
@@ -173,6 +173,7 @@ QgsFeatureList QgsWedgeBuffersAlgorithm::processFeature( const QgsFeature &featu
     {
       const QgsMultiPoint *mp = static_cast< const QgsMultiPoint * >( g.constGet() );
       std::unique_ptr< QgsMultiSurface > result = qgis::make_unique< QgsMultiSurface >();
+      result->reserve( mp->numGeometries() );
       for ( int i = 0; i < mp->numGeometries(); ++i )
       {
         const QgsPoint *p = static_cast< const QgsPoint * >( mp->geometryN( i ) );

--- a/src/core/geometry/qgscurve.cpp
+++ b/src/core/geometry/qgscurve.cpp
@@ -139,6 +139,7 @@ QgsAbstractGeometry *QgsCurve::boundary() const
     return nullptr;
 
   QgsMultiPoint *multiPoint = new QgsMultiPoint();
+  multiPoint->reserve( 2 );
   multiPoint->addGeometry( new QgsPoint( startPoint() ) );
   multiPoint->addGeometry( new QgsPoint( endPoint() ) );
   return multiPoint;

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -499,8 +499,9 @@ QgsAbstractGeometry *QgsCurvePolygon::boundary() const
   else
   {
     QgsMultiCurve *multiCurve = new QgsMultiCurve();
-    multiCurve->addGeometry( mExteriorRing->clone() );
     int nInteriorRings = mInteriorRings.size();
+    multiCurve->reserve( nInteriorRings + 1 );
+    multiCurve->addGeometry( mExteriorRing->clone() );
     for ( int i = 0; i < nInteriorRings; ++i )
     {
       multiCurve->addGeometry( mInteriorRings.at( i )->clone() );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1381,6 +1381,7 @@ bool QgsGeometry::convertGeometryCollectionToSubclass( QgsWkbTypes::GeometryType
   if ( !resGeom )
     return false;
 
+  resGeom->reserve( origGeom->numGeometries() );
   for ( int i = 0; i < origGeom->numGeometries(); ++i )
   {
     const QgsAbstractGeometry *g = origGeom->geometryN( i );
@@ -2441,6 +2442,7 @@ QgsGeometry QgsGeometry::forceRHR() const
   {
     const QgsGeometryCollection *collection = qgsgeometry_cast< const QgsGeometryCollection * >( d->geometry.get() );
     std::unique_ptr< QgsGeometryCollection > newCollection( collection->createEmptyWithSameType() );
+    newCollection->reserve( collection->numGeometries() );
     for ( int i = 0; i < collection->numGeometries(); ++i )
     {
       const QgsAbstractGeometry *g = collection->geometryN( i );
@@ -2953,6 +2955,7 @@ QgsGeometry QgsGeometry::smooth( const unsigned int iterations, const double off
       QgsMultiLineString *multiLine = static_cast< QgsMultiLineString * >( d->geometry.get() );
 
       std::unique_ptr< QgsMultiLineString > resultMultiline = qgis::make_unique< QgsMultiLineString> ();
+      resultMultiline->reserve( multiLine->numGeometries() );
       for ( int i = 0; i < multiLine->numGeometries(); ++i )
       {
         resultMultiline->addGeometry( smoothLine( *( static_cast< QgsLineString * >( multiLine->geometryN( i ) ) ), iterations, offset, minimumDistance, maxAngle ).release() );
@@ -2971,6 +2974,7 @@ QgsGeometry QgsGeometry::smooth( const unsigned int iterations, const double off
       QgsMultiPolygon *multiPoly = static_cast< QgsMultiPolygon * >( d->geometry.get() );
 
       std::unique_ptr< QgsMultiPolygon > resultMultiPoly = qgis::make_unique< QgsMultiPolygon >();
+      resultMultiPoly->reserve( multiPoly->numGeometries() );
       for ( int i = 0; i < multiPoly->numGeometries(); ++i )
       {
         resultMultiPoly->addGeometry( smoothPolygon( *( static_cast< QgsPolygon * >( multiPoly->geometryN( i ) ) ), iterations, offset, minimumDistance, maxAngle ).release() );

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -195,6 +195,11 @@ int QgsGeometryCollection::vertexNumberFromVertexId( QgsVertexId id ) const
   return -1; // should not happen
 }
 
+void QgsGeometryCollection::reserve( int size )
+{
+  mGeometries.reserve( size );
+}
+
 QgsAbstractGeometry *QgsGeometryCollection::geometryN( int n )
 {
   clearCache();
@@ -317,6 +322,7 @@ bool QgsGeometryCollection::fromWkb( QgsConstWkbPtr &wkbPtr )
 
   QVector<QgsAbstractGeometry *> geometryListBackup = mGeometries;
   mGeometries.clear();
+  mGeometries.reserve( nGeometries );
   for ( int i = 0; i < nGeometries; ++i )
   {
     std::unique_ptr< QgsAbstractGeometry > geom( QgsGeometryFactory::geomFromWkb( wkbPtr ) );  // also updates wkbPtr
@@ -706,6 +712,7 @@ QgsAbstractGeometry *QgsGeometryCollection::segmentize( double tolerance, Segmen
     return clone();
   }
 
+  geomCollection->reserve( mGeometries.size() );
   QVector< QgsAbstractGeometry * >::const_iterator geomIt = mGeometries.constBegin();
   for ( ; geomIt != mGeometries.constEnd(); ++geomIt )
   {
@@ -887,6 +894,7 @@ void QgsGeometryCollection::swapXy()
 QgsGeometryCollection *QgsGeometryCollection::toCurveType() const
 {
   std::unique_ptr< QgsGeometryCollection > newCollection( new QgsGeometryCollection() );
+  newCollection->reserve( mGeometries.size() );
   for ( QgsAbstractGeometry *geom : mGeometries )
   {
     newCollection->addGeometry( geom->toCurveType() );

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -120,6 +120,16 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     void adjacentVertices( QgsVertexId vertex, QgsVertexId &previousVertex SIP_OUT, QgsVertexId &nextVertex SIP_OUT ) const override;
     int vertexNumberFromVertexId( QgsVertexId id ) const override;
 
+    /**
+     * Attempts to allocate memory for at least \a size geometries.
+     *
+     * If the number of geometries is known in advance, calling this function prior to adding geometries will prevent
+     * reallocations and memory fragmentation.
+     *
+     * \since QGIS 3.10
+     */
+    void reserve( int size );
+
     //! Adds a geometry and takes ownership. Returns TRUE in case of success.
     virtual bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER );
 

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -141,6 +141,7 @@ std::unique_ptr<QgsMultiPoint> QgsGeometryFactory::fromMultiPointXY( const QgsMu
 {
   std::unique_ptr< QgsMultiPoint > mp = qgis::make_unique< QgsMultiPoint >();
   QgsMultiPointXY::const_iterator ptIt = multipoint.constBegin();
+  mp->reserve( multipoint.size() );
   for ( ; ptIt != multipoint.constEnd(); ++ptIt )
   {
     QgsPoint *pt = new QgsPoint( ptIt->x(), ptIt->y() );
@@ -157,6 +158,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeometryFactory::fromPolylineXY( const Q
 std::unique_ptr<QgsMultiLineString> QgsGeometryFactory::fromMultiPolylineXY( const QgsMultiPolylineXY &multiline )
 {
   std::unique_ptr< QgsMultiLineString > mLine = qgis::make_unique< QgsMultiLineString >();
+  mLine->reserve( multiline.size() );
   for ( int i = 0; i < multiline.size(); ++i )
   {
     mLine->addGeometry( fromPolylineXY( multiline.at( i ) ).release() );
@@ -191,6 +193,7 @@ std::unique_ptr<QgsPolygon> QgsGeometryFactory::fromPolygonXY( const QgsPolygonX
 std::unique_ptr< QgsMultiPolygon > QgsGeometryFactory::fromMultiPolygonXY( const QgsMultiPolygonXY &multipoly )
 {
   std::unique_ptr< QgsMultiPolygon > mp = qgis::make_unique< QgsMultiPolygon >();
+  mp->reserve( multipoly.size() );
   for ( int i = 0; i < multipoly.size(); ++i )
   {
     mp->addGeometry( fromPolygonXY( multipoly.at( i ) ).release() );

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -1109,6 +1109,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     {
       std::unique_ptr< QgsMultiPoint > multiPoint( new QgsMultiPoint() );
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
+      multiPoint->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
         const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit.ctxt, GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) );
@@ -1123,6 +1124,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     {
       std::unique_ptr< QgsMultiLineString > multiLineString( new QgsMultiLineString() );
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
+      multiLineString->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
         std::unique_ptr< QgsLineString >line( sequenceToLinestring( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ), hasZ, hasM ) );
@@ -1138,6 +1140,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
       std::unique_ptr< QgsMultiPolygon > multiPolygon( new QgsMultiPolygon() );
 
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
+      multiPolygon->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
         std::unique_ptr< QgsPolygon > poly = fromGeosPolygon( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) );
@@ -1152,6 +1155,7 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     {
       std::unique_ptr< QgsGeometryCollection > geomCollection( new QgsGeometryCollection() );
       int nParts = GEOSGetNumGeometries_r( geosinit.ctxt, geos );
+      geomCollection->reserve( nParts );
       for ( int i = 0; i < nParts; ++i )
       {
         std::unique_ptr< QgsAbstractGeometry > geom( fromGeos( GEOSGetGeometryN_r( geosinit.ctxt, geos, i ) ) );

--- a/src/core/geometry/qgsmulticurve.cpp
+++ b/src/core/geometry/qgsmulticurve.cpp
@@ -169,6 +169,7 @@ bool QgsMultiCurve::insertGeometry( QgsAbstractGeometry *g, int index )
 QgsMultiCurve *QgsMultiCurve::reversed() const
 {
   QgsMultiCurve *reversedMultiCurve = new QgsMultiCurve();
+  reversedMultiCurve->reserve( mGeometries.size() );
   for ( const QgsAbstractGeometry *geom : mGeometries )
   {
     if ( qgsgeometry_cast<const QgsCurve *>( geom ) )
@@ -182,6 +183,7 @@ QgsMultiCurve *QgsMultiCurve::reversed() const
 QgsAbstractGeometry *QgsMultiCurve::boundary() const
 {
   std::unique_ptr< QgsMultiPoint > multiPoint( new QgsMultiPoint() );
+  multiPoint->reserve( mGeometries.size() * 2 );
   for ( int i = 0; i < mGeometries.size(); ++i )
   {
     if ( QgsCurve *curve = qgsgeometry_cast<QgsCurve *>( mGeometries.at( i ) ) )

--- a/src/core/geometry/qgsmultilinestring.cpp
+++ b/src/core/geometry/qgsmultilinestring.cpp
@@ -155,6 +155,7 @@ bool QgsMultiLineString::insertGeometry( QgsAbstractGeometry *g, int index )
 QgsMultiCurve *QgsMultiLineString::toCurveType() const
 {
   QgsMultiCurve *multiCurve = new QgsMultiCurve();
+  multiCurve->reserve( mGeometries.size() );
   for ( int i = 0; i < mGeometries.size(); ++i )
   {
     multiCurve->addGeometry( mGeometries.at( i )->toCurveType() );

--- a/src/core/geometry/qgsmultipolygon.cpp
+++ b/src/core/geometry/qgsmultipolygon.cpp
@@ -170,6 +170,7 @@ bool QgsMultiPolygon::insertGeometry( QgsAbstractGeometry *g, int index )
 QgsMultiSurface *QgsMultiPolygon::toCurveType() const
 {
   QgsMultiSurface *multiSurface = new QgsMultiSurface();
+  multiSurface->reserve( mGeometries.size() );
   for ( int i = 0; i < mGeometries.size(); ++i )
   {
     multiSurface->addGeometry( mGeometries.at( i )->clone() );
@@ -180,6 +181,7 @@ QgsMultiSurface *QgsMultiPolygon::toCurveType() const
 QgsAbstractGeometry *QgsMultiPolygon::boundary() const
 {
   std::unique_ptr< QgsMultiLineString > multiLine( new QgsMultiLineString() );
+  multiLine->reserve( mGeometries.size() );
   for ( int i = 0; i < mGeometries.size(); ++i )
   {
     if ( QgsPolygon *polygon = qgsgeometry_cast<QgsPolygon *>( mGeometries.at( i ) ) )

--- a/src/core/geometry/qgsmultisurface.cpp
+++ b/src/core/geometry/qgsmultisurface.cpp
@@ -180,6 +180,7 @@ bool QgsMultiSurface::insertGeometry( QgsAbstractGeometry *g, int index )
 QgsAbstractGeometry *QgsMultiSurface::boundary() const
 {
   std::unique_ptr< QgsMultiCurve > multiCurve( new QgsMultiCurve() );
+  multiCurve->reserve( mGeometries.size() );
   for ( int i = 0; i < mGeometries.size(); ++i )
   {
     if ( QgsSurface *surface = qgsgeometry_cast<QgsSurface *>( mGeometries.at( i ) ) )

--- a/src/core/geometry/qgspolygon.cpp
+++ b/src/core/geometry/qgspolygon.cpp
@@ -223,8 +223,9 @@ QgsAbstractGeometry *QgsPolygon::boundary() const
   else
   {
     QgsMultiLineString *multiLine = new QgsMultiLineString();
-    multiLine->addGeometry( mExteriorRing->clone() );
     int nInteriorRings = mInteriorRings.size();
+    multiLine->reserve( nInteriorRings + 1 );
+    multiLine->addGeometry( mExteriorRing->clone() );
     for ( int i = 0; i < nInteriorRings; ++i )
     {
       multiLine->addGeometry( mInteriorRings.at( i )->clone() );

--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -352,6 +352,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
     const QgsGeometryCollection &srcCollection = dynamic_cast<const QgsGeometryCollection &>( geometry );
     std::unique_ptr<QgsGeometryCollection> collection( srcCollection.createEmptyWithSameType() );
     const int numGeoms = srcCollection.numGeometries();
+    collection->reserve( numGeoms );
     for ( int i = 0; i < numGeoms; ++i )
     {
       const QgsAbstractGeometry *sub = srcCollection.geometryN( i );

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -349,6 +349,7 @@ std::unique_ptr< QgsMultiPoint > ogrGeometryToQgsMultiPoint( OGRGeometryH geom )
   std::unique_ptr< QgsMultiPoint > mp = qgis::make_unique< QgsMultiPoint >();
 
   const int count = OGR_G_GetGeometryCount( geom );
+  mp->reserve( count );
   for ( int i = 0; i < count; ++i )
   {
     mp->addGeometry( ogrGeometryToQgsPoint( OGR_G_GetGeometryRef( geom, i ) ).release() );
@@ -388,6 +389,7 @@ std::unique_ptr< QgsMultiLineString > ogrGeometryToQgsMultiLineString( OGRGeomet
   std::unique_ptr< QgsMultiLineString > mp = qgis::make_unique< QgsMultiLineString >();
 
   const int count = OGR_G_GetGeometryCount( geom );
+  mp->reserve( count );
   for ( int i = 0; i < count; ++i )
   {
     mp->addGeometry( ogrGeometryToQgsLineString( OGR_G_GetGeometryRef( geom, i ) ).release() );

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -554,6 +554,7 @@ std::unique_ptr<QgsMultiPolygon> QgsTessellator::asMultiPolygon() const
 {
   std::unique_ptr< QgsMultiPolygon > mp = qgis::make_unique< QgsMultiPolygon >();
   const QVector<float> data = mData;
+  mp->reserve( mData.size() );
   for ( auto it = data.constBegin(); it != data.constEnd(); )
   {
     QgsPoint p1 = getPointFromData( it );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -201,6 +201,7 @@ std::unique_ptr< QgsMultiPoint > QgsArcGisRestUtils::parseEsriGeometryMultiPoint
   const QVariantList coordsList = geometryData[QStringLiteral( "points" )].toList();
 
   std::unique_ptr< QgsMultiPoint > multiPoint = qgis::make_unique< QgsMultiPoint >();
+  multiPoint->reserve( coordsList.size() );
   for ( const QVariant &coordData : coordsList )
   {
     const QVariantList coordList = coordData.toList();
@@ -237,6 +238,7 @@ std::unique_ptr< QgsMultiCurve > QgsArcGisRestUtils::parseEsriGeometryPolyline( 
   if ( pathsList.isEmpty() )
     return nullptr;
   std::unique_ptr< QgsMultiCurve > multiCurve = qgis::make_unique< QgsMultiCurve >();
+  multiCurve->reserve( pathsList.size() );
   for ( const QVariant &pathData : qgis::as_const( pathsList ) )
   {
     std::unique_ptr< QgsCompoundCurve > curve = parseCompoundCurve( pathData.toList(), pointType );
@@ -275,6 +277,7 @@ std::unique_ptr< QgsMultiSurface > QgsArcGisRestUtils::parseEsriGeometryPolygon(
 
   std::sort( curves.begin(), curves.end(), []( const QgsCompoundCurve * a, const QgsCompoundCurve * b )->bool{ double a_area = 0.0; double b_area = 0.0; a->sumUpArea( a_area ); b->sumUpArea( b_area ); return std::abs( a_area ) > std::abs( b_area ); } );
   std::unique_ptr< QgsMultiSurface > result = qgis::make_unique< QgsMultiSurface >();
+  result->reserve( curves.size() );
   while ( !curves.isEmpty() )
   {
     QgsCompoundCurve *exterior = curves.takeFirst();

--- a/src/providers/mssql/qgsmssqlgeometryparser.cpp
+++ b/src/providers/mssql/qgsmssqlgeometryparser.cpp
@@ -353,6 +353,7 @@ std::unique_ptr< QgsPoint > QgsMssqlGeometryParser::readPoint( int iFigure )
 std::unique_ptr< QgsMultiPoint > QgsMssqlGeometryParser::readMultiPoint( int iShape )
 {
   std::unique_ptr< QgsMultiPoint > poMultiPoint = qgis::make_unique< QgsMultiPoint >();
+  poMultiPoint->reserve( mNumShapes );
   for ( int i = iShape + 1; i < mNumShapes; i++ )
   {
     if ( ParentOffset( i ) == ( unsigned int )iShape )
@@ -405,6 +406,7 @@ std::unique_ptr< QgsCircularString > QgsMssqlGeometryParser::readCircularString(
 std::unique_ptr< QgsMultiLineString > QgsMssqlGeometryParser::readMultiLineString( int iShape )
 {
   std::unique_ptr< QgsMultiLineString > poMultiLineString = qgis::make_unique< QgsMultiLineString >();
+  poMultiLineString->reserve( mNumShapes );
   for ( int i = iShape + 1; i < mNumShapes; i++ )
   {
     if ( ParentOffset( i ) == ( unsigned int )iShape )
@@ -439,6 +441,7 @@ std::unique_ptr< QgsPolygon > QgsMssqlGeometryParser::readPolygon( int iShape )
 std::unique_ptr< QgsMultiPolygon > QgsMssqlGeometryParser::readMultiPolygon( int iShape )
 {
   std::unique_ptr< QgsMultiPolygon > poMultiPolygon = qgis::make_unique< QgsMultiPolygon >();
+  poMultiPolygon->reserve( mNumShapes );
   for ( int i = iShape + 1; i < mNumShapes; i++ )
   {
     if ( ParentOffset( i ) == ( unsigned int )iShape )
@@ -552,6 +555,7 @@ std::unique_ptr< QgsCurvePolygon > QgsMssqlGeometryParser::readCurvePolygon( int
 std::unique_ptr< QgsGeometryCollection > QgsMssqlGeometryParser::readGeometryCollection( int iShape )
 {
   std::unique_ptr< QgsGeometryCollection> poGeomColl = qgis::make_unique< QgsGeometryCollection >();
+  poGeomColl->reserve( mNumShapes );
   for ( int i = iShape + 1; i < mNumShapes; i++ )
   {
     if ( ParentOffset( i ) == ( unsigned int )iShape )

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -757,6 +757,7 @@ void QgsWFSFeatureDownloader::run( bool serializeFeatures, int maxFeatures )
               {
                 newGC = new QgsMultiPolygon();
               }
+              newGC->reserve( gc->numGeometries() );
               for ( int i = 0; i < gc->numGeometries(); ++i )
               {
                 newGC->addGeometry( gc->geometryN( i )->clone() );

--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -178,6 +178,12 @@ void TestQgsOgrUtils::ogrGeometryToQgsGeometry2_data()
   QTest::newRow( "linestringm" ) << QStringLiteral( "LineStringM (1.1 2.2 3.3, 4.4 5.5 6.6)" ) <<  static_cast< int >( QgsWkbTypes::LineStringM );
   QTest::newRow( "linestringzm" ) << QStringLiteral( "LineStringZM (1.1 2.2 3.3 4.4, 5.5 6.6 7.7 8.8)" ) <<  static_cast< int >( QgsWkbTypes::LineStringZM );
   QTest::newRow( "linestring25d" ) << QStringLiteral( "LineString25D (1.1 2.2 3.3, 4.4 5.5 6.6)" ) <<  static_cast< int >( QgsWkbTypes::LineString25D );
+
+  QTest::newRow( "linestring" ) << QStringLiteral( "MultiLineString ((1.1 2.2, 3.3 4.4))" ) << static_cast< int >( QgsWkbTypes::MultiLineString );
+  QTest::newRow( "linestring" ) << QStringLiteral( "MultiLineString ((1.1 2.2, 3.3 4.4),(5 5, 6 6))" ) << static_cast< int >( QgsWkbTypes::MultiLineString );
+  QTest::newRow( "linestring" ) << QStringLiteral( "MultiLineStringZ ((1.1 2.2 3, 3.3 4.4 6),(5 5 3, 6 6 1))" ) << static_cast< int >( QgsWkbTypes::MultiLineStringZ );
+  QTest::newRow( "linestring" ) << QStringLiteral( "MultiLineStringM ((1.1 2.2 4, 3.3 4.4 7),(5 5 4, 6 6 2))" ) << static_cast< int >( QgsWkbTypes::MultiLineStringM );
+  QTest::newRow( "linestring" ) << QStringLiteral( "MultiLineStringZM ((1.1 2.2 4 5, 3.3 4.4 8 9),(5 5 7 1, 6 6 2 3))" ) << static_cast< int >( QgsWkbTypes::MultiLineStringZM );
 }
 
 void TestQgsOgrUtils::ogrGeometryToQgsGeometry2()


### PR DESCRIPTION
Attempts to allocate memory for at least the specified number of geometries.

If the number of geometries is known in advance, calling this function
prior to adding geometries will prevent reallocations and memory fragmentation.

Sponsored by QGIS grant program, identified by KDAB's hotspot