### PR TITLE
[bugfix]Fix preview for circle with 3 tangents

### DIFF
--- a/src/app/qgsmaptoolcircle3tangents.cpp
+++ b/src/app/qgsmaptoolcircle3tangents.cpp
@@ -95,13 +95,24 @@ void QgsMapToolCircle3Tangents::cadCanvasMoveEvent( QgsMapMouseEvent *e )
   {
     QgsPointXY p1, p2;
     match.edgePoints( p1, p2 );
-    std::unique_ptr<QgsLineString> line( new QgsLineString() );
+    if ( mPoints.size() == 4 )
+    {
+      mCircle = QgsCircle().from3Tangents( mPoints.at( 0 ), mPoints.at( 1 ), mPoints.at( 2 ), mPoints.at( 3 ), QgsPoint( p1 ), QgsPoint( p2 ) );
+      mTempRubberBand->setGeometry( mCircle.toLineString() );
+      mTempRubberBand->show();
+    }
+    else
+    {
+      std::unique_ptr<QgsLineString> line( new QgsLineString() );
 
-    line->addVertex( mapPoint( p1 ) );
-    line->addVertex( mapPoint( p2 ) );
+      line->addVertex( mapPoint( p1 ) );
+      line->addVertex( mapPoint( p2 ) );
 
-    mTempRubberBand->setGeometry( line.release() );
-    mTempRubberBand->show();
+      mTempRubberBand->setGeometry( line.release() );
+      mTempRubberBand->show();
+
+
+    }
   }
 
 }


### PR DESCRIPTION
## Description
There is no preview of the circle for this maptool!

Now:
![out](https://user-images.githubusercontent.com/7521540/61850474-b7a68280-aeb4-11e9-9496-7badd8fd4611.gif)

cc @SrNetoChan @pigreco 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
