### PR TITLE
Copy/paste symbols in style manager

### DIFF
--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -2211,8 +2211,11 @@ void QgsStyleManagerDialog::listitemsContextMenu( QPoint point )
   // Clear all actions and create new actions for every group
   mGroupListMenu->clear();
 
+  const QModelIndexList indices = listItems->selectionModel()->selectedRows();
+
   if ( !mReadOnly )
   {
+    const QStringList currentTags = indices.count() == 1 ? indices.at( 0 ).data( QgsStyleModel::TagRole ).toStringList() : QStringList();
     QAction *a = nullptr;
     QStringList tags = mStyle->tags();
     tags.sort();
@@ -2220,6 +2223,11 @@ void QgsStyleManagerDialog::listitemsContextMenu( QPoint point )
     {
       a = new QAction( tag, mGroupListMenu );
       a->setData( tag );
+      if ( indices.count() == 1 )
+      {
+        a->setCheckable( true );
+        a->setChecked( currentTags.contains( tag ) );
+      }
       connect( a, &QAction::triggered, this, [ = ]( bool ) { tagSelectedSymbols(); }
              );
       mGroupListMenu->addAction( a );

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -331,6 +331,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     void copyItemsToDefault();
 
+    void copyItem();
+
   private:
     int selectedItemType();
 
@@ -390,6 +392,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     QMenu *mMenuBtnAddItemLabelSettings = nullptr;
 
     QAction *mActionCopyToDefault = nullptr;
+
+    QAction *mActionCopySymbol = nullptr;
 
     int mBlockGroupUpdates = 0;
 

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -333,6 +333,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     void copyItem();
 
+    void pasteItem();
+
   private:
     int selectedItemType();
 
@@ -393,7 +395,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     QAction *mActionCopyToDefault = nullptr;
 
-    QAction *mActionCopySymbol = nullptr;
+    QAction *mActionCopyItem = nullptr;
+    QAction *mActionPasteItem = nullptr;
 
     int mBlockGroupUpdates = 0;
 


### PR DESCRIPTION
Allows symbols to be copied or pasted in the style manager dialog.

@nirvn, as previously discussed...