### PR TITLE
 Reset selection when data source select dialog is reopened

### DIFF
--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -50,6 +50,17 @@ Concrete classes should implement the right behavior depending on the layer
 being added.
 %End
 
+    virtual void reset();
+%Docstring
+Called when this source select widget is being shown in a "new and clean" dialog.
+
+The data source manager recycles exisiting source select widgets but will call
+this method on every reopening.
+This should clear any selection that has previously been done.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void connectionsChanged();

--- a/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsabstractdatasourcewidget.sip.in
@@ -54,7 +54,7 @@ being added.
 %Docstring
 Called when this source select widget is being shown in a "new and clean" dialog.
 
-The data source manager recycles exisiting source select widgets but will call
+The data source manager recycles existing source select widgets but will call
 this method on every reopening.
 This should clear any selection that has previously been done.
 

--- a/python/gui/auto_generated/qgsowssourceselect.sip.in
+++ b/python/gui/auto_generated/qgsowssourceselect.sip.in
@@ -38,13 +38,14 @@ layers from the WCS server to the map canvas.
 Constructor
 %End
 
-  public slots:
-
     virtual void refresh();
 
 %Docstring
 Triggered when the provider's connections need to be refreshed
 %End
+
+    virtual void reset();
+
 
   protected slots:
     void showError( const QString &title, const QString &format, const QString &error );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1892,6 +1892,10 @@ void QgisApp::dataSourceManager( const QString &pageName )
     connect( mDataSourceManagerDialog, &QgsDataSourceManagerDialog::openFile, this, &QgisApp::openFile );
 
   }
+  else
+  {
+    mDataSourceManagerDialog->reset();
+  }
   // Try to open the dialog on a particular page
   if ( ! pageName.isEmpty() )
   {

--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -61,3 +61,11 @@ void QgsAbstractDataSourceWidget::setMapCanvas( const QgsMapCanvas *mapCanvas )
   mMapCanvas = mapCanvas;
 }
 
+void QgsAbstractDataSourceWidget::addButtonClicked()
+{
+}
+
+void QgsAbstractDataSourceWidget::reset()
+{
+}
+

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -70,7 +70,7 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
     /**
      * Called when this source select widget is being shown in a "new and clean" dialog.
      *
-     * The data source manager recycles exisiting source select widgets but will call
+     * The data source manager recycles existing source select widgets but will call
      * this method on every reopening.
      * This should clear any selection that has previously been done.
      *

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -65,7 +65,18 @@ class GUI_EXPORT QgsAbstractDataSourceWidget : public QDialog
      * Concrete classes should implement the right behavior depending on the layer
      * being added.
      */
-    virtual void addButtonClicked() { }
+    virtual void addButtonClicked();
+
+    /**
+     * Called when this source select widget is being shown in a "new and clean" dialog.
+     *
+     * The data source manager recycles exisiting source select widgets but will call
+     * this method on every reopening.
+     * This should clear any selection that has previously been done.
+     *
+     * \since QGIS 3.10
+     */
+    virtual void reset();
 
   signals:
 

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -118,6 +118,19 @@ void QgsDataSourceManagerDialog::refresh()
   emit providerDialogsRefreshRequested();
 }
 
+void QgsDataSourceManagerDialog::reset()
+{
+  int pageCount = ui->mOptionsStackedWidget->count();
+  for ( int i = 0; i < pageCount; ++i )
+  {
+    QWidget *widget = ui->mOptionsStackedWidget->widget( i );
+    QgsAbstractDataSourceWidget *dataSourceWidget = qobject_cast<QgsAbstractDataSourceWidget *>( widget );
+    if ( dataSourceWidget )
+      dataSourceWidget->reset();
+  }
+
+}
+
 void QgsDataSourceManagerDialog::rasterLayerAdded( const QString &uri, const QString &baseName, const QString &providerKey )
 {
   emit addRasterLayer( uri, baseName, providerKey );

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -75,9 +75,10 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
     //! Sync current page with the leftbar list
     void setCurrentPage( int index );
 
+    // TODO: use this with an internal source select dialog instead of forwarding the whole raster selection to app
+
     /**
      * A raster layer was added: for signal forwarding to QgisApp
-     * TODO: use this with an internal source select dialog instead of forwarding the whole raster selection to app
      */
     void rasterLayerAdded( QString const &uri, QString const &baseName, QString const &providerKey );
     //! A vector layer was added: for signal forwarding to QgisApp
@@ -89,6 +90,13 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
     //! Refresh the browser view
     void refresh();
 
+    /**
+     * Resets the interface of the datasource manager after reopening the dialog.
+     *
+     * Will clear the selection of embedded all source selection widgets.
+     *
+     * \since QGIS 3.10
+     */
     void reset();
 
   protected:

--- a/src/gui/qgsdatasourcemanagerdialog.h
+++ b/src/gui/qgsdatasourcemanagerdialog.h
@@ -89,6 +89,8 @@ class GUI_EXPORT QgsDataSourceManagerDialog : public QgsOptionsDialogBase, priva
     //! Refresh the browser view
     void refresh();
 
+    void reset();
+
   protected:
     void showEvent( QShowEvent *event ) override;
 

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -124,6 +124,11 @@ void QgsOWSSourceSelect::refresh()
   populateConnectionList();
 }
 
+void QgsOWSSourceSelect::reset()
+{
+  mLayersTreeWidget->clearSelection();
+}
+
 void QgsOWSSourceSelect::clearFormats()
 {
   mFormatComboBox->clear();

--- a/src/gui/qgsowssourceselect.h
+++ b/src/gui/qgsowssourceselect.h
@@ -63,10 +63,10 @@ class GUI_EXPORT QgsOWSSourceSelect : public QgsAbstractDataSourceWidget, protec
     //! Constructor
     QgsOWSSourceSelect( const QString &service, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
 
-  public slots:
-
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
+
+    void reset() override;
 
   protected slots:
     //! show whatever error is exposed.

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -20,10 +20,10 @@
 #include "qgsguiutils.h"
 #include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"
+#include "qgsdelimitedtextfile.h"
 
 class QButtonGroup;
 class QgisInterface;
-class QgsDelimitedTextFile;
 
 /**
  * \class QgsDelimitedTextSourceSelect
@@ -34,9 +34,6 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
 
   public:
     QgsDelimitedTextSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
-    ~QgsDelimitedTextSourceSelect() override;
-
-    QStringList splitLine( QString line );
 
   private:
     bool loadDelimitedFileDefinition();
@@ -50,10 +47,10 @@ class QgsDelimitedTextSourceSelect : public QgsAbstractDataSourceWidget, private
     bool trySetXYField( QStringList &fields, QList<bool> &isValidNumber, const QString &xname, const QString &yname );
 
   private:
-    QgsDelimitedTextFile *mFile = nullptr;
+    std::unique_ptr<QgsDelimitedTextFile> mFile;
     int mExampleRowCount = 20;
     int mBadRowCount = 0;
-    QString mPluginKey;
+    QString mSettingsKey;
     QString mLastFileType;
     QButtonGroup *bgFileFormat = nullptr;
     QButtonGroup *bgGeomType = nullptr;

--- a/src/providers/geonode/qgsgeonodesourceselect.cpp
+++ b/src/providers/geonode/qgsgeonodesourceselect.cpp
@@ -77,6 +77,11 @@ QgsGeoNodeSourceSelect::~QgsGeoNodeSourceSelect()
   emit abortRequests();
 }
 
+void QgsGeoNodeSourceSelect::reset()
+{
+  treeView->clearSelection();
+}
+
 void QgsGeoNodeSourceSelect::addConnectionsEntryList()
 {
   QgsGeoNodeNewConnection nc( this );

--- a/src/providers/geonode/qgsgeonodesourceselect.h
+++ b/src/providers/geonode/qgsgeonodesourceselect.h
@@ -45,7 +45,9 @@ class QgsGeoNodeSourceSelect: public QgsAbstractDataSourceWidget, private Ui::Qg
     QgsGeoNodeSourceSelect( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
     ~QgsGeoNodeSourceSelect() override;
 
-  public slots:
+    void reset() override;
+
+  private:
 
     void addButtonClicked() override;
 

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -662,6 +662,11 @@ QString QgsMssqlSourceSelect::connectionInfo()
   return mConnInfo;
 }
 
+void QgsMssqlSourceSelect::reset()
+{
+  mTablesTreeView->clearSelection();
+}
+
 void QgsMssqlSourceSelect::refresh()
 {
   populateConnectionList();

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -79,6 +79,8 @@ class QgsMssqlSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qgs
     //! Connection info (database, host, user, password)
     QString connectionInfo();
 
+    void reset() override;
+
   signals:
     void addGeometryColumn( const QgsMssqlLayerProperty & );
 

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -595,6 +595,11 @@ void QgsPgSourceSelect::columnThreadFinished()
   finishList();
 }
 
+void QgsPgSourceSelect::reset()
+{
+  mTablesTreeView->clearSelection();
+}
+
 QStringList QgsPgSourceSelect::selectedTables()
 {
   return mSelectedTables;

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -58,12 +58,12 @@ QWidget *QgsPgSourceSelectDelegate::createEditor( QWidget *parent, const QStyleO
   {
     QComboBox *cb = new QComboBox( parent );
     static const QList<QgsWkbTypes::Type> types { QgsWkbTypes::Point
-                                            , QgsWkbTypes::LineString
-                                            , QgsWkbTypes::Polygon
-                                            , QgsWkbTypes::MultiPoint
-                                            , QgsWkbTypes::MultiLineString
-                                            , QgsWkbTypes::MultiPolygon
-                                            , QgsWkbTypes::NoGeometry };
+        , QgsWkbTypes::LineString
+        , QgsWkbTypes::Polygon
+        , QgsWkbTypes::MultiPoint
+        , QgsWkbTypes::MultiLineString
+        , QgsWkbTypes::MultiPolygon
+        , QgsWkbTypes::NoGeometry };
     for ( QgsWkbTypes::Type type : types )
     {
       cb->addItem( QgsPgTableModel::iconForWkbType( type ), QgsPostgresConn::displayStringForWkbType( type ), type );

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -57,15 +57,14 @@ QWidget *QgsPgSourceSelectDelegate::createEditor( QWidget *parent, const QStyleO
   if ( index.column() == QgsPgTableModel::DbtmType && index.data( Qt::UserRole + 1 ).toBool() )
   {
     QComboBox *cb = new QComboBox( parent );
-    Q_FOREACH ( QgsWkbTypes::Type type,
-                QList<QgsWkbTypes::Type>()
-                << QgsWkbTypes::Point
-                << QgsWkbTypes::LineString
-                << QgsWkbTypes::Polygon
-                << QgsWkbTypes::MultiPoint
-                << QgsWkbTypes::MultiLineString
-                << QgsWkbTypes::MultiPolygon
-                << QgsWkbTypes::NoGeometry )
+    static const QList<QgsWkbTypes::Type> types { QgsWkbTypes::Point
+                                            , QgsWkbTypes::LineString
+                                            , QgsWkbTypes::Polygon
+                                            , QgsWkbTypes::MultiPoint
+                                            , QgsWkbTypes::MultiLineString
+                                            , QgsWkbTypes::MultiPolygon
+                                            , QgsWkbTypes::NoGeometry };
+    for ( QgsWkbTypes::Type type : types )
     {
       cb->addItem( QgsPgTableModel::iconForWkbType( type ), QgsPostgresConn::displayStringForWkbType( type ), type );
     }
@@ -74,7 +73,7 @@ QWidget *QgsPgSourceSelectDelegate::createEditor( QWidget *parent, const QStyleO
 
   if ( index.column() == QgsPgTableModel::DbtmPkCol )
   {
-    QStringList values = index.data( Qt::UserRole + 1 ).toStringList();
+    const QStringList values = index.data( Qt::UserRole + 1 ).toStringList();
 
     if ( !values.isEmpty() )
     {
@@ -84,8 +83,7 @@ QWidget *QgsPgSourceSelectDelegate::createEditor( QWidget *parent, const QStyleO
       QStandardItemModel *model = new QStandardItemModel( values.size(), 1, cb );
 
       int row = 0;
-      const auto constValues = values;
-      for ( const QString &value : constValues )
+      for ( const QString &value : values )
       {
         QStandardItem *item = new QStandardItem( value );
         item->setFlags( Qt::ItemIsUserCheckable | Qt::ItemIsEnabled );

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -122,6 +122,8 @@ class QgsPgSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsDbS
 
     void columnThreadFinished();
 
+    void reset() override;
+
   private:
     typedef QPair<QString, QString> geomPair;
     typedef QList<geomPair> geomCol;

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -126,6 +126,11 @@ QgsWFSSourceSelect::~QgsWFSSourceSelect()
   delete mBuildQueryButton;
 }
 
+void QgsWFSSourceSelect::reset()
+{
+  treeView->clearSelection();
+}
+
 void QgsWFSSourceSelect::populateConnectionList()
 {
   QStringList keys = QgsWfsConnection::connectionList();

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -67,6 +67,8 @@ class QgsWFSSourceSelect: public QgsAbstractDataSourceWidget, private Ui::QgsWFS
     QgsWFSSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
     ~QgsWFSSourceSelect() override;
 
+    void reset() override;
+
   private:
     QgsWFSSourceSelect(); //default constructor is forbidden
     QgsProjectionSelectionDialog *mProjectionSelector = nullptr;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -956,9 +956,9 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
     ++it2;
   }
 
-  QString layers = visibleLayers.join( QStringLiteral( "," ) );
+  QString layers = visibleLayers.join( ',' );
   layers = layers.isNull() ? QString() : layers;
-  QString styles = visibleStyles.join( QStringLiteral( "," ) );
+  QString styles = visibleStyles.join( ',' );
   styles = styles.isNull() ? QString() : styles;
 
   QgsDebugMsg( "Visible layer list of " + layers + " and style list of " + styles );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -592,6 +592,11 @@ void QgsWMSSourceSelect::addButtonClicked()
                        QStringLiteral( "wms" ) );
 }
 
+void QgsWMSSourceSelect::reset()
+{
+  lstLayers->clearSelection();
+}
+
 void QgsWMSSourceSelect::enableLayersForCrs( QTreeWidgetItem *item )
 {
   QString layerName = item->data( 0, Qt::UserRole + 0 ).toString();

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -276,7 +276,7 @@ void QgsWMSSourceSelect::clear()
 
 bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabilities )
 {
-  QVector<QgsWmsLayerProperty> layers = capabilities.supportedLayers();
+  const QVector<QgsWmsLayerProperty> layers = capabilities.supportedLayers();
 
   bool first = true;
   QSet<QString> alreadyAddedLabels;
@@ -316,32 +316,30 @@ bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabiliti
 
   int layerAndStyleCount = -1;
 
-  for ( QVector<QgsWmsLayerProperty>::iterator layer = layers.begin();
-        layer != layers.end();
-        ++layer )
+  for ( const QgsWmsLayerProperty &layer : layers )
   {
-    QgsTreeWidgetItem *lItem = createItem( layer->orderId, QStringList() << layer->name << layer->title << layer->abstract, items, layerAndStyleCount, layerParents, layerParentNames );
+    QgsTreeWidgetItem *lItem = createItem( layer.orderId, QStringList() << layer.name << layer.title << layer.abstract, items, layerAndStyleCount, layerParents, layerParentNames );
 
-    lItem->setData( 0, Qt::UserRole + 0, layer->name );
+    lItem->setData( 0, Qt::UserRole + 0, layer.name );
     lItem->setData( 0, Qt::UserRole + 1, "" );
-    lItem->setData( 0, Qt::UserRole + 2, layer->crs );
-    lItem->setData( 0, Qt::UserRole + 3, layer->title.isEmpty() ? layer->name : layer->title );
+    lItem->setData( 0, Qt::UserRole + 2, layer.crs );
+    lItem->setData( 0, Qt::UserRole + 3, layer.title.isEmpty() ? layer.name : layer.title );
 
     // Also insert the styles
     // Layer Styles
-    for ( int j = 0; j < layer->style.size(); j++ )
+    for ( const QgsWmsStyleProperty &property : layer.style )
     {
-      QgsDebugMsg( QStringLiteral( "got style name %1 and title '%2'." ).arg( layer->style.at( j ).name, layer->style.at( j ).title ) );
+      QgsDebugMsg( QStringLiteral( "got style name %1 and title '%2'." ).arg( property.name, property.title ) );
 
       QgsTreeWidgetItem *lItem2 = new QgsTreeWidgetItem( lItem );
       lItem2->setText( 0, QString::number( ++layerAndStyleCount ) );
-      lItem2->setText( 1, layer->style.at( j ).name.simplified() );
-      lItem2->setText( 2, layer->style.at( j ).title.simplified() );
-      lItem2->setText( 3, layer->style.at( j ).abstract.simplified() );
+      lItem2->setText( 1, property.name.simplified() );
+      lItem2->setText( 2, property.title.simplified() );
+      lItem2->setText( 3, property.abstract.simplified() );
 
-      lItem2->setData( 0, Qt::UserRole + 0, layer->name );
-      lItem2->setData( 0, Qt::UserRole + 1, layer->style.at( j ).name );
-      lItem2->setData( 0, Qt::UserRole + 3, layer->style.at( j ).title.isEmpty() ? layer->style.at( j ).name : layer->style.at( j ).title );
+      lItem2->setData( 0, Qt::UserRole + 0, layer.name );
+      lItem2->setData( 0, Qt::UserRole + 1, property.name );
+      lItem2->setData( 0, Qt::UserRole + 3, property.title.isEmpty() ? property.name : property.title );
     }
   }
 

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -51,10 +51,15 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
     //! Constructor
     QgsWMSSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
 
-  public slots:
-
     //! Triggered when the provider's connections need to be refreshed
     void refresh() override;
+
+    //! Determines the layers the user selected
+    void addButtonClicked() override;
+
+    void reset() override;
+
+  private slots:
 
     //! Opens the create connection dialog to build a new connection
     void btnNew_clicked();
@@ -72,9 +77,6 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
      * Once connected, available layers are displayed.
      */
     void btnConnect_clicked();
-
-    //! Determines the layers the user selected
-    void addButtonClicked() override;
 
     void searchFinished();
 


### PR DESCRIPTION
When the data source select dialog is closed and reopened it's much more likely that the user wants to add a different layer than last time he was using the dialog. So instead of offering him to add the same layer again, the selection is cleared and he is requested to make a new selection.