### PR TITLE
[QgsQuick] Custom filepaths for external resource widget

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -42,7 +42,23 @@ Item {
    * 2 - Relative path to defualtRoot (targetDir)
    */
   property int relativeStorageMode: config["RelativeStorage"]
-  property string targetDir: config["DefaultRoot"] ? config["DefaultRoot"] : homePath
+  property string targetDir: {
+    var expression = undefined
+    var collection = config["PropertyCollection"]
+    var props = collection["properties"]
+    if (props) {
+      if(props["propertyRootPath"]) {
+        var rootPathProps = props["propertyRootPath"]
+        expression = rootPathProps["expression"]
+      }
+    }
+
+    if (expression) {
+      QgsQuick.Utils.evaluateExpression(featurePair, activeProject, expression)
+    } else {
+      config["DefaultRoot"] ? config["DefaultRoot"] : homePath
+    }
+  }
   property string prefixToRelativePath: relativeStorageMode === 2 ? targetDir : homePath
   // Meant to be use with the save callback - stores image source
   property string sourceToDelete

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -114,7 +114,7 @@ Item {
   }
 
   function getAbsolutePath(prefix, pathFromValue) {
-    return (prefix) ? prefixToRelativePath + "/" + pathFromValue : pathFromValue
+    return (prefix) ? prefix + "/" + pathFromValue : pathFromValue
   }
 
   id: fieldItem
@@ -271,7 +271,6 @@ Item {
             }
             photoCapturePanelLoader.item.visible = true
             photoCapturePanelLoader.item.targetDir = targetDir
-            photoCapturePanelLoader.item.homePath = homePath
             photoCapturePanelLoader.item.prefixToRelativePath = prefixToRelativePath
             photoCapturePanelLoader.item.fieldItem = fieldItem
           }

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -254,7 +254,7 @@ Item {
     id: text
     height: parent.height
     width: imageContainer.width - 2* fieldItem.textMargin
-    wrapMode: Text.WordWrap
+    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
     minimumPixelSize: 50 * QgsQuick.Utils.dp
     text: qsTr("Image is not available: ") + image.currentValue
     font.pixelSize: buttonsContainer.itemHeight * 0.75

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -39,9 +39,16 @@ Item {
   /**
    * 0 - Relative path disabled
    * 1 - Relative path to project
-   * 2 - Relative path to defualtRoot (targetDir)
+   * 2 - Relative path to defaultRoot defined in the config - Default path field in the widget configuration form
    */
   property int relativeStorageMode: config["RelativeStorage"]
+
+  /**
+   * This evaluates the "default path" with the following order:
+   * 1. evaluate default path expression if defined,
+   * 2. use default path value if not empty,
+   * 3. use project home folder
+   */
   property string targetDir: {
     var expression = undefined
     var collection = config["PropertyCollection"]
@@ -59,7 +66,16 @@ Item {
       config["DefaultRoot"] ? config["DefaultRoot"] : homePath
     }
   }
-  property string prefixToRelativePath: relativeStorageMode === 2 ? targetDir : homePath
+  property string prefixToRelativePath: {
+    if (relativeStorageMode === 1 ) {
+      return homePath
+    } else if (relativeStorageMode === 2 ) {
+      return targetDir
+    }
+
+    // Prefix for absolute paths is empty
+    return ""
+  }
   // Meant to be use with the save callback - stores image source
   property string sourceToDelete
 
@@ -92,11 +108,11 @@ Item {
   ]
 
   Loader {
-    id: photoCaptuePanelLoader
+    id: photoCapturePanelLoader
   }
 
   Connections {
-    target: photoCaptuePanelLoader.item
+    target: photoCapturePanelLoader.item
     onConfirmButtonClicked: externalResourceHandler.confirmImage(fieldItem, path, filename)
   }
 
@@ -212,20 +228,20 @@ Item {
         MouseArea {
           anchors.fill: parent
           onClicked: {
-            var photoCapturePanel = photoCaptuePanelLoader.item
-            if (!photoCaptuePanelLoader.item) {
+            var photoCapturePanel = photoCapturePanelLoader.item
+            if (!photoCapturePanelLoader.item) {
               // Load the photo capture panel if not loaded yet
-              photoCaptuePanelLoader.setSource("qgsquickphotopanel.qml")
-              photoCaptuePanelLoader.item.height = window.height
-              photoCaptuePanelLoader.item.width = window.width
-              photoCaptuePanelLoader.item.edge = Qt.RightEdge
-              photoCaptuePanelLoader.item.imageButtonSize = fieldItem.iconSize
+              photoCapturePanelLoader.setSource("qgsquickphotopanel.qml")
+              photoCapturePanelLoader.item.height = window.height
+              photoCapturePanelLoader.item.width = window.width
+              photoCapturePanelLoader.item.edge = Qt.RightEdge
+              photoCapturePanelLoader.item.imageButtonSize = fieldItem.iconSize
             }
-            photoCaptuePanelLoader.item.visible = true
-            photoCaptuePanelLoader.item.targetDir = targetDir
-            photoCaptuePanelLoader.item.homePath = homePath
-            photoCaptuePanelLoader.item.prefixToRelativePath = prefixToRelativePath
-            photoCaptuePanelLoader.item.fieldItem = fieldItem
+            photoCapturePanelLoader.item.visible = true
+            photoCapturePanelLoader.item.targetDir = targetDir
+            photoCapturePanelLoader.item.homePath = homePath
+            photoCapturePanelLoader.item.prefixToRelativePath = prefixToRelativePath
+            photoCapturePanelLoader.item.fieldItem = fieldItem
           }
         }
       }

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -91,13 +91,12 @@ Item {
     }
   ]
 
-  QgsQuick.PhotoCapture {
-    id: photoCapturePanel
-    visible: false
-    height: window.height
-    width: window.width
-    edge: Qt.RightEdge
-    imageButtonSize: fieldItem.iconSize
+  Loader {
+    id: photoCaptuePanelLoader
+  }
+
+  Connections {
+    target: photoCaptuePanelLoader.item
     onConfirmButtonClicked: externalResourceHandler.confirmImage(fieldItem, path, filename)
   }
 
@@ -213,11 +212,20 @@ Item {
         MouseArea {
           anchors.fill: parent
           onClicked: {
-            photoCapturePanel.visible = true
-            photoCapturePanel.targetDir = targetDir
-            photoCapturePanel.homePath = homePath
-            photoCapturePanel.prefixToRelativePath = prefixToRelativePath
-            photoCapturePanel.fieldItem = fieldItem
+            var photoCapturePanel = photoCaptuePanelLoader.item
+            if (!photoCaptuePanelLoader.item) {
+              // Load the photo capture panel if not loaded yet
+              photoCaptuePanelLoader.setSource("qgsquickphotopanel.qml")
+              photoCaptuePanelLoader.item.height = window.height
+              photoCaptuePanelLoader.item.width = window.width
+              photoCaptuePanelLoader.item.edge = Qt.RightEdge
+              photoCaptuePanelLoader.item.imageButtonSize = fieldItem.iconSize
+            }
+            photoCaptuePanelLoader.item.visible = true
+            photoCaptuePanelLoader.item.targetDir = targetDir
+            photoCaptuePanelLoader.item.homePath = homePath
+            photoCaptuePanelLoader.item.prefixToRelativePath = prefixToRelativePath
+            photoCaptuePanelLoader.item.fieldItem = fieldItem
           }
         }
       }

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -38,12 +38,12 @@ Item {
   property real textMargin: QgsQuick.Utils.dp * 10
   /**
    * 0 - Relative path disabled
-   * 1 - Relative path to defualtRoot (targetDir)
-   * 2 - Relative path to project
+   * 1 - Relative path to project
+   * 2 - Relative path to defualtRoot (targetDir)
    */
   property int relativeStorageMode: config["RelativeStorage"]
   property string targetDir: config["DefaultRoot"] ? config["DefaultRoot"] : homePath
-  property string prefixToRelativePath: relativeStorageMode === 1 ? targetDir : homePath
+  property string prefixToRelativePath: relativeStorageMode === 2 ? targetDir : homePath
   // Meant to be use with the save callback - stores image source
   property string sourceToDelete
 
@@ -82,6 +82,7 @@ Item {
     width: window.width
     edge: Qt.RightEdge
     imageButtonSize: fieldItem.iconSize
+    onConfirmButtonClicked: externalResourceHandler.confirmImage(fieldItem, path, filename)
   }
 
   Rectangle {

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -36,6 +36,14 @@ Item {
   property var notAvailableImageIcon: customStyle.icons.notAvailable
   property real iconSize:  customStyle.fields.height
   property real textMargin: QgsQuick.Utils.dp * 10
+  /**
+   * 0 - Relative path disabled
+   * 1 - Relative path to defualtRoot (targetDir)
+   * 2 - Relative path to project
+   */
+  property int relativeStorageMode: config["RelativeStorage"]
+  property string targetDir: config["DefaultRoot"] ? config["DefaultRoot"] : homePath
+  property string prefixToRelativePath: relativeStorageMode === 1 ? targetDir : homePath
   // Meant to be use with the save callback - stores image source
   property string sourceToDelete
 
@@ -97,7 +105,7 @@ Item {
 
       MouseArea {
         anchors.fill: parent
-        onClicked: externalResourceHandler.previewImage(homePath + "/" + image.currentValue)
+        onClicked: externalResourceHandler.previewImage(prefixToRelativePath + "/" + image.currentValue)
       }
 
       onCurrentValueChanged: {
@@ -111,16 +119,16 @@ Item {
           fieldItem.state = "notAvailable"
           return ""
         }
-        else if (image.currentValue && QgsQuick.Utils.fileExists(homePath + "/" + image.currentValue)) {
+        else if (image.currentValue && QgsQuick.Utils.fileExists(prefixToRelativePath + "/" + image.currentValue)) {
           fieldItem.state = "valid"
-          return homePath + "/" + image.currentValue
+          return prefixToRelativePath + "/" + image.currentValue
         }
         else if (!image.currentValue) {
           fieldItem.state = "notSet"
           return ""
         }
         fieldItem.state = "notAvailable"
-        return homePath + "/" + image.currentValue
+        return prefixToRelativePath + "/" + image.currentValue
       }
     }
   }
@@ -136,7 +144,7 @@ Item {
     anchors.bottom: imageContainer.bottom
     anchors.margins: buttonsContainer.itemHeight/4
 
-    onClicked: externalResourceHandler.removeImage(fieldItem, homePath + "/" + image.currentValue)
+    onClicked: externalResourceHandler.removeImage(fieldItem, prefixToRelativePath + "/" + image.currentValue)
 
     background: Image {
       id: deleteIcon
@@ -189,7 +197,9 @@ Item {
           anchors.fill: parent
           onClicked: {
             photoCapturePanel.visible = true
-            photoCapturePanel.targetDir = homePath
+            photoCapturePanel.targetDir = targetDir
+            photoCapturePanel.homePath = homePath
+            photoCapturePanel.prefixToRelativePath = prefixToRelativePath
             photoCapturePanel.fieldItem = fieldItem
           }
         }

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -66,7 +66,7 @@ Item {
         /**
           * Called when clicked on the OK icon after taking a photo with the Photo panel.
           * \param itemWidget editorWidget for modified field to send valueChanged signal.
-          * \param prefixToRelativePath Absolute path to the image extracted by current value.
+          * \param prefixToRelativePath Together with the value creates absolute path
           * \param value Relative path of taken photo.
           */
         property var confirmImage: function confirmImage(itemWidget, prefixToRelativePath, value) {

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -62,6 +62,17 @@ Item {
           */
         property var removeImage: function removeImage(itemWidget, imagePath) {
         }
+
+        /**
+          * Called when clicked on the OK icon after taking a photo with the Photo panel.
+          * \param itemWidget editorWidget for modified field to send valueChanged signal.
+          * \param prefixToRelativePath Absolute path to the image extracted by current value.
+          * \param value Relative path of taken photo.
+          */
+        property var confirmImage: function confirmImage(itemWidget, prefixToRelativePath, value) {
+          itemWidget.image.source = prefixToRelativePath + "/" + value
+          itemWidget.valueChanged(value, value === "" || value === null)
+        }
     }
 
   /**

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -387,6 +387,8 @@ Item {
           property var customStyle: form.style
           property var externalResourceHandler: form.externalResourceHandler
           property bool readOnly: form.state == "ReadOnly" || !AttributeEditable
+          property var featurePair: form.model.attributeModel.featureLayerPair
+          property var activeProject: form.project
 
           active: widget !== 'Hidden'
 

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -24,9 +24,7 @@ import QgsQuick 0.1 as QgsQuick
 Drawer {
   // Capture path
   property var targetDir
-  // Path to project
-  property var homePath
-  // Along with lastPhotName creates an absolute path to a photo. Its either project path or defaultRoot.
+  // Along with lastPhotoName creates an absolute path to a photo. Its either project path or defaultRoot.
   property var prefixToRelativePath
   property var lastPhotoName
   property int iconSize: photoPanel.width/20

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -22,7 +22,12 @@ import QtGraphicalEffects 1.0
 import QgsQuick 0.1 as QgsQuick
 
 Drawer {
+  // Capture path
   property var targetDir
+  // Path to project
+  property var homePath
+  // Along with lastPhotName creates an absolute path to a photo. Its either project path or defaultRoot.
+  property var prefixToRelativePath
   property var lastPhotoName
   property int iconSize: photoPanel.width/20
   property var fieldItem
@@ -114,6 +119,7 @@ Drawer {
           id: mouseArea
           anchors.fill: parent
           onClicked: {
+            console.log("!!!mouseAreamouseArea@#!#Q@#TRGEWR TOOR", targetDir)
             if (targetDir !== "") {
               camera.imageCapture.captureToLocation(photoPanel.targetDir);
             } else {
@@ -200,9 +206,9 @@ Drawer {
             onClicked: {
               captureItem.saveImage = true
               photoPanel.visible = false
-              photoPanel.lastPhotoName = QgsQuick.Utils.getRelativePath(camera.imageCapture.capturedImagePath, photoPanel.targetDir)
+              photoPanel.lastPhotoName = QgsQuick.Utils.getRelativePath(camera.imageCapture.capturedImagePath, photoPanel.prefixToRelativePath)
               if (photoPanel.lastPhotoName !== "") {
-                fieldItem.image.source = photoPanel.targetDir + "/" + photoPanel.lastPhotoName
+                fieldItem.image.source = photoPanel.prefixToRelativePath + "/" + photoPanel.lastPhotoName
                 fieldItem.valueChanged(photoPanel.lastPhotoName, photoPanel.lastPhotoName === "" || photoPanel.lastPhotoName === null)
               }
             }

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -38,12 +38,13 @@ Drawer {
 
   // icons:
   property var captureButtonIcon: QgsQuick.Utils.getThemeIcon("ic_camera_alt_border")
-  property var okButtonIcon: QgsQuick.Utils.getThemeIcon("ic_check_black")
+  property var confirmButtonIcon: QgsQuick.Utils.getThemeIcon("ic_check_black")
   property var cancelButtonIcon: QgsQuick.Utils.getThemeIcon("ic_clear_black")
   property real imageButtonSize: 45 * QgsQuick.Utils.dp
   property real buttonSize: imageButtonSize * 1.2
   property var buttonsPosition
 
+  signal confirmButtonClicked(string path, string filename)
 
   id: photoPanel
   visible: false
@@ -119,7 +120,6 @@ Drawer {
           id: mouseArea
           anchors.fill: parent
           onClicked: {
-            console.log("!!!mouseAreamouseArea@#!#Q@#TRGEWR TOOR", targetDir)
             if (targetDir !== "") {
               camera.imageCapture.captureToLocation(photoPanel.targetDir);
             } else {
@@ -185,7 +185,7 @@ Drawer {
           }
         }
 
-        // OK button
+        // Confirm button
         Rectangle {
           id: confirmButton
           visible: camera.imageCapture.capturedImagePath != ""
@@ -207,10 +207,7 @@ Drawer {
               captureItem.saveImage = true
               photoPanel.visible = false
               photoPanel.lastPhotoName = QgsQuick.Utils.getRelativePath(camera.imageCapture.capturedImagePath, photoPanel.prefixToRelativePath)
-              if (photoPanel.lastPhotoName !== "") {
-                fieldItem.image.source = photoPanel.prefixToRelativePath + "/" + photoPanel.lastPhotoName
-                fieldItem.valueChanged(photoPanel.lastPhotoName, photoPanel.lastPhotoName === "" || photoPanel.lastPhotoName === null)
-              }
+              confirmButtonClicked(photoPanel.prefixToRelativePath, photoPanel.lastPhotoName)
             }
           }
 
@@ -221,7 +218,7 @@ Drawer {
             sourceSize.width: imageButtonSize
             height: imageButtonSize
             width: imageButtonSize
-            source: photoPanel.okButtonIcon
+            source: photoPanel.confirmButtonIcon
           }
         }
       }

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -147,6 +147,7 @@ Drawer {
         width: parent.width
         height: parent.height
         fillMode: Image.PreserveAspectFit
+        onVisibleChanged: if (!photoPreview.visible) photoPreview.source = ""
 
         // Cancel button
         Rectangle {

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -98,19 +98,21 @@ bool QgsQuickUtils::fileExists( const QString &path )
 
 QString QgsQuickUtils::getRelativePath( const QString &path, const QString &prefixPath )
 {
-  QDir absoluteDir(path);
-  QDir prefixDir(prefixPath);
+  QDir absoluteDir( path );
+  QDir prefixDir( prefixPath );
 
   QString canonicalPath = absoluteDir.canonicalPath();
   QString prefixCanonicalPath = prefixDir.canonicalPath() + "/";
 
-  if (canonicalPath.startsWith(prefixCanonicalPath)) {
-      return canonicalPath.replace(prefixCanonicalPath, QString());
+  if ( canonicalPath.startsWith( prefixCanonicalPath ) )
+  {
+    return canonicalPath.replace( prefixCanonicalPath, QString() );
   }
 
   QString filePrefixPath = QStringLiteral( "file://%1" ).arg( prefixCanonicalPath );
-  if ( canonicalPath.startsWith( filePrefixPath ) ) {
-      return canonicalPath.replace( filePrefixPath, QString() );
+  if ( canonicalPath.startsWith( filePrefixPath ) )
+  {
+    return canonicalPath.replace( filePrefixPath, QString() );
   }
 
   return QString();

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -98,18 +98,20 @@ bool QgsQuickUtils::fileExists( const QString &path )
 
 QString QgsQuickUtils::getRelativePath( const QString &path, const QString &prefixPath )
 {
-  QString resultPath = path;
-  QString prefixPathWithSlash;
-  if ( !prefixPath.endsWith( "/" ) )
-    prefixPathWithSlash = QStringLiteral( "%1/" ).arg( prefixPath );
-  else
-    prefixPathWithSlash = prefixPath;
+  QDir absoluteDir(path);
+  QDir prefixDir(prefixPath);
 
-  if ( resultPath.startsWith( prefixPathWithSlash ) )
-    return resultPath.replace( prefixPathWithSlash, QString() );
-  QString filePrefixPath = QStringLiteral( "file://%1" ).arg( prefixPathWithSlash );
-  if ( resultPath.startsWith( filePrefixPath ) )
-    return resultPath.replace( filePrefixPath, QString() );
+  QString canonicalPath = absoluteDir.canonicalPath();
+  QString prefixCanonicalPath = prefixDir.canonicalPath() + "/";
+
+  if (canonicalPath.startsWith(prefixCanonicalPath)) {
+      return canonicalPath.replace(prefixCanonicalPath, QString());
+  }
+
+  QString filePrefixPath = QStringLiteral( "file://%1" ).arg( prefixCanonicalPath );
+  if ( canonicalPath.startsWith( filePrefixPath ) ) {
+      return canonicalPath.replace( filePrefixPath, QString() );
+  }
 
   return QString();
 }

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -98,21 +98,24 @@ bool QgsQuickUtils::fileExists( const QString &path )
 
 QString QgsQuickUtils::getRelativePath( const QString &path, const QString &prefixPath )
 {
-  QDir absoluteDir( path );
-  QDir prefixDir( prefixPath );
+  QString modPath = path;
+  QString filePrefix( "file://" );
 
+  if ( path.startsWith( filePrefix ) )
+  {
+    modPath = modPath.replace( filePrefix, QString() );
+  }
+
+  if ( prefixPath.isEmpty() ) return modPath;
+
+  QDir absoluteDir( modPath );
+  QDir prefixDir( prefixPath );
   QString canonicalPath = absoluteDir.canonicalPath();
   QString prefixCanonicalPath = prefixDir.canonicalPath() + "/";
 
-  if ( canonicalPath.startsWith( prefixCanonicalPath ) )
+  if ( prefixCanonicalPath.length() > 1 && canonicalPath.startsWith( prefixCanonicalPath ) )
   {
     return canonicalPath.replace( prefixCanonicalPath, QString() );
-  }
-
-  QString filePrefixPath = QStringLiteral( "file://%1" ).arg( prefixCanonicalPath );
-  if ( canonicalPath.startsWith( filePrefixPath ) )
-  {
-    return canonicalPath.replace( filePrefixPath, QString() );
   }
 
   return QString();

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -108,14 +108,25 @@ QString QgsQuickUtils::getRelativePath( const QString &path, const QString &pref
 
   if ( prefixPath.isEmpty() ) return modPath;
 
-  QDir absoluteDir( modPath );
-  QDir prefixDir( prefixPath );
-  QString canonicalPath = absoluteDir.canonicalPath();
-  QString prefixCanonicalPath = prefixDir.canonicalPath() + "/";
-
-  if ( prefixCanonicalPath.length() > 1 && canonicalPath.startsWith( prefixCanonicalPath ) )
+  // Do not use a canonical path for non-existing path
+  if ( !QFileInfo( path ).exists() )
   {
-    return canonicalPath.replace( prefixCanonicalPath, QString() );
+    if ( !prefixPath.isEmpty() && modPath.startsWith( prefixPath ) )
+    {
+      return modPath.replace( prefixPath, QString() );
+    }
+  }
+  else
+  {
+    QDir absoluteDir( modPath );
+    QDir prefixDir( prefixPath );
+    QString canonicalPath = absoluteDir.canonicalPath();
+    QString prefixCanonicalPath = prefixDir.canonicalPath() + "/";
+
+    if ( prefixCanonicalPath.length() > 1 && canonicalPath.startsWith( prefixCanonicalPath ) )
+    {
+      return canonicalPath.replace( prefixCanonicalPath, QString() );
+    }
   }
 
   return QString();

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -343,6 +343,19 @@ QVariantMap QgsQuickUtils::createValueRelationCache( const QVariantMap &config, 
   return valueMap;
 }
 
+QString QgsQuickUtils::evaluateExpression( const QgsQuickFeatureLayerPair &pair, QgsProject *activeProject, const QString &expression )
+{
+  QList<QgsExpressionContextScope *> scopes;
+  scopes << QgsExpressionContextUtils::globalScope();
+  scopes << QgsExpressionContextUtils::projectScope( activeProject );
+  scopes << QgsExpressionContextUtils::layerScope( pair.layer() );
+
+  QgsExpressionContext context( scopes );
+  context.setFeature( pair.feature() );
+  QgsExpression expr( expression );
+  return expr.evaluate( &context ).toString();
+}
+
 qreal QgsQuickUtils::screenDensity() const
 {
   return mScreenDensity;

--- a/src/quickgui/qgsquickutils.h
+++ b/src/quickgui/qgsquickutils.h
@@ -25,6 +25,7 @@
 #include <limits>
 
 #include "qgis.h"
+#include "qgsexpressioncontextutils.h"
 #include "qgsmessagelog.h"
 #include "qgspoint.h"
 #include "qgspointxy.h"
@@ -240,6 +241,17 @@ class QUICK_EXPORT QgsQuickUtils: public QObject
      * \since QGIS 3.6
      */
     Q_INVOKABLE static QVariantMap createValueRelationCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature() );
+
+    /**
+     * Evaluates expression.
+     * \param pair Used to define a context scope.
+     * \param activeProject Used to define a context scope.
+     * \param expression
+     * \return Evaluated expression
+     *
+     * \since QGIS 3.10
+     */
+    Q_INVOKABLE static QString evaluateExpression( const QgsQuickFeatureLayerPair &pair, QgsProject *activeProject, const QString &expression );
 
   private:
     static void formatToMetricDistance( double srcDistance,

--- a/tests/src/quickgui/testqgsquickutils.cpp
+++ b/tests/src/quickgui/testqgsquickutils.cpp
@@ -185,6 +185,9 @@ void TestQgsQuickUtils::getRelativePath()
 
   QString relativePath4 = utils.getRelativePath( path2, QStringLiteral( "/dummy/path/" ) );
   QCOMPARE( QString(), relativePath4 );
+
+  QString relativePath5 = utils.getRelativePath( path2, QStringLiteral( "" ) );
+  QCOMPARE( path2, relativePath5 );
 }
 
 


### PR DESCRIPTION
* Added support for defining defaultPath:
 while taking pictures with external widget's photoPanel. Default path is taken from a widget config `path -> default path`. Also options `Relative to project path` or `Relative to default path` are taken into account. In addition, default path can also contain expression, which is evaluated in global, project and layer scope. Therefore these properties have been added while creating widgets.
* Loading PhotoCapturePanel only when needed:
The panel has been loaded with a form even if it wasn't needed at that moment. In addition, it was asking permissions for accessing camera on form load which was odd. Since the loader is used, its loaded after 'capture' action is initialised. 
* Long filenames wrapping
WrapAtWordBoundaryOrAnywhere is used now to prevent overflowing of a long name of files.
