### PR TITLE
Hide browse button on attachment widget in attribute table

### DIFF
--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -175,7 +175,8 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
     }
     if ( cfg.contains( QStringLiteral( "FileWidgetButton" ) ) )
     {
-      mQgsWidget->fileWidget()->setFileWidgetButtonVisible( cfg.value( QStringLiteral( "FileWidgetButton" ) ).toBool() );
+      // Prevent from showing the button in the attribute table, see https://github.com/qgis/QGIS/issues/26948
+      mQgsWidget->fileWidget()->setFileWidgetButtonVisible( cfg.value( QStringLiteral( "FileWidgetButton" ) ).toBool() && context().formMode() != QgsAttributeEditorContext::Popup );
     }
     if ( cfg.contains( QStringLiteral( "DocumentViewer" ) ) )
     {


### PR DESCRIPTION
Basically a workaround for a crash in the attachment/external resource widget. By hiding the browse button it's simply not possible for a user to trigger the crash.

It would be nicer to "really" fix the issue, but that will probably involve advanced black magic, to control the focus of the editor while the file browser dialog is open. Or prevent the widget from being deleted when the focus changes (but still making sure it's deleted at an appropriate time). Or maybe it's not that complicated and someone just needs to find the right Qt docs that advise how to properly solve the issue.

Be it as it may, this band aid patch avoids a crash/data corruption.

References #26948 