### PR TITLE
[processing] Use lists, not maps in overlap analysis algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/overlap_analysis_3.gml
+++ b/python/plugins/processing/tests/testdata/expected/overlap_analysis_3.gml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ overlap_analysis_3.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>1</gml:X><gml:Y>1</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>16</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,1 5,1 5,5 1,5 1,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A1</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>5.46318091048328</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>34.3750000042063</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>3.9732224830741</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>25.0000000201901</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>3.9732224787957</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>24.99999999327</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>2.97991685909677</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>18.7499999949525</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>2.97991685909677</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>18.7499999949525</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>2.97991685909677</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>18.7499999949525</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,2 4,2 4,4 2,4 2,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A2</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0.993305619698925</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>25</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0.993305619698925</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>25</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0.993305619698925</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>25</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>1.98661123939785</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>50</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>7,2 9,2 9,4 7,4 7,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A3</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>1.98661123939785</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>50</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>1.98661123939785</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>50</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,5 6,5 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A4</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>2.97991686016637</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>18.7500000016825</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>4.96652810063382</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>31.2500000050475</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0.993305619698925</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>6.24999999831749</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0.993305619698925</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>6.24999999831749</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.4">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,6 3,6 3,10 1,10 1,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A5</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>3.9732224798653</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>50</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,6 5,6 5,10 3,10 3,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A6</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>1.98661123939785</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>24.99999999327</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>1.98661123939785</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>24.99999999327</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.6">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,6 10,6 10,10 6,10 6,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A7</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>2.97991685909677</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>18.7499999949525</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>2.97991685909677</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>18.7499999949525</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.7">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,11 4,11 4,14 1,14 1,11</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A8</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.8">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,13 4,13 4,16 1,16 1,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A9</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.9">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,12 5,12 5,15 2,15 2,12</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A10</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.10">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,11 10,11 10,12 7,12 7,15 6,15 6,11</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A11</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:overlap_analysis_3 fid="overlap_analysis_3.11">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:3857"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>8,13 10,13 10,15 8,15 8,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:id_a>A12</ogr:id_a>
+      <ogr:custom_overlay3_b.geojson_area>0</ogr:custom_overlay3_b.geojson_area>
+      <ogr:custom_overlay3_b.geojson_pc>0</ogr:custom_overlay3_b.geojson_pc>
+      <ogr:custom_overlay1_b.geojson_area>0</ogr:custom_overlay1_b.geojson_area>
+      <ogr:custom_overlay1_b.geojson_pc>0</ogr:custom_overlay1_b.geojson_pc>
+      <ogr:custom_overlay2_a.geojson_area>0</ogr:custom_overlay2_a.geojson_area>
+      <ogr:custom_overlay2_a.geojson_pc>0</ogr:custom_overlay2_a.geojson_pc>
+      <ogr:custom_overlay2_b.geojson_area>0</ogr:custom_overlay2_b.geojson_area>
+      <ogr:custom_overlay2_b.geojson_pc>0</ogr:custom_overlay2_b.geojson_pc>
+      <ogr:custom_overlay1_a.geojson_area>0</ogr:custom_overlay1_a.geojson_area>
+      <ogr:custom_overlay1_a.geojson_pc>0</ogr:custom_overlay1_a.geojson_pc>
+      <ogr:custom_overlay3_a.geojson_area>0</ogr:custom_overlay3_a.geojson_area>
+      <ogr:custom_overlay3_a.geojson_pc>0</ogr:custom_overlay3_a.geojson_pc>
+    </ogr:overlap_analysis_3>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/overlap_analysis_3.xsd
+++ b/python/plugins/processing/tests/testdata/expected/overlap_analysis_3.xsd
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="overlap_analysis_3" type="ogr:overlap_analysis_3_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="overlap_analysis_3_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id_a" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay3_b.geojson_area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay3_b.geojson_pc" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay1_b.geojson_area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay1_b.geojson_pc" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay2_a.geojson_area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay2_a.geojson_pc" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay2_b.geojson_area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay2_b.geojson_pc" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay1_a.geojson_area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay1_a.geojson_pc" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay3_a.geojson_area" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="custom_overlay3_a.geojson_pc" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2209,4 +2209,58 @@ tests:
             custom_overlay2_b.geojson_pc:
               precision: 7
 
+  - algorithm: native:calculatevectoroverlaps
+    name: Overlap analysis 3, reordered inputs
+    ellipsoid: GRS80
+    project_crs: EPSG:4326
+    params:
+      INPUT:
+        name: custom/overlay0.geojson
+        type: vector
+      LAYERS:
+        params:
+        - name: custom/overlay3_b.geojson
+          type: vector
+        - name: custom/overlay1_b.geojson
+          type: vector
+        - name: custom/overlay2_a.geojson
+          type: vector
+        - name: custom/overlay2_b.geojson
+          type: vector
+        - name: custom/overlay1_a.geojson
+          type: vector
+        - name: custom/overlay3_a.geojson
+          type: vector
+        type: multi
+    results:
+      OUTPUT:
+        name: expected/overlap_analysis_3.gml
+        type: vector
+        compare:
+          fields:
+            custom_overlay1_a.geojson_area:
+              precision: 8
+            custom_overlay1_a.geojson_pc:
+              precision: 3
+            custom_overlay1_b.geojson_area:
+              precision: 8
+            custom_overlay1_b.geojson_pc:
+              precision: 3
+            custom_overlay2_a.geojson_area:
+              precision: 8
+            custom_overlay2_a.geojson_pc:
+              precision: 3
+            custom_overlay2_b.geojson_area:
+              precision: 8
+            custom_overlay2_b.geojson_pc:
+              precision: 3
+            custom_overlay3_a.geojson_area:
+              precision: 8
+            custom_overlay3_a.geojson_pc:
+              precision: 3
+            custom_overlay3_b.geojson_area:
+              precision: 8
+            custom_overlay3_b.geojson_pc:
+              precision: 3
+
 # See ../README.md for a description of the file format

--- a/src/analysis/processing/qgsalgorithmcalculateoverlaps.h
+++ b/src/analysis/processing/qgsalgorithmcalculateoverlaps.h
@@ -56,7 +56,8 @@ class QgsCalculateVectorOverlapsAlgorithm : public QgsProcessingAlgorithm
   private:
 
     std::unique_ptr< QgsProcessingFeatureSource > mSource;
-    std::map< QString, std::unique_ptr< QgsVectorLayerFeatureSource > > mOverlayerSources;
+    QStringList mLayerNames;
+    std::vector< std::unique_ptr< QgsVectorLayerFeatureSource > > mOverlayerSources;
     QgsFields mOutputFields;
     QgsWkbTypes::Type mOutputType = QgsWkbTypes::Unknown;
     QgsCoordinateReferenceSystem mCrs;


### PR DESCRIPTION
Ensures consistent field ordering and that fields are always matched to input layer order
