### PR TITLE
[FEATURE] [needs-docs] Add circular data dependencies

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1656,9 +1656,9 @@ Sets error message
  bool hasDependencyCycle( const QSet<QgsMapLayerDependency> & ) const;
 %Docstring
 Checks whether a new set of dependencies will introduce a cycle
+this method is now deprecated and always return false, because circular dependencies are now correctly managed.
 
-.. deprecated:: since QGIS 3.10, this method always return false, because circular dependencies
-are now correctly managed.
+.. deprecated:: since QGIS 3.10
 %End
 
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1653,11 +1653,6 @@ Sets error message
 
 
 
-    bool hasDependencyCycle( const QSet<QgsMapLayerDependency> &layers ) const;
-%Docstring
-Checks whether a new set of dependencies will introduce a cycle
-%End
-
 
 
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1653,6 +1653,14 @@ Sets error message
 
 
 
+ bool hasDependencyCycle( const QSet<QgsMapLayerDependency> & ) const;
+%Docstring
+Checks whether a new set of dependencies will introduce a cycle
+
+.. deprecated:: since QGIS 3.10, this method always return false, because circular dependencies
+are now correctly managed.
+%End
+
 
 
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -350,11 +350,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   restoreOptionsBaseUi( title );
 
   mLayersDependenciesTreeGroup.reset( QgsProject::instance()->layerTreeRoot()->clone() );
-  QgsLayerTreeLayer *layer = mLayersDependenciesTreeGroup->findLayer( mLayer->id() );
-  if ( layer )
-  {
-    layer->parent()->takeChild( layer );
-  }
   mLayersDependenciesTreeModel.reset( new QgsLayerTreeModel( mLayersDependenciesTreeGroup.get() ) );
   // use visibility as selection
   mLayersDependenciesTreeModel->setFlag( QgsLayerTreeModel::AllowNodeChangeVisibility );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1769,7 +1769,12 @@ QgsAbstract3DRenderer *QgsMapLayer::renderer3D() const
 
 void QgsMapLayer::triggerRepaint( bool deferredUpdate )
 {
+  if ( mRepaintRequestedFired )
+    return;
+
+  mRepaintRequestedFired = true;
   emit repaintRequested( deferredUpdate );
+  mRepaintRequestedFired = false;
 }
 
 void QgsMapLayer::setMetadata( const QgsLayerMetadata &metadata )
@@ -1797,54 +1802,6 @@ void QgsMapLayer::emitStyleChanged()
 void QgsMapLayer::setExtent( const QgsRectangle &r )
 {
   mExtent = r;
-}
-
-static QList<const QgsMapLayer *> _depOutEdges( const QgsMapLayer *vl, const QgsMapLayer *that, const QSet<QgsMapLayerDependency> &layers )
-{
-  QList<const QgsMapLayer *> lst;
-  if ( vl == that )
-  {
-    const auto constLayers = layers;
-    for ( const QgsMapLayerDependency &dep : constLayers )
-    {
-      if ( const QgsMapLayer *l = QgsProject::instance()->mapLayer( dep.layerId() ) )
-        lst << l;
-    }
-  }
-  else
-  {
-    const auto constDependencies = vl->dependencies();
-    for ( const QgsMapLayerDependency &dep : constDependencies )
-    {
-      if ( const QgsMapLayer *l = QgsProject::instance()->mapLayer( dep.layerId() ) )
-        lst << l;
-    }
-  }
-  return lst;
-}
-
-static bool _depHasCycleDFS( const QgsMapLayer *n, QHash<const QgsMapLayer *, int> &mark, const QgsMapLayer *that, const QSet<QgsMapLayerDependency> &layers )
-{
-  if ( mark.value( n ) == 1 ) // temporary
-    return true;
-  if ( mark.value( n ) == 0 ) // not visited
-  {
-    mark[n] = 1; // temporary
-    const auto depOutEdges { _depOutEdges( n, that, layers ) };
-    for ( const QgsMapLayer *m : depOutEdges )
-    {
-      if ( _depHasCycleDFS( m, mark, that, layers ) )
-        return true;
-    }
-    mark[n] = 2; // permanent
-  }
-  return false;
-}
-
-bool QgsMapLayer::hasDependencyCycle( const QSet<QgsMapLayerDependency> &layers ) const
-{
-  QHash<const QgsMapLayer *, int> marks;
-  return _depHasCycleDFS( this, marks, this, layers );
 }
 
 bool QgsMapLayer::isReadOnly() const
@@ -1902,8 +1859,6 @@ bool QgsMapLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     if ( dep.origin() == QgsMapLayerDependency::FromUser )
       deps << dep;
   }
-  if ( hasDependencyCycle( deps ) )
-    return false;
 
   mDependencies = deps;
   emit dependenciesChanged();
@@ -1933,4 +1888,3 @@ void QgsMapLayer::onNotifiedTriggerRepaint( const QString &message )
   if ( refreshOnNotifyMessage().isEmpty() || refreshOnNotifyMessage() == message )
     triggerRepaint();
 }
-

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1501,8 +1501,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Checks whether a new set of dependencies will introduce a cycle
-     * \deprecated since QGIS 3.10, this method always return false, because circular dependencies
-     * are now correctly managed.
+     * this method is now deprecated and always return false, because circular dependencies are now correctly managed.
+     * \deprecated since QGIS 3.10
      */
     Q_DECL_DEPRECATED bool hasDependencyCycle( const QSet<QgsMapLayerDependency> & ) const {return false;}
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1499,9 +1499,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! List of layers that may modify this layer on modification
     QSet<QgsMapLayerDependency> mDependencies;
 
-    //! Checks whether a new set of dependencies will introduce a cycle
-    bool hasDependencyCycle( const QSet<QgsMapLayerDependency> &layers ) const;
-
     bool mIsRefreshOnNofifyEnabled = false;
     QString mRefreshOnNofifyMessage;
 
@@ -1585,7 +1582,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     QString mOriginalXmlProperties;
 
-
+    //! To avoid firing multiple time repaintRequested signal on circular layer circular dependencies
+    bool mRepaintRequestedFired = false;
 };
 
 Q_DECLARE_METATYPE( QgsMapLayer * )

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1499,6 +1499,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! List of layers that may modify this layer on modification
     QSet<QgsMapLayerDependency> mDependencies;
 
+    /**
+     * Checks whether a new set of dependencies will introduce a cycle
+     * \deprecated since QGIS 3.10, this method always return false, because circular dependencies
+     * are now correctly managed.
+     */
+    Q_DECL_DEPRECATED bool hasDependencyCycle( const QSet<QgsMapLayerDependency> & ) const {return false;}
+
     bool mIsRefreshOnNofifyEnabled = false;
     QString mRefreshOnNofifyMessage;
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -170,7 +170,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
     setDataSource( vectorLayerPath, baseName, providerKey, providerOptions, options.loadDefaultStyle );
   }
 
-  connect( this, &QgsVectorLayer::selectionChanged, this, [ = ] { emit repaintRequested(); } );
+  connect( this, &QgsVectorLayer::selectionChanged, this, [ = ] { triggerRepaint(); } );
   connect( QgsProject::instance()->relationManager(), &QgsRelationManager::relationsLoaded, this, &QgsVectorLayer::onRelationsLoaded );
 
   connect( this, &QgsVectorLayer::subsetStringChanged, this, &QgsMapLayer::configChanged );
@@ -901,7 +901,7 @@ bool QgsVectorLayer::setSubsetString( const QString &subset )
   if ( res )
   {
     emit subsetStringChanged();
-    emit repaintRequested();
+    triggerRepaint();
   }
 
   return res;
@@ -1578,7 +1578,7 @@ void QgsVectorLayer::setDataSource( const QString &dataSource, const QString &ba
   }
 
   emit dataSourceChanged();
-  emit repaintRequested();
+  triggerRepaint();
 }
 
 QString QgsVectorLayer::loadDefaultStyle( bool &resultFlag )
@@ -1702,7 +1702,7 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
     mDataSource = mDataSource + QStringLiteral( "&uid=%1" ).arg( QUuid::createUuid().toString() );
   }
 
-  connect( mDataProvider, &QgsVectorDataProvider::dataChanged, this, &QgsVectorLayer::dataChanged );
+  connect( mDataProvider, &QgsVectorDataProvider::dataChanged, this, &QgsVectorLayer::emitDataChanged );
   connect( mDataProvider, &QgsVectorDataProvider::dataChanged, this, &QgsVectorLayer::removeSelection );
 
   return true;
@@ -2991,7 +2991,7 @@ bool QgsVectorLayer::commitChanges()
 
   mDataProvider->leaveUpdateMode();
 
-  emit repaintRequested();
+  triggerRepaint();
 
   return success;
 }
@@ -3040,7 +3040,7 @@ bool QgsVectorLayer::rollBack( bool deleteBuffer )
 
   mDataProvider->leaveUpdateMode();
 
-  emit repaintRequested();
+  triggerRepaint();
   return true;
 }
 
@@ -4654,6 +4654,16 @@ QSet<QgsMapLayerDependency> QgsVectorLayer::dependencies() const
   return mDependencies;
 }
 
+void QgsVectorLayer::emitDataChanged()
+{
+  if ( mDataChangedFired )
+    return;
+
+  mDataChangedFired = true;
+  emit dataChanged();
+  mDataChangedFired = false;
+}
+
 bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
 {
   QSet<QgsMapLayerDependency> deps;
@@ -4663,8 +4673,6 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     if ( dep.origin() == QgsMapLayerDependency::FromUser )
       deps << dep;
   }
-  if ( hasDependencyCycle( deps ) )
-    return false;
 
   QSet<QgsMapLayerDependency> toAdd = deps - dependencies();
 
@@ -4674,10 +4682,10 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     QgsVectorLayer *lyr = static_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( dep.layerId() ) );
     if ( !lyr )
       continue;
-    disconnect( lyr, &QgsVectorLayer::featureAdded, this, &QgsVectorLayer::dataChanged );
-    disconnect( lyr, &QgsVectorLayer::featureDeleted, this, &QgsVectorLayer::dataChanged );
-    disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::dataChanged );
-    disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::dataChanged );
+    disconnect( lyr, &QgsVectorLayer::featureAdded, this, &QgsVectorLayer::emitDataChanged );
+    disconnect( lyr, &QgsVectorLayer::featureDeleted, this, &QgsVectorLayer::emitDataChanged );
+    disconnect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
+    disconnect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     disconnect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
   }
 
@@ -4694,16 +4702,16 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
     QgsVectorLayer *lyr = static_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( dep.layerId() ) );
     if ( !lyr )
       continue;
-    connect( lyr, &QgsVectorLayer::featureAdded, this, &QgsVectorLayer::dataChanged );
-    connect( lyr, &QgsVectorLayer::featureDeleted, this, &QgsVectorLayer::dataChanged );
-    connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::dataChanged );
-    connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::dataChanged );
+    connect( lyr, &QgsVectorLayer::featureAdded, this, &QgsVectorLayer::emitDataChanged );
+    connect( lyr, &QgsVectorLayer::featureDeleted, this, &QgsVectorLayer::emitDataChanged );
+    connect( lyr, &QgsVectorLayer::geometryChanged, this, &QgsVectorLayer::emitDataChanged );
+    connect( lyr, &QgsVectorLayer::dataChanged, this, &QgsVectorLayer::emitDataChanged );
     connect( lyr, &QgsVectorLayer::repaintRequested, this, &QgsVectorLayer::triggerRepaint );
   }
 
   // if new layers are present, emit a data change
   if ( ! toAdd.isEmpty() )
-    emit dataChanged();
+    emitDataChanged();
 
   return true;
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2464,6 +2464,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onRelationsLoaded();
     void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
+    void emitDataChanged();
 
   private:
     void updateDefaultValues( QgsFeatureId fid, QgsFeature feature = QgsFeature() );
@@ -2626,6 +2627,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     bool mAllowCommit = true;
 
     friend class QgsVectorLayerFeatureSource;
+
+    //! To avoid firing multiple time dataChanged signal on circular layer circular dependencies
+    bool mDataChangedFired = false;
 };
 
 

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -176,7 +176,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.pointsLayer.setDependencies([])
         self.pointsLayer2.setDependencies([])
 
-    def test_circularDependencies_with_2_layers(self):
+    def test_circular_dependencies_with_2_layers(self):
 
         spy_points_data_changed = QSignalSpy(self.pointsLayer.dataChanged)
         spy_lines_data_changed = QSignalSpy(self.linesLayer.dataChanged)
@@ -219,7 +219,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.assertEqual(len(spy_lines_repaint_requested), 1)
         self.assertEqual(len(spy_points_repaint_requested), 1)
 
-    def test_circularDependencies_with_1_layer(self):
+    def test_circular_dependencies_with_1_layer(self):
 
         # You can define a layer dependent on it self (for instance, a line
         # layer that trigger connected lines modifications when you modify
@@ -237,14 +237,14 @@ class TestLayerDependencies(unittest.TestCase):
         f.setGeometry(geom)
         self.linesLayer.startEditing()
 
-        # line fire featureAdded so dependening line fire dataChanged once more
-        self.pointsLayer.addFeatures([f])
+        # line fire featureAdded so depending line fire dataChanged once more
+        self.linesLayer.addFeatures([f])
         self.assertEqual(len(spy_lines_data_changed), 2)
 
         # added feature is deleted and added with its new defined id
         # (it was -1 before) so it fires 2 more signal dataChanged on
         # depending line (on featureAdded and on featureDeleted)
-        self.pointsLayer.commitChanges()
+        self.linesLayer.commitChanges()
         self.assertEqual(len(spy_lines_data_changed), 4)
 
         # repaintRequested is called only once on commit changes on line

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -45,12 +45,20 @@ class TestLayerDependencies(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Run before all tests"""
+        pass
 
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+        pass
+
+    def setUp(self):
+        """Run before each test."""
         # create a temp SpatiaLite db with a trigger
         fo = tempfile.NamedTemporaryFile()
         fn = fo.name
         fo.close()
-        cls.fn = fn
+        self.fn = fn
         con = spatialite_connect(fn)
         cur = con.cursor()
         cur.execute("SELECT InitSpatialMetadata(1)")
@@ -67,33 +75,25 @@ class TestLayerDependencies(unittest.TestCase):
         con.commit()
         con.close()
 
-        cls.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % fn, "points", "spatialite")
-        assert (cls.pointsLayer.isValid())
-        cls.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % fn, "lines", "spatialite")
-        assert (cls.linesLayer.isValid())
-        cls.pointsLayer2 = QgsVectorLayer("dbname='%s' table=\"node2\" (geom) sql=" % fn, "_points2", "spatialite")
-        assert (cls.pointsLayer2.isValid())
-        QgsProject.instance().addMapLayers([cls.pointsLayer, cls.linesLayer, cls.pointsLayer2])
+        self.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % fn, "points", "spatialite")
+        assert (self.pointsLayer.isValid())
+        self.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % fn, "lines", "spatialite")
+        assert (self.linesLayer.isValid())
+        self.pointsLayer2 = QgsVectorLayer("dbname='%s' table=\"node2\" (geom) sql=" % fn, "_points2", "spatialite")
+        assert (self.pointsLayer2.isValid())
+        QgsProject.instance().addMapLayers([self.pointsLayer, self.linesLayer, self.pointsLayer2])
 
         # save the project file
         fo = tempfile.NamedTemporaryFile()
         fn = fo.name
         fo.close()
-        cls.projectFile = fn
-        QgsProject.instance().setFileName(cls.projectFile)
+        self.projectFile = fn
+        QgsProject.instance().setFileName(self.projectFile)
         QgsProject.instance().write()
-
-    @classmethod
-    def tearDownClass(cls):
-        """Run after all tests"""
-        pass
-
-    def setUp(self):
-        """Run before each test."""
-        pass
 
     def tearDown(self):
         """Run after each test."""
+        QgsProject.instance().clear()
         pass
 
     def test_resetSnappingIndex(self):

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -30,6 +30,7 @@ from qgis.core import (QgsProject,
 from qgis.testing import start_app, unittest
 
 from qgis.PyQt.QtCore import QSize, QPoint
+from qgis.PyQt.QtTest import QSignalSpy
 
 import tempfile
 
@@ -175,11 +176,79 @@ class TestLayerDependencies(unittest.TestCase):
         self.pointsLayer.setDependencies([])
         self.pointsLayer2.setDependencies([])
 
-    def test_cycleDetection(self):
+    def test_circularDependencies_with_2_layers(self):
+
+        spy_points_data_changed = QSignalSpy(self.pointsLayer.dataChanged)
+        spy_lines_data_changed = QSignalSpy(self.linesLayer.dataChanged)
+        spy_points_repaint_requested = QSignalSpy(self.pointsLayer.repaintRequested)
+        spy_lines_repaint_requested = QSignalSpy(self.linesLayer.repaintRequested)
+
+        # only points fire dataChanged because we change its dependencies
         self.assertTrue(self.pointsLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())]))
-        self.assertFalse(self.linesLayer.setDependencies([QgsMapLayerDependency(self.pointsLayer.id())]))
-        self.pointsLayer.setDependencies([])
-        self.linesLayer.setDependencies([])
+        self.assertEqual(len(spy_points_data_changed), 1)
+        self.assertEqual(len(spy_lines_data_changed), 0)
+
+        # lines fire dataChanged because we changes its dependencies
+        # points fire dataChanged because it depends on line
+        self.assertTrue(self.linesLayer.setDependencies([QgsMapLayerDependency(self.pointsLayer.id())]))
+        self.assertEqual(len(spy_points_data_changed), 2)
+        self.assertEqual(len(spy_lines_data_changed), 1)
+
+        f = QgsFeature(self.pointsLayer.fields())
+        f.setId(1)
+        geom = QgsGeometry.fromWkt("POINT(0 0)")
+        f.setGeometry(geom)
+        self.pointsLayer.startEditing()
+
+        # new point fire featureAdded so dependening line fire dataChanged
+        # point depends on line, so fire dataChanged
+        self.pointsLayer.addFeatures([f])
+        self.assertEqual(len(spy_points_data_changed), 3)
+        self.assertEqual(len(spy_lines_data_changed), 2)
+
+        # added feature is deleted and added with its new defined id
+        # (it was -1 before) so it fires 2 more signal dataChanged on
+        # depending line (on featureAdded and on featureDeleted)
+        # and so 2 more signal on points because it depends on line
+        self.pointsLayer.commitChanges()
+        self.assertEqual(len(spy_points_data_changed), 5)
+        self.assertEqual(len(spy_lines_data_changed), 4)
+
+        # repaintRequested is called on commit changes on point
+        # so it is on depending line
+        self.assertEqual(len(spy_lines_repaint_requested), 1)
+        self.assertEqual(len(spy_points_repaint_requested), 1)
+
+    def test_circularDependencies_with_1_layer(self):
+
+        # You can define a layer dependent on it self (for instance, a line
+        # layer that trigger connected lines modifications when you modify
+        # one line)
+        spy_lines_data_changed = QSignalSpy(self.linesLayer.dataChanged)
+        spy_lines_repaint_requested = QSignalSpy(self.linesLayer.repaintRequested)
+
+        # line fire dataChanged because we change its dependencies
+        self.assertTrue(self.linesLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())]))
+        self.assertEqual(len(spy_lines_data_changed), 1)
+
+        f = QgsFeature(self.linesLayer.fields())
+        f.setId(1)
+        geom = QgsGeometry.fromWkt("LINESTRING(0 0,1 1)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+
+        # line fire featureAdded so dependening line fire dataChanged once more
+        self.pointsLayer.addFeatures([f])
+        self.assertEqual(len(spy_lines_data_changed), 2)
+
+        # added feature is deleted and added with its new defined id
+        # (it was -1 before) so it fires 2 more signal dataChanged on
+        # depending line (on featureAdded and on featureDeleted)
+        self.pointsLayer.commitChanges()
+        self.assertEqual(len(spy_lines_data_changed), 4)
+
+        # repaintRequested is called only once on commit changes on line
+        self.assertEqual(len(spy_lines_repaint_requested), 1)
 
     def test_layerDefinitionRewriteId(self):
         tmpfile = os.path.join(tempfile.tempdir, "test.qlr")


### PR DESCRIPTION
## Description

This PR is the first step of the proposed GRANT [Snap Cache Improvements](https://docs.google.com/document/d/1VzgLJ-hy2GtcWrAy5geivhDDdXRGJUDcikCWUtXRe9k/edit#heading=h.uau3di2m4nvn). 

If fixes the QGEP issue described [here](https://github.com/QGEP/QGEP/issues/492)

It add the possibility to define circular data dependencies (layer1 depends on layer2 that depends on layer 1), and by extension on the layer itself (layer1 depends on layer1). This last is useful for instance when you modify one line in a line layer that trigger connected lines modifications on database side. In this case, `dataChanged` signal needs to be fired in order to refresh the snapping cache (and avoid what is described in QGEP issue). 

This PR doesn't propose any optimisations on snap cache indexing. It will be done in a separate PR.

**API BREAK** : I remove the `QgsMapLayer::hasDependencyCycle` method because it has no use anymore. Even if the method was protected, it changes the API. Is it an issue? Is it better to keep it and mark it as deprecated? I remove it for now.

cc @mhugo @lbartoletti @m-kuhn @haubourg 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
