### PR TITLE
[QgsQuick] Range widget

### DIFF
--- a/src/quickgui/plugin/CMakeLists.txt
+++ b/src/quickgui/plugin/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(QGIS_QUICK_PLUGIN_RESOURCES
   editor/qgsquickcheckbox.qml
   editor/qgsquickdatetime.qml
   editor/qgsquickexternalresource.qml
+  editor/qgsquickrange.qml
   editor/qgsquicktextedit.qml
   editor/qgsquickvaluemap.qml
   editor/qgsquickvaluerelation.qml

--- a/src/quickgui/plugin/editor/qgsquickrange.qml
+++ b/src/quickgui/plugin/editor/qgsquickrange.qml
@@ -1,0 +1,93 @@
+/***************************************************************************
+ qgsquickrange.qml
+  --------------------------------------
+  Date                 : 2019
+  Copyright            : (C) 2019 by Viktor Sklencar
+  Email                : viktor.sklencar@lutraconsulting.co.uk
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+import QgsQuick 0.1 as QgsQuick
+
+Item {
+  signal valueChanged(var value, bool isNull)
+
+  property var currentValue: value
+  property real customMargin: 10 * QgsQuick.Utils.dp
+
+  id: fieldItem
+  enabled: !readOnly
+  height: customStyle.fields.height
+
+  anchors {
+    left: parent.left
+    right: parent.right
+    rightMargin: fieldItem.customMargin
+  }
+
+  // background
+  Rectangle {
+    anchors.fill: parent
+    border.color: customStyle.fields.normalColor
+    border.width: 1 * QgsQuick.Utils.dp
+    color: customStyle.fields.backgroundColor
+    radius: customStyle.fields.cornerRadius
+  }
+
+  Row {
+    id: rowLayout
+    anchors.fill: parent
+    anchors.rightMargin: fieldItem.customMargin
+    anchors.leftMargin: fieldItem.customMargin
+
+    Text {
+      id: valueLabel
+      width: rowLayout.width/3
+      height: fieldItem.height
+      elide: Text.ElideRight
+      text: Number(control.value).toFixed(config["Precision"]).toLocaleString(Qt.locale())
+      verticalAlignment: Text.AlignVCenter
+      horizontalAlignment: Text.AlignLeft
+      font.pixelSize: customStyle.fields.fontPixelSize
+      color: customStyle.fields.fontColor
+      topPadding: fieldItem.customMargin
+      bottomPadding: fieldItem.customMargin
+    }
+
+    Slider {
+      id: control
+      value: fieldItem.currentValue
+      width: parent.width - valueLabel.width
+      height: fieldItem.height
+      implicitWidth: width
+      from: config["Min"]
+      to: config["Max"]
+      stepSize: config["Step"] ? config["Step"] : 1
+
+      onValueChanged: {
+        fieldItem.valueChanged(control.value, false)
+      }
+
+      background: Rectangle {
+        x: control.leftPadding
+        y: control.topPadding + control.availableHeight / 2 - height / 2
+        implicitWidth: control.width
+        implicitHeight: control.height * 0.1
+        width: control.availableWidth
+        height: implicitHeight
+        radius: 2 * QgsQuick.Utils.dp
+        color:  fieldItem.enabled ? customStyle.fields.fontColor : customStyle.fields.backgroundColorInactive
+      }
+    }
+  }
+
+}

--- a/src/quickgui/plugin/editor/qgsquickrange.qml
+++ b/src/quickgui/plugin/editor/qgsquickrange.qml
@@ -52,8 +52,6 @@ Item {
   Row {
     id: rowLayout
     anchors.fill: parent
-    anchors.rightMargin: fieldItem.customMargin
-    anchors.leftMargin: fieldItem.customMargin
 
     // SpinBox
     SpinBox {
@@ -71,6 +69,14 @@ Item {
       height: parent.height
       editable: true
       visible: fieldItem.widgetStyle === "SpinBox"
+
+      background:   Rectangle {
+        anchors.fill: parent
+        border.color: customStyle.fields.normalColor
+        border.width: 1 * QgsQuick.Utils.dp
+        color: customStyle.fields.backgroundColor
+        radius: customStyle.fields.cornerRadius
+      }
 
       onValueChanged: {
         if (visible) {
@@ -117,6 +123,14 @@ Item {
         validator: spinbox.validator
         inputMethodHints: Qt.ImhFormattedNumbersOnly
       }
+
+      Component.onCompleted: {
+        up.indicator.color = customStyle.fields.backgroundColor
+        up.indicator.radius = customStyle.fields.cornerRadius
+        down.indicator.radius = customStyle.fields.cornerRadius
+        down.indicator.color = customStyle.fields.backgroundColor
+      }
+
     }
 
     // Slider
@@ -131,8 +145,7 @@ Item {
       horizontalAlignment: Text.AlignLeft
       font.pixelSize: customStyle.fields.fontPixelSize
       color: customStyle.fields.fontColor
-      topPadding: fieldItem.customMargin
-      bottomPadding: fieldItem.customMargin
+      padding: fieldItem.customMargin
     }
 
     Slider {

--- a/src/quickgui/plugin/editor/qgsquickrange.qml
+++ b/src/quickgui/plugin/editor/qgsquickrange.qml
@@ -22,7 +22,7 @@ Item {
   signal valueChanged(var value, bool isNull)
 
   property real customMargin: 10 * QgsQuick.Utils.dp
-  property string widgetStyle: config["Style"] ? config["Style"] : "SpinBox" // Slider
+  property string widgetStyle: config["Style"] ? config["Style"] : "SpinBox"
   property int precision: config["Precision"]
   property real from: config["Min"]
   property real to: config["Max"]
@@ -73,9 +73,9 @@ Item {
       visible: fieldItem.widgetStyle === "SpinBox"
 
       onValueChanged: {
-         if (visible) {
-           fieldItem.valueChanged(spinbox.value / multiplier, false)
-         }
+        if (visible) {
+          fieldItem.valueChanged(spinbox.value / multiplier, false)
+        }
       }
 
       validator: DoubleValidator {

--- a/src/quickgui/plugin/editor/qgsquickrange.qml
+++ b/src/quickgui/plugin/editor/qgsquickrange.qml
@@ -70,11 +70,11 @@ Item {
       editable: true
       visible: fieldItem.widgetStyle === "SpinBox"
 
-      background:   Rectangle {
+      background: Rectangle {
         anchors.fill: parent
         border.color: customStyle.fields.normalColor
         border.width: 1 * QgsQuick.Utils.dp
-        color: customStyle.fields.backgroundColor
+        color: fieldItem.enabled ? "#ffffff" : customStyle.fields.backgroundColor
         radius: customStyle.fields.cornerRadius
       }
 

--- a/src/quickgui/plugin/qgsquick.qrc
+++ b/src/quickgui/plugin/qgsquick.qrc
@@ -6,6 +6,7 @@
         <file>editor/qgsquickdatetime.qml</file>
         <file>editor/qgsquickexternalresource.qml</file>
         <file>editor/qgsquicktextedit.qml</file>
+        <file>editor/qgsquickrange.qml</file>
         <file>editor/qgsquickvaluemap.qml</file>
         <file>editor/qgsquickvaluerelation.qml</file>
         <file>qgsquickfeatureform.qml</file>

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -139,7 +139,8 @@ const QUrl QgsQuickUtils::getEditorComponentSource( const QString &widgetName )
                                    QStringLiteral( "valuerelation" ),
                                    QStringLiteral( "checkbox" ),
                                    QStringLiteral( "externalresource" ),
-                                   QStringLiteral( "datetime" )
+                                   QStringLiteral( "datetime" ),
+                                   QStringLiteral( "range" )
                                  };
   if ( supportedWidgets.contains( widgetName ) )
   {


### PR DESCRIPTION
Added support for a range field - added SpinBox and Slider widget.
Since SpinBox's value is of type `int` and it is used to represent also float values, the length of a number is currently restricted.
Widgets takes `Minimum`, `Maximum`, `Step`, `Suffix` as well as `Editable`/`Slider` options from the config.

<img width="633" alt="Screenshot 2019-07-30 at 17 07 38" src="https://user-images.githubusercontent.com/6735606/62141363-bcbc6500-b2ec-11e9-8f64-d1164f32f63a.png">
<img width="632" alt="Screenshot 2019-07-26 at 13 16 48" src="https://user-images.githubusercontent.com/6735606/61948290-b0ac6c80-afa7-11e9-90b0-d5f4ec878a4a.png">
