### PR TITLE
Allow changing the default ellipsoid to planimetric

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -88,6 +88,9 @@ NewsFeed\http00008000\lang=
 NewsFeed\http00008000\lat=
 NewsFeed\http00008000\long=
 
+# When new projects are created, default to planimetric measurement.
+measure\planimetric=false
+
 [colors]
 # These colors are used in logs.
 default=

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5515,7 +5515,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   const QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem( settings.value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString() );
   // write the projections _proj string_ to project settings
   const bool planimetric = settings.value( QStringLiteral( "/qgis/measure/planimetric" ), true ).toBool();
-  prj->setCrs( srs, !planimetric ); // If the default ellipsoid is not planimetric, set it from the defualt crs
+  prj->setCrs( srs, !planimetric ); // If the default ellipsoid is not planimetric, set it from the default crs
   if ( planimetric )
     prj->setEllipsoid( GEO_NONE );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5515,7 +5515,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   const QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem( settings.value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString() );
   // write the projections _proj string_ to project settings
   const bool planimetric = settings.value( QStringLiteral( "/qgis/measure/planimetric" ), true ).toBool();
-  prj->setCrs( srs );
+  prj->setCrs( srs, !planimetric ); // If the default ellipsoid is not planimetric, set it from the defualt crs
   if ( planimetric )
     prj->setEllipsoid( GEO_NONE );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5514,7 +5514,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   // set project CRS
   const QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem( settings.value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString() );
   // write the projections _proj string_ to project settings
-  const bool planimetric = settings.value( QStringLiteral( "/qgis/measure/planimetric" ), true ).toBool();
+  const bool planimetric = settings.value( QStringLiteral( "measure/planimetric" ), true, QgsSettings::Core ).toBool();
   prj->setCrs( srs, !planimetric ); // If the default ellipsoid is not planimetric, set it from the default crs
   if ( planimetric )
     prj->setEllipsoid( GEO_NONE );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5514,7 +5514,10 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   // set project CRS
   const QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem( settings.value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString() );
   // write the projections _proj string_ to project settings
-  prj->setCrs( srs, true );
+  const bool ellipsoidFollowProjectCrs = settings.value( QStringLiteral( "/qgis/measure/followProjectCrs" ), true ).toBool();
+  prj->setCrs( srs, ellipsoidFollowProjectCrs );
+  if ( !ellipsoidFollowProjectCrs )
+    prj->setEllipsoid( settings.value( QStringLiteral( "/qgis/measure/defaultCrs" ), GEO_NONE ).toString() );
 
   /* New Empty Project Created
       (before attempting to load custom project templates/filepaths) */

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5514,10 +5514,10 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
   // set project CRS
   const QgsCoordinateReferenceSystem srs = QgsCoordinateReferenceSystem( settings.value( QStringLiteral( "/projections/defaultProjectCrs" ), GEO_EPSG_CRS_AUTHID, QgsSettings::App ).toString() );
   // write the projections _proj string_ to project settings
-  const bool ellipsoidFollowProjectCrs = settings.value( QStringLiteral( "/qgis/measure/followProjectCrs" ), true ).toBool();
-  prj->setCrs( srs, ellipsoidFollowProjectCrs );
-  if ( !ellipsoidFollowProjectCrs )
-    prj->setEllipsoid( settings.value( QStringLiteral( "/qgis/measure/defaultCrs" ), GEO_NONE ).toString() );
+  const bool planimetric = settings.value( QStringLiteral( "/qgis/measure/planimetric" ), true ).toBool();
+  prj->setCrs( srs );
+  if ( planimetric )
+    prj->setEllipsoid( GEO_NONE );
 
   /* New Empty Project Created
       (before attempting to load custom project templates/filepaths) */

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -556,7 +556,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   {
     mKeepBaseUnitCheckBox->setChecked( false );
   }
-  mPlanimetricMeasurementsComboBox->setChecked( mSettings->value( QStringLiteral( "/qgis/measure/planimetric" ), false ).toBool() );
+  mPlanimetricMeasurementsComboBox->setChecked( mSettings->value( QStringLiteral( "measure/planimetric" ), false, QgsSettings::Core ).toBool() );
 
   cmbIconSize->setCurrentIndex( cmbIconSize->findText( mSettings->value( QStringLiteral( "qgis/iconSize" ), QGIS_ICON_SIZE ).toString() ) );
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -83,9 +83,6 @@
 
 #include "qgsconfig.h"
 
-// TODO Move to generic place
-const char *QgsOptions::GEO_NONE_DESC = QT_TRANSLATE_NOOP( "QgsOptions", "None / Planimetric" );
-
 /**
  * \class QgsOptions - Set user options and preferences
  * Constructor
@@ -559,10 +556,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   {
     mKeepBaseUnitCheckBox->setChecked( false );
   }
-  initEllipsoidList();
-  mOverrideDefaultEllipsoid->setChecked( !mSettings->value( QStringLiteral( "/qgis/measure/followProjectCrs" ), true ).toBool() );
-  const QString defaultEllipsoid = mSettings->value( QStringLiteral( "/qgis/measure/defaultCrs" ), GEO_NONE ).toString();
-  mEllipsoidComboBox->setCurrentIndex( mEllipsoidComboBox->findData( defaultEllipsoid ) );
+  mPlanimetricMeasurementsComboBox->setChecked( mSettings->value( QStringLiteral( "/qgis/measure/planimetric" ), false ).toBool() );
 
   cmbIconSize->setCurrentIndex( cmbIconSize->findText( mSettings->value( QStringLiteral( "qgis/iconSize" ), QGIS_ICON_SIZE ).toString() ) );
 
@@ -1586,8 +1580,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), mShowDatumTransformDialogCheckBox->isChecked(), QgsSettings::App );
 
   //measurement settings
-  mSettings->setValue( QStringLiteral( "/qgis/measure/followProjectCrs" ), ! mOverrideDefaultEllipsoid->isChecked() );
-  mSettings->setValue( QStringLiteral( "/qgis/measure/defaultCrs" ), mEllipsoidComboBox->currentData().toString() );
+  mSettings->setValue( QStringLiteral( "/qgis/measure/planimetric" ), mPlanimetricMeasurementsComboBox->isChecked() );
 
   QgsUnitTypes::DistanceUnit distanceUnit = static_cast< QgsUnitTypes::DistanceUnit >( mDistanceUnitsComboBox->currentData().toInt() );
   mSettings->setValue( QStringLiteral( "/qgis/measure/displayunits" ), QgsUnitTypes::encodeUnit( distanceUnit ) );
@@ -1910,17 +1903,6 @@ QStringList QgsOptions::i18nList()
     myList << myFileName.remove( QStringLiteral( "qgis_" ) ).remove( QStringLiteral( ".qm" ) );
   }
   return myList;
-}
-
-void QgsOptions::initEllipsoidList()
-{
-  mEllipsoidComboBox->addItem( tr( GEO_NONE_DESC ), GEO_NONE );
-
-  const auto definitions {QgsEllipsoidUtils::definitions()};
-  for ( const QgsEllipsoidUtils::EllipsoidDefinition &def : definitions )
-  {
-    mEllipsoidComboBox->addItem( def.description, def.acronym );
-  }
 }
 
 void QgsOptions::restoreDefaultWindowState()

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -230,8 +230,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     QgsSettings *mSettings = nullptr;
     QStringList i18nList();
 
-    void initEllipsoidList();
-
     void initContrastEnhancement( QComboBox *cbox, const QString &name, const QString &defaultVal );
     void saveContrastEnhancement( QComboBox *cbox, const QString &name );
     void initMinMaxLimits( QComboBox *cbox, const QString &name, const QString &defaultVal );
@@ -269,8 +267,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void updateActionsForCurrentColorScheme( QgsColorScheme *scheme );
 
     void checkPageWidgetNameMap();
-
-    static const char *GEO_NONE_DESC;
 
     friend class QgsAppScreenShots;
 };

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -229,6 +229,9 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
   private:
     QgsSettings *mSettings = nullptr;
     QStringList i18nList();
+
+    void initEllipsoidList();
+
     void initContrastEnhancement( QComboBox *cbox, const QString &name, const QString &defaultVal );
     void saveContrastEnhancement( QComboBox *cbox, const QString &name );
     void initMinMaxLimits( QComboBox *cbox, const QString &name, const QString &defaultVal );
@@ -266,6 +269,8 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void updateActionsForCurrentColorScheme( QgsColorScheme *scheme );
 
     void checkPageWidgetNameMap();
+
+    static const char *GEO_NONE_DESC;
 
     friend class QgsAppScreenShots;
 };

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1692,18 +1692,21 @@ void QgsProjectProperties::srIdUpdated()
   if ( mCrs.isValid() )
   {
     cmbEllipsoid->setEnabled( true );
-    // attempt to reset the projection ellipsoid according to the srs
-    int index = 0;
-    for ( int i = 0; i < mEllipsoidList.length(); i++ )
+    if ( cmbEllipsoid->currentIndex() != 0 )
     {
-      // TODO - use parameters instead of acronym
-      if ( mEllipsoidList[ i ].acronym == mCrs.ellipsoidAcronym() )
+      // attempt to reset the projection ellipsoid according to the srs
+      int index = 0;
+      for ( int i = 0; i < mEllipsoidList.length(); i++ )
       {
-        index = i;
-        break;
+        // TODO - use parameters instead of acronym
+        if ( mEllipsoidList[ i ].acronym == mCrs.ellipsoidAcronym() )
+        {
+          index = i;
+          break;
+        }
       }
+      updateEllipsoidUI( index );
     }
-    updateEllipsoidUI( index );
   }
   else
   {

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2393,8 +2393,7 @@ void QgsProjectProperties::populateEllipsoidList()
   }
   // Add all items to selector
 
-  const auto constMEllipsoidList = mEllipsoidList;
-  for ( const EllipsoidDefs &i : constMEllipsoidList )
+  for ( const EllipsoidDefs &i : qgis::as_const( mEllipsoidList ) )
   {
     cmbEllipsoid->addItem( i.description );
   }

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -116,8 +116,9 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
     {
       case QgsGui::UseCrsOfFirstLayerAdded:
       {
-        const bool ellipsoidFollowProjectCrs = QgsSettings().value( QStringLiteral( "/qgis/measure/followProjectCrs" ), true ).toBool();
-        QgsProject::instance()->setCrs( mFirstCRS, ellipsoidFollowProjectCrs );
+        const bool planimetric = QgsSettings().value( QStringLiteral( "/qgis/measure/planimetric" ), true ).toBool();
+        // Only adjust ellipsoid to CRS if it's not set to planimetric
+        QgsProject::instance()->setCrs( mFirstCRS, !planimetric );
         break;
       }
 

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -116,7 +116,7 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
     {
       case QgsGui::UseCrsOfFirstLayerAdded:
       {
-        const bool planimetric = QgsSettings().value( QStringLiteral( "/qgis/measure/planimetric" ), true ).toBool();
+        const bool planimetric = QgsSettings().value( QStringLiteral( "measure/planimetric" ), true, QgsSettings::Core ).toBool();
         // Only adjust ellipsoid to CRS if it's not set to planimetric
         QgsProject::instance()->setCrs( mFirstCRS, !planimetric );
         break;

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -115,8 +115,11 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
     switch ( projectCrsBehavior )
     {
       case QgsGui::UseCrsOfFirstLayerAdded:
-        QgsProject::instance()->setCrs( mFirstCRS, true );
+      {
+        const bool ellipsoidFollowProjectCrs = QgsSettings().value( QStringLiteral( "/qgis/measure/followProjectCrs" ), true ).toBool();
+        QgsProject::instance()->setCrs( mFirstCRS, ellipsoidFollowProjectCrs );
         break;
+      }
 
       case QgsGui::UsePresetCrs:
         break;

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -143,6 +143,9 @@ void QgsProjectionSelectionTreeWidget::resizeEvent( QResizeEvent *event )
 
 void QgsProjectionSelectionTreeWidget::showEvent( QShowEvent *event )
 {
+  if ( mInitialized )
+    return;
+
   // ensure the projection list view is actually populated
   // before we show this widget
   loadCrsList( &mCrsFilter );
@@ -162,6 +165,7 @@ void QgsProjectionSelectionTreeWidget::showEvent( QShowEvent *event )
 
   // Pass up the inheritance hierarchy
   QWidget::showEvent( event );
+  mInitialized = true;
 }
 
 QString QgsProjectionSelectionTreeWidget::ogcWmsCrsFilterAsSqlExpression( QSet<QString> *crsFilter )

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -289,6 +289,8 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
 
     bool mShowMap = true;
 
+    bool mInitialized = false;
+
   private slots:
     //! Gets list of authorities
     void updateBoundsPreview();

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1691,40 +1691,7 @@
                  </layout>
                 </widget>
                </item>
-               <item row="4" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mDefaultDatumTransformGroupBox">
-                 <property name="title">
-                  <string>Default Datum Transformations</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_10">
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_40">
-                    <property name="text">
-                     <string>Enter default datum transformations which will be used in any newly created project</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QCheckBox" name="mShowDatumTransformDialogCheckBox">
-                    <property name="text">
-                     <string>Ask for datum transformation if several are available</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="Line" name="line_2">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QgsDatumTransformTableWidget" name="mDefaultDatumTransformTableWidget" native="true"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="5" column="0">
+               <item row="6" column="0">
                 <spacer name="verticalSpacer">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
@@ -1793,22 +1760,44 @@
                  </layout>
                 </widget>
                </item>
-               <item row="5" column="0">
-                <widget class="QGroupBox" name="mOverrideDefaultEllipsoid">
-                 <property name="toolTip">
-                  <string>If the default ellipsoid is disabled, the project will take the ellipsoid imposed by the project CRS.</string>
-                 </property>
+               <item row="4" column="0">
+                <widget class="QgsCollapsibleGroupBox" name="mDefaultDatumTransformGroupBox">
                  <property name="title">
-                  <string>Default Ellipsoid for Measurement</string>
+                  <string>Default Datum Transformations</string>
                  </property>
-                 <property name="checkable">
-                  <bool>true</bool>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_30">
+                 <layout class="QGridLayout" name="gridLayout_10">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_40">
+                    <property name="text">
+                     <string>Enter default datum transformations which will be used in any newly created project</string>
+                    </property>
+                   </widget>
+                  </item>
                   <item row="0" column="0">
-                   <widget class="QComboBox" name="mEllipsoidComboBox"/>
+                   <widget class="QCheckBox" name="mShowDatumTransformDialogCheckBox">
+                    <property name="text">
+                     <string>Ask for datum transformation if several are available</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="Line" name="line_2">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QgsDatumTransformTableWidget" name="mDefaultDatumTransformTableWidget" native="true"/>
                   </item>
                  </layout>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QCheckBox" name="mPlanimetricMeasurementsComboBox">
+                 <property name="text">
+                  <string>Planimetric measurements</string>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1793,6 +1793,24 @@
                  </layout>
                 </widget>
                </item>
+               <item row="5" column="0">
+                <widget class="QGroupBox" name="mOverrideDefaultEllipsoid">
+                 <property name="toolTip">
+                  <string>If the default ellipsoid is disabled, the project will take the ellipsoid imposed by the project CRS.</string>
+                 </property>
+                 <property name="title">
+                  <string>Default Ellipsoid for Measurement</string>
+                 </property>
+                 <property name="checkable">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_30">
+                  <item row="0" column="0">
+                   <widget class="QComboBox" name="mEllipsoidComboBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
             </widget>


### PR DESCRIPTION
The overall goal for this PR is to enable a user to have new projects defaulting to his favourite CRS while keeping measurements planimetric.
Is this ok where it is or should it go to the measurement settings?

![Screenshot from 2019-07-30 11-52-34](https://user-images.githubusercontent.com/588407/62119765-8d8ffe80-b2c0-11e9-8a10-fca1c018dd7a.png)
