### PR TITLE
Enable widget filtering in Interface Customization dialog

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -58,6 +58,8 @@ QgsCustomizationDialog::QgsCustomizationDialog( QWidget * parent, QSettings * se
   connect( mCustomizationEnabledCheckBox, &QCheckBox::toggled, this, &QgsCustomizationDialog::enableCustomization );
   connect( mLeFilter, &QgsFilterLineEdit::textChanged, this, &QgsCustomizationDialog::filterItems );
 
+  mLeFilter->setShowSearchIcon( true );
+
   init();
   QStringList myHeaders;
   myHeaders << tr( "Object name" ) << tr( "Label" );
@@ -137,7 +139,7 @@ bool QgsCustomizationDialog::filterItems( const QString &text )
   success = !items.empty();
   mTreeInitialExpand.clear();
 
-  for ( QTreeWidgetItem *item : items )
+  for ( QTreeWidgetItem *item : qgis::as_const( items ) )
   {
     setChildrenVisible( item, true );
 

--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -55,7 +55,8 @@ QgsCustomizationDialog::QgsCustomizationDialog( QWidget * parent, QSettings * se
   connect( actionExpandAll, &QAction::triggered, this, &QgsCustomizationDialog::actionExpandAll_triggered );
   connect( actionCollapseAll, &QAction::triggered, this, &QgsCustomizationDialog::actionCollapseAll_triggered );
   connect( actionSelectAll, &QAction::triggered, this, &QgsCustomizationDialog::actionSelectAll_triggered );
-  connect( mCustomizationEnabledCheckBox, &QCheckBox::toggled, this, &QgsCustomizationDialog::mCustomizationEnabledCheckBox_toggled );
+  connect( mCustomizationEnabledCheckBox, &QCheckBox::toggled, this, &QgsCustomizationDialog::enableCustomization );
+  connect( mLeFilter, &QgsFilterLineEdit::textChanged, this, &QgsCustomizationDialog::filterItems );
 
   init();
   QStringList myHeaders;
@@ -113,6 +114,46 @@ QTreeWidgetItem *QgsCustomizationDialog::item( const QString &path, QTreeWidgetI
   }
   QgsDebugMsg( QStringLiteral( "not found" ) );
   return nullptr;
+}
+
+bool QgsCustomizationDialog::filterItems( const QString &text )
+{
+  bool success = false;
+
+  mTreeInitialVisible.clear();
+  // initially hide everything
+  std::function< void( QTreeWidgetItem *, bool ) > setChildrenVisible;
+  setChildrenVisible = [this, &setChildrenVisible]( QTreeWidgetItem * item, bool visible )
+  {
+    for ( int i = 0; i < item->childCount(); ++i )
+      setChildrenVisible( item->child( i ), visible );
+    mTreeInitialVisible.insert( item, !item->isHidden() );
+    item->setHidden( !visible );
+  };
+  setChildrenVisible( treeWidget->invisibleRootItem(), false );
+
+  QList<QTreeWidgetItem *> items = treeWidget->findItems( text, Qt::MatchContains | Qt::MatchRecursive, 0 );
+  items.append( treeWidget->findItems( text, Qt::MatchContains | Qt::MatchRecursive, 1 ) );
+  success = !items.empty();
+  mTreeInitialExpand.clear();
+
+  for ( QTreeWidgetItem *item : items )
+  {
+    setChildrenVisible( item, true );
+
+    QTreeWidgetItem *parent = item;
+    while ( parent )
+    {
+      if ( mTreeInitialExpand.contains( parent ) )
+        break;
+      mTreeInitialExpand.insert( parent, parent->isExpanded() );
+      parent->setExpanded( true );
+      parent->setHidden( false );
+      parent = parent->parent();
+    }
+  }
+
+  return success;
 }
 
 bool QgsCustomizationDialog::itemChecked( const QString &path )
@@ -195,6 +236,8 @@ void QgsCustomizationDialog::reset()
   mCustomizationEnabledCheckBox->setChecked( enabled );
   treeWidget->setEnabled( enabled );
   toolBar->setEnabled( enabled );
+  mLeFilter->setEnabled( enabled );
+  mTreeInitialExpand.clear();
 }
 
 void QgsCustomizationDialog::ok()
@@ -286,10 +329,11 @@ void QgsCustomizationDialog::actionSelectAll_triggered( bool checked )
     item->setCheckState( 0, Qt::Checked );
 }
 
-void QgsCustomizationDialog::mCustomizationEnabledCheckBox_toggled( bool checked )
+void QgsCustomizationDialog::enableCustomization( bool checked )
 {
   treeWidget->setEnabled( checked );
   toolBar->setEnabled( checked );
+  mLeFilter->setEnabled( checked );
 }
 
 void QgsCustomizationDialog::init()

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -104,8 +104,8 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
     QSettings *mSettings = nullptr;
 
   protected:
-    QMap<QTreeWidgetItem *, bool> mTreeInitialExpand = QMap<QTreeWidgetItem *, bool>();
-    QMap<QTreeWidgetItem *, bool> mTreeInitialVisible = QMap<QTreeWidgetItem *, bool>();
+    QMap<QTreeWidgetItem *, bool> mTreeInitialExpand;
+    QMap<QTreeWidgetItem *, bool> mTreeInitialVisible;
 };
 
 class APP_EXPORT QgsCustomization : public QObject

--- a/src/app/qgscustomization.h
+++ b/src/app/qgscustomization.h
@@ -92,7 +92,8 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
     void actionCollapseAll_triggered( bool checked );
     void actionSelectAll_triggered( bool checked );
 
-    void mCustomizationEnabledCheckBox_toggled( bool checked );
+    void enableCustomization( bool checked );
+    bool filterItems( const QString &text );
 
   private:
     void init();
@@ -101,6 +102,10 @@ class APP_EXPORT QgsCustomizationDialog : public QMainWindow, private Ui::QgsCus
 
     QString mLastDirSettingsName;
     QSettings *mSettings = nullptr;
+
+  protected:
+    QMap<QTreeWidgetItem *, bool> mTreeInitialExpand = QMap<QTreeWidgetItem *, bool>();
+    QMap<QTreeWidgetItem *, bool> mTreeInitialVisible = QMap<QTreeWidgetItem *, bool>();
 };
 
 class APP_EXPORT QgsCustomization : public QObject

--- a/src/ui/qgscustomizationdialogbase.ui
+++ b/src/ui/qgscustomizationdialogbase.ui
@@ -23,6 +23,13 @@
      </widget>
     </item>
     <item>
+     <widget class="QgsFilterLineEdit" name="mLeFilter">
+      <property name="placeholderText">
+       <string>Search…</string>
+      </property>
+     </widget>
+    </item>
+    <item>
      <widget class="QTreeWidget" name="treeWidget">
       <property name="selectionBehavior">
        <enum>QAbstractItemView::SelectItems</enum>


### PR DESCRIPTION
using both widget name and label
![image](https://user-images.githubusercontent.com/7983394/61993083-c9c82280-b066-11e9-8acd-29e6f964a61a.png)

Code is inspired from [qgsoptionsdialoghighlightwidgetsimpl](https://github.com/qgis/QGIS/blob/6749cb3d1fcc61cb0b13444badfa5bf56378129b/src/gui/qgsoptionsdialoghighlightwidgetsimpl.cpp#L219) and TBH I don't know whether the protected variables are well handled but it builds, helped me do what I needed it for with no crash. And here it's for your review.
 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
