### PR TITLE
Disable alignment combo boxes in label properties dialog for non-pinned labels

### DIFF
--- a/src/app/qgslabelpropertydialog.h
+++ b/src/app/qgslabelpropertydialog.h
@@ -30,7 +30,14 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
 {
     Q_OBJECT
   public:
-    QgsLabelPropertyDialog( const QString &layerId, const QString &providerId, int featureId, const QFont &labelFont, const QString &labelText, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
+    QgsLabelPropertyDialog( const QString &layerId,
+                            const QString &providerId,
+                            int featureId,
+                            const QFont &labelFont,
+                            const QString &labelText,
+                            bool isPinned,
+                            QWidget *parent = nullptr,
+                            Qt::WindowFlags f = nullptr );
 
     //! Returns properties changed by the user
     const QgsAttributeMap &changedProperties() const { return mChangedProperties; }
@@ -94,6 +101,8 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
     //! Insert changed value into mChangedProperties
     void insertChangedValue( QgsPalLayerSettings::Property p, const QVariant &value );
 
+    void enableWidgetsForPinnedLabels();
+
     QgsAttributeMap mChangedProperties;
     QgsPropertyCollection mDataDefinedProperties;
     QFont mLabelFont;
@@ -101,10 +110,14 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
     QFontDatabase mFontDB;
 
     //! Label field for the current layer (or -1 if none)
-    int mCurLabelField;
+    int mCurLabelField = -1;
 
     //! Current feature
     QgsFeature mCurLabelFeat;
+
+    bool mIsPinned = false;
+    bool mCanSetHAlignment = false;
+    bool mCanSetVAlignment = false;
 };
 
 #endif // QGSLAYERPROPERTYDIALOG_H

--- a/src/app/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/qgsmaptoolchangelabelproperties.cpp
@@ -105,7 +105,9 @@ void QgsMapToolChangeLabelProperties::canvasReleaseEvent( QgsMapMouseEvent *e )
                               mCurrentLabel.pos.providerID,
                               mCurrentLabel.pos.featureId,
                               mCurrentLabel.pos.labelFont,
-                              labeltext, nullptr );
+                              labeltext,
+                              mCurrentLabel.pos.isPinned,
+                              nullptr );
     d.setMapCanvas( canvas() );
 
     connect( &d, &QgsLabelPropertyDialog::applied, this, &QgsMapToolChangeLabelProperties::dialogPropertiesApplied );


### PR DESCRIPTION
These have no effect, so enabling them is misleading