### PR TITLE
Add option to show superseded (but not deprecated) coordinate operations when selecting operations

### DIFF
--- a/python/core/auto_generated/qgsdatumtransform.sip.in
+++ b/python/core/auto_generated/qgsdatumtransform.sip.in
@@ -120,7 +120,7 @@ and ``destinationTransformId`` transforms.
       QList< QgsDatumTransform::SingleOperationDetails > operationDetails;
     };
 
-    static QList< QgsDatumTransform::TransformDetails > operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
+    static QList< QgsDatumTransform::TransformDetails > operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, bool includeSuperseded = false );
 %Docstring
 Returns a list of coordinate operations available for transforming
 coordinates from the ``source`` to ``destination`` CRS.
@@ -131,6 +131,9 @@ operation listed first.
 Not all operations may be available for use. Check QgsDatumTransform.TransformDetails.isAvailable
 first. Operations may require grid transformation files which are not available on the local
 install.
+
+If ``includeSuperseded`` is ``True``, superseded (but not deprecated) transforms will be included
+in the results. This requires Proj >= 6.2.
 
 .. note::
 

--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -25,12 +25,13 @@
 #include <proj.h>
 #endif
 
-QList<QgsDatumTransform::TransformDetails> QgsDatumTransform::operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
+QList<QgsDatumTransform::TransformDetails> QgsDatumTransform::operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, bool includeSuperseded )
 {
   QList< QgsDatumTransform::TransformDetails > res;
 #if PROJ_VERSION_MAJOR<6
   Q_UNUSED( source )
   Q_UNUSED( destination )
+  Q_UNUSED( includeSuperseded )
 #else
   if ( !source.projObject() || !destination.projObject() )
     return res;
@@ -43,8 +44,14 @@ QList<QgsDatumTransform::TransformDetails> QgsDatumTransform::operations( const 
   proj_operation_factory_context_set_grid_availability_use( pjContext, operationContext, PROJ_GRID_AVAILABILITY_IGNORED );
 
   // See https://lists.osgeo.org/pipermail/proj/2019-May/008604.html
-  proj_operation_factory_context_set_spatial_criterion( pjContext,   operationContext,  PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION );
+  proj_operation_factory_context_set_spatial_criterion( pjContext, operationContext,  PROJ_SPATIAL_CRITERION_PARTIAL_INTERSECTION );
 
+#if PROJ_VERSION_MAJOR> 6 or PROJ_VERSION_MINOR >= 2
+  if ( includeSuperseded )
+    proj_operation_factory_context_set_discard_superseded( pjContext, operationContext, false );
+#else
+  Q_UNUSED( includeSuperseded )
+#endif
   if ( PJ_OBJ_LIST *ops = proj_create_operations( pjContext, source.projObject(), destination.projObject(), operationContext ) )
   {
     int count = proj_list_get_count( ops );

--- a/src/core/qgsdatumtransform.h
+++ b/src/core/qgsdatumtransform.h
@@ -268,12 +268,15 @@ class CORE_EXPORT QgsDatumTransform
      * first. Operations may require grid transformation files which are not available on the local
      * install.
      *
+     * If \a includeSuperseded is TRUE, superseded (but not deprecated) transforms will be included
+     * in the results. This requires Proj >= 6.2.
+     *
      * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will always return an empty list,
      * and the deprecated API from QgsDatumTransform must be used instead.
      *
      * \since QGIS 3.8
      */
-    static QList< QgsDatumTransform::TransformDetails > operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
+    static QList< QgsDatumTransform::TransformDetails > operations( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination, bool includeSuperseded = false );
 
     /**
      * Returns a list of datum transformations which are available for the given \a source and \a destination CRS.

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -175,13 +175,21 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
   // proj 6 doesn't provide deprecated operations
   mHideDeprecatedCheckBox->setVisible( false );
 
+#if PROJ_VERSION_MAJOR>6 or PROJ_VERSION_MINOR>=2
+  mShowSupersededCheckBox->setVisible( true );
+#else
+  mShowSupersededCheckBox->setVisible( false );
+#endif
+
   mLabelDstDescription->hide();
 #else
+  mShowSupersededCheckBox->setVisible( false );
   QgsSettings settings;
   mHideDeprecatedCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/hideDeprecated" ), true ).toBool() );
 #endif
 
   connect( mHideDeprecatedCheckBox, &QCheckBox::stateChanged, this, [ = ] { load(); } );
+  connect( mShowSupersededCheckBox, &QCheckBox::toggled, this, &QgsDatumTransformDialog::showSupersededToggled );
   connect( mDatumTransformTableWidget, &QTableWidget::currentItemChanged, this, &QgsDatumTransformDialog::tableCurrentItemChanged );
 
   connect( mSourceProjectionSelectionWidget, &QgsProjectionSelectionWidget::crsChanged, this, &QgsDatumTransformDialog::setSourceCrs );
@@ -191,7 +199,7 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
   mSourceCrs = sourceCrs;
   mDestinationCrs = destinationCrs;
 #if PROJ_VERSION_MAJOR>=6
-  mDatumTransforms = QgsDatumTransform::operations( sourceCrs, destinationCrs );
+  mDatumTransforms = QgsDatumTransform::operations( sourceCrs, destinationCrs, mShowSupersededCheckBox->isChecked() );
 #else
   Q_NOWARN_DEPRECATED_PUSH
   mDatumTransforms = QgsDatumTransform::datumTransformations( sourceCrs, destinationCrs );
@@ -810,7 +818,7 @@ void QgsDatumTransformDialog::setSourceCrs( const QgsCoordinateReferenceSystem &
 {
   mSourceCrs = sourceCrs;
 #if PROJ_VERSION_MAJOR>=6
-  mDatumTransforms = QgsDatumTransform::operations( mSourceCrs, mDestinationCrs );
+  mDatumTransforms = QgsDatumTransform::operations( mSourceCrs, mDestinationCrs, mShowSupersededCheckBox->isChecked() );
 #else
   Q_NOWARN_DEPRECATED_PUSH
   mDatumTransforms = QgsDatumTransform::datumTransformations( mSourceCrs, mDestinationCrs );
@@ -824,7 +832,20 @@ void QgsDatumTransformDialog::setDestinationCrs( const QgsCoordinateReferenceSys
 {
   mDestinationCrs = destinationCrs;
 #if PROJ_VERSION_MAJOR>=6
-  mDatumTransforms = QgsDatumTransform::operations( mSourceCrs, mDestinationCrs );
+  mDatumTransforms = QgsDatumTransform::operations( mSourceCrs, mDestinationCrs, mShowSupersededCheckBox->isChecked() );
+#else
+  Q_NOWARN_DEPRECATED_PUSH
+  mDatumTransforms = QgsDatumTransform::datumTransformations( mSourceCrs, mDestinationCrs );
+  Q_NOWARN_DEPRECATED_POP
+#endif
+  load();
+  setOKButtonEnabled();
+}
+
+void QgsDatumTransformDialog::showSupersededToggled( bool )
+{
+#if PROJ_VERSION_MAJOR>=6
+  mDatumTransforms = QgsDatumTransform::operations( mSourceCrs, mDestinationCrs, mShowSupersededCheckBox->isChecked() );
 #else
   Q_NOWARN_DEPRECATED_PUSH
   mDatumTransforms = QgsDatumTransform::datumTransformations( mSourceCrs, mDestinationCrs );

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -107,6 +107,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     void tableCurrentItemChanged( QTableWidgetItem *, QTableWidgetItem * );
     void setSourceCrs( const QgsCoordinateReferenceSystem &sourceCrs );
     void setDestinationCrs( const QgsCoordinateReferenceSystem &destinationCrs );
+    void showSupersededToggled( bool toggled );
 
   private:
 

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -24,6 +24,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="mShowSupersededCheckBox">
+       <property name="text">
+        <string>Show superseded transformations</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This is the closest equivalent for the existing "hide deprecated"
checkbox which is available in proj < 6 builds.

Requires Proj >= 6.2
