### PR TITLE
Allow custom drop handlers to indicate that they will accept a mime type in advance

### DIFF
--- a/python/gui/auto_generated/qgscustomdrophandler.sip.in
+++ b/python/gui/auto_generated/qgscustomdrophandler.sip.in
@@ -60,6 +60,19 @@ value which the handler accepts.
 .. seealso:: :py:func:`customUriProviderKey`
 %End
 
+    virtual bool canHandleMimeData( const QMimeData *data );
+%Docstring
+Returns ``True`` if the handler is capable of handling the provided mime ``data``.
+The base class implementation returns ``False`` regardless of mime data.
+
+This method is called when mime data is dragged over the QGIS window, in order
+to determine whether any handlers are capable of handling the data and to
+determine whether the drag action should be accepted.
+
+.. versionadded:: 3.10
+%End
+
+
     virtual void handleMimeData( const QMimeData *data );
 %Docstring
 Called when the specified mime ``data`` has been dropped onto QGIS.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1662,6 +1662,17 @@ void QgisApp::dragEnterEvent( QDragEnterEvent *event )
     if ( !event->mimeData()->hasFormat( QStringLiteral( "application/qgis.layertreemodeldata" ) ) )
       event->acceptProposedAction();
   }
+
+  // check if any custom handlers can operate on the data
+  const QVector<QPointer<QgsCustomDropHandler >> handlers = mCustomDropHandlers;
+  for ( QgsCustomDropHandler *handler : handlers )
+  {
+    if ( handler && handler->canHandleMimeData( event->mimeData() ) )
+    {
+      event->acceptProposedAction();
+      return;
+    }
+  }
 }
 
 void QgisApp::dropEvent( QDropEvent *event )

--- a/src/gui/qgscustomdrophandler.cpp
+++ b/src/gui/qgscustomdrophandler.cpp
@@ -25,6 +25,11 @@ void QgsCustomDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri
   Q_UNUSED( uri )
 }
 
+bool QgsCustomDropHandler::canHandleMimeData( const QMimeData * )
+{
+  return false;
+}
+
 void QgsCustomDropHandler::handleMimeData( const QMimeData *data )
 {
   Q_UNUSED( data )

--- a/src/gui/qgscustomdrophandler.h
+++ b/src/gui/qgscustomdrophandler.h
@@ -71,6 +71,20 @@ class GUI_EXPORT QgsCustomDropHandler : public QObject
     virtual void handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const;
 
     /**
+     * Returns TRUE if the handler is capable of handling the provided mime \a data.
+     * The base class implementation returns FALSE regardless of mime data.
+     *
+     * This method is called when mime data is dragged over the QGIS window, in order
+     * to determine whether any handlers are capable of handling the data and to
+     * determine whether the drag action should be accepted.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool canHandleMimeData( const QMimeData *data );
+
+    // TODO QGIS 4.0 - return bool
+
+    /**
      * Called when the specified mime \a data has been dropped onto QGIS.
      *
      * The base class implementation does nothing.


### PR DESCRIPTION
Allows non-standard mime types to be dropped onto the QGIS window, which will be handled by custom drop handlers
