### PR TITLE
topological editing: Fix Z for add feature

### DIFF
--- a/python/core/auto_generated/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayereditutils.sip.in
@@ -182,24 +182,20 @@ Adds topological points for every vertex of the geometry.
 
     int addTopologicalPoints( const QgsPointXY &p );
 %Docstring
-Adds a vertex to segments which intersect point p but don't
+Adds a vertex to segments which intersect point ``p`` but don't
 already have a vertex there. If a feature already has a vertex at position p,
 no additional vertex is inserted. This method is useful for topological
 editing.
-
-:param p: position of the vertex
 
 :return: 0 in case of success
 %End
 
     int addTopologicalPoints( const QgsPoint &p );
 %Docstring
-Adds a vertex to segments which intersect point p but don't
+Adds a vertex to segments which intersect point ``p`` but don't
 already have a vertex there. If a feature already has a vertex at position p,
 no additional vertex is inserted. This method is useful for topological
 editing.
-
-:param p: position of the vertex
 
 :return: 0 in case of success
 

--- a/python/core/auto_generated/qgsvectorlayereditutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayereditutils.sip.in
@@ -192,6 +192,20 @@ editing.
 :return: 0 in case of success
 %End
 
+    int addTopologicalPoints( const QgsPoint &p );
+%Docstring
+Adds a vertex to segments which intersect point p but don't
+already have a vertex there. If a feature already has a vertex at position p,
+no additional vertex is inserted. This method is useful for topological
+editing.
+
+:param p: position of the vertex
+
+:return: 0 in case of success
+
+.. versionadded:: 3.10
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsmaptooledit.sip.in
+++ b/python/gui/auto_generated/qgsmaptooledit.sip.in
@@ -68,18 +68,16 @@ Returns the current vector layer of the map canvas or 0
       InvalidLayer,
     };
 
-    TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &geom );
+    TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &vertices );
 %Docstring
-Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
-
-:param geom: list of points (in layer coordinate system)
+Adds a list of ``vertices`` to other features to keep topology up to date, e.g. to neighbouring polygons.
+The ``vertices`` list specifies a set of topological points to add, in the layer's coordinate reference system.
 %End
 
-    TopologicalResult addTopologicalPoints( const QVector<QgsPoint> &geom );
+    TopologicalResult addTopologicalPoints( const QVector<QgsPoint> &vertices );
 %Docstring
-Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
-
-:param geom: list of points (in layer coordinate system)
+Adds a list of ``vertices`` to other features to keep topology up to date, e.g. to neighbouring polygons.
+The ``vertices`` list specifies a set of topological points to add, in the layer's coordinate reference system.
 
 .. versionadded:: 3.10
 %End

--- a/python/gui/auto_generated/qgsmaptooledit.sip.in
+++ b/python/gui/auto_generated/qgsmaptooledit.sip.in
@@ -70,6 +70,17 @@ Adds vertices to other features to keep topology up to date, e.g. to neighbourin
 :return: 0 in case of success
 %End
 
+    int addTopologicalPoints( const QVector<QgsPoint> &geom );
+%Docstring
+Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
+
+:param geom: list of points (in layer coordinate system)
+
+:return: 0 in case of success
+
+.. versionadded:: 3.10
+%End
+
     void notifyNotVectorLayer();
 %Docstring
 Display a timed message bar noting the active layer is not vector.

--- a/python/gui/auto_generated/qgsmaptooledit.sip.in
+++ b/python/gui/auto_generated/qgsmaptooledit.sip.in
@@ -61,22 +61,25 @@ returned object
 Returns the current vector layer of the map canvas or 0
 %End
 
-    int addTopologicalPoints( const QVector<QgsPointXY> &geom );
+    enum TopologicalResult
+    {
+      Success,
+      InvalidCanvas,
+      InvalidLayer,
+    };
+
+    TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &geom );
 %Docstring
 Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
 
 :param geom: list of points (in layer coordinate system)
-
-:return: 0 in case of success
 %End
 
-    int addTopologicalPoints( const QVector<QgsPoint> &geom );
+    TopologicalResult addTopologicalPoints( const QVector<QgsPoint> &geom );
 %Docstring
 Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
 
 :param geom: list of points (in layer coordinate system)
-
-:return: 0 in case of success
 
 .. versionadded:: 3.10
 %End

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -176,6 +176,17 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      */
     int addTopologicalPoints( const QgsPointXY &p );
 
+    /**
+     * Adds a vertex to segments which intersect point p but don't
+     * already have a vertex there. If a feature already has a vertex at position p,
+     * no additional vertex is inserted. This method is useful for topological
+     * editing.
+     * \param p position of the vertex
+     * \return 0 in case of success
+     * \since QGIS 3.10
+     */
+    int addTopologicalPoints( const QgsPoint &p );
+
   private:
 
     /**

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -167,21 +167,19 @@ class CORE_EXPORT QgsVectorLayerEditUtils
     int addTopologicalPoints( const QgsGeometry &geom );
 
     /**
-     * Adds a vertex to segments which intersect point p but don't
+     * Adds a vertex to segments which intersect point \a p but don't
      * already have a vertex there. If a feature already has a vertex at position p,
      * no additional vertex is inserted. This method is useful for topological
      * editing.
-     * \param p position of the vertex
      * \return 0 in case of success
      */
     int addTopologicalPoints( const QgsPointXY &p );
 
     /**
-     * Adds a vertex to segments which intersect point p but don't
+     * Adds a vertex to segments which intersect point \a p but don't
      * already have a vertex there. If a feature already has a vertex at position p,
      * no additional vertex is inserted. This method is useful for topological
      * editing.
-     * \param p position of the vertex
      * \return 0 in case of success
      * \since QGIS 3.10
      */

--- a/src/gui/qgsmaptooledit.cpp
+++ b/src/gui/qgsmaptooledit.cpp
@@ -92,7 +92,7 @@ QgsVectorLayer *QgsMapToolEdit::currentVectorLayer()
 }
 
 
-QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &geom )
+QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &vertices )
 {
   if ( !mCanvas )
   {
@@ -107,15 +107,15 @@ QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QV
     return QgsMapToolEdit::InvalidLayer;
   }
 
-  QVector<QgsPoint>::const_iterator list_it = geom.constBegin();
-  for ( ; list_it != geom.constEnd(); ++list_it )
+  QVector<QgsPoint>::const_iterator list_it = vertices.constBegin();
+  for ( ; list_it != vertices.constEnd(); ++list_it )
   {
     vlayer->addTopologicalPoints( *list_it );
   }
   return QgsMapToolEdit::Success;
 }
 
-QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &geom )
+QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &vertices )
 {
   if ( !mCanvas )
   {
@@ -130,8 +130,8 @@ QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QV
     return QgsMapToolEdit::InvalidLayer;
   }
 
-  QVector<QgsPointXY>::const_iterator list_it = geom.constBegin();
-  for ( ; list_it != geom.constEnd(); ++list_it )
+  QVector<QgsPointXY>::const_iterator list_it = vertices.constBegin();
+  for ( ; list_it != vertices.constEnd(); ++list_it )
   {
     vlayer->addTopologicalPoints( *list_it );
   }

--- a/src/gui/qgsmaptooledit.cpp
+++ b/src/gui/qgsmaptooledit.cpp
@@ -92,11 +92,11 @@ QgsVectorLayer *QgsMapToolEdit::currentVectorLayer()
 }
 
 
-int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &geom )
+QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &geom )
 {
   if ( !mCanvas )
   {
-    return 1;
+    return QgsMapToolEdit::InvalidCanvas;
   }
 
   //find out current vector layer
@@ -104,7 +104,7 @@ int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &geom )
 
   if ( !vlayer )
   {
-    return 2;
+    return QgsMapToolEdit::InvalidLayer;
   }
 
   QVector<QgsPoint>::const_iterator list_it = geom.constBegin();
@@ -112,14 +112,14 @@ int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &geom )
   {
     vlayer->addTopologicalPoints( *list_it );
   }
-  return 0;
+  return QgsMapToolEdit::Success;
 }
 
-int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &geom )
+QgsMapToolEdit::TopologicalResult QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &geom )
 {
   if ( !mCanvas )
   {
-    return 1;
+    return QgsMapToolEdit::InvalidCanvas;
   }
 
   //find out current vector layer
@@ -127,7 +127,7 @@ int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &geom )
 
   if ( !vlayer )
   {
-    return 2;
+    return QgsMapToolEdit::InvalidLayer;
   }
 
   QVector<QgsPointXY>::const_iterator list_it = geom.constBegin();
@@ -135,7 +135,7 @@ int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &geom )
   {
     vlayer->addTopologicalPoints( *list_it );
   }
-  return 0;
+  return QgsMapToolEdit::Success;
 }
 
 QgsGeometryRubberBand *QgsMapToolEdit::createGeometryRubberBand( QgsWkbTypes::GeometryType geometryType, bool alternativeBand ) const

--- a/src/gui/qgsmaptooledit.cpp
+++ b/src/gui/qgsmaptooledit.cpp
@@ -92,6 +92,29 @@ QgsVectorLayer *QgsMapToolEdit::currentVectorLayer()
 }
 
 
+int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPoint> &geom )
+{
+  if ( !mCanvas )
+  {
+    return 1;
+  }
+
+  //find out current vector layer
+  QgsVectorLayer *vlayer = currentVectorLayer();
+
+  if ( !vlayer )
+  {
+    return 2;
+  }
+
+  QVector<QgsPoint>::const_iterator list_it = geom.constBegin();
+  for ( ; list_it != geom.constEnd(); ++list_it )
+  {
+    vlayer->addTopologicalPoints( *list_it );
+  }
+  return 0;
+}
+
 int QgsMapToolEdit::addTopologicalPoints( const QVector<QgsPointXY> &geom )
 {
   if ( !mCanvas )

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -76,17 +76,17 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
     };
 
     /**
-     * Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
-     * \param geom list of points (in layer coordinate system)
+     * Adds a list of \a vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
+     * The \a vertices list specifies a set of topological points to add, in the layer's coordinate reference system.
      */
-    TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &geom );
+    TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &vertices );
 
     /**
-     * Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
-     * \param geom list of points (in layer coordinate system)
+     * Adds a list of \a vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
+     * The \a vertices list specifies a set of topological points to add, in the layer's coordinate reference system.
      * \since QGIS 3.10
      */
-    TopologicalResult addTopologicalPoints( const QVector<QgsPoint> &geom );
+    TopologicalResult addTopologicalPoints( const QVector<QgsPoint> &vertices );
 
     //! Display a timed message bar noting the active layer is not vector.
     void notifyNotVectorLayer();

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -67,20 +67,26 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
     //! Returns the current vector layer of the map canvas or 0
     QgsVectorLayer *currentVectorLayer();
 
-    /**
-     * Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
-     * \param geom list of points (in layer coordinate system)
-     * \returns 0 in case of success
-     */
-    int addTopologicalPoints( const QVector<QgsPointXY> &geom );
+    //! Result of addTopologicalPoints
+    enum TopologicalResult
+    {
+      Success = 0, //!< AddTopologicalPoints was successful
+      InvalidCanvas = 1, //!< AddTopologicalPoints failed due to an invalid canvas
+      InvalidLayer = 2, //!< AddTopologicalPoints failed due to an invalid canvas
+    };
 
     /**
      * Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
      * \param geom list of points (in layer coordinate system)
-     * \returns 0 in case of success
+     */
+    TopologicalResult addTopologicalPoints( const QVector<QgsPointXY> &geom );
+
+    /**
+     * Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
+     * \param geom list of points (in layer coordinate system)
      * \since QGIS 3.10
      */
-    int addTopologicalPoints( const QVector<QgsPoint> &geom );
+    TopologicalResult addTopologicalPoints( const QVector<QgsPoint> &geom );
 
     //! Display a timed message bar noting the active layer is not vector.
     void notifyNotVectorLayer();

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -74,6 +74,14 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
      */
     int addTopologicalPoints( const QVector<QgsPointXY> &geom );
 
+    /**
+     * Adds vertices to other features to keep topology up to date, e.g. to neighbouring polygons.
+     * \param geom list of points (in layer coordinate system)
+     * \returns 0 in case of success
+     * \since QGIS 3.10
+     */
+    int addTopologicalPoints( const QVector<QgsPoint> &geom );
+
     //! Display a timed message bar noting the active layer is not vector.
     void notifyNotVectorLayer();
     //! Display a timed message bar noting the active vector layer is not editable.

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -165,12 +165,9 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
   mLayerTopoZ->startEditing();
   QgsFeature topoFeat;
   topoFeat.setGeometry( QgsGeometry::fromWkt( "MultiLineStringZ ((7.25 6 0, 7.25 7 0, 7.5 7 0, 7.5 6 0, 7.25 6 0),(6 6 0, 6 7 0, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.25 0)));" ) );
-  qDebug() << topoFeat.geometry().asWkt() << "\n";
 
   mLayerTopoZ->addFeature( topoFeat );
   QCOMPARE( mLayerTopoZ->featureCount(), ( long ) 1 );
-
-  qDebug() << mLayerTopoZ->getFeature( 1 ).geometry().asWkt() << "\n";
 
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineZ << mLayerPointZM << mLayerTopoZ );
 
@@ -423,8 +420,6 @@ void TestQgsMapToolAddFeatureLine::testTopologicalEditingZ()
   QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/default_z_value" ), 333 );
 
   QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
-
-  qDebug() << mLayerTopoZ->getFeature( 0 ).geometry().asWkt() << "\n";
 
   QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
   bool topologicalEditing = cfg.project()->topologicalEditing();

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -29,7 +29,6 @@
 #include "qgsmapmouseevent.h"
 #include "testqgsmaptoolutils.h"
 
-
 bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
 {
   if ( g1.isNull() && g2.isNull() )
@@ -68,6 +67,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     void testTracingWithOffset();
     void testZ();
     void testZMSnapping();
+    void testTopologicalEditingZ();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -78,6 +78,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     QgsVectorLayer *mLayerLine = nullptr;
     QgsVectorLayer *mLayerLineZ = nullptr;
     QgsVectorLayer *mLayerPointZM = nullptr;
+    QgsVectorLayer *mLayerTopoZ = nullptr;
     QgsFeatureId mFidLineF1 = 0;
 };
 
@@ -156,7 +157,22 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
   mLayerPointZM->addFeature( pointF );
   QCOMPARE( mLayerPointZM->featureCount(), ( long )1 );
 
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineZ << mLayerPointZM ); //<< mLayerPolygon << mLayerPoint );
+  // make layer for topologicalEditing with Z
+  mLayerTopoZ = new QgsVectorLayer( QStringLiteral( "MultiLineStringZ?crs=EPSG:27700" ), QStringLiteral( "layer topologicalEditing Z" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerTopoZ->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerTopoZ );
+
+  mLayerTopoZ->startEditing();
+  QgsFeature topoFeat;
+  topoFeat.setGeometry( QgsGeometry::fromWkt( "MultiLineStringZ ((7.25 6 0, 7.25 7 0, 7.5 7 0, 7.5 6 0, 7.25 6 0),(6 6 0, 6 7 0, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.25 0)));" ) );
+  qDebug() << topoFeat.geometry().asWkt() << "\n";
+
+  mLayerTopoZ->addFeature( topoFeat );
+  QCOMPARE( mLayerTopoZ->featureCount(), ( long ) 1 );
+
+  qDebug() << mLayerTopoZ->getFeature( 1 ).geometry().asWkt() << "\n";
+
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineZ << mLayerPointZM << mLayerTopoZ );
 
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
@@ -397,5 +413,46 @@ void TestQgsMapToolAddFeatureLine::testZMSnapping()
   mCanvas->snappingUtils()->setConfig( cfg );
 }
 
+void TestQgsMapToolAddFeatureLine::testTopologicalEditingZ()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  mCanvas->setCurrentLayer( mLayerTopoZ );
+
+  // test with default Z value = 333
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/default_z_value" ), 333 );
+
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+
+  qDebug() << mLayerTopoZ->getFeature( 0 ).geometry().asWkt() << "\n";
+
+  QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
+  bool topologicalEditing = cfg.project()->topologicalEditing();
+  cfg.project()->setTopologicalEditing( true );
+
+  cfg.setMode( QgsSnappingConfig::AllLayers );
+  cfg.setEnabled( true );
+  mCanvas->snappingUtils()->setConfig( cfg );
+
+  oldFids = utils.existingFeatureIds();
+  utils.mouseClick( 6, 6.5, Qt::LeftButton );
+  utils.mouseClick( 6.25, 6.5, Qt::LeftButton );
+  utils.mouseClick( 6.75, 6.5, Qt::LeftButton );
+  utils.mouseClick( 7.25, 6.5, Qt::LeftButton );
+  utils.mouseClick( 7.5, 6.5, Qt::LeftButton );
+  utils.mouseClick( 8, 6.5, Qt::RightButton );
+  QgsFeatureId newFid = utils.newFeatureId( oldFids );
+
+  QString wkt = "LineStringZ (6 6.5 333, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
+  QCOMPARE( mLayerTopoZ->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
+  wkt = "MultiLineStringZ ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 333, 6 7 0, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
+  QCOMPARE( mLayerTopoZ->getFeature( oldFids.toList().last() ).geometry(), QgsGeometry::fromWkt( wkt ) );
+
+  mLayerLine->undoStack()->undo();
+
+  cfg.setEnabled( false );
+  mCanvas->snappingUtils()->setConfig( cfg );
+  cfg.project()->setTopologicalEditing( topologicalEditing );
+}
 QGSTEST_MAIN( TestQgsMapToolAddFeatureLine )
 #include "testqgsmaptooladdfeatureline.moc"


### PR DESCRIPTION
## Description

Topological editing does not work for Z geometries. NaN value is returned instead of the default Z value.

This PR fixes it.

Before
![before](https://user-images.githubusercontent.com/7521540/62131561-b5409000-b2db-11e9-9b6e-4a04ba70ec86.gif)

After
![after](https://user-images.githubusercontent.com/7521540/62131578-bbcf0780-b2db-11e9-896a-ddfa11c945d5.gif)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
