### PR TITLE
Do not specify srid in dbmanager. It goes crazy

### DIFF
--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -985,7 +985,6 @@ class VectorTable(Table):
 
     def uri(self):
         uri = super().uri()
-        uri.setSrid(str(self.srid))
         for f in self.fields():
             if f.primaryKey:
                 uri.setKeyColumn(f.name)


### PR DESCRIPTION
If srid is specified in an uri, it disables type detection.

Fix #30787