### PR TITLE
Deprecate existing QgsCustomDropHandler::handleMimeData method, add handleMimeDataV2

### DIFF
--- a/python/gui/auto_generated/qgscustomdrophandler.sip.in
+++ b/python/gui/auto_generated/qgscustomdrophandler.sip.in
@@ -73,7 +73,7 @@ determine whether the drag action should be accepted.
 %End
 
 
-    virtual void handleMimeData( const QMimeData *data );
+ virtual void handleMimeData( const QMimeData *data ) /Deprecated/;
 %Docstring
 Called when the specified mime ``data`` has been dropped onto QGIS.
 
@@ -87,6 +87,29 @@ lock the explorer window until the drop handling has been complete).
 Accordingly, only implementations must be lightweight and return ASAP.
 (For instance by copying the relevant parts of ``data`` and then handling
 the data after a short timeout).
+
+.. deprecated:: in QGIS 3.10 - use handleMimeDataV2() instead.
+%End
+
+    virtual bool handleMimeDataV2( const QMimeData *data );
+%Docstring
+Called when the specified mime ``data`` has been dropped onto QGIS.
+
+The base class implementation does nothing.
+
+Subclasses should take care when overriding this method. When a drop event
+occurs, Qt will lock the source application of the drag for the duration
+of the drop event handling (e.g. dragging files from explorer to QGIS will
+lock the explorer window until the drop handling has been complete).
+
+Accordingly, only implementations must be lightweight and return ASAP.
+(For instance by copying the relevant parts of ``data`` and then handling
+the data after a short timeout).
+
+If the function returns ``True``, it means the handler has accepted the drop
+and it should not be further processed (e.g. by other QgsCustomDropHandlers)
+
+.. versionadded:: 3.10
 %End
 
     virtual bool handleFileDrop( const QString &file );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1689,7 +1689,18 @@ void QgisApp::dropEvent( QDropEvent *event )
   for ( QgsCustomDropHandler *handler : handlers )
   {
     if ( handler )
+    {
+      if ( handler->handleMimeDataV2( event->mimeData() ) )
+      {
+        // custom handler completely handled this data, no further processing required
+        event->acceptProposedAction();
+        return;
+      }
+
+      Q_NOWARN_DEPRECATED_PUSH
       handler->handleMimeData( event->mimeData() );
+      Q_NOWARN_DEPRECATED_POP
+    }
   }
 
   // get the file list

--- a/src/gui/qgscustomdrophandler.cpp
+++ b/src/gui/qgscustomdrophandler.cpp
@@ -35,6 +35,11 @@ void QgsCustomDropHandler::handleMimeData( const QMimeData *data )
   Q_UNUSED( data )
 }
 
+bool QgsCustomDropHandler::handleMimeDataV2( const QMimeData * )
+{
+  return false;
+}
+
 bool QgsCustomDropHandler::handleFileDrop( const QString &file )
 {
   Q_UNUSED( file )

--- a/src/gui/qgscustomdrophandler.h
+++ b/src/gui/qgscustomdrophandler.h
@@ -97,8 +97,31 @@ class GUI_EXPORT QgsCustomDropHandler : public QObject
      * Accordingly, only implementations must be lightweight and return ASAP.
      * (For instance by copying the relevant parts of \a data and then handling
      * the data after a short timeout).
+     *
+     * \deprecated in QGIS 3.10 - use handleMimeDataV2() instead.
      */
-    virtual void handleMimeData( const QMimeData *data );
+    Q_DECL_DEPRECATED virtual void handleMimeData( const QMimeData *data ) SIP_DEPRECATED;
+
+    /**
+     * Called when the specified mime \a data has been dropped onto QGIS.
+     *
+     * The base class implementation does nothing.
+     *
+     * Subclasses should take care when overriding this method. When a drop event
+     * occurs, Qt will lock the source application of the drag for the duration
+     * of the drop event handling (e.g. dragging files from explorer to QGIS will
+     * lock the explorer window until the drop handling has been complete).
+     *
+     * Accordingly, only implementations must be lightweight and return ASAP.
+     * (For instance by copying the relevant parts of \a data and then handling
+     * the data after a short timeout).
+     *
+     * If the function returns TRUE, it means the handler has accepted the drop
+     * and it should not be further processed (e.g. by other QgsCustomDropHandlers)
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool handleMimeDataV2( const QMimeData *data );
 
     /**
      * Called when the specified \a file has been dropped onto QGIS. If TRUE


### PR DESCRIPTION
...method which returns a bool

This allows custom drop handlers to indicate that they've fully handled dropped mime data, and that no further processing should be done on the mime data
