### PR TITLE
[Processing][TilesXYZ] Multithreaded Tile generation with ThreadPoolExecutor

### DIFF
--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -187,7 +187,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         if self.feedback.isCanceled():
             return
             # Haven't found a better way to break than to make all the new threads return instantly
- 
+
         if "Dummy" in threading.current_thread().name: # single thread testing
             threadSpecificSettings = list(self.settingsDictionary.values())[0]
         else:
@@ -196,14 +196,14 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
                 threadSpecificSettings = self.settingsDictionary[threading.current_thread().name[-1]] # last number only
             except:
                 print("Exception! our threads don't match with our settings! ")
- 
+
         size = QSize(self.tile_width * metatile.rows(), self.tile_height * metatile.columns())
         extent = QgsRectangle(*metatile.extent())
         threadSpecificSettings.setExtent(self.wgs_to_dest.transformBoundingBox(extent))
         threadSpecificSettings.setOutputSize(size)
- 
+
         image = QImage(size, QImage.Format_ARGB32_Premultiplied)
-        image.fill(self.color) 
+        image.fill(self.color)
         dpm = threadSpecificSettings.outputDpi() / 25.4 * 1000
         image.setDotsPerMeterX(dpm)
         image.setDotsPerMeterY(dpm)
@@ -211,7 +211,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         job = QgsMapRendererCustomPainterJob(threadSpecificSettings, painter)
         job.renderSynchronously()
         painter.end()
- 
+
         ## For analysing metatiles (labels, etc.)
         ## metatile_dir = os.path.join(output_dir, str(zoom))
         ## os.makedirs(metatile_dir, exist_ok=True)
@@ -225,7 +225,6 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         with self.progressThreadLock:
             self.progress += 1
             self.feedback.setProgress(100 * (self.progress / self.totalMetatiles))
-
 
     def generate(self, writer, parameters, context, feedback):
         self.feedback = feedback
@@ -255,7 +254,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
 
         self.maxThreads = cpu_count() # from multithreading
         #self.maxThreads = 2
-                # without re-writing, we need a different settings for each thread to stop async errors
+        # without re-writing, we need a different settings for each thread to stop async errors
         # naming doesn't always line up, but the last number does
         #self.settingsDictionary = {'ThreadPoolExecutor-o_' + str(i): QgsMapSettings() for i in range(self.maxThreads)}
         self.settingsDictionary = {str(i): QgsMapSettings() for i in range(self.maxThreads)}
@@ -277,7 +276,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
                            self.wgs_extent.yMaximum()]
 
         metatiles_by_zoom = {}
-        self.totalMetatiles =  0
+        self.totalMetatiles = 0
         allMetatiles = []
         for zoom in range(self.min_zoom, self.max_zoom + 1):
             metatiles = get_metatiles(self.wgs_extent, zoom, self.metatilesize)
@@ -308,11 +307,9 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         # single thread testing
         #for zoom in range(self.min_zoom, self.max_zoom + 1):
             #for i, metatile in enumerate(metatiles_by_zoom[zoom]):
-                #self.renderSingleMetatile(metatile)
-
+            #self.renderSingleMetatile(metatile)
 
         writer.close()
-
 
     def checkParameterValues(self, parameters, context):
         min_zoom = self.parameterAsInt(parameters, self.ZOOM_MIN, context)

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -300,14 +300,14 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
 
         self.progressThreadLock = threading.Lock()
         if self.maxThreads > 1:
-            feedback.pushConsoleInfo('Using %s CPU Threads:' % self.maxThreads)
-            feedback.pushConsoleInfo('Pushing all tiles at once: %s tiles.' % len(allMetatiles))
+            feedback.pushConsoleInfo(self.tr('Using {max_threads} CPU Threads:').format(max_threads=self.maxThreads))
+            feedback.pushConsoleInfo(self.tr('Pushing all tiles at once: {meta_count} tiles.').format(meta_count=len(allMetatiles)))
             with ThreadPoolExecutor(max_workers=self.maxThreads) as threadPool:
                 threadPool.map(self.renderSingleMetatile, allMetatiles)
         else:
-            feedback.pushConsoleInfo('Using 1 CPU Thread:')
+            feedback.pushConsoleInfo(self.tr('Using 1 CPU Thread:'))
             for zoom in range(self.min_zoom, self.max_zoom + 1):
-                feedback.pushConsoleInfo('Generating tiles for zoom level: %s' % zoom)
+                feedback.pushConsoleInfo(self.tr('Generating tiles for zoom level: {zoom}').format(zoom=zoom))
                 for i, metatile in enumerate(metatiles_by_zoom[zoom]):
                     self.renderSingleMetatile(metatile)
 

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -192,11 +192,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         if "Dummy" in threading.current_thread().name: # single thread testing
             threadSpecificSettings = list(self.settingsDictionary.values())[0]
         else:
-            try:
-                # guess we're not the only one using TPE in QGIS, cannot assume 0_#, it's sometimes 3 or 4_#
-                threadSpecificSettings = self.settingsDictionary[threading.current_thread().name[-1]] # last number only
-            except:
-                print("Exception! our threads don't match with our settings! ")
+            threadSpecificSettings = self.settingsDictionary[threading.current_thread().name[-1]] # last number only
 
         size = QSize(self.tile_width * metatile.rows(), self.tile_height * metatile.columns())
         extent = QgsRectangle(*metatile.extent())

--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -50,7 +50,7 @@ from qgis.core import (QgsProcessingException,
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from multiprocessing import cpu_count
+from processing.core.ProcessingConfig import ProcessingConfig
 
 
 # TMS functions taken from https://alastaira.wordpress.com/2011/07/06/converting-tms-tile-coordinates-to-googlebingosm-tile-coordinates/ #spellok
@@ -235,8 +235,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         self.tile_format = self.formats[self.parameterAsEnum(parameters, self.TILE_FORMAT, context)]
         self.quality = self.parameterAsInt(parameters, self.QUALITY, context)
         self.metatilesize = self.parameterAsInt(parameters, self.METATILESIZE, context)
-        self.maxThreads = QgsApplication.maxThreads()
-        self.maxThreads = cpu_count() if self.maxThreads == -1 else self.maxThreads # if unbound, maxThreads() returns -1
+        self.maxThreads = int(ProcessingConfig.getSetting(ProcessingConfig.MAX_THREADS))
         try:
             self.tile_width = self.parameterAsInt(parameters, self.TILE_WIDTH, context)
             self.tile_height = self.parameterAsInt(parameters, self.TILE_HEIGHT, context)

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -31,6 +31,7 @@ from qgis.core import (NULL,
                        QgsRasterFileWriter)
 from processing.tools.system import defaultOutputFolder
 import processing.tools.dataobjects
+from multiprocessing import cpu_count
 
 
 class SettingsWatcher(QObject):
@@ -56,6 +57,7 @@ class ProcessingConfig:
     WARN_UNMATCHING_CRS = 'WARN_UNMATCHING_CRS'
     SHOW_PROVIDERS_TOOLTIP = 'SHOW_PROVIDERS_TOOLTIP'
     SHOW_ALGORITHMS_KNOWN_ISSUES = 'SHOW_ALGORITHMS_KNOWN_ISSUES'
+    MAX_THREADS = 'MAX_THREADS'
 
     settings = {}
     settingIcons = {}
@@ -134,6 +136,14 @@ class ProcessingConfig:
             invalidFeaturesOptions[2],
             valuetype=Setting.SELECTION,
             options=invalidFeaturesOptions))
+
+        threads = QgsApplication.maxThreads() # if user specified limit for rendering, lets keep that as default here, otherwise max
+        threads = cpu_count() if threads == -1 else threads # if unset, maxThreads() returns -1
+        ProcessingConfig.addSetting(Setting(
+            ProcessingConfig.tr('General'),
+            ProcessingConfig.MAX_THREADS,
+            ProcessingConfig.tr('Max Threads'), threads,
+            valuetype=Setting.INT))
 
     @staticmethod
     def setGroupIcon(group, icon):


### PR DESCRIPTION
Rendering tiles is changed from single thread to multithread using python standard library ThreadPoolExecutor (TPE) class, resulting in a large performance boost for multithreaded CPUs.

Most of the looped code in TilesXYZAlgorithmBase::generate() was relocated into a separate function (per metatile), then all metatiles are mapped to this function by the TPE, which handles thread management for us. To prevent the thread conflicts on the settings, settings were duplicated per thread. 

~~There is one additional addition I think would be good to add: The user interface should have an option to set how many threads are created for the rendering job, right now the code uses all cores available to it(multithreading::cpu_count()) but I don't know how to add this to the user interface.~~ done

This is a re-attempt of a previous pull-request: https://github.com/qgis/QGIS/pull/30473

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

Not sure if this counts as a feature..? It's more a change than an addition I think.

This isn't core, right? It's processing, and I don't know how to make unit tests or what new tests would need to be created