### PR TITLE
Fix trim/extend map tool crash

### DIFF
--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -228,13 +228,15 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
         {
           filter.setLayer( mVlayer );
           match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter );
+          if ( match.layer() )
+          {
+            match.layer()->beginEditCommand( tr( "Trim/Extend feature" ) );
+            match.layer()->changeGeometry( match.featureId(), mGeom );
+            match.layer()->endEditCommand();
+            match.layer()->triggerRepaint();
 
-          match.layer()->beginEditCommand( tr( "Trim/Extend feature" ) );
-          match.layer()->changeGeometry( match.featureId(), mGeom );
-          match.layer()->endEditCommand();
-          match.layer()->triggerRepaint();
-
-          emit messageEmitted( tr( "Feature trimmed/extended." ) );
+            emit messageEmitted( tr( "Feature trimmed/extended." ) );
+          }
         }
         else
         {


### PR DESCRIPTION
## Description
While trying to replicate a trim/extend map tool crash raised in issue #31016 , I stumbled on an access to null pointer crash. I'm not sure this fixes the issue raised; the stack trace (if valid) indicates the crash is occurring in a different part of the code for this  tool.

Anyhow, a crash fixes is a crash fixed, let's celebrate ;)

@lbartoletti , I had never used this tool before, and I must admit I find it extremely confusing. A bit of love on the UI/UX front would definitively help. For e.g., if snapping isn't active, the tool doesn't do anything. Maybe you should add a message bar item saying "this tool requires snapping, please activate".

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
