### PR TITLE
topological editing: fix topological editing for trim/extend map tool

### DIFF
--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -221,6 +221,7 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
         {
           getPoints( match, pLimit1, pLimit2 );
           mStep = StepExtend;
+          mLimitLayer = match.layer();
         }
         break;
       case StepExtend:
@@ -231,6 +232,8 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
 
           match.layer()->beginEditCommand( tr( "Trim/Extend feature" ) );
           match.layer()->changeGeometry( match.featureId(), mGeom );
+          match.layer()->addTopologicalPoints( mIntersection );
+          mLimitLayer->addTopologicalPoints( mIntersection );
           match.layer()->endEditCommand();
           match.layer()->triggerRepaint();
 

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -255,8 +255,11 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
 
             match.layer()->beginEditCommand( tr( "Trim/Extend feature" ) );
             match.layer()->changeGeometry( match.featureId(), mGeom );
-            match.layer()->addTopologicalPoints( mIntersection );
-            mLimitLayer->addTopologicalPoints( mIntersection );
+            if ( QgsProject::instance()->topologicalEditing() )
+            {
+              match.layer()->addTopologicalPoints( mIntersection );
+              mLimitLayer->addTopologicalPoints( mIntersection );
+            }
             match.layer()->endEditCommand();
             match.layer()->triggerRepaint();
 

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -109,14 +109,23 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
 
       QgsMapLayer *currentLayer = mCanvas->currentLayer();
       if ( !currentLayer )
+      {
+        mIsModified = false;
         break;
+      }
 
       mVlayer = qobject_cast<QgsVectorLayer *>( currentLayer );
       if ( !mVlayer )
+      {
+        mIsModified = false;
         break;
+      }
 
       if ( !mVlayer->isEditable() )
+      {
+        mIsModified = false;
         break;
+      }
 
       filter.setLayer( mVlayer );
       match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter );
@@ -189,6 +198,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
 
           if ( mIsModified )
           {
+            mGeom.removeDuplicateNodes();
             mRubberBandExtend->setToGeometry( mGeom );
             mRubberBandExtend->show();
           }

--- a/src/app/qgsmaptooltrimextendfeature.h
+++ b/src/app/qgsmaptooltrimextendfeature.h
@@ -55,6 +55,8 @@ class APP_EXPORT QgsMapToolTrimExtendFeature : public QgsMapToolEdit
     QgsPointXY mMapPoint;
     //! geometry that will be returned
     QgsGeometry mGeom;
+    //! Limit layer which will be snapped
+    QgsVectorLayer *mLimitLayer = nullptr;
     //! Current layer which will be modified
     QgsVectorLayer *mVlayer = nullptr;
     //! Keep information about the state of the intersection

--- a/tests/src/app/testqgsmaptooltrimextendfeature.cpp
+++ b/tests/src/app/testqgsmaptooltrimextendfeature.cpp
@@ -41,7 +41,7 @@ class TestQgsMapToolTrimExtendFeature : public QObject
     TestQgsMapToolTrimExtendFeature() = default;
 
   private:
-    std::unique_ptr<QgsVectorLayer> vlPolygon, vlMultiLine, vlLineZ;
+    std::unique_ptr<QgsVectorLayer> vlPolygon, vlMultiLine, vlLineZ, vlTopoEdit, vlTopoLimit;
     QgsFeature f1, f2;
     QgsMapCanvas *mCanvas = nullptr;
 
@@ -131,16 +131,37 @@ class TestQgsMapToolTrimExtendFeature : public QObject
       vlLineZ->dataProvider()->addFeatures( QgsFeatureList() << linez << linez2 );
 
 
+      /*
+       *       |
+       * ----  |
+       *       |
+       *
+       */
+      vlTopoEdit.reset( new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:3946&field=pk:int" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+      QVERIFY( vlTopoEdit->isValid() );
+      vlTopoLimit.reset( new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:3946&field=pk:int" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+      QVERIFY( vlTopoLimit->isValid() );
+      QgsFeature lineEdit( vlTopoEdit->dataProvider()->fields(), 1 );
+      lineEdit.setAttribute( QStringLiteral( "pk" ), 1 );
+      lineEdit.setGeometry( QgsGeometry::fromWkt( QStringLiteral( " LineString (20 15, 25 15) " ) ) );
+      QgsFeature lineLimit( vlTopoLimit->dataProvider()->fields(), 1 );
+      lineLimit.setAttribute( QStringLiteral( "pk" ), 1 );
+      lineLimit.setGeometry( QgsGeometry::fromWkt( QStringLiteral( " LineString (30 0, 30 30) " ) ) );
+
+      vlTopoEdit->dataProvider()->addFeatures( QgsFeatureList() << lineEdit );
+      vlTopoLimit->dataProvider()->addFeatures( QgsFeatureList() << lineLimit );
+
+
       mCanvas = new QgsMapCanvas();
       mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
-      mCanvas->setLayers( QList<QgsMapLayer *>() << vlPolygon.get() << vlMultiLine.get() << vlLineZ.get() );
+      mCanvas->setLayers( QList<QgsMapLayer *>() << vlPolygon.get() << vlMultiLine.get() << vlLineZ.get() << vlTopoEdit.get() << vlTopoLimit.get() );
 
       QgsMapSettings mapSettings;
       mapSettings.setOutputSize( QSize( 50, 50 ) );
       mapSettings.setExtent( QgsRectangle( -1, -1, 4, 4 ) );
       QVERIFY( mapSettings.hasValidSettings() );
 
-      mapSettings.setLayers( QList<QgsMapLayer *>() << vlPolygon.get() << vlMultiLine.get() << vlLineZ.get() );
+      mapSettings.setLayers( QList<QgsMapLayer *>() << vlPolygon.get() << vlMultiLine.get() << vlLineZ.get() << vlTopoEdit.get() << vlTopoLimit.get() );
 
       QgsSnappingUtils *mSnappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
       QgsSnappingConfig snappingConfig = mSnappingUtils->config();
@@ -442,6 +463,63 @@ class TestQgsMapToolTrimExtendFeature : public QObject
 
       vlLineZ->rollBack();
     }
+
+    void testTopologicalPoints()
+    {
+      bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+      QgsProject::instance()->setTopologicalEditing( true );
+
+      mCanvas->setCurrentLayer( vlTopoEdit.get() );
+      std::unique_ptr< QgsMapToolTrimExtendFeature > tool( new QgsMapToolTrimExtendFeature( mCanvas ) );
+
+      vlTopoLimit->startEditing();
+      vlTopoEdit->startEditing();
+      // Limit
+      QgsPointXY pt;
+      pt = tool->canvas()->mapSettings().mapToPixel().transform( 30, 15 );
+      std::unique_ptr< QgsMapMouseEvent > event( new QgsMapMouseEvent(
+            mCanvas,
+            QEvent::MouseMove,
+            QPoint( std::round( pt.x() ), std::round( pt.y() ) )
+          ) );
+      tool->canvasMoveEvent( event.get() );
+      event.reset( new QgsMapMouseEvent(
+                     mCanvas,
+                     QEvent::MouseButtonRelease,
+                     QPoint( std::round( pt.x() ), std::round( pt.y() ) ),
+                     Qt::LeftButton
+                   ) );
+      tool->canvasReleaseEvent( event.get() );
+
+      // Extend
+      pt = tool->canvas()->mapSettings().mapToPixel().transform( 22, 15 );
+      event.reset( new QgsMapMouseEvent(
+                     mCanvas,
+                     QEvent::MouseMove,
+                     QPoint( std::round( pt.x() ), std::round( pt.y() ) )
+                   ) );
+      tool->canvasMoveEvent( event.get() );
+      event.reset( new QgsMapMouseEvent(
+                     mCanvas,
+                     QEvent::MouseButtonRelease,
+                     QPoint( std::round( pt.x() ), std::round( pt.y() ) ),
+                     Qt::LeftButton
+                   ) );
+      tool->canvasReleaseEvent( event.get() );
+
+      QgsFeature fEdit = vlTopoEdit->getFeature( 1 );
+      QgsFeature fLimit = vlTopoLimit->getFeature( 1 );
+
+      QString wktEdit = "LineString (20 15, 30 15)";
+      QString wktLimit = "LineString (30 0, 30 15, 30 30)";
+      QCOMPARE( fEdit.geometry().asWkt(), wktEdit );
+      QCOMPARE( fLimit.geometry().asWkt(), wktLimit );
+
+      vlTopoEdit->rollBack();
+
+      QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsMapToolTrimExtendFeature )


### PR DESCRIPTION
## Description

Add support of topological editing for trim/extend map tool.

The intersection point is added on the limit layer as on the modified layer.

Before
![before](https://user-images.githubusercontent.com/7521540/62201797-5c7b0100-b388-11e9-9ac0-5e39c217514a.gif)

After
![after](https://user-images.githubusercontent.com/7521540/62201795-5be26a80-b388-11e9-8286-d9cdfc97e4fe.gif)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
