### PR TITLE
Fix potential crash in marker symbol layer

### DIFF
--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -359,7 +359,7 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureIterator &fit )
   }
 
   QgsExpressionContextScope *symbolScope = QgsExpressionContextUtils::updateSymbolScope( nullptr, new QgsExpressionContextScope() );
-  mContext.expressionContext().appendScope( symbolScope );
+  std::unique_ptr< QgsExpressionContextScopePopper > scopePopper = qgis::make_unique< QgsExpressionContextScopePopper >( mContext.expressionContext(), symbolScope );
 
   // 1. fetch features
   QgsFeature fet;
@@ -369,7 +369,6 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureIterator &fit )
     {
       qDebug( "rendering stop!" );
       stopRenderer( selRenderer );
-      delete mContext.expressionContext().popScope();
       return;
     }
 
@@ -417,7 +416,7 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureIterator &fit )
     }
   }
 
-  delete mContext.expressionContext().popScope();
+  scopePopper.reset();
 
   if ( features.empty() )
   {

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -25,6 +25,7 @@
 #include "qgsgeometrysimplifier.h"
 #include "qgsunittypes.h"
 #include "qgsproperty.h"
+#include "qgsexpressioncontextutils.h"
 
 #include <QPainter>
 #include <QDomDocument>
@@ -1080,7 +1081,7 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineInterval( const QPolygonF &p
   double interval = mInterval;
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope();
-  context.renderContext().expressionContext().appendScope( scope );
+  QgsExpressionContextScopePopper scopePopper( context.renderContext().expressionContext(), scope );
 
   if ( mDataDefinedProperties.isActive( QgsSymbolLayer::PropertyInterval ) )
   {
@@ -1211,8 +1212,6 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineInterval( const QPolygonF &p
     }
 
   }
-
-  delete context.renderContext().expressionContext().popScope();
 }
 
 static double _averageAngle( QPointF prevPt, QPointF pt, QPointF nextPt )
@@ -1237,7 +1236,7 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineVertex( const QPolygonF &poi
   bool isRing = false;
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope();
-  context.renderContext().expressionContext().appendScope( scope );
+  QgsExpressionContextScopePopper scopePopper( context.renderContext().expressionContext(), scope );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_GEOMETRY_POINT_COUNT, points.size(), true ) );
 
   double offsetAlongLine = mOffsetAlongLine;
@@ -1293,7 +1292,6 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineVertex( const QPolygonF &poi
       }
     }
 
-    delete context.renderContext().expressionContext().popScope();
     return;
   }
 
@@ -1326,7 +1324,6 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineVertex( const QPolygonF &poi
     case CentralPoint:
     case CurvePoint:
     {
-      delete context.renderContext().expressionContext().popScope();
       return;
     }
   }
@@ -1339,7 +1336,6 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineVertex( const QPolygonF &poi
     // restore original rotation
     setSymbolAngle( origAngle );
 
-    delete context.renderContext().expressionContext().popScope();
     return;
   }
 
@@ -1364,8 +1360,6 @@ void QgsTemplatedLineSymbolLayerBase::renderPolylineVertex( const QPolygonF &poi
 
   // restore original rotation
   setSymbolAngle( origAngle );
-
-  delete context.renderContext().expressionContext().popScope();
 }
 
 double QgsTemplatedLineSymbolLayerBase::markerAngle( const QPolygonF &points, bool isRing, int vertex )

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -22,6 +22,7 @@
 #include "qgsmultipoint.h"
 #include "qgslogger.h"
 #include "qgsstyleentityvisitor.h"
+#include "qgsexpressioncontextutils.h"
 
 #include <QDomElement>
 #include <QPainter>
@@ -151,9 +152,8 @@ void QgsPointDistanceRenderer::drawGroup( const ClusteredGroup &group, QgsRender
   QPointF pt = centroid.asQPointF();
   context.mapToPixel().transformInPlace( pt.rx(), pt.ry() );
 
-  context.expressionContext().appendScope( createGroupScope( group ) );
+  QgsExpressionContextScopePopper scopePopper( context.expressionContext(), createGroupScope( group ) );
   drawGroup( pt, context, group );
-  delete context.expressionContext().popScope();
 }
 
 void QgsPointDistanceRenderer::setEmbeddedRenderer( QgsFeatureRenderer *r )


### PR DESCRIPTION
(the expression context scope wasn't being deleted in all return
paths, resulting in crashes when rendering was complete and
everything was being cleaned up)

And some other code safer against this same risk
