### PR TITLE
Use real symbol buttons in categorized and graduated renderer widgets, instead of fake ones

### DIFF
--- a/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -26,6 +26,8 @@ class QgsCategorizedSymbolRendererWidget : QgsRendererWidget
 
     virtual QgsFeatureRenderer *renderer();
 
+    virtual void setContext( const QgsSymbolWidgetContext &context );
+
 
     int matchToSymbols( QgsStyle *style );
 %Docstring
@@ -94,8 +96,6 @@ from the XML file with a matching name.
   protected:
 
     void updateUiFromRenderer();
-
-    void updateCategorizedSymbolIcon();
 
     void populateCategories();
 

--- a/python/gui/auto_generated/symbology/qgsgraduatedsymbolrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsgraduatedsymbolrendererwidget.sip.in
@@ -24,9 +24,10 @@ class QgsGraduatedSymbolRendererWidget : QgsRendererWidget
 
     virtual QgsFeatureRenderer *renderer();
 
+    virtual void setContext( const QgsSymbolWidgetContext &context );
+
 
   public slots:
-    void changeGraduatedSymbol();
     void graduatedColumnChanged( const QString &field );
     void classifyGraduated();
     void reapplyColorRamp();
@@ -70,8 +71,6 @@ Toggle the link between classes boundaries
     void connectUpdateHandlers();
     void disconnectUpdateHandlers();
     bool rowsOrdered();
-
-    void updateGraduatedSymbolIcon();
 
     QList<int> selectedClasses();
 %Docstring

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -99,6 +99,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     ~QgsCategorizedSymbolRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
+    void setContext( const QgsSymbolWidgetContext &context ) override;
 
     /**
      * Replaces category symbols with the symbols from a style that have a matching
@@ -156,6 +157,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
     void cleanUpSymbolSelector( QgsPanelWidget *container );
     void updateSymbolsFromWidget();
+    void updateSymbolsFromButton();
     void dataDefinedSizeLegend();
 
     /**
@@ -174,11 +176,11 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
 
     void showContextMenu( QPoint p );
 
+    void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
+
   protected:
 
     void updateUiFromRenderer();
-
-    void updateCategorizedSymbolIcon();
 
     // Called by virtual refreshSymbolView()
     void populateCategories();

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -468,6 +468,9 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   mExpressionWidget->setFilters( QgsFieldProxyModel::Numeric | QgsFieldProxyModel::Date );
   mExpressionWidget->setLayer( mLayer );
 
+  btnChangeGraduatedSymbol->setLayer( mLayer );
+  btnChangeGraduatedSymbol->registerExpressionContextGenerator( this );
+
   mSizeUnitWidget->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderMapUnits << QgsUnitTypes::RenderPixels
                              << QgsUnitTypes::RenderPoints << QgsUnitTypes::RenderInches );
 
@@ -493,6 +496,8 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   viewGraduated->setStyle( new QgsGraduatedSymbolRendererViewStyle( viewGraduated ) );
 
   mGraduatedSymbol.reset( QgsSymbol::defaultSymbol( mLayer->geometryType() ) );
+  btnChangeGraduatedSymbol->setSymbolType( mGraduatedSymbol->type() );
+  btnChangeGraduatedSymbol->setSymbol( mGraduatedSymbol->clone() );
 
   methodComboBox->blockSignals( true );
   methodComboBox->addItem( QStringLiteral( "Color" ) );
@@ -516,7 +521,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   connect( viewGraduated, &QTreeView::customContextMenuRequested,  this, &QgsGraduatedSymbolRendererWidget::contextMenuViewCategories );
 
   connect( btnGraduatedClassify, &QAbstractButton::clicked, this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
-  connect( btnChangeGraduatedSymbol, &QAbstractButton::clicked, this, &QgsGraduatedSymbolRendererWidget::changeGraduatedSymbol );
+  connect( btnChangeGraduatedSymbol, &QgsSymbolButton::changed, this, &QgsGraduatedSymbolRendererWidget::changeGraduatedSymbol );
   connect( btnGraduatedDelete, &QAbstractButton::clicked, this, &QgsGraduatedSymbolRendererWidget::deleteClasses );
   connect( btnDeleteAllClasses, &QAbstractButton::clicked, this, &QgsGraduatedSymbolRendererWidget::deleteAllClasses );
   connect( btnGraduatedAdd, &QAbstractButton::clicked, this, &QgsGraduatedSymbolRendererWidget::addClass );
@@ -557,7 +562,6 @@ void QgsGraduatedSymbolRendererWidget::mSizeUnitWidget_changed()
   if ( !mGraduatedSymbol ) return;
   mGraduatedSymbol->setOutputUnit( mSizeUnitWidget->unit() );
   mGraduatedSymbol->setMapUnitScale( mSizeUnitWidget->getMapUnitScale() );
-  updateGraduatedSymbolIcon();
   mRenderer->updateSymbols( mGraduatedSymbol.get() );
   refreshSymbolView();
 }
@@ -570,6 +574,13 @@ QgsGraduatedSymbolRendererWidget::~QgsGraduatedSymbolRendererWidget()
 QgsFeatureRenderer *QgsGraduatedSymbolRendererWidget::renderer()
 {
   return mRenderer.get();
+}
+
+void QgsGraduatedSymbolRendererWidget::setContext( const QgsSymbolWidgetContext &context )
+{
+  QgsRendererWidget::setContext( context );
+  btnChangeGraduatedSymbol->setMapCanvas( context.mapCanvas() );
+  btnChangeGraduatedSymbol->setMessageBar( context.messageBar() );
 }
 
 // Connect/disconnect event handlers which trigger updating renderer
@@ -617,7 +628,6 @@ void QgsGraduatedSymbolRendererWidget::disconnectUpdateHandlers()
 void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
 {
   disconnectUpdateHandlers();
-  updateGraduatedSymbolIcon();
   spinSymmetryPointForOtherMethods->setShowClearButton( false );
 
   // update UI from the graduated renderer (update combo boxes, view)
@@ -701,11 +711,13 @@ void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
   if ( mRenderer->sourceSymbol() )
   {
     mGraduatedSymbol.reset( mRenderer->sourceSymbol()->clone() );
-    updateGraduatedSymbolIcon();
+    whileBlocking( btnChangeGraduatedSymbol )->setSymbol( mGraduatedSymbol->clone() );
   }
 
   mModel->setRenderer( mRenderer.get() );
   viewGraduated->setModel( mModel );
+
+  connect( viewGraduated->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsGraduatedSymbolRendererWidget::selectionChanged );
 
   if ( mGraduatedSymbol )
   {
@@ -1029,43 +1041,6 @@ void QgsGraduatedSymbolRendererWidget::reapplySizes()
   refreshSymbolView();
 }
 
-void QgsGraduatedSymbolRendererWidget::changeGraduatedSymbol()
-{
-  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
-  std::unique_ptr< QgsSymbol > newSymbol( mGraduatedSymbol->clone() );
-  if ( panel && panel->dockMode() )
-  {
-    QgsSymbolSelectorWidget *dlg = new QgsSymbolSelectorWidget( newSymbol.release(), mStyle, mLayer, panel );
-    dlg->setContext( mContext );
-
-    connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsGraduatedSymbolRendererWidget::updateSymbolsFromWidget );
-    connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::cleanUpSymbolSelector );
-    connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsGraduatedSymbolRendererWidget::updateGraduatedSymbolIcon );
-    panel->openPanel( dlg );
-  }
-  else
-  {
-    QgsSymbolSelectorDialog dlg( newSymbol.get(), mStyle, mLayer, panel );
-    if ( !dlg.exec() || !newSymbol )
-    {
-      return;
-    }
-
-    mGraduatedSymbol = std::move( newSymbol );
-    updateGraduatedSymbolIcon();
-    applyChangeToSymbol();
-  }
-}
-
-void QgsGraduatedSymbolRendererWidget::updateGraduatedSymbolIcon()
-{
-  if ( !mGraduatedSymbol )
-    return;
-
-  QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( mGraduatedSymbol.get(), btnChangeGraduatedSymbol->iconSize() );
-  btnChangeGraduatedSymbol->setIcon( icon );
-}
-
 #if 0
 int QgsRendererPropertiesDialog::currentRangeRow()
 {
@@ -1151,6 +1126,7 @@ void QgsGraduatedSymbolRendererWidget::changeRangeSymbol( int rangeIdx )
     }
 
     mGraduatedSymbol = std::move( newSymbol );
+    whileBlocking( btnChangeGraduatedSymbol )->setSymbol( mGraduatedSymbol->clone() );
     applyChangeToSymbol();
   }
 }
@@ -1388,6 +1364,20 @@ void QgsGraduatedSymbolRendererWidget::keyPressEvent( QKeyEvent *event )
   }
 }
 
+void QgsGraduatedSymbolRendererWidget::selectionChanged( const QItemSelection &, const QItemSelection & )
+{
+  const QgsRangeList ranges = selectedRanges();
+  if ( !ranges.isEmpty() )
+  {
+    whileBlocking( btnChangeGraduatedSymbol )->setSymbol( ranges.at( 0 ).symbol()->clone() );
+  }
+  else if ( mRenderer->sourceSymbol() )
+  {
+    whileBlocking( btnChangeGraduatedSymbol )->setSymbol( mRenderer->sourceSymbol()->clone() );
+  }
+  btnChangeGraduatedSymbol->setDialogTitle( ranges.size() == 1 ? ranges.at( 0 ).label() : tr( "Symbol Settings" ) );
+}
+
 void QgsGraduatedSymbolRendererWidget::dataDefinedSizeLegend()
 {
   QgsMarkerSymbol *s = static_cast<QgsMarkerSymbol *>( mGraduatedSymbol.get() ); // this should be only enabled for marker symbols
@@ -1401,6 +1391,12 @@ void QgsGraduatedSymbolRendererWidget::dataDefinedSizeLegend()
     } );
     openPanel( panel );  // takes ownership of the panel
   }
+}
+
+void QgsGraduatedSymbolRendererWidget::changeGraduatedSymbol()
+{
+  mGraduatedSymbol.reset( btnChangeGraduatedSymbol->symbol()->clone() );
+  applyChangeToSymbol();
 }
 
 void QgsGraduatedSymbolRendererWidget::pasteSymbolToSelection()

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -94,9 +94,9 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     ~QgsGraduatedSymbolRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
+    void setContext( const QgsSymbolWidgetContext &context ) override;
 
   public slots:
-    void changeGraduatedSymbol();
     void graduatedColumnChanged( const QString &field );
     void classifyGraduated();
     void reapplyColorRamp();
@@ -129,6 +129,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void updateSymbolsFromWidget();
     void toggleMethodWidgets( int idx );
     void dataDefinedSizeLegend();
+    void changeGraduatedSymbol();
+    void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
 
   protected slots:
 
@@ -139,8 +141,6 @@ class GUI_EXPORT QgsGraduatedSymbolRendererWidget : public QgsRendererWidget, pr
     void connectUpdateHandlers();
     void disconnectUpdateHandlers();
     bool rowsOrdered();
-
-    void updateGraduatedSymbolIcon();
 
     //! Returns a list of indexes for the classes under selection
     QList<int> selectedClasses();

--- a/src/ui/qgscategorizedsymbolrendererwidget.ui
+++ b/src/ui/qgscategorizedsymbolrendererwidget.ui
@@ -44,19 +44,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnChangeCategorizedSymbol">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Change…</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_10">
      <property name="sizePolicy">
@@ -190,6 +177,19 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="1">
+    <widget class="QgsSymbolButton" name="btnChangeCategorizedSymbol">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Change…</string>
+     </property>
+    </widget>
+   </item>
   </layout>
   <zorder>viewCategories</zorder>
   <zorder>btnChangeCategorizedSymbol</zorder>
@@ -211,6 +211,11 @@
    <header>qgscolorrampbutton.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mExpressionWidget</tabstop>
@@ -224,38 +229,6 @@
   <tabstop>btnAdvanced</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsgraduatedsymbolrendererwidget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererwidget.ui
@@ -47,19 +47,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnChangeGraduatedSymbol">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>1</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Change…</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -498,6 +485,19 @@ Negative rounds to powers of 10</string>
      </widget>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QgsSymbolButton" name="btnChangeGraduatedSymbol">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Change…</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -523,6 +523,11 @@ Negative rounds to powers of 10</string>
    <extends>QToolButton</extends>
    <header>qgscolorrampbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsGraduatedHistogramWidget</class>


### PR DESCRIPTION
Gives these buttons the full power of the usual QgsSymbolButton,
including copy/paste symbols, color/opacity changes, etc. Plus,
some nice additional interface consistency!
