### PR TITLE
topological editing: fix topological editing for reshape map tool

### DIFF
--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -182,6 +182,21 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
 
   if ( reshapeDone )
   {
+    // Add topological points
+    if ( QgsProject::instance()->topologicalEditing() )
+    {
+      QList<QgsPointLocator::Match> sm = snappingMatches();
+      if ( pts.size() == sm.size() ) // should be always true
+      {
+        for ( int i = 0; i < sm.size() ; ++i )
+        {
+          if ( sm.at( i ).layer() )
+          {
+            sm.at( i ).layer()->addTopologicalPoints( pts.at( i ) );
+          }
+        }
+      }
+    }
     vlayer->endEditCommand();
   }
   else

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -186,14 +186,12 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
     if ( QgsProject::instance()->topologicalEditing() )
     {
       QList<QgsPointLocator::Match> sm = snappingMatches();
-      if ( pts.size() == sm.size() ) // should be always true
+      Q_ASSERT( pts.size() == sm.size() );
+      for ( int i = 0; i < sm.size() ; ++i )
       {
-        for ( int i = 0; i < sm.size() ; ++i )
+        if ( sm.at( i ).layer() )
         {
-          if ( sm.at( i ).layer() )
-          {
-            sm.at( i ).layer()->addTopologicalPoints( pts.at( i ) );
-          }
+          sm.at( i ).layer()->addTopologicalPoints( pts.at( i ) );
         }
       }
     }

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -45,6 +45,7 @@ class TestQgsMapToolReshape: public QObject
     void cleanupTestCase();// will be called after the last testfunction was executed.
 
     void testReshapeZ();
+    void testTopologicalEditing();
     void reshapeWithBindingLine();
 
   private:
@@ -54,6 +55,7 @@ class TestQgsMapToolReshape: public QObject
     QgsVectorLayer *mLayerLineZ = nullptr;
     QgsVectorLayer *mLayerPointZ = nullptr;
     QgsVectorLayer *mLayerPolygonZ = nullptr;
+    QgsVectorLayer *mLayerTopo = nullptr;
 };
 
 TestQgsMapToolReshape::TestQgsMapToolReshape() = default;
@@ -97,6 +99,9 @@ void TestQgsMapToolReshape::initTestCase()
   QVERIFY( mLayerPolygonZ->isValid() );
   QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerPolygonZ );
 
+  mLayerTopo = new QgsVectorLayer( QStringLiteral( "Polygon?crs=EPSG:3946" ), QStringLiteral( "topo" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerTopo->isValid() );
+
   mLayerLineZ->startEditing();
   QString wkt1 = "LineStringZ (0 0 0, 1 1 0, 1 2 0)";
   QString wkt2 = "LineStringZ (2 1 5, 3 3 5)";
@@ -136,6 +141,20 @@ void TestQgsMapToolReshape::initTestCase()
   mLayerPolygonZ->dataProvider()->addFeatures( flistPolygon );
   QCOMPARE( mLayerPolygonZ->featureCount(), ( long )1 );
   QCOMPARE( mLayerPolygonZ->getFeature( 1 ).geometry().asWkt(), wkt5 );
+
+  mLayerTopo->startEditing();
+  QString wkt6 = "Polygon ((0 0, 4 0, 4 4, 0 4))";
+  QgsFeature f6;
+  f6.setGeometry( QgsGeometry::fromWkt( wkt6 ) );
+  QString wkt7 = "Polygon ((7 0, 8 0, 8 4, 7 4))";
+  QgsFeature f7;
+  f7.setGeometry( QgsGeometry::fromWkt( wkt7 ) );
+  QgsFeatureList flistTopo;
+  flistTopo << f6 << f7;
+  mLayerTopo->dataProvider()->addFeatures( flistTopo );
+  QCOMPARE( mLayerTopo->featureCount(), ( long )2 );
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), wkt6 );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), wkt7 );
 
   QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
   cfg.setMode( QgsSnappingConfig::AllLayers );
@@ -199,6 +218,37 @@ void TestQgsMapToolReshape::testReshapeZ()
   QCOMPARE( mLayerLineZ->getFeature( 1 ).geometry().asWkt(), wkt3 );
   mLayerLineZ->undoStack()->undo();
 
+}
+
+void TestQgsMapToolReshape::testTopologicalEditing()
+{
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerTopo );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerTopo );
+
+  bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  QgsProject::instance()->setTopologicalEditing( true );
+  mCanvas->setCurrentLayer( mLayerTopo );
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  // test with default Z value = 333
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/default_z_value" ), 333 );
+
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+
+  utils.mouseClick( 4, 4, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 7, 2, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 4, 0, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 4, 0, Qt::RightButton );
+
+  QString wkt = "Polygon ((4 0, 8 2, 4 4, 0 4, 0 0, 4 0))";
+  QString wkt2 = "Polygon ((7 0, 8 0, 8 2, 8 4, 7 4))";
+
+  QCOMPARE( mLayerTopo->getFeature( 1 ).geometry().asWkt(), wkt );
+  QCOMPARE( mLayerTopo->getFeature( 2 ).geometry().asWkt(), wkt2 );
+
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+
+  mLayerTopo->undoStack()->undo();
 }
 
 void TestQgsMapToolReshape::reshapeWithBindingLine()


### PR DESCRIPTION
## Description

I continue the work on topological editing. Today: reshape map tool.  

Before
![before](https://user-images.githubusercontent.com/7521540/62277011-9100c280-b445-11e9-833d-9e0d05a8e06e.gif)

After
![after](https://user-images.githubusercontent.com/7521540/62277010-9100c280-b445-11e9-97fd-3e1451400bee.gif)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
