### PR TITLE
Add a new qgis_desktop build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ IF(WITH_CORE)
     # The qgis_desktop target is meant to build a minimal but complete running QGIS during development
     # This should help to reduce compile time while still having a "complete enough" QGIS for most of the development
     ADD_CUSTOM_TARGET(qgis_desktop
-    	DEPENDS qgis qgispython pycore pygui pyanalysis postgresprovider
+    	DEPENDS qgis qgispython pycore pygui pyanalysis postgresprovider staged-plugins pyplugin-installer
     )
   ENDIF ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,14 @@ IF(WITH_CORE)
     MESSAGE(FATAL_ERROR "Desktop cannot be built without analysis")
   ENDIF()
 
+  IF ( WITH_DESKTOP )
+    # The qgis_desktop target is meant to build a minimal but complete running QGIS during development
+    # This should help to reduce compile time while still having a "complete enough" QGIS for most of the development
+    ADD_CUSTOM_TARGET(qgis_desktop
+    	DEPENDS qgis qgispython pycore pygui pyanalysis postgresprovider
+    )
+  ENDIF ()
+
   # try to configure and build MDAL support
   SET (WITH_INTERNAL_MDAL TRUE CACHE BOOL "Determines whether MDAL support should be built")
   IF (NOT WITH_INTERNAL_MDAL)


### PR DESCRIPTION
This is meant for development, to quickly get a test build
including python bindings and the most important core providers

It's pretty much like the `qgis` target, but if the core ABI changes, this relinks relevant python and provider parts, while skipping server, tests etc.

This probably needs some further targets to be added over time (but let's see that we keep it small enough to keep build times low for a quick manual testing turnaround time).