### PR TITLE
Add checkbox to allow non core devs to indicate backport desire

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,22 @@
 ## Description
-Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.
+<!-- Include below a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.-->
 
 ## Checklist
 
-> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
+<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
+-->
 
 - [ ] Commit messages are descriptive and explain the rationale for changes
 - [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
 - [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
 - [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
 - [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
 - [ ] New unit tests have been added for core changes
 - [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
+
+## Backport
+
+<!-- Bug fixes can concern more than a version and may require backporting. To ease the process, appropriate labels can be set and automatically open the pull request in the corresponding branch, once this PR is merged. Indicate below the version(s) you would like to backport to. You are however responsible of your code and should ensure there's no regression beforehand.-->
+
+- [ ] I request the backport of the changes to the Latest Release
+- [ ] I request the backport of the changes to the Long Term Release


### PR DESCRIPTION
## Description
Backport labels are a nice way to ease PR creation in other branches. But since label addition is a feature only core developers can trigger, the benefit is not really shared by the whole contributors, who still have to go the manual route.
This PR tries to fill the gap, allowing any contributor to indicate the branch the automatic backport can be done to (then those with write access can add the appropriate label) while the responsibility of the code is still on the contributor shoulders.
Also set existing texts as comments.