### PR TITLE
Fix r.grow.distance

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.grow.distance.txt
+++ b/python/plugins/processing/algs/grass7/description/r.grow.distance.txt
@@ -2,7 +2,7 @@ r.grow.distance
 Generates a raster layer of distance to features in input layer.
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input input raster layer|None|False
-QgsProcessingParameterEnum|metric|Metric|euclidean;squared;maximum;manhattan|False|0|True
+QgsProcessingParameterEnum|metric|Metric|euclidean;squared;maximum;manhattan;geodesic|False|0|True
 *QgsProcessingParameterBoolean|-m|Output distances in meters instead of map units|False
 *QgsProcessingParameterBoolean|-|Calculate distance to nearest NULL cell|False
 QgsProcessingParameterRasterDestination|distance|Distance


### PR DESCRIPTION
Bug fix for ERROR: Output distance in meters for lat/lon is only possible with 'metric=geodesic'

Fix #31048
