### PR TITLE
[API/feature?] Cache feature ids for each symbol in the QgsVectorLayer

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -975,6 +975,8 @@ Ids of features rendered with specified legend key. Features must be first
 calculated by countSymbolFeatures()
 
 :return: Ids of features rendered by symbol or -1 if failed or Ids are not available
+
+.. versionadded:: 3.10
 %End
 
     virtual FeatureAvailability hasFeatures() const ${SIP_FINAL};

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -969,6 +969,14 @@ calculated by countSymbolFeatures()
 :return: number of features rendered by symbol or -1 if failed or counts are not available
 %End
 
+    QgsFeatureIds symbolFeatureIds( const QString &legendKey ) const;
+%Docstring
+Ids of features rendered with specified legend key. Features must be first
+calculated by countSymbolFeatures()
+
+:return: Ids of features rendered by symbol or -1 if failed or Ids are not available
+%End
+
     virtual FeatureAvailability hasFeatures() const ${SIP_FINAL};
 
 %Docstring

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -697,10 +697,16 @@ long QgsVectorLayer::featureCount( const QString &legendKey ) const
   if ( !mSymbolFeatureCounted )
     return -1;
 
-  return mSymbolFeatureCountMap.value( legendKey );
+  return mSymbolFeatureCountMap.value( legendKey, -1 );
 }
 
+QgsFeatureIds QgsVectorLayer::symbolFeatureIds( const QString &legendKey ) const
+{
+  if ( !mSymbolFeatureCounted )
+    return QgsFeatureIds();
 
+  return mSymbolFeatureIdMap.value( legendKey, QgsFeatureIds() );
+}
 
 QgsVectorLayerFeatureCounter *QgsVectorLayer::countSymbolFeatures()
 {
@@ -708,6 +714,7 @@ QgsVectorLayerFeatureCounter *QgsVectorLayer::countSymbolFeatures()
     return mFeatureCounter;
 
   mSymbolFeatureCountMap.clear();
+  mSymbolFeatureIdMap.clear();
 
   if ( !mValid )
   {
@@ -3332,6 +3339,7 @@ void QgsVectorLayer::setRenderer( QgsFeatureRenderer *r )
     mRenderer = r;
     mSymbolFeatureCounted = false;
     mSymbolFeatureCountMap.clear();
+    mSymbolFeatureIdMap.clear();
 
     emit rendererChanged();
     emit styleChanged();
@@ -4571,8 +4579,9 @@ void QgsVectorLayer::onSymbolsCounted()
 {
   if ( mFeatureCounter )
   {
-    mSymbolFeatureCountMap = mFeatureCounter->symbolFeatureCountMap();
     mSymbolFeatureCounted = true;
+    mSymbolFeatureCountMap = mFeatureCounter->symbolFeatureCountMap();
+    mSymbolFeatureIdMap = mFeatureCounter->symbolFeatureIdMap();
     emit symbolFeatureCountMapChanged();
   }
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1001,6 +1001,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * Ids of features rendered with specified legend key. Features must be first
      * calculated by countSymbolFeatures()
      * \returns Ids of features rendered by symbol or -1 if failed or Ids are not available
+     * \since QGIS 3.10
      */
     QgsFeatureIds symbolFeatureIds( const QString &legendKey ) const;
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -998,6 +998,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     long featureCount( const QString &legendKey ) const;
 
     /**
+     * Ids of features rendered with specified legend key. Features must be first
+     * calculated by countSymbolFeatures()
+     * \returns Ids of features rendered by symbol or -1 if failed or Ids are not available
+     */
+    QgsFeatureIds symbolFeatureIds( const QString &legendKey ) const;
+
+    /**
      * Determines if this vector layer has features.
      *
      * \warning when a layer is editable and some features
@@ -2622,6 +2629,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     // Feature counts for each renderer legend key
     QHash<QString, long> mSymbolFeatureCountMap;
+    QHash<QString, QgsFeatureIds> mSymbolFeatureIdMap;
 
     //! True while an undo command is active
     bool mEditCommandActive = false;


### PR DESCRIPTION
## Description
This is a proposal to cache the feature ids in the vector layer, similar to what is currently done with the counts.

The method to the the Fids is an extra in case someone would need it eventually.

This replaces the PR #30950 where it was proposed to use the counter directly but was discarded due to thread safety issues as highlighted by @nyalldawson 

The need to have the fids comes from the symbology expression PRs where I need to provide the fids of the features to the expression and I need to store and access this list of fids from somewhere when the aggregate function is evaluated.

Any feedback is appreciated

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
