### PR TITLE
Show auxiliary fields in field calculator dialog

### DIFF
--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -29,6 +29,7 @@
 #include "qgsguiutils.h"
 #include "qgsproxyprogresstask.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsvectorlayerjoinbuffer.h"
 
 #include <QMessageBox>
 
@@ -213,11 +214,10 @@ void QgsFieldCalculator::accept()
       }
       else
       {
-        QMap<QString, int>::const_iterator fieldIt = mFieldMap.constFind( mExistingFieldComboBox->currentText() );
-        if ( fieldIt != mFieldMap.constEnd() )
-        {
-          mAttributeId = fieldIt.value();
-        }
+        bool ok = false;
+        int id = mExistingFieldComboBox->currentData().toInt( &ok );
+        if ( ok )
+          mAttributeId = id;
       }
     }
     else
@@ -470,14 +470,40 @@ void QgsFieldCalculator::populateFields()
   const QgsFields &fields = mVectorLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    if ( fields.fieldOrigin( idx ) != QgsFields::OriginExpression && fields.fieldOrigin( idx ) != QgsFields::OriginJoin )
+    switch ( fields.fieldOrigin( idx ) )
     {
-      QString fieldName = fields.at( idx ).name();
+      case QgsFields::OriginExpression:
+      case QgsFields::OriginUnknown:
 
-      //insert into field list and field combo box
-      mFieldMap.insert( fieldName, idx );
-      mExistingFieldComboBox->addItem( fields.iconForField( idx ), fieldName );
+        continue; // can't be edited
+
+      case QgsFields::OriginProvider:
+      case QgsFields::OriginEdit:
+        break; // can always be edited
+
+      case QgsFields::OriginJoin:
+      {
+        // show joined fields (e.g. auxiliary fields) only if they have a non-hidden editor widget.
+        // This enables them to be bulk field-calculated when a user needs to, but hides them by default
+        // (since there's often MANY of these, e.g. after using the label properties tool on a layer)
+        if ( fields.at( idx ).editorWidgetSetup().type() == QLatin1String( "Hidden" ) )
+          continue;
+
+        // only show editable joins
+        int srcFieldIndex;
+        const QgsVectorLayerJoinInfo *info = mVectorLayer->joinBuffer()->joinForFieldIndex( idx, fields, srcFieldIndex );
+
+        if ( !info || !info->isEditable() )
+          continue; // join is not editable
+
+        break;
+      }
     }
+
+    QString fieldName = fields.at( idx ).name();
+
+    //insert into field combo box
+    mExistingFieldComboBox->addItem( fields.iconForField( idx ), fieldName, idx );
   }
 
   if ( mVectorLayer->geometryType() != QgsWkbTypes::NullGeometry )

--- a/src/app/qgsfieldcalculator.h
+++ b/src/app/qgsfieldcalculator.h
@@ -56,8 +56,6 @@ class APP_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
     void populateOutputFieldTypes();
 
     QgsVectorLayer *mVectorLayer = nullptr;
-    //! Key: field name, Value: field index
-    QMap<QString, int> mFieldMap;
 
     //! Create a field based on the definitions
     QgsField fieldDefinition();


### PR DESCRIPTION
BUT only if they have a non-hidden editor widget.

Rationale: it's very handy to be able to bulk-update these in certain
circumstances (e.g. select a bunch of features, set their label alignment
to "right"). But on the other hand, using the label tools creates a LOT
of auxiliary fields which clutter this dialog (which is why they were
hidden in the first place).

SO instead, default to hiding them all, but if a user HAS specifically
changed the field to show it, then allow them to edit it through
field calculator....
