### PR TITLE
Fix multi edits are discarded when edited field is an editable join

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -544,7 +544,7 @@ bool QgsAttributeForm::saveMultiEdits()
       continue;
 
     if ( !w->currentValue().isValid() // if the widget returns invalid (== do not change)
-         || mLayer->editFormConfig().readOnly( wIt.key() ) ) // or the field cannot be edited ...
+         || !fieldIsEditable( wIt.key() ) ) // or the field cannot be edited ...
     {
       continue;
     }


### PR DESCRIPTION
Allows the multi-edit dialog to be used to edit editable joins when a user wants to edit an editable field from an editable join when a layer is in edit mode and they use the multi-edit dialog to edit it.