### PR TITLE
Apply same logic regarding joined fields as is used in field calculator...

### DIFF
--- a/python/core/auto_generated/qgsfieldmodel.sip.in
+++ b/python/core/auto_generated/qgsfieldmodel.sip.in
@@ -36,6 +36,8 @@ It can be associated with a QgsMapLayerModel to dynamically display a layer and 
       FieldTypeRole,
       FieldOriginRole,
       IsEmptyRole,
+      EditorWidgetType,
+      JoinedFieldIsEditable,
     };
 
     explicit QgsFieldModel( QObject *parent /TransferThis/ = 0 );

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -55,6 +55,8 @@ class CORE_EXPORT QgsFieldModel : public QAbstractItemModel
       FieldTypeRole = Qt::UserRole + 6, //!< Return the field type (if a field, return QVariant if expression)
       FieldOriginRole = Qt::UserRole + 7, //!< Return the field origin (if a field, returns QVariant if expression)
       IsEmptyRole = Qt::UserRole + 8, //!< Return if the index corresponds to the empty value
+      EditorWidgetType = Qt::UserRole + 9, //!< Editor widget type
+      JoinedFieldIsEditable = Qt::UserRole + 10, //!< TRUE if a joined field is editable (returns QVariant if not a joined field)
     };
 
     /**

--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -44,8 +44,18 @@ bool QgsFieldProxyModel::isReadOnly( const QModelIndex &index ) const
   QgsFields::FieldOrigin origin = static_cast< QgsFields::FieldOrigin >( originVariant.toInt() );
   switch ( origin )
   {
-    case QgsFields::OriginUnknown:
     case QgsFields::OriginJoin:
+    {
+      // show joined fields (e.g. auxiliary fields) only if they have a non-hidden editor widget.
+      // This enables them to be bulk field-calculated when a user needs to, but hides them by default
+      // (since there's often MANY of these, e.g. after using the label properties tool on a layer)
+      if ( sourceModel()->data( index, QgsFieldModel::EditorWidgetType ).toString() == QLatin1String( "Hidden" ) )
+        return true;
+
+      return !sourceModel()->data( index, QgsFieldModel::JoinedFieldIsEditable ).toBool();
+    }
+
+    case QgsFields::OriginUnknown:
     case QgsFields::OriginExpression:
       //read only
       return true;


### PR DESCRIPTION
to QgsFieldProxyModel set to hiding read only fields

I.e. show editable joined fields, but only if they are set to a non-hidden
editor widget
