### PR TITLE
Add tooltips to vector layer properties tabs

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -173,7 +173,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Source Fields</string>
+           <string>Fields</string>
           </property>
           <property name="toolTip">
            <string>Manage fields</string>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -104,7 +104,7 @@
            <string>Information</string>
           </property>
           <property name="toolTip">
-           <string>Information</string>
+           <string>General information</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -128,7 +128,7 @@
            <string>Symbology</string>
           </property>
           <property name="toolTip">
-           <string>Symbology</string>
+           <string>Control feature symbology</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -140,7 +140,7 @@
            <string>Labels</string>
           </property>
           <property name="toolTip">
-           <string>Labels</string>
+           <string>Control feature labeling</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -176,7 +176,7 @@
            <string>Source Fields</string>
           </property>
           <property name="toolTip">
-           <string>Source Fields</string>
+           <string>Manage fields</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -188,7 +188,7 @@
            <string>Attributes Form</string>
           </property>
           <property name="toolTip">
-           <string>Form</string>
+           <string>Manage custom forms and field editor configuration</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -200,7 +200,7 @@
            <string>Joins</string>
           </property>
           <property name="toolTip">
-           <string>Joins</string>
+           <string>Manage joins to other layers</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -210,6 +210,9 @@
          <item>
           <property name="text">
            <string>Auxiliary Storage</string>
+          </property>
+          <property name="toolTip">
+           <string>Manage additional per-project fields associated with the layer</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -221,7 +224,7 @@
            <string>Actions</string>
           </property>
           <property name="toolTip">
-           <string>Actions</string>
+           <string>Manage automated actions</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -268,6 +271,9 @@
           <property name="text">
            <string>Metadata</string>
           </property>
+          <property name="toolTip">
+           <string>Layer metadata</string>
+          </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
             <normaloff>:/images/themes/default/propertyicons/editmetadata.svg</normaloff>:/images/themes/default/propertyicons/editmetadata.svg</iconset>
@@ -278,7 +284,7 @@
            <string>Dependencies</string>
           </property>
           <property name="toolTip">
-           <string>Dependencies</string>
+           <string>Set dependent layers for automatic update</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
@@ -290,7 +296,7 @@
            <string>Legend</string>
           </property>
           <property name="toolTip">
-           <string>Legend</string>
+           <string>Manage the layer's legend</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
## Description
Some vector layer properties tabs (metadata, auxiliary storage) were showing a weird tooltip when hovered, because they had no tooltip. While fixing that I opted to add more useful tooltip (was already the case for digitizing and qgis server tabs).
Text review welcome and eventually, suggestions for remaining ones.
![Capture du 2019-08-04 12-55-38](https://user-images.githubusercontent.com/7983394/62422734-6c138600-b6b7-11e9-9fae-0226f70f9cab.png)

Affects 3.4 and 3.8 too.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
