### PR TITLE
Add API for custom handlers for rendered features

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -659,6 +659,27 @@ The default is to use no global simplification, and fallback to individual layer
 .. versionadded:: 3.10
 %End
 
+    void addRenderedFeatureHandler( QgsRenderedFeatureHandlerInterface *handler );
+%Docstring
+Adds a rendered feature ``handler`` to use while rendering the map settings.
+
+Ownership of ``handler`` is NOT transferred, and it is the caller's responsibility to ensure
+that the handler exists for the lifetime of the map render job.
+
+.. seealso:: :py:func:`renderedFeatureHandlers`
+
+.. versionadded:: 3.10
+%End
+
+    QList< QgsRenderedFeatureHandlerInterface * > renderedFeatureHandlers() const;
+%Docstring
+Returns the list of rendered feature handlers to use while rendering the map settings.
+
+.. seealso:: :py:func:`addRenderedFeatureHandler`
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
 

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -571,6 +571,24 @@ Sets the text render ``format``, which dictates how text is rendered (e.g. as pa
 .. versionadded:: 3.4.3
 %End
 
+    QList<QgsRenderedFeatureHandlerInterface *> renderedFeatureHandlers() const;
+%Docstring
+Returns the list of rendered feature handlers to use while rendering map layers.
+
+.. seealso:: :py:func:`hasRenderedFeatureHandlers`
+
+.. versionadded:: 3.10
+%End
+
+    bool hasRenderedFeatureHandlers() const;
+%Docstring
+Returns ``True`` if the context has any rendered feature handlers.
+
+.. seealso:: :py:func:`renderedFeatureHandlers`
+
+.. versionadded:: 3.10
+%End
+
 };
 
 QFlags<QgsRenderContext::Flag> operator|(QgsRenderContext::Flag f1, QFlags<QgsRenderContext::Flag> f2);

--- a/python/core/auto_generated/qgsrenderedfeaturehandlerinterface.sip.in
+++ b/python/core/auto_generated/qgsrenderedfeaturehandlerinterface.sip.in
@@ -57,6 +57,11 @@ map units).
 The ``context`` argument is used to provide additional context relating to the rendering of a feature.
 %End
 
+    virtual QSet<QString> usedAttributes( QgsVectorLayer *layer, const QgsRenderContext &context ) const;
+%Docstring
+Returns a list of attributes required by this handler, for the specified ``layer``. Attributes not listed in here may
+not be requested from the provider at rendering time.
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsrenderedfeaturehandlerinterface.sip.in
+++ b/python/core/auto_generated/qgsrenderedfeaturehandlerinterface.sip.in
@@ -36,7 +36,6 @@ of all features rendered on a map.
 
     struct RenderedFeatureContext
     {
-      bool dummy;
     };
 
     virtual void handleRenderedFeature( const QgsFeature &feature, const QgsGeometry &renderedBounds, const QgsRenderedFeatureHandlerInterface::RenderedFeatureContext &context ) = 0;

--- a/python/core/auto_generated/qgsrenderedfeaturehandlerinterface.sip.in
+++ b/python/core/auto_generated/qgsrenderedfeaturehandlerinterface.sip.in
@@ -1,0 +1,68 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsrenderedfeaturehandlerinterface.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsRenderedFeatureHandlerInterface
+{
+%Docstring
+
+An interface for classes which provider custom handlers for features rendered
+as part of a map render job.
+
+QgsRenderedFeatureHandlerInterface objects are registered in the QgsMapSettings
+objects used to construct map render jobs. During the rendering operation,
+the handleRenderedFeature() method will be called once for every rendered feature,
+allowing the handler to perform some custom task based on the provided information.
+
+They can be used for custom tasks which operate on a set of rendered features,
+such as creating spatial indexes of the location and rendered symbology bounding box
+of all features rendered on a map.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgsrenderedfeaturehandlerinterface.h"
+%End
+  public:
+    virtual ~QgsRenderedFeatureHandlerInterface();
+
+    struct RenderedFeatureContext
+    {
+      bool dummy;
+    };
+
+    virtual void handleRenderedFeature( const QgsFeature &feature, const QgsGeometry &renderedBounds, const QgsRenderedFeatureHandlerInterface::RenderedFeatureContext &context ) = 0;
+%Docstring
+Called whenever a ``feature`` is rendered during a map render job.
+
+The ``renderedBounds`` argument specifies the (approximate) bounds of the rendered feature's
+symbology. E.g. for point geometry features, this will be the bounding box of the marker symbol
+used to symbolize the point. ``renderedBounds`` geometries are specified in painter units (not
+map units).
+
+.. warning::
+
+   This method may be called from many different threads (for multi-threaded map render operations),
+   and accordingly care must be taken to ensure that handleRenderedFeature() implementations are
+   appropriately thread safe.
+
+The ``context`` argument is used to provide additional context relating to the rendering of a feature.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsrenderedfeaturehandlerinterface.h                        *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -112,6 +112,7 @@
 %Include auto_generated/qgsreadwritelocker.sip
 %Include auto_generated/qgsrenderchecker.sip
 %Include auto_generated/qgsrendercontext.sip
+%Include auto_generated/qgsrenderedfeaturehandlerinterface.sip
 %Include auto_generated/qgsrulebasedlabeling.sip
 %Include auto_generated/qgsruntimeprofiler.sip
 %Include auto_generated/qgsscalecalculator.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -994,6 +994,7 @@ SET(QGIS_CORE_HDRS
   qgsreadwritelocker.h
   qgsrenderchecker.h
   qgsrendercontext.h
+  qgsrenderedfeaturehandlerinterface.h
   qgsrulebasedlabeling.h
   qgsruntimeprofiler.h
   qgsscalecalculator.h

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -677,3 +677,13 @@ void QgsMapSettings::setLabelBoundaryGeometry( const QgsGeometry &boundary )
 {
   mLabelBoundaryGeometry = boundary;
 }
+
+void QgsMapSettings::addRenderedFeatureHandler( QgsRenderedFeatureHandlerInterface *handler )
+{
+  mRenderedFeatureHandlers.append( handler );
+}
+
+QList<QgsRenderedFeatureHandlerInterface *> QgsMapSettings::renderedFeatureHandlers() const
+{
+  return mRenderedFeatureHandlers;
+}

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -38,6 +38,7 @@ class QPainter;
 class QgsCoordinateTransform;
 class QgsScaleCalculator;
 class QgsMapRendererJob;
+class QgsRenderedFeatureHandlerInterface;
 
 /**
  * \class QgsLabelBlockingRegion
@@ -578,6 +579,24 @@ class CORE_EXPORT QgsMapSettings
      */
     const QgsVectorSimplifyMethod &simplifyMethod() const { return mSimplifyMethod; }
 
+    /**
+     * Adds a rendered feature \a handler to use while rendering the map settings.
+     *
+     * Ownership of \a handler is NOT transferred, and it is the caller's responsibility to ensure
+     * that the handler exists for the lifetime of the map render job.
+     *
+     * \see renderedFeatureHandlers()
+     * \since QGIS 3.10
+     */
+    void addRenderedFeatureHandler( QgsRenderedFeatureHandlerInterface *handler );
+
+    /**
+     * Returns the list of rendered feature handlers to use while rendering the map settings.
+     * \see addRenderedFeatureHandler()
+     * \since QGIS 3.10
+     */
+    QList< QgsRenderedFeatureHandlerInterface * > renderedFeatureHandlers() const;
+
   protected:
 
     double mDpi;
@@ -642,6 +661,7 @@ class CORE_EXPORT QgsMapSettings
   private:
 
     QList< QgsLabelBlockingRegion > mLabelBlockingRegions;
+    QList< QgsRenderedFeatureHandlerInterface * > mRenderedFeatureHandlers;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapSettings::Flags )

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -59,6 +59,8 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mTransformContext( rh.mTransformContext )
   , mPathResolver( rh.mPathResolver )
   , mTextRenderFormat( rh.mTextRenderFormat )
+  , mRenderedFeatureHandlers( rh.mRenderedFeatureHandlers )
+  , mHasRenderedFeatureHandlers( rh.mHasRenderedFeatureHandlers )
 #ifdef QGISDEBUG
   , mHasTransformContext( rh.mHasTransformContext )
 #endif
@@ -88,6 +90,8 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mTransformContext = rh.mTransformContext;
   mPathResolver = rh.mPathResolver;
   mTextRenderFormat = rh.mTextRenderFormat;
+  mRenderedFeatureHandlers = rh.mRenderedFeatureHandlers;
+  mHasRenderedFeatureHandlers = rh.mHasRenderedFeatureHandlers;
 #ifdef QGISDEBUG
   mHasTransformContext = rh.mHasTransformContext;
 #endif
@@ -185,6 +189,8 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setPathResolver( mapSettings.pathResolver() );
   ctx.setTextRenderFormat( mapSettings.textRenderFormat() );
   ctx.setVectorSimplifyMethod( mapSettings.simplifyMethod() );
+  ctx.mRenderedFeatureHandlers = mapSettings.renderedFeatureHandlers();
+  ctx.mHasRenderedFeatureHandlers = !mapSettings.renderedFeatureHandlers().isEmpty();
   //this flag is only for stopping during the current rendering progress,
   //so must be false at every new render operation
   ctx.setRenderingStopped( false );
@@ -458,6 +464,11 @@ double QgsRenderContext::convertMetersToMapUnits( double meters ) const
       return ( meters * QgsUnitTypes::fromUnitToUnitFactor( QgsUnitTypes::DistanceMeters, mDistanceArea.sourceCrs().mapUnits() ) );
   }
   return meters;
+}
+
+QList<QgsRenderedFeatureHandlerInterface *> QgsRenderContext::renderedFeatureHandlers() const
+{
+  return mRenderedFeatureHandlers;
 }
 
 

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -38,6 +38,7 @@ class QPainter;
 class QgsAbstractGeometry;
 class QgsLabelingEngine;
 class QgsMapSettings;
+class QgsRenderedFeatureHandlerInterface;
 
 
 /**
@@ -595,6 +596,20 @@ class CORE_EXPORT QgsRenderContext
       mTextRenderFormat = format;
     }
 
+    /**
+     * Returns the list of rendered feature handlers to use while rendering map layers.
+     * \see hasRenderedFeatureHandlers()
+     * \since QGIS 3.10
+     */
+    QList<QgsRenderedFeatureHandlerInterface *> renderedFeatureHandlers() const;
+
+    /**
+     * Returns TRUE if the context has any rendered feature handlers.
+     * \see renderedFeatureHandlers()
+     * \since QGIS 3.10
+     */
+    bool hasRenderedFeatureHandlers() const { return mHasRenderedFeatureHandlers; }
+
   private:
 
     Flags mFlags;
@@ -653,6 +668,8 @@ class CORE_EXPORT QgsRenderContext
     QgsPathResolver mPathResolver;
 
     TextRenderFormat mTextRenderFormat = TextFormatAlwaysOutlines;
+    QList< QgsRenderedFeatureHandlerInterface * > mRenderedFeatureHandlers;
+    bool mHasRenderedFeatureHandlers = false;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgsrenderedfeaturehandlerinterface.h
+++ b/src/core/qgsrenderedfeaturehandlerinterface.h
@@ -17,9 +17,13 @@
 #define QGSRENDEREDFEATUREHANDLERINTERFACE_H
 
 #include "qgis_core.h"
+#include <QSet>
+#include <QString>
 
 class QgsFeature;
 class QgsGeometry;
+class QgsRenderContext;
+class QgsVectorLayer;
 
 /**
  * \ingroup core
@@ -67,6 +71,11 @@ class CORE_EXPORT QgsRenderedFeatureHandlerInterface
      */
     virtual void handleRenderedFeature( const QgsFeature &feature, const QgsGeometry &renderedBounds, const QgsRenderedFeatureHandlerInterface::RenderedFeatureContext &context ) = 0;
 
+    /**
+     * Returns a list of attributes required by this handler, for the specified \a layer. Attributes not listed in here may
+     * not be requested from the provider at rendering time.
+     */
+    virtual QSet<QString> usedAttributes( QgsVectorLayer *layer, const QgsRenderContext &context ) const { Q_UNUSED( layer ); Q_UNUSED( context ); return QSet< QString >(); }
 };
 
 #endif // QGSRENDEREDFEATUREHANDLERINTERFACE_H

--- a/src/core/qgsrenderedfeaturehandlerinterface.h
+++ b/src/core/qgsrenderedfeaturehandlerinterface.h
@@ -17,6 +17,7 @@
 #define QGSRENDEREDFEATUREHANDLERINTERFACE_H
 
 #include "qgis_core.h"
+#include "qgis_sip.h"
 #include <QSet>
 #include <QString>
 
@@ -51,7 +52,7 @@ class CORE_EXPORT QgsRenderedFeatureHandlerInterface
     {
       ///@cond PRIVATE
       // required to allow compilation only until real members are present
-      bool dummy;
+      bool dummy; SIP_SKIP
       ///@endcond
     };
 

--- a/src/core/qgsrenderedfeaturehandlerinterface.h
+++ b/src/core/qgsrenderedfeaturehandlerinterface.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+  qgsrenderedfeaturehandlerinterface.h
+  --------------------------------------
+  Date                 : August 2019
+  Copyright            : (C) 2019 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDEREDFEATUREHANDLERINTERFACE_H
+#define QGSRENDEREDFEATUREHANDLERINTERFACE_H
+
+#include "qgis_core.h"
+
+class QgsFeature;
+class QgsGeometry;
+
+/**
+ * \ingroup core
+ *
+ * An interface for classes which provider custom handlers for features rendered
+ * as part of a map render job.
+ *
+ * QgsRenderedFeatureHandlerInterface objects are registered in the QgsMapSettings
+ * objects used to construct map render jobs. During the rendering operation,
+ * the handleRenderedFeature() method will be called once for every rendered feature,
+ * allowing the handler to perform some custom task based on the provided information.
+ *
+ * They can be used for custom tasks which operate on a set of rendered features,
+ * such as creating spatial indexes of the location and rendered symbology bounding box
+ * of all features rendered on a map.
+ *
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsRenderedFeatureHandlerInterface
+{
+  public:
+    virtual ~QgsRenderedFeatureHandlerInterface() = default;
+
+    struct CORE_EXPORT RenderedFeatureContext
+    {
+      ///@cond PRIVATE
+      // required to allow compilation only until real members are present
+      bool dummy;
+      ///@endcond
+    };
+
+    /**
+     * Called whenever a \a feature is rendered during a map render job.
+     *
+     * The \a renderedBounds argument specifies the (approximate) bounds of the rendered feature's
+     * symbology. E.g. for point geometry features, this will be the bounding box of the marker symbol
+     * used to symbolize the point. \a renderedBounds geometries are specified in painter units (not
+     * map units).
+     *
+     * \warning This method may be called from many different threads (for multi-threaded map render operations),
+     * and accordingly care must be taken to ensure that handleRenderedFeature() implementations are
+     * appropriately thread safe.
+     *
+     * The \a context argument is used to provide additional context relating to the rendering of a feature.
+     */
+    virtual void handleRenderedFeature( const QgsFeature &feature, const QgsGeometry &renderedBounds, const QgsRenderedFeatureHandlerInterface::RenderedFeatureContext &context ) = 0;
+
+};
+
+#endif // QGSRENDEREDFEATUREHANDLERINTERFACE_H

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -37,6 +37,7 @@
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsrenderedfeaturehandlerinterface.h"
 
 #include <QPicture>
 
@@ -107,6 +108,12 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
   mContext.expressionContext() << QgsExpressionContextUtils::layerScope( layer );
 
   mAttrNames = mRenderer->usedAttributes( context );
+  if ( context.hasRenderedFeatureHandlers() )
+  {
+    const QList< QgsRenderedFeatureHandlerInterface * > handlers = context.renderedFeatureHandlers();
+    for ( QgsRenderedFeatureHandlerInterface *handler : handlers )
+      mAttrNames.unite( handler->usedAttributes( layer, context ) );
+  }
 
   //register label and diagram layer to the labeling engine
   prepareLabeling( layer, mAttrNames );

--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -22,6 +22,7 @@
 #include "qgspainteffect.h"
 #include "qgspointclusterrenderer.h"
 #include "qgsstyleentityvisitor.h"
+#include "qgsrenderedfeaturehandlerinterface.h"
 
 #include <QPainter>
 #include <cmath>
@@ -462,6 +463,14 @@ void QgsPointDisplacementRenderer::drawSymbols( const ClusteredGroup &group, Qgs
     context.expressionContext().setFeature( groupIt->feature );
     groupIt->symbol()->startRender( context );
     groupIt->symbol()->renderPoint( *symbolPosIt, &( groupIt->feature ), context, -1, groupIt->isSelected );
+    if ( context.hasRenderedFeatureHandlers() )
+    {
+      const QgsGeometry bounds( QgsGeometry::fromRect( QgsRectangle( groupIt->symbol()->bounds( *symbolPosIt, context, groupIt->feature ) ) ) );
+      const QList< QgsRenderedFeatureHandlerInterface * > handlers = context.renderedFeatureHandlers();
+      QgsRenderedFeatureHandlerInterface::RenderedFeatureContext featureContext;
+      for ( QgsRenderedFeatureHandlerInterface *handler : handlers )
+        handler->handleRenderedFeature( groupIt->feature, bounds, featureContext );
+    }
     groupIt->symbol()->stopRender( context );
   }
 }

--- a/tests/src/core/testqgsmaprendererjob.cpp
+++ b/tests/src/core/testqgsmaprendererjob.cpp
@@ -38,6 +38,7 @@
 #include <qgsapplication.h>
 #include <qgsproviderregistry.h>
 #include <qgsproject.h>
+#include "qgsrenderedfeaturehandlerinterface.h"
 
 //qgs unit test utility class
 #include "qgsrenderchecker.h"
@@ -75,6 +76,8 @@ class TestQgsMapRendererJob : public QObject
      */
     void testFourAdjacentTiles_data();
     void testFourAdjacentTiles();
+
+    void testRenderedFeatureHandlers();
 
   private:
     QString mEncoding;
@@ -328,6 +331,112 @@ void TestQgsMapRendererJob::testFourAdjacentTiles()
   bool result = checker.compareImages( QTest::currentDataTag(), 100, renderedImagePath );
   mReport += checker.report();
   QVERIFY( result );
+}
+
+
+class TestHandler : public QgsRenderedFeatureHandlerInterface
+{
+  public:
+
+    TestHandler( QList< QgsFeature > &features, QList< QgsGeometry > &geometries )
+      : features( features )
+      , geometries( geometries )
+    {}
+
+    void handleRenderedFeature( const QgsFeature &feature, const QgsGeometry &geom, const QgsRenderedFeatureHandlerInterface::RenderedFeatureContext & ) override
+    {
+      features.append( feature );
+      geometries.append( geom );
+    }
+
+    QList< QgsFeature > &features;
+    QList< QgsGeometry > &geometries;
+
+};
+
+
+void TestQgsMapRendererJob::testRenderedFeatureHandlers()
+{
+  std::unique_ptr< QgsVectorLayer > pointsLayer = qgis::make_unique< QgsVectorLayer >( TEST_DATA_DIR + QStringLiteral( "/points.shp" ),
+      QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
+  QVERIFY( pointsLayer->isValid() );
+  std::unique_ptr< QgsVectorLayer > linesLayer = qgis::make_unique< QgsVectorLayer >( TEST_DATA_DIR + QStringLiteral( "/lines.shp" ),
+      QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
+  QVERIFY( linesLayer->isValid() );
+  std::unique_ptr< QgsVectorLayer > polygonsLayer = qgis::make_unique< QgsVectorLayer >( TEST_DATA_DIR + QStringLiteral( "/polys.shp" ),
+      QStringLiteral( "polys" ), QStringLiteral( "ogr" ) );
+  QVERIFY( polygonsLayer->isValid() );
+
+  QgsMapSettings mapSettings;
+  mapSettings.setExtent( linesLayer->extent() );
+  mapSettings.setDestinationCrs( linesLayer->crs() );
+  mapSettings.setOutputSize( QSize( 256, 256 ) );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << pointsLayer.get() << linesLayer.get() << polygonsLayer.get() );
+  mapSettings.setFlags( QgsMapSettings::RenderMapTile );
+  mapSettings.setOutputDpi( 96 );
+
+  QList< QgsFeature > features1;
+  QList< QgsGeometry > geometries1;
+  TestHandler handler1( features1, geometries1 );
+  QList< QgsFeature > features2;
+  QList< QgsGeometry > geometries2;
+  TestHandler handler2( features2, geometries2 );
+  mapSettings.addRenderedFeatureHandler( &handler1 );
+  mapSettings.addRenderedFeatureHandler( &handler2 );
+
+  QgsMapRendererSequentialJob renderJob( mapSettings );
+  renderJob.start();
+  renderJob.waitForFinished();
+
+  QCOMPARE( features1.count(), 33 );
+  QCOMPARE( geometries1.count(), 33 );
+  QCOMPARE( features2.count(), 33 );
+  QCOMPARE( geometries2.count(), 33 );
+  features1.clear();
+  geometries1.clear();
+  features2.clear();
+  geometries2.clear();
+
+  polygonsLayer->setSubsetString( QStringLiteral( "value=13" ) );
+  pointsLayer->setSubsetString( QStringLiteral( "importance<=3 and \"Cabin Crew\">=1 and \"Cabin Crew\"<=2 and \"heading\" > 90 and \"heading\" < 290" ) );
+  linesLayer->setSubsetString( QStringLiteral( "name='Highway'" ) );
+
+  QgsMapRendererSequentialJob renderJob2( mapSettings );
+  renderJob2.start();
+  renderJob2.waitForFinished();
+
+  QCOMPARE( features1.count(), 5 );
+  QCOMPARE( geometries1.count(), 5 );
+  QCOMPARE( features2.count(), 5 );
+  QCOMPARE( geometries2.count(), 5 );
+
+  QStringList attributes;
+  for ( const QgsFeature &f : qgis::as_const( features1 ) )
+  {
+    QStringList bits;
+    for ( const QVariant &v : f.attributes() )
+      bits << v.toString();
+    attributes << bits.join( ',' );
+  }
+  attributes.sort();
+  QCOMPARE( attributes.at( 0 ), QStringLiteral( "Biplane,,,,," ) );
+  QCOMPARE( attributes.at( 1 ), QStringLiteral( "Dam," ) );
+  QCOMPARE( attributes.at( 2 ), QStringLiteral( "Highway," ) );
+  QCOMPARE( attributes.at( 3 ), QStringLiteral( "Highway," ) );
+  QCOMPARE( attributes.at( 4 ), QStringLiteral( "Jet,,,,," ) );
+
+  QStringList wkts;
+  for ( const QgsGeometry &g : qgis::as_const( geometries1 ) )
+  {
+    QgsDebugMsg( g.asWkt( 1 ) );
+    wkts << g.asWkt( 1 );
+  }
+  wkts.sort();
+  QCOMPARE( wkts.at( 0 ), QStringLiteral( "MultiLineString ((0 124.4, 0.3 124.4, 4 123.4, 5.5 121.9, 7.3 119.5, 8.2 118.9, 10.6 116.4, 11.2 115.8, 15.8 113.1, 20.4 111, 24 110.1, 30.7 108.5, 32.8 108.5, 36.5 108.5, 42.6 109.1, 44.4 109.5, 47.4 110.4, 49.9 110.4, 54.1 111.9, 55 112.5, 57.2 113.1, 58.4 113.7, 60.8 114.9, 62 115.5, 63.8 116.4, 64.8 116.8, 66.3 117.4, 72.4 119.2, 80 119.5, 83.9 120.7, 85.7 121.3, 87.3 121.6, 89.4 121.6, 91.8 121.6, 93.6 121.9, 95.5 122.2, 99.7 122.2, 100.3 122.2, 103.7 122.8, 106.4 122.8, 109.8 122.5, 112.8 122.5, 117.1 122.5, 121 121, 125.6 119.5, 127.4 118.3, 134.7 118, 144.7 120.4, 148.4 121.3, 156 121.9, 159.6 121.9, 168.4 119.2, 173.6 116.4, 179.1 112.5, 183.9 110.1, 188.5 107.6, 197.3 104.9, 197.3 104.9, 198.5 104.6, 204 105.2, 206.4 106.4, 211.3 107.6, 216.2 109.5, 218 110.1, 221 111, 229.5 112.2, 230.8 112.2, 243.2 111.6, 243.5 111, 251.4 107.3, 253.3 106.7))" ) );
+  QCOMPARE( wkts.at( 1 ), QStringLiteral( "MultiLineString ((93.3 45.3, 94.6 48.3, 95.2 49.6, 95.8 50.5, 97.9 52.3, 104 55.3, 110.4 58.1, 112.2 59.6, 115.2 62.6, 115.5 63.2, 116.1 66.9, 116.4 68.7, 117.4 71.4, 117.7 72.7, 118 75.7, 118.6 76.6, 119.5 78.4, 120.4 80.3, 122.5 82.7, 122.8 83.3, 123.1 85.1, 123.1 87.9, 123.1 89.1, 123.7 91.5, 124.4 92.7, 126.8 94.6, 128.9 95.8, 131 97, 133.2 97.9, 133.5 99.7, 133.5 100.9, 132.3 103.1, 131.6 103.7, 130.7 105.5, 129.8 106.7, 128.9 107.6, 128.6 108.2, 128.3 109.8, 128 111, 128 112.2, 128.9 114.3, 129.5 115.5, 129.5 115.5, 132.6 122.2, 131 125.3, 129.8 126.5, 127.7 130.1, 127.7 132.6, 125 135, 124 136.5, 122.5 138.9, 122.5 140.2, 122.5 141.7, 122.5 142.9, 122.5 144.4, 123.4 145.6, 123.7 147.2, 124.4 148.4, 125.6 149.6, 126.8 151.4, 128.6 153.5, 131.6 159.3, 132 159.6, 134.1 161.7, 135 162.7, 137.1 165.7, 138.6 166.9, 141.4 168.7, 143.2 170.3, 145.3 172.4, 146.9 173.3, 149 175.1, 151.7 176.6, 153.8 178.2, 157.2 180.6, 158.4 181.8, 159.3 183.9, 159.3 185.8, 159.3 187.6, 159 188.2, 157.8 190, 156 192.8, 154.8 194, 154.5 195.2, 154.5 196.7, 154.8 197.9, 155.7 200.4, 156 201.6, 157.8 203.7, 158.7 204.6, 159.9 206.4, 161.7 209.2, 166.6 211.3))" ) );
+  QCOMPARE( wkts.at( 2 ), QStringLiteral( "MultiPolygon (((26.5 151.7, 31.3 153.8, 32.2 155.7, 32.8 156.3, 38 156.6, 41.3 156.6, 43.8 156.6, 48.3 157.5, 50.8 158.7, 52.9 160.8, 55 165.1, 55 165.1, 52.6 180.6, 52.6 182.7, 52.3 186.4, 50.2 190.3, 47.7 192.8, 45.9 194, 45 194.3, 30.4 193.7, 25.8 192.8, 20.4 190.9, 15.8 190, 13.4 188.8, 12.8 188.5, 11.6 187.9, 9.7 186.1, 8.8 184.9, 7.9 183.6, 7 181.8, 6.7 180.3, 7 177.9, 7.6 176.3, 8.5 173.9, 8.5 172.4, 7.9 170.6, 6.7 170, 4 168.4, -0.3 165.7, -1.8 163, -1.8 159.6, -1.5 156.6, 0 152.3, 7.6 147.5, 18.9 148.4, 25.2 150.5, 26.5 151.7)))" ) );
+  QCOMPARE( wkts.at( 3 ), QStringLiteral( "Polygon ((122.4 105.6, 165.2 105.6, 165.2 148.4, 122.4 148.4, 122.4 105.6))" ) );
+  QCOMPARE( wkts.at( 4 ), QStringLiteral( "Polygon ((4.2 59.5, 73.5 59.5, 73.5 128.8, 4.2 128.8, 4.2 59.5))" ) );
 }
 
 

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -21,7 +21,8 @@ from qgis.core import (QgsRenderContext,
                        QgsUnitTypes,
                        QgsProject,
                        QgsRectangle,
-                       QgsVectorSimplifyMethod)
+                       QgsVectorSimplifyMethod,
+                       QgsRenderedFeatureHandlerInterface)
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QPainter, QImage
 from qgis.testing import start_app, unittest
@@ -30,6 +31,12 @@ import math
 # Convenience instances in case you may need them
 # to find the srs.db
 start_app()
+
+
+class TestFeatureHandler(QgsRenderedFeatureHandlerInterface):
+
+    def handleRenderedFeature(self, feature, geometry, context):
+        pass
 
 
 class TestQgsRenderContext(unittest.TestCase):
@@ -134,6 +141,29 @@ class TestQgsRenderContext(unittest.TestCase):
 
         rc2 = QgsRenderContext(rc)
         self.assertEqual(rc2.vectorSimplifyMethod().simplifyHints(), QgsVectorSimplifyMethod.GeometrySimplification)
+
+    def testRenderedFeatureHandlers(self):
+        rc = QgsRenderContext()
+        self.assertFalse(rc.renderedFeatureHandlers())
+        self.assertFalse(rc.hasRenderedFeatureHandlers())
+
+        ms = QgsMapSettings()
+        rc = QgsRenderContext.fromMapSettings(ms)
+        self.assertFalse(rc.renderedFeatureHandlers())
+        self.assertFalse(rc.hasRenderedFeatureHandlers())
+
+        handler = TestFeatureHandler()
+        handler2 = TestFeatureHandler()
+        ms.addRenderedFeatureHandler(handler)
+        ms.addRenderedFeatureHandler(handler2)
+
+        rc = QgsRenderContext.fromMapSettings(ms)
+        self.assertEqual(rc.renderedFeatureHandlers(), [handler, handler2])
+        self.assertTrue(rc.hasRenderedFeatureHandlers())
+
+        rc2 = QgsRenderContext(rc)
+        self.assertEqual(rc2.renderedFeatureHandlers(), [handler, handler2])
+        self.assertTrue(rc2.hasRenderedFeatureHandlers())
 
     def testRenderMetersInMapUnits(self):
 


### PR DESCRIPTION
This PR adds an interface for classes which provider custom handlers for features which are rendered as part of a map render job.

QgsRenderedFeatureHandlerInterface objects are registered in the QgsMapSettings objects used to construct map render jobs. During the rendering operation, the handleRenderedFeature() method will be called once for every rendered feature, allowing the handler to perform some custom task based on the provided information.

They can be used for custom tasks which operate on a set of rendered features, such as creating spatial indexes of the location and rendered symbology bounding box of all features rendered on a map.

The initial use case for this is for GeoPDF exports, where we need to collect a list of all rendered features, along with the approximate bounds of the symbol used to represent the feature. But the API here has been specifically designed with other demonstrated future use cases in mind, such as:

- creating an index of rendered point feature bounds, for use in QGIS server identify requests, allowing for identification to work correctly with offset or displaced points
- creating an index of rendered point features bounds for use in the QGIS desktop "rotate point features" or "offset point features" map tools, to allow existing marker symbols to be clicked on a map and moved/rotated (instead of the current behaviour, where the actual point geometry location must be clicked)
- allowing the displaced point rendered to collect and register the actual rendered location of displaced points for use when labeling these points 
...etc



