### PR TITLE
Add option to simplify PDF or SVG exports 

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -190,6 +190,8 @@ Constructor for PdfExportSettings
 
       QgsRenderContext::TextRenderFormat textRenderFormat;
 
+      bool simplifyGeometries;
+
     };
 
     ExportResult exportToPdf( const QString &filePath, const QgsLayoutExporter::PdfExportSettings &settings );
@@ -289,6 +291,8 @@ Constructor for SvgExportSettings
       QgsLayoutRenderContext::Flags flags;
 
       QgsRenderContext::TextRenderFormat textRenderFormat;
+
+      bool simplifyGeometries;
 
     };
 

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -223,6 +223,45 @@ Sets the text render ``format``, which dictates how text is rendered (e.g. as pa
 .. versionadded:: 3.4.3
 %End
 
+    void setSimplifyMethod( const QgsVectorSimplifyMethod &method );
+%Docstring
+Sets the simplification setting to use when rendering vector layers.
+
+If the simplify ``method`` is enabled, it apply to all vector layers rendered inside map items.
+
+This can be used to specify global simplification methods to apply during map exports,
+e.g. to allow vector layers to be simplified to an appropriate maximum level of detail
+during PDF exports (avoiding excessive PDF size due to huge numbers of vertices).
+
+The default is to use no simplification.
+
+.. note::
+
+   This simplification method is only used during non-preview renders.
+
+.. seealso:: :py:func:`simplifyMethod`
+
+
+.. versionadded:: 3.10
+%End
+
+    const QgsVectorSimplifyMethod &simplifyMethod() const;
+%Docstring
+Returns the simplification settings to use when rendering vector layers.
+
+If enabled, it will apply to all vector layers rendered for the map.
+
+The default is to use no simplification.
+
+.. note::
+
+   This simplification method is only used during non-preview renders.
+
+.. seealso:: :py:func:`setSimplifyMethod`
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void flagsChanged( QgsLayoutRenderContext::Flags flags );

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -627,7 +627,40 @@ Returns the list of regions to avoid placing labels within.
 .. versionadded:: 3.6
 %End
 
+    void setSimplifyMethod( const QgsVectorSimplifyMethod &method );
+%Docstring
+Sets the simplification setting to use when rendering vector layers.
+
+If the simplify ``method`` is enabled, it will override all other layer-specific simplification
+settings and will apply to all vector layers rendered for the map.
+
+This can be used to specify global simplification methods to apply during map exports,
+e.g. to allow vector layers to be simplified to an appropriate maximum level of detail
+during PDF exports.
+
+The default is to use no global simplification, and fallback to individual layer's settings instead.
+
+.. seealso:: :py:func:`simplifyMethod`
+
+.. versionadded:: 3.10
+%End
+
+    const QgsVectorSimplifyMethod &simplifyMethod() const;
+%Docstring
+Returns the simplification settings to use when rendering vector layers.
+
+If enabled, it will override all other layer-specific simplification
+settings and will apply to all vector layers rendered for the map.
+
+The default is to use no global simplification, and fallback to individual layer's settings instead.
+
+.. seealso:: :py:func:`setSimplifyMethod`
+
+.. versionadded:: 3.10
+%End
+
   protected:
+
 
 
 

--- a/python/core/auto_generated/qgsmaptopixelgeometrysimplifier.sip.in
+++ b/python/core/auto_generated/qgsmaptopixelgeometrysimplifier.sip.in
@@ -28,6 +28,7 @@ This class enables simplify the geometries to be rendered in a MapCanvas target 
       Distance,
       SnapToGrid,
       Visvalingam,
+      SnappedToGridGlobal,
     };
 
     QgsMapToPixelSimplifier( int simplifyFlags, double tolerance, SimplifyAlgorithm simplifyAlgorithm = Distance );

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -416,9 +416,29 @@ Returns ``True`` if the rendering optimization (geometry simplification) can be 
 
     const QgsVectorSimplifyMethod &vectorSimplifyMethod() const;
 %Docstring
-Added in QGIS v2.4
+Returns the simplification settings to use when rendering vector layers.
+
+The default is to use no simplification.
+
+.. seealso:: :py:func:`setVectorSimplifyMethod`
+
+.. versionadded:: 2.4
 %End
+
     void setVectorSimplifyMethod( const QgsVectorSimplifyMethod &simplifyMethod );
+%Docstring
+Sets the simplification setting to use when rendering vector layers.
+
+This can be used to specify simplification methods to apply during map exports and renders,
+e.g. to allow vector layers to be simplified to an appropriate maximum level of detail
+during PDF exports or to speed up layer rendering
+
+The default is to use no simplification.
+
+.. seealso:: :py:func:`vectorSimplifyMethod`
+
+.. versionadded:: 2.4
+%End
 
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring

--- a/python/core/auto_generated/qgsvectorsimplifymethod.sip.in
+++ b/python/core/auto_generated/qgsvectorsimplifymethod.sip.in
@@ -53,6 +53,7 @@ Gets the simplification hints of the vector layer managed
       Distance,
       SnapToGrid,
       Visvalingam,
+      SnappedToGridGlobal,
     };
 
     void setSimplifyAlgorithm( SimplifyAlgorithm simplifyAlgorithm );

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -4068,6 +4068,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   double leftMargin = 0.0;
   bool includeMetadata = true;
   bool disableRasterTiles = false;
+  bool simplify = true;
   if ( mLayout )
   {
     settings.flags = mLayout->renderContext().flags();
@@ -4081,6 +4082,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
     leftMargin = mLayout->customProperty( QStringLiteral( "svgCropMarginLeft" ), 0 ).toInt();
     includeMetadata = mLayout->customProperty( QStringLiteral( "svgIncludeMetadata" ), 1 ).toBool();
     disableRasterTiles = mLayout->customProperty( QStringLiteral( "svgDisableRasterTiles" ), 0 ).toBool();
+    simplify = mLayout->customProperty( QStringLiteral( "svgSimplify" ), 1 ).toBool();
     const int prevLayoutSettingLabelsAsOutlines = mLayout->customProperty( QStringLiteral( "svgTextFormat" ), -1 ).toInt();
     if ( prevLayoutSettingLabelsAsOutlines >= 0 )
     {
@@ -4113,6 +4115,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   options.mLeftMarginSpinBox->setValue( leftMargin );
   options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
   options.mDisableRasterTilingCheckBox->setChecked( disableRasterTiles );
+  options.mSimplifyGeometriesCheckbox->setChecked( simplify );
 
   if ( dialog.exec() != QDialog::Accepted )
     return false;
@@ -4126,6 +4129,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
   forceVector = options.mForceVectorCheckBox->isChecked();
   disableRasterTiles = options.mDisableRasterTilingCheckBox->isChecked();
+  simplify = options.mSimplifyGeometriesCheckbox->isChecked();
   QgsRenderContext::TextRenderFormat textRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
 
   if ( mLayout )
@@ -4141,6 +4145,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
     mLayout->setCustomProperty( QStringLiteral( "forceVector" ), forceVector ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "svgTextFormat" ), static_cast< int >( textRenderFormat ) );
     mLayout->setCustomProperty( QStringLiteral( "svgDisableRasterTiles" ), disableRasterTiles ? 1 : 0 );
+    mLayout->setCustomProperty( QStringLiteral( "svgSimplify" ), simplify ? 1 : 0 );
   }
 
   settings.cropToContents = clipToContent;
@@ -4149,6 +4154,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   settings.exportAsLayers = groupLayers;
   settings.exportMetadata = includeMetadata;
   settings.textRenderFormat = textRenderFormat;
+  settings.simplifyGeometries = simplify;
 
   if ( disableRasterTiles )
     settings.flags = settings.flags | QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;
@@ -4164,12 +4170,14 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   bool forceVector = false;
   bool includeMetadata = true;
   bool disableRasterTiles = false;
+  bool simplify = true;
   if ( mLayout )
   {
     settings.flags = mLayout->renderContext().flags();
     forceVector = mLayout->customProperty( QStringLiteral( "forceVector" ), 0 ).toBool();
     includeMetadata = mLayout->customProperty( QStringLiteral( "pdfIncludeMetadata" ), 1 ).toBool();
     disableRasterTiles = mLayout->customProperty( QStringLiteral( "pdfDisableRasterTiles" ), 0 ).toBool();
+    simplify = mLayout->customProperty( QStringLiteral( "pdfSimplify" ), 1 ).toBool();
     const int prevLayoutSettingLabelsAsOutlines = mLayout->customProperty( QStringLiteral( "pdfTextFormat" ), -1 ).toInt();
     if ( prevLayoutSettingLabelsAsOutlines >= 0 )
     {
@@ -4196,6 +4204,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   options.mForceVectorCheckBox->setChecked( forceVector );
   options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
   options.mDisableRasterTilingCheckBox->setChecked( disableRasterTiles );
+  options.mSimplifyGeometriesCheckbox->setChecked( simplify );
 
   if ( dialog.exec() != QDialog::Accepted )
     return false;
@@ -4203,6 +4212,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
   forceVector = options.mForceVectorCheckBox->isChecked();
   disableRasterTiles = options.mDisableRasterTilingCheckBox->isChecked();
+  simplify = options.mSimplifyGeometriesCheckbox->isChecked();
   QgsRenderContext::TextRenderFormat textRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
 
   if ( mLayout )
@@ -4212,11 +4222,13 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
     mLayout->setCustomProperty( QStringLiteral( "pdfIncludeMetadata" ), includeMetadata ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfDisableRasterTiles" ), disableRasterTiles ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfTextFormat" ), static_cast< int >( textRenderFormat ) );
+    mLayout->setCustomProperty( QStringLiteral( "pdfSimplify" ), simplify ? 1 : 0 );
   }
 
   settings.forceVectorOutput = forceVector;
   settings.exportMetadata = includeMetadata;
   settings.textRenderFormat = textRenderFormat;
+  settings.simplifyGeometries = simplify;
   if ( disableRasterTiles )
     settings.flags = settings.flags | QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders;
   else

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -496,6 +496,11 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
   ( void )contextRestorer;
   mLayout->renderContext().setDpi( settings.dpi );
 
+  if ( settings.simplifyGeometries )
+  {
+    mLayout->renderContext().setSimplifyMethod( createExportSimplifyMethod() );
+  }
+
   mLayout->renderContext().setFlags( settings.flags );
 
   // If we are not printing as raster, temporarily disable advanced effects
@@ -570,6 +575,11 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( QgsAbstractLayou
     iterator->layout()->renderContext().setDpi( settings.dpi );
 
     iterator->layout()->renderContext().setFlags( settings.flags );
+
+    if ( settings.simplifyGeometries )
+    {
+      iterator->layout()->renderContext().setSimplifyMethod( createExportSimplifyMethod() );
+    }
 
     // If we are not printing as raster, temporarily disable advanced effects
     // as QPrinter does not support composition modes and can result
@@ -800,6 +810,11 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToSvg( const QString &f
   mLayout->renderContext().setFlags( settings.flags );
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagForceVectorOutput, settings.forceVectorOutput );
   mLayout->renderContext().setTextRenderFormat( s.textRenderFormat );
+
+  if ( settings.simplifyGeometries )
+  {
+    mLayout->renderContext().setSimplifyMethod( createExportSimplifyMethod() );
+  }
 
   QFileInfo fi( filePath );
   PageExportDetails pageDetails;
@@ -1449,6 +1464,16 @@ bool QgsLayoutExporter::georeferenceOutputPrivate( const QString &file, QgsLayou
   CPLSetConfigOption( "GDAL_PDF_DPI", nullptr );
 
   return true;
+}
+
+QgsVectorSimplifyMethod QgsLayoutExporter::createExportSimplifyMethod()
+{
+  QgsVectorSimplifyMethod simplifyMethod;
+  simplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::GeometrySimplification );
+  simplifyMethod.setForceLocalOptimization( true );
+  simplifyMethod.setSimplifyAlgorithm( QgsVectorSimplifyMethod::SnapToGrid );
+  simplifyMethod.setThreshold( 0.5 ); // pixels
+  return simplifyMethod;
 }
 
 void QgsLayoutExporter::computeWorldFileParameters( double &a, double &b, double &c, double &d, double &e, double &f, double dpi ) const

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -301,6 +301,7 @@ class LayoutContextSettingsRestorer
       , mPreviousFlags( layout->renderContext().flags() )
       , mPreviousTextFormat( layout->renderContext().textRenderFormat() )
       , mPreviousExportLayer( layout->renderContext().currentExportLayer() )
+      , mPreviousSimplifyMethod( layout->renderContext().simplifyMethod() )
     {
     }
 
@@ -310,6 +311,7 @@ class LayoutContextSettingsRestorer
       mLayout->renderContext().setFlags( mPreviousFlags );
       mLayout->renderContext().setTextRenderFormat( mPreviousTextFormat );
       mLayout->renderContext().setCurrentExportLayer( mPreviousExportLayer );
+      mLayout->renderContext().setSimplifyMethod( mPreviousSimplifyMethod );
     }
 
     LayoutContextSettingsRestorer( const LayoutContextSettingsRestorer &other ) = delete;
@@ -321,6 +323,8 @@ class LayoutContextSettingsRestorer
     QgsLayoutRenderContext::Flags mPreviousFlags = nullptr;
     QgsRenderContext::TextRenderFormat mPreviousTextFormat = QgsRenderContext::TextFormatAlwaysOutlines;
     int mPreviousExportLayer = 0;
+    QgsVectorSimplifyMethod mPreviousSimplifyMethod;
+
 };
 ///@endcond PRIVATE
 

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1471,8 +1471,9 @@ QgsVectorSimplifyMethod QgsLayoutExporter::createExportSimplifyMethod()
   QgsVectorSimplifyMethod simplifyMethod;
   simplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::GeometrySimplification );
   simplifyMethod.setForceLocalOptimization( true );
-  simplifyMethod.setSimplifyAlgorithm( QgsVectorSimplifyMethod::SnapToGrid );
-  simplifyMethod.setThreshold( 0.5 ); // pixels
+  // we use SnappedToGridGlobal, because it avoids gaps and slivers between previously adjacent polygons
+  simplifyMethod.setSimplifyAlgorithm( QgsVectorSimplifyMethod::SnappedToGridGlobal );
+  simplifyMethod.setThreshold( 0.1f ); // (pixels). We are quite conservative here. This could possibly be bumped all the way up to 1. But let's play it safe.
   return simplifyMethod;
 }
 

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -286,6 +286,14 @@ class CORE_EXPORT QgsLayoutExporter
        */
       QgsRenderContext::TextRenderFormat textRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
+      /**
+       * Indicates whether vector geometries should be simplified to avoid redundant extraneous detail,
+       * such as vertices which are not visible at the specified dpi of the output.
+       *
+       * \since QGIS 3.10
+       */
+      bool simplifyGeometries = true;
+
     };
 
     /**
@@ -433,6 +441,14 @@ class CORE_EXPORT QgsLayoutExporter
        */
       QgsRenderContext::TextRenderFormat textRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
+      /**
+       * Indicates whether vector geometries should be simplified to avoid redundant extraneous detail,
+       * such as vertices which are not visible at the specified dpi of the output.
+       *
+       * \since QGIS 3.10
+       */
+      bool simplifyGeometries = true;
+
     };
 
     /**
@@ -576,6 +592,7 @@ class CORE_EXPORT QgsLayoutExporter
     bool georeferenceOutputPrivate( const QString &file, QgsLayoutItemMap *referenceMap = nullptr,
                                     const QRectF &exportRegion = QRectF(), double dpi = -1, bool includeGeoreference = true, bool includeMetadata = false ) const;
 
+    static QgsVectorSimplifyMethod createExportSimplifyMethod();
     friend class TestQgsLayout;
 
 };

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1172,8 +1172,14 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
 
   if ( !mLayout->renderContext().isPreviewRender() )
   {
-    //if outputting layout, disable optimisations like layer simplification
-    jobMapSettings.setFlag( QgsMapSettings::UseRenderingOptimization, false );
+    //if outputting layout, we disable optimisations like layer simplification by default, UNLESS the context specifically tells us to use them
+    jobMapSettings.setFlag( QgsMapSettings::UseRenderingOptimization, mLayout->renderContext().simplifyMethod().simplifyHints() != QgsVectorSimplifyMethod::NoSimplification );
+    jobMapSettings.setSimplifyMethod( mLayout->renderContext().simplifyMethod() );
+  }
+  else
+  {
+    // preview render - always use optimization
+    jobMapSettings.setFlag( QgsMapSettings::UseRenderingOptimization, true );
   }
 
   jobMapSettings.setExpressionContext( expressionContext );

--- a/src/core/layout/qgslayoutrendercontext.cpp
+++ b/src/core/layout/qgslayoutrendercontext.cpp
@@ -21,7 +21,9 @@ QgsLayoutRenderContext::QgsLayoutRenderContext( QgsLayout *layout )
   : QObject( layout )
   , mFlags( FlagAntialiasing | FlagUseAdvancedEffects )
   , mLayout( layout )
-{}
+{
+  mSimplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::NoSimplification );
+}
 
 void QgsLayoutRenderContext::setFlags( const QgsLayoutRenderContext::Flags flags )
 {

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -293,6 +293,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
     friend class QgsLayoutExporter;
     friend class TestQgsLayout;
     friend class LayoutContextPreviewSettingRestorer;
+    friend class TestQgsLayoutMap;
 
 };
 

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -223,6 +223,39 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
       mTextRenderFormat = format;
     }
 
+    /**
+     * Sets the simplification setting to use when rendering vector layers.
+     *
+     * If the simplify \a method is enabled, it apply to all vector layers rendered inside map items.
+     *
+     * This can be used to specify global simplification methods to apply during map exports,
+     * e.g. to allow vector layers to be simplified to an appropriate maximum level of detail
+     * during PDF exports (avoiding excessive PDF size due to huge numbers of vertices).
+     *
+     * The default is to use no simplification.
+     *
+     * \note This simplification method is only used during non-preview renders.
+     *
+     * \see simplifyMethod()
+     *
+     * \since QGIS 3.10
+     */
+    void setSimplifyMethod( const QgsVectorSimplifyMethod &method ) { mSimplifyMethod = method; }
+
+    /**
+     * Returns the simplification settings to use when rendering vector layers.
+     *
+     * If enabled, it will apply to all vector layers rendered for the map.
+     *
+     * The default is to use no simplification.
+     *
+     * \note This simplification method is only used during non-preview renders.
+     *
+     * \see setSimplifyMethod()
+     * \since QGIS 3.10
+     */
+    const QgsVectorSimplifyMethod &simplifyMethod() const { return mSimplifyMethod; }
+
   signals:
 
     /**
@@ -254,6 +287,8 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
     bool mPagesVisible = true;
 
     QgsRenderContext::TextRenderFormat mTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
+
+    QgsVectorSimplifyMethod mSimplifyMethod;
 
     friend class QgsLayoutExporter;
     friend class TestQgsLayout;

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -40,6 +40,7 @@ QgsMapSettings::QgsMapSettings()
   , mSegmentationTolerance( M_PI_2 / 90 )
 {
   mScaleCalculator.setMapUnits( QgsUnitTypes::DistanceUnknownUnit );
+  mSimplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::NoSimplification );
 
   updateDerived();
 }

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -547,6 +547,37 @@ class CORE_EXPORT QgsMapSettings
      */
     QList< QgsLabelBlockingRegion > labelBlockingRegions() const { return mLabelBlockingRegions; }
 
+    /**
+     * Sets the simplification setting to use when rendering vector layers.
+     *
+     * If the simplify \a method is enabled, it will override all other layer-specific simplification
+     * settings and will apply to all vector layers rendered for the map.
+     *
+     * This can be used to specify global simplification methods to apply during map exports,
+     * e.g. to allow vector layers to be simplified to an appropriate maximum level of detail
+     * during PDF exports.
+     *
+     * The default is to use no global simplification, and fallback to individual layer's settings instead.
+     *
+     * \see simplifyMethod()
+     *
+     * \since QGIS 3.10
+     */
+    void setSimplifyMethod( const QgsVectorSimplifyMethod &method ) { mSimplifyMethod = method; }
+
+    /**
+     * Returns the simplification settings to use when rendering vector layers.
+     *
+     * If enabled, it will override all other layer-specific simplification
+     * settings and will apply to all vector layers rendered for the map.
+     *
+     * The default is to use no global simplification, and fallback to individual layer's settings instead.
+     *
+     * \see setSimplifyMethod()
+     * \since QGIS 3.10
+     */
+    const QgsVectorSimplifyMethod &simplifyMethod() const { return mSimplifyMethod; }
+
   protected:
 
     double mDpi;
@@ -599,6 +630,8 @@ class CORE_EXPORT QgsMapSettings
     QgsRenderContext::TextRenderFormat mTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
     QgsGeometry mLabelBoundaryGeometry;
+
+    QgsVectorSimplifyMethod mSimplifyMethod;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -227,6 +227,12 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
         break;
       }
 
+      case SnappedToGridGlobal:
+      {
+        output.reset( qgsgeometry_cast< QgsCurve * >( srcCurve.snappedToGrid( map2pixelTol, map2pixelTol ) ) );
+        break;
+      }
+
       case Visvalingam:
       {
         map2pixelTol *= map2pixelTol; //-> Use mappixelTol for 'Area' calculations.

--- a/src/core/qgsmaptopixelgeometrysimplifier.h
+++ b/src/core/qgsmaptopixelgeometrysimplifier.h
@@ -44,6 +44,7 @@ class CORE_EXPORT QgsMapToPixelSimplifier : public QgsAbstractGeometrySimplifier
       Distance    = 0, //!< The simplification uses the distance between points to remove duplicate points
       SnapToGrid  = 1, //!< The simplification uses a grid (similar to ST_SnapToGrid) to remove duplicate points
       Visvalingam = 2, //!< The simplification gives each point in a line an importance weighting, so that least important points are removed first
+      SnappedToGridGlobal = 3, //!< Snap to a global grid based on the tolerance. Good for consistent results for incoming vertices, regardless of their feature
     };
 
     //! Constructor

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -184,6 +184,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setTransformContext( mapSettings.transformContext() );
   ctx.setPathResolver( mapSettings.pathResolver() );
   ctx.setTextRenderFormat( mapSettings.textRenderFormat() );
+  ctx.setVectorSimplifyMethod( mapSettings.simplifyMethod() );
   //this flag is only for stopping during the current rendering progress,
   //so must be false at every new render operation
   ctx.setRenderingStopped( false );

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -455,8 +455,29 @@ class CORE_EXPORT QgsRenderContext
 
     void setUseRenderingOptimization( bool enabled );
 
-    //! Added in QGIS v2.4
+    /**
+     * Returns the simplification settings to use when rendering vector layers.
+     *
+     * The default is to use no simplification.
+     *
+     * \see setVectorSimplifyMethod()
+     * \since QGIS 2.4
+     */
     const QgsVectorSimplifyMethod &vectorSimplifyMethod() const { return mVectorSimplifyMethod; }
+
+    /**
+     * Sets the simplification setting to use when rendering vector layers.
+     *
+     * This can be used to specify simplification methods to apply during map exports and renders,
+     * e.g. to allow vector layers to be simplified to an appropriate maximum level of detail
+     * during PDF exports or to speed up layer rendering
+     *
+     * The default is to use no simplification.
+     *
+     * \see vectorSimplifyMethod()
+     *
+     * \since QGIS 2.4
+     */
     void setVectorSimplifyMethod( const QgsVectorSimplifyMethod &simplifyMethod ) { mVectorSimplifyMethod = simplifyMethod; }
 
     /**

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -60,8 +60,20 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRender
   mGeometryType = layer->geometryType();
 
   mFeatureBlendMode = layer->featureBlendMode();
-  mSimplifyMethod = layer->simplifyMethod();
-  mSimplifyGeometry = layer->simplifyDrawingCanbeApplied( mContext, QgsVectorSimplifyMethod::GeometrySimplification );
+
+  // if there's already a simplification method specified via the context, we respect that. Otherwise, we fall back
+  // to the layer's individual setting
+  if ( mContext.vectorSimplifyMethod().simplifyHints() != QgsVectorSimplifyMethod::NoSimplification )
+  {
+    mSimplifyMethod = mContext.vectorSimplifyMethod();
+    mSimplifyGeometry = mContext.vectorSimplifyMethod().simplifyHints() & QgsVectorSimplifyMethod::GeometrySimplification ||
+                        mContext.vectorSimplifyMethod().simplifyHints() & QgsVectorSimplifyMethod::FullSimplification;
+  }
+  else
+  {
+    mSimplifyMethod = layer->simplifyMethod();
+    mSimplifyGeometry = layer->simplifyDrawingCanbeApplied( mContext, QgsVectorSimplifyMethod::GeometrySimplification );
+  }
 
   QgsSettings settings;
   mVertexMarkerOnlyForSelection = settings.value( QStringLiteral( "qgis/digitizing/marker_only_for_selected" ), true ).toBool();

--- a/src/core/qgsvectorsimplifymethod.h
+++ b/src/core/qgsvectorsimplifymethod.h
@@ -56,6 +56,7 @@ class CORE_EXPORT QgsVectorSimplifyMethod
       Distance    = 0, //!< The simplification uses the distance between points to remove duplicate points
       SnapToGrid  = 1, //!< The simplification uses a grid (similar to ST_SnapToGrid) to remove duplicate points
       Visvalingam = 2, //!< The simplification gives each point in a line an importance weighting, so that least important points are removed first
+      SnappedToGridGlobal = 3, //!< Snap to a global grid based on the tolerance. Good for consistent results for incoming vertices, regardless of their feature
     };
     Q_ENUM( SimplifyAlgorithm )
 

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>276</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,6 +44,16 @@
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
          <string>Export RDF metadata</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
+        <property name="text">
+         <string>Simplify geometries to reduce output file size</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -111,7 +121,9 @@
  <tabstops>
   <tabstop>mForceVectorCheckBox</tabstop>
   <tabstop>mIncludeMetadataCheckbox</tabstop>
+  <tabstop>mSimplifyGeometriesCheckbox</tabstop>
   <tabstop>mTextRenderFormatComboBox</tabstop>
+  <tabstop>mDisableRasterTilingCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/layout/qgssvgexportoptions.ui
+++ b/src/ui/layout/qgssvgexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>464</height>
+    <height>483</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,13 +30,16 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_6">
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
-         <string>Text export</string>
+         <string>Export RDF metadata</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -50,10 +53,17 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Export RDF metadata</string>
+         <string>Text export</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
+        <property name="text">
+         <string>Simplify geometries to reduce output file size</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -232,12 +242,14 @@
   <tabstop>chkMapLayersAsGroup</tabstop>
   <tabstop>mForceVectorCheckBox</tabstop>
   <tabstop>mIncludeMetadataCheckbox</tabstop>
+  <tabstop>mSimplifyGeometriesCheckbox</tabstop>
   <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>mClipToContentGroupBox</tabstop>
   <tabstop>mTopMarginSpinBox</tabstop>
   <tabstop>mLeftMarginSpinBox</tabstop>
   <tabstop>mRightMarginSpinBox</tabstop>
   <tabstop>mBottomMarginSpinBox</tabstop>
+  <tabstop>mDisableRasterTilingCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/tests/src/core/testqgslayoutcontext.cpp
+++ b/tests/src/core/testqgslayoutcontext.cpp
@@ -48,6 +48,7 @@ class TestQgsLayoutContext: public QObject
     void exportLayer();
     void geometry();
     void scales();
+    void simplifyMethod();
 
   private:
     QString mReport;
@@ -271,6 +272,18 @@ void TestQgsLayoutContext::scales()
 
   // should be sorted
   QCOMPARE( context.predefinedScales(), QVector< qreal >() << 1 << 5 << 10 << 15 );
+}
+
+void TestQgsLayoutContext::simplifyMethod()
+{
+  QgsLayout l( QgsProject::instance() );
+  QgsLayoutRenderContext context( &l );
+  // must default to no simplification
+  QCOMPARE( context.simplifyMethod().simplifyHints(), QgsVectorSimplifyMethod::NoSimplification );
+  QgsVectorSimplifyMethod simplify;
+  simplify.setSimplifyHints( QgsVectorSimplifyMethod::GeometrySimplification );
+  context.setSimplifyMethod( simplify );
+  QCOMPARE( context.simplifyMethod().simplifyHints(), QgsVectorSimplifyMethod::GeometrySimplification );
 }
 
 QGSTEST_MAIN( TestQgsLayoutContext )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -98,6 +98,13 @@ void TestQgsMapSettings::testGettersSetters()
   QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
   ms.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
   QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+
+  // must default to no simplification
+  QCOMPARE( ms.simplifyMethod().simplifyHints(), QgsVectorSimplifyMethod::NoSimplification );
+  QgsVectorSimplifyMethod simplify;
+  simplify.setSimplifyHints( QgsVectorSimplifyMethod::GeometrySimplification );
+  ms.setSimplifyMethod( simplify );
+  QCOMPARE( ms.simplifyMethod().simplifyHints(), QgsVectorSimplifyMethod::GeometrySimplification );
 }
 
 void TestQgsMapSettings::testLabelingEngineSettings()

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -20,7 +20,8 @@ from qgis.core import (QgsRenderContext,
                        QgsMapUnitScale,
                        QgsUnitTypes,
                        QgsProject,
-                       QgsRectangle)
+                       QgsRectangle,
+                       QgsVectorSimplifyMethod)
 from qgis.PyQt.QtCore import QSize
 from qgis.PyQt.QtGui import QPainter, QImage
 from qgis.testing import start_app, unittest
@@ -109,6 +110,30 @@ class TestQgsRenderContext(unittest.TestCase):
         self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
 
         self.assertEqual(rc.mapExtent(), QgsRectangle(10000, 20000, 30000, 40000))
+
+    def testVectorSimplification(self):
+        """
+        Test vector simplification hints, ensure they are copied correctly from map settings
+        """
+        rc = QgsRenderContext()
+        self.assertEqual(rc.vectorSimplifyMethod().simplifyHints(), QgsVectorSimplifyMethod.NoSimplification)
+
+        ms = QgsMapSettings()
+
+        rc = QgsRenderContext.fromMapSettings(ms)
+        self.assertEqual(rc.vectorSimplifyMethod().simplifyHints(), QgsVectorSimplifyMethod.NoSimplification)
+        rc2 = QgsRenderContext(rc)
+        self.assertEqual(rc2.vectorSimplifyMethod().simplifyHints(), QgsVectorSimplifyMethod.NoSimplification)
+
+        method = QgsVectorSimplifyMethod()
+        method.setSimplifyHints(QgsVectorSimplifyMethod.GeometrySimplification)
+        ms.setSimplifyMethod(method)
+
+        rc = QgsRenderContext.fromMapSettings(ms)
+        self.assertEqual(rc.vectorSimplifyMethod().simplifyHints(), QgsVectorSimplifyMethod.GeometrySimplification)
+
+        rc2 = QgsRenderContext(rc)
+        self.assertEqual(rc2.vectorSimplifyMethod().simplifyHints(), QgsVectorSimplifyMethod.GeometrySimplification)
 
     def testRenderMetersInMapUnits(self):
 


### PR DESCRIPTION
This new setting, "Simplify geometries to reduce output file size", is exposed in the SVG or PDF export settings dialogs shown when exporting a layout/atlas/report to PDF or SVG.

If checked (the new default), geometries will be simplified while exporting layouts in order to remove any redundant vertices which are not discernably different at the export DPI. (e.g. if export DPI is 300 dpi, vertices less then 1/600 inch different from each other will be removed).

This avoids exporting ALL geometry vertices during PDF/SVG export, which can result in a ridiculously complex and large export file size. Aside from the file size issues, it also causes problems when trying to load these outputs into other applications, e.g. Inkscape, which chokes on the huge number of vertices and grinds to a crawl.

Sponsored by the GeoPDF export group