### PR TITLE
Add mutex locker when accessing QgsPostGressConn attribute member

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -371,8 +371,15 @@ QgsPostgresConn::~QgsPostgresConn()
   mConn = nullptr;
 }
 
+void QgsPostgresConn::ref()
+{
+  QMutexLocker locker( &mLock );
+  ++mRef;
+}
+
 void QgsPostgresConn::unref()
 {
+  QMutexLocker locker( &mLock );
   if ( --mRef > 0 )
     return;
 
@@ -386,6 +393,8 @@ void QgsPostgresConn::unref()
     connections.remove( key );
   }
 
+  // to avoid destroying locked mutex
+  locker.unlock();
   delete this;
 }
 
@@ -429,6 +438,7 @@ void QgsPostgresConn::addColumnInfo( QgsPostgresLayerProperty &layerProperty, co
 
 bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, const QString &schema )
 {
+  QMutexLocker locker( &mLock );
   int nColumns = 0;
   int foundInTables = 0;
   QgsPostgresResult result;
@@ -832,6 +842,8 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
 
 bool QgsPostgresConn::supportedLayers( QVector<QgsPostgresLayerProperty> &layers, bool searchGeometryColumnsOnly, bool searchPublicOnly, bool allowGeometrylessTables, const QString &schema )
 {
+  QMutexLocker locker( &mLock );
+
   // Get the list of supported tables
   if ( !getTableInfo( searchGeometryColumnsOnly, searchPublicOnly, allowGeometrylessTables, schema ) )
   {
@@ -913,6 +925,7 @@ bool QgsPostgresConn::hasRaster()
 /* Functions for determining available features in postGIS */
 QString QgsPostgresConn::postgisVersion()
 {
+  QMutexLocker locker( &mLock );
   if ( mGotPostgisVersion )
     return mPostgisVersionInfo;
 
@@ -1333,12 +1346,14 @@ QString QgsPostgresConn::PQerrorMessage() const
 
 int QgsPostgresConn::PQsendQuery( const QString &query )
 {
+  QMutexLocker locker( &mLock );
   Q_ASSERT( mConn );
   return ::PQsendQuery( mConn, query.toUtf8() );
 }
 
 bool QgsPostgresConn::begin()
 {
+  QMutexLocker locker( &mLock );
   if ( mTransaction )
   {
     return PQexecNR( QStringLiteral( "SAVEPOINT transaction_savepoint" ) );
@@ -1351,6 +1366,7 @@ bool QgsPostgresConn::begin()
 
 bool QgsPostgresConn::commit()
 {
+  QMutexLocker locker( &mLock );
   if ( mTransaction )
   {
     return PQexecNR( QStringLiteral( "RELEASE SAVEPOINT transaction_savepoint" ) );
@@ -1363,6 +1379,7 @@ bool QgsPostgresConn::commit()
 
 bool QgsPostgresConn::rollback()
 {
+  QMutexLocker locker( &mLock );
   if ( mTransaction )
   {
     return PQexecNR( QStringLiteral( "ROLLBACK TO SAVEPOINT transaction_savepoint" ) )
@@ -1376,6 +1393,7 @@ bool QgsPostgresConn::rollback()
 
 qint64 QgsPostgresConn::getBinaryInt( QgsPostgresResult &queryResult, int row, int col )
 {
+  QMutexLocker locker( &mLock );
   quint64 oid;
   char *p = PQgetvalue( queryResult.result(), row, col );
   size_t s = PQgetlength( queryResult.result(), row, col );
@@ -1495,6 +1513,7 @@ QString QgsPostgresConn::fieldExpression( const QgsField &fld, QString expr )
 
 void QgsPostgresConn::deduceEndian()
 {
+  QMutexLocker locker( &mLock );
   // need to store the PostgreSQL endian format used in binary cursors
   // since it appears that starting with
   // version 7.4, binary cursors return data in XDR whereas previous versions
@@ -1996,6 +2015,7 @@ void QgsPostgresConn::deleteConnection( const QString &connName )
 
 bool QgsPostgresConn::cancel()
 {
+  QMutexLocker locker( &mLock );
   PGcancel *c = ::PQgetCancel( mConn );
   if ( !c )
   {
@@ -2016,6 +2036,7 @@ bool QgsPostgresConn::cancel()
 
 QString QgsPostgresConn::currentDatabase() const
 {
+  QMutexLocker locker( &mLock );
   QString database;
   QString sql = "SELECT current_database()";
   QgsPostgresResult res( PQexec( sql ) );

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -198,7 +198,7 @@ class QgsPostgresConn : public QObject
      */
     static QgsPostgresConn *connectDb( const QString &connInfo, bool readOnly, bool shared = true, bool transaction = false );
 
-    void ref() { ++mRef; }
+    void ref();
     void unref();
 
     //! Gets postgis version string


### PR DESCRIPTION
## Description

I come with dead lock/seg fault issues in QgsPostGresConn trying to parallelize prepareIndex in QgsSnappingUtils while working on Snap Cache improvements (https://docs.google.com/document/d/1VzgLJ-hy2GtcWrAy5geivhDDdXRGJUDcikCWUtXRe9k/edit#heading=h.uau3di2m4nvn).

Postgres connections are shared and can be accessed from different threads during a parallel rendering process for instance (or while computing snapping cache for several postgres layer in parallel).

But some of the methods that access attribute members are not mutex protected. This PR fixes that. 

I didn't add some unit tests because it seems quite impossible to write a deterministic test while testing thread. 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
