### PR TITLE
Thread safety in duplicates check

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -70,7 +70,7 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
       }
       QString errMsg;
       QgsGeometry geomB = layerFeatureB.geometry();
-      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( geomB.constGet(), &errMsg );
+      std::unique_ptr<QgsAbstractGeometry> diffGeom( geomEngineA->symDifference( geomB.constGet(), &errMsg ) );
       if ( errMsg.isEmpty() && diffGeom && diffGeom->isEmpty() )
       {
         duplicates[layerFeatureB.layer()->id()].append( layerFeatureB.feature().id() );
@@ -79,7 +79,6 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
       {
         messages.append( tr( "Duplicate check failed for (%1, %2): %3" ).arg( layerFeatureA.id(), layerFeatureB.id(), errMsg ) );
       }
-      delete diffGeom;
     }
     if ( !duplicates.isEmpty() )
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -49,8 +49,9 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
 
-    QgsRectangle bboxA = layerFeatureA.geometry().boundingBox();
-    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
+    QgsGeometry geomA = layerFeatureA.geometry();
+    QgsRectangle bboxA = geomA.boundingBox();
+    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( geomA.constGet(), mContext->tolerance );
     if ( !geomEngineA->isValid() )
     {
       messages.append( tr( "Duplicate check failed for (%1): the geometry is invalid" ).arg( layerFeatureA.id() ) );
@@ -58,7 +59,7 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
     }
     QMap<QString, QList<QgsFeatureId>> duplicates;
 
-    QgsWkbTypes::GeometryType geomType = layerFeatureA.feature().geometry().type();
+    QgsWkbTypes::GeometryType geomType = geomA.type();
     QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( featurePools, QList<QString>() << layerFeatureA.layer()->id() << layerIds, bboxA, {geomType}, mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
     {
@@ -68,7 +69,8 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
         continue;
       }
       QString errMsg;
-      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( layerFeatureB.geometry().constGet(), &errMsg );
+      QgsGeometry geomB = layerFeatureB.geometry();
+      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( geomB.constGet(), &errMsg );
       if ( errMsg.isEmpty() && diffGeom && diffGeom->isEmpty() )
       {
         duplicates[layerFeatureB.layer()->id()].append( layerFeatureB.feature().id() );
@@ -81,7 +83,7 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
     }
     if ( !duplicates.isEmpty() )
     {
-      errors.append( new QgsGeometryDuplicateCheckError( this, layerFeatureA, layerFeatureA.geometry().constGet()->centroid(), featurePools, duplicates ) );
+      errors.append( new QgsGeometryDuplicateCheckError( this, layerFeatureA, geomA.constGet()->centroid(), featurePools, duplicates ) );
     }
   }
 }


### PR DESCRIPTION
It's dangerous to work on a pointer owned by a temporary.
Especially if the temporary is implicitly shared with a threaded cache.
Fix #30798
Fix #29470