### PR TITLE
Allow setting the raster renderer for invalid raster layers

### DIFF
--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -72,7 +72,10 @@ bool QgsRasterRenderer::setInput( QgsRasterInterface *input )
 
   for ( int i = 1; i <= input->bandCount(); i++ )
   {
-    if ( !QgsRasterBlock::typeIsNumeric( input->dataType( i ) ) )
+    const Qgis::DataType bandType = input->dataType( i );
+    // we always allow unknown data types to connect - overwise invalid layers cannot setup
+    // their original rendering pipe and this information is lost
+    if ( bandType != Qgis::UnknownDataType && !QgsRasterBlock::typeIsNumeric( bandType ) )
     {
       return false;
     }

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -59,7 +59,7 @@ QgsRendererRasterPropertiesWidget::QgsRendererRasterPropertiesWidget( QgsMapLaye
 {
   mRasterLayer = qobject_cast<QgsRasterLayer *>( layer );
 
-  if ( !( mRasterLayer && mRasterLayer->isValid() ) )
+  if ( !mRasterLayer )
     return;
 
   setupUi( this );
@@ -128,31 +128,28 @@ void QgsRendererRasterPropertiesWidget::rendererChanged()
 
 void QgsRendererRasterPropertiesWidget::apply()
 {
+  if ( QgsBrightnessContrastFilter *brightnessFilter = mRasterLayer->brightnessFilter() )
+  {
+    brightnessFilter->setBrightness( mSliderBrightness->value() );
+    brightnessFilter->setContrast( mSliderContrast->value() );
+  }
 
-  if ( ! mRasterLayer->isValid() )
-    return;
-
-  mRasterLayer->brightnessFilter()->setBrightness( mSliderBrightness->value() );
-  mRasterLayer->brightnessFilter()->setContrast( mSliderContrast->value() );
-
-  QgsRasterRendererWidget *rendererWidget = dynamic_cast<QgsRasterRendererWidget *>( stackedWidget->currentWidget() );
-  if ( rendererWidget )
+  if ( QgsRasterRendererWidget *rendererWidget = dynamic_cast<QgsRasterRendererWidget *>( stackedWidget->currentWidget() ) )
   {
     rendererWidget->doComputations();
 
-    QgsRasterRenderer *newRenderer = rendererWidget->renderer();
-
-    // there are transparency related data stored in renderer instances, but they
-    // are not configured in the widget, so we need to copy them over from existing renderer
-    QgsRasterRenderer *oldRenderer = mRasterLayer->renderer();
-    if ( oldRenderer )
-      newRenderer->copyCommonProperties( oldRenderer, false );
-    mRasterLayer->setRenderer( newRenderer );
+    if ( QgsRasterRenderer *newRenderer = rendererWidget->renderer() )
+    {
+      // there are transparency related data stored in renderer instances, but they
+      // are not configured in the widget, so we need to copy them over from existing renderer
+      if ( QgsRasterRenderer *oldRenderer = mRasterLayer->renderer() )
+        newRenderer->copyCommonProperties( oldRenderer, false );
+      mRasterLayer->setRenderer( newRenderer );
+    }
   }
 
   // Hue and saturation controls
-  QgsHueSaturationFilter *hueSaturationFilter = mRasterLayer->hueSaturationFilter();
-  if ( hueSaturationFilter )
+  if ( QgsHueSaturationFilter *hueSaturationFilter = mRasterLayer->hueSaturationFilter() )
   {
     hueSaturationFilter->setSaturation( sliderSaturation->value() );
     hueSaturationFilter->setGrayscaleMode( ( QgsHueSaturationFilter::GrayscaleMode ) comboGrayscale->currentIndex() );
@@ -161,8 +158,7 @@ void QgsRendererRasterPropertiesWidget::apply()
     hueSaturationFilter->setColorizeStrength( sliderColorizeStrength->value() );
   }
 
-  QgsRasterResampleFilter *resampleFilter = mRasterLayer->resampleFilter();
-  if ( resampleFilter )
+  if ( QgsRasterResampleFilter *resampleFilter = mRasterLayer->resampleFilter() )
   {
     QgsRasterResampler *zoomedInResampler = nullptr;
     QString zoomedInResamplingMethod = mZoomedInResamplingComboBox->currentText();
@@ -215,14 +211,12 @@ void QgsRendererRasterPropertiesWidget::syncToLayer( QgsRasterLayer *layer )
   cboRenderers->setCurrentIndex( -1 );
   cboRenderers->blockSignals( false );
 
-  QgsRasterRenderer *renderer = mRasterLayer->renderer();
-  if ( renderer )
+  if ( QgsRasterRenderer *renderer = mRasterLayer->renderer() )
   {
     setRendererWidget( renderer->type() );
   }
 
-  QgsBrightnessContrastFilter *brightnessFilter = mRasterLayer->brightnessFilter();
-  if ( brightnessFilter )
+  if ( QgsBrightnessContrastFilter *brightnessFilter = mRasterLayer->brightnessFilter() )
   {
     mSliderBrightness->setValue( brightnessFilter->brightness() );
     mSliderContrast->setValue( brightnessFilter->contrast() );
@@ -232,9 +226,8 @@ void QgsRendererRasterPropertiesWidget::syncToLayer( QgsRasterLayer *layer )
   btnColorizeColor->setContext( QStringLiteral( "symbology" ) );
 
   // Hue and saturation color control
-  const QgsHueSaturationFilter *hueSaturationFilter = mRasterLayer->hueSaturationFilter();
   //set hue and saturation controls to current values
-  if ( hueSaturationFilter )
+  if ( const QgsHueSaturationFilter *hueSaturationFilter = mRasterLayer->hueSaturationFilter() )
   {
     sliderSaturation->setValue( hueSaturationFilter->saturation() );
     comboGrayscale->setCurrentIndex( ( int ) hueSaturationFilter->grayscaleMode() );
@@ -252,9 +245,8 @@ void QgsRendererRasterPropertiesWidget::syncToLayer( QgsRasterLayer *layer )
   //blend mode
   mBlendModeComboBox->setBlendMode( mRasterLayer->blendMode() );
 
-  const QgsRasterResampleFilter *resampleFilter = mRasterLayer->resampleFilter();
   //set combo boxes to current resampling types
-  if ( resampleFilter )
+  if ( const QgsRasterResampleFilter *resampleFilter = mRasterLayer->resampleFilter() )
   {
     const QgsRasterResampler *zoomedInResampler = resampleFilter->zoomedInResampler();
     if ( zoomedInResampler )
@@ -329,11 +321,10 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
 {
   QgsDebugMsg( "rendererName = " + rendererName );
   QgsRasterRendererWidget *oldWidget = mRendererWidget;
-  QgsRasterRenderer *oldRenderer = mRasterLayer->renderer();
 
   int alphaBand = -1;
   double opacity = 1;
-  if ( oldRenderer )
+  if ( QgsRasterRenderer *oldRenderer = mRasterLayer->renderer() )
   {
     // Retain alpha band and opacity when switching renderer
     alphaBand = oldRenderer->alphaBand();

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -1107,15 +1107,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         self.assertFalse(rl2.isValid())
         self.assertEqual(rl2.name(), 'test_raster')
 
-        # ideally this would still be set, but raster renderers are very heavily tied to dataproviders currently
-        self.assertIsNone(rl2.renderer())
-
-        # now, fix path
-        rl2.setDataSource(source_path, 'test_raster', 'gdal', QgsDataProvider.ProviderOptions())
-        self.assertTrue(rl2.isValid())
-        self.assertEqual(rl2.name(), 'test_raster')
-
-        # at this stage, the original style should be recreated...
+        # invalid layers should still have renderer available
         self.assertIsInstance(rl2.renderer(), QgsSingleBandPseudoColorRenderer)
         self.assertEqual(rl2.renderer().classificationMin(), 101)
         self.assertEqual(rl2.renderer().classificationMax(), 131)
@@ -1124,6 +1116,24 @@ class TestQgsRasterLayer(unittest.TestCase):
         self.assertIsInstance(rl2.resampleFilter().zoomedInResampler(), QgsCubicRasterResampler)
         self.assertIsInstance(rl2.resampleFilter().zoomedOutResampler(), QgsBilinearRasterResampler)
         self.assertEqual(rl2.renderer().opacity(), 0.6)
+        # make a little change
+        rl2.renderer().setOpacity(0.8)
+
+        # now, fix path
+        rl2.setDataSource(source_path, 'test_raster', 'gdal', QgsDataProvider.ProviderOptions())
+        self.assertTrue(rl2.isValid())
+        self.assertEqual(rl2.name(), 'test_raster')
+
+        # at this stage, the original style should be retained...
+        self.assertIsInstance(rl2.renderer(), QgsSingleBandPseudoColorRenderer)
+        self.assertEqual(rl2.renderer().classificationMin(), 101)
+        self.assertEqual(rl2.renderer().classificationMax(), 131)
+        self.assertEqual(rl2.renderer().shader().rasterShaderFunction().sourceColorRamp().color1().name(), '#ffff00')
+        self.assertEqual(rl2.renderer().shader().rasterShaderFunction().sourceColorRamp().color2().name(), '#0000ff')
+        self.assertIsInstance(rl2.resampleFilter().zoomedInResampler(), QgsCubicRasterResampler)
+        self.assertIsInstance(rl2.resampleFilter().zoomedOutResampler(), QgsBilinearRasterResampler)
+        # the opacity change (and other renderer changes made while the layer was invalid) should be retained
+        self.assertEqual(rl2.renderer().opacity(), 0.8)
 
         # break path
         rl2.setDataSource(tmp_path, 'test_raster', 'gdal', QgsDataProvider.ProviderOptions())
@@ -1140,7 +1150,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         self.assertEqual(rl2.renderer().shader().rasterShaderFunction().sourceColorRamp().color2().name(), '#0000ff')
         self.assertIsInstance(rl2.resampleFilter().zoomedInResampler(), QgsCubicRasterResampler)
         self.assertIsInstance(rl2.resampleFilter().zoomedOutResampler(), QgsBilinearRasterResampler)
-        self.assertEqual(rl2.renderer().opacity(), 0.6)
+        self.assertEqual(rl2.renderer().opacity(), 0.8)
 
         # break again
         rl2.setDataSource(tmp_path, 'test_raster', 'gdal', QgsDataProvider.ProviderOptions())
@@ -1165,7 +1175,7 @@ class TestQgsRasterLayer(unittest.TestCase):
         self.assertEqual(rl2.renderer().shader().rasterShaderFunction().sourceColorRamp().color2().name(), '#0000ff')
         self.assertIsInstance(rl2.resampleFilter().zoomedInResampler(), QgsCubicRasterResampler)
         self.assertIsInstance(rl2.resampleFilter().zoomedOutResampler(), QgsBilinearRasterResampler)
-        self.assertEqual(rl2.renderer().opacity(), 0.6)
+        self.assertEqual(rl2.renderer().opacity(), 0.8)
 
         # another test
         rl = QgsRasterLayer(source_path, 'test_raster', 'gdal')


### PR DESCRIPTION
Fixes inaccessible (and unsettable) raster renderer information and styling properties when a raster layer is invalid.

This brings invalid raster layer handling closer in line with invalid vector layer handling, where the renderer information is still available for view in the UI for layers with broken paths.

No intention to backport -- it's too risky, and there'll likely be follow up fixes required.

Sponsored by SLYR