### PR TITLE
Color code welcome page items

### DIFF
--- a/src/app/qgsprojectlistitemdelegate.cpp
+++ b/src/app/qgsprojectlistitemdelegate.cpp
@@ -41,33 +41,32 @@ void QgsProjectListItemDelegate::paint( QPainter *painter, const QStyleOptionVie
   QAbstractTextDocumentLayout::PaintContext ctx;
   QStyleOptionViewItem optionV4 = option;
 
-  QColor color = optionV4.palette.color( QPalette::Active, QPalette::Window );
+  QColor color = index.data( Qt::BackgroundColorRole ).value< QColor >();
+  color.setAlpha( 50 );
+  QColor stroke = index.data( Qt::ForegroundRole ).value< QColor >();
   if ( option.state & QStyle::State_Selected && option.state & QStyle::State_HasFocus )
   {
-    color.setAlpha( 40 );
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::HighlightedText ) );
+    stroke = stroke.darker( 130 );
+    ctx.palette.setColor( QPalette::Text, QColor( 30, 30, 30 ) );
 
     QStyle *style = QApplication::style();
     style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
   }
   else if ( option.state & QStyle::State_Enabled )
   {
-    if ( option.state & QStyle::State_Selected )
-    {
-      color.setAlpha( 40 );
-    }
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::Text ) );
+    stroke = stroke.darker( 110 );
+    ctx.palette.setColor( QPalette::Text, QColor( 80, 80, 80 ) );
 
     QStyle *style = QApplication::style();
     style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
   }
   else
   {
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Disabled, QPalette::Text ) );
+    ctx.palette.setColor( QPalette::Text, QColor( 150, 150, 150 ) );
   }
 
   painter->setRenderHint( QPainter::Antialiasing );
-  painter->setPen( QColor( 0, 0, 0, 0 ) );
+  painter->setPen( stroke );
   painter->setBrush( QBrush( color ) );
   painter->drawRoundedRect( option.rect.left() + 0.625 * mRoundedRectSizePixels, option.rect.top() + 0.625 * mRoundedRectSizePixels,
                             option.rect.width() - 2 * 0.625 * mRoundedRectSizePixels, option.rect.height() - 2 * 0.625 * mRoundedRectSizePixels, mRoundedRectSizePixels, mRoundedRectSizePixels );
@@ -197,11 +196,13 @@ void QgsNewsItemListItemDelegate::paint( QPainter *painter, const QStyleOptionVi
   QAbstractTextDocumentLayout::PaintContext ctx;
   QStyleOptionViewItem optionV4 = option;
 
-  QColor color = optionV4.palette.color( QPalette::Active, QPalette::Window );
+  QColor color = index.data( Qt::BackgroundColorRole ).value< QColor >();
+  color.setAlpha( 50 );
+  QColor stroke = index.data( Qt::ForegroundRole ).value< QColor >();
   if ( option.state & QStyle::State_Selected && option.state & QStyle::State_HasFocus )
   {
-    color.setAlpha( 40 );
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::HighlightedText ) );
+    stroke = stroke.darker( 130 );
+    ctx.palette.setColor( QPalette::Text, QColor( 30, 30, 30 ) );
 
     QStyle *style = QApplication::style();
     style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
@@ -212,18 +213,19 @@ void QgsNewsItemListItemDelegate::paint( QPainter *painter, const QStyleOptionVi
     {
       color.setAlpha( 40 );
     }
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::Text ) );
+    stroke = stroke.darker( 110 );
+    ctx.palette.setColor( QPalette::Text, QColor( 80, 80, 80 ) );
 
     QStyle *style = QApplication::style();
     style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, nullptr );
   }
   else
   {
-    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Disabled, QPalette::Text ) );
+    ctx.palette.setColor( QPalette::Text, QColor( 150, 150, 150 ) );
   }
 
   painter->setRenderHint( QPainter::Antialiasing );
-  painter->setPen( QColor( 0, 0, 0, 0 ) );
+  painter->setPen( stroke );
   painter->setBrush( QBrush( color ) );
   painter->drawRoundedRect( option.rect.left() + 0.625 * mRoundedRectSizePixels, option.rect.top() + 0.625 * mRoundedRectSizePixels,
                             option.rect.width() - 2 * 0.625 * mRoundedRectSizePixels, option.rect.height() - 2 * 0.625 * mRoundedRectSizePixels, mRoundedRectSizePixels, mRoundedRectSizePixels );

--- a/src/app/qgsrecentprojectsitemsmodel.cpp
+++ b/src/app/qgsrecentprojectsitemsmodel.cpp
@@ -86,6 +86,12 @@ QVariant QgsRecentProjectItemsModel::data( const QModelIndex &index, int role ) 
       return thumbnail.pixmap();
     }
 
+    case Qt::BackgroundColorRole:
+      return QColor( 238, 242, 131 );
+
+    case Qt::ForegroundRole:
+      return QColor( 234, 226, 118 );
+
     case Qt::ToolTipRole:
       return mRecentProjects.at( index.row() ).path;
 

--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -55,6 +55,10 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
   emptyProjectItem->setData( tr( "New Empty Project" ), QgsProjectListItemDelegate::TitleRole );
   connect( QgsProject::instance(), &QgsProject::crsChanged, this, [emptyProjectItem]() { emptyProjectItem->setData( QgsProject::instance()->crs().description(), QgsProjectListItemDelegate::CrsRole ); } );
   emptyProjectItem->setData( QgsProject::instance()->crs().description(), QgsProjectListItemDelegate::CrsRole );
+
+  emptyProjectItem->setData( QColor( 172, 196, 114 ), Qt::BackgroundColorRole );
+  emptyProjectItem->setData( QColor( 90, 140, 90 ), Qt::ForegroundRole );
+
   emptyProjectItem->setFlags( Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsEnabled ) ;
   QSize previewSize( 250, 177 );
   QImage image( previewSize, QImage::Format_ARGB32 );
@@ -113,6 +117,9 @@ void QgsTemplateProjectsModel::scanDirectory( const QString &path )
     }
     item->setData( file.baseName(), QgsProjectListItemDelegate::TitleRole );
     item->setData( file.filePath(), QgsProjectListItemDelegate::NativePathRole );
+
+    item->setData( QColor( 172, 196, 114 ), Qt::BackgroundColorRole );
+    item->setData( QColor( 90, 140, 90 ), Qt::ForegroundRole );
 
     item->setFlags( Qt::ItemFlag::ItemIsSelectable | Qt::ItemFlag::ItemIsEnabled ) ;
     appendRow( item.release() );

--- a/src/core/qgsnewsfeedmodel.cpp
+++ b/src/core/qgsnewsfeedmodel.cpp
@@ -70,6 +70,12 @@ QVariant QgsNewsFeedModel::data( const QModelIndex &index, int role ) const
       if ( entry.image.isNull() )
         return QVariant();
       return entry.image;
+
+    case Qt::BackgroundColorRole:
+      return QColor( 232, 186, 140 );
+
+    case Qt::ForegroundRole:
+      return QColor( 248, 135, 33 );
   }
   return QVariant();
 }


### PR DESCRIPTION
For consideration: the welcome page now has 3 distinct types of items (projects, templates and news). I think we need greater visual distinction between these. 

This mockup shows a possible approach - using colors based on the QGIS logo to shade the different item types:

![image](https://user-images.githubusercontent.com/1829991/62667314-6b863280-b9ca-11e9-8f6f-ec536a4c0e58.png)
