### PR TITLE
"Allowed gaps" layer for gap check

### DIFF
--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -177,6 +177,8 @@ Create a new geometry check.
     virtual void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
 %Docstring
 Will be run in the main thread before collectErrors is called (which may be run from a background thread).
+
+.. versionadded:: 3.10
 %End
 
 

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheck.sip.in
@@ -174,6 +174,11 @@ Create a new geometry check.
 %End
     virtual ~QgsGeometryCheck();
 
+    virtual void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
+%Docstring
+Will be run in the main thread before collectErrors is called (which may be run from a background thread).
+%End
+
 
     virtual bool isCompatible( QgsVectorLayer *layer ) const;
 %Docstring

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -8,12 +8,26 @@
 
 
 
-struct QgsGeometryCheckContext
+class QgsGeometryCheckContext
 {
+%Docstring
+Base configuration for geometry checks.
+
+.. note::
+
+   This class is a technology preview and unstable API.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgsgeometrycheckcontext.h"
+%End
+  public:
     QgsGeometryCheckContext( int precision,
                              const QgsCoordinateReferenceSystem &mapCrs,
                              const QgsCoordinateTransformContext &transformContext,
-                             const QgsProject *project );
+                             const QgsProject *mProject );
 
     const double tolerance;
 
@@ -23,7 +37,14 @@ struct QgsGeometryCheckContext
 
     const QgsCoordinateTransformContext transformContext;
 
-    const QgsProject *project;
+    const QgsProject *project() const;
+%Docstring
+The project can be used to resolve additional layers.
+
+This must only be accessed from the main thread (i.e. do not access from the collectError method)
+
+.. versionadded:: 3.10
+%End
 
   private:
     QgsGeometryCheckContext( const QgsGeometryCheckContext &rh );

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -12,7 +12,8 @@ struct QgsGeometryCheckContext
 {
     QgsGeometryCheckContext( int precision,
                              const QgsCoordinateReferenceSystem &mapCrs,
-                             const QgsCoordinateTransformContext &transformContext );
+                             const QgsCoordinateTransformContext &transformContext,
+                             const QgsProject *project );
 
     const double tolerance;
 
@@ -21,6 +22,8 @@ struct QgsGeometryCheckContext
     const QgsCoordinateReferenceSystem mapCrs;
 
     const QgsCoordinateTransformContext transformContext;
+
+    const QgsProject *project;
 
   private:
     QgsGeometryCheckContext( const QgsGeometryCheckContext &rh );

--- a/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
+++ b/python/analysis/auto_generated/vector/geometry_checker/qgsgeometrycheckcontext.sip.in
@@ -24,10 +24,14 @@ Base configuration for geometry checks.
 #include "qgsgeometrycheckcontext.h"
 %End
   public:
+
     QgsGeometryCheckContext( int precision,
                              const QgsCoordinateReferenceSystem &mapCrs,
                              const QgsCoordinateTransformContext &transformContext,
                              const QgsProject *mProject );
+%Docstring
+Creates a new QgsGeometryCheckContext.
+%End
 
     const double tolerance;
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -31,6 +31,11 @@ QgsGeometryCheck::QgsGeometryCheck( const QgsGeometryCheckContext *context, cons
   , mConfiguration( configuration )
 {}
 
+void QgsGeometryCheck::prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration )
+{
+
+}
+
 bool QgsGeometryCheck::isCompatible( QgsVectorLayer *layer ) const
 {
   return compatibleGeometryTypes().contains( layer->geometryType() );

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -33,7 +33,8 @@ QgsGeometryCheck::QgsGeometryCheck( const QgsGeometryCheckContext *context, cons
 
 void QgsGeometryCheck::prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration )
 {
-
+  Q_UNUSED( context )
+  Q_UNUSED( configuration )
 }
 
 bool QgsGeometryCheck::isCompatible( QgsVectorLayer *layer ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -302,7 +302,8 @@ class ANALYSIS_EXPORT QgsGeometryCheck
     virtual void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors SIP_INOUT, QStringList &messages SIP_INOUT, QgsFeedback *feedback, const LayerFeatureIds &ids = QgsGeometryCheck::LayerFeatureIds() ) const = 0;
 
     /**
-     * Fix the error \a error with the specified \a method.
+     * Fixes the error \a error with the specified \a method.
+     * Is executed on the main thread.
      *
      * \since QGIS 3.4
      */

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -253,6 +253,11 @@ class ANALYSIS_EXPORT QgsGeometryCheck
     QgsGeometryCheck( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
     virtual ~QgsGeometryCheck() = default;
 
+    /**
+     * Will be run in the main thread before collectErrors is called (which may be run from a background thread).
+     */
+    virtual void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
+
 #ifndef SIP_RUN
 
     /**

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -255,6 +255,8 @@ class ANALYSIS_EXPORT QgsGeometryCheck
 
     /**
      * Will be run in the main thread before collectErrors is called (which may be run from a background thread).
+     *
+     * \since QGIS 3.10
      */
     virtual void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.cpp
@@ -15,10 +15,11 @@
 
 #include "qgsgeometrycheckcontext.h"
 
-QgsGeometryCheckContext::QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext )
+QgsGeometryCheckContext::QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *project )
   : tolerance( std::pow( 10, -precision ) )
   , reducedTolerance( std::pow( 10, -precision / 2 ) )
   , mapCrs( mapCrs )
   , transformContext( transformContext )
+  , project( project )
 {
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.cpp
@@ -14,12 +14,19 @@
  ***************************************************************************/
 
 #include "qgsgeometrycheckcontext.h"
+#include <QThread>
 
 QgsGeometryCheckContext::QgsGeometryCheckContext( int precision, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &transformContext, const QgsProject *project )
   : tolerance( std::pow( 10, -precision ) )
   , reducedTolerance( std::pow( 10, -precision / 2 ) )
   , mapCrs( mapCrs )
   , transformContext( transformContext )
-  , project( project )
+  , mProject( project )
 {
+}
+
+const QgsProject *QgsGeometryCheckContext::project() const
+{
+  Q_ASSERT( qApp->thread() == QThread::currentThread() );
+  return mProject;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -27,12 +27,13 @@
  * \note This class is a technology preview and unstable API.
  * \since QGIS 3.4
  */
-struct ANALYSIS_EXPORT QgsGeometryCheckContext
+class ANALYSIS_EXPORT QgsGeometryCheckContext
 {
+  public:
     QgsGeometryCheckContext( int precision,
                              const QgsCoordinateReferenceSystem &mapCrs,
                              const QgsCoordinateTransformContext &transformContext,
-                             const QgsProject *project );
+                             const QgsProject *mProject );
 
     /**
      * The tolerance to allow for in geometry checks.
@@ -66,7 +67,10 @@ struct ANALYSIS_EXPORT QgsGeometryCheckContext
      *
      * \since QGIS 3.10
      */
-    const QgsProject *project;
+    const QgsProject *project() const;
+
+  private:
+    const QgsProject *mProject;
 
   private:
 #ifdef SIP_RUN

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -30,6 +30,10 @@
 class ANALYSIS_EXPORT QgsGeometryCheckContext
 {
   public:
+
+    /**
+     * Creates a new QgsGeometryCheckContext.
+     */
     QgsGeometryCheckContext( int precision,
                              const QgsCoordinateReferenceSystem &mapCrs,
                              const QgsCoordinateTransformContext &transformContext,

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -31,7 +31,8 @@ struct ANALYSIS_EXPORT QgsGeometryCheckContext
 {
     QgsGeometryCheckContext( int precision,
                              const QgsCoordinateReferenceSystem &mapCrs,
-                             const QgsCoordinateTransformContext &transformContext );
+                             const QgsCoordinateTransformContext &transformContext,
+                             const QgsProject *project );
 
     /**
      * The tolerance to allow for in geometry checks.
@@ -57,6 +58,12 @@ struct ANALYSIS_EXPORT QgsGeometryCheckContext
      * The coordinate transform context with which transformations will be done.
      */
     const QgsCoordinateTransformContext transformContext;
+
+    /**
+     * The project ... blablabla
+     * Only to be used in the main thread (prepare method)
+     */
+    const QgsProject *project;
 
   private:
 #ifdef SIP_RUN

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -22,6 +22,7 @@
 #include "qgsfeaturepool.h"
 
 /**
+ * \ingroup analysis
  * Base configuration for geometry checks.
  *
  * \note This class is a technology preview and unstable API.

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckcontext.h
@@ -60,8 +60,11 @@ struct ANALYSIS_EXPORT QgsGeometryCheckContext
     const QgsCoordinateTransformContext transformContext;
 
     /**
-     * The project ... blablabla
-     * Only to be used in the main thread (prepare method)
+     * The project can be used to resolve additional layers.
+     *
+     * This must only be accessed from the main thread (i.e. do not access from the collectError method)
+     *
+     * \since QGIS 3.10
      */
     const QgsProject *project;
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
@@ -29,7 +29,7 @@
 #include "qgsfeatureid.h"
 
 typedef qint64 QgsFeatureId;
-struct QgsGeometryCheckContext;
+class QgsGeometryCheckContext;
 class QgsGeometryCheck;
 class QgsGeometryCheckError;
 class QgsMapLayer;

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckfactory.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckfactory.h
@@ -30,7 +30,7 @@
 class QgsGeometryCheck;
 class QgsSingleGeometryCheck;
 
-struct QgsGeometryCheckContext;
+class QgsGeometryCheckContext;
 
 /**
  * \ingroup analysis

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckregistry.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckregistry.h
@@ -25,7 +25,7 @@
 #include "qgsgeometrycheck.h"
 
 class QgsGeometryCheckFactory;
-struct QgsGeometryCheckContext;
+class QgsGeometryCheckContext;
 
 
 /**

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -70,7 +70,7 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
       }
       QString errMsg;
       QgsGeometry geomB = layerFeatureB.geometry();
-      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( geomB.constGet(), &errMsg );
+      std::unique_ptr<QgsAbstractGeometry> diffGeom( geomEngineA->symDifference( geomB.constGet(), &errMsg ) );
       if ( errMsg.isEmpty() && diffGeom && diffGeom->isEmpty() )
       {
         duplicates[layerFeatureB.layer()->id()].append( layerFeatureB.feature().id() );
@@ -79,7 +79,6 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
       {
         messages.append( tr( "Duplicate check failed for (%1, %2): %3" ).arg( layerFeatureA.id(), layerFeatureB.id(), errMsg ) );
       }
-      delete diffGeom;
     }
     if ( !duplicates.isEmpty() )
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -49,8 +49,9 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
 
-    QgsRectangle bboxA = layerFeatureA.geometry().boundingBox();
-    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
+    QgsGeometry geomA = layerFeatureA.geometry();
+    QgsRectangle bboxA = geomA.boundingBox();
+    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( geomA.constGet(), mContext->tolerance );
     if ( !geomEngineA->isValid() )
     {
       messages.append( tr( "Duplicate check failed for (%1): the geometry is invalid" ).arg( layerFeatureA.id() ) );
@@ -58,7 +59,7 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
     }
     QMap<QString, QList<QgsFeatureId>> duplicates;
 
-    QgsWkbTypes::GeometryType geomType = layerFeatureA.feature().geometry().type();
+    QgsWkbTypes::GeometryType geomType = geomA.type();
     QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( featurePools, QList<QString>() << layerFeatureA.layer()->id() << layerIds, bboxA, {geomType}, mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
     {
@@ -68,7 +69,8 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
         continue;
       }
       QString errMsg;
-      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( layerFeatureB.geometry().constGet(), &errMsg );
+      QgsGeometry geomB = layerFeatureB.geometry();
+      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( geomB.constGet(), &errMsg );
       if ( errMsg.isEmpty() && diffGeom && diffGeom->isEmpty() )
       {
         duplicates[layerFeatureB.layer()->id()].append( layerFeatureB.feature().id() );
@@ -81,7 +83,7 @@ void QgsGeometryDuplicateCheck::collectErrors( const QMap<QString, QgsFeaturePoo
     }
     if ( !duplicates.isEmpty() )
     {
-      errors.append( new QgsGeometryDuplicateCheckError( this, layerFeatureA, layerFeatureA.geometry().constGet()->centroid(), featurePools, duplicates ) );
+      errors.append( new QgsGeometryDuplicateCheckError( this, layerFeatureA, geomA.constGet()->centroid(), featurePools, duplicates ) );
     }
   }
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -72,7 +72,6 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
     }
 
     std::unique_ptr< QgsGeometryEngine > allowedGapsEngine = QgsGeometryCheckerUtils::createGeomEngine( nullptr, mContext->tolerance );
-    allowedGapsEngine->prepareGeometry();
 
     // Create union of allowed gaps
     QString errMsg;
@@ -101,7 +100,6 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
   }
 
   std::unique_ptr< QgsGeometryEngine > geomEngine = QgsGeometryCheckerUtils::createGeomEngine( nullptr, mContext->tolerance );
-  geomEngine->prepareGeometry();
 
   // Create union of geometry
   QString errMsg;

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -36,7 +36,7 @@ void QgsGeometryGapCheck::prepare( const QgsGeometryCheckContext *context, const
 {
   if ( configuration.value( QStringLiteral( "allowedGapsEnabled" ) ).toBool() )
   {
-    QgsVectorLayer *layer = context->project->mapLayer<QgsVectorLayer *>( configuration.value( "allowedGapsLayer" ).toString() );
+    QgsVectorLayer *layer = context->project()->mapLayer<QgsVectorLayer *>( configuration.value( "allowedGapsLayer" ).toString() );
     mAllowedGapsLayer = layer;
     mAllowedGapsSource = qgis::make_unique<QgsVectorLayerFeatureSource>( layer );
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -244,7 +244,10 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( const QMap<QString, QgsFeaturePool 
 
 QStringList QgsGeometryGapCheck::resolutionMethods() const
 {
-  static QStringList methods = QStringList() << tr( "Add gap area to neighboring polygon with longest shared edge" ) << tr( "No action" );
+  static QStringList methods = QStringList()
+                               << tr( "Add gap area to neighboring polygon with longest shared edge" )
+                               << tr( "Add gap area to " )
+                               << tr( "No action" );
   return methods;
 }
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -176,7 +176,7 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
       continue;
     }
 
-    if ( allowedGapsGeomEngine->contains( gapGeom ) )
+    if ( allowedGapsGeomEngine && allowedGapsGeomEngine->contains( gapGeom ) )
     {
       continue;
     }

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -140,7 +140,7 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
   QgsGeometryPartIterator parts = diffGeom->parts();
   while ( parts.hasNext() )
   {
-    QgsAbstractGeometry *gapGeom = parts.next();
+    const QgsAbstractGeometry *gapGeom = parts.next();
     // Skip the gap between features and boundingbox
     const double spacing = context()->tolerance;
     if ( gapGeom->boundingBox().snappedToGrid( spacing ) == envelope->boundingBox().snappedToGrid( spacing ) )

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
@@ -106,6 +106,8 @@ class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
      */
     explicit QgsGeometryGapCheck( const QgsGeometryCheckContext *context, const QVariantMap &configuration );
 
+    void prepare( const QgsGeometryCheckContext *context, const QVariantMap &configuration ) override;
+
     QList<QgsWkbTypes::GeometryType> compatibleGeometryTypes() const override { return factoryCompatibleGeometryTypes(); }
     void collectErrors( const QMap<QString, QgsFeaturePool *> &featurePools, QList<QgsGeometryCheckError *> &errors, QStringList &messages, QgsFeedback *feedback, const LayerFeatureIds &ids = LayerFeatureIds() ) const override;
     void fixError( const QMap<QString, QgsFeaturePool *> &featurePools, QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
@@ -115,6 +117,8 @@ class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
     QString id() const override;
     QgsGeometryCheck::Flags flags() const override;
     QgsGeometryCheck::CheckType checkType() const override { return factoryCheckType(); }
+    std::unique_ptr<QgsVectorLayerFeatureSource> mAllowedGapsSource;
+    double mAllowedGapsBuffer;
 
 ///@cond private
     static QString factoryDescription() SIP_SKIP;

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
@@ -94,7 +94,8 @@ class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
     enum ResolutionMethod
     {
       MergeLongestEdge, //!< Merge the gap with the polygon with the longest shared edge.
-      NoChange //!< Do not handle the error.
+      NoChange, //!< Do not handle the error.
+      AddToAllowedGaps
     };
     Q_ENUM( ResolutionMethod )
 
@@ -117,8 +118,6 @@ class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
     QString id() const override;
     QgsGeometryCheck::Flags flags() const override;
     QgsGeometryCheck::CheckType checkType() const override { return factoryCheckType(); }
-    std::unique_ptr<QgsVectorLayerFeatureSource> mAllowedGapsSource;
-    double mAllowedGapsBuffer;
 
 ///@cond private
     static QString factoryDescription() SIP_SKIP;
@@ -134,6 +133,10 @@ class ANALYSIS_EXPORT QgsGeometryGapCheck : public QgsGeometryCheck
                             QgsGeometryGapCheckError *err, Changes &changes, QString &errMsg ) const;
 
     const double mGapThresholdMapUnits;
+    QgsWeakMapLayerPointer mAllowedGapsLayer;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mAllowedGapsSource;
+    double mAllowedGapsBuffer;
+
 };
 
 #endif // QGS_GEOMETRY_GAP_CHECK_H

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -223,7 +223,7 @@ void QgsGeometryValidationService::enableLayerChecks( QgsVectorLayer *layer )
       precision = 8;
   }
 
-  checkInformation.context = qgis::make_unique<QgsGeometryCheckContext>( precision, mProject->crs(), mProject->transformContext() );
+  checkInformation.context = qgis::make_unique<QgsGeometryCheckContext>( precision, mProject->crs(), mProject->transformContext(), mProject );
 
   QList<QgsGeometryCheck *> layerChecks;
 
@@ -424,7 +424,10 @@ void QgsGeometryValidationService::triggerTopologyChecks( QgsVectorLayer *layer 
 
   QHash<const QgsGeometryCheck *, QgsFeedback *> feedbacks;
   for ( QgsGeometryCheck *check : checks )
+  {
     feedbacks.insert( check, new QgsFeedback() );
+    check->prepare( mLayerChecks[layer].context.get(), layer->geometryOptions()->checkConfiguration( check->id() ) );
+  }
 
   mLayerChecks[layer].topologyCheckFeedbacks = feedbacks.values();
 

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -269,6 +269,14 @@ void QgsGeometryValidationService::enableLayerChecks( QgsVectorLayer *layer )
     {
       const QVariantMap checkConfiguration = layer->geometryOptions()->checkConfiguration( checkId );
       topologyChecks.append( factory->createGeometryCheck( checkInformation.context.get(), checkConfiguration ) );
+
+      if ( checkConfiguration.value( QStringLiteral( "allowedGapsEnabled" ) ).toBool() )
+      {
+        QgsVectorLayer *gapsLayer = QgsProject::instance()->mapLayer<QgsVectorLayer *>( checkConfiguration.value( "allowedGapsLayer" ).toString() );
+        connect( layer, &QgsVectorLayer::editingStarted, gapsLayer, [gapsLayer] { gapsLayer->startEditing(); } );
+        connect( layer, &QgsVectorLayer::beforeRollBack, gapsLayer, [gapsLayer] { gapsLayer->rollBack(); } );
+        connect( layer, &QgsVectorLayer::editingStopped, gapsLayer, [gapsLayer] { gapsLayer->commitChanges(); } );
+      }
     }
   }
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -475,13 +475,14 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
         topologyCheckLayout->addWidget( mGapCheckAllowExceptionsActivatedCheckBox );
         mGapCheckAllowExceptionsLayerComboBox = new QgsMapLayerComboBox();
         mGapCheckAllowExceptionsLayerComboBox->setFilters( QgsMapLayerProxyModel::PolygonLayer );
+        mGapCheckAllowExceptionsLayerComboBox->setExceptedLayerList( QList<QgsMapLayer *> { mLayer } );
         mGapCheckAllowExceptionsLayerComboBox->setLayer( QgsProject::instance()->mapLayer( gapCheckConfig.value( QStringLiteral( "allowedGapsLayer" ) ).toString() ) );
         layout->addRow( new QLabel( tr( "Layer" ) ), mGapCheckAllowExceptionsLayerComboBox );
-        mGapCheckAllowExceptionsBufferLineEdit = new QLineEdit();
-        mGapCheckAllowExceptionsBufferLineEdit->setInputMethodHints( Qt::ImhFormattedNumbersOnly );
-        mGapCheckAllowExceptionsBufferLineEdit->setPlaceholderText( QStringLiteral( "0" ) );
-        mGapCheckAllowExceptionsBufferLineEdit->setText( gapCheckConfig.value( QStringLiteral( "allowedGapsBuffer" ) ).toString() );
-        layout->addRow( new QLabel( tr( "Buffer" ) ), mGapCheckAllowExceptionsBufferLineEdit );
+        mGapCheckAllowExceptionsBufferSpinBox = new QgsDoubleSpinBox();
+        mGapCheckAllowExceptionsBufferSpinBox->setInputMethodHints( Qt::ImhFormattedNumbersOnly );
+        mGapCheckAllowExceptionsBufferSpinBox->setSuffix( QgsUnitTypes::toAbbreviatedString( mLayer->crs().mapUnits() ) );
+        mGapCheckAllowExceptionsBufferSpinBox->setValue( gapCheckConfig.value( QStringLiteral( "allowedGapsBuffer" ) ).toDouble() );
+        layout->addRow( new QLabel( tr( "Buffer" ) ), mGapCheckAllowExceptionsBufferSpinBox );
       }
     }
     mTopologyChecksGroupBox->setLayout( topologyCheckLayout );
@@ -872,7 +873,7 @@ void QgsVectorLayerProperties::apply()
     gapCheckConfig.insert( QStringLiteral( "allowedGapsEnabled" ), mGapCheckAllowExceptionsActivatedCheckBox->isChecked() );
     QgsMapLayer *currentLayer = mGapCheckAllowExceptionsLayerComboBox->currentLayer();
     gapCheckConfig.insert( QStringLiteral( "allowedGapsLayer" ), currentLayer ? currentLayer->id() : QString() );
-    gapCheckConfig.insert( QStringLiteral( "allowedGapsBuffer" ), mGapCheckAllowExceptionsBufferLineEdit->text() );
+    gapCheckConfig.insert( QStringLiteral( "allowedGapsBuffer" ), mGapCheckAllowExceptionsBufferSpinBox->value() );
 
     mLayer->geometryOptions()->setCheckConfiguration( QStringLiteral( "QgsGeometryGapCheck" ), gapCheckConfig );
   }

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -467,7 +467,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
       {
         const QVariantMap gapCheckConfig = mLayer->geometryOptions()->checkConfiguration( QStringLiteral( "QgsGeometryGapCheck" ) );
 
-        mGapCheckAllowExceptionsActivatedCheckBox = new QgsCollapsibleGroupBox( tr( "Allowed gaps" ) );
+        mGapCheckAllowExceptionsActivatedCheckBox = new QgsCollapsibleGroupBox( tr( "Allowed Gaps" ) );
         mGapCheckAllowExceptionsActivatedCheckBox->setCheckable( true );
         mGapCheckAllowExceptionsActivatedCheckBox->setChecked( gapCheckConfig.value( QStringLiteral( "allowedGapsEnabled" ), false ).toBool() );
         QFormLayout *layout = new QFormLayout();

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -45,6 +45,7 @@ class QgsMapLayerConfigWidget;
 class QgsMetadataWidget;
 class QgsPanelWidget;
 class QgsVectorLayer3DRendererWidget;
+class QgsMapLayerComboBox;
 
 class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private Ui::QgsVectorLayerPropertiesBase, private QgsExpressionContextGenerator
 {
@@ -246,6 +247,10 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QHash<QCheckBox *, QString> mGeometryCheckFactoriesGroupBoxes;
 
     bool mRemoveDuplicateNodesManuallyActivated = false;
+
+    QgsCollapsibleGroupBox *mGapCheckAllowExceptionsActivatedCheckBox = nullptr;
+    QgsMapLayerComboBox *mGapCheckAllowExceptionsLayerComboBox = nullptr;
+    QLineEdit *mGapCheckAllowExceptionsBufferLineEdit = nullptr;
 
   private slots:
     void openPanel( QgsPanelWidget *panel );

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -46,6 +46,7 @@ class QgsMetadataWidget;
 class QgsPanelWidget;
 class QgsVectorLayer3DRendererWidget;
 class QgsMapLayerComboBox;
+class QgsDoubleSpinBox;
 
 class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private Ui::QgsVectorLayerPropertiesBase, private QgsExpressionContextGenerator
 {
@@ -250,7 +251,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     QgsCollapsibleGroupBox *mGapCheckAllowExceptionsActivatedCheckBox = nullptr;
     QgsMapLayerComboBox *mGapCheckAllowExceptionsLayerComboBox = nullptr;
-    QLineEdit *mGapCheckAllowExceptionsBufferLineEdit = nullptr;
+    QgsDoubleSpinBox *mGapCheckAllowExceptionsBufferSpinBox = nullptr;
 
   private slots:
     void openPanel( QgsPanelWidget *panel );

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -427,7 +427,7 @@ void QgsGeometryCheckerSetupTab::runChecks()
     featurePools.insert( layer->id(), new QgsVectorDataProviderFeaturePool( layer, selectedOnly ) );
   }
 
-  QgsGeometryCheckContext *context = new QgsGeometryCheckContext( ui.spinBoxTolerance->value(), QgsProject::instance()->crs(), QgsProject::instance()->transformContext() );
+  QgsGeometryCheckContext *context = new QgsGeometryCheckContext( ui.spinBoxTolerance->value(), QgsProject::instance()->crs(), QgsProject::instance()->transformContext(), QgsProject::instance() );
 
   QList<QgsGeometryCheck *> checks;
   for ( const QgsGeometryCheckFactory *factory : QgsGeometryCheckFactoryRegistry::getCheckFactories() )

--- a/src/plugins/geometry_checker/qgsgeometrycheckfactory.h
+++ b/src/plugins/geometry_checker/qgsgeometrycheckfactory.h
@@ -18,7 +18,7 @@
 #include "qgis.h"
 #include "ui_qgsgeometrycheckersetuptab.h"
 
-struct QgsGeometryCheckContext;
+class QgsGeometryCheckContext;
 class QgsGeometryCheck;
 
 class QgsGeometryCheckFactory

--- a/tests/src/geometry_checker/testqgsgeometrychecks.cpp
+++ b/tests/src/geometry_checker/testqgsgeometrychecks.cpp
@@ -936,7 +936,7 @@ void TestQgsGeometryChecks::testSelfContactCheck()
 
   // https://github.com/qgis/QGIS/issues/28228
   // test with a linestring which collapses to an empty linestring
-  QgsGeometryCheckContext context( 1, QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext() );
+  QgsGeometryCheckContext context( 1, QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), QgsCoordinateTransformContext(), nullptr );
   QgsGeometrySelfContactCheck check2( &context, QVariantMap() );
   QgsGeometry g = QgsGeometry::fromWkt( QStringLiteral( "MultiLineString ((2988987 10262483, 2988983 10262480, 2988991 10262432, 2988990 10262419, 2988977 10262419, 2988976 10262420, 2988967 10262406, 2988970 10262421, 2988971 10262424),(2995620 10301368))" ) );
   QList<QgsSingleGeometryCheckError *> errors = check2.processGeometry( g );
@@ -1128,7 +1128,7 @@ QPair<QgsGeometryCheckContext *, QMap<QString, QgsFeaturePool *> > TestQgsGeomet
     layer->dataProvider()->enterUpdateMode();
     featurePools.insert( layer->id(), createFeaturePool( layer ) );
   }
-  return qMakePair( new QgsGeometryCheckContext( prec, mapCrs, QgsProject::instance()->transformContext() ), featurePools );
+  return qMakePair( new QgsGeometryCheckContext( prec, mapCrs, QgsProject::instance()->transformContext(), nullptr ), featurePools );
 }
 
 void TestQgsGeometryChecks::cleanupTestContext( QPair<QgsGeometryCheckContext *, QMap<QString, QgsFeaturePool *> > ctx ) const


### PR DESCRIPTION
This adds a new option for the gaps geometry check to add an "allowed gaps" layer with a buffer parameter.

This allowed gaps layer acts as a mask in the check and gaps in this area are not reported as errors. This can e.g. be interesting for a topological land use map where there are lakes which are allowed to be excluded.
The buffer parameter can be used for tolerance for slight variations along the borders of the lake.

There is a new fix available to add a reported gap as a new polygon to the allowed gaps layer. It is the users responsibility to guarantee that this can be done fully automated (e.g. no NOT NULL constraints etc.).
One thing to note is that if a gap grows and is added again, it will just be added on top of the existing gap polygon. There are alternatives to that (like only adding the missing bits, but especially with buffering enabled, that's almost impossible to do, or removing overlapping geometries, but removing geometries also seems uncontrollable)

![Peek 2019-08-06 11-06](https://user-images.githubusercontent.com/588407/62681585-50abc200-b9ba-11e9-9c7c-c9284b6d57b1.gif)
