### PR TITLE
Expression based QgsProperty optimisations

### DIFF
--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -352,6 +352,9 @@ void QgsLabelingEngine::run( QgsRenderContext &context )
   // prepare for rendering
   for ( QgsAbstractLabelProvider *provider : qgis::as_const( mProviders ) )
   {
+    // provider will require the correct layer scope for expression preparation - at this stage, the existing expression context
+    // only contains generic scopes
+    QgsExpressionContextScopePopper popper( context.expressionContext(), QgsExpressionContextUtils::layerScope( provider->layer() ) );
     provider->startRender( context );
   }
 

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -475,7 +475,6 @@ QVariant QgsProperty::propertyValue( const QgsExpressionContext &context, const 
 
     case ExpressionBasedProperty:
     {
-      d.detach();
       if ( d->expressionIsInvalid )
         return defaultValue;
 

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -309,6 +309,7 @@ void QgsProperty::setExpressionString( const QString &expression )
   d->expressionString = expression;
   d->expression = QgsExpression( expression );
   d->expressionPrepared = false;
+  d->expressionIsInvalid = false;
 }
 
 QString QgsProperty::expressionString() const
@@ -370,10 +371,12 @@ bool QgsProperty::prepare( const QgsExpressionContext &context ) const
       {
         d->expressionReferencedCols.clear();
         d->expressionPrepared = false;
+        d->expressionIsInvalid = true;
         return false;
       }
 
       d->expressionPrepared = true;
+      d->expressionIsInvalid = false;
       d->expressionReferencedCols = d->expression.referencedColumns();
       return true;
     }
@@ -407,9 +410,15 @@ QSet<QString> QgsProperty::referencedFields( const QgsExpressionContext &context
 
     case ExpressionBasedProperty:
     {
+      if ( d->expressionIsInvalid )
+        return QSet< QString >();
+
       d.detach();
       if ( !d->expressionPrepared && !prepare( context ) )
+      {
+        d->expressionIsInvalid = true;
         return QSet< QString >();
+      }
 
       return d->expressionReferencedCols;
     }
@@ -467,6 +476,9 @@ QVariant QgsProperty::propertyValue( const QgsExpressionContext &context, const 
     case ExpressionBasedProperty:
     {
       d.detach();
+      if ( d->expressionIsInvalid )
+        return defaultValue;
+
       if ( !d->expressionPrepared && !prepare( context ) )
         return defaultValue;
 
@@ -706,6 +718,7 @@ bool QgsProperty::loadVariant( const QVariant &property )
 
       d->expression = QgsExpression( d->expressionString );
       d->expressionPrepared = false;
+      d->expressionIsInvalid = false;
       d->expressionReferencedCols.clear();
       break;
 

--- a/src/core/qgsproperty_p.h
+++ b/src/core/qgsproperty_p.h
@@ -50,6 +50,7 @@ class QgsPropertyPrivate : public QSharedData
       , cachedFieldIdx( other.cachedFieldIdx )
       , expressionString( other.expressionString )
       , expressionPrepared( other.expressionPrepared )
+      , expressionIsInvalid( other.expressionIsInvalid )
       , expression( other.expression )
       , expressionReferencedCols( other.expressionReferencedCols )
     {}
@@ -77,6 +78,7 @@ class QgsPropertyPrivate : public QSharedData
     // ExpressionData
     QString expressionString;
     mutable bool expressionPrepared = false;
+    mutable bool expressionIsInvalid = false;
     mutable QgsExpression expression;
     //! Cached set of referenced columns
     mutable QSet< QString > expressionReferencedCols;


### PR DESCRIPTION
Some optimisations to QgsProperty which greatly speed up data defined symbology rendering in some circumstances.

(I don't plan on backporting this ones -- there's a small chance (I guess around 0.5%) it may cause a regression, so I'd rather it just waits it out in master only for now)

Thanks to QGIS grant, sponsored by Hotspot.