### PR TITLE
Update widgets with default values on attribute form

### DIFF
--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -194,7 +194,8 @@ Invalid < NULL < Values
 
 bool qgsVariantEqual( const QVariant &lhs, const QVariant &rhs );
 %Docstring
-Compares two QVariant values and returns whether they are equal, NULL values are treated as equal.
+Compares two QVariant values and returns whether they are equal, two NULL values are
+always treated as equal and 0 is not treated as equal with NULL
 
 :param lhs: first value
 :param rhs: second value

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -297,5 +297,5 @@ uint qHash( const QVariant &variant )
 
 bool qgsVariantEqual( const QVariant &lhs, const QVariant &rhs )
 {
-  return lhs.isNull() == rhs.isNull() && lhs == rhs;
+  return ( lhs.isNull() == rhs.isNull() && lhs == rhs ) || ( lhs.isNull() && rhs.isNull() );
 }

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -28,6 +28,7 @@
 #include "qgsconfig.h"
 #include "qgslogger.h"
 #include "qgswkbtypes.h"
+#include <QDebug>
 
 #include <gdal.h>
 #include <ogr_api.h>
@@ -297,5 +298,5 @@ uint qHash( const QVariant &variant )
 
 bool qgsVariantEqual( const QVariant &lhs, const QVariant &rhs )
 {
-  return ( lhs.isNull() == rhs.isNull() && lhs == rhs ) || ( lhs.isNull() && rhs.isNull() );
+  return ( lhs.isNull() == rhs.isNull() && lhs == rhs ) || ( lhs.isNull() && rhs.isNull() && lhs.isValid() && rhs.isValid() );
 }

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -28,7 +28,6 @@
 #include "qgsconfig.h"
 #include "qgslogger.h"
 #include "qgswkbtypes.h"
-#include <QDebug>
 
 #include <gdal.h>
 #include <ogr_api.h>

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -503,7 +503,8 @@ CORE_EXPORT qlonglong qgsPermissiveToLongLong( QString string, bool &ok );
 CORE_EXPORT bool qgsVariantLessThan( const QVariant &lhs, const QVariant &rhs );
 
 /**
- * Compares two QVariant values and returns whether they are equal, NULL values are treated as equal.
+ * Compares two QVariant values and returns whether they are equal, two NULL values are
+ * always treated as equal and 0 is not treated as equal with NULL
  *
  * \param lhs first value
  * \param rhs second value

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -319,12 +319,7 @@ bool QgsAttributeForm::saveEdits()
         QVariant dstVar = dst.at( eww->fieldIdx() );
         QVariant srcVar = eww->value();
 
-        // need to check dstVar.isNull() != srcVar.isNull()
-        // otherwise if dstVar=NULL and scrVar=0, then dstVar = srcVar
-        // be careful- sometimes two null qvariants will be reported as not equal!! (e.g., different types)
-        bool changed = ( dstVar != srcVar && !dstVar.isNull() && !srcVar.isNull() )
-                       || ( dstVar.isNull() != srcVar.isNull() );
-        if ( changed && srcVar.isValid() && fieldIsEditable( eww->fieldIdx() ) )
+        if ( !qgsVariantEqual( dstVar, srcVar ) && srcVar.isValid() && fieldIsEditable( eww->fieldIdx() ) )
         {
           dst[eww->fieldIdx()] = srcVar;
 
@@ -437,12 +432,7 @@ bool QgsAttributeForm::updateDefaultValues( const int originIdx )
         QVariant dstVar = dst.at( eww->fieldIdx() );
         QVariant srcVar = eww->value();
 
-        // need to check dstVar.isNull() != srcVar.isNull()
-        // otherwise if dstVar=NULL and scrVar=0, then dstVar = srcVar
-        // be careful- sometimes two null qvariants will be reported as not equal!! (e.g., different types)
-        bool changed = ( dstVar != srcVar && !dstVar.isNull() && !srcVar.isNull() )
-                       || ( dstVar.isNull() != srcVar.isNull() );
-        if ( changed && srcVar.isValid() && fieldIsEditable( eww->fieldIdx() ) )
+        if ( !qgsVariantEqual( dstVar, srcVar ) && srcVar.isValid() && fieldIsEditable( eww->fieldIdx() ) )
         {
           dst[eww->fieldIdx()] = srcVar;
         }
@@ -465,12 +455,8 @@ bool QgsAttributeForm::updateDefaultValues( const int originIdx )
 
         //do not update when this widget is already updating (avoid recursions)
         if ( mAlreadyUpdatedFields.contains( eww->fieldIdx() ) )
-        {
-          qDebug() << "we don't update field [" << eww->fieldIdx() << "] " << eww->field().name() << " because it's already 'updating'";
           continue;
-        }
 
-        qDebug() << "update field [" << eww->fieldIdx() << "] " << eww->field().name() << " with field of id " << originIdx << " because " << eww->layer()->fields().at( originIdx ).name() << " is in " << eww->field().defaultValueDefinition().expression();
         QString value = mLayer->defaultValue( eww->fieldIdx(), updatedFeature ).toString();
         eww->setValue( value );
       }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1490,7 +1490,8 @@ void QgsAttributeForm::init()
     if ( eww )
     {
       QgsExpression exp( eww->field().defaultValueDefinition().expression() );
-      for ( const QString &referencedColumn : exp.referencedColumns().toList() )
+      const QSet<QString> referencedColumns = exp.referencedColumns();
+      for ( const QString &referencedColumn : referencedColumns )
       {
         if ( referencedColumn == QgsFeatureRequest::ALL_ATTRIBUTES )
         {

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -450,10 +450,13 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     QMap<QWidget *, QSvgWidget *> mIconMap;
 
-    //! dependency map for default values
+    /**
+     * Dependency map for default values. Attribute index -> widget wrapper.
+     * Attribute indexes will be added multiple times if more than one widget depends on them.
+     */
     QMap<int, QgsWidgetWrapper *> mDefaultValueDependencies;
 
-    //! list of updated fields to avoid recursion on the setting of defaultValues
+    //! List of updated fields to avoid recursion on the setting of defaultValues
     QList<int> mAlreadyUpdatedFields;
 
     friend class TestQgsDualView;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -352,6 +352,12 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     //! Save single feature or add feature edits
     bool saveEdits();
 
+    //! fill up dependency map for default values
+    void createDefaultValueDependencies();
+
+    //! update the default values in the fields after a referenced field changed
+    bool updateDefaultValues( const int originIdx );
+
     int messageTimeout();
     void clearMultiEditMessages();
     void pushSelectedFeaturesMessage();
@@ -443,6 +449,12 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QgsAttributeEditorContext::Mode mMode;
 
     QMap<QWidget *, QSvgWidget *> mIconMap;
+
+    //! dependency map for default values
+    QMap<int, QgsWidgetWrapper *> mDefaultValueDependencies;
+
+    //! list of updated fields to avoid recursion on the setting of defaultValues
+    QList<int> mAlreadyUpdatedFields;
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeForm;

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -395,6 +395,9 @@ void TestQgis::testQgsVariantEqual()
   QVERIFY( qgsVariantEqual( QVariant( QVariant::Double ), QVariant( QVariant::Double ) ) );
   QVERIFY( qgsVariantEqual( QVariant( QVariant::Int ), QVariant( QVariant::Double ) ) );
   QVERIFY( qgsVariantEqual( QVariant( QVariant::Int ), QVariant( QVariant::String ) ) );
+
+  // NULL should not be equal to invalid
+  QVERIFY( !qgsVariantEqual( QVariant(), QVariant( QVariant::Int ) ) );
 }
 
 void TestQgis::testQgsEnumValueToKey()

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -393,6 +393,8 @@ void TestQgis::testQgsVariantEqual()
   // NULL identities
   QVERIFY( qgsVariantEqual( QVariant( QVariant::Int ), QVariant( QVariant::Int ) ) );
   QVERIFY( qgsVariantEqual( QVariant( QVariant::Double ), QVariant( QVariant::Double ) ) );
+  QVERIFY( qgsVariantEqual( QVariant( QVariant::Int ), QVariant( QVariant::Double ) ) );
+  QVERIFY( qgsVariantEqual( QVariant( QVariant::Int ), QVariant( QVariant::String ) ) );
 }
 
 void TestQgis::testQgsEnumValueToKey()


### PR DESCRIPTION
Updates widget values on real time while editing the referenced fields.
![default_value_01](https://user-images.githubusercontent.com/28384354/62712413-13b3ef80-b9fb-11e9-84f9-973e17369c2b.gif)

To avoid recursion it stores the currently updated fields index in `mAlreadyUpdatedFields`. The widgets contains as default value the value of the previous one plus 1:
![default_value_02](https://user-images.githubusercontent.com/28384354/62712430-17e00d00-b9fb-11e9-8619-4781614839af.gif)

To Do:
-[ ] Testfunction in `testqgsattributeform`