### PR TITLE
Do not create sAuthIdToQgisSrsIdMap for proj5 builds

### DIFF
--- a/src/core/qgscoordinatereferencesystem_legacy.h
+++ b/src/core/qgscoordinatereferencesystem_legacy.h
@@ -19,6 +19,7 @@
 #include <QMap>
 #include <QString>
 
+#if PROJ_VERSION_MAJOR>=6
 // maps QGIS custom db srs ids to proj auth/codes
 const QMap< QString, QString > sAuthIdToQgisSrsIdMap
 {
@@ -6782,3 +6783,4 @@ const QMap< QString, QString > sAuthIdToQgisSrsIdMap
   {"EPSG:8320", "29667,8320"},
   {"EPSG:8321", "29668,8321"}
 };
+#endif // PROJ_VERSION_MAJOR>=6


### PR DESCRIPTION
I hit the https://bugs.llvm.org/show_bug.cgi?id=42515 issue for cross compilation of OSGeo4A for android on mac...