### PR TITLE
Fix bison warnings: deprecated directive

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -608,8 +608,10 @@ IF (QT_MOBILITY_LOCATION_FOUND OR Qt5Positioning_FOUND)
   )
 ENDIF (QT_MOBILITY_LOCATION_FOUND OR Qt5Positioning_FOUND)
 
-ADD_FLEX_FILES(QGIS_CORE_SRCS qgsexpressionlexer.ll qgssqlstatementlexer.ll)
-ADD_BISON_FILES(QGIS_CORE_SRCS qgsexpressionparser.yy qgssqlstatementparser.yy)
+ADD_FLEX_FILES_PREFIX(QGIS_CORE_SRCS exp_ qgsexpressionlexer.ll)
+ADD_FLEX_FILES_PREFIX(QGIS_CORE_SRCS sqlstatement_ qgssqlstatementlexer.ll)
+ADD_BISON_FILES_PREFIX(QGIS_CORE_SRCS exp_ qgsexpressionparser.yy)
+ADD_BISON_FILES_PREFIX(QGIS_CORE_SRCS sqlstatement_ qgssqlstatementparser.yy)
 
 IF(NOT MSVC)
   SET_SOURCE_FILES_PROPERTIES(qgsexpressionparser.cpp qgssqlstatementparser.cpp PROPERTIES COMPILE_FLAGS -w)
@@ -1020,7 +1022,7 @@ SET(QGIS_CORE_HDRS
   qgstilecache.h
   qgstracer.h
   qgstranslationcontext.h
-  qobjectuniqueptr.h 
+  qobjectuniqueptr.h
 
   qgsvectordataprovider.h
   qgsvectorlayercache.h

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -90,7 +90,7 @@ void addParserLocation(YYLTYPE* yyloc, QgsExpressionNode *node)
 %lex-param {void * scanner}
 %parse-param {expression_parser_context* parser_ctx}
 
-%name-prefix "exp_"
+%define api.prefix {exp_}
 
 %union
 {
@@ -145,7 +145,7 @@ void addParserLocation(YYLTYPE* yyloc, QgsExpressionNode *node)
 %type <namednode> named_node
 
 // debugging
-%error-verbose
+%define parse.error verbose
 
 //
 // operator precedence

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -90,8 +90,6 @@ void addParserLocation(YYLTYPE* yyloc, QgsExpressionNode *node)
 %lex-param {void * scanner}
 %parse-param {expression_parser_context* parser_ctx}
 
-%define api.prefix {exp_}
-
 %union
 {
   QgsExpressionNode* node;

--- a/src/core/qgssqlstatementparser.yy
+++ b/src/core/qgssqlstatementparser.yy
@@ -87,8 +87,6 @@ struct sqlstatement_parser_context
 %lex-param {void * scanner}
 %parse-param {sqlstatement_parser_context* parser_ctx}
 
-%define api.prefix {sqlstatement_}
-
 %union
 {
   QgsSQLStatement::Node* node;
@@ -376,7 +374,7 @@ selected_column:
             delete $1;
             QgsSQLStatement::NodeList* nodeList = new QgsSQLStatement::NodeList();
             nodeList->append( new QgsSQLStatement::NodeColumnRef("*", true) );
-            $$ = new QgsSQLStatement::NodeSelectedColumn( 
+            $$ = new QgsSQLStatement::NodeSelectedColumn(
                     new QgsSQLStatement::NodeFunction( "COUNT", nodeList) );
         }
 
@@ -393,7 +391,7 @@ selected_column:
             delete $1;
             QgsSQLStatement::NodeList* nodeList = new QgsSQLStatement::NodeList();
             nodeList->append( new QgsSQLStatement::NodeColumnRef("*", true) );
-            $$ = new QgsSQLStatement::NodeSelectedColumn( 
+            $$ = new QgsSQLStatement::NodeSelectedColumn(
                     new QgsSQLStatement::NodeFunction( "COUNT", nodeList) );
             $$->setAlias(*$5);
             delete $5;
@@ -414,7 +412,7 @@ selected_column:
             QgsSQLStatement::NodeList* nodeList = new QgsSQLStatement::NodeList();
             $4->setDistinct();
             nodeList->append( $4 );
-            $$ = new QgsSQLStatement::NodeSelectedColumn( 
+            $$ = new QgsSQLStatement::NodeSelectedColumn(
                     new QgsSQLStatement::NodeFunction( "COUNT", nodeList) );
         }
 
@@ -434,7 +432,7 @@ selected_column:
             QgsSQLStatement::NodeList* nodeList = new QgsSQLStatement::NodeList();
             $4->setDistinct();
             nodeList->append( $4 );
-            $$ = new QgsSQLStatement::NodeSelectedColumn( 
+            $$ = new QgsSQLStatement::NodeSelectedColumn(
                     new QgsSQLStatement::NodeFunction( "COUNT", nodeList) );
             $$->setAlias(*$6);
             delete $6;

--- a/src/core/qgssqlstatementparser.yy
+++ b/src/core/qgssqlstatementparser.yy
@@ -87,7 +87,7 @@ struct sqlstatement_parser_context
 %lex-param {void * scanner}
 %parse-param {sqlstatement_parser_context* parser_ctx}
 
-%name-prefix "sqlstatement_"
+%define api.prefix {sqlstatement_}
 
 %union
 {
@@ -164,7 +164,7 @@ struct sqlstatement_parser_context
 %type <boolVal> select_type;
 
 // debugging
-%error-verbose
+%define parse.error verbose
 
 //
 // operator precedence


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.-->

Warnings with bison 3.4:
```
[16/5156] Generating qgsexpressionparser.cpp
/home/lbartoletti/QGIS/src/core/qgsexpressionparser.yy:93.1-19: warning: deprecated directive, use '%define api.prefix {exp_}' [-Wdeprecated]
   93 | %name-prefix "exp_"
      | ^~~~~~~~~~~~~~~~~~~
/home/lbartoletti/QGIS/src/core/qgsexpressionparser.yy:148.1-14: warning: deprecated directive, use '%define parse.error verbose' [-Wdeprecated]
  148 | %error-verbose
      | ^~~~~~~~~~~~~~
/home/lbartoletti/QGIS/src/core/qgsexpressionparser.yy: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
[24/5156] Building /home/lbartoletti/build/doc/news.html from /home/lbartoletti/QGIS/doc/news.t2t
txt2tags wrote /home/lbartoletti/build/doc/news.html
[39/5156] Generating qgssqlstatementparser.cpp
/home/lbartoletti/QGIS/src/core/qgssqlstatementparser.yy:90.1-28: warning: deprecated directive, use '%define api.prefix {sqlstatement_}' [-Wdeprecated]
   90 | %name-prefix "sqlstatement_"
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/lbartoletti/QGIS/src/core/qgssqlstatementparser.yy:167.1-14: warning: deprecated directive, use '%define parse.error verbose' [-Wdeprecated]
  167 | %error-verbose
      | ^~~~~~~~~~~~~~
/home/lbartoletti/QGIS/src/core/qgssqlstatementparser.yy: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```

Fixed with `bison --update`

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

## Backport

<!-- Bug fixes can concern more than a version and may require backporting. To ease the process, appropriate labels can be set and automatically open the pull request in the corresponding branch, once this PR is merged. Indicate below the version(s) you would like to backport to. You are however responsible of your code and should ensure there's no regression beforehand.-->

- [ ] I request the backport of the changes to the Latest Release
- [ ] I request the backport of the changes to the Long Term Release
