### PR TITLE
[FEATURE] Add option to georeference PDFs and TIFs to save map canvas as image/PDF

### DIFF
--- a/python/core/auto_generated/qgsmaprenderertask.sip.in
+++ b/python/core/auto_generated/qgsmaprenderertask.sip.in
@@ -57,7 +57,7 @@ Adds ``decorations`` to be rendered on the map.
 
     void setSaveWorldFile( bool save );
 %Docstring
-Sets whether a world file will be created alongside an image file.
+Sets whether the image file will be georeferenced (embedded or via a world file).
 %End
 
     virtual void cancel();

--- a/python/core/auto_generated/qgsmapsettingsutils.sip.in
+++ b/python/core/auto_generated/qgsmapsettingsutils.sip.in
@@ -30,6 +30,20 @@ Checks whether any of the layers attached to a map settings object contain advan
 :param mapSettings: map settings
 %End
 
+    static void worldFileParameters( const QgsMapSettings &mapSettings, double &a /Out/, double &b /Out/, double &c /Out/, double &d /Out/, double &e /Out/, double &f /Out/ );
+%Docstring
+Computes the six parameters of a world file.
+
+:param mapSettings: map settings
+:param b: the b parameter
+:param c: the c parameter
+:param d: the d parameter
+:param e: the e parameter
+:param f: the f parameter
+
+.. versionadded:: 3.10
+%End
+
     static QString worldFileContent( const QgsMapSettings &mapSettings );
 %Docstring
 Creates the content of a world file.

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -95,8 +95,6 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
 
   if ( mDialogType == QgsMapSaveDialog::Pdf )
   {
-    mSaveWorldFile->setVisible( false );
-
     QStringList layers = QgsMapSettingsUtils::containsAdvancedEffects( mMapCanvas->mapSettings() );
     if ( !layers.isEmpty() )
     {

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -71,7 +71,7 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
     //! returns whether the draw decorations element is checked
     bool drawDecorations() const;
 
-    //! returns whether a world file will be created
+    //! returns whether the resulting image will be georeferenced (embedded or via world file)
     bool saveWorldFile() const;
 
     //! returns whether the map will be rasterized

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -76,7 +76,7 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
     void addDecorations( const QList<QgsMapDecoration *> &decorations );
 
     /**
-     * Sets whether a world file will be created alongside an image file.
+     * Sets whether the image file will be georeferenced (embedded or via a world file).
      */
     void setSaveWorldFile( bool save ) { mSaveWorldFile = save; }
 

--- a/src/core/qgsmapsettingsutils.cpp
+++ b/src/core/qgsmapsettingsutils.cpp
@@ -66,7 +66,7 @@ const QStringList QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSett
   return layers.toList();
 }
 
-QString QgsMapSettingsUtils::worldFileContent( const QgsMapSettings &mapSettings )
+void QgsMapSettingsUtils::worldFileParameters( const QgsMapSettings &mapSettings, double &a, double &b, double &c, double &d, double &e, double &f )
 {
   QgsMapSettings ms = mapSettings;
 
@@ -101,14 +101,20 @@ QString QgsMapSettingsUtils::worldFileContent( const QgsMapSettings &mapSettings
   r[5] = - xCenter * std::sin( alpha ) + yCenter * ( 1 - std::cos( alpha ) );
 
   // result = rotation x scaling = rotation(scaling(X))
-  double a = r[0] * s[0] + r[1] * s[3];
-  double b = r[0] * s[1] + r[1] * s[4];
-  double c = r[0] * s[2] + r[1] * s[5] + r[2];
-  double d = r[3] * s[0] + r[4] * s[3];
+  a = r[0] * s[0] + r[1] * s[3];
+  b = r[0] * s[1] + r[1] * s[4];
+  c = r[0] * s[2] + r[1] * s[5] + r[2];
+  d = r[3] * s[0] + r[4] * s[3];
   // Pixel YDim - almost always negative
   // See https://en.wikipedia.org/wiki/World_file#cite_ref-3, https://github.com/qgis/QGIS/issues/26379
-  double e =  r[3] * s[1] + r[4] * s[4];
-  double f = r[3] * s[2] + r[4] * s[5] + r[5];
+  e = r[3] * s[1] + r[4] * s[4];
+  f = r[3] * s[2] + r[4] * s[5] + r[5];
+}
+
+QString QgsMapSettingsUtils::worldFileContent( const QgsMapSettings &mapSettings )
+{
+  double a, b, c, d, e, f;
+  worldFileParameters( mapSettings, a, b, c, d, e, f );
 
   QString content;
   // Pixel XDim
@@ -119,9 +125,9 @@ QString QgsMapSettingsUtils::worldFileContent( const QgsMapSettings &mapSettings
   content += qgsDoubleToString( b ) + "\r\n";
   // Pixel YDim
   content += qgsDoubleToString( e ) + "\r\n";
-  // Origin X (center of top left cell)
+  // Origin X (top left cell)
   content += qgsDoubleToString( c ) + "\r\n";
-  // Origin Y (center of top left cell)
+  // Origin Y (top left cell)
   content += qgsDoubleToString( f ) + "\r\n";
 
   return content;

--- a/src/core/qgsmapsettingsutils.h
+++ b/src/core/qgsmapsettingsutils.h
@@ -40,6 +40,19 @@ class CORE_EXPORT QgsMapSettingsUtils
     static const QStringList containsAdvancedEffects( const QgsMapSettings &mapSettings );
 
     /**
+     * Computes the six parameters of a world file.
+     * \param mapSettings map settings
+     * \param a the a parameter
+     * \param b the b parameter
+     * \param c the c parameter
+     * \param d the d parameter
+     * \param e the e parameter
+     * \param f the f parameter
+     * \since QGIS 3.10
+     */
+    static void worldFileParameters( const QgsMapSettings &mapSettings, double &a SIP_OUT, double &b SIP_OUT, double &c SIP_OUT, double &d SIP_OUT, double &e SIP_OUT, double &f SIP_OUT );
+
+    /**
      * Creates the content of a world file.
      * \param mapSettings map settings
      * \note Uses 17 places of precision for all numbers output

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -43,7 +43,7 @@ Rasterizing the map is recommended when such effects are used.</string>
      <item row="7" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveWorldFile">
        <property name="text">
-        <string>Save world file</string>
+        <string>Append georeference information (embedded or via world file)</string>
        </property>
        <property name="checked">
         <bool>true</bool>

--- a/tests/src/core/testqgsmapsettingsutils.cpp
+++ b/tests/src/core/testqgsmapsettingsutils.cpp
@@ -48,6 +48,15 @@ void TestQgsMapSettingsUtils::initTestCase()
 
 void TestQgsMapSettingsUtils::createWorldFileContent()
 {
+  double a, b, c, d, e, f;
+  QgsMapSettingsUtils::worldFileParameters( mMapSettings, a, b, c, d, e, f );
+  QCOMPARE( a, 1.0 );
+  QCOMPARE( b, 0.0 );
+  QCOMPARE( c, 0.5 );
+  QCOMPARE( d, 0.0 );
+  QCOMPARE( e, -1.0 );
+  QCOMPARE( f, 0.5 );
+
   QCOMPARE( QgsMapSettingsUtils::worldFileContent( mMapSettings ), QString( "1\r\n0\r\n0\r\n-1\r\n0.5\r\n0.5\r\n" ) );
 
   mMapSettings.setRotation( 45 );


### PR DESCRIPTION
## Description
Title says it all. This comes in quite handy when users need to quickly export georeferenced PDFs or TIFs to use with apps such as Avenza Maps et cie.

@nyalldawson , review appreciated.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
