### PR TITLE
 [needs-docs][layout] Give user explicit option to georeference (or not) PDF exports

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -184,6 +184,8 @@ Constructor for PdfExportSettings
 
       bool forceVectorOutput;
 
+      bool appendGeoreference;
+
       bool exportMetadata;
 
       QgsLayoutRenderContext::Flags flags;

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -4168,6 +4168,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
 {
   QgsRenderContext::TextRenderFormat prevTextRenderFormat = mMasterLayout->layoutProject()->labelingEngineSettings().defaultTextRenderFormat();
   bool forceVector = false;
+  bool appendGeoreference = true;
   bool includeMetadata = true;
   bool disableRasterTiles = false;
   bool simplify = true;
@@ -4175,6 +4176,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   {
     settings.flags = mLayout->renderContext().flags();
     forceVector = mLayout->customProperty( QStringLiteral( "forceVector" ), 0 ).toBool();
+    appendGeoreference = mLayout->customProperty( QStringLiteral( "pdfAppendGeoreference" ), 1 ).toBool();
     includeMetadata = mLayout->customProperty( QStringLiteral( "pdfIncludeMetadata" ), 1 ).toBool();
     disableRasterTiles = mLayout->customProperty( QStringLiteral( "pdfDisableRasterTiles" ), 0 ).toBool();
     simplify = mLayout->customProperty( QStringLiteral( "pdfSimplify" ), 1 ).toBool();
@@ -4202,6 +4204,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
 
   options.mTextRenderFormatComboBox->setCurrentIndex( options.mTextRenderFormatComboBox->findData( prevTextRenderFormat ) );
   options.mForceVectorCheckBox->setChecked( forceVector );
+  options.mAppendGeoreferenceCheckbox->setChecked( appendGeoreference );
   options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
   options.mDisableRasterTilingCheckBox->setChecked( disableRasterTiles );
   options.mSimplifyGeometriesCheckbox->setChecked( simplify );
@@ -4209,6 +4212,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   if ( dialog.exec() != QDialog::Accepted )
     return false;
 
+  appendGeoreference = options.mAppendGeoreferenceCheckbox->isChecked();
   includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
   forceVector = options.mForceVectorCheckBox->isChecked();
   disableRasterTiles = options.mDisableRasterTilingCheckBox->isChecked();
@@ -4219,6 +4223,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   {
     //save dialog settings
     mLayout->setCustomProperty( QStringLiteral( "forceVector" ), forceVector ? 1 : 0 );
+    mLayout->setCustomProperty( QStringLiteral( "pdfAppendGeoreference" ), appendGeoreference ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfIncludeMetadata" ), includeMetadata ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfDisableRasterTiles" ), disableRasterTiles ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfTextFormat" ), static_cast< int >( textRenderFormat ) );
@@ -4226,6 +4231,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   }
 
   settings.forceVectorOutput = forceVector;
+  settings.appendGeoreference = appendGeoreference;
   settings.exportMetadata = includeMetadata;
   settings.textRenderFormat = textRenderFormat;
   settings.simplifyGeometries = simplify;

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -4204,6 +4204,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
 
   options.mTextRenderFormatComboBox->setCurrentIndex( options.mTextRenderFormatComboBox->findData( prevTextRenderFormat ) );
   options.mForceVectorCheckBox->setChecked( forceVector );
+  options.mAppendGeoreferenceCheckbox->setEnabled( mLayout && mLayout->referenceMap() && mLayout->referenceMap()->page() == 0 );
   options.mAppendGeoreferenceCheckbox->setChecked( appendGeoreference );
   options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
   options.mDisableRasterTilingCheckBox->setChecked( disableRasterTiles );

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -532,9 +532,10 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
   ExportResult result = printPrivate( printer, p, false, settings.dpi, settings.rasterizeWholeImage );
   p.end();
 
+  bool shouldAppendGeoreference = settings.appendGeoreference && mLayout && mLayout->referenceMap() && mLayout->referenceMap()->page() == 0;
   if ( settings.appendGeoreference || settings.exportMetadata )
   {
-    georeferenceOutputPrivate( filePath, nullptr, QRectF(), settings.dpi, settings.appendGeoreference, settings.exportMetadata );
+    georeferenceOutputPrivate( filePath, nullptr, QRectF(), settings.dpi, shouldAppendGeoreference, settings.exportMetadata );
   }
   return result;
 }

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -532,10 +532,9 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
   ExportResult result = printPrivate( printer, p, false, settings.dpi, settings.rasterizeWholeImage );
   p.end();
 
-  const bool shouldGeoreference = mLayout->pageCollection()->pageCount() == 1;
-  if ( shouldGeoreference || settings.exportMetadata )
+  if ( settings.appendGeoreference || settings.exportMetadata )
   {
-    georeferenceOutputPrivate( filePath, nullptr, QRectF(), settings.dpi, shouldGeoreference, settings.exportMetadata );
+    georeferenceOutputPrivate( filePath, nullptr, QRectF(), settings.dpi, settings.appendGeoreference, settings.exportMetadata );
   }
   return result;
 }

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -267,6 +267,13 @@ class CORE_EXPORT QgsLayoutExporter
       bool forceVectorOutput = false;
 
       /**
+       * Indicates whether PDF export should append georeference data
+       *
+       * \since QGIS 3.10
+       */
+      bool appendGeoreference = true;
+
+      /**
        * Indicates whether PDF export should include metadata generated
        * from the layout's project's metadata.
        *

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -53,7 +53,7 @@
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
-         <string>Export RDF metadata</string>
+         <string>Export RDF metadata (title, author, etc.)</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -20,7 +20,7 @@
       <string>Export Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
       </item>
       <item row="0" column="0" colspan="2">
@@ -33,7 +33,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Text export</string>
@@ -41,6 +41,16 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="mAppendGeoreferenceCheckbox">
+        <property name="text">
+         <string>Append georeference information</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
          <string>Export RDF metadata</string>
@@ -50,7 +60,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
         <property name="text">
          <string>Simplify geometries to reduce output file size</string>

--- a/src/ui/layout/qgssvgexportoptions.ui
+++ b/src/ui/layout/qgssvgexportoptions.ui
@@ -36,7 +36,7 @@
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
-         <string>Export RDF metadata</string>
+         <string>Export RDF metadata (title, author, etc.)</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -463,6 +463,72 @@ class TestQgsLayoutExporter(unittest.TestCase):
         self.assertEqual(metadata['SUBJECT'], 'proj abstract')
         self.assertEqual(metadata['TITLE'], 'proj title')
 
+    def testExportToPdfGeoreference(self):
+        md = QgsProject.instance().metadata()
+        md.setTitle('proj title')
+        md.setAuthor('proj author')
+        md.setCreationDateTime(QDateTime(QDate(2011, 5, 3), QTime(9, 4, 5), QTimeZone(36000)))
+        md.setIdentifier('proj identifier')
+        md.setAbstract('proj abstract')
+        md.setKeywords({'kw': ['kw1', 'kw2'], 'KWx': ['kw3', 'kw4']})
+        QgsProject.instance().setMetadata(md)
+
+        l = QgsLayout(QgsProject.instance())
+        l.initializeDefaults()
+
+        # add some items
+        map = QgsLayoutItemMap(l)
+        map.attemptSetSceneRect(QRectF(30, 60, 200, 100))
+        extent = QgsRectangle(333218, 1167809, 348781, 1180875)
+        map.setCrs(QgsCoordinateReferenceSystem('EPSG:3148'))
+        map.setExtent(extent)
+        l.addLayoutItem(map)
+
+        exporter = QgsLayoutExporter(l)
+        # setup settings
+        settings = QgsLayoutExporter.PdfExportSettings()
+        settings.dpi = 96
+        settings.rasterizeWholeImage = False
+        settings.forceVectorOutput = False
+        settings.appendGeoreference = True
+        settings.exportMetadata = False
+
+        pdf_file_path = os.path.join(self.basetestpath, 'test_exporttopdf_georeference.pdf')
+        self.assertEqual(exporter.exportToPdf(pdf_file_path, settings), QgsLayoutExporter.Success)
+        self.assertTrue(os.path.exists(pdf_file_path))
+
+        d = gdal.Open(pdf_file_path)
+
+        # check if georeferencing was successful
+        geoTransform = d.GetGeoTransform()
+        self.assertAlmostEqual(geoTransform[0], 330883.5499999996, 4)
+        self.assertAlmostEqual(geoTransform[1], 13.184029109934016, 4)
+        self.assertAlmostEqual(geoTransform[2], 0.0, 4)
+        self.assertAlmostEqual(geoTransform[3], 1185550.768915511, 4)
+        self.assertAlmostEqual(geoTransform[4], 0.0, 4)
+        self.assertAlmostEqual(geoTransform[5], -13.183886222186642, 4)
+
+        # check that the metadata has _not_ been added to the exported PDF
+        metadata = d.GetMetadata()
+        self.assertFalse('AUTHOR' in metadata)
+
+        exporter = QgsLayoutExporter(l)
+        # setup settings
+        settings = QgsLayoutExporter.PdfExportSettings()
+        settings.dpi = 96
+        settings.rasterizeWholeImage = False
+        settings.forceVectorOutput = False
+        settings.appendGeoreference = False
+        settings.exportMetadata = False
+
+        pdf_file_path = os.path.join(self.basetestpath, 'test_exporttopdf_nogeoreference.pdf')
+        self.assertEqual(exporter.exportToPdf(pdf_file_path, settings), QgsLayoutExporter.Success)
+        self.assertTrue(os.path.exists(pdf_file_path))
+
+        d = gdal.Open(pdf_file_path)
+        # check that georeference information has _not_ been added to the exported PDF
+        self.assertEqual(d.GetGeoTransform(), (0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+
     def testExportToPdfSkipFirstPage(self):
         l = QgsLayout(QgsProject.instance())
         l.initializeDefaults()


### PR DESCRIPTION
## Description
@nyalldawson , as discussed, this PR adds a switch for the user to explicitly control whether an exported PDF will be georeferenced or not. 

I've also updated the 'Export RDF metadata' to add a few examples of what is being attached to the PDF. The idea here is to avoid people attaching identity fingerprint without realizing it via demystifying  the option :)



## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
