### PR TITLE
Optional "Toggle labels" layer tree widget

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -698,6 +698,8 @@ Returns whether the layer contains labels which are enabled and should be drawn.
 
 .. seealso:: :py:func:`setLabelsEnabled`
 
+.. seealso:: :py:func:`labelsToggled`
+
 .. versionadded:: 2.9
 %End
 
@@ -713,6 +715,8 @@ Sets whether labels should be ``enabled`` for the layer.
 .. seealso:: :py:func:`labelsEnabled`
 
 .. seealso:: :py:func:`labeling`
+
+.. seealso:: :py:func:`labelsToggled`
 %End
 
     bool diagramsEnabled() const;
@@ -2561,6 +2565,17 @@ and 1 (opaque).
 .. seealso:: :py:func:`opacity`
 
 .. versionadded:: 3.0
+%End
+
+    void labelsToggled( bool enabled );
+%Docstring
+Emitted when labels are toggled in the layer.
+
+.. seealso:: :py:func:`labelsEnabled`
+
+.. seealso:: :py:func:`setLabelsEnabled`
+
+.. versionadded:: 3.10
 %End
 
     void editCommandStarted( const QString &text );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -676,7 +676,11 @@ bool QgsVectorLayer::labelsEnabled() const
 
 void QgsVectorLayer::setLabelsEnabled( bool enabled )
 {
+  if ( enabled == mLabelsEnabled )
+    return;
+
   mLabelsEnabled = enabled;
+  emit labelsToggled( enabled );
 }
 
 bool QgsVectorLayer::diagramsEnabled() const
@@ -1317,8 +1321,11 @@ void QgsVectorLayer::setLabeling( QgsAbstractVectorLayerLabeling *labeling )
   if ( mLabeling == labeling )
     return;
 
+  const bool prevEnabled = labelsEnabled();
   delete mLabeling;
   mLabeling = labeling;
+  if ( prevEnabled != labelsEnabled() )
+    emit labelsToggled( labelsEnabled() );
 }
 
 bool QgsVectorLayer::startEditing()

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -763,6 +763,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \returns TRUE if layer contains enabled labels
      *
      * \see setLabelsEnabled()
+     * \see labelsToggled()
      * \since QGIS 2.9
      */
     bool labelsEnabled() const;
@@ -775,6 +776,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \see labelsEnabled()
      * \see labeling()
+     * \see labelsToggled()
      */
     void setLabelsEnabled( bool enabled );
 
@@ -2366,6 +2368,15 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \since QGIS 3.0
      */
     void opacityChanged( double opacity );
+
+    /**
+     * Emitted when labels are toggled in the layer.
+     *
+     * \see labelsEnabled()
+     * \see setLabelsEnabled()
+     * \since QGIS 3.10
+     */
+    void labelsToggled( bool enabled );
 
     /**
      * Signal emitted when a new edit command has been started

--- a/src/gui/layertree/qgslayertreeembeddedwidgetregistry.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetregistry.cpp
@@ -22,6 +22,7 @@ QgsLayerTreeEmbeddedWidgetRegistry::QgsLayerTreeEmbeddedWidgetRegistry()
 {
   // populate with default implementations
   addProvider( new QgsLayerTreeOpacityWidget::Provider() );
+  addProvider( new QgsLayerTreeToggleLabelsWidget::Provider() );
 }
 
 QgsLayerTreeEmbeddedWidgetRegistry::~QgsLayerTreeEmbeddedWidgetRegistry()

--- a/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.h
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.h
@@ -23,6 +23,7 @@
 class QSlider;
 class QTimer;
 class QgsMapLayer;
+class QCheckBox;
 
 SIP_NO_FILE
 
@@ -59,6 +60,34 @@ class QgsLayerTreeOpacityWidget : public QWidget
     QgsMapLayer *mLayer = nullptr;
     QSlider *mSlider = nullptr;
     QTimer *mTimer = nullptr;
+};
+
+/**
+ * \brief Implementation of checkbox to enable labels in the layer tree
+ *
+ * \note private class - not in QGIS API
+ */
+class QgsLayerTreeToggleLabelsWidget : public QWidget
+{
+    Q_OBJECT
+  public:
+    QgsLayerTreeToggleLabelsWidget( QgsMapLayer *layer );
+    class Provider : public QgsLayerTreeEmbeddedWidgetProvider
+    {
+      public:
+        QString id() const override;
+        QString name() const override;
+        QgsLayerTreeToggleLabelsWidget *createWidget( QgsMapLayer *layer, int widgetIndex ) override;
+        bool supportsLayer( QgsMapLayer *layer ) override;
+    };
+
+  public slots:
+    void toggled( bool active );
+    void layerSettingChanged();
+
+  private:
+    QgsMapLayer *mLayer = nullptr;
+    QCheckBox *mCheckBox = nullptr;
 };
 ///@endcond
 #endif // QGSLAYERTREEEMBEDDEDWIDGETSIMPL_H

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -42,6 +42,7 @@ class TestQgsLabelingEngine : public QObject
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
     void testEngineSettings();
+    void testLayerSetting();
     void testBasic();
     void testDiagrams();
     void testRuleBased();
@@ -172,6 +173,39 @@ void TestQgsLabelingEngine::testEngineSettings()
   p2.writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), true );
   settings3.readSettingsFromProject( &p2 );
   QCOMPARE( settings3.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+}
+
+void TestQgsLabelingEngine::testLayerSetting()
+{
+  QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
+  QgsVectorLayer *vl2 = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
+  QVERIFY( vl2->isValid() );
+  QSignalSpy spy( vl2, &QgsVectorLayer::labelsToggled );
+
+  QVERIFY( !vl2->labelsEnabled() );
+
+  QgsPalLayerSettings settings;
+  vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
+  QVERIFY( vl2->labelsEnabled() );
+  QCOMPARE( spy.count(), 1 );
+
+  vl2->setLabelsEnabled( true );
+  QCOMPARE( spy.count(), 1 );
+  QVERIFY( spy.at( 0 ).at( 0 ).toBool() );
+  vl2->setLabelsEnabled( true );
+  QCOMPARE( spy.count(), 1 );
+  vl2->setLabelsEnabled( false );
+  QCOMPARE( spy.count(), 2 );
+  QVERIFY( !spy.at( 1 ).at( 0 ).toBool() );
+  QVERIFY( !vl2->labelsEnabled() );
+
+  vl2->setLabelsEnabled( false );
+  QCOMPARE( spy.count(), 2 );
+
+  vl2->setLabelsEnabled( true );
+  QCOMPARE( spy.count(), 3 );
+
+  delete vl2;
 }
 
 void TestQgsLabelingEngine::setDefaultLabelParams( QgsPalLayerSettings &settings )


### PR DESCRIPTION
When enabled for a layer (via the Layer's Properties - Legend setting), this layer tree widget adds a checkbox to allow labels to be quickly toggled on and off for a layer.

![Peek 2019-08-13 14-57](https://user-images.githubusercontent.com/1829991/62916219-d379b600-bdda-11e9-8f5c-bd5353561916.gif)

Also available as a plugin for existing QGIS versions: https://plugins.qgis.org/plugins/toggle_labels_widget/
