### PR TITLE
Add an indicator in the status bar while a map redraw is occurring in the background

### DIFF
--- a/python/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/core/auto_generated/layout/qgslayout.sip.in
@@ -657,6 +657,13 @@ Emitted when the layout has been refreshed and items should also be refreshed
 and updated.
 %End
 
+    void backgroundTaskCountChanged( int total );
+%Docstring
+Emitted whenever the ``total`` number of background tasks running in items from the layout changes.
+
+.. versionadded:: 3.10
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -1053,6 +1053,13 @@ Emitted on item rotation change.
 Emitted when the item's size or position changes.
 %End
 
+    void backgroundTaskCountChanged( int count );
+%Docstring
+Emitted whenever the number of background tasks an item is executing changes.
+
+.. versionadded:: 3.10
+%End
+
   protected:
 
     virtual void drawDebugRect( QPainter *painter );

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -36,6 +36,7 @@ class QgsLayoutRuler;
 class QComboBox;
 class QSlider;
 class QLabel;
+class QProgressBar;
 class QgsLayoutAppMenuProvider;
 class QgsLayoutItem;
 class QgsPanelWidgetStack;
@@ -382,6 +383,8 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
 
     void updateWindowTitle();
 
+    void backgroundTaskCountChanged( int total );
+
   private:
 
     static bool sInitializedRegistry;
@@ -449,6 +452,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
     QAction *mActionCut = nullptr;
     QAction *mActionCopy = nullptr;
     QAction *mActionPaste = nullptr;
+    QProgressBar *mStatusProgressBar = nullptr;
 
     struct PanelStatus
     {

--- a/src/core/layout/qgslayout.cpp
+++ b/src/core/layout/qgslayout.cpp
@@ -877,6 +877,7 @@ void QgsLayout::addLayoutItemPrivate( QgsLayoutItem *item )
   addItem( item );
   updateBounds();
   mItemsModel->rebuildZList();
+  connect( item, &QgsLayoutItem::backgroundTaskCountChanged, this, &QgsLayout::itemBackgroundTaskCountChanged );
 }
 
 void QgsLayout::removeLayoutItemPrivate( QgsLayoutItem *item )
@@ -1106,4 +1107,25 @@ QList< QgsLayoutItem * > QgsLayout::addItemsFromXml( const QDomElement &parentEl
 void QgsLayout::updateBounds()
 {
   setSceneRect( layoutBounds( false, 0.05 ) );
+}
+
+void QgsLayout::itemBackgroundTaskCountChanged( int count )
+{
+  QgsLayoutItem *item = qobject_cast<QgsLayoutItem *>( sender() );
+  if ( !item )
+    return;
+
+  if ( count > 0 )
+    mBackgroundTaskCount.insert( item, count );
+  else
+    mBackgroundTaskCount.remove( item );
+
+  // sum up new count of background tasks
+  int total = 0;
+  for ( auto it = mBackgroundTaskCount.constBegin(); it != mBackgroundTaskCount.constEnd(); ++it )
+  {
+    total += it.value();
+  }
+
+  emit backgroundTaskCountChanged( total );
 }

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -700,6 +700,16 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      */
     void refreshed();
 
+    /**
+     * Emitted whenever the \a total number of background tasks running in items from the layout changes.
+     *
+     * \since QGIS 3.10
+     */
+    void backgroundTaskCountChanged( int total );
+
+  private slots:
+    void itemBackgroundTaskCountChanged( int count );
+
   private:
 
     QgsProject *mProject = nullptr;
@@ -721,6 +731,8 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
 
     //! Item ID for layout map to use for the world file generation
     QString mWorldFileMapId;
+
+    QHash< QgsLayoutItem *, int > mBackgroundTaskCount;
 
     //! Writes only the layout settings (not member settings like grid settings, etc) to XML
     void writeXmlLayoutSettings( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const;

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -986,6 +986,13 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      */
     void sizePositionChanged();
 
+    /**
+     * Emitted whenever the number of background tasks an item is executing changes.
+     *
+     * \since QGIS 3.10
+     */
+    void backgroundTaskCountChanged( int count );
+
   protected:
 
     /**

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -65,6 +65,7 @@ QgsLayoutItemMap::~QgsLayoutItemMap()
   if ( mPainterJob )
   {
     disconnect( mPainterJob.get(), &QgsMapRendererCustomPainterJob::finished, this, &QgsLayoutItemMap::painterJobFinished );
+    emit backgroundTaskCountChanged( 0 );
     mPainterJob->cancel(); // blocks
     mPainter->end();
   }
@@ -1101,6 +1102,7 @@ void QgsLayoutItemMap::recreateCachedImageInBackground()
   else
   {
     mCacheRenderingImage.reset( nullptr );
+    emit backgroundTaskCountChanged( 1 );
   }
 
   Q_ASSERT( !mPainterJob );
@@ -1580,6 +1582,7 @@ void QgsLayoutItemMap::painterJobFinished()
   mCacheFinalImage = std::move( mCacheRenderingImage );
   mLastRenderedImageOffsetX = 0;
   mLastRenderedImageOffsetY = 0;
+  emit backgroundTaskCountChanged( 0 );
   update();
 }
 


### PR DESCRIPTION
Otherwise there's no way to tell if a redraw is humming away in
the background, or is completed...
