### PR TITLE
Fix multi edit button not displayed for auxiliary storage attribute

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -465,6 +465,7 @@ Returns the join buffer object.
 
 .. versionadded:: 2.14.7
 %End
+
     const QList<QgsVectorLayerJoinInfo> vectorJoins() const;
 
     virtual bool setDependencies( const QSet<QgsMapLayerDependency> &layers ) ${SIP_FINAL};

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -277,13 +277,11 @@ The following operations will be performed to convert the input features:
 %End
 
 
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, QgsFeatureId fid = -1 );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
 %Docstring
 
-:return: true if the field at index:param fieldIndex: from:param layer: is editable,
-          false if the field is readonly
-
-:param fid: feature id value, -1 if it's a new feature
+:return: true if the:param feature: field at index:param fieldIndex: from:param layer:
+          is editable, false if the field is readonly
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -276,6 +276,18 @@ The following operations will be performed to convert the input features:
 .. versionadded:: 3.4
 %End
 
+
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, QgsFeatureId fid = -1 );
+%Docstring
+
+:return: true if the field at index:param fieldIndex: from:param layer: is editable,
+          false if the field is readonly
+
+:param fid: feature id value, -1 if it's a new feature
+
+.. versionadded:: 3.10
+%End
+
 };
 
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -568,6 +568,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \since QGIS 2.14.7
      */
     QgsVectorLayerJoinBuffer *joinBuffer() { return mJoinBuffer; }
+
+    /**
+     * Returns a const pointer on join buffer object.
+     * \since QGIS 3.10
+     */
+    const QgsVectorLayerJoinBuffer *joinBuffer() const { return mJoinBuffer; } SIP_SKIP;
+
     const QList<QgsVectorLayerJoinInfo> vectorJoins() const;
 
     /**

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -33,6 +33,7 @@
 #include "qgspolygon.h"
 #include "qgslinestring.h"
 #include "qgsmultipoint.h"
+#include "qgsvectorlayerjoinbuffer.h"
 
 QgsFeatureIterator QgsVectorLayerUtils::getValuesIterator( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly )
 {
@@ -900,4 +901,29 @@ QgsGeometry QgsVectorLayerUtils::QgsFeatureData::geometry() const
 QgsAttributeMap QgsVectorLayerUtils::QgsFeatureData::attributes() const
 {
   return mAttributes;
+}
+
+bool _fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex,  QgsFeatureId fid )
+{
+  return layer->isEditable() &&
+         !layer->editFormConfig().readOnly( fieldIndex ) &&
+         ( ( layer->dataProvider() && layer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) || FID_IS_NEW( fid ) );
+}
+
+bool QgsVectorLayerUtils::fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, QgsFeatureId fid )
+{
+  bool editable = false;
+
+  if ( layer->fields().fieldOrigin( fieldIndex ) == QgsFields::OriginJoin )
+  {
+    int srcFieldIndex;
+    const QgsVectorLayerJoinInfo *info = layer->joinBuffer()->joinForFieldIndex( fieldIndex, layer->fields(), srcFieldIndex );
+
+    if ( info && info->isEditable() )
+      editable = _fieldIsEditable( info->joinLayer(), srcFieldIndex, fid );
+  }
+  else
+    editable = _fieldIsEditable( layer, fieldIndex, fid );
+
+  return editable;
 }

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -285,13 +285,12 @@ class CORE_EXPORT QgsVectorLayerUtils
 
 
     /**
-     * \return true if the field at index \param fieldIndex from \param layer is editable,
-     * false if the field is readonly
-     * \param fid feature id value, -1 if it's a new feature
+     * \return true if the \param feature field at index \param fieldIndex from \param layer
+     * is editable, false if the field is readonly
      *
      * \since QGIS 3.10
      */
-    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, QgsFeatureId fid = -1 );
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, const QgsFeature &feature );
 
 };
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -283,6 +283,16 @@ class CORE_EXPORT QgsVectorLayerUtils
      */
     static QgsFeatureList makeFeaturesCompatible( const QgsFeatureList &features, const QgsVectorLayer *layer );
 
+
+    /**
+     * \return true if the field at index \param fieldIndex from \param layer is editable,
+     * false if the field is readonly
+     * \param fid feature id value, -1 if it's a new feature
+     *
+     * \since QGIS 3.10
+     */
+    static bool fieldIsEditable( const QgsVectorLayer *layer, int fieldIndex, QgsFeatureId fid = -1 );
+
 };
 
 

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -40,6 +40,7 @@
 #include "qgsfieldmodel.h"
 #include "qgstexteditwidgetfactory.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsvectorlayerutils.h"
 
 #include <QVariant>
 
@@ -761,31 +762,13 @@ Qt::ItemFlags QgsAttributeTableModel::flags( const QModelIndex &index ) const
 
   Qt::ItemFlags flags = QAbstractTableModel::flags( index );
 
-  bool editable = false;
   const int fieldIndex = mAttributes[index.column()];
   const QgsFeatureId fid = rowToId( index.row() );
-  if ( layer()->fields().fieldOrigin( fieldIndex ) == QgsFields::OriginJoin )
-  {
-    int srcFieldIndex;
-    const QgsVectorLayerJoinInfo *info = layer()->joinBuffer()->joinForFieldIndex( fieldIndex, layer()->fields(), srcFieldIndex );
 
-    if ( info && info->isEditable() )
-      editable = fieldIsEditable( *info->joinLayer(), srcFieldIndex, fid );
-  }
-  else
-    editable = fieldIsEditable( *layer(), fieldIndex, fid );
-
-  if ( editable )
+  if ( QgsVectorLayerUtils::fieldIsEditable( layer(), fieldIndex, fid ) )
     flags |= Qt::ItemIsEditable;
 
   return flags;
-}
-
-bool QgsAttributeTableModel::fieldIsEditable( const QgsVectorLayer &layer, int fieldIndex, QgsFeatureId fid ) const
-{
-  return ( layer.isEditable() &&
-           !layer.editFormConfig().readOnly( fieldIndex ) &&
-           ( ( layer.dataProvider() && layer.dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) || FID_IS_NEW( fid ) ) );
 }
 
 void QgsAttributeTableModel::bulkEditCommandStarted()

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -362,8 +362,6 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
      */
     virtual bool loadFeatureAtId( QgsFeatureId fid ) const;
 
-    bool fieldIsEditable( const QgsVectorLayer &layer, int fieldIndex, QgsFeatureId fid ) const;
-
     QgsFeatureRequest mFeatureRequest;
 
     struct SortCache

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2390,28 +2390,16 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
 
 bool QgsAttributeForm::fieldIsEditable( int fieldIndex ) const
 {
-  bool editable = false;
-
   if ( mLayer->fields().fieldOrigin( fieldIndex ) == QgsFields::OriginJoin )
   {
     int srcFieldIndex;
     const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
 
     if ( info && !info->hasUpsertOnEdit() && mMode == QgsAttributeEditorContext::AddFeatureMode )
-      editable = false;
-    else if ( info && info->isEditable() && info->joinLayer()->isEditable() )
-      editable = fieldIsEditable( *( info->joinLayer() ), srcFieldIndex, mFeature.id() );
+      return false;
   }
-  else
-    editable = fieldIsEditable( *mLayer, fieldIndex, mFeature.id() );
 
-  return editable;
-}
-
-bool QgsAttributeForm::fieldIsEditable( const QgsVectorLayer &layer, int fieldIndex,  QgsFeatureId fid ) const
-{
-  return !layer.editFormConfig().readOnly( fieldIndex ) &&
-         ( ( layer.dataProvider() && layer.dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) || FID_IS_NEW( fid ) );
+  return QgsVectorLayerUtils::fieldIsEditable( mLayer, fieldIndex, mFeature.id() );
 }
 
 void QgsAttributeForm::updateIcon( QgsEditorWidgetWrapper *eww )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2390,16 +2390,7 @@ void QgsAttributeForm::updateJoinedFields( const QgsEditorWidgetWrapper &eww )
 
 bool QgsAttributeForm::fieldIsEditable( int fieldIndex ) const
 {
-  if ( mLayer->fields().fieldOrigin( fieldIndex ) == QgsFields::OriginJoin )
-  {
-    int srcFieldIndex;
-    const QgsVectorLayerJoinInfo *info = mLayer->joinBuffer()->joinForFieldIndex( fieldIndex, mLayer->fields(), srcFieldIndex );
-
-    if ( info && !info->hasUpsertOnEdit() && mMode == QgsAttributeEditorContext::AddFeatureMode )
-      return false;
-  }
-
-  return QgsVectorLayerUtils::fieldIsEditable( mLayer, fieldIndex, mFeature.id() );
+  return QgsVectorLayerUtils::fieldIsEditable( mLayer, fieldIndex, mFeature );
 }
 
 void QgsAttributeForm::updateIcon( QgsEditorWidgetWrapper *eww )

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -157,6 +157,7 @@ void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, boo
   setIsMixed( mixedValues );
   mMultiEditButton->setIsChanged( false );
   mIsChanged = false;
+  updateWidgets();
 }
 
 QVariant QgsAttributeFormEditorWidget::currentValue() const
@@ -230,7 +231,14 @@ void QgsAttributeFormEditorWidget::updateWidgets()
   bool hasMultiEditButton = ( editPage()->layout()->indexOf( mMultiEditButton ) >= 0 );
 
   const int fieldIndex = mEditorWidget->fieldIdx();
-  bool fieldReadOnly = !QgsVectorLayerUtils::fieldIsEditable( layer(), fieldIndex );
+
+  bool fieldReadOnly = false;
+  QgsFeature feature;
+  auto it = layer()->getSelectedFeatures();
+  while ( it.nextFeature( feature ) )
+  {
+    fieldReadOnly |= !QgsVectorLayerUtils::fieldIsEditable( layer(), fieldIndex, feature );
+  }
 
   if ( hasMultiEditButton )
   {

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -24,6 +24,7 @@
 #include "qgsaggregatetoolbutton.h"
 #include "qgsgui.h"
 #include "qgsvectorlayerjoinbuffer.h"
+#include "qgsvectorlayerutils.h"
 
 #include <QLayout>
 #include <QLabel>
@@ -228,18 +229,8 @@ void QgsAttributeFormEditorWidget::updateWidgets()
   //first update the tool buttons
   bool hasMultiEditButton = ( editPage()->layout()->indexOf( mMultiEditButton ) >= 0 );
 
-  bool fieldReadOnly = false;
   const int fieldIndex = mEditorWidget->fieldIdx();
-  if ( layer()->fields().fieldOrigin( fieldIndex ) == QgsFields::OriginJoin )
-  {
-    int srcFieldIndex;
-    const QgsVectorLayerJoinInfo *info = layer()->joinBuffer()->joinForFieldIndex( fieldIndex, layer()->fields(), srcFieldIndex );
-
-    if ( info && info->isEditable() && info->joinLayer()->isEditable() )
-      fieldReadOnly = info->joinLayer()->editFormConfig().readOnly( fieldIndex );
-  }
-  else
-    fieldReadOnly = layer()->editFormConfig().readOnly( fieldIndex );
+  bool fieldReadOnly = !QgsVectorLayerUtils::fieldIsEditable( layer(), fieldIndex );
 
   if ( hasMultiEditButton )
   {

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -152,6 +152,8 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     bool mIsChanged;
 
     void updateWidgets() override;
+
+    friend class TestQgsAttributeForm;
 };
 
 #endif // QGSATTRIBUTEFORMEDITORWIDGET_H

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -945,6 +945,8 @@ void TestQgsAttributeForm::testDefaultValueUpdate()
   layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "\"col0\"+\"col1\"" ) ) );
   layer->setDefaultValueDefinition( 3, QgsDefaultValue( QStringLiteral( "\"col2\"" ) ) );
 
+  layer->startEditing();
+
   // build a form for this feature
   QgsFeature ft( layer->dataProvider()->fields(), 1 );
   ft.setAttribute( QStringLiteral( "col0" ), 0 );
@@ -1005,6 +1007,8 @@ void TestQgsAttributeForm::testDefaultValueUpdateRecursion()
   layer->setDefaultValueDefinition( 1, QgsDefaultValue( QStringLiteral( "\"col0\"+1" ) ) );
   layer->setDefaultValueDefinition( 2, QgsDefaultValue( QStringLiteral( "\"col1\"+1" ) ) );
   layer->setDefaultValueDefinition( 3, QgsDefaultValue( QStringLiteral( "\"col2\"+1" ) ) );
+
+  layer->startEditing();
 
   // build a form for this feature
   QgsFeature ft( layer->dataProvider()->fields(), 1 );

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -29,6 +29,7 @@
 #include "qgsgui.h"
 #include "qgsattributeformeditorwidget.h"
 #include "qgsattributeforminterface.h"
+#include "qgsmultiedittoolbutton.h"
 
 class TestQgsAttributeForm : public QObject
 {
@@ -619,6 +620,17 @@ void TestQgsAttributeForm::testEditableJoin()
 
   ft0C = layerC->getFeature( 1 );
   QCOMPARE( ft0C.attribute( "col0" ), QVariant( 13 ) );
+
+  // all editor widget must have a multi edit button
+  form.setMode( QgsAttributeEditorContext::MultiEditMode );
+  QgsAttributeFormEditorWidget *formWidget = qobject_cast<QgsAttributeFormEditorWidget *>( form.mFormWidgets[1] );
+  QVERIFY( formWidget->mMultiEditButton->parent() );
+
+  formWidget = qobject_cast<QgsAttributeFormEditorWidget *>( form.mFormWidgets[1] );
+  QVERIFY( formWidget->mMultiEditButton->parent() );
+
+  formWidget = qobject_cast<QgsAttributeFormEditorWidget *>( form.mFormWidgets[2] );
+  QVERIFY( formWidget->mMultiEditButton->parent() );
 
   // clean
   delete layerA;

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -625,6 +625,7 @@ void TestQgsAttributeForm::testEditableJoin()
   layerA->startEditing();
   layerB->startEditing();
   layerC->startEditing();
+  layerA->select( ftA.id() );
   form.setMode( QgsAttributeEditorContext::MultiEditMode );
 
   // multi edit button must be displayed for A

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -622,15 +622,22 @@ void TestQgsAttributeForm::testEditableJoin()
   QCOMPARE( ft0C.attribute( "col0" ), QVariant( 13 ) );
 
   // all editor widget must have a multi edit button
+  layerA->startEditing();
+  layerB->startEditing();
+  layerC->startEditing();
   form.setMode( QgsAttributeEditorContext::MultiEditMode );
+
+  // multi edit button must be displayed for A
   QgsAttributeFormEditorWidget *formWidget = qobject_cast<QgsAttributeFormEditorWidget *>( form.mFormWidgets[1] );
   QVERIFY( formWidget->mMultiEditButton->parent() );
 
+  // multi edit button must be displayed for B (join is editable)
   formWidget = qobject_cast<QgsAttributeFormEditorWidget *>( form.mFormWidgets[1] );
   QVERIFY( formWidget->mMultiEditButton->parent() );
 
+  // multi edit button must not be displayed for C (join is not editable)
   formWidget = qobject_cast<QgsAttributeFormEditorWidget *>( form.mFormWidgets[2] );
-  QVERIFY( formWidget->mMultiEditButton->parent() );
+  QVERIFY( !formWidget->mMultiEditButton->parent() );
 
   // clean
   delete layerA;


### PR DESCRIPTION
## Description

The multi-edit button is not displayed when attribute form deal with field coming from auxiliary storage attribute.

![aux_storage_and_multiedit](https://user-images.githubusercontent.com/14358135/62965790-08e7c900-be06-11e9-83ae-983f695f33e2.png)

This PR fixes this. 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
