### PR TITLE
[layout] Fix crash an attribute table item tries to access a destroyed map

### DIFF
--- a/src/core/layout/qgslayout.cpp
+++ b/src/core/layout/qgslayout.cpp
@@ -854,7 +854,8 @@ QDomElement QgsLayout::writeXml( QDomDocument &document, const QgsReadWriteConte
   //save multiframes
   for ( QgsLayoutMultiFrame *mf : mMultiFrames )
   {
-    mf->writeXml( element, document, context );
+    if ( mf->frameCount() > 0 )
+      mf->writeXml( element, document, context );
   }
 
   writeXmlLayoutSettings( element, document, context );

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -298,6 +298,10 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     bool writePropertiesToElement( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     bool readPropertiesFromElement( const QDomElement &itemElem, const QDomDocument &doc, const QgsReadWriteContext &context ) override;
 
+  private slots:
+
+    void disconnectCurrentMap();
+
   private:
 
     //! Attribute source


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR fixes issues #31232 -- crash casued by the attribute table item trying to access a destroyed reference map item when writing its properties to XML.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
