### PR TITLE
Final tweaks to vertically oriented text / labels

### DIFF
--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -276,6 +276,17 @@ A custom delimiter can be specified to use instead of space characters.
 
 .. versionadded:: 3.4
 %End
+
+    static QString substituteVerticalCharacters( QString string );
+%Docstring
+Returns a string with characters having vertical representation form substituted.
+
+:param string: input string
+
+:return: string with substition applied
+
+.. versionadded:: 3.10
+%End
 };
 
 /************************************************************************

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -545,6 +545,13 @@ void QgsPalLayerSettings::startRender( QgsRenderContext &context )
     return;
   }
 
+  if ( placement == QgsPalLayerSettings::Curved )
+  {
+    // force horizontal orientation, other orientation modes aren't unsupported for curved placement
+    mFormat.setOrientation( QgsTextFormat::HorizontalOrientation );
+    mDataDefinedProperties.property( QgsPalLayerSettings::TextOrientation ).setActive( false );
+  }
+
   if ( mCallout )
   {
     mCallout->startRender( context );

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -518,6 +518,28 @@ QString QgsStringUtils::wordWrap( const QString &string, const int length, const
   return newstr;
 }
 
+QString QgsStringUtils::substituteVerticalCharacters( QString string )
+{
+  string = string.replace( ',', QChar( 65040 ) ).replace( QChar( 8229 ), QChar( 65072 ) ); // comma & two-dot leader
+  string = string.replace( QChar( 12289 ), QChar( 65041 ) ).replace( QChar( 12290 ), QChar( 65042 ) ); // ideographic comma & full stop
+  string = string.replace( ':', QChar( 65043 ) ).replace( ';', QChar( 65044 ) );
+  string = string.replace( '!', QChar( 65045 ) ).replace( '?', QChar( 65046 ) );
+  string = string.replace( QChar( 12310 ), QChar( 65047 ) ).replace( QChar( 12311 ), QChar( 65048 ) ); // white lenticular brackets
+  string = string.replace( QChar( 8230 ), QChar( 65049 ) ); // three-dot ellipse
+  string = string.replace( QChar( 8212 ), QChar( 65073 ) ).replace( QChar( 8211 ), QChar( 65074 ) ); // em & en dash
+  string = string.replace( '_', QChar( 65075 ) ).replace( QChar( 65103 ), QChar( 65076 ) ); // low line & wavy low line
+  string = string.replace( '(', QChar( 65077 ) ).replace( ')', QChar( 65078 ) );
+  string = string.replace( '{', QChar( 65079 ) ).replace( '}', QChar( 65080 ) );
+  string = string.replace( '<', QChar( 65087 ) ).replace( '>', QChar( 65088 ) );
+  string = string.replace( '[', QChar( 65095 ) ).replace( ']', QChar( 65096 ) );
+  string = string.replace( QChar( 12308 ), QChar( 65081 ) ).replace( QChar( 12309 ), QChar( 65082 ) );   // tortoise shell brackets
+  string = string.replace( QChar( 12304 ), QChar( 65083 ) ).replace( QChar( 12305 ), QChar( 65084 ) );   // black lenticular brackets
+  string = string.replace( QChar( 12298 ), QChar( 65085 ) ).replace( QChar( 12299 ), QChar( 65086 ) ); // double angle brackets
+  string = string.replace( QChar( 12300 ), QChar( 65089 ) ).replace( QChar( 12301 ), QChar( 65090 ) );   // corner brackets
+  string = string.replace( QChar( 12302 ), QChar( 65091 ) ).replace( QChar( 12303 ), QChar( 65092 ) );   // white corner brackets
+  return string;
+}
+
 QgsStringReplacement::QgsStringReplacement( const QString &match, const QString &replacement, bool caseSensitive, bool wholeWordOnly )
   : mMatch( match )
   , mReplacement( replacement )

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -275,6 +275,14 @@ class CORE_EXPORT QgsStringUtils
      * \since QGIS 3.4
      */
     static QString wordWrap( const QString &string, int length, bool useMaxLineLength = true, const QString &customDelimiter = QString() );
+
+    /**
+     * Returns a string with characters having vertical representation form substituted.
+     * \param string input string
+     * \returns string with substition applied
+     * \since QGIS 3.10
+     */
+    static QString substituteVerticalCharacters( QString string );
 };
 
 #endif //QGSSTRINGUTILS_H

--- a/src/core/qgstextrenderer.cpp
+++ b/src/core/qgstextrenderer.cpp
@@ -3550,8 +3550,28 @@ void QgsTextRenderer::drawTextInternal( TextPart drawType,
 
       bool adjustForAlignment = alignment != AlignLeft && ( mode != Label || textLines.size() > 1 );
 
-      const auto constTextLines = textLines;
-      for ( const QString &line : constTextLines )
+      // apply some character replacement to draw symbols in vertical presentation
+      QString lines = textLines.join( '\n' );
+      lines = lines.replace( ',', QChar( 65040 ) ).replace( QChar( 8229 ), QChar( 65072 ) ); // comma & two-dot leader
+      lines = lines.replace( QChar( 12289 ), QChar( 65041 ) ).replace( QChar( 12290 ), QChar( 65042 ) ); // ideographic comma & full stop
+      lines = lines.replace( ':', QChar( 65043 ) ).replace( ';', QChar( 65044 ) );
+      lines = lines.replace( '!', QChar( 65045 ) ).replace( '?', QChar( 65046 ) );
+      lines = lines.replace( QChar( 12310 ), QChar( 65047 ) ).replace( QChar( 12311 ), QChar( 65048 ) ); // white lenticular brackets
+      lines = lines.replace( QChar( 8230 ), QChar( 65049 ) ); // three-dot ellipse
+      lines = lines.replace( QChar( 8212 ), QChar( 65073 ) ).replace( QChar( 8211 ), QChar( 65074 ) ); // em & en dash
+      lines = lines.replace( '_', QChar( 65075 ) ).replace( QChar( 65103 ), QChar( 65076 ) ); // low line & wavy low line
+      lines = lines.replace( '(', QChar( 65077 ) ).replace( ')', QChar( 65078 ) );
+      lines = lines.replace( '{', QChar( 65079 ) ).replace( '}', QChar( 65080 ) );
+      lines = lines.replace( '<', QChar( 65087 ) ).replace( '>', QChar( 65088 ) );
+      lines = lines.replace( '[', QChar( 65095 ) ).replace( ']', QChar( 65096 ) );
+      lines = lines.replace( QChar( 12308 ), QChar( 65081 ) ).replace( QChar( 12309 ), QChar( 65082 ) );   // tortoise shell brackets
+      lines = lines.replace( QChar( 12304 ), QChar( 65083 ) ).replace( QChar( 12305 ), QChar( 65084 ) );   // black lenticular brackets
+      lines = lines.replace( QChar( 12298 ), QChar( 65085 ) ).replace( QChar( 12299 ), QChar( 65086 ) ); // double angle brackets
+      lines = lines.replace( QChar( 12300 ), QChar( 65089 ) ).replace( QChar( 12301 ), QChar( 65090 ) );   // corner brackets
+      lines = lines.replace( QChar( 12302 ), QChar( 65091 ) ).replace( QChar( 12303 ), QChar( 65092 ) );   // white corner brackets
+
+      const auto constTextLines = lines.split( '\n' );
+      for ( QString line : constTextLines )
       {
         context.painter()->save();
         if ( context.flags() & QgsRenderContext::Antialiasing )

--- a/src/core/qgstextrenderer.cpp
+++ b/src/core/qgstextrenderer.cpp
@@ -3552,25 +3552,7 @@ void QgsTextRenderer::drawTextInternal( TextPart drawType,
 
       // apply some character replacement to draw symbols in vertical presentation
       QString lines = textLines.join( '\n' );
-      lines = lines.replace( ',', QChar( 65040 ) ).replace( QChar( 8229 ), QChar( 65072 ) ); // comma & two-dot leader
-      lines = lines.replace( QChar( 12289 ), QChar( 65041 ) ).replace( QChar( 12290 ), QChar( 65042 ) ); // ideographic comma & full stop
-      lines = lines.replace( ':', QChar( 65043 ) ).replace( ';', QChar( 65044 ) );
-      lines = lines.replace( '!', QChar( 65045 ) ).replace( '?', QChar( 65046 ) );
-      lines = lines.replace( QChar( 12310 ), QChar( 65047 ) ).replace( QChar( 12311 ), QChar( 65048 ) ); // white lenticular brackets
-      lines = lines.replace( QChar( 8230 ), QChar( 65049 ) ); // three-dot ellipse
-      lines = lines.replace( QChar( 8212 ), QChar( 65073 ) ).replace( QChar( 8211 ), QChar( 65074 ) ); // em & en dash
-      lines = lines.replace( '_', QChar( 65075 ) ).replace( QChar( 65103 ), QChar( 65076 ) ); // low line & wavy low line
-      lines = lines.replace( '(', QChar( 65077 ) ).replace( ')', QChar( 65078 ) );
-      lines = lines.replace( '{', QChar( 65079 ) ).replace( '}', QChar( 65080 ) );
-      lines = lines.replace( '<', QChar( 65087 ) ).replace( '>', QChar( 65088 ) );
-      lines = lines.replace( '[', QChar( 65095 ) ).replace( ']', QChar( 65096 ) );
-      lines = lines.replace( QChar( 12308 ), QChar( 65081 ) ).replace( QChar( 12309 ), QChar( 65082 ) );   // tortoise shell brackets
-      lines = lines.replace( QChar( 12304 ), QChar( 65083 ) ).replace( QChar( 12305 ), QChar( 65084 ) );   // black lenticular brackets
-      lines = lines.replace( QChar( 12298 ), QChar( 65085 ) ).replace( QChar( 12299 ), QChar( 65086 ) ); // double angle brackets
-      lines = lines.replace( QChar( 12300 ), QChar( 65089 ) ).replace( QChar( 12301 ), QChar( 65090 ) );   // corner brackets
-      lines = lines.replace( QChar( 12302 ), QChar( 65091 ) ).replace( QChar( 12303 ), QChar( 65092 ) );   // white corner brackets
-
-      const auto constTextLines = lines.split( '\n' );
+      const auto constTextLines = QgsStringUtils::substituteVerticalCharacters( lines ).split( '\n' );
       for ( QString line : constTextLines )
       {
         context.painter()->save();

--- a/tests/src/python/test_qgsstringutils.py
+++ b/tests/src/python/test_qgsstringutils.py
@@ -175,6 +175,10 @@ class PyQgsStringUtils(unittest.TestCase):
         self.assertEqual(QgsStringUtils.capitalize('    testing abc', QgsStringUtils.ForceFirstLetterToCapital),
                          '    Testing Abc')
 
+    def testSubstituteVerticalCharacters(self):
+        """ test subsitute vertical characters """
+        self.assertEqual(QgsStringUtils.substituteVerticalCharacters('123{[(45654)]}321'), '123︷﹇︵45654︶﹈︸321')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@nyalldawson , curved placement isn't compatible with non horizontal orientation for a few reasons. When it comes to rotation-based orientation, that mode can result is a mixture of rotated and non-rotated characters for the same label (bad!); for the vertical orientation mode, since we break strings into graphemes, it ends up rotating 90 degrees along the curves, which is also nonsensical.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
