### PR TITLE
modify editor widget wrappers to handle additional fields

### DIFF
--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -21,6 +21,9 @@ widget or use a pre-existent widget. It is able to set the widget to the value i
 by a field of a vector layer, or return the value it currently holds. Every time it is changed
 it has to emit a valueChanged signal. If it fails to do so, there is no guarantee that the
 changed status of the widget will be saved.
+
+It can also handle additional fields of a vector layer and would set the widget
+for their corresponding values and emit valuesChanged signal.
 %End
 
 %TypeHeaderCode
@@ -240,7 +243,7 @@ Emit this signal, whenever the value changed.
 :param value: The new value
 %End
 
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalfieldValues );
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
 %Docstring
 Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -236,7 +236,16 @@ This will be disabled when the form is not editable.
 
   signals:
 
-    void valueChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+ void valueChanged( const QVariant &value );
+%Docstring
+Emit this signal, whenever the value changed.
+
+:param value: The new value
+
+.. deprecated:: since QGIS 3.10 use valuesChanged signal instead
+%End
+
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 %Docstring
 Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget
@@ -275,15 +284,23 @@ Is forwarded to the slot setValue()
 :param feature: The new feature
 %End
 
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
+    virtual void setValue( const QVariant &value ) = 0;
 %Docstring
-Is called, when the value of the widget needs to be changed.
-Update the widget representation to reflect the new value
-of the field, but also values for potential additional
-fields which might be handled by the widget
+Is called, when the value of the widget needs to be changed. Update the widget representation
+to reflect the new value.
+
+:param value: The new value of the attribute
+%End
+
+    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
+%Docstring
+Is called, when the value of the widget needs to be changed. Update the widget representation
+It will set the value for the field but also values for potential additional fields which are handled by the widget
 
 :param value: The new value of the attribute
 :param addtionalFieldValues: A map of field names with their corresponding values
+
+.. versionadded:: 3.10
 %End
 
     void emitValueChanged();

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -59,18 +59,20 @@ Be sure to return a NULL QVariant if it should be set to NULL.
 :return: The current value the widget represents
 %End
 
-    virtual QgsAttributeList additionalFields() const;
+    virtual QStringList additionalFields() const;
 %Docstring
 Return the list of additional fields which the editor handles
 
 .. versionadded:: 3.10
 %End
 
-    virtual QgsAttributeMap additionalFieldValues();
+    virtual QVariantList additionalFieldValues();
 %Docstring
 Will be used to access the widget's values for potential additional fields handled by the widget
 
 :return: A map of additional field names with their corresponding values
+
+.. seealso:: :py:func:`additionalFields`
 
 .. versionadded:: 3.10
 %End
@@ -245,7 +247,7 @@ Emit this signal, whenever the value changed.
 .. deprecated:: since QGIS 3.10 use valuesChanged signal instead
 %End
 
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void valuesChanged( const QVariant &value, const QVariantList &additionalFieldValues = QVariantList() );
 %Docstring
 Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget
@@ -286,7 +288,7 @@ Is forwarded to the slot setValues()
 
     virtual void setValue( const QVariant &value ) /Deprecated/;
 
-    void setValues( const QVariant &value, const QgsAttributeMap &additionalValues );
+    void setValues( const QVariant &value, const QVariantList &additionalValues );
 %Docstring
 Is called, when the value of the widget or additional field values
 needs to be changed. Update the widget representation

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -236,16 +236,7 @@ This will be disabled when the form is not editable.
 
   signals:
 
- void valueChanged( const QVariant &value );
-%Docstring
-Emit this signal, whenever the value changed.
-
-:param value: The new value
-
-.. deprecated:: since QGIS 3.10 use valuesChanged signal instead
-%End
-
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void valueChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 %Docstring
 Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget
@@ -284,23 +275,15 @@ Is forwarded to the slot setValue()
 :param feature: The new feature
 %End
 
-    virtual void setValue( const QVariant &value ) = 0;
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
 %Docstring
-Is called, when the value of the widget needs to be changed. Update the widget representation
-to reflect the new value.
-
-:param value: The new value of the attribute
-%End
-
-    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
-%Docstring
-Is called, when the value of the widget needs to be changed. Update the widget representation
-It will set the value for the field but also values for potential additional fields which are handled by the widget
+Is called, when the value of the widget needs to be changed.
+Update the widget representation to reflect the new value
+of the field, but also values for potential additional
+fields which might be handled by the widget
 
 :param value: The new value of the attribute
 :param addtionalFieldValues: A map of field names with their corresponding values
-
-.. versionadded:: 3.10
 %End
 
     void emitValueChanged();

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -279,26 +279,18 @@ Emit this signal when the constraint result visibility changed.
 %Docstring
 Will be called when the feature changes
 
-Is forwarded to the slot setValue()
+Is forwarded to the slot setValues()
 
 :param feature: The new feature
 %End
 
-    virtual void setValue( const QVariant &value ) = 0;
+    virtual void setValue( const QVariant &value ) /Deprecated/;
+
+    void setValues( const QVariant &value, const QgsAttributeMap &additionalValues );
 %Docstring
-Is called, when the value of the widget needs to be changed. Update the widget representation
-to reflect the new value.
-
-:param value: The new value of the attribute
-%End
-
-    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
-%Docstring
-Is called, when the value of the widget needs to be changed. Update the widget representation
-It will set the value for the field but also values for potential additional fields which are handled by the widget
-
-:param value: The new value of the attribute
-:param addtionalFieldValues: A map of field names with their corresponding values
+Is called, when the value of the widget or additional field values
+needs to be changed. Update the widget representation
+to reflect the new values.
 
 .. versionadded:: 3.10
 %End

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -61,7 +61,7 @@ Be sure to return a NULL QVariant if it should be set to NULL.
 
     virtual QStringList additionalFields() const;
 %Docstring
-Return the list of additional fields which the editor handles
+Returns the list of additional fields which the editor handles
 
 .. versionadded:: 3.10
 %End
@@ -253,7 +253,7 @@ Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget
 
 :param value: The new value
-:param addtionalFieldValues: A map of additional field names with their corresponding values
+:param additionalFieldValues: A map of additional field names with their corresponding values
 
 .. versionadded:: 3.10
 %End

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -236,14 +236,16 @@ This will be disabled when the form is not editable.
 
   signals:
 
-    void valueChanged( const QVariant &value );
+ void valueChanged( const QVariant &value );
 %Docstring
 Emit this signal, whenever the value changed.
 
 :param value: The new value
+
+.. deprecated:: since QGIS 3.10 use valuesChanged signal instead
 %End
 
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 %Docstring
 Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -56,6 +56,22 @@ Be sure to return a NULL QVariant if it should be set to NULL.
 :return: The current value the widget represents
 %End
 
+    virtual QgsAttributeList additionalFields() const;
+%Docstring
+Return the list of additional fields which the editor handles
+
+.. versionadded:: 3.10
+%End
+
+    virtual QgsAttributeMap additionalFieldValues();
+%Docstring
+Will be used to access the widget's values for potential additional fields handled by the widget
+
+:return: A map of additional field names with their corresponding values
+
+.. versionadded:: 3.10
+%End
+
     int fieldIdx() const;
 %Docstring
 Access the field index.
@@ -224,6 +240,17 @@ Emit this signal, whenever the value changed.
 :param value: The new value
 %End
 
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalfieldValues );
+%Docstring
+Emit this signal, whenever the value changed.
+It will also return the values for the additional fields handled by the widget
+
+:param value: The new value
+:param addtionalFieldValues: A map of additional field names with their corresponding values
+
+.. versionadded:: 3.10
+%End
+
     void constraintStatusChanged( const QString &constraint, const QString &desc, const QString &err, QgsEditorWidgetWrapper::ConstraintResult status );
 %Docstring
 Emit this signal when the constraint status changed.
@@ -258,6 +285,17 @@ Is called, when the value of the widget needs to be changed. Update the widget r
 to reflect the new value.
 
 :param value: The new value of the attribute
+%End
+
+    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
+%Docstring
+Is called, when the value of the widget needs to be changed. Update the widget representation
+It will set the value for the field but also values for potential additional fields which are handled by the widget
+
+:param value: The new value of the attribute
+:param addtionalFieldValues: A map of field names with their corresponding values
+
+.. versionadded:: 3.10
 %End
 
     void emitValueChanged();

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -242,7 +242,7 @@ Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget
 
 :param value: The new value
-:param addtionalFieldValues: A map of additional field names with their corresponding values
+:param additionalFieldValues: A map of additional field names with their corresponding values
 
 .. versionadded:: 3.10
 %End
@@ -275,7 +275,7 @@ Is forwarded to the slot setValue()
 :param feature: The new feature
 %End
 
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) = 0;
 %Docstring
 Is called, when the value of the widget needs to be changed.
 Update the widget representation to reflect the new value
@@ -283,7 +283,7 @@ of the field, but also values for potential additional
 fields which might be handled by the widget
 
 :param value: The new value of the attribute
-:param addtionalFieldValues: A map of field names with their corresponding values
+:param additionalFieldValues: A map of field names with their corresponding values
 %End
 
     void emitValueChanged();

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -242,7 +242,7 @@ Emit this signal, whenever the value changed.
 It will also return the values for the additional fields handled by the widget
 
 :param value: The new value
-:param additionalFieldValues: A map of additional field names with their corresponding values
+:param addtionalFieldValues: A map of additional field names with their corresponding values
 
 .. versionadded:: 3.10
 %End
@@ -275,7 +275,7 @@ Is forwarded to the slot setValue()
 :param feature: The new feature
 %End
 
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) = 0;
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
 %Docstring
 Is called, when the value of the widget needs to be changed.
 Update the widget representation to reflect the new value
@@ -283,7 +283,7 @@ of the field, but also values for potential additional
 fields which might be handled by the widget
 
 :param value: The new value of the attribute
-:param additionalFieldValues: A map of field names with their corresponding values
+:param addtionalFieldValues: A map of field names with their corresponding values
 %End
 
     void emitValueChanged();

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
@@ -53,13 +53,10 @@ Constructor for QgsRelationReferenceWidgetWrapper
 
 
   public slots:
-    virtual void setValue( const QVariant &value );
-
     virtual void setEnabled( bool enabled );
 
 
   protected:
-
     virtual void updateConstraintWidgetStatus();
 
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
@@ -53,7 +53,7 @@ Constructor for QgsRelationReferenceWidgetWrapper
 
 
   public slots:
-    virtual void setValue( const QVariant &value );
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 
     virtual void setEnabled( bool enabled );
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidgetwrapper.sip.in
@@ -53,7 +53,7 @@ Constructor for QgsRelationReferenceWidgetWrapper
 
 
   public slots:
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    virtual void setValue( const QVariant &value );
 
     virtual void setEnabled( bool enabled );
 

--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -74,7 +74,7 @@ Set the constraint result label visible or invisible according to the layer edit
 
     QgsEditorWidgetWrapper *editorWidget() const;
 %Docstring
-Return the editor widget wrapper
+Returns the editor widget wrapper
 
 .. versionadded:: 3.10
 %End

--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -41,12 +41,13 @@ Constructor for QgsAttributeFormEditorWidget.
     virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
 
-    void initialize( const QVariant &initialValue, bool mixedValues = false );
+    void initialize( const QVariant &initialValue, bool mixedValues = false, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 %Docstring
 Resets the widget to an initial value.
 
 :param initialValue: initial value to show in widget
 :param mixedValues: set to ``True`` to initially show the mixed values state
+:param additionalValues: a variant map of additional field names with their corresponding values
 %End
 
     bool hasChanged() const;
@@ -69,6 +70,13 @@ Set the constraint status for this widget.
     void setConstraintResultVisible( bool editable );
 %Docstring
 Set the constraint result label visible or invisible according to the layer editable status
+%End
+
+    QgsEditorWidgetWrapper *editorWidget() const;
+%Docstring
+Return the editor widget wrapper
+
+.. versionadded:: 3.10
 %End
 
   public slots:

--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -41,7 +41,7 @@ Constructor for QgsAttributeFormEditorWidget.
     virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
 
-    void initialize( const QVariant &initialValue, bool mixedValues = false, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void initialize( const QVariant &initialValue, bool mixedValues = false, const QVariantList &additionalFieldValues = QVariantList() );
 %Docstring
 Resets the widget to an initial value.
 
@@ -104,7 +104,7 @@ Emitted when the widget's value changes
 .. deprecated:: since QGIS 3.10 use valuesChanged instead
 %End
 
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void valuesChanged( const QVariant &value, const QVariantList &additionalFieldValues );
 %Docstring
 Emitted when the widget's value changes
 

--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -47,7 +47,7 @@ Resets the widget to an initial value.
 
 :param initialValue: initial value to show in widget
 :param mixedValues: set to ``True`` to initially show the mixed values state
-:param additionalValues: a variant map of additional field names with their corresponding values
+:param additionalFieldValues: a variant map of additional field names with their corresponding values
 %End
 
     bool hasChanged() const;
@@ -109,6 +109,7 @@ Emitted when the widget's value changes
 Emitted when the widget's value changes
 
 :param value: new widget value
+:param additionalFieldValues: of the potential additional fields
 
 .. versionadded:: 3.10
 %End

--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -95,11 +95,22 @@ Called when field values have been committed;
 
   signals:
 
-    void valueChanged( const QVariant &value );
+ void valueChanged( const QVariant &value );
 %Docstring
 Emitted when the widget's value changes
 
 :param value: new widget value
+
+.. deprecated:: since QGIS 3.10 use valuesChanged instead
+%End
+
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+%Docstring
+Emitted when the widget's value changes
+
+:param value: new widget value
+
+.. versionadded:: 3.10
 %End
 
 };

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -152,7 +152,7 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
         const QVariant fieldValue = feat.attribute( fieldIndex );
         additionalFieldValues.insert( fieldIndex, fieldValue );
       }
-      eww->setValues( value, additionalFieldValues );
+      eww->setValue( value, additionalFieldValues );
     }
   }
   else

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -140,7 +140,7 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
   QVariant value = index.model()->data( index, Qt::EditRole );
   const QgsAttributeList additionalFields = eww->additionalFields();
 
-  if ( additionalFields.count() > 0 )
+  if ( !additionalFields.empty() )
   {
     const QgsAttributeTableModel *model = masterModel( index.model() );
     if ( model )

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -157,7 +157,7 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
   }
   else
   {
-    eww->setValue( value );
+    eww->setValues( value, QgsAttributeMap() );
   }
 }
 

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -137,7 +137,28 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
   if ( !eww )
     return;
 
-  eww->setValue( index.model()->data( index, Qt::EditRole ) );
+  QVariant value = index.model()->data( index, Qt::EditRole );
+  const QgsAttributeList additionalFields = eww->additionalFields();
+
+  if ( additionalFields.count() > 0 )
+  {
+    const QgsAttributeTableModel *model = masterModel( index.model() );
+    if ( model )
+    {
+      QgsFeature feat = model->feature( index );
+      QgsAttributeMap additionalFieldValues;
+      for ( int fieldIndex : additionalFields )
+      {
+        const QVariant fieldValue = feat.attribute( fieldIndex );
+        additionalFieldValues.insert( fieldIndex, fieldValue );
+      }
+      eww->setValues( value, additionalFieldValues );
+    }
+  }
+  else
+  {
+    eww->setValue( value );
+  }
 }
 
 void QgsAttributeTableDelegate::setFeatureSelectionModel( QgsFeatureSelectionModel *featureSelectionModel )

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -152,7 +152,7 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
         const QVariant fieldValue = feat.attribute( fieldIndex );
         additionalFieldValues.insert( fieldIndex, fieldValue );
       }
-      eww->setValue( value, additionalFieldValues );
+      eww->setValues( value, additionalFieldValues );
     }
   }
   else

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -138,7 +138,7 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
     return;
 
   QVariant value = index.model()->data( index, Qt::EditRole );
-  const QgsAttributeList additionalFields = eww->additionalFields();
+  const QStringList additionalFields = eww->additionalFields();
 
   if ( !additionalFields.empty() )
   {
@@ -146,18 +146,17 @@ void QgsAttributeTableDelegate::setEditorData( QWidget *editor, const QModelInde
     if ( model )
     {
       QgsFeature feat = model->feature( index );
-      QgsAttributeMap additionalFieldValues;
-      for ( int fieldIndex : additionalFields )
+      QVariantList additionalFieldValues;
+      for ( QString fieldName : additionalFields )
       {
-        const QVariant fieldValue = feat.attribute( fieldIndex );
-        additionalFieldValues.insert( fieldIndex, fieldValue );
+        additionalFieldValues << feat.attribute( fieldName );
       }
       eww->setValues( value, additionalFieldValues );
     }
   }
   else
   {
-    eww->setValues( value, QgsAttributeMap() );
+    eww->setValues( value, QVariantList() );
   }
 }
 

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
       FieldIndexRole,               //!< Get the field index of this column
       UserRole,                     //!< Start further roles starting from this role
       // Insert new values here, SortRole needs to be the last one
-      SortRole,                     //!< Roles used for sorting start here
+      SortRole,                     //!< Role used for sorting start here
     };
 
   public:

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -69,10 +69,10 @@ void QgsEditorWidgetWrapper::setEnabled( bool enabled )
 void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
 {
   setFormFeature( feature );
-  QgsAttributeMap newAdditionalFieldValues;
-  const QgsAttributeList additionalFieldIndexes = additionalFields();
-  for ( int fieldIndex : additionalFieldIndexes )
-    newAdditionalFieldValues.insert( fieldIndex, feature.attribute( fieldIndex ) );
+  QVariantList newAdditionalFieldValues;
+  const QStringList constAdditionalFields = additionalFields();
+  for ( const QString &fieldName : constAdditionalFields )
+    newAdditionalFieldValues << feature.attribute( fieldName );
   setValues( feature.attribute( mFieldIdx ), newAdditionalFieldValues );
 }
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -73,13 +73,19 @@ void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
   const QgsAttributeList additionalFieldIndexes = additionalFields();
   for ( int fieldIndex : additionalFieldIndexes )
     newAdditionalFieldValues.insert( fieldIndex, feature.attribute( fieldIndex ) );
-  updateValues( feature.attribute( mFieldIdx ), newAdditionalFieldValues );
+  setValues( feature.attribute( mFieldIdx ), newAdditionalFieldValues );
 }
 
-void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues )
+void QgsEditorWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( addtionalFieldValues );
-  setValue( value );
+  isRunningDeprecatedSetValue = true;
+  updateValues( value, QgsAttributeMap() );
+  isRunningDeprecatedSetValue = false;
+}
+
+void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &additionalValues )
+{
+  updateValues( value, additionalValues );
 }
 
 void QgsEditorWidgetWrapper::emitValueChanged()
@@ -115,6 +121,16 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
 bool QgsEditorWidgetWrapper::setFormFeatureAttribute( const QString &attributeName, const QVariant &attributeValue )
 {
   return mFormFeature.setAttribute( attributeName, attributeValue );
+}
+
+void QgsEditorWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap &additionalValues )
+{
+  Q_UNUSED( additionalValues );
+  Q_NOWARN_DEPRECATED_PUSH
+  // avoid infinte recursive loop
+  if ( !isRunningDeprecatedSetValue )
+    setValue( value );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 QgsEditorWidgetWrapper::ConstraintResult QgsEditorWidgetWrapper::constraintResult() const

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -69,7 +69,11 @@ void QgsEditorWidgetWrapper::setEnabled( bool enabled )
 void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
 {
   setFormFeature( feature );
-  setValue( feature.attribute( mFieldIdx ) );
+  QgsAttributeMap newAdditionalFieldValues;
+  const QgsAttributeList additionalFieldIndexes = additionalFields();
+  for ( int fieldIndex : additionalFieldIndexes )
+    newAdditionalFieldValues.insert( fieldIndex, feature.attribute( fieldIndex ) );
+  updateValues( feature.attribute( mFieldIdx ), newAdditionalFieldValues );
 }
 
 void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues )

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -80,7 +80,7 @@ void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttribut
 
 void QgsEditorWidgetWrapper::emitValueChanged()
 {
-  emit valueChanged( value() );
+  emit valuesChanged( value(), additionalFieldValues() );
 }
 
 void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -72,6 +72,12 @@ void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
   setValue( feature.attribute( mFieldIdx ) );
 }
 
+void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues )
+{
+  Q_UNUSED( addtionalFieldValues );
+  setValue( value );
+}
+
 void QgsEditorWidgetWrapper::emitValueChanged()
 {
   emit valueChanged( value() );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -79,11 +79,11 @@ void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
 void QgsEditorWidgetWrapper::setValue( const QVariant &value )
 {
   isRunningDeprecatedSetValue = true;
-  updateValues( value, QgsAttributeMap() );
+  updateValues( value, QVariantList() );
   isRunningDeprecatedSetValue = false;
 }
 
-void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &additionalValues )
+void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QVariantList &additionalValues )
 {
   updateValues( value, additionalValues );
 }
@@ -123,8 +123,9 @@ bool QgsEditorWidgetWrapper::setFormFeatureAttribute( const QString &attributeNa
   return mFormFeature.setAttribute( attributeName, attributeValue );
 }
 
-void QgsEditorWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap &additionalValues )
+void QgsEditorWidgetWrapper::updateValues( const QVariant &value, const QVariantList &additionalValues )
 {
+  // this method should be made pure virtual in QGIS 4
   Q_UNUSED( additionalValues );
   Q_NOWARN_DEPRECATED_PUSH
   // avoid infinte recursive loop

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -90,6 +90,9 @@ void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QVariantLis
 
 void QgsEditorWidgetWrapper::emitValueChanged()
 {
+  Q_NOWARN_DEPRECATED_PUSH
+  emit valueChanged( value() );
+  Q_NOWARN_DEPRECATED_POP
   emit valuesChanged( value(), additionalFieldValues() );
 }
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -69,18 +69,16 @@ void QgsEditorWidgetWrapper::setEnabled( bool enabled )
 void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
 {
   setFormFeature( feature );
-  setValue( feature.attribute( mFieldIdx ) );
-}
-
-void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues )
-{
-  Q_UNUSED( addtionalFieldValues );
-  setValue( value );
+  QgsAttributeMap newAdditionalFieldValues;
+  const QgsAttributeList additionalFieldIndexes = additionalFields();
+  for ( int fieldIndex : additionalFieldIndexes )
+    newAdditionalFieldValues.insert( fieldIndex, feature.attribute( fieldIndex ) );
+  setValue( feature.attribute( mFieldIdx ), newAdditionalFieldValues );
 }
 
 void QgsEditorWidgetWrapper::emitValueChanged()
 {
-  emit valuesChanged( value(), additionalFieldValues() );
+  emit valueChanged( value(), additionalFieldValues() );
 }
 
 void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -69,16 +69,18 @@ void QgsEditorWidgetWrapper::setEnabled( bool enabled )
 void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
 {
   setFormFeature( feature );
-  QgsAttributeMap newAdditionalFieldValues;
-  const QgsAttributeList additionalFieldIndexes = additionalFields();
-  for ( int fieldIndex : additionalFieldIndexes )
-    newAdditionalFieldValues.insert( fieldIndex, feature.attribute( fieldIndex ) );
-  setValue( feature.attribute( mFieldIdx ), newAdditionalFieldValues );
+  setValue( feature.attribute( mFieldIdx ) );
+}
+
+void QgsEditorWidgetWrapper::setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues )
+{
+  Q_UNUSED( addtionalFieldValues );
+  setValue( value );
 }
 
 void QgsEditorWidgetWrapper::emitValueChanged()
 {
-  emit valueChanged( value(), additionalFieldValues() );
+  emit valuesChanged( value(), additionalFieldValues() );
 }
 
 void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -241,7 +241,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * It will also return the values for the additional fields handled by the widget
      *
      * \param value The new value
-     * \param addtionalFieldValues A map of additional field names with their corresponding values
+     * \param additionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
     void valueChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
@@ -279,9 +279,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * fields which might be handled by the widget
      *
      * \param value The new value of the attribute
-     * \param addtionalFieldValues A map of field names with their corresponding values
+     * \param additionalFieldValues A map of field names with their corresponding values
      */
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) = 0;
 
     /**
      * Will call the value() method to determine the emitted value

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -38,6 +38,9 @@ class QgsField;
  * it has to emit a valueChanged signal. If it fails to do so, there is no guarantee that the
  * changed status of the widget will be saved.
  *
+ * It can also handle additional fields of a vector layer and would set the widget
+ * for their corresponding values and emit valuesChanged signal.
+ *
  */
 class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 {
@@ -248,7 +251,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param addtionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalfieldValues );
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
 
     /**
      * Emit this signal when the constraint status changed.
@@ -291,7 +294,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param addtionalFieldValues A map of field names with their corresponding values
      * \since QGIS 3.10
      */
-    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues ) {Q_UNUSED( addtionalFieldValues ); setValue( value );}
+    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
 
     /**
      * Will call the value() method to determine the emitted value

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -241,7 +241,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * It will also return the values for the additional fields handled by the widget
      *
      * \param value The new value
-     * \param additionalFieldValues A map of additional field names with their corresponding values
+     * \param addtionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
     void valueChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
@@ -279,9 +279,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * fields which might be handled by the widget
      *
      * \param value The new value of the attribute
-     * \param additionalFieldValues A map of field names with their corresponding values
+     * \param addtionalFieldValues A map of field names with their corresponding values
      */
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) = 0;
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
 
     /**
      * Will call the value() method to determine the emitted value

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -354,6 +354,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     * to reflect the new value.
     *
     * \param value The new value of the attribute
+    * \param additionalValues The values of potential additional fields
     * \note Will be pure virtual in QGIS 4.x
     * \since QGIS 3.10
     */

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -238,21 +238,13 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 
     /**
      * Emit this signal, whenever the value changed.
-     *
-     * \param value The new value
-     * \deprecated since QGIS 3.10 use valuesChanged signal instead
-     */
-    Q_DECL_DEPRECATED void valueChanged( const QVariant &value );
-
-    /**
-     * Emit this signal, whenever the value changed.
      * It will also return the values for the additional fields handled by the widget
      *
      * \param value The new value
      * \param addtionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void valueChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 
     /**
      * Emit this signal when the constraint status changed.
@@ -281,21 +273,15 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void setFeature( const QgsFeature &feature ) override;
 
     /**
-     * Is called, when the value of the widget needs to be changed. Update the widget representation
-     * to reflect the new value.
+     * Is called, when the value of the widget needs to be changed.
+     * Update the widget representation to reflect the new value
+     * of the field, but also values for potential additional
+     * fields which might be handled by the widget
      *
      * \param value The new value of the attribute
-     */
-    virtual void setValue( const QVariant &value ) = 0;
-
-    /**
-     * Is called, when the value of the widget needs to be changed. Update the widget representation
-     * It will set the value for the field but also values for potential additional fields which are handled by the widget
-     * \param value The new value of the attribute
      * \param addtionalFieldValues A map of field names with their corresponding values
-     * \since QGIS 3.10
      */
-    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
+    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
 
     /**
      * Will call the value() method to determine the emitted value

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -88,14 +88,15 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * Return the list of additional fields which the editor handles
      * \since QGIS 3.10
      */
-    virtual QgsAttributeList additionalFields() const {return QgsAttributeList();}
+    virtual QStringList additionalFields() const {return QStringList();}
 
     /**
      * Will be used to access the widget's values for potential additional fields handled by the widget
      * \returns A map of additional field names with their corresponding values
+     * \see additionalFields
      * \since QGIS 3.10
      */
-    virtual QgsAttributeMap additionalFieldValues() {return QgsAttributeMap();}
+    virtual QVariantList additionalFieldValues() {return QVariantList();}
 
     /**
      * Access the field index.
@@ -253,7 +254,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param addtionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void valuesChanged( const QVariant &value, const QVariantList &additionalFieldValues = QVariantList() );
 
     /**
      * Emit this signal when the constraint status changed.
@@ -297,7 +298,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * to reflect the new values.
      * \since QGIS 3.10
      */
-    void setValues( const QVariant &value, const QgsAttributeMap &additionalValues );
+    void setValues( const QVariant &value, const QVariantList &additionalValues );
 
     /**
      * Will call the value() method to determine the emitted value
@@ -356,7 +357,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     * \note Will be pure virtual in QGIS 4.x
     * \since QGIS 3.10
     */
-    virtual void updateValues( const QVariant &value, const QgsAttributeMap &additionalValues = QgsAttributeMap() ); //TODO QGIS 4: make it pure virtual
+    virtual void updateValues( const QVariant &value, const QVariantList &additionalValues = QVariantList() ); //TODO QGIS 4: make it pure virtual
 
     // TODO QGIS 4: remove
     bool isRunningDeprecatedSetValue = false;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -240,8 +240,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * Emit this signal, whenever the value changed.
      *
      * \param value The new value
+     * \deprecated since QGIS 3.10 use valuesChanged signal instead
      */
-    void valueChanged( const QVariant &value );
+    Q_DECL_DEPRECATED void valueChanged( const QVariant &value );
 
     /**
      * Emit this signal, whenever the value changed.
@@ -251,7 +252,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param addtionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 
     /**
      * Emit this signal when the constraint status changed.

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -26,6 +26,7 @@ class QgsField;
 
 #include "qgswidgetwrapper.h"
 #include "qgis_gui.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup gui
@@ -274,7 +275,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     /**
      * Will be called when the feature changes
      *
-     * Is forwarded to the slot setValue()
+     * Is forwarded to the slot setValues()
      *
      * \param feature The new feature
      */
@@ -285,17 +286,18 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * to reflect the new value.
      *
      * \param value The new value of the attribute
+     * \deprecated since QGIS 3.10
      */
-    virtual void setValue( const QVariant &value ) = 0;
+    // TODO Q_DECL_DEPRECATED
+    virtual void setValue( const QVariant &value ) SIP_DEPRECATED;
 
     /**
-     * Is called, when the value of the widget needs to be changed. Update the widget representation
-     * It will set the value for the field but also values for potential additional fields which are handled by the widget
-     * \param value The new value of the attribute
-     * \param addtionalFieldValues A map of field names with their corresponding values
+     * Is called, when the value of the widget or additional field values
+     * needs to be changed. Update the widget representation
+     * to reflect the new values.
      * \since QGIS 3.10
      */
-    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
+    void setValues( const QVariant &value, const QgsAttributeMap &additionalValues );
 
     /**
      * Will call the value() method to determine the emitted value
@@ -345,6 +347,19 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 
 
   private:
+
+    /**
+    * Is called, when the value of the widget needs to be changed. Update the widget representation
+    * to reflect the new value.
+    *
+    * \param value The new value of the attribute
+    * \note Will be pure virtual in QGIS 4.x
+    * \since QGIS 3.10
+    */
+    virtual void updateValues( const QVariant &value, const QgsAttributeMap &additionalValues = QgsAttributeMap() ); //TODO QGIS 4: make it pure virtual
+
+    // TODO QGIS 4: remove
+    bool isRunningDeprecatedSetValue = false;
 
     /**
      * mFieldIdx the widget feature field id

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -81,6 +81,19 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     virtual QVariant value() const = 0;
 
     /**
+     * Return the list of additional fields which the editor handles
+     * \since QGIS 3.10
+     */
+    virtual QgsAttributeList additionalFields() const {return QgsAttributeList();}
+
+    /**
+     * Will be used to access the widget's values for potential additional fields handled by the widget
+     * \returns A map of additional field names with their corresponding values
+     * \since QGIS 3.10
+     */
+    virtual QgsAttributeMap additionalFieldValues() {return QgsAttributeMap();}
+
+    /**
      * Access the field index.
      *
      * \returns The index of the field you are working on
@@ -228,6 +241,16 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void valueChanged( const QVariant &value );
 
     /**
+     * Emit this signal, whenever the value changed.
+     * It will also return the values for the additional fields handled by the widget
+     *
+     * \param value The new value
+     * \param addtionalFieldValues A map of additional field names with their corresponding values
+     * \since QGIS 3.10
+     */
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalfieldValues );
+
+    /**
      * Emit this signal when the constraint status changed.
      * \brief constraintStatusChanged
      * \param constraint represented as a string
@@ -260,6 +283,15 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \param value The new value of the attribute
      */
     virtual void setValue( const QVariant &value ) = 0;
+
+    /**
+     * Is called, when the value of the widget needs to be changed. Update the widget representation
+     * It will set the value for the field but also values for potential additional fields which are handled by the widget
+     * \param value The new value of the attribute
+     * \param addtionalFieldValues A map of field names with their corresponding values
+     * \since QGIS 3.10
+     */
+    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues ) {Q_UNUSED( addtionalFieldValues ); setValue( value );}
 
     /**
      * Will call the value() method to determine the emitted value
@@ -314,6 +346,8 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * mFieldIdx the widget feature field id
      */
     int mFieldIdx = -1;
+
+    QList<int> mAdditionalFieldIndexes;
 
     /**
      * The feature currently being edited, in its current state

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -85,7 +85,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     virtual QVariant value() const = 0;
 
     /**
-     * Return the list of additional fields which the editor handles
+     * Returns the list of additional fields which the editor handles
      * \since QGIS 3.10
      */
     virtual QStringList additionalFields() const {return QStringList();}
@@ -251,7 +251,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * It will also return the values for the additional fields handled by the widget
      *
      * \param value The new value
-     * \param addtionalFieldValues A map of additional field names with their corresponding values
+     * \param additionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
     void valuesChanged( const QVariant &value, const QVariantList &additionalFieldValues = QVariantList() );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -238,13 +238,21 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
 
     /**
      * Emit this signal, whenever the value changed.
+     *
+     * \param value The new value
+     * \deprecated since QGIS 3.10 use valuesChanged signal instead
+     */
+    Q_DECL_DEPRECATED void valueChanged( const QVariant &value );
+
+    /**
+     * Emit this signal, whenever the value changed.
      * It will also return the values for the additional fields handled by the widget
      *
      * \param value The new value
      * \param addtionalFieldValues A map of additional field names with their corresponding values
      * \since QGIS 3.10
      */
-    void valueChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 
     /**
      * Emit this signal when the constraint status changed.
@@ -273,15 +281,21 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void setFeature( const QgsFeature &feature ) override;
 
     /**
-     * Is called, when the value of the widget needs to be changed.
-     * Update the widget representation to reflect the new value
-     * of the field, but also values for potential additional
-     * fields which might be handled by the widget
+     * Is called, when the value of the widget needs to be changed. Update the widget representation
+     * to reflect the new value.
      *
      * \param value The new value of the attribute
-     * \param addtionalFieldValues A map of field names with their corresponding values
      */
-    virtual void setValue( const QVariant &value, const QgsAttributeMap &addtionalFieldValues = QgsAttributeMap() ) = 0;
+    virtual void setValue( const QVariant &value ) = 0;
+
+    /**
+     * Is called, when the value of the widget needs to be changed. Update the widget representation
+     * It will set the value for the field but also values for potential additional fields which are handled by the widget
+     * \param value The new value of the attribute
+     * \param addtionalFieldValues A map of field names with their corresponding values
+     * \since QGIS 3.10
+     */
+    virtual void setValues( const QVariant &value, const QgsAttributeMap &addtionalFieldValues );
 
     /**
      * Will call the value() method to determine the emitted value

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -109,9 +109,8 @@ bool QgsBinaryWidgetWrapper::valid() const
   return mLabel && mButton;
 }
 
-void QgsBinaryWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsBinaryWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   mValue = value.isValid() && !value.isNull() && value.canConvert< QByteArray >() ? value.toByteArray() : QByteArray();
   if ( mValue.length() == 0 )
     mValue = QByteArray();

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -109,7 +109,7 @@ bool QgsBinaryWidgetWrapper::valid() const
   return mLabel && mButton;
 }
 
-void QgsBinaryWidgetWrapper::setValue( const QVariant &value )
+void QgsBinaryWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   mValue = value.isValid() && !value.isNull() && value.canConvert< QByteArray >() ? value.toByteArray() : QByteArray();
   if ( mValue.length() == 0 )
@@ -178,7 +178,7 @@ void QgsBinaryWidgetWrapper::setContent()
     return;
   }
 
-  setValue( fileSource.readAll() );
+  updateValues( fileSource.readAll() );
   emitValueChanged();
 }
 
@@ -187,7 +187,7 @@ void QgsBinaryWidgetWrapper::clear()
   if ( QMessageBox::question( nullptr, tr( "Clear Contents" ), tr( "Are you sure you want the clear this field's content?" ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 
-  setValue( QByteArray() );
+  updateValues( QByteArray() );
   emitValueChanged();
 }
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -109,8 +109,9 @@ bool QgsBinaryWidgetWrapper::valid() const
   return mLabel && mButton;
 }
 
-void QgsBinaryWidgetWrapper::setValue( const QVariant &value )
+void QgsBinaryWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   mValue = value.isValid() && !value.isNull() && value.canConvert< QByteArray >() ? value.toByteArray() : QByteArray();
   if ( mValue.length() == 0 )
     mValue = QByteArray();

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -109,7 +109,7 @@ bool QgsBinaryWidgetWrapper::valid() const
   return mLabel && mButton;
 }
 
-void QgsBinaryWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsBinaryWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   mValue = value.isValid() && !value.isNull() && value.canConvert< QByteArray >() ? value.toByteArray() : QByteArray();
   if ( mValue.length() == 0 )

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
@@ -61,7 +61,7 @@ class GUI_EXPORT QgsBinaryWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private slots:
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
@@ -61,7 +61,7 @@ class GUI_EXPORT QgsBinaryWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private slots:
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsBinaryWidgetWrapper : public QgsEditorWidgetWrapper
     void clear();
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
 
     QString defaultPath();
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.h
@@ -60,9 +60,6 @@ class GUI_EXPORT QgsBinaryWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private slots:
 
     void saveContent();
@@ -70,6 +67,8 @@ class GUI_EXPORT QgsBinaryWidgetWrapper : public QgsEditorWidgetWrapper
     void clear();
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
     QString defaultPath();
 
     QByteArray mValue;

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -74,7 +74,7 @@ bool QgsCheckboxWidgetWrapper::valid() const
   return mCheckBox || mGroupBox;
 }
 
-void QgsCheckboxWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsCheckboxWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   bool state = false;
 

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -64,9 +64,9 @@ void QgsCheckboxWidgetWrapper::initWidget( QWidget *editor )
   mGroupBox = qobject_cast<QGroupBox *>( editor );
 
   if ( mCheckBox )
-    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valueChanged( state ); } );
+    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
   if ( mGroupBox )
-    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valueChanged( state ); } );
+    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
 }
 
 bool QgsCheckboxWidgetWrapper::valid() const

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -64,9 +64,9 @@ void QgsCheckboxWidgetWrapper::initWidget( QWidget *editor )
   mGroupBox = qobject_cast<QGroupBox *>( editor );
 
   if ( mCheckBox )
-    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
+    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valueChanged( state ); } );
   if ( mGroupBox )
-    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
+    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valueChanged( state ); } );
 }
 
 bool QgsCheckboxWidgetWrapper::valid() const
@@ -74,8 +74,9 @@ bool QgsCheckboxWidgetWrapper::valid() const
   return mCheckBox || mGroupBox;
 }
 
-void QgsCheckboxWidgetWrapper::setValue( const QVariant &value )
+void QgsCheckboxWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   bool state = false;
 
   if ( field().type() == QVariant::Bool )

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -74,7 +74,7 @@ bool QgsCheckboxWidgetWrapper::valid() const
   return mCheckBox || mGroupBox;
 }
 
-void QgsCheckboxWidgetWrapper::setValue( const QVariant &value )
+void QgsCheckboxWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   bool state = false;
 

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -64,9 +64,9 @@ void QgsCheckboxWidgetWrapper::initWidget( QWidget *editor )
   mGroupBox = qobject_cast<QGroupBox *>( editor );
 
   if ( mCheckBox )
-    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valueChanged( state ); } );
+    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
   if ( mGroupBox )
-    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valueChanged( state ); } );
+    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
 }
 
 bool QgsCheckboxWidgetWrapper::valid() const
@@ -74,9 +74,8 @@ bool QgsCheckboxWidgetWrapper::valid() const
   return mCheckBox || mGroupBox;
 }
 
-void QgsCheckboxWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsCheckboxWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   bool state = false;
 
   if ( field().type() == QVariant::Bool )

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.cpp
@@ -64,9 +64,21 @@ void QgsCheckboxWidgetWrapper::initWidget( QWidget *editor )
   mGroupBox = qobject_cast<QGroupBox *>( editor );
 
   if ( mCheckBox )
-    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
+    connect( mCheckBox, &QAbstractButton::toggled, this, [ = ]( bool state )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
+    emit valueChanged( state );
+    Q_NOWARN_DEPRECATED_POP
+    emit valuesChanged( state );
+  } );
   if ( mGroupBox )
-    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state ) { emit valuesChanged( state ); } );
+    connect( mGroupBox, &QGroupBox::toggled, this, [ = ]( bool state )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
+    emit valueChanged( state );
+    Q_NOWARN_DEPRECATED_POP
+    emit valuesChanged( state );
+  } );
 }
 
 bool QgsCheckboxWidgetWrapper::valid() const

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     QCheckBox *mCheckBox = nullptr;

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
 
     QCheckBox *mCheckBox = nullptr;
     QGroupBox *mGroupBox = nullptr;

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     QCheckBox *mCheckBox = nullptr;

--- a/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxwidgetwrapper.h
@@ -65,10 +65,9 @@ class GUI_EXPORT QgsCheckboxWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+
     QCheckBox *mCheckBox = nullptr;
     QGroupBox *mGroupBox = nullptr;
 };

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
@@ -70,7 +70,8 @@ bool QgsClassificationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsClassificationWidgetWrapper::setValue( const QVariant &value )
+void QgsClassificationWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   mComboBox->setCurrentIndex( mComboBox->findData( value ) );
 }

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
@@ -70,8 +70,7 @@ bool QgsClassificationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsClassificationWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsClassificationWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   mComboBox->setCurrentIndex( mComboBox->findData( value ) );
 }

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
@@ -70,7 +70,7 @@ bool QgsClassificationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsClassificationWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsClassificationWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   mComboBox->setCurrentIndex( mComboBox->findData( value ) );
 }

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.cpp
@@ -70,7 +70,7 @@ bool QgsClassificationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsClassificationWidgetWrapper::setValue( const QVariant &value )
+void QgsClassificationWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   mComboBox->setCurrentIndex( mComboBox->findData( value ) );
 }

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsClassificationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
 
     QComboBox *mComboBox = nullptr;
 };

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
@@ -56,10 +56,9 @@ class GUI_EXPORT QgsClassificationWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
     QComboBox *mComboBox = nullptr;
 };
 

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsClassificationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsclassificationwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsClassificationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -74,7 +74,7 @@ bool QgsColorWidgetWrapper::valid() const
   return mColorButton;
 }
 
-void QgsColorWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsColorWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mColorButton )
     mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -74,8 +74,9 @@ bool QgsColorWidgetWrapper::valid() const
   return mColorButton;
 }
 
-void QgsColorWidgetWrapper::setValue( const QVariant &value )
+void QgsColorWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mColorButton )
     mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );
 }

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -74,7 +74,7 @@ bool QgsColorWidgetWrapper::valid() const
   return mColorButton;
 }
 
-void QgsColorWidgetWrapper::setValue( const QVariant &value )
+void QgsColorWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( mColorButton )
     mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -74,9 +74,8 @@ bool QgsColorWidgetWrapper::valid() const
   return mColorButton;
 }
 
-void QgsColorWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsColorWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mColorButton )
     mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );
 }

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -56,10 +56,8 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
     void updateConstraintWidgetStatus() override;
 
     QgsColorButton *mColorButton = nullptr;

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     void updateConstraintWidgetStatus() override;

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     void updateConstraintWidgetStatus() override;

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
     void updateConstraintWidgetStatus() override;
 
     QgsColorButton *mColorButton = nullptr;

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -118,18 +118,18 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
   switch ( field().type() )
   {
     case QVariant::DateTime:
-      emit valueChanged( dateTime );
+      emit valuesChanged( dateTime );
       break;
     case QVariant::Date:
-      emit valueChanged( dateTime.date() );
+      emit valuesChanged( dateTime.date() );
       break;
     case QVariant::Time:
-      emit valueChanged( dateTime.time() );
+      emit valuesChanged( dateTime.time() );
       break;
     default:
       if ( !dateTime.isValid() || dateTime.isNull() )
       {
-        emit valueChanged( QVariant( field().type() ) );
+        emit valuesChanged( QVariant( field().type() ) );
       }
       else
       {
@@ -137,11 +137,11 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
         const QString fieldFormat = config( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field().type() ) ).toString();
         if ( fieldIsoFormat )
         {
-          emit valueChanged( dateTime.toString( Qt::ISODate ) );
+          emit valuesChanged( dateTime.toString( Qt::ISODate ) );
         }
         else
         {
-          emit valueChanged( dateTime.toString( fieldFormat ) );
+          emit valuesChanged( dateTime.toString( fieldFormat ) );
         }
       }
       break;
@@ -167,10 +167,13 @@ QVariant QgsDateTimeEditWrapper::value() const
   {
     case QVariant::DateTime:
       return dateTime;
+      break;
     case QVariant::Date:
       return dateTime.date();
+      break;
     case QVariant::Time:
       return dateTime.time();
+      break;
     default:
       const bool fieldIsoFormat = config( QStringLiteral( "field_iso_format" ), false ).toBool();
       const QString fieldFormat = config( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field().type() ) ).toString();
@@ -182,15 +185,15 @@ QVariant QgsDateTimeEditWrapper::value() const
       {
         return dateTime.toString( fieldFormat );
       }
+      break;
   }
 #ifndef _MSC_VER // avoid warnings
   return QVariant(); // avoid warnings
 #endif
 }
 
-void QgsDateTimeEditWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsDateTimeEditWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( !mQDateTimeEdit )
     return;
 

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -192,7 +192,7 @@ QVariant QgsDateTimeEditWrapper::value() const
 #endif
 }
 
-void QgsDateTimeEditWrapper::setValue( const QVariant &value )
+void QgsDateTimeEditWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( !mQDateTimeEdit )
     return;

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -118,18 +118,18 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
   switch ( field().type() )
   {
     case QVariant::DateTime:
-      emit valueChanged( dateTime );
+      emit valuesChanged( dateTime );
       break;
     case QVariant::Date:
-      emit valueChanged( dateTime.date() );
+      emit valuesChanged( dateTime.date() );
       break;
     case QVariant::Time:
-      emit valueChanged( dateTime.time() );
+      emit valuesChanged( dateTime.time() );
       break;
     default:
       if ( !dateTime.isValid() || dateTime.isNull() )
       {
-        emit valueChanged( QVariant( field().type() ) );
+        emit valuesChanged( QVariant( field().type() ) );
       }
       else
       {
@@ -137,11 +137,11 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
         const QString fieldFormat = config( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field().type() ) ).toString();
         if ( fieldIsoFormat )
         {
-          emit valueChanged( dateTime.toString( Qt::ISODate ) );
+          emit valuesChanged( dateTime.toString( Qt::ISODate ) );
         }
         else
         {
-          emit valueChanged( dateTime.toString( fieldFormat ) );
+          emit valuesChanged( dateTime.toString( fieldFormat ) );
         }
       }
       break;

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -118,17 +118,29 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
   switch ( field().type() )
   {
     case QVariant::DateTime:
+      Q_NOWARN_DEPRECATED_PUSH
+      emit valueChanged( dateTime );
+      Q_NOWARN_DEPRECATED_POP
       emit valuesChanged( dateTime );
       break;
     case QVariant::Date:
+      Q_NOWARN_DEPRECATED_PUSH
+      emit valueChanged( dateTime.date() );
+      Q_NOWARN_DEPRECATED_POP
       emit valuesChanged( dateTime.date() );
       break;
     case QVariant::Time:
+      Q_NOWARN_DEPRECATED_PUSH
+      emit valueChanged( dateTime.time() );
+      Q_NOWARN_DEPRECATED_POP
       emit valuesChanged( dateTime.time() );
       break;
     default:
       if ( !dateTime.isValid() || dateTime.isNull() )
       {
+        Q_NOWARN_DEPRECATED_PUSH
+        emit valueChanged( QVariant( field().type() ) );
+        Q_NOWARN_DEPRECATED_POP
         emit valuesChanged( QVariant( field().type() ) );
       }
       else
@@ -137,10 +149,16 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
         const QString fieldFormat = config( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field().type() ) ).toString();
         if ( fieldIsoFormat )
         {
+          Q_NOWARN_DEPRECATED_PUSH
+          emit valueChanged( dateTime.toString( Qt::ISODate ) );
+          Q_NOWARN_DEPRECATED_POP
           emit valuesChanged( dateTime.toString( Qt::ISODate ) );
         }
         else
         {
+          Q_NOWARN_DEPRECATED_PUSH
+          emit valueChanged( dateTime.toString( fieldFormat ) );
+          Q_NOWARN_DEPRECATED_POP
           emit valuesChanged( dateTime.toString( fieldFormat ) );
         }
       }

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -118,18 +118,18 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
   switch ( field().type() )
   {
     case QVariant::DateTime:
-      emit valuesChanged( dateTime );
+      emit valueChanged( dateTime );
       break;
     case QVariant::Date:
-      emit valuesChanged( dateTime.date() );
+      emit valueChanged( dateTime.date() );
       break;
     case QVariant::Time:
-      emit valuesChanged( dateTime.time() );
+      emit valueChanged( dateTime.time() );
       break;
     default:
       if ( !dateTime.isValid() || dateTime.isNull() )
       {
-        emit valuesChanged( QVariant( field().type() ) );
+        emit valueChanged( QVariant( field().type() ) );
       }
       else
       {
@@ -137,11 +137,11 @@ void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime &dateTime )
         const QString fieldFormat = config( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field().type() ) ).toString();
         if ( fieldIsoFormat )
         {
-          emit valuesChanged( dateTime.toString( Qt::ISODate ) );
+          emit valueChanged( dateTime.toString( Qt::ISODate ) );
         }
         else
         {
-          emit valuesChanged( dateTime.toString( fieldFormat ) );
+          emit valueChanged( dateTime.toString( fieldFormat ) );
         }
       }
       break;
@@ -167,13 +167,10 @@ QVariant QgsDateTimeEditWrapper::value() const
   {
     case QVariant::DateTime:
       return dateTime;
-      break;
     case QVariant::Date:
       return dateTime.date();
-      break;
     case QVariant::Time:
       return dateTime.time();
-      break;
     default:
       const bool fieldIsoFormat = config( QStringLiteral( "field_iso_format" ), false ).toBool();
       const QString fieldFormat = config( QStringLiteral( "field_format" ), QgsDateTimeFieldFormatter::defaultFormat( field().type() ) ).toString();
@@ -185,15 +182,15 @@ QVariant QgsDateTimeEditWrapper::value() const
       {
         return dateTime.toString( fieldFormat );
       }
-      break;
   }
 #ifndef _MSC_VER // avoid warnings
   return QVariant(); // avoid warnings
 #endif
 }
 
-void QgsDateTimeEditWrapper::setValue( const QVariant &value )
+void QgsDateTimeEditWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( !mQDateTimeEdit )
     return;
 

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -192,7 +192,7 @@ QVariant QgsDateTimeEditWrapper::value() const
 #endif
 }
 
-void QgsDateTimeEditWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsDateTimeEditWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( !mQDateTimeEdit )
     return;

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -73,7 +73,7 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
     void showIndeterminateState() override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 };
 

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
     void setEnabled( bool enabled ) override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
 };
 
 #endif // QGSDATETIMEEDITWRAPPER_H

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -73,8 +73,10 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
     void showIndeterminateState() override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
+
+  private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
 };
 
 #endif // QGSDATETIMEEDITWRAPPER_H

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -73,7 +73,7 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
     void showIndeterminateState() override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
     void setEnabled( bool enabled ) override;
 };
 

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
@@ -72,7 +72,7 @@ bool QgsEnumerationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsEnumerationWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsEnumerationWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mComboBox )
   {

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
@@ -72,7 +72,7 @@ bool QgsEnumerationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsEnumerationWidgetWrapper::setValue( const QVariant &value )
+void QgsEnumerationWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( mComboBox )
   {

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
@@ -72,8 +72,9 @@ bool QgsEnumerationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsEnumerationWidgetWrapper::setValue( const QVariant &value )
+void QgsEnumerationWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mComboBox )
   {
     mComboBox->setCurrentIndex( mComboBox->findData( value ) );

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.cpp
@@ -72,9 +72,8 @@ bool QgsEnumerationWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsEnumerationWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsEnumerationWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mComboBox )
   {
     mComboBox->setCurrentIndex( mComboBox->findData( value ) );

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
@@ -56,10 +56,9 @@ class GUI_EXPORT QgsEnumerationWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+
     QComboBox *mComboBox = nullptr;
 };
 

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsEnumerationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsEnumerationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
 
     QComboBox *mComboBox = nullptr;
 };

--- a/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsenumerationwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsEnumerationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -189,7 +189,13 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
   }
 
   if ( mLineEdit )
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
+    emit valueChanged( value );
+    Q_NOWARN_DEPRECATED_POP
+    emit valuesChanged( value );
+  } );
 
 }
 
@@ -210,6 +216,9 @@ void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, cons
   if ( mLabel )
   {
     mLabel->setText( value.toString() );
+    Q_NOWARN_DEPRECATED_PUSH
+    emit valueChanged( value.toString() );
+    Q_NOWARN_DEPRECATED_POP
     emit valuesChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
   }
 

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -189,7 +189,7 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
   }
 
   if ( mLineEdit )
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
 
 }
 
@@ -210,7 +210,7 @@ void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value )
   if ( mLabel )
   {
     mLabel->setText( value.toString() );
-    emit valueChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
+    emit valuesChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
   }
 
   if ( mQgsWidget )

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -189,13 +189,12 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
   }
 
   if ( mLineEdit )
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
 
 }
 
-void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mLineEdit )
   {
     if ( value.isNull() )
@@ -211,7 +210,7 @@ void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value, const Qg
   if ( mLabel )
   {
     mLabel->setText( value.toString() );
-    emit valueChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
+    emit valuesChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
   }
 
   if ( mQgsWidget )

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -193,7 +193,7 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
 
 }
 
-void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value )
+void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( mLineEdit )
   {

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -193,7 +193,7 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
 
 }
 
-void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsExternalResourceWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mLineEdit )
   {

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -189,12 +189,13 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
   }
 
   if ( mLineEdit )
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
 
 }
 
-void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value )
+void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mLineEdit )
   {
     if ( value.isNull() )
@@ -210,7 +211,7 @@ void QgsExternalResourceWidgetWrapper::setValue( const QVariant &value )
   if ( mLabel )
   {
     mLabel->setText( value.toString() );
-    emit valuesChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
+    emit valueChanged( value.toString() ); // emit signal that value has changed, do not do it for other widgets
   }
 
   if ( mQgsWidget )

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -66,10 +66,10 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
 
   public slots:
     void setFeature( const QgsFeature &feature ) override;
-    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
     void updateConstraintWidgetStatus() override;
 
     QLineEdit *mLineEdit = nullptr;

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
     void setEnabled( bool enabled ) override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
     void updateConstraintWidgetStatus() override;
 
     QLineEdit *mLineEdit = nullptr;

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
 
   public slots:
     void setFeature( const QgsFeature &feature ) override;
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
     void setEnabled( bool enabled ) override;
 
   private:

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
 
   public slots:
     void setFeature( const QgsFeature &feature ) override;
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private:

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
@@ -45,7 +45,7 @@ bool QgsHiddenWidgetWrapper::valid() const
   return true;
 }
 
-void QgsHiddenWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsHiddenWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   mValue = value;
 }

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
@@ -45,7 +45,7 @@ bool QgsHiddenWidgetWrapper::valid() const
   return true;
 }
 
-void QgsHiddenWidgetWrapper::setValue( const QVariant &value )
+void QgsHiddenWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   mValue = value;
 }

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
@@ -45,8 +45,7 @@ bool QgsHiddenWidgetWrapper::valid() const
   return true;
 }
 
-void QgsHiddenWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsHiddenWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   mValue = value;
 }

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.cpp
@@ -45,7 +45,8 @@ bool QgsHiddenWidgetWrapper::valid() const
   return true;
 }
 
-void QgsHiddenWidgetWrapper::setValue( const QVariant &value )
+void QgsHiddenWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   mValue = value;
 }

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsHiddenWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
 
     QVariant mValue;
 };

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
@@ -53,10 +53,9 @@ class GUI_EXPORT QgsHiddenWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+
     QVariant mValue;
 };
 

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsHiddenWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     QVariant mValue;

--- a/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgshiddenwidgetwrapper.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsHiddenWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     QVariant mValue;

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -79,5 +79,5 @@ void QgsKeyValueWidgetWrapper::updateConstraintWidgetStatus()
 
 void QgsKeyValueWidgetWrapper::onValueChanged()
 {
-  emit valueChanged( value() );
+  emit valuesChanged( value() );
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -67,8 +67,9 @@ bool QgsKeyValueWidgetWrapper::valid() const
   return true;
 }
 
-void QgsKeyValueWidgetWrapper::setValue( const QVariant &value )
+void QgsKeyValueWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   mWidget->setMap( value.toMap() );
 }
 
@@ -79,5 +80,5 @@ void QgsKeyValueWidgetWrapper::updateConstraintWidgetStatus()
 
 void QgsKeyValueWidgetWrapper::onValueChanged()
 {
-  emit valuesChanged( value() );
+  emit valueChanged( value() );
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -67,7 +67,7 @@ bool QgsKeyValueWidgetWrapper::valid() const
   return true;
 }
 
-void QgsKeyValueWidgetWrapper::setValue( const QVariant &value )
+void QgsKeyValueWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   mWidget->setMap( value.toMap() );
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -79,5 +79,5 @@ void QgsKeyValueWidgetWrapper::updateConstraintWidgetStatus()
 
 void QgsKeyValueWidgetWrapper::onValueChanged()
 {
-  emit valuesChanged( value() );
+  emitValueChanged();
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -67,9 +67,8 @@ bool QgsKeyValueWidgetWrapper::valid() const
   return true;
 }
 
-void QgsKeyValueWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsKeyValueWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   mWidget->setMap( value.toMap() );
 }
 
@@ -80,5 +79,5 @@ void QgsKeyValueWidgetWrapper::updateConstraintWidgetStatus()
 
 void QgsKeyValueWidgetWrapper::onValueChanged()
 {
-  emit valueChanged( value() );
+  emit valuesChanged( value() );
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.cpp
@@ -67,7 +67,7 @@ bool QgsKeyValueWidgetWrapper::valid() const
   return true;
 }
 
-void QgsKeyValueWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsKeyValueWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   mWidget->setMap( value.toMap() );
 }

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private slots:
     void onValueChanged();

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private slots:
     void onValueChanged();

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
     void onValueChanged();
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
     void updateConstraintWidgetStatus() override;
 
     QgsKeyValueWidget *mWidget = nullptr;

--- a/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgskeyvaluewidgetwrapper.h
@@ -56,13 +56,11 @@ class GUI_EXPORT QgsKeyValueWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private slots:
     void onValueChanged();
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
     void updateConstraintWidgetStatus() override;
 
     QgsKeyValueWidget *mWidget = nullptr;

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -84,7 +84,7 @@ QVariant QgsListWidgetWrapper::value() const
 
 void QgsListWidgetWrapper::onValueChanged()
 {
-  emit valueChanged( value() );
+  emit valuesChanged( value() );
 }
 
 void QgsListWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -84,7 +84,7 @@ QVariant QgsListWidgetWrapper::value() const
 
 void QgsListWidgetWrapper::onValueChanged()
 {
-  emit valuesChanged( value() );
+  emitValueChanged();
 }
 
 void QgsListWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -61,9 +61,8 @@ bool QgsListWidgetWrapper::valid() const
   return mWidget ? mWidget->valid() : true;
 }
 
-void QgsListWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsListWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   mWidget->setList( value.toList() );
 }
 
@@ -85,7 +84,7 @@ QVariant QgsListWidgetWrapper::value() const
 
 void QgsListWidgetWrapper::onValueChanged()
 {
-  emit valueChanged( value() );
+  emit valuesChanged( value() );
 }
 
 void QgsListWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -61,7 +61,7 @@ bool QgsListWidgetWrapper::valid() const
   return mWidget ? mWidget->valid() : true;
 }
 
-void QgsListWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsListWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   mWidget->setList( value.toList() );
 }

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -61,8 +61,9 @@ bool QgsListWidgetWrapper::valid() const
   return mWidget ? mWidget->valid() : true;
 }
 
-void QgsListWidgetWrapper::setValue( const QVariant &value )
+void QgsListWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   mWidget->setList( value.toList() );
 }
 
@@ -84,7 +85,7 @@ QVariant QgsListWidgetWrapper::value() const
 
 void QgsListWidgetWrapper::onValueChanged()
 {
-  emit valuesChanged( value() );
+  emit valueChanged( value() );
 }
 
 void QgsListWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.cpp
@@ -61,7 +61,7 @@ bool QgsListWidgetWrapper::valid() const
   return mWidget ? mWidget->valid() : true;
 }
 
-void QgsListWidgetWrapper::setValue( const QVariant &value )
+void QgsListWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   mWidget->setList( value.toList() );
 }

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private slots:
     void onValueChanged();

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -56,13 +56,11 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private slots:
     void onValueChanged();
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
     void updateConstraintWidgetStatus() override;
 
     QgsListWidget *mWidget = nullptr;

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private slots:
     void onValueChanged();

--- a/src/gui/editorwidgets/qgslistwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgslistwidgetwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsListWidgetWrapper : public QgsEditorWidgetWrapper
     void onValueChanged();
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
     void updateConstraintWidgetStatus() override;
 
     QgsListWidget *mWidget = nullptr;

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -187,9 +187,9 @@ bool QgsRangeWidgetWrapper::valid() const
 void QgsRangeWidgetWrapper::valueChangedVariant( const QVariant &v )
 {
   if ( v.type() == QVariant::Int )
-    emit valuesChanged( v.toInt() );
+    emit valueChanged( v.toInt() );
   if ( v.type() == QVariant::Double )
-    emit valuesChanged( v.toDouble() );
+    emit valueChanged( v.toDouble() );
 }
 
 QVariant QgsRangeWidgetWrapper::value() const
@@ -232,8 +232,9 @@ QVariant QgsRangeWidgetWrapper::value() const
   return value;
 }
 
-void QgsRangeWidgetWrapper::setValue( const QVariant &value )
+void QgsRangeWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mDoubleSpinBox )
   {
     if ( value.isNull() && config( QStringLiteral( "AllowNull" ), true ).toBool() )

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -187,9 +187,9 @@ bool QgsRangeWidgetWrapper::valid() const
 void QgsRangeWidgetWrapper::valueChangedVariant( const QVariant &v )
 {
   if ( v.type() == QVariant::Int )
-    emit valueChanged( v.toInt() );
+    emit valuesChanged( v.toInt() );
   if ( v.type() == QVariant::Double )
-    emit valueChanged( v.toDouble() );
+    emit valuesChanged( v.toDouble() );
 }
 
 QVariant QgsRangeWidgetWrapper::value() const
@@ -232,9 +232,8 @@ QVariant QgsRangeWidgetWrapper::value() const
   return value;
 }
 
-void QgsRangeWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsRangeWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mDoubleSpinBox )
   {
     if ( value.isNull() && config( QStringLiteral( "AllowNull" ), true ).toBool() )

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -187,9 +187,19 @@ bool QgsRangeWidgetWrapper::valid() const
 void QgsRangeWidgetWrapper::valueChangedVariant( const QVariant &v )
 {
   if ( v.type() == QVariant::Int )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
+    emit valueChanged( v.toInt() );
+    Q_NOWARN_DEPRECATED_POP
     emit valuesChanged( v.toInt() );
+  }
   if ( v.type() == QVariant::Double )
+  {
+    Q_NOWARN_DEPRECATED_PUSH
+    emit valueChanged( v.toDouble() );
+    Q_NOWARN_DEPRECATED_POP
     emit valuesChanged( v.toDouble() );
+  }
 }
 
 QVariant QgsRangeWidgetWrapper::value() const

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -232,7 +232,7 @@ QVariant QgsRangeWidgetWrapper::value() const
   return value;
 }
 
-void QgsRangeWidgetWrapper::setValue( const QVariant &value )
+void QgsRangeWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( mDoubleSpinBox )
   {

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -232,7 +232,7 @@ QVariant QgsRangeWidgetWrapper::value() const
   return value;
 }
 
-void QgsRangeWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsRangeWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mDoubleSpinBox )
   {

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -187,9 +187,9 @@ bool QgsRangeWidgetWrapper::valid() const
 void QgsRangeWidgetWrapper::valueChangedVariant( const QVariant &v )
 {
   if ( v.type() == QVariant::Int )
-    emit valueChanged( v.toInt() );
+    emit valuesChanged( v.toInt() );
   if ( v.type() == QVariant::Double )
-    emit valueChanged( v.toDouble() );
+    emit valuesChanged( v.toDouble() );
 }
 
 QVariant QgsRangeWidgetWrapper::value() const

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -71,16 +71,14 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private slots:
-
     // NOTE - cannot be named "valueChanged", otherwise implicit conversion to QVariant results in
     // infinite recursion
     void valueChangedVariant( const QVariant & );
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
     QSpinBox *mIntSpinBox = nullptr;
     QDoubleSpinBox *mDoubleSpinBox = nullptr;
     QSlider *mSlider = nullptr;

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -77,7 +77,7 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
     void valueChangedVariant( const QVariant & );
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
 
     QSpinBox *mIntSpinBox = nullptr;
     QDoubleSpinBox *mDoubleSpinBox = nullptr;

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -72,7 +72,7 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private slots:
 

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -72,7 +72,7 @@ class GUI_EXPORT QgsRangeWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private slots:
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -124,7 +124,7 @@ void QgsRelationReferenceWidgetWrapper::showIndeterminateState()
   mIndeterminateState = true;
 }
 
-void QgsRelationReferenceWidgetWrapper::updateValues( const QVariant &val, const QgsAttributeMap & )
+void QgsRelationReferenceWidgetWrapper::updateValues( const QVariant &val, const QVariantList & )
 {
   if ( !mWidget || ( !mIndeterminateState && val == value() && val.isNull() == value().isNull() ) )
     return;

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -124,9 +124,8 @@ void QgsRelationReferenceWidgetWrapper::showIndeterminateState()
   mIndeterminateState = true;
 }
 
-void QgsRelationReferenceWidgetWrapper::setValue( const QVariant &val, const QgsAttributeMap &additionalFieldValues )
+void QgsRelationReferenceWidgetWrapper::setValue( const QVariant &val )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( !mWidget || ( !mIndeterminateState && val == value() && val.isNull() == value().isNull() ) )
     return;
 
@@ -148,7 +147,7 @@ void QgsRelationReferenceWidgetWrapper::foreignKeyChanged( QVariant value )
   {
     value = QVariant( field().type() );
   }
-  emit valueChanged( value );
+  emit valuesChanged( value );
 }
 
 void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -147,7 +147,7 @@ void QgsRelationReferenceWidgetWrapper::foreignKeyChanged( QVariant value )
   {
     value = QVariant( field().type() );
   }
-  emit valueChanged( value );
+  emit valuesChanged( value );
 }
 
 void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -147,6 +147,9 @@ void QgsRelationReferenceWidgetWrapper::foreignKeyChanged( QVariant value )
   {
     value = QVariant( field().type() );
   }
+  Q_NOWARN_DEPRECATED_PUSH
+  emit valueChanged( value );
+  Q_NOWARN_DEPRECATED_POP
   emit valuesChanged( value );
 }
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -124,7 +124,7 @@ void QgsRelationReferenceWidgetWrapper::showIndeterminateState()
   mIndeterminateState = true;
 }
 
-void QgsRelationReferenceWidgetWrapper::setValue( const QVariant &val )
+void QgsRelationReferenceWidgetWrapper::updateValues( const QVariant &val, const QgsAttributeMap & )
 {
   if ( !mWidget || ( !mIndeterminateState && val == value() && val.isNull() == value().isNull() ) )
     return;

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -124,8 +124,9 @@ void QgsRelationReferenceWidgetWrapper::showIndeterminateState()
   mIndeterminateState = true;
 }
 
-void QgsRelationReferenceWidgetWrapper::setValue( const QVariant &val )
+void QgsRelationReferenceWidgetWrapper::setValue( const QVariant &val, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( !mWidget || ( !mIndeterminateState && val == value() && val.isNull() == value().isNull() ) )
     return;
 
@@ -147,7 +148,7 @@ void QgsRelationReferenceWidgetWrapper::foreignKeyChanged( QVariant value )
   {
     value = QVariant( field().type() );
   }
-  emit valuesChanged( value );
+  emit valueChanged( value );
 }
 
 void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus()

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     void showIndeterminateState() override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
     void setEnabled( bool enabled ) override;
 
   private slots:

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -60,17 +60,17 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     void showIndeterminateState() override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private slots:
     void foreignKeyChanged( QVariant value );
 
   protected:
-
     void updateConstraintWidgetStatus() override;
 
   private:
+    void updateValues( const QVariant &val, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
     QgsRelationReferenceWidget *mWidget = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     void showIndeterminateState() override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private slots:

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
     void updateConstraintWidgetStatus() override;
 
   private:
-    void updateValues( const QVariant &val, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &val, const QVariantList & = QVariantList() ) override;
 
     QgsRelationReferenceWidget *mWidget = nullptr;
     QgsMapCanvas *mCanvas = nullptr;

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -133,7 +133,7 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
       fle->setNullValue( defVal.toString() );
     }
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
     connect( mLineEdit, &QLineEdit::textChanged, this, &QgsTextEditWrapper::textChanged );
 
     mWritablePalette = mLineEdit->palette();
@@ -171,9 +171,8 @@ void QgsTextEditWrapper::showIndeterminateState()
     mLineEdit->blockSignals( false );
 }
 
-void QgsTextEditWrapper::setValue( const QVariant &val, const QgsAttributeMap &additionalFieldValues )
+void QgsTextEditWrapper::setValue( const QVariant &val )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mLineEdit )
   {
     //restore placeholder text, which may have been removed by showIndeterminateState()

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -133,7 +133,7 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
       fle->setNullValue( defVal.toString() );
     }
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
     connect( mLineEdit, &QLineEdit::textChanged, this, &QgsTextEditWrapper::textChanged );
 
     mWritablePalette = mLineEdit->palette();

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -133,7 +133,13 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
       fle->setNullValue( defVal.toString() );
     }
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value )
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      emit valueChanged( value );
+      Q_NOWARN_DEPRECATED_POP
+      emit valuesChanged( value );
+    } );
     connect( mLineEdit, &QLineEdit::textChanged, this, &QgsTextEditWrapper::textChanged );
 
     mWritablePalette = mLineEdit->palette();

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -171,7 +171,7 @@ void QgsTextEditWrapper::showIndeterminateState()
     mLineEdit->blockSignals( false );
 }
 
-void QgsTextEditWrapper::setValue( const QVariant &val )
+void QgsTextEditWrapper::updateValues( const QVariant &val, const QgsAttributeMap & )
 {
   if ( mLineEdit )
   {

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -171,7 +171,7 @@ void QgsTextEditWrapper::showIndeterminateState()
     mLineEdit->blockSignals( false );
 }
 
-void QgsTextEditWrapper::updateValues( const QVariant &val, const QgsAttributeMap & )
+void QgsTextEditWrapper::updateValues( const QVariant &val, const QVariantList & )
 {
   if ( mLineEdit )
   {

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -133,7 +133,7 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
       fle->setNullValue( defVal.toString() );
     }
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
     connect( mLineEdit, &QLineEdit::textChanged, this, &QgsTextEditWrapper::textChanged );
 
     mWritablePalette = mLineEdit->palette();
@@ -171,8 +171,9 @@ void QgsTextEditWrapper::showIndeterminateState()
     mLineEdit->blockSignals( false );
 }
 
-void QgsTextEditWrapper::setValue( const QVariant &val )
+void QgsTextEditWrapper::setValue( const QVariant &val, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mLineEdit )
   {
     //restore placeholder text, which may have been removed by showIndeterminateState()

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -72,7 +72,7 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private slots:

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -72,7 +72,7 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
     void setEnabled( bool enabled ) override;
 
   private slots:

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     void textChanged( const QString &text );
 
   private:
-    void updateValues( const QVariant &val, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &val, const QVariantList & = QVariantList() ) override;
 
     QTextBrowser *mTextBrowser = nullptr;
     QTextEdit *mTextEdit = nullptr;

--- a/src/gui/editorwidgets/qgstexteditwrapper.h
+++ b/src/gui/editorwidgets/qgstexteditwrapper.h
@@ -72,13 +72,14 @@ class GUI_EXPORT QgsTextEditWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private slots:
     void textChanged( const QString &text );
 
   private:
+    void updateValues( const QVariant &val, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
     QTextBrowser *mTextBrowser = nullptr;
     QTextEdit *mTextEdit = nullptr;
     QPlainTextEdit *mPlainTextEdit = nullptr;

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -117,7 +117,7 @@ void QgsUniqueValuesWidgetWrapper::showIndeterminateState()
   }
 }
 
-void QgsUniqueValuesWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsUniqueValuesWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mComboBox )
   {

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -90,7 +90,13 @@ void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor )
     c->setCompletionMode( QCompleter::PopupCompletion );
     mLineEdit->setCompleter( c );
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value )
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      emit valueChanged( value );
+      Q_NOWARN_DEPRECATED_POP
+      emit valuesChanged( value );
+    } );
   }
 
   if ( mComboBox )

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -90,7 +90,7 @@ void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor )
     c->setCompletionMode( QCompleter::PopupCompletion );
     mLineEdit->setCompleter( c );
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
   }
 
   if ( mComboBox )
@@ -117,9 +117,8 @@ void QgsUniqueValuesWidgetWrapper::showIndeterminateState()
   }
 }
 
-void QgsUniqueValuesWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsUniqueValuesWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mComboBox )
   {
     mComboBox->setCurrentIndex( mComboBox->findData( value ) );

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -90,7 +90,7 @@ void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor )
     c->setCompletionMode( QCompleter::PopupCompletion );
     mLineEdit->setCompleter( c );
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
   }
 
   if ( mComboBox )
@@ -117,8 +117,9 @@ void QgsUniqueValuesWidgetWrapper::showIndeterminateState()
   }
 }
 
-void QgsUniqueValuesWidgetWrapper::setValue( const QVariant &value )
+void QgsUniqueValuesWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mComboBox )
   {
     mComboBox->setCurrentIndex( mComboBox->findData( value ) );

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -117,7 +117,7 @@ void QgsUniqueValuesWidgetWrapper::showIndeterminateState()
   }
 }
 
-void QgsUniqueValuesWidgetWrapper::setValue( const QVariant &value )
+void QgsUniqueValuesWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( mComboBox )
   {

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -90,7 +90,7 @@ void QgsUniqueValuesWidgetWrapper::initWidget( QWidget *editor )
     c->setCompletionMode( QCompleter::PopupCompletion );
     mLineEdit->setCompleter( c );
 
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); } );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); } );
   }
 
   if ( mComboBox )

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
@@ -62,10 +62,9 @@ class GUI_EXPORT QgsUniqueValuesWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+
     QComboBox *mComboBox = nullptr;
     QLineEdit *mLineEdit = nullptr;
 };

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsUniqueValuesWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsUniqueValuesWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
 
     QComboBox *mComboBox = nullptr;
     QLineEdit *mLineEdit = nullptr;

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsUniqueValuesWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -53,7 +53,7 @@ bool QgsUuidWidgetWrapper::valid() const
   return mLineEdit || mLabel;
 }
 
-void QgsUuidWidgetWrapper::setValue( const QVariant &value )
+void QgsUuidWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( value.isNull() )
   {

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -53,9 +53,8 @@ bool QgsUuidWidgetWrapper::valid() const
   return mLineEdit || mLabel;
 }
 
-void QgsUuidWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsUuidWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( value.isNull() )
   {
     if ( mLineEdit )

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -53,7 +53,7 @@ bool QgsUuidWidgetWrapper::valid() const
   return mLineEdit || mLabel;
 }
 
-void QgsUuidWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsUuidWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( value.isNull() )
   {

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.cpp
@@ -53,8 +53,9 @@ bool QgsUuidWidgetWrapper::valid() const
   return mLineEdit || mLabel;
 }
 
-void QgsUuidWidgetWrapper::setValue( const QVariant &value )
+void QgsUuidWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( value.isNull() )
   {
     if ( mLineEdit )

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
@@ -58,7 +58,7 @@ class GUI_EXPORT QgsUuidWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private:

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
@@ -58,10 +58,11 @@ class GUI_EXPORT QgsUuidWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
     void setEnabled( bool enabled ) override;
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+
     QLabel *mLabel = nullptr;
     QLineEdit *mLineEdit = nullptr;
 };

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
@@ -61,7 +61,7 @@ class GUI_EXPORT QgsUuidWidgetWrapper : public QgsEditorWidgetWrapper
     void setEnabled( bool enabled ) override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap  & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
 
     QLabel *mLabel = nullptr;
     QLineEdit *mLineEdit = nullptr;

--- a/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsuuidwidgetwrapper.h
@@ -58,7 +58,7 @@ class GUI_EXPORT QgsUuidWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
     void setEnabled( bool enabled ) override;
 
   private:

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -69,7 +69,7 @@ bool QgsValueMapWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsValueMapWidgetWrapper::setValue( const QVariant &value )
+void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   QString v;
   if ( value.isNull() )

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -69,9 +69,8 @@ bool QgsValueMapWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsValueMapWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsValueMapWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   QString v;
   if ( value.isNull() )
     v = QgsValueMapFieldFormatter::NULL_VALUE;

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -69,8 +69,9 @@ bool QgsValueMapWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsValueMapWidgetWrapper::setValue( const QVariant &value )
+void QgsValueMapWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   QString v;
   if ( value.isNull() )
     v = QgsValueMapFieldFormatter::NULL_VALUE;

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -69,7 +69,7 @@ bool QgsValueMapWidgetWrapper::valid() const
   return mComboBox;
 }
 
-void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsValueMapWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   QString v;
   if ( value.isNull() )

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -65,7 +65,7 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -65,7 +65,7 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
   private:
     QComboBox *mComboBox = nullptr;

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -65,7 +65,7 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
 
     QComboBox *mComboBox = nullptr;
 };

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.h
@@ -64,10 +64,9 @@ class GUI_EXPORT QgsValueMapWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-    void setValue( const QVariant &value ) override;
-
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
     QComboBox *mComboBox = nullptr;
 };
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -172,7 +172,7 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
   }
   else if ( mLineEdit )
   {
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); }, Qt::UniqueConnection );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); }, Qt::UniqueConnection );
   }
 }
 
@@ -181,9 +181,8 @@ bool QgsValueRelationWidgetWrapper::valid() const
   return mTableWidget || mLineEdit || mComboBox;
 }
 
-void QgsValueRelationWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
 {
-  Q_UNUSED( additionalFieldValues );
   if ( mTableWidget )
   {
     QStringList checkList;

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -172,7 +172,13 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
   }
   else if ( mLineEdit )
   {
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); }, Qt::UniqueConnection );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value )
+    {
+      Q_NOWARN_DEPRECATED_PUSH
+      emit valueChanged( value );
+      Q_NOWARN_DEPRECATED_POP
+      emit valuesChanged( value );
+    }, Qt::UniqueConnection );
   }
 }
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -181,7 +181,7 @@ bool QgsValueRelationWidgetWrapper::valid() const
   return mTableWidget || mLineEdit || mComboBox;
 }
 
-void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
+void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
 {
   if ( mTableWidget )
   {
@@ -268,7 +268,7 @@ void QgsValueRelationWidgetWrapper::widgetValueChanged( const QString &attribute
     {
       populate();
       // Restore value
-      setValue( value( ) );
+      updateValues( value( ) );
       // If the value has changed as a result of another widget's value change,
       // we need to emit the signal to make sure other dependent widgets are
       // updated.
@@ -305,7 +305,7 @@ void QgsValueRelationWidgetWrapper::setFeature( const QgsFeature &feature )
     // set in the next, which is typically the "down" in a drill-down
     QTimer::singleShot( 0, this, [ this ]
     {
-      setValue( mCache.at( 0 ).key );
+      updateValues( mCache.at( 0 ).key );
     } );
   }
 }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -172,7 +172,7 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
   }
   else if ( mLineEdit )
   {
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); }, Qt::UniqueConnection );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); }, Qt::UniqueConnection );
   }
 }
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -172,7 +172,7 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
   }
   else if ( mLineEdit )
   {
-    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valuesChanged( value ); }, Qt::UniqueConnection );
+    connect( mLineEdit, &QLineEdit::textChanged, this, [ = ]( const QString & value ) { emit valueChanged( value ); }, Qt::UniqueConnection );
   }
 }
 
@@ -181,8 +181,9 @@ bool QgsValueRelationWidgetWrapper::valid() const
   return mTableWidget || mLineEdit || mComboBox;
 }
 
-void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
+void QgsValueRelationWidgetWrapper::setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
+  Q_UNUSED( additionalFieldValues );
   if ( mTableWidget )
   {
     QStringList checkList;

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -181,7 +181,7 @@ bool QgsValueRelationWidgetWrapper::valid() const
   return mTableWidget || mLineEdit || mComboBox;
 }
 
-void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const QgsAttributeMap & )
+void QgsValueRelationWidgetWrapper::updateValues( const QVariant &value, const QVariantList & )
 {
   if ( mTableWidget )
   {

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -104,7 +104,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
 
   private:
-    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+    void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
 
 
     /**

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -78,10 +78,6 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     void initWidget( QWidget *editor ) override;
     bool valid() const override;
 
-  public slots:
-
-    void setValue( const QVariant &value ) override;
-
     /**
      * Will be called when a value in the current edited form or table row
      * changes
@@ -108,6 +104,8 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
 
   private:
+    void updateValues( const QVariant &value, const QgsAttributeMap & = QgsAttributeMap() ) override;
+
 
     /**
      * Returns the value configured in `NofColumns` or 1 if not

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
   public slots:
 
-    void setValue( const QVariant &value ) override;
+    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
 
     /**
      * Will be called when a value in the current edited form or table row

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
   public slots:
 
-    void setValue( const QVariant &value, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() ) override;
+    void setValue( const QVariant &value ) override;
 
     /**
      * Will be called when a value in the current edited form or table row

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -798,10 +798,10 @@ void QgsAttributeForm::onAttributeChanged( const QVariant &value, const QVariant
       emit widgetValueChanged( eww->field().name(), value, !mIsSettingFeature );
 
       // also emit the signal for additional values
-      const QStringList addtionalFields = eww->additionalFields();
-      for ( int i = 0; i < addtionalFields.count(); i++ )
+      const QStringList additionalFields = eww->additionalFields();
+      for ( int i = 0; i < additionalFields.count(); i++ )
       {
-        const QString fieldName = addtionalFields.at( i );
+        const QString fieldName = additionalFields.at( i );
         const QVariant value = additionalFieldValues.at( i );
         emit widgetValueChanged( fieldName, value, !mIsSettingFeature );
       }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -255,7 +255,7 @@ void QgsAttributeForm::changeAttribute( const QString &field, const QVariant &va
       QVariant mainValue = eww->value();
       QgsAttributeMap additionalFieldValues = eww->additionalFieldValues();
       additionalFieldValues[index] = value;
-      eww->setValue( mainValue, additionalFieldValues );
+      eww->setValues( mainValue, additionalFieldValues );
       eww->setHint( hintText );
     }
   }
@@ -1989,8 +1989,8 @@ void QgsAttributeForm::addWidgetWrapper( QgsEditorWidgetWrapper *eww )
       // synchronise them
       if ( meww->field() == eww->field() )
       {
-        connect( meww, &QgsEditorWidgetWrapper::valueChanged, eww, &QgsEditorWidgetWrapper::setValue );
-        connect( eww, &QgsEditorWidgetWrapper::valueChanged, meww, &QgsEditorWidgetWrapper::setValue );
+        connect( meww, &QgsEditorWidgetWrapper::valuesChanged, eww, &QgsEditorWidgetWrapper::setValues );
+        connect( eww, &QgsEditorWidgetWrapper::valuesChanged, meww, &QgsEditorWidgetWrapper::setValues );
         break;
       }
     }
@@ -2056,7 +2056,7 @@ void QgsAttributeForm::afterWidgetInit()
         isFirstEww = false;
       }
 
-      connect( eww, &QgsEditorWidgetWrapper::valueChanged, this, &QgsAttributeForm::onAttributeChanged );
+      connect( eww, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeForm::onAttributeChanged );
       connect( eww, &QgsEditorWidgetWrapper::constraintStatusChanged, this, &QgsAttributeForm::onConstraintStatusChanged );
     }
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -255,7 +255,7 @@ void QgsAttributeForm::changeAttribute( const QString &field, const QVariant &va
       QVariant mainValue = eww->value();
       QgsAttributeMap additionalFieldValues = eww->additionalFieldValues();
       additionalFieldValues[index] = value;
-      eww->setValues( mainValue, additionalFieldValues );
+      eww->setValue( mainValue, additionalFieldValues );
       eww->setHint( hintText );
     }
   }
@@ -1989,8 +1989,8 @@ void QgsAttributeForm::addWidgetWrapper( QgsEditorWidgetWrapper *eww )
       // synchronise them
       if ( meww->field() == eww->field() )
       {
-        connect( meww, &QgsEditorWidgetWrapper::valuesChanged, eww, &QgsEditorWidgetWrapper::setValues );
-        connect( eww, &QgsEditorWidgetWrapper::valuesChanged, meww, &QgsEditorWidgetWrapper::setValues );
+        connect( meww, &QgsEditorWidgetWrapper::valueChanged, eww, &QgsEditorWidgetWrapper::setValue );
+        connect( eww, &QgsEditorWidgetWrapper::valueChanged, meww, &QgsEditorWidgetWrapper::setValue );
         break;
       }
     }
@@ -2056,7 +2056,7 @@ void QgsAttributeForm::afterWidgetInit()
         isFirstEww = false;
       }
 
-      connect( eww, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeForm::onAttributeChanged );
+      connect( eww, &QgsEditorWidgetWrapper::valueChanged, this, &QgsAttributeForm::onAttributeChanged );
       connect( eww, &QgsEditorWidgetWrapper::constraintStatusChanged, this, &QgsAttributeForm::onConstraintStatusChanged );
     }
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -246,7 +246,7 @@ void QgsAttributeForm::changeAttribute( const QString &field, const QVariant &va
     QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
     if ( eww && eww->field().name() == field )
     {
-      eww->setValue( value );
+      eww->setValues( value, QgsAttributeMap() );
       eww->setHint( hintText );
     }
     int index = mLayer->fields().indexFromName( field );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2168,7 +2168,7 @@ void QgsAttributeForm::setMultiEditFeatureIds( const QgsFeatureIds &fids )
   fit.nextFeature( firstFeature );
 
   const auto constMixedValueFields = mixedValueFields;
-  for ( int fieldIndex : constMixedValueFields )
+  for ( int fieldIndex : qgis::as_const( mixedValueFields ) )
   {
     if ( QgsAttributeFormEditorWidget *w = mFormEditorWidgets.value( fieldIndex, nullptr ) )
     {

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -286,7 +286,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void refreshFeature();
 
   private slots:
-    void onAttributeChanged( const QVariant &value );
+    void onAttributeChanged(const QVariant &value, const QgsAttributeMap &additionalFieldValues );
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -286,7 +286,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void refreshFeature();
 
   private slots:
-    void onAttributeChanged(const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void onAttributeChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -286,7 +286,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void refreshFeature();
 
   private slots:
-    void onAttributeChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void onAttributeChanged(const QVariant &value, const QgsAttributeMap &additionalFieldValues );
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -286,7 +286,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void refreshFeature();
 
   private slots:
-    void onAttributeChanged(const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void onAttributeChanged( const QVariant &value, const QVariantList &additionalFieldValues );
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -31,7 +31,7 @@
 QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapper *editorWidget, const QString &widgetType, QgsAttributeForm *form )
   : QgsAttributeFormWidget( editorWidget, form )
   , mWidgetType( widgetType )
-  , mWidget( editorWidget )
+  , mEditorWidget( editorWidget )
   , mForm( form )
   , mMultiEditButton( new QgsMultiEditToolButton() )
   , mBlockValueUpdate( false )
@@ -42,22 +42,22 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
   mConstraintResultLabel->setObjectName( QStringLiteral( "ConstraintStatus" ) );
   mConstraintResultLabel->setSizePolicy( QSizePolicy::Fixed, mConstraintResultLabel->sizePolicy().verticalPolicy() );
 
-  mMultiEditButton->setField( mWidget->field() );
+  mMultiEditButton->setField( mEditorWidget->field() );
   mAggregateButton = new QgsAggregateToolButton();
   mAggregateButton->setType( editorWidget->field().type() );
   connect( mAggregateButton, &QgsAggregateToolButton::aggregateChanged, this, &QgsAttributeFormEditorWidget::onAggregateChanged );
 
-  if ( mWidget->widget() )
+  if ( mEditorWidget->widget() )
   {
-    mWidget->widget()->setObjectName( mWidget->field().name() );
+    mEditorWidget->widget()->setObjectName( mEditorWidget->field().name() );
   }
 
-  connect( mWidget, static_cast<void ( QgsEditorWidgetWrapper::* )( const QVariant &value )>( &QgsEditorWidgetWrapper::valueChanged ), this, &QgsAttributeFormEditorWidget::editorWidgetChanged );
+  connect( mEditorWidget, static_cast<void ( QgsEditorWidgetWrapper::* )( const QVariant &value )>( &QgsEditorWidgetWrapper::valueChanged ), this, &QgsAttributeFormEditorWidget::editorWidgetValueChanged );
 
   connect( mMultiEditButton, &QgsMultiEditToolButton::resetFieldValueTriggered, this, &QgsAttributeFormEditorWidget::resetValue );
   connect( mMultiEditButton, &QgsMultiEditToolButton::setFieldValueTriggered, this, &QgsAttributeFormEditorWidget::setFieldTriggered );
 
-  mMultiEditButton->setField( mWidget->field() );
+  mMultiEditButton->setField( mEditorWidget->field() );
 
   updateWidgets();
 }
@@ -71,8 +71,8 @@ QgsAttributeFormEditorWidget::~QgsAttributeFormEditorWidget()
 void QgsAttributeFormEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )
 {
   Q_ASSERT( !mWidgetType.isEmpty() );
-  const QVariantMap config = mWidget->config();
-  const int fieldIdx = mWidget->fieldIdx();
+  const QVariantMap config = mEditorWidget->config();
+  const int fieldIdx = mEditorWidget->fieldIdx();
 
   QgsSearchWidgetWrapper *sww = QgsGui::editorWidgetRegistry()->createSearchWidget( mWidgetType, layer(), fieldIdx, config,
                                 searchWidgetFrame(), context );
@@ -114,18 +114,26 @@ void QgsAttributeFormEditorWidget::setConstraintResultVisible( bool editable )
   mConstraintResultLabel->setHidden( !editable );
 }
 
+QgsEditorWidgetWrapper *QgsAttributeFormEditorWidget::editorWidget() const
+{
+  return mEditorWidget;
+}
+
 void QgsAttributeFormEditorWidget::setIsMixed( bool mixed )
 {
-  if ( mWidget && mixed )
-    mWidget->showIndeterminateState();
+  if ( mEditorWidget && mixed )
+    mEditorWidget->showIndeterminateState();
   mMultiEditButton->setIsMixed( mixed );
   mIsMixed = mixed;
 }
 
 void QgsAttributeFormEditorWidget::changesCommitted()
 {
-  if ( mWidget )
-    mPreviousValue = mWidget->value();
+  if ( mEditorWidget )
+  {
+    mPreviousValue = mEditorWidget->value();
+    mPreviousAdditionalValues = mEditorWidget->additionalFieldValues();
+  }
 
   setIsMixed( false );
   mMultiEditButton->changesCommitted();
@@ -134,15 +142,16 @@ void QgsAttributeFormEditorWidget::changesCommitted()
 
 
 
-void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, bool mixedValues )
+void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, bool mixedValues, const QgsAttributeMap &additionalFieldValues )
 {
-  if ( mWidget )
+  if ( mEditorWidget )
   {
     mBlockValueUpdate = true;
-    mWidget->setValue( initialValue );
+    mEditorWidget->setValues( initialValue, additionalFieldValues );
     mBlockValueUpdate = false;
   }
   mPreviousValue = initialValue;
+  mPreviousAdditionalValues = additionalFieldValues;
   setIsMixed( mixedValues );
   mMultiEditButton->setIsChanged( false );
   mIsChanged = false;
@@ -150,12 +159,12 @@ void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, boo
 
 QVariant QgsAttributeFormEditorWidget::currentValue() const
 {
-  return mWidget->value();
+  return mEditorWidget->value();
 }
 
 
 
-void QgsAttributeFormEditorWidget::editorWidgetChanged( const QVariant &value )
+void QgsAttributeFormEditorWidget::editorWidgetValueChanged( const QVariant &value )
 {
   if ( mBlockValueUpdate )
     return;
@@ -179,8 +188,8 @@ void QgsAttributeFormEditorWidget::resetValue()
 {
   mIsChanged = false;
   mBlockValueUpdate = true;
-  if ( mWidget )
-    mWidget->setValue( mPreviousValue );
+  if ( mEditorWidget )
+    mEditorWidget->setValues( mPreviousValue, mPreviousAdditionalValues );
   mBlockValueUpdate = false;
 
   switch ( mode() )
@@ -192,8 +201,8 @@ void QgsAttributeFormEditorWidget::resetValue()
     case MultiEditMode:
     {
       mMultiEditButton->setIsChanged( false );
-      if ( mWidget && mIsMixed )
-        mWidget->showIndeterminateState();
+      if ( mEditorWidget && mIsMixed )
+        mEditorWidget->showIndeterminateState();
       break;
     }
   }
@@ -214,7 +223,7 @@ void QgsAttributeFormEditorWidget::updateWidgets()
 {
   //first update the tool buttons
   bool hasMultiEditButton = ( editPage()->layout()->indexOf( mMultiEditButton ) >= 0 );
-  bool fieldReadOnly = layer()->editFormConfig().readOnly( mWidget->fieldIdx() );
+  bool fieldReadOnly = layer()->editFormConfig().readOnly( mEditorWidget->fieldIdx() );
 
   if ( hasMultiEditButton )
   {

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -52,7 +52,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
     mEditorWidget->widget()->setObjectName( mEditorWidget->field().name() );
   }
 
-  connect( mEditorWidget, static_cast<void ( QgsEditorWidgetWrapper::* )( const QVariant &value )>( &QgsEditorWidgetWrapper::valueChanged ), this, &QgsAttributeFormEditorWidget::editorWidgetValueChanged );
+  connect( mEditorWidget, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeFormEditorWidget::editorWidgetValuesChanged );
 
   connect( mMultiEditButton, &QgsMultiEditToolButton::resetFieldValueTriggered, this, &QgsAttributeFormEditorWidget::resetValue );
   connect( mMultiEditButton, &QgsMultiEditToolButton::setFieldValueTriggered, this, &QgsAttributeFormEditorWidget::setFieldTriggered );
@@ -164,7 +164,7 @@ QVariant QgsAttributeFormEditorWidget::currentValue() const
 
 
 
-void QgsAttributeFormEditorWidget::editorWidgetValueChanged( const QVariant &value )
+void QgsAttributeFormEditorWidget::editorWidgetValuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
 {
   if ( mBlockValueUpdate )
     return;
@@ -181,7 +181,7 @@ void QgsAttributeFormEditorWidget::editorWidgetValueChanged( const QVariant &val
       mMultiEditButton->setIsChanged( true );
   }
 
-  emit valueChanged( value );
+  emit valuesChanged( value, additionalFieldValues );
 }
 
 void QgsAttributeFormEditorWidget::resetValue()

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -52,7 +52,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
     mEditorWidget->widget()->setObjectName( mEditorWidget->field().name() );
   }
 
-  connect( mEditorWidget, &QgsEditorWidgetWrapper::valueChanged, this, &QgsAttributeFormEditorWidget::editorWidgetValuesChanged );
+  connect( mEditorWidget, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeFormEditorWidget::editorWidgetValuesChanged );
 
   connect( mMultiEditButton, &QgsMultiEditToolButton::resetFieldValueTriggered, this, &QgsAttributeFormEditorWidget::resetValue );
   connect( mMultiEditButton, &QgsMultiEditToolButton::setFieldValueTriggered, this, &QgsAttributeFormEditorWidget::setFieldTriggered );
@@ -147,7 +147,7 @@ void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, boo
   if ( mEditorWidget )
   {
     mBlockValueUpdate = true;
-    mEditorWidget->setValue( initialValue, additionalFieldValues );
+    mEditorWidget->setValues( initialValue, additionalFieldValues );
     mBlockValueUpdate = false;
   }
   mPreviousValue = initialValue;
@@ -189,7 +189,7 @@ void QgsAttributeFormEditorWidget::resetValue()
   mIsChanged = false;
   mBlockValueUpdate = true;
   if ( mEditorWidget )
-    mEditorWidget->setValue( mPreviousValue, mPreviousAdditionalValues );
+    mEditorWidget->setValues( mPreviousValue, mPreviousAdditionalValues );
   mBlockValueUpdate = false;
 
   switch ( mode() )

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -142,7 +142,7 @@ void QgsAttributeFormEditorWidget::changesCommitted()
 
 
 
-void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, bool mixedValues, const QgsAttributeMap &additionalFieldValues )
+void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, bool mixedValues, const QVariantList &additionalFieldValues )
 {
   if ( mEditorWidget )
   {
@@ -164,7 +164,7 @@ QVariant QgsAttributeFormEditorWidget::currentValue() const
 
 
 
-void QgsAttributeFormEditorWidget::editorWidgetValuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues )
+void QgsAttributeFormEditorWidget::editorWidgetValuesChanged( const QVariant &value, const QVariantList &additionalFieldValues )
 {
   if ( mBlockValueUpdate )
     return;

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -52,7 +52,7 @@ QgsAttributeFormEditorWidget::QgsAttributeFormEditorWidget( QgsEditorWidgetWrapp
     mEditorWidget->widget()->setObjectName( mEditorWidget->field().name() );
   }
 
-  connect( mEditorWidget, &QgsEditorWidgetWrapper::valuesChanged, this, &QgsAttributeFormEditorWidget::editorWidgetValuesChanged );
+  connect( mEditorWidget, &QgsEditorWidgetWrapper::valueChanged, this, &QgsAttributeFormEditorWidget::editorWidgetValuesChanged );
 
   connect( mMultiEditButton, &QgsMultiEditToolButton::resetFieldValueTriggered, this, &QgsAttributeFormEditorWidget::resetValue );
   connect( mMultiEditButton, &QgsMultiEditToolButton::setFieldValueTriggered, this, &QgsAttributeFormEditorWidget::setFieldTriggered );
@@ -147,7 +147,7 @@ void QgsAttributeFormEditorWidget::initialize( const QVariant &initialValue, boo
   if ( mEditorWidget )
   {
     mBlockValueUpdate = true;
-    mEditorWidget->setValues( initialValue, additionalFieldValues );
+    mEditorWidget->setValue( initialValue, additionalFieldValues );
     mBlockValueUpdate = false;
   }
   mPreviousValue = initialValue;
@@ -189,7 +189,7 @@ void QgsAttributeFormEditorWidget::resetValue()
   mIsChanged = false;
   mBlockValueUpdate = true;
   if ( mEditorWidget )
-    mEditorWidget->setValues( mPreviousValue, mPreviousAdditionalValues );
+    mEditorWidget->setValue( mPreviousValue, mPreviousAdditionalValues );
   mBlockValueUpdate = false;
 
   switch ( mode() )

--- a/src/gui/qgsattributeformeditorwidget.cpp
+++ b/src/gui/qgsattributeformeditorwidget.cpp
@@ -181,6 +181,9 @@ void QgsAttributeFormEditorWidget::editorWidgetValuesChanged( const QVariant &va
       mMultiEditButton->setIsChanged( true );
   }
 
+  Q_NOWARN_DEPRECATED_PUSH
+  emit valueChanged( value );
+  Q_NOWARN_DEPRECATED_POP
   emit valuesChanged( value, additionalFieldValues );
 }
 

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -65,7 +65,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
      * \param mixedValues set to TRUE to initially show the mixed values state
      * \param additionalValues a variant map of additional field names with their corresponding values
      */
-    void initialize( const QVariant &initialValue, bool mixedValues = false, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
+    void initialize( const QVariant &initialValue, bool mixedValues = false, const QVariantList &additionalFieldValues = QVariantList() );
 
     /**
      * Returns TRUE if the widget's value has been changed since it was initialized.
@@ -121,12 +121,12 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
      * \param value new widget value
      * \since QGIS 3.10
      */
-    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void valuesChanged( const QVariant &value, const QVariantList &additionalFieldValues );
 
   private slots:
 
     //! Triggered when editor widget's value changes
-    void editorWidgetValuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
+    void editorWidgetValuesChanged( const QVariant &value, const QVariantList &additionalFieldValues );
 
     //! Triggered when multi edit tool button requests value reset
     void resetValue();
@@ -145,7 +145,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     QgsMultiEditToolButton *mMultiEditButton = nullptr;
     QgsAggregateToolButton *mAggregateButton = nullptr;
     QVariant mPreviousValue;
-    QgsAttributeMap mPreviousAdditionalValues;
+    QVariantList mPreviousAdditionalValues;
     bool mBlockValueUpdate;
     bool mIsMixed;
     bool mIsChanged;

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -63,8 +63,9 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
      * Resets the widget to an initial value.
      * \param initialValue initial value to show in widget
      * \param mixedValues set to TRUE to initially show the mixed values state
+     * \param additionalValues a variant map of additional field names with their corresponding values
      */
-    void initialize( const QVariant &initialValue, bool mixedValues = false );
+    void initialize( const QVariant &initialValue, bool mixedValues = false, const QgsAttributeMap &additionalFieldValues = QgsAttributeMap() );
 
     /**
      * Returns TRUE if the widget's value has been changed since it was initialized.
@@ -86,6 +87,12 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
      * Set the constraint result label visible or invisible according to the layer editable status
      */
     void setConstraintResultVisible( bool editable );
+
+    /**
+     * Return the editor widget wrapper
+     * \since QGIS 3.10
+     */
+    QgsEditorWidgetWrapper *editorWidget() const;
 
   public slots:
 
@@ -111,7 +118,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
   private slots:
 
     //! Triggered when editor widget's value changes
-    void editorWidgetChanged( const QVariant &value );
+    void editorWidgetValueChanged( const QVariant &value );
 
     //! Triggered when multi edit tool button requests value reset
     void resetValue();
@@ -123,13 +130,14 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
 
   private:
     QString mWidgetType;
-    QgsEditorWidgetWrapper *mWidget = nullptr;
+    QgsEditorWidgetWrapper *mEditorWidget = nullptr;
     QgsAttributeForm *mForm = nullptr;
     QLabel *mConstraintResultLabel = nullptr;
 
     QgsMultiEditToolButton *mMultiEditButton = nullptr;
     QgsAggregateToolButton *mAggregateButton = nullptr;
     QVariant mPreviousValue;
+    QgsAttributeMap mPreviousAdditionalValues;
     bool mBlockValueUpdate;
     bool mIsMixed;
     bool mIsChanged;

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -63,7 +63,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
      * Resets the widget to an initial value.
      * \param initialValue initial value to show in widget
      * \param mixedValues set to TRUE to initially show the mixed values state
-     * \param additionalValues a variant map of additional field names with their corresponding values
+     * \param additionalFieldValues a variant map of additional field names with their corresponding values
      */
     void initialize( const QVariant &initialValue, bool mixedValues = false, const QVariantList &additionalFieldValues = QVariantList() );
 
@@ -119,6 +119,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     /**
      * Emitted when the widget's value changes
      * \param value new widget value
+     * \param additionalFieldValues of the potential additional fields
      * \since QGIS 3.10
      */
     void valuesChanged( const QVariant &value, const QVariantList &additionalFieldValues );

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -89,7 +89,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     void setConstraintResultVisible( bool editable );
 
     /**
-     * Return the editor widget wrapper
+     * Returns the editor widget wrapper
      * \since QGIS 3.10
      */
     QgsEditorWidgetWrapper *editorWidget() const;

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -112,13 +112,21 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
     /**
      * Emitted when the widget's value changes
      * \param value new widget value
+     * \deprecated since QGIS 3.10 use valuesChanged instead
      */
-    void valueChanged( const QVariant &value );
+    Q_DECL_DEPRECATED void valueChanged( const QVariant &value );
+
+    /**
+     * Emitted when the widget's value changes
+     * \param value new widget value
+     * \since QGIS 3.10
+     */
+    void valuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
 
   private slots:
 
     //! Triggered when editor widget's value changes
-    void editorWidgetValueChanged( const QVariant &value );
+    void editorWidgetValuesChanged( const QVariant &value, const QgsAttributeMap &additionalFieldValues );
 
     //! Triggered when multi edit tool button requests value reset
     void resetValue();

--- a/src/gui/qgsformannotation.cpp
+++ b/src/gui/qgsformannotation.cpp
@@ -99,7 +99,13 @@ QWidget *QgsFormAnnotation::createDesignerWidget( const QString &filePath )
           QgsEditorWidgetWrapper *eww = QgsGui::editorWidgetRegistry()->create( vectorLayer, i, attWidget, widget, context );
           if ( eww )
           {
-            eww->setValue( attrs.at( i ) );
+            const QgsAttributeList additionalFields = eww->additionalFields();
+            QgsAttributeMap additionalFieldValues;
+            for ( int index : additionalFields )
+            {
+              additionalFieldValues.insert( index, attrs.at( index ) );
+            }
+            eww->setValues( attrs.at( i ), additionalFieldValues );
           }
         }
       }

--- a/src/gui/qgsformannotation.cpp
+++ b/src/gui/qgsformannotation.cpp
@@ -105,7 +105,7 @@ QWidget *QgsFormAnnotation::createDesignerWidget( const QString &filePath )
             {
               additionalFieldValues.insert( index, attrs.at( index ) );
             }
-            eww->setValues( attrs.at( i ), additionalFieldValues );
+            eww->setValue( attrs.at( i ), additionalFieldValues );
           }
         }
       }

--- a/src/gui/qgsformannotation.cpp
+++ b/src/gui/qgsformannotation.cpp
@@ -99,10 +99,11 @@ QWidget *QgsFormAnnotation::createDesignerWidget( const QString &filePath )
           QgsEditorWidgetWrapper *eww = QgsGui::editorWidgetRegistry()->create( vectorLayer, i, attWidget, widget, context );
           if ( eww )
           {
-            const QgsAttributeList additionalFields = eww->additionalFields();
-            QgsAttributeMap additionalFieldValues;
-            for ( int index : additionalFields )
+            const QStringList additionalFields = eww->additionalFields();
+            QVariantList additionalFieldValues;
+            for ( const QString &additionalField : additionalFields )
             {
+              int index = vectorLayer->fields().indexFromName( additionalField );
               additionalFieldValues.insert( index, attrs.at( index ) );
             }
             eww->setValues( attrs.at( i ), additionalFieldValues );

--- a/src/gui/qgsformannotation.cpp
+++ b/src/gui/qgsformannotation.cpp
@@ -105,7 +105,7 @@ QWidget *QgsFormAnnotation::createDesignerWidget( const QString &filePath )
             {
               additionalFieldValues.insert( index, attrs.at( index ) );
             }
-            eww->setValue( attrs.at( i ), additionalFieldValues );
+            eww->setValues( attrs.at( i ), additionalFieldValues );
           }
         }
       }

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -120,19 +120,19 @@ void TestQgsAttributeForm::testFieldConstraint()
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[0] );
 
   // set value to 1
-  ww->setValues( 1, QgsAttributeMap() );
+  ww->setValues( 1, QVariantList() );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( constraintsLabel( &form2, ww )->text(), validLabel );
 
   // set value to null
   spy.clear();
-  ww->setValues( QVariant(), QgsAttributeMap() );
+  ww->setValues( QVariant(), QVariantList() );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( constraintsLabel( &form2, ww )->text(), invalidLabel );
 
   // set value to 1
   spy.clear();
-  ww->setValues( 1, QgsAttributeMap() );
+  ww->setValues( 1, QVariantList() );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( constraintsLabel( &form2, ww )->text(), validLabel );
 
@@ -145,15 +145,15 @@ void TestQgsAttributeForm::testFieldConstraint()
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form3.mWidgets[0] );
 
   // set value to 1
-  ww->setValues( 1, QgsAttributeMap() );
+  ww->setValues( 1, QVariantList() );
   QCOMPARE( constraintsLabel( &form3, ww )->text(), validLabel );
 
   // set value to null
-  ww->setValues( QVariant(), QgsAttributeMap() );
+  ww->setValues( QVariant(), QVariantList() );
   QCOMPARE( constraintsLabel( &form3, ww )->text(), warningLabel );
 
   // set value to 1
-  ww->setValues( 1, QgsAttributeMap() );
+  ww->setValues( 1, QVariantList() );
   QCOMPARE( constraintsLabel( &form3, ww )->text(), validLabel );
 }
 
@@ -213,7 +213,7 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   QSignalSpy spy2( &form2, SIGNAL( widgetValueChanged( QString, QVariant, bool ) ) );
 
   // change value
-  ww0->setValues( 2, QgsAttributeMap() ); // update col0
+  ww0->setValues( 2, QVariantList() ); // update col0
   QCOMPARE( spy2.count(), 1 );
 
   QCOMPARE( constraintsLabel( &form2, ww0 )->text(), inv ); // 2 < ( 1 + 2 )
@@ -223,7 +223,7 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
 
   // change value
   spy2.clear();
-  ww0->setValues( 1, QgsAttributeMap() ); // update col0
+  ww0->setValues( 1, QVariantList() ); // update col0
   QCOMPARE( spy2.count(), 1 );
 
   QCOMPARE( constraintsLabel( &form2, ww0 )->text(), val ); // 1 < ( 1 + 2 )
@@ -277,7 +277,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   form2.setFeature( ft );
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[0] );
   okButton = form2.mButtonBox->button( QDialogButtonBox::Ok );
-  ww->setValues( 1, QgsAttributeMap() );
+  ww->setValues( 1, QVariantList() );
   QCOMPARE( okButton->isEnabled(), false );
 
   // valid constraint and editable layer : OK button enabled
@@ -287,7 +287,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form3.mWidgets[0] );
   okButton = form3.mButtonBox->button( QDialogButtonBox::Ok );
 
-  ww->setValues( 2, QgsAttributeMap() );
+  ww->setValues( 2, QVariantList() );
   QCOMPARE( okButton->isEnabled(), true );
 
   // valid constraint and not editable layer : OK button disabled
@@ -302,7 +302,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   form4.setFeature( ft );
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form4.mWidgets[0] );
   okButton = form4.mButtonBox->button( QDialogButtonBox::Ok );
-  ww->setValues( 1, QgsAttributeMap() );
+  ww->setValues( 1, QVariantList() );
   QVERIFY( !okButton->isEnabled() );
   layer->startEditing();
   // just a soft constraint, so OK should be enabled

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -120,19 +120,19 @@ void TestQgsAttributeForm::testFieldConstraint()
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[0] );
 
   // set value to 1
-  ww->setValue( 1 );
+  ww->setValues( 1, QgsAttributeMap() );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( constraintsLabel( &form2, ww )->text(), validLabel );
 
   // set value to null
   spy.clear();
-  ww->setValue( QVariant() );
+  ww->setValues( QVariant(), QgsAttributeMap() );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( constraintsLabel( &form2, ww )->text(), invalidLabel );
 
   // set value to 1
   spy.clear();
-  ww->setValue( 1 );
+  ww->setValues( 1, QgsAttributeMap() );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( constraintsLabel( &form2, ww )->text(), validLabel );
 
@@ -145,15 +145,15 @@ void TestQgsAttributeForm::testFieldConstraint()
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form3.mWidgets[0] );
 
   // set value to 1
-  ww->setValue( 1 );
+  ww->setValues( 1, QgsAttributeMap() );
   QCOMPARE( constraintsLabel( &form3, ww )->text(), validLabel );
 
   // set value to null
-  ww->setValue( QVariant() );
+  ww->setValues( QVariant(), QgsAttributeMap() );
   QCOMPARE( constraintsLabel( &form3, ww )->text(), warningLabel );
 
   // set value to 1
-  ww->setValue( 1 );
+  ww->setValues( 1, QgsAttributeMap() );
   QCOMPARE( constraintsLabel( &form3, ww )->text(), validLabel );
 }
 
@@ -213,7 +213,7 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   QSignalSpy spy2( &form2, SIGNAL( widgetValueChanged( QString, QVariant, bool ) ) );
 
   // change value
-  ww0->setValue( 2 ); // update col0
+  ww0->setValues( 2, QgsAttributeMap() ); // update col0
   QCOMPARE( spy2.count(), 1 );
 
   QCOMPARE( constraintsLabel( &form2, ww0 )->text(), inv ); // 2 < ( 1 + 2 )
@@ -223,7 +223,7 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
 
   // change value
   spy2.clear();
-  ww0->setValue( 1 ); // update col0
+  ww0->setValues( 1, QgsAttributeMap() ); // update col0
   QCOMPARE( spy2.count(), 1 );
 
   QCOMPARE( constraintsLabel( &form2, ww0 )->text(), val ); // 1 < ( 1 + 2 )
@@ -277,7 +277,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   form2.setFeature( ft );
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form2.mWidgets[0] );
   okButton = form2.mButtonBox->button( QDialogButtonBox::Ok );
-  ww->setValue( 1 );
+  ww->setValues( 1, QgsAttributeMap() );
   QCOMPARE( okButton->isEnabled(), false );
 
   // valid constraint and editable layer : OK button enabled
@@ -287,7 +287,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form3.mWidgets[0] );
   okButton = form3.mButtonBox->button( QDialogButtonBox::Ok );
 
-  ww->setValue( 2 );
+  ww->setValues( 2, QgsAttributeMap() );
   QCOMPARE( okButton->isEnabled(), true );
 
   // valid constraint and not editable layer : OK button disabled
@@ -302,7 +302,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   form4.setFeature( ft );
   ww = qobject_cast<QgsEditorWidgetWrapper *>( form4.mWidgets[0] );
   okButton = form4.mButtonBox->button( QDialogButtonBox::Ok );
-  ww->setValue( 1 );
+  ww->setValues( 1, QgsAttributeMap() );
   QVERIFY( !okButton->isEnabled() );
   layer->startEditing();
   // just a soft constraint, so OK should be enabled

--- a/tests/src/gui/testqgskeyvaluewidget.cpp
+++ b/tests/src/gui/testqgskeyvaluewidget.cpp
@@ -51,7 +51,7 @@ class TestQgsKeyValueWidget : public QObject
       QVariantMap initial;
       initial[QStringLiteral( "1" )] = "one";
       initial[QStringLiteral( "2" )] = "two";
-      wrapper->setValue( initial );
+      wrapper->setValues( initial, QgsAttributeMap() );
 
       const QVariant value = wrapper->value();
       QCOMPARE( int( value.type() ), int( QVariant::Map ) );

--- a/tests/src/gui/testqgskeyvaluewidget.cpp
+++ b/tests/src/gui/testqgskeyvaluewidget.cpp
@@ -51,7 +51,7 @@ class TestQgsKeyValueWidget : public QObject
       QVariantMap initial;
       initial[QStringLiteral( "1" )] = "one";
       initial[QStringLiteral( "2" )] = "two";
-      wrapper->setValues( initial, QgsAttributeMap() );
+      wrapper->setValues( initial, QVariantList() );
 
       const QVariant value = wrapper->value();
       QCOMPARE( int( value.type() ), int( QVariant::Map ) );

--- a/tests/src/gui/testqgslistwidget.cpp
+++ b/tests/src/gui/testqgslistwidget.cpp
@@ -49,7 +49,7 @@ class TestQgsListWidget : public QObject
 
       QStringList initial;
       initial << QStringLiteral( "one" ) << QStringLiteral( "two" );
-      wrapper->setValues( initial, QgsAttributeMap() );
+      wrapper->setValues( initial, QVariantList() );
 
       const QVariant value = wrapper->value();
       QCOMPARE( int( value.type() ), int( QVariant::StringList ) );
@@ -84,7 +84,7 @@ class TestQgsListWidget : public QObject
 
       QVariantList initial;
       initial << 1 << -2;
-      wrapper->setValues( initial, QgsAttributeMap() );
+      wrapper->setValues( initial, QVariantList() );
 
       const QVariant value = wrapper->value();
       QCOMPARE( int( value.type() ), int( QVariant::List ) );

--- a/tests/src/gui/testqgslistwidget.cpp
+++ b/tests/src/gui/testqgslistwidget.cpp
@@ -49,7 +49,7 @@ class TestQgsListWidget : public QObject
 
       QStringList initial;
       initial << QStringLiteral( "one" ) << QStringLiteral( "two" );
-      wrapper->setValue( initial );
+      wrapper->setValues( initial, QgsAttributeMap() );
 
       const QVariant value = wrapper->value();
       QCOMPARE( int( value.type() ), int( QVariant::StringList ) );
@@ -84,7 +84,7 @@ class TestQgsListWidget : public QObject
 
       QVariantList initial;
       initial << 1 << -2;
-      wrapper->setValue( initial );
+      wrapper->setValues( initial, QgsAttributeMap() );
 
       const QVariant value = wrapper->value();
       QCOMPARE( int( value.type() ), int( QVariant::List ) );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -180,7 +180,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   QCOMPARE( w_municipality.mComboBox->count(), 2 );
 
   // check that valueChanged signal is correctly triggered
-  QSignalSpy spy( &w_municipality, &QgsEditorWidgetWrapper::valueChanged );
+  QSignalSpy spy( &w_municipality, &QgsEditorWidgetWrapper::valuesChanged );
 
   w_municipality.setFeature( f3 );
   QCOMPARE( spy.count(), 1 );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -180,7 +180,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   QCOMPARE( w_municipality.mComboBox->count(), 2 );
 
   // check that valueChanged signal is correctly triggered
-  QSignalSpy spy( &w_municipality, &QgsEditorWidgetWrapper::valuesChanged );
+  QSignalSpy spy( &w_municipality, &QgsEditorWidgetWrapper::valueChanged );
 
   w_municipality.setFeature( f3 );
   QCOMPARE( spy.count(), 1 );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -322,7 +322,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
 #endif
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
-  w_municipality.setValues( QStringLiteral( "{1,2}" ), QgsAttributeMap() );
+  w_municipality.setValues( QStringLiteral( "{1,2}" ), QVariantList() );
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,4,0)
   QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 2, 1 } ) ) );
 #else
@@ -332,7 +332,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
 
   // Check with passing a variant list
-  w_municipality.setValues( QVariantList( {1, 2} ), QgsAttributeMap() );
+  w_municipality.setValues( QVariantList( {1, 2} ), QVariantList() );
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,4,0)
   QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 2, 1 } ) ) );
 #else
@@ -405,7 +405,7 @@ void TestQgsValueRelationWidgetWrapper::testZeroIndexInRelatedTable()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  w_municipality.setValues( 0, QgsAttributeMap() );
+  w_municipality.setValues( 0, QVariantList() );
   QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );
   QCOMPARE( w_municipality.mComboBox->currentText(), QStringLiteral( "Some Place By The River" ) );
 }
@@ -1585,7 +1585,7 @@ void TestQgsValueRelationWidgetWrapper::testMatchLayerName()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  w_municipality.setValues( 0, QgsAttributeMap() );
+  w_municipality.setValues( 0, QVariantList() );
   QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );
   QCOMPARE( w_municipality.mComboBox->currentText(), QStringLiteral( "Some Place By The River" ) );
 }

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -322,7 +322,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
 #endif
   QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
-  w_municipality.setValue( QStringLiteral( "{1,2}" ) );
+  w_municipality.setValues( QStringLiteral( "{1,2}" ), QgsAttributeMap() );
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,4,0)
   QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 2, 1 } ) ) );
 #else
@@ -332,7 +332,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
   QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
 
   // Check with passing a variant list
-  w_municipality.setValue( QVariantList( {1, 2} ) );
+  w_municipality.setValues( QVariantList( {1, 2} ), QgsAttributeMap() );
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,4,0)
   QCOMPARE( w_municipality.value(), QVariant( QVariantList( { 2, 1 } ) ) );
 #else
@@ -405,7 +405,7 @@ void TestQgsValueRelationWidgetWrapper::testZeroIndexInRelatedTable()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  w_municipality.setValue( 0 );
+  w_municipality.setValues( 0, QgsAttributeMap() );
   QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );
   QCOMPARE( w_municipality.mComboBox->currentText(), QStringLiteral( "Some Place By The River" ) );
 }
@@ -1585,7 +1585,7 @@ void TestQgsValueRelationWidgetWrapper::testMatchLayerName()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  w_municipality.setValue( 0 );
+  w_municipality.setValues( 0, QgsAttributeMap() );
   QCOMPARE( w_municipality.mComboBox->currentIndex(), 1 );
   QCOMPARE( w_municipality.mComboBox->currentText(), QStringLiteral( "Some Place By The River" ) );
 }


### PR DESCRIPTION
This allows editor widgets to take responsibility over several additional fields.
This is intended to be used for the relation reference widget for composite keys.