### PR TITLE
[style manager] Fetch remote style XML file using QgsNetworkContentFetcherTask

### DIFF
--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -417,7 +417,7 @@ void QgsStyleExportImportDialog::downloadStyleXml( const QUrl &url )
         mTempFile->close();
         populateStyles();
       }
-      delete progressDlg;
+      progressDlg->deleteLater();
     } );
 
     QgsApplication::taskManager()->addTask( fetcher );

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -17,11 +17,13 @@
 #include "qgsstyleexportimportdialog.h"
 #include "ui_qgsstyleexportimportdialogbase.h"
 
+#include "qgsapplication.h"
 #include "qgsstyle.h"
 #include "qgssymbol.h"
 #include "qgssymbollayerutils.h"
 #include "qgscolorramp.h"
 #include "qgslogger.h"
+#include "qgsnetworkcontentfetchertask.h"
 #include "qgsstylegroupselectiondialog.h"
 #include "qgsguiutils.h"
 #include "qgssettings.h"
@@ -33,11 +35,10 @@
 #include <QCloseEvent>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QNetworkReply>
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QStandardItemModel>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
 
 
 QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget *parent, Mode mode )
@@ -62,11 +63,8 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
   mTempStyle->createMemoryDatabase();
 
   // TODO validate
-  mProgressDlg = nullptr;
   mGroupSelectionDlg = nullptr;
   mTempFile = nullptr;
-  mNetManager = new QNetworkAccessManager( this );
-  mNetReply = nullptr;
 
   if ( mDialogMode == Import )
   {
@@ -387,77 +385,43 @@ void QgsStyleExportImportDialog::importFileChanged( const QString &path )
 
 void QgsStyleExportImportDialog::downloadStyleXml( const QUrl &url )
 {
-  // XXX Try to move this code to some core Network interface,
-  // HTTP downloading is a generic functionality that might be used elsewhere
-
   mTempFile = new QTemporaryFile();
   if ( mTempFile->open() )
   {
     mFileName = mTempFile->fileName();
 
-    if ( mProgressDlg )
+    QProgressDialog *progressDlg = new QProgressDialog( this );
+    progressDlg->setLabelText( tr( "Downloading style…" ) );
+    progressDlg->setAutoClose( true );
+    progressDlg->show();
+
+    QgsNetworkContentFetcherTask *fetcher = new QgsNetworkContentFetcherTask( url );
+    fetcher->setDescription( tr( "Downloading style" ) );
+    connect( progressDlg, &QProgressDialog::canceled, fetcher, &QgsNetworkContentFetcherTask::cancel );
+    connect( fetcher, &QgsNetworkContentFetcherTask::progressChanged, [progressDlg]( double progress ) { progressDlg->setValue( progress ); } );
+    connect( fetcher, &QgsNetworkContentFetcherTask::fetched, this, [this, fetcher, progressDlg]
     {
-      QProgressDialog *dummy = mProgressDlg;
-      mProgressDlg = nullptr;
-      delete dummy;
-    }
-    mProgressDlg = new QProgressDialog();
-    mProgressDlg->setLabelText( tr( "Downloading style…" ) );
-    mProgressDlg->setAutoClose( true );
+      QNetworkReply *reply = fetcher->reply();
+      if ( !reply || reply->error() != QNetworkReply::NoError )
+      {
+        mTempFile->remove();
+        mFileName.clear();
+        if ( reply )
+          QMessageBox::information( this, tr( "Import from URL" ),
+                                    tr( "HTTP Error! Download failed: %1." ).arg( reply->errorString() ) );
+      }
+      else
+      {
+        mTempFile->write( reply->readAll() );
+        mTempFile->flush();
+        mTempFile->close();
+        populateStyles();
+      }
+      delete progressDlg;
+    } );
 
-    connect( mProgressDlg, &QProgressDialog::canceled, this, &QgsStyleExportImportDialog::downloadCanceled );
-
-    // open the network connection and connect the respective slots
-    if ( mNetReply )
-    {
-      QNetworkReply *dummyReply = mNetReply;
-      mNetReply = nullptr;
-      delete dummyReply;
-    }
-    mNetReply = mNetManager->get( QNetworkRequest( url ) );
-
-    connect( mNetReply, &QNetworkReply::finished, this, &QgsStyleExportImportDialog::httpFinished );
-    connect( mNetReply, &QIODevice::readyRead, this, &QgsStyleExportImportDialog::fileReadyRead );
-    connect( mNetReply, &QNetworkReply::downloadProgress, this, &QgsStyleExportImportDialog::updateProgress );
+    QgsApplication::taskManager()->addTask( fetcher );
   }
-}
-
-void QgsStyleExportImportDialog::httpFinished()
-{
-  if ( mNetReply->error() )
-  {
-    mTempFile->remove();
-    mFileName.clear();
-    mProgressDlg->hide();
-    QMessageBox::information( this, tr( "Import from URL" ),
-                              tr( "HTTP Error! Download failed: %1." ).arg( mNetReply->errorString() ) );
-    return;
-  }
-  else
-  {
-    mTempFile->flush();
-    mTempFile->close();
-    mTempStyle->clear();
-    populateStyles();
-  }
-}
-
-void QgsStyleExportImportDialog::fileReadyRead()
-{
-  mTempFile->write( mNetReply->readAll() );
-}
-
-void QgsStyleExportImportDialog::updateProgress( qint64 bytesRead, qint64 bytesTotal )
-{
-  mProgressDlg->setMaximum( bytesTotal );
-  mProgressDlg->setValue( bytesRead );
-}
-
-void QgsStyleExportImportDialog::downloadCanceled()
-{
-  mNetReply->abort();
-  mTempFile->remove();
-  mFileName.clear();
 }
 
 void QgsStyleExportImportDialog::selectionChanged( const QItemSelection &selected, const QItemSelection &deselected )

--- a/src/gui/symbology/qgsstyleexportimportdialog.h
+++ b/src/gui/symbology/qgsstyleexportimportdialog.h
@@ -32,9 +32,6 @@ class QgsStyleGroupSelectionDialog;
 class QgsTemporaryCursorOverride;
 class QgsStyleModel;
 class QTemporaryFile;
-class QProgressDialog;
-class QNetworkAccessManager;
-class QNetworkReply;
 
 /**
  * \ingroup gui
@@ -126,10 +123,6 @@ class GUI_EXPORT QgsStyleExportImportDialog : public QDialog, private Ui::QgsSty
     void importTypeChanged( int );
 
   private slots:
-    void httpFinished();
-    void fileReadyRead();
-    void updateProgress( qint64, qint64 );
-    void downloadCanceled();
     void selectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
     void showHelp();
 
@@ -149,11 +142,8 @@ class GUI_EXPORT QgsStyleExportImportDialog : public QDialog, private Ui::QgsSty
     bool populateStyles();
     void moveStyles( QModelIndexList *selection, QgsStyle *src, QgsStyle *dst );
 
-    QProgressDialog *mProgressDlg = nullptr;
     QgsStyleGroupSelectionDialog *mGroupSelectionDlg = nullptr;
     QTemporaryFile *mTempFile = nullptr;
-    QNetworkAccessManager *mNetManager = nullptr;
-    QNetworkReply *mNetReply = nullptr;
 
     QString mFileName;
     Mode mDialogMode;


### PR DESCRIPTION
## Description
Advantages include:
- automatic handling of URL redirects
- use the user's authentication settings

@nyalldawson , as discussed a while back.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
