### PR TITLE
[needs-docs] Remove duplicate 'Ctrl+Shift+M' shortcuts

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -213,11 +213,11 @@ class ProcessingPlugin:
 
         self.modelerAction = QAction(
             QgsApplication.getThemeIcon("/processingModel.svg"),
-            QCoreApplication.translate('ProcessingPlugin', 'Graphical &Modeler…'), self.iface.mainWindow())
+            QCoreApplication.translate('ProcessingPlugin', '&Graphical Modeler…'), self.iface.mainWindow())
         self.modelerAction.setObjectName('modelerAction')
         self.modelerAction.triggered.connect(self.openModeler)
         self.iface.registerMainWindowAction(self.modelerAction,
-                                            QKeySequence('Ctrl+Alt+M').toString(QKeySequence.NativeText))
+                                            QKeySequence('Ctrl+Alt+G').toString(QKeySequence.NativeText))
         self.menu.addAction(self.modelerAction)
 
         self.historyAction = QAction(

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1257,7 +1257,7 @@
     <string>Measure Line</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+M</string>
+    <string>Ctrl+Shift+K</string>
    </property>
   </action>
   <action name="mActionMeasureArea">
@@ -3060,7 +3060,7 @@ Acts on the currently active editable layer only.</string>
     <string>New 3D Map View</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+M</string>
+    <string>Ctrl+Alt+M</string>
    </property>
   </action>
   <action name="mActionShowLayoutManager">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1257,7 +1257,7 @@
     <string>Measure Line</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Shift+K</string>
+    <string>Ctrl+Shift+M</string>
    </property>
   </action>
   <action name="mActionMeasureArea">
@@ -1534,9 +1534,6 @@
    </property>
    <property name="text">
     <string>Add MSSQL Spatial Layer…</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Shift+M</string>
    </property>
   </action>
   <action name="mActionAddDb2Layer">


### PR DESCRIPTION
Fix #31183 
`Ctrl+Shift+M` shortcut failed because it's shared by three commands all accessible from the main window:
  * by "New 3D Map View" whose close neighbour "New Map View" uses `Ctrl+M` (note that `Ctrl+Alt+M` is used by the "Processing Graphical Modeler" whose neighbors are also of `Ctrl+Alt+` type)
  * by "Measure Line" whose neighbors "Measure Area" has `Ctrl+Shift+J` and "Measure Angle" has nothing
  * by "Add MSSQL Layer" whose neigbors are of `Ctrl+Shift+` type

So here's a proposal:
- Keep `Ctrl+Shift+M` for ""Add MSSQL Layer"
- The "New 3D Map View" takes `Ctrl+Alt+M`
- Then "Processing Graphical Modeler" moved to `Ctrl+Alt+G` (I checked, it's not assigned by default)
- For the Measure Line, I go with `Ctrl+Shift+K` (if we really need a shortcut and since J is used for area). And Angle?

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
