### PR TITLE
GeoPDF export, gui parts (#1)

### DIFF
--- a/python/core/auto_generated/qgsmaprenderertask.sip.in
+++ b/python/core/auto_generated/qgsmaprenderertask.sip.in
@@ -35,8 +35,7 @@ task. This can be used to draw maps without blocking the QGIS interface.
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
-                        bool forceRaster = false,
-                        bool geoPdf = false, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails = QgsAbstractGeoPdfExporter::ExportDetails() );
+                        bool forceRaster = false );
 %Docstring
 Constructor for QgsMapRendererTask to render a map to an image file.
 

--- a/python/core/auto_generated/qgsmaprenderertask.sip.in
+++ b/python/core/auto_generated/qgsmaprenderertask.sip.in
@@ -36,7 +36,7 @@ task. This can be used to draw maps without blocking the QGIS interface.
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
                         bool forceRaster = false,
-                        bool geoPdf = false );
+                        bool geoPdf = false, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails = QgsAbstractGeoPdfExporter::ExportDetails() );
 %Docstring
 Constructor for QgsMapRendererTask to render a map to an image file.
 

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -121,11 +121,11 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
 
       const bool geoPdfAvailable = QgsAbstractGeoPdfExporter::geoPDFCreationAvailable();
       mGeoPDFGroupBox->setEnabled( geoPdfAvailable );
+      mGeoPDFGroupBox->setChecked( false );
       if ( !geoPdfAvailable )
       {
-        mGeoPDFGroupBox->setChecked( false );
         mGeoPDFOptionsStackedWidget->setCurrentIndex( 0 );
-        mGeoPdfUnavailableReason->setText( mGeoPdfUnavailableReason::geoPDFAvailabilityExplanation() );
+        mGeoPdfUnavailableReason->setText( QgsAbstractGeoPdfExporter::geoPDFAvailabilityExplanation() );
       }
       else
       {
@@ -472,7 +472,21 @@ void QgsMapSaveDialog::onAccepted()
         QgsMapSettings ms = QgsMapSettings();
         applyMapSettings( ms );
 
-        QgsMapRendererTask *mapRendererTask = new QgsMapRendererTask( ms, fileName, QStringLiteral( "PDF" ), saveAsRaster(), mGeoPDFGroupBox->isChecked() );
+        QgsAbstractGeoPdfExporter::ExportDetails geoPdfExportDetails;
+        if ( mGeoPDFGroupBox->isChecked() )
+        {
+          if ( mExportMetadataCheckBox->isChecked() )
+          {
+            geoPdfExportDetails.author = QgsProject::instance()->metadata().author();
+            geoPdfExportDetails.producer = QStringLiteral( "QGIS %1" ).arg( Qgis::QGIS_VERSION );
+            geoPdfExportDetails.creator = QStringLiteral( "QGIS %1" ).arg( Qgis::QGIS_VERSION );
+            geoPdfExportDetails.creationDateTime = QDateTime::currentDateTime();
+            geoPdfExportDetails.subject = QgsProject::instance()->metadata().abstract();
+            geoPdfExportDetails.title = QgsProject::instance()->metadata().title();
+            geoPdfExportDetails.keywords = QgsProject::instance()->metadata().keywords();
+          }
+        }
+        QgsMapRendererTask *mapRendererTask = new QgsMapRendererTask( ms, fileName, QStringLiteral( "PDF" ), saveAsRaster(), mGeoPDFGroupBox->isChecked(), geoPdfExportDetails );
 
         if ( drawAnnotations() )
         {

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -517,6 +517,8 @@ void QgsMapSaveDialog::onAccepted()
             geoPdfExportDetails.useIso32000ExtensionFormatGeoreferencing = false;
             geoPdfExportDetails.useOgcBestPracticeFormatGeoreferencing = true;
           }
+
+          geoPdfExportDetails.includeFeatures = mExportGeoPdfFeaturesCheckBox->isChecked();
         }
         QgsMapRendererTask *mapRendererTask = new QgsMapRendererTask( ms, fileName, QStringLiteral( "PDF" ), saveAsRaster(), mGeoPDFGroupBox->isChecked(), geoPdfExportDetails );
 

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -128,6 +128,11 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
       {
         mGeoPDFOptionsStackedWidget->setCurrentIndex( 0 );
         mGeoPdfUnavailableReason->setText( QgsAbstractGeoPdfExporter::geoPDFAvailabilityExplanation() );
+        // avoid showing reason in disabled text color - we want it to stand out
+        QPalette p = mGeoPdfUnavailableReason->palette();
+        p.setColor( QPalette::Disabled, QPalette::WindowText, QPalette::WindowText );
+        mGeoPdfUnavailableReason->setPalette( p );
+        mGeoPDFOptionsStackedWidget->removeWidget( mGeoPDFOptionsStackedWidget->widget( 1 ) );
       }
       else
       {

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -137,6 +137,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
     case Image:
     {
       mGeoPDFGroupBox->hide();
+      mSimplifyGeometriesCheckbox->hide();
       QPushButton *button = new QPushButton( tr( "Copy to Clipboard" ) );
       buttonBox->addButton( button, QDialogButtonBox::ResetRole );
       connect( button, &QPushButton::clicked, this, &QgsMapSaveDialog::copyToClipboard );
@@ -473,6 +474,17 @@ void QgsMapSaveDialog::onAccepted()
 
         QgsMapSettings ms = QgsMapSettings();
         applyMapSettings( ms );
+
+        if ( mSimplifyGeometriesCheckbox->isChecked() )
+        {
+          QgsVectorSimplifyMethod simplifyMethod;
+          simplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::GeometrySimplification );
+          simplifyMethod.setForceLocalOptimization( true );
+          // we use SnappedToGridGlobal, because it avoids gaps and slivers between previously adjacent polygons
+          simplifyMethod.setSimplifyAlgorithm( QgsVectorSimplifyMethod::SnappedToGridGlobal );
+          simplifyMethod.setThreshold( 0.1f ); // (pixels). We are quite conservative here. This could possibly be bumped all the way up to 1. But let's play it safe.
+          ms.setSimplifyMethod( simplifyMethod );
+        }
 
         QgsAbstractGeoPdfExporter::ExportDetails geoPdfExportDetails;
         if ( mGeoPDFGroupBox->isChecked() )

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -119,6 +119,9 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
 
       this->setWindowTitle( tr( "Save Map as PDF" ) );
 
+      mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Paths (Recommended)" ), QgsRenderContext::TextFormatAlwaysOutlines );
+      mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Text Objects" ), QgsRenderContext::TextFormatAlwaysText );
+
       const bool geoPdfAvailable = QgsAbstractGeoPdfExporter::geoPDFCreationAvailable();
       mGeoPDFGroupBox->setEnabled( geoPdfAvailable );
       mGeoPDFGroupBox->setChecked( false );
@@ -140,6 +143,8 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
     {
       mGeoPDFGroupBox->hide();
       mSimplifyGeometriesCheckbox->hide();
+      mTextRenderFormatComboBox->hide();
+      mTextExportLabel->hide();
       QPushButton *button = new QPushButton( tr( "Copy to Clipboard" ) );
       buttonBox->addButton( button, QDialogButtonBox::ResetRole );
       connect( button, &QPushButton::clicked, this, &QgsMapSaveDialog::copyToClipboard );
@@ -487,6 +492,8 @@ void QgsMapSaveDialog::onAccepted()
           simplifyMethod.setThreshold( 0.1f ); // (pixels). We are quite conservative here. This could possibly be bumped all the way up to 1. But let's play it safe.
           ms.setSimplifyMethod( simplifyMethod );
         }
+
+        ms.setTextRenderFormat( static_cast< QgsRenderContext::TextRenderFormat >( mTextRenderFormatComboBox->currentData().toInt() ) );
 
         QgsAbstractGeoPdfExporter::ExportDetails geoPdfExportDetails;
         if ( mGeoPDFGroupBox->isChecked() )

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -130,6 +130,8 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
       else
       {
         mGeoPDFOptionsStackedWidget->setCurrentIndex( 1 );
+        mGeoPdfFormatComboBox->addItem( tr( "ISO 32000 Extension (recommended)" ) );
+        mGeoPdfFormatComboBox->addItem( tr( "OGC Best Practice" ) );
       }
       break;
     }
@@ -498,6 +500,17 @@ void QgsMapSaveDialog::onAccepted()
             geoPdfExportDetails.subject = QgsProject::instance()->metadata().abstract();
             geoPdfExportDetails.title = QgsProject::instance()->metadata().title();
             geoPdfExportDetails.keywords = QgsProject::instance()->metadata().keywords();
+          }
+
+          if ( mGeoPdfFormatComboBox->currentIndex() == 0 )
+          {
+            geoPdfExportDetails.useIso32000ExtensionFormatGeoreferencing = true;
+            geoPdfExportDetails.useOgcBestPracticeFormatGeoreferencing = false;
+          }
+          else
+          {
+            geoPdfExportDetails.useIso32000ExtensionFormatGeoreferencing = false;
+            geoPdfExportDetails.useOgcBestPracticeFormatGeoreferencing = true;
           }
         }
         QgsMapRendererTask *mapRendererTask = new QgsMapRendererTask( ms, fileName, QStringLiteral( "PDF" ), saveAsRaster(), mGeoPDFGroupBox->isChecked(), geoPdfExportDetails );

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -43,7 +43,7 @@
 #include "qgsmessagebar.h"
 #include "qgsapplication.h"
 #include "qgsexpressioncontextutils.h"
-
+#include "qgsfileutils.h"
 
 Q_GUI_EXPORT extern int qt_defaultDpiX();
 
@@ -467,6 +467,8 @@ void QgsMapSaveDialog::onAccepted()
       QString fileName = QFileDialog::getSaveFileName( QgisApp::instance(), tr( "Save Map As" ), lastUsedDir, tr( "PDF Format" ) + " (*.pdf *.PDF)" );
       if ( !fileName.isEmpty() )
       {
+        fileName = QgsFileUtils::ensureFileNameHasExtension( fileName, QStringList() << QStringLiteral( "pdf" ) );
+
         settings.setValue( QStringLiteral( "UI/lastSaveAsImageDir" ), QFileInfo( fileName ).absolutePath() );
 
         QgsMapSettings ms = QgsMapSettings();

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -115,7 +115,6 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
       {
         mSaveAsRaster->setChecked( false );
       }
-      mSaveAsRaster->setVisible( true );
 
       this->setWindowTitle( tr( "Save Map as PDF" ) );
 
@@ -142,8 +141,7 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
     case Image:
     {
       mGeoPDFGroupBox->hide();
-      mSimplifyGeometriesCheckbox->hide();
-      mTextRenderFormatComboBox->hide();
+      mAdvancedPdfSettings->hide();
       mTextExportLabel->hide();
       QPushButton *button = new QPushButton( tr( "Copy to Clipboard" ) );
       buttonBox->addButton( button, QDialogButtonBox::ResetRole );

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -306,6 +306,7 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
     if ( section.crs.isValid() )
     {
       QDomElement srs = doc.createElement( QStringLiteral( "SRS" ) );
+      // not currently used by GDAL or the PDF spec, but exposed in the GDAL XML schema. Maybe something we'll need to consider down the track...
       // srs.setAttribute( QStringLiteral( "dataAxisToSRSAxisMapping" ), QStringLiteral( "2,1" ) );
       if ( !section.crs.authid().startsWith( QStringLiteral( "user" ), Qt::CaseInsensitive ) )
       {

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -296,8 +296,8 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
 #if 0
   QDomElement georeferencing = doc.createElement( QStringLiteral( "Georeferencing" ) );
   georeferencing.setAttribute( QStringLiteral( "id" ), QStringLiteral( "georeferenced" ) );
-  georeferencing.setAttribute( QStringLiteral( "OGCBestPracticeFormat" ), QStringLiteral( "false" ) );
-  georeferencing.setAttribute( QStringLiteral( "ISO32000ExtensionFormat" ), QStringLiteral( "true" ) );
+  georeferencing.setAttribute( QStringLiteral( "OGCBestPracticeFormat" ), details.useOgcBestPracticeFormatGeoreferencing ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  georeferencing.setAttribute( QStringLiteral( "ISO32000ExtensionFormat" ), details.useIso32000ExtensionFormatGeoreferencing ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
   QDomElement srs = doc.createElement( QStringLiteral( "SRS" ) );
   // srs.setAttribute( QStringLiteral( "dataAxisToSRSAxisMapping" ), QStringLiteral( "2,1" ) );
   srs.appendChild( doc.createTextNode( QStringLiteral( "EPSG:4326" ) ) );

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -159,6 +159,23 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
       //! Metadata keyword map
       QgsAbstractMetadataBase::KeywordMap keywords;
 
+      /**
+       * TRUE if ISO3200 extension format georeferencing should be used.
+       *
+       * This is a recommended setting which results in Geospatial PDF files compatible
+       * with the built-in Acrobat geospatial tools.
+       */
+      bool useIso32000ExtensionFormatGeoreferencing = true;
+
+      /**
+       * TRUE if OGC "best practice" format georeferencing should be used.
+       *
+       * \warning This results in GeoPDF files compatible with the TerraGo suite of tools, but
+       * can break compatibility with the built-in Acrobat geospatial tools (yes, GeoPDF
+       * format is a mess!).
+      */
+      bool useOgcBestPracticeFormatGeoreferencing = false;
+
     };
 
     /**

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -125,6 +125,43 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
     };
 
     /**
+     * Contains details of a control point used during georeferencing GeoPDF outputs.
+     * \ingroup core
+     * \since QGIS 3.10
+     */
+    struct ControlPoint
+    {
+
+      /**
+       * Constructor for ControlPoint, at the specified \a pagePoint (in millimeters)
+       * and \a geoPoint (in CRS units).
+       */
+      ControlPoint( const QgsPointXY &pagePoint, const QgsPointXY &geoPoint )
+        : pagePoint( pagePoint )
+        , geoPoint( geoPoint )
+      {}
+
+      //! Coordinate on the page of the control point, in millimeters
+      QgsPointXY pagePoint;
+
+      //! Georeferenced coordinate of the control point, in CRS units
+      QgsPointXY geoPoint;
+    };
+
+    struct GeoReferencedSection
+    {
+      //! Bounds of the georeferenced section on the page, in millimeters
+      QgsRectangle pageBoundsMm;
+
+      //! Coordinate reference system for georeferenced section
+      QgsCoordinateReferenceSystem crs;
+
+      //! List of control points corresponding to this georeferenced section
+      QList< QgsAbstractGeoPdfExporter::ControlPoint > controlPoints;
+
+    };
+
+    /**
      * Called multiple times during the rendering operation, whenever a \a feature associated with the specified
      * \a layerId is rendered.
      */
@@ -137,6 +174,9 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
 
       //! Output DPI
       double dpi = 300;
+
+      //! List of georeferenced sections
+      QList< QgsAbstractGeoPdfExporter::GeoReferencedSection > georeferencedSections;
 
       //! Metadata author tag
       QString author;

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -176,6 +176,11 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
       */
       bool useOgcBestPracticeFormatGeoreferencing = false;
 
+      /**
+       * TRUE if feature vector information (such as attributes) should be exported.
+       */
+      bool includeFeatures = true;
+
     };
 
     /**

--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -108,13 +108,15 @@ class QgsMapRendererTaskRenderedFeatureHandler : public QgsRenderedFeatureHandle
 
 ///@endcond
 
-QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster, const bool geoPDF )
+QgsMapRendererTask::QgsMapRendererTask( const QgsMapSettings &ms, const QString &fileName, const QString &fileFormat, const bool forceRaster,
+                                        const bool geoPDF, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails )
   : QgsTask( tr( "Saving as image" ) )
   , mMapSettings( ms )
   , mFileName( fileName )
   , mFileFormat( fileFormat )
   , mForceRaster( forceRaster )
   , mGeoPDF( geoPDF && mFileFormat == QStringLiteral( "PDF" ) && QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() )
+  , mGeoPdfExportDetails( geoPdfExportDetails )
 {
   prepare();
 }
@@ -194,7 +196,7 @@ bool QgsMapRendererTask::run()
       outputLayer++;
       job->nextPart();
     }
-    QgsAbstractGeoPdfExporter::ExportDetails exportDetails;
+    QgsAbstractGeoPdfExporter::ExportDetails exportDetails = mGeoPdfExportDetails;
     exportDetails.pageSizeMm = mMapSettings.outputSize() * 25.4 / mMapSettings.outputDpi();
     exportDetails.dpi = mMapSettings.outputDpi();
 

--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -366,6 +366,16 @@ void QgsMapRendererTask::finished( bool result )
 
 void QgsMapRendererTask::prepare()
 {
+  if ( mGeoPDF )
+  {
+    mGeoPdfExporter = qgis::make_unique< QgsMapRendererTaskGeoPdfExporter >( mMapSettings );
+    mRenderedFeatureHandler = qgis::make_unique< QgsMapRendererTaskRenderedFeatureHandler >( static_cast< QgsMapRendererTaskGeoPdfExporter * >( mGeoPdfExporter.get() ) );
+    mMapSettings.addRenderedFeatureHandler( mRenderedFeatureHandler.get() );
+    mJob.reset( new QgsMapRendererStagedRenderJob( mMapSettings, QgsMapRendererStagedRenderJob::RenderLabelsByMapLayer ) );
+    mJob->start();
+    return;
+  }
+
   mDestPainter = mPainter;
 
   if ( mFileFormat == QStringLiteral( "PDF" ) )
@@ -416,17 +426,6 @@ void QgsMapRendererTask::prepare()
     return;
   }
 
-  if ( mGeoPDF )
-  {
-    mGeoPdfExporter = qgis::make_unique< QgsMapRendererTaskGeoPdfExporter >( mMapSettings );
-    mRenderedFeatureHandler = qgis::make_unique< QgsMapRendererTaskRenderedFeatureHandler >( static_cast< QgsMapRendererTaskGeoPdfExporter * >( mGeoPdfExporter.get() ) );
-    mMapSettings.addRenderedFeatureHandler( mRenderedFeatureHandler.get() );
-    mJob.reset( new QgsMapRendererStagedRenderJob( mMapSettings, QgsMapRendererStagedRenderJob::RenderLabelsByMapLayer ) );
-    mJob->start();
-  }
-  else
-  {
-    mJob.reset( new QgsMapRendererCustomPainterJob( mMapSettings, mDestPainter ) );
-    static_cast< QgsMapRendererCustomPainterJob *>( mJob.get() )->prepare();
-  }
+  mJob.reset( new QgsMapRendererCustomPainterJob( mMapSettings, mDestPainter ) );
+  static_cast< QgsMapRendererCustomPainterJob *>( mJob.get() )->prepare();
 }

--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -166,7 +166,6 @@ bool QgsMapRendererTask::run()
 
   if ( mGeoPDF )
   {
-
     QList< QgsAbstractGeoPdfExporter::ComponentLayerDetail > pdfComponents;
 
     QgsMapRendererStagedRenderJob *job = static_cast< QgsMapRendererStagedRenderJob * >( mJob.get() );
@@ -369,8 +368,11 @@ void QgsMapRendererTask::prepare()
   if ( mGeoPDF )
   {
     mGeoPdfExporter = qgis::make_unique< QgsMapRendererTaskGeoPdfExporter >( mMapSettings );
-    mRenderedFeatureHandler = qgis::make_unique< QgsMapRendererTaskRenderedFeatureHandler >( static_cast< QgsMapRendererTaskGeoPdfExporter * >( mGeoPdfExporter.get() ) );
-    mMapSettings.addRenderedFeatureHandler( mRenderedFeatureHandler.get() );
+    if ( mGeoPdfExportDetails.includeFeatures )
+    {
+      mRenderedFeatureHandler = qgis::make_unique< QgsMapRendererTaskRenderedFeatureHandler >( static_cast< QgsMapRendererTaskGeoPdfExporter * >( mGeoPdfExporter.get() ) );
+      mMapSettings.addRenderedFeatureHandler( mRenderedFeatureHandler.get() );
+    }
     mJob.reset( new QgsMapRendererStagedRenderJob( mMapSettings, QgsMapRendererStagedRenderJob::RenderLabelsByMapLayer ) );
     mJob->start();
     return;

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -61,11 +61,18 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
      * If the output \a fileFormat is set to PDF, the \a geoPdf argument controls whether a GeoPDF file is created.
      * See QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() for conditions on GeoPDF creation availability.
      */
+#ifndef SIP_RUN
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
                         bool forceRaster = false,
                         bool geoPdf = false, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails = QgsAbstractGeoPdfExporter::ExportDetails() );
+#else
+    QgsMapRendererTask( const QgsMapSettings &ms,
+                        const QString &fileName,
+                        const QString &fileFormat = QString( "PNG" ),
+                        bool forceRaster = false );
+#endif
 
     /**
      * Constructor for QgsMapRendererTask to render a map to a QPainter object.

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -26,6 +26,7 @@
 #include "qgsmapdecoration.h"
 #include "qgstaskmanager.h"
 #include "qgsmaprenderercustompainterjob.h"
+#include "qgsabstractgeopdfexporter.h"
 
 #include <QPainter>
 #include <QPrinter>
@@ -64,7 +65,7 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
                         bool forceRaster = false,
-                        bool geoPdf = false );
+                        bool geoPdf = false, const QgsAbstractGeoPdfExporter::ExportDetails &geoPdfExportDetails = QgsAbstractGeoPdfExporter::ExportDetails() );
 
     /**
      * Constructor for QgsMapRendererTask to render a map to a QPainter object.
@@ -136,6 +137,7 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
     bool mForceRaster = false;
     bool mSaveWorldFile = false;
     bool mGeoPDF = true;
+    QgsAbstractGeoPdfExporter::ExportDetails mGeoPdfExportDetails;
 
     QList< QgsAnnotation * > mAnnotations;
     QList< QgsMapDecoration * > mDecorations;

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>439</height>
+    <height>559</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,1,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -41,6 +41,87 @@
        <property name="title">
         <string>Extent</string>
        </property>
+      </widget>
+     </item>
+     <item row="9" column="0" colspan="2">
+      <widget class="QGroupBox" name="mGeoPDFGroupBox">
+       <property name="title">
+        <string>Create Geospatial PDF (GeoPDF)</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QStackedWidget" name="mGeoPDFOptionsStackedWidget">
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <widget class="QWidget" name="page">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="mGeoPdfUnavailableReason">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="page_2">
+           <layout class="QGridLayout" name="gridLayout_2">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item row="1" column="0">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="mExportMetadataCheckBox">
+              <property name="text">
+               <string>Export RDF metadata (title, author, etc.)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
      <item row="4" column="0">
@@ -77,7 +158,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveAsRaster">
        <property name="visible">
         <bool>false</bool>
@@ -206,73 +287,17 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="0" colspan="2">
+     <item row="11" column="0" colspan="2">
       <widget class="QLabel" name="mInfo">
        <property name="enabled">
         <bool>false</bool>
        </property>
       </widget>
      </item>
-     <item row="8" column="0" colspan="2">
-      <widget class="QGroupBox" name="mGeoPDFGroupBox">
-       <property name="title">
-        <string>Create Geospatial PDF (GeoPDF)</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QStackedWidget" name="mGeoPDFOptionsStackedWidget">
-          <property name="currentIndex">
-           <number>1</number>
-          </property>
-          <widget class="QWidget" name="page">
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="mGeoPdfUnavailableReason">
-              <property name="text">
-               <string/>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-          <widget class="QWidget" name="page_2"/>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+     <item row="8" column="0">
+      <widget class="QTextBrowser" name="textBrowser"/>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -38,12 +38,15 @@
      </item>
      <item row="0" column="0" colspan="2">
       <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
        <property name="title">
         <string>Extent</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <widget class="QGroupBox" name="mGeoPDFGroupBox">
        <property name="title">
         <string>Create Geospatial PDF (GeoPDF)</string>
@@ -148,6 +151,16 @@
        </property>
       </widget>
      </item>
+     <item row="8" column="0" colspan="2">
+      <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
+       <property name="text">
+        <string>Simplify geometries to reduce output file size</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
@@ -155,7 +168,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0" colspan="2">
+     <item row="11" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveAsRaster">
        <property name="visible">
         <bool>false</bool>
@@ -284,22 +297,22 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="0" colspan="2">
+     <item row="12" column="0" colspan="2">
       <widget class="QLabel" name="mInfo">
        <property name="enabled">
         <bool>false</bool>
        </property>
       </widget>
      </item>
-     <item row="8" column="0" colspan="2">
-      <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
+     <item row="9" column="0">
+      <widget class="QLabel" name="mTextExportLabel">
        <property name="text">
-        <string>Simplify geometries to reduce output file size</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
+        <string>Text export</string>
        </property>
       </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
      </item>
     </layout>
    </item>
@@ -360,8 +373,18 @@ Rasterizing the map is recommended when such effects are used.</string>
  </customwidgets>
  <tabstops>
   <tabstop>mExtentGroupBox</tabstop>
-  <tabstop>mDrawAnnotations</tabstop>
+  <tabstop>mResolutionSpinBox</tabstop>
+  <tabstop>mOutputWidthSpinBox</tabstop>
+  <tabstop>mLockAspectRatio</tabstop>
+  <tabstop>mOutputHeightSpinBox</tabstop>
   <tabstop>mDrawDecorations</tabstop>
+  <tabstop>mDrawAnnotations</tabstop>
+  <tabstop>mSaveWorldFile</tabstop>
+  <tabstop>mSimplifyGeometriesCheckbox</tabstop>
+  <tabstop>mTextRenderFormatComboBox</tabstop>
+  <tabstop>mGeoPDFGroupBox</tabstop>
+  <tabstop>mGeoPdfFormatComboBox</tabstop>
+  <tabstop>mExportMetadataCheckBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -84,7 +84,7 @@
            </layout>
           </widget>
           <widget class="QWidget" name="page_2">
-           <layout class="QGridLayout" name="gridLayout_2">
+           <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -97,28 +97,25 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item row="2" column="0">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>102</height>
-               </size>
-              </property>
-             </spacer>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="mGeoPdfFormatComboBox"/>
             </item>
-            <item row="0" column="0">
-             <widget class="QCheckBox" name="mExportMetadataCheckBox">
+            <item row="1" column="0">
+             <widget class="QLabel" name="label">
               <property name="text">
-               <string>Export RDF metadata (title, author, etc.)</string>
+               <string>Format</string>
               </property>
              </widget>
             </item>
            </layout>
           </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="mExportMetadataCheckBox">
+          <property name="text">
+           <string>Export RDF metadata (title, author, etc.)</string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -305,6 +302,19 @@ Rasterizing the map is recommended when such effects are used.</string>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,1,0,0,0">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -43,7 +43,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0" colspan="2">
+     <item row="8" column="0" colspan="2">
       <widget class="QGroupBox" name="mGeoPDFGroupBox">
        <property name="title">
         <string>Create Geospatial PDF (GeoPDF)</string>
@@ -105,7 +105,7 @@
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>133</height>
                </size>
               </property>
              </spacer>
@@ -158,7 +158,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0" colspan="2">
+     <item row="9" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveAsRaster">
        <property name="visible">
         <bool>false</bool>
@@ -287,15 +287,12 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <widget class="QLabel" name="mInfo">
        <property name="enabled">
         <bool>false</bool>
        </property>
       </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QTextBrowser" name="textBrowser"/>
      </item>
     </layout>
    </item>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>559</height>
+    <height>629</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -46,7 +46,7 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0" colspan="2">
+     <item row="8" column="0" colspan="2">
       <widget class="QGroupBox" name="mGeoPDFGroupBox">
        <property name="title">
         <string>Create Geospatial PDF (GeoPDF)</string>
@@ -124,6 +124,52 @@
        </layout>
       </widget>
      </item>
+     <item row="9" column="0" colspan="2">
+      <widget class="QgsCollapsibleGroupBox" name="mAdvancedPdfSettings">
+       <property name="title">
+        <string>Advanced Settings</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
+        <item row="2" column="0">
+         <widget class="QLabel" name="mTextExportLabel">
+          <property name="text">
+           <string>Text export</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
+          <property name="text">
+           <string>Simplify geometries to reduce output file size</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0" colspan="2">
+         <widget class="QCheckBox" name="mSaveAsRaster">
+          <property name="visible">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Advanced effects such as blend modes or vector layer transparency cannot be exported as vectors.
+Rasterizing the map is recommended when such effects are used.</string>
+          </property>
+          <property name="text">
+           <string>Rasterize map</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
@@ -151,37 +197,10 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0" colspan="2">
-      <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
-       <property name="text">
-        <string>Simplify geometries to reduce output file size</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Output width</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0" colspan="2">
-      <widget class="QCheckBox" name="mSaveAsRaster">
-       <property name="visible">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Advanced effects such as blend modes or vector layer transparency cannot be exported as vectors.
-Rasterizing the map is recommended when such effects are used.</string>
-       </property>
-       <property name="text">
-        <string>Rasterize map</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -297,22 +316,12 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="12" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <widget class="QLabel" name="mInfo">
        <property name="enabled">
         <bool>false</bool>
        </property>
       </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="mTextExportLabel">
-       <property name="text">
-        <string>Text export</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
      </item>
     </layout>
    </item>
@@ -380,11 +389,12 @@ Rasterizing the map is recommended when such effects are used.</string>
   <tabstop>mDrawDecorations</tabstop>
   <tabstop>mDrawAnnotations</tabstop>
   <tabstop>mSaveWorldFile</tabstop>
-  <tabstop>mSimplifyGeometriesCheckbox</tabstop>
-  <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>mGeoPDFGroupBox</tabstop>
   <tabstop>mGeoPdfFormatComboBox</tabstop>
   <tabstop>mExportMetadataCheckBox</tabstop>
+  <tabstop>mSaveAsRaster</tabstop>
+  <tabstop>mSimplifyGeometriesCheckbox</tabstop>
+  <tabstop>mTextRenderFormatComboBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -119,6 +119,19 @@
           <property name="text">
            <string>Export RDF metadata (title, author, etc.)</string>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="mExportGeoPdfFeaturesCheckBox">
+          <property name="text">
+           <string>Include vector feature information</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
        </layout>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -100,6 +100,16 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
+            <item row="2" column="0" colspan="2">
+             <widget class="QCheckBox" name="mExportMetadataCheckBox">
+              <property name="text">
+               <string>Export RDF metadata (title, author, etc.)</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="1">
              <widget class="QComboBox" name="mGeoPdfFormatComboBox"/>
             </item>
@@ -110,28 +120,18 @@
               </property>
              </widget>
             </item>
+            <item row="3" column="0" colspan="2">
+             <widget class="QCheckBox" name="mExportGeoPdfFeaturesCheckBox">
+              <property name="text">
+               <string>Include vector feature information</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="mExportMetadataCheckBox">
-          <property name="text">
-           <string>Export RDF metadata (title, author, etc.)</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="mExportGeoPdfFeaturesCheckBox">
-          <property name="text">
-           <string>Include vector feature information</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
        </layout>
@@ -405,6 +405,7 @@ Rasterizing the map is recommended when such effects are used.</string>
   <tabstop>mGeoPDFGroupBox</tabstop>
   <tabstop>mGeoPdfFormatComboBox</tabstop>
   <tabstop>mExportMetadataCheckBox</tabstop>
+  <tabstop>mExportGeoPdfFeaturesCheckBox</tabstop>
   <tabstop>mSaveAsRaster</tabstop>
   <tabstop>mSimplifyGeometriesCheckbox</tabstop>
   <tabstop>mTextRenderFormatComboBox</tabstop>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>318</height>
+    <height>439</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,27 +16,10 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="9" column="0" colspan="2">
-      <widget class="QLabel" name="mInfo">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0" colspan="2">
-      <widget class="QCheckBox" name="mSaveAsRaster">
-       <property name="visible">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>Advanced effects such as blend modes or vector layer transparency cannot be exported as vectors.
-Rasterizing the map is recommended when such effects are used.</string>
-       </property>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Rasterize map</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
+        <string>Resolution</string>
        </property>
       </widget>
      </item>
@@ -47,6 +30,23 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
        <property name="checked">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QgsScaleWidget" name="mScaleWidget" native="true"/>
+     </item>
+     <item row="0" column="0" colspan="2">
+      <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
+       <property name="title">
+        <string>Extent</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Output height</string>
        </property>
       </widget>
      </item>
@@ -70,17 +70,27 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Output height</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Output width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0" colspan="2">
+      <widget class="QCheckBox" name="mSaveAsRaster">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Advanced effects such as blend modes or vector layer transparency cannot be exported as vectors.
+Rasterizing the map is recommended when such effects are used.</string>
+       </property>
+       <property name="text">
+        <string>Rasterize map</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -170,13 +180,6 @@ Rasterizing the map is recommended when such effects are used.</string>
        </item>
       </layout>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Resolution</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="1">
       <widget class="QgsSpinBox" name="mResolutionSpinBox">
        <property name="suffix">
@@ -203,14 +206,57 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QgsScaleWidget" name="mScaleWidget" native="true"/>
-     </item>
-     <item row="0" column="0" colspan="2">
-      <widget class="QgsExtentGroupBox" name="mExtentGroupBox">
-       <property name="title">
-        <string>Extent</string>
+     <item row="10" column="0" colspan="2">
+      <widget class="QLabel" name="mInfo">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
+      </widget>
+     </item>
+     <item row="8" column="0" colspan="2">
+      <widget class="QGroupBox" name="mGeoPDFGroupBox">
+       <property name="title">
+        <string>Create Geospatial PDF (GeoPDF)</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QStackedWidget" name="mGeoPDFOptionsStackedWidget">
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <widget class="QWidget" name="page">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="mGeoPdfUnavailableReason">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="page_2"/>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0">
+    <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0">
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -43,7 +43,7 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="0" colspan="2">
+     <item row="9" column="0" colspan="2">
       <widget class="QGroupBox" name="mGeoPDFGroupBox">
        <property name="title">
         <string>Create Geospatial PDF (GeoPDF)</string>
@@ -97,7 +97,7 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <item row="1" column="0">
+            <item row="2" column="0">
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -105,7 +105,7 @@
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>133</height>
+                <height>102</height>
                </size>
               </property>
              </spacer>
@@ -158,7 +158,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="0" colspan="2">
+     <item row="10" column="0" colspan="2">
       <widget class="QCheckBox" name="mSaveAsRaster">
        <property name="visible">
         <bool>false</bool>
@@ -287,10 +287,20 @@ Rasterizing the map is recommended when such effects are used.</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="0" colspan="2">
+     <item row="11" column="0" colspan="2">
       <widget class="QLabel" name="mInfo">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0" colspan="2">
+      <widget class="QCheckBox" name="mSimplifyGeometriesCheckbox">
+       <property name="text">
+        <string>Simplify geometries to reduce output file size</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Adds all the GUI for exporting to GeoPDF from the canvas Save as PDF option (+required follow up fixes). Also exposes a bunch of other useful PDF output tweaks which are available from print layouts to the canvas option:

![image](https://user-images.githubusercontent.com/1829991/63234246-d3186980-c277-11e9-9726-af65fdd672a2.png)

And here's what mere mortals running GDAL < 3 see:
![image](https://user-images.githubusercontent.com/1829991/63234286-f3e0bf00-c277-11e9-93dc-6d693b8e03f0.png)

