### PR TITLE
add interpolate Z on segment snapping

### DIFF
--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -164,6 +164,14 @@ The id of the feature to which the snapped geometry belongs.
 Only for a valid edge match - obtain endpoints of the edge
 %End
 
+        QgsPoint interpolatedPoint() const;
+%Docstring
+Convenient method to return a point on an edge with linear
+interpolation of the Z value.
+
+.. versionadded:: 3.10
+%End
+
         bool operator==( const QgsPointLocator::Match &other ) const;
 
       protected:

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -17,7 +17,6 @@
 #define QGSPOINTLOCATOR_H
 
 class QgsPointXY;
-class QgsVectorLayer;
 class QgsFeatureRenderer;
 class QgsRenderContext;
 class QgsRectangle;
@@ -29,6 +28,9 @@ class QgsVectorLayerFeatureSource;
 #include "qgscoordinatetransform.h"
 #include "qgsfeatureid.h"
 #include "qgsgeometry.h"
+#include "qgsgeometryutils.h"
+#include "qgsvectorlayer.h"
+#include "qgslinestring.h"
 #include <memory>
 
 class QgsPointLocator_VisitorNearestVertex;
@@ -197,6 +199,24 @@ class CORE_EXPORT QgsPointLocator : public QObject
         {
           pt1 = mEdgePoints[0];
           pt2 = mEdgePoints[1];
+        }
+
+        /**
+         * Convenient method to return a point on an edge with linear
+         * interpolation of the Z value.
+         * \since 3.10
+         */
+        QgsPoint interpolatedPoint() const
+        {
+          QgsPoint point;
+          const QgsGeometry geom = mLayer->getGeometry( mFid );
+          if ( !( geom.isNull() || geom.isEmpty() ) )
+          {
+            QgsLineString line( geom.vertexAt( mVertexIndex ), geom.vertexAt( mVertexIndex + 1 ) );
+
+            point = QgsGeometryUtils::closestPoint( line, QgsPoint( mPoint ) );
+          }
+          return point;
         }
 
         bool operator==( const QgsPointLocator::Match &other ) const

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -687,9 +687,10 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
    * but they do not take into account if when you snap on a vertex it has
    * a Z value.
    * To get the value we use the snapPoint method. However, we only apply it
-   * when the snapped point corresponds to the constrained point.
+   * when the snapped point corresponds to the constrained point or on an edge
+   * if the topological editing is activated.
    */
-  if ( mSnapMatch.hasVertex() && ( point == mSnapMatch.point() ) )
+  if ( ( mSnapMatch.hasVertex() && ( point == mSnapMatch.point() ) ) || ( mSnapMatch.hasEdge() && QgsProject::instance()->topologicalEditing() ) )
   {
     e->snapPoint();
   }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -397,18 +397,19 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex(), vId ) )
         return 2;
 
+      const QgsGeometry geom( f.geometry() );
       if ( QgsProject::instance()->topologicalEditing() && match.hasEdge() )
       {
         QgsVertexId vId2;
         if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex() + 1, vId2 ) )
           return 2;
-        QgsLineString line( f.geometry().constGet()->vertexAt( vId ), f.geometry().constGet()->vertexAt( vId2 ) );
+        QgsLineString line( geom.constGet()->vertexAt( vId ), geom.constGet()->vertexAt( vId2 ) );
 
         layerPoint = QgsGeometryUtils::closestPoint( line,  QgsPoint( match.point() ) );
       }
       else
       {
-        layerPoint = f.geometry().constGet()->vertexAt( vId );
+        layerPoint = geom.constGet()->vertexAt( vId );
       }
 
       // ZM support depends on the target layer

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -383,7 +383,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
   QgsVectorLayer *sourceLayer = match.layer();
-  if ( match.isValid() && match.hasVertex() && sourceLayer &&
+  if ( match.isValid() && ( match.hasVertex() || match.hasEdge() ) && sourceLayer &&
        ( sourceLayer->crs() == vlayer->crs() ) )
   {
     QgsFeature f;
@@ -396,7 +396,14 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex(), vId ) )
         return 2;
 
-      layerPoint = f.geometry().constGet()->vertexAt( vId );
+      if ( match.hasEdge() )
+      {
+        layerPoint = match.interpolatedPoint();
+      }
+      else
+      {
+        layerPoint = f.geometry().constGet()->vertexAt( vId );
+      }
 
       // ZM support depends on the target layer
       if ( !QgsWkbTypes::hasZ( vlayer->wkbType() ) )

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -398,7 +398,12 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
 
       if ( match.hasEdge() )
       {
-        layerPoint = match.interpolatedPoint();
+        QgsVertexId vId2;
+        if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex() + 1, vId2 ) )
+          return 2;
+        QgsLineString line( f.geometry().constGet()->vertexAt( vId ), f.geometry().constGet()->vertexAt( vId2 ) );
+
+        layerPoint = QgsGeometryUtils::closestPoint( line,  QgsPoint( match.point() ) );
       }
       else
       {

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -32,6 +32,7 @@
 #include "qgssettings.h"
 #include "qgsapplication.h"
 #include "qgsadvanceddigitizingdockwidget.h"
+#include "qgsproject.h"
 
 #include <QAction>
 #include <QCursor>
@@ -383,7 +384,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
   QgsVectorLayer *sourceLayer = match.layer();
-  if ( match.isValid() && ( match.hasVertex() || match.hasEdge() ) && sourceLayer &&
+  if ( match.isValid() && ( match.hasVertex() || ( QgsProject::instance()->topologicalEditing() && match.hasEdge() ) ) && sourceLayer &&
        ( sourceLayer->crs() == vlayer->crs() ) )
   {
     QgsFeature f;
@@ -396,7 +397,7 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex(), vId ) )
         return 2;
 
-      if ( match.hasEdge() )
+      if ( QgsProject::instance()->topologicalEditing() && match.hasEdge() )
       {
         QgsVertexId vId2;
         if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex() + 1, vId2 ) )

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -164,7 +164,7 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
 
   mLayerTopoZ->startEditing();
   QgsFeature topoFeat;
-  topoFeat.setGeometry( QgsGeometry::fromWkt( "MultiLineStringZ ((7.25 6 0, 7.25 7 0, 7.5 7 0, 7.5 6 0, 7.25 6 0),(6 6 0, 6 7 0, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.25 0)));" ) );
+  topoFeat.setGeometry( QgsGeometry::fromWkt( "MultiLineStringZ ((7.25 6 0, 7.25 7 0, 7.5 7 0, 7.5 6 0, 7.25 6 0),(6 6 0, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.25 0)));" ) );
 
   mLayerTopoZ->addFeature( topoFeat );
   QCOMPARE( mLayerTopoZ->featureCount(), ( long ) 1 );
@@ -438,9 +438,9 @@ void TestQgsMapToolAddFeatureLine::testTopologicalEditingZ()
   utils.mouseClick( 8, 6.5, Qt::RightButton );
   QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
-  QString wkt = "LineStringZ (6 6.5 333, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
+  QString wkt = "LineStringZ (6 6.5 5, 6.25 6.5 333, 6.75 6.5 333, 7.25 6.5 333, 7.5 6.5 333)";
   QCOMPARE( mLayerTopoZ->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
-  wkt = "MultiLineStringZ ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 333, 6 7 0, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
+  wkt = "MultiLineStringZ ((7.25 6 0, 7.25 6.5 333, 7.25 7 0, 7.5 7 0, 7.5 6.5 333, 7.5 6 0, 7.25 6 0),(6 6 0, 6 6.5 5, 6 7 10, 7 7 0, 7 6 0, 6 6 0),(6.25 6.25 0, 6.75 6.25 0, 6.75 6.5 333, 6.75 6.75 0, 6.25 6.75 0, 6.25 6.5 333, 6.25 6.25 0))";
   QCOMPARE( mLayerTopoZ->getFeature( oldFids.toList().last() ).geometry(), QgsGeometry::fromWkt( wkt ) );
 
   mLayerLine->undoStack()->undo();


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Snap on a segment in Z layer returns always the Z default value (except for some tools like trim/extend which uses Z interpolation). This is not correct. 

Before
![before](https://user-images.githubusercontent.com/7521540/63246233-85ddcd00-c262-11e9-9b4c-1705d7bd71d1.gif)

After
![after](https://user-images.githubusercontent.com/7521540/63246241-8a09ea80-c262-11e9-9685-8672c765f984.gif)

Sponsored by QWAT group @ponceta

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
