### PR TITLE
[ui fix] Rename Parent to Child

### DIFF
--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -135,7 +135,7 @@ QgsRelationAddDlg::QgsRelationAddDlg( QWidget *parent )
   QLabel *referencedLabel = new QLabel( tr( "Referenced layer (parent)" ), this );
   layout->addWidget( referencedLabel, 1, 1 );
   // col 2
-  QLabel *referencingLabel = new QLabel( tr( "Referencing layer (parent)" ), this );
+  QLabel *referencingLabel = new QLabel( tr( "Referencing layer (child)" ), this );
   layout->addWidget( referencingLabel, 1, 2 );
 
   // row 2: layer comboboxes


### PR DESCRIPTION
## Description
Small UI fix in Properties -> Relations changing **Parent** to **Child** to avoid confusion. No backport needed.

Before:

![before](https://user-images.githubusercontent.com/2884884/63250274-8af34a00-c26b-11e9-9859-e98298209533.png)

After:

![after](https://user-images.githubusercontent.com/2884884/63250285-9181c180-c26b-11e9-80b4-b72bbddd3f7f.png)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
