### PR TITLE
[FEATURE] Brand new map canvas image decoration

### DIFF
--- a/images/icons/qgis-icon-minimal-black.svg
+++ b/images/icons/qgis-icon-minimal-black.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="64px" height="64px" viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve"><script xmlns=""/>
+<polygon points="34.613,35.471 43.81,35.438 35.836,27.625 26.613,27.625 26.613,36.695 34.613,44.593 " fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(outline)" stroke-opacity="param(outline-opacity) 0" stroke-width="param(outline-width) 0.5"/>
+<polygon points="63.613,54.844 47.819,39.367 38.613,39.354 38.613,48.688 53.553,63.625 63.613,63.625 " fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(outline)" stroke-opacity="param(outline-opacity) 0" stroke-width="param(outline-width) 0.5"/>
+<path d="M35.553,50.859c-1.359,0.313-1.988,0.312-3.446,0.312c-10.429,0-19.299-8.575-19.299-19.696  c0-11.12,8.772-19.506,19.299-19.506s18.911,8.387,18.911,19.506c0,1.809-0.227,3.548-0.644,5.198l9.653,9.651  c2.488-4.36,3.881-9.43,3.881-14.922c0-17.138-13.678-29.971-31.997-29.971C13.677,1.431,0,14.179,0,31.401  c0,17.306,13.677,30.308,31.912,30.308c4.708,0,8.394-0.586,12.334-2.161L35.553,50.859z" fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(outline)" stroke-opacity="param(outline-opacity) 0" stroke-width="param(outline-width) 0.5"/>
+</svg>

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -700,6 +700,7 @@
         <file>themes/default/mActionAddGeoPackageLayer.svg</file>
         <file>themes/default/mActionFindReplace.svg</file>
         <file>icons/qgis_icon.svg</file>
+        <file>icons/qgis-icon-minimal-black.svg</file>
         <file>themes/default/mActionCircle2TangentsPoint.svg</file>
         <file>themes/default/mActionRegularPolygonCenterPoint.svg</file>
         <file>themes/default/3d.svg</file>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -122,6 +122,8 @@ SET(QGIS_APP_SRCS
   decorations/qgsdecorationtitledialog.cpp
   decorations/qgsdecorationcopyright.cpp
   decorations/qgsdecorationcopyrightdialog.cpp
+  decorations/qgsdecorationimage.cpp
+  decorations/qgsdecorationimagedialog.cpp
   decorations/qgsdecorationlayoutextent.cpp
   decorations/qgsdecorationlayoutextentdialog.cpp
   decorations/qgsdecorationnortharrow.cpp
@@ -383,6 +385,8 @@ SET (QGIS_APP_MOC_HDRS
   decorations/qgsdecorationtitledialog.h
   decorations/qgsdecorationcopyright.h
   decorations/qgsdecorationcopyrightdialog.h
+  decorations/qgsdecorationimage.h
+  decorations/qgsdecorationimagedialog.h
   decorations/qgsdecorationlayoutextent.h
   decorations/qgsdecorationlayoutextentdialog.h
   decorations/qgsdecorationnortharrow.h

--- a/src/app/decorations/qgsdecorationimage.cpp
+++ b/src/app/decorations/qgsdecorationimage.cpp
@@ -64,7 +64,7 @@ void QgsDecorationImage::saveToProject()
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Size" ), mSize );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ImagePath" ), mImagePath );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ImagePath" ), QgsProject::instance()->pathResolver().writePath( mImagePath ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
 }
@@ -104,6 +104,7 @@ void QgsDecorationImage::setImagePath( const QString &imagePath )
     if ( svg.isValid() )
     {
       mImageFormat = FormatSVG;
+      return;
     }
     bool cached;
     QImage img = QgsApplication::imageCache()->pathAsImage( mImagePath, QSize( 1, 0 ), true, 1.0, cached );

--- a/src/app/decorations/qgsdecorationimage.cpp
+++ b/src/app/decorations/qgsdecorationimage.cpp
@@ -1,0 +1,279 @@
+/***************************************************************************
+  qgsdecorationimage.cpp
+  --------------------------------------
+  Date                 : August 2019
+  Copyright            : (C) 2019 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationimage.h"
+
+#include "qgsdecorationimagedialog.h"
+
+#include "qgisapp.h"
+#include "qgscoordinatetransform.h"
+#include "qgsexception.h"
+#include "qgsimagecache.h"
+#include "qgslogger.h"
+#include "qgsmaplayer.h"
+#include "qgsproject.h"
+#include "qgssymbollayerutils.h"
+#include "qgssvgcache.h"
+
+#include <QPainter>
+#include <QMenu>
+#include <QDir>
+#include <QFile>
+#include <QSvgRenderer>
+
+#include <cmath>
+#include <cassert>
+
+
+QgsDecorationImage::QgsDecorationImage( QObject *parent )
+  : QgsDecorationItem( parent )
+{
+  mPlacement = BottomLeft;
+  mMarginUnit = QgsUnitTypes::RenderMillimeters;
+
+  setName( "Image" );
+  projectRead();
+}
+
+void QgsDecorationImage::projectRead()
+{
+  QgsDecorationItem::projectRead();
+  mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
+  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
+  mSize = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/Size" ), 16.0 );
+  setImagePath( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/ImagePath" ), QString() ) );
+  mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
+  mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
+}
+
+void QgsDecorationImage::saveToProject()
+{
+  QgsDecorationItem::saveToProject();
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Size" ), mSize );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ImagePath" ), mImagePath );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
+}
+
+// Slot called when the buffer menu item is activated
+void QgsDecorationImage::run()
+{
+  QgsDecorationImageDialog dlg( *this, QgisApp::instance() );
+  dlg.exec();
+}
+
+void QgsDecorationImage::setImagePath( const QString &imagePath )
+{
+  mImagePath = imagePath;
+  mImageFormat = FormatUnknown;
+
+  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( mImagePath, QgsProject::instance()->pathResolver() );
+  QFileInfo fileInfo( resolvedPath );
+  if ( fileInfo.exists() )
+  {
+    QString suffix = fileInfo.suffix();
+    if ( suffix.compare( QLatin1String( "svg" ), Qt::CaseInsensitive ) == 0 )
+    {
+      mImageFormat = FormatSVG;
+    }
+    else
+    {
+      mImageFormat = FormatRaster;
+    }
+  }
+  else
+  {
+    QSvgRenderer svg;
+    const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( mImagePath, 1.0, mColor, mOutlineColor, 1.0, 1.0 );
+    svg.load( svgContent );
+
+    if ( svg.isValid() )
+    {
+      mImageFormat = FormatSVG;
+    }
+    bool cached;
+    QImage img = QgsApplication::imageCache()->pathAsImage( mImagePath, QSize( 1, 0 ), true, 1.0, cached );
+    if ( !img.isNull() )
+    {
+      mImageFormat = FormatRaster;
+    }
+  }
+}
+
+QString QgsDecorationImage::imagePath()
+{
+  if ( !mImagePath.isEmpty() )
+  {
+    QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( mImagePath, QgsProject::instance()->pathResolver() );
+    bool validSvg = QFileInfo::exists( resolvedPath );
+    if ( validSvg )
+    {
+      return resolvedPath;
+    }
+  }
+
+  return QStringLiteral( ":/images/icons/qgis-icon-minimal-black.svg" );
+}
+
+void QgsDecorationImage::render( const QgsMapSettings &mapSettings, QgsRenderContext &context )
+{
+  if ( !enabled() )
+    return;
+
+  double maxLength = mSize * mapSettings.outputDpi() / 25.4;
+  QSize size( maxLength, maxLength );
+
+  QSvgRenderer svg;
+  QImage img;
+  switch ( mImageFormat )
+  {
+    case FormatSVG:
+    {
+      const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( imagePath(), maxLength, mColor, mOutlineColor, 1.0, 1.0 );
+      svg.load( svgContent );
+
+      if ( svg.isValid() )
+      {
+        QRectF viewBox = svg.viewBoxF();
+        if ( viewBox.height() > viewBox.width() )
+        {
+          size.setWidth( maxLength * viewBox.width() / viewBox.height() );
+        }
+        else
+        {
+          size.setHeight( maxLength * viewBox.height() / viewBox.width() );
+        }
+      }
+      else
+      {
+        // SVG can't be parsed
+        return;
+      }
+      break;
+    }
+
+    case FormatRaster:
+    {
+      QSize originalSize = QgsApplication::imageCache()->originalSize( imagePath() );
+      if ( originalSize.isValid() )
+      {
+        if ( originalSize.height() > originalSize.width() )
+        {
+          size.setWidth( originalSize.width() * maxLength / originalSize.height() );
+          size.setHeight( maxLength );
+        }
+        else
+        {
+          size.setWidth( maxLength );
+          size.setHeight( originalSize.height() * maxLength / originalSize.width() );
+        }
+        bool cached;
+        img = QgsApplication::imageCache()->pathAsImage( imagePath(), size, true, 1.0, cached );
+      }
+      else
+      {
+        // Image can't be read
+        return;
+      }
+      break;
+    }
+
+    case FormatUnknown:
+      // Broken / unavailable image
+      return;
+  }
+
+  context.painter()->save();
+
+  // need width/height of paint device
+  QPaintDevice *device = context.painter()->device();
+  int deviceHeight = device->height() / device->devicePixelRatioF();
+  int deviceWidth = device->width() / device->devicePixelRatioF();
+
+  // Set  margin according to selected units
+  int xOffset = 0;
+  int yOffset = 0;
+  switch ( mMarginUnit )
+  {
+    case QgsUnitTypes::RenderMillimeters:
+    {
+      int pixelsInchX = context.painter()->device()->logicalDpiX();
+      int pixelsInchY = context.painter()->device()->logicalDpiY();
+      xOffset = pixelsInchX * INCHES_TO_MM * mMarginHorizontal;
+      yOffset = pixelsInchY * INCHES_TO_MM * mMarginVertical;
+      break;
+    }
+
+    case QgsUnitTypes::RenderPixels:
+      xOffset = mMarginHorizontal - 5; // Minus 5 to shift tight into corner
+      yOffset = mMarginVertical - 5;
+      break;
+
+    case QgsUnitTypes::RenderPercentage:
+      xOffset = ( ( deviceWidth - size.width() ) / 100. ) * mMarginHorizontal;
+      yOffset = ( ( deviceHeight - size.width() ) / 100. ) * mMarginVertical;
+      break;
+    case QgsUnitTypes::RenderMapUnits:
+    case QgsUnitTypes::RenderPoints:
+    case QgsUnitTypes::RenderInches:
+    case QgsUnitTypes::RenderUnknownUnit:
+    case QgsUnitTypes::RenderMetersInMapUnits:
+      break;
+  }
+
+  //Determine placement of label from form combo box
+  switch ( mPlacement )
+  {
+    case BottomLeft:
+      context.painter()->translate( xOffset, deviceHeight - yOffset - size.height() );
+      break;
+    case TopLeft:
+      context.painter()->translate( xOffset, yOffset );
+      break;
+    case TopRight:
+      context.painter()->translate( deviceWidth - xOffset - size.width(), yOffset );
+      break;
+    case BottomRight:
+      context.painter()->translate( deviceWidth - xOffset - size.width(),
+                                    deviceHeight - yOffset - size.height() );
+      break;
+    case TopCenter:
+      context.painter()->translate( deviceWidth / 2 - size.width() / 2 + xOffset, yOffset );
+      break;
+    case BottomCenter:
+      context.painter()->translate( deviceWidth / 2 - size.width() / 2 + xOffset,
+                                    deviceHeight - yOffset - size.height() );
+      break;
+    default:
+      QgsDebugMsg( QStringLiteral( "Unsupported placement index of %1" ).arg( static_cast<int>( mPlacement ) ) );
+  }
+
+  switch ( mImageFormat )
+  {
+    case FormatSVG:
+      svg.render( context.painter(), QRectF( 0, 0, size.width(), size.height() ) );
+      break;
+    case FormatRaster:
+      context.painter()->drawImage( QRectF( 0, 0, size.width(), size.height() ), img );
+      break;
+    case FormatUnknown:
+      // nothing happening here, function already returned in the first switch
+      break;
+  }
+
+  context.painter()->restore();
+}

--- a/src/app/decorations/qgsdecorationimage.h
+++ b/src/app/decorations/qgsdecorationimage.h
@@ -1,0 +1,85 @@
+/***************************************************************************
+  qgsdecorationimage.h
+  --------------------------------------
+  Date                 : August 2019
+  Copyright            : (C) 2019 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDECORATIONIMAGE_H
+#define QGSDECORATIONIMAGE_H
+
+#include "qgsdecorationitem.h"
+
+#include <QStringList>
+#include "qgis_app.h"
+
+class QAction;
+class QToolBar;
+class QPainter;
+
+class APP_EXPORT QgsDecorationImage: public QgsDecorationItem
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Format of source image
+     */
+    enum Format
+    {
+      FormatSVG, //!< SVG image
+      FormatRaster, //!< Raster image
+      FormatUnknown, //!< Invalid or unknown image type
+    };
+
+    /**
+     * Constructor for QgsDecorationImage, with the specified \a parent object.
+     */
+    QgsDecorationImage( QObject *parent = nullptr );
+
+  public slots:
+    //! Sets values on the GUI when a project is read or the GUI first loaded
+    void projectRead() override;
+    //! Save values to the project
+    void saveToProject() override;
+
+    //! Show the dialog box
+    void run() override;
+    //! Draw some arbitrary text to the screen
+    void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
+
+    //! Sets the image path
+    void setImagePath( const QString &imagePath );
+
+    //! Returns the image path
+    QString imagePath();
+
+  private:
+
+    //! The image fill color used with parameter-enabled SVG files
+    QColor mColor;
+    //! The image outline color used with parameter-enabled SVG files
+    QColor mOutlineColor;
+    //! The image size in millimeter
+    double mSize = 16.0;
+    //! The image path
+    QString mImagePath;
+    QgsDecorationImage::Format mImageFormat = FormatUnknown;
+
+    //! margin values
+    int mMarginHorizontal = 0;
+    int mMarginVertical = 0;
+
+    friend class QgsDecorationImageDialog;
+};
+
+#endif

--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -1,0 +1,274 @@
+/***************************************************************************
+  qgsdecorationimagedialog.cpp
+  --------------------------------------
+  Date                 : August 2019
+  Copyright            : (C) 2019 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationimagedialog.h"
+#include "qgsdecorationimage.h"
+#include "qgsimagecache.h"
+#include "qgslogger.h"
+#include "qgshelp.h"
+#include "qgsproject.h"
+#include "qgssymbollayerutils.h"
+#include "qgssvgcache.h"
+#include "qgssvgselectorwidget.h"
+#include "qgsgui.h"
+
+#include <QPainter>
+#include <cmath>
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QSvgRenderer>
+
+QgsDecorationImageDialog::QgsDecorationImageDialog( QgsDecorationImage &deco, QWidget *parent )
+  : QDialog( parent )
+  , mDeco( deco )
+{
+  setupUi( this );
+
+  QgsGui::enableAutoGeometryRestore( this );
+
+  connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsDecorationImageDialog::buttonBox_accepted );
+  connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsDecorationImageDialog::buttonBox_rejected );
+
+  QPushButton *applyButton = buttonBox->button( QDialogButtonBox::Apply );
+  connect( applyButton, &QAbstractButton::clicked, this, &QgsDecorationImageDialog::apply );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationImageDialog::showHelp );
+
+  spinSize->setValue( mDeco.mSize );
+
+  // placement
+  cboPlacement->addItem( tr( "Top Left" ), QgsDecorationItem::TopLeft );
+  cboPlacement->addItem( tr( "Top Center" ), QgsDecorationItem::TopCenter );
+  cboPlacement->addItem( tr( "Top Right" ), QgsDecorationItem::TopRight );
+  cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
+  cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
+  cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
+  cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
+  spinHorizontal->setValue( mDeco.mMarginHorizontal );
+  spinVertical->setValue( mDeco.mMarginVertical );
+  wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );
+  wgtUnitSelection->setUnit( mDeco.mMarginUnit );
+
+  // enabled
+  grpEnable->setChecked( mDeco.enabled() );
+
+  wgtImagePath->setFilePath( mDeco.imagePath() );
+  connect( wgtImagePath, &QgsFileWidget::fileChanged, this, &QgsDecorationImageDialog::updateImagePath );
+  updateImagePath( mDeco.imagePath() );
+
+  pbnChangeColor->setAllowOpacity( true );
+  pbnChangeColor->setColor( mDeco.mColor );
+  pbnChangeColor->setContext( QStringLiteral( "gui" ) );
+  pbnChangeColor->setColorDialogTitle( tr( "Select SVG Image Fill Color" ) );
+  pbnChangeOutlineColor->setAllowOpacity( true );
+  pbnChangeOutlineColor->setColor( mDeco.mOutlineColor );
+  pbnChangeOutlineColor->setContext( QStringLiteral( "gui" ) );
+  pbnChangeOutlineColor->setColorDialogTitle( tr( "Select SVG Image Outline Color" ) );
+  connect( pbnChangeColor, &QgsColorButton::colorChanged, this, [ = ]( QColor ) { drawImage(); } );
+  connect( pbnChangeOutlineColor, &QgsColorButton::colorChanged, this, [ = ]( QColor ) { drawImage(); } );
+
+  drawImage();
+}
+
+void QgsDecorationImageDialog::showHelp()
+{
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#image" ) );
+}
+
+void QgsDecorationImageDialog::buttonBox_accepted()
+{
+  apply();
+  accept();
+}
+
+void QgsDecorationImageDialog::buttonBox_rejected()
+{
+  reject();
+}
+
+void QgsDecorationImageDialog::apply()
+{
+  mDeco.mColor = pbnChangeColor->color();
+  mDeco.mOutlineColor = pbnChangeOutlineColor->color();
+  mDeco.mSize = spinSize->value();
+  mDeco.setPlacement( static_cast< QgsDecorationItem::Placement>( cboPlacement->currentData().toInt() ) );
+  mDeco.mMarginUnit = wgtUnitSelection->unit();
+  mDeco.setEnabled( grpEnable->isChecked() );
+  mDeco.mMarginHorizontal = spinHorizontal->value();
+  mDeco.mMarginVertical = spinVertical->value();
+  mDeco.update();
+}
+
+void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
+{
+  if ( mDeco.imagePath() != imagePath )
+    mDeco.setImagePath( imagePath );
+
+  if ( mDeco.mImageFormat == QgsDecorationImage::FormatSVG )
+  {
+    QColor defaultFill, defaultStroke;
+    double defaultStrokeWidth, defaultFillOpacity, defaultStrokeOpacity;
+    bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultStrokeColor, hasDefaultStrokeWidth, hasDefaultStrokeOpacity;
+    bool hasFillParam, hasFillOpacityParam, hasStrokeParam, hasStrokeWidthParam, hasStrokeOpacityParam;
+    QgsApplication::svgCache()->containsParams( imagePath, hasFillParam, hasDefaultFillColor, defaultFill,
+        hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
+        hasStrokeParam, hasDefaultStrokeColor, defaultStroke,
+        hasStrokeWidthParam, hasDefaultStrokeWidth, defaultStrokeWidth,
+        hasStrokeOpacityParam, hasDefaultStrokeOpacity, defaultStrokeOpacity );
+
+    pbnChangeColor->setEnabled( hasFillParam );
+    pbnChangeColor->setAllowOpacity( hasFillOpacityParam );
+    if ( hasFillParam )
+    {
+      QColor fill = hasDefaultFillColor ? defaultFill : pbnChangeColor->color();
+      fill.setAlphaF( hasFillOpacityParam && hasDefaultFillOpacity ? defaultFillOpacity : 1.0 );
+      pbnChangeColor->setColor( fill );
+    }
+    pbnChangeOutlineColor->setEnabled( hasStrokeParam );
+    pbnChangeOutlineColor->setAllowOpacity( hasStrokeOpacityParam );
+    if ( hasStrokeParam )
+    {
+      QColor stroke = hasDefaultStrokeColor ? defaultStroke : pbnChangeOutlineColor->color();
+      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
+      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
+      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
+      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
+      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
+      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
+      stroke.setAlphaF( hasStrokeOpacityParam && hasDefaultStrokeOpacity ? defaultStrokeOpacity : 1.0 );
+      pbnChangeOutlineColor->setColor( stroke );
+    }
+  }
+  else
+  {
+    pbnChangeColor->setEnabled( false );
+    pbnChangeOutlineColor->setEnabled( false );
+  }
+
+  drawImage();
+}
+
+void QgsDecorationImageDialog::drawImage()
+{
+  bool missing = false;
+  double maxLength = 64;
+  QSize size( maxLength, maxLength );
+  QSvgRenderer svg;
+  QImage img;
+  switch ( mDeco.mImageFormat )
+  {
+    case QgsDecorationImage::FormatSVG:
+    {
+      const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( mDeco.imagePath(), maxLength, pbnChangeColor->color(), pbnChangeOutlineColor->color(), 1.0, 1.0 );
+      svg.load( svgContent );
+
+      if ( svg.isValid() )
+      {
+        QRectF viewBox = svg.viewBoxF();
+        if ( viewBox.height() > viewBox.width() )
+        {
+          size.setWidth( maxLength * viewBox.width() / viewBox.height() );
+        }
+        else
+        {
+          size.setHeight( maxLength * viewBox.height() / viewBox.width() );
+        }
+      }
+      else
+      {
+        // SVG can't be parsed
+        missing = true;
+      }
+      break;
+    }
+
+    case QgsDecorationImage::FormatRaster:
+    {
+      QSize originalSize = QgsApplication::imageCache()->originalSize( mDeco.imagePath() );
+      if ( originalSize.isValid() )
+      {
+        if ( originalSize.height() > originalSize.width() )
+        {
+          size.setWidth( originalSize.width() * maxLength / originalSize.height() );
+          size.setHeight( maxLength );
+        }
+        else
+        {
+          size.setWidth( maxLength );
+          size.setHeight( originalSize.height() * maxLength / originalSize.width() );
+        }
+        bool cached;
+        img = QgsApplication::imageCache()->pathAsImage( mDeco.imagePath(), size, true, 1.0, cached );
+      }
+      else
+      {
+        // Image can't be read
+        missing = true;
+      }
+      break;
+    }
+
+    case QgsDecorationImage::FormatUnknown:
+      // Broken / unavailable image
+      missing = true;
+  }
+
+  if ( !missing )
+  {
+    QPixmap  px( maxLength, maxLength );
+    px.fill();
+
+    QPainter painter;
+    painter.begin( &px );
+    painter.setRenderHint( QPainter::SmoothPixmapTransform );
+    switch ( mDeco.mImageFormat )
+    {
+      case QgsDecorationImage::FormatSVG:
+        svg.render( &painter, QRectF( 0, 0, size.width(), size.height() ) );
+        break;
+      case QgsDecorationImage::FormatRaster:
+        painter.drawImage( QRectF( 0, 0, size.width(), size.height() ), img );
+        break;
+      case QgsDecorationImage::FormatUnknown:
+        // Nothing to do here
+        break;
+    }
+    painter.end();
+
+    pixmapLabel->setPixmap( px );
+  }
+  else
+  {
+    QPixmap  px( 200, 200 );
+    px.fill();
+    QPainter painter;
+    painter.begin( &px );
+    QFont font( QStringLiteral( "time" ), 12, QFont::Bold );
+    painter.setFont( font );
+    painter.setPen( Qt::red );
+    painter.drawText( 10, 20, tr( "Pixmap not found" ) );
+    painter.end();
+    pixmapLabel->setPixmap( px );
+  }
+}
+
+//
+// Called when the widget has been resized.
+//
+
+void QgsDecorationImageDialog::resizeEvent( QResizeEvent *resizeEvent )
+{
+  Q_UNUSED( resizeEvent )
+  drawImage();
+}

--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -140,12 +140,6 @@ void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
     if ( hasStrokeParam )
     {
       QColor stroke = hasDefaultStrokeColor ? defaultStroke : pbnChangeOutlineColor->color();
-      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
-      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
-      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
-      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
-      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
-      QgsDebugMsg( QString( "XXXXXXXXXX %1" ).arg( defaultStrokeOpacity ) );
       stroke.setAlphaF( hasStrokeOpacityParam && hasDefaultStrokeOpacity ? defaultStrokeOpacity : 1.0 );
       pbnChangeOutlineColor->setColor( stroke );
     }

--- a/src/app/decorations/qgsdecorationimagedialog.h
+++ b/src/app/decorations/qgsdecorationimagedialog.h
@@ -1,0 +1,46 @@
+/***************************************************************************
+  qgsdecorationimagedialog.h
+  --------------------------------------
+  Date                 : August 2019
+  Copyright            : (C) 2019 by Mathieu Pellerin
+  Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDECORATIONIMAGEDIALOG_H
+#define QGSDECORATIONIMAGEDIALOG_H
+
+#include "ui_qgsdecorationimagedialog.h"
+#include "qgis_app.h"
+
+class QgsDecorationImage;
+
+class APP_EXPORT QgsDecorationImageDialog : public QDialog, private Ui::QgsDecorationImageDialog
+{
+    Q_OBJECT
+
+  public:
+    QgsDecorationImageDialog( QgsDecorationImage &deco, QWidget *parent = nullptr );
+
+  private:
+    void drawImage();
+    void updateImagePath( const QString &imagePath );
+    void resizeEvent( QResizeEvent * ) override; //overloads qwidget
+
+  private slots:
+    void buttonBox_accepted();
+    void buttonBox_rejected();
+    void showHelp();
+    void apply();
+
+  protected:
+    QgsDecorationImage &mDeco;
+};
+
+#endif

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -186,6 +186,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsdwgimportdialog.h"
 #include "qgsdecorationtitle.h"
 #include "qgsdecorationcopyright.h"
+#include "qgsdecorationimage.h"
 #include "qgsdecorationnortharrow.h"
 #include "qgsdecorationscalebar.h"
 #include "qgsdecorationgrid.h"
@@ -3446,6 +3447,7 @@ void QgisApp::setTheme( const QString &themeName )
   mActionDiagramProperties->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/propertyicons/diagram.svg" ) ) );
   mActionDecorationTitle->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/title_label.svg" ) ) );
   mActionDecorationCopyright->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/copyright_label.svg" ) ) );
+  mActionDecorationImage->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddImage.svg" ) ) );
   mActionDecorationNorthArrow->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/north_arrow.svg" ) ) );
   mActionDecorationScaleBar->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionScaleBar.svg" ) ) );
   mActionDecorationGrid->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/grid.svg" ) ) );
@@ -4192,30 +4194,34 @@ void QgisApp::setMapTipsDelay( int timerInterval )
 
 void QgisApp::createDecorations()
 {
-  QgsDecorationTitle *mDecorationTitle = new QgsDecorationTitle( this );
-  connect( mActionDecorationTitle, &QAction::triggered, mDecorationTitle, &QgsDecorationTitle::run );
+  QgsDecorationTitle *decorationTitle = new QgsDecorationTitle( this );
+  connect( mActionDecorationTitle, &QAction::triggered, decorationTitle, &QgsDecorationTitle::run );
 
-  QgsDecorationCopyright *mDecorationCopyright = new QgsDecorationCopyright( this );
-  connect( mActionDecorationCopyright, &QAction::triggered, mDecorationCopyright, &QgsDecorationCopyright::run );
+  QgsDecorationCopyright *decorationCopyright = new QgsDecorationCopyright( this );
+  connect( mActionDecorationCopyright, &QAction::triggered, decorationCopyright, &QgsDecorationCopyright::run );
 
-  QgsDecorationNorthArrow *mDecorationNorthArrow = new QgsDecorationNorthArrow( this );
-  connect( mActionDecorationNorthArrow, &QAction::triggered, mDecorationNorthArrow, &QgsDecorationNorthArrow::run );
+  QgsDecorationImage *decorationImage = new QgsDecorationImage( this );
+  connect( mActionDecorationImage, &QAction::triggered, decorationImage, &QgsDecorationImage::run );
 
-  QgsDecorationScaleBar *mDecorationScaleBar = new QgsDecorationScaleBar( this );
-  connect( mActionDecorationScaleBar, &QAction::triggered, mDecorationScaleBar, &QgsDecorationScaleBar::run );
+  QgsDecorationNorthArrow *decorationNorthArrow = new QgsDecorationNorthArrow( this );
+  connect( mActionDecorationNorthArrow, &QAction::triggered, decorationNorthArrow, &QgsDecorationNorthArrow::run );
 
-  QgsDecorationGrid *mDecorationGrid = new QgsDecorationGrid( this );
-  connect( mActionDecorationGrid, &QAction::triggered, mDecorationGrid, &QgsDecorationGrid::run );
+  QgsDecorationScaleBar *decorationScaleBar = new QgsDecorationScaleBar( this );
+  connect( mActionDecorationScaleBar, &QAction::triggered, decorationScaleBar, &QgsDecorationScaleBar::run );
+
+  QgsDecorationGrid *decorationGrid = new QgsDecorationGrid( this );
+  connect( mActionDecorationGrid, &QAction::triggered, decorationGrid, &QgsDecorationGrid::run );
 
   QgsDecorationLayoutExtent *decorationLayoutExtent = new QgsDecorationLayoutExtent( this );
   connect( mActionDecorationLayoutExtent, &QAction::triggered, decorationLayoutExtent, &QgsDecorationLayoutExtent::run );
 
   // add the decorations in a particular order so they are rendered in that order
-  addDecorationItem( mDecorationGrid );
-  addDecorationItem( mDecorationTitle );
-  addDecorationItem( mDecorationCopyright );
-  addDecorationItem( mDecorationNorthArrow );
-  addDecorationItem( mDecorationScaleBar );
+  addDecorationItem( decorationGrid );
+  addDecorationItem( decorationImage );
+  addDecorationItem( decorationTitle );
+  addDecorationItem( decorationCopyright );
+  addDecorationItem( decorationNorthArrow );
+  addDecorationItem( decorationScaleBar );
   addDecorationItem( decorationLayoutExtent );
   connect( mMapCanvas, &QgsMapCanvas::renderComplete, this, &QgisApp::renderDecorationItems );
   connect( this, &QgisApp::newProject, this, &QgisApp::projectReadDecorationItems );

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -105,6 +105,7 @@
      </property>
      <addaction name="mActionDecorationGrid"/>
      <addaction name="mActionDecorationScaleBar"/>
+     <addaction name="mActionDecorationImage"/>
      <addaction name="mActionDecorationNorthArrow"/>
      <addaction name="mActionDecorationTitle"/>
      <addaction name="mActionDecorationCopyright"/>
@@ -2028,6 +2029,21 @@ Acts on all editable layers.</string>
    </property>
    <property name="whatsThis">
     <string>Creates a copyright label that is displayed on the map canvas.</string>
+   </property>
+  </action>
+  <action name="mActionDecorationImage">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionAddImage.svg</normaloff>:/images/themes/default/mActionAddImage.svg</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Image…</string>
+   </property>
+   <property name="toolTip">
+    <string>Image</string>
+   </property>
+   <property name="whatsThis">
+    <string>&quot;Creates an image that is displayed on the map canvas&quot;</string>
    </property>
   </action>
   <action name="mActionDecorationNorthArrow">

--- a/src/ui/qgsdecorationimagedialog.ui
+++ b/src/ui/qgsdecorationimagedialog.ui
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDecorationImageDialog</class>
+ <widget class="QDialog" name="QgsDecorationImageDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>578</width>
+    <height>259</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Image Decoration</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff/>
+   </iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="grpEnable">
+     <property name="title">
+      <string>Enable Image</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="2" column="1">
+       <widget class="QLabel" name="sizeLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="3">
+       <widget class="QgsDoubleSpinBox" name="spinSize">
+        <property name="suffix">
+         <string> mm</string>
+        </property>
+        <property name="minimum">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="svgLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Image path</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2" colspan="3">
+       <widget class="QgsFileWidget" name="wgtImagePath" native="true"/>       
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="colorLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="3">
+       <layout class="QHBoxLayout" name="colorLayout">
+        <item>
+         <widget class="QLabel" name="fillLabel">
+          <property name="text">
+           <string>Fill</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsColorButton" name="pbnChangeColor">
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>120</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="outlineLabel">
+          <property name="text">
+           <string>Stroke</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsColorButton" name="pbnChangeOutlineColor">
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>120</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="5" column="2" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="labelHorizontal">
+          <property name="text">
+           <string>Horizontal</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsSpinBox" name="spinHorizontal">
+          <property name="minimumSize">
+           <size>
+            <width>90</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="whatsThis">
+           <string extracomment="Distance from the top of the canvas as a percentage of page height"/>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelVertical">
+          <property name="text">
+           <string>Vertical</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsSpinBox" name="spinVertical">
+          <property name="minimumSize">
+           <size>
+            <width>90</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="whatsThis">
+           <string extracomment="Distance from the left of the canvas as a percentage of page width"/>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsUnitSelectionWidget" name="wgtUnitSelection" native="true">
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="placementLabel">
+        <property name="text">
+         <string>Placement</string>
+        </property>
+        <property name="buddy">
+         <cstring>cboPlacement</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="lblMargin">
+        <property name="minimumSize">
+         <size>
+          <width>155</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Margin from edge</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2" colspan="3">
+       <widget class="QComboBox" name="cboPlacement">
+        <property name="toolTip">
+         <string>Placement on screen</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>7</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0" rowspan="6">
+       <widget class="QLabel" name="pixmapLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Preview of image</string>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>grpEnable</tabstop>
+  <tabstop>pbnChangeColor</tabstop>
+  <tabstop>pbnChangeOutlineColor</tabstop>
+  <tabstop>spinSize</tabstop>
+  <tabstop>wgtImagePath</tabstop>
+  <tabstop>cboPlacement</tabstop>
+  <tabstop>spinHorizontal</tabstop>
+  <tabstop>spinVertical</tabstop>
+  <tabstop>wgtUnitSelection</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Description
This PR introduces a new map canvas decoration item, namely the image decoration. This allows users to quickly overlay an image (logo, legend)  on top of their canvas:
![Screenshot from 2019-08-19 15-25-02](https://user-images.githubusercontent.com/1728657/63250490-f9e59880-c295-11e9-8c08-876cea8ba777.png)

_The default image decoration's image is a neat QGIS SVG logo with customizable fill and outline parameters, defaulting to a black fill and a transparent outline_

Gone are the days the north arrow decoration is misused to add a logo on top of the canvas. In addition to allowing the presence of a logo and a north arrow at the same time, the image decoration allows for top center and bottom center alignment. It also supports non-SVG image formats.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
