### PR TITLE
Fix nlohman::json array list initializer broken on GCC

### DIFF
--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -235,10 +235,9 @@ json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features
     { "type", "FeatureCollection" },
     { "features", json::array() }
   };
-  const auto constFeatures = features;
-  for ( const QgsFeature &feature : constFeatures )
+  for ( const QgsFeature &feature : qgis::as_const( features ) )
   {
-    data[ "features" ].push_back( exportFeatureToJsonObject( feature ) );
+    data["features"].push_back( exportFeatureToJsonObject( feature ) );
   }
   return data;
 }

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -238,7 +238,7 @@ json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features
   const auto constFeatures = features;
   for ( const QgsFeature &feature : constFeatures )
   {
-    data["features"].push_back( exportFeatureToJsonObject( feature ) );
+    data[ "features" ].push_back( exportFeatureToJsonObject( feature ) );
   }
   return data;
 }

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -85,7 +85,7 @@ QString QgsServerOgcApiHandler::contentTypeForAccept( const QString &accept ) co
 
 void QgsServerOgcApiHandler::write( json &data, const QgsServerApiContext &context, const json &htmlMetadata ) const
 {
-  const auto contentType { contentTypeFromRequest( context.request() ) };
+  const QgsServerOgcApi::ContentType contentType { contentTypeFromRequest( context.request() ) };
   switch ( contentType )
   {
     case QgsServerOgcApi::ContentType::HTML:
@@ -105,8 +105,8 @@ void QgsServerOgcApiHandler::write( json &data, const QgsServerApiContext &conte
 }
 void QgsServerOgcApiHandler::write( QVariant &data, const QgsServerApiContext &context, const QVariantMap &htmlMetadata ) const
 {
-  json j { QgsJsonUtils::jsonFromVariant( data ) };
-  json jm { QgsJsonUtils::jsonFromVariant( htmlMetadata ) };
+  json j = QgsJsonUtils::jsonFromVariant( data );
+  json jm = QgsJsonUtils::jsonFromVariant( htmlMetadata );
   QgsServerOgcApiHandler::write( j, context, jm );
 }
 
@@ -307,7 +307,11 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
     // links_filter( <links>, <key>, <value> )
     env.add_callback( "links_filter", 3, [ = ]( Arguments & args )
     {
-      json links { args.at( 0 )->get<json>( ) };
+      json links = args.at( 0 )->get<json>( );
+      if ( ! links.is_array() )
+      {
+        links = json::array();
+      }
       std::string key { args.at( 1 )->get<std::string>( ) };
       std::string value { args.at( 2 )->get<std::string>( ) };
       json result = json::array();
@@ -344,6 +348,7 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
     throw QgsServerApiInternalServerError( QStringLiteral( "Error parsing template file: %1" ).arg( e.what() ) );
   }
 }
+
 QgsServerOgcApi::ContentType QgsServerOgcApiHandler::contentTypeFromRequest( const QgsServerRequest *request ) const
 {
   // Fallback to default

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -500,8 +500,7 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
 
   const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
   const QString shortName { mapLayer->shortName().isEmpty() ? mapLayer->name() : mapLayer->shortName() };
-  json linksList = json::array( );
-  linksList = links( context );
+  json linksList = links( context );
   linksList.push_back(
   {
     { "href", href( context, QStringLiteral( "/items" ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::JSON ) )  },

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -98,7 +98,7 @@ void QgsWfs3APIHandler::handleRequest( const QgsServerApiContext &context ) cons
   for ( const auto &h : mApi->handlers() )
   {
     // Skip null schema
-    const auto hSchema { h->schema( context ) };
+    const json hSchema = h->schema( context );
     if ( ! hSchema.is_null() )
       paths.merge_patch( hSchema );
   }
@@ -500,7 +500,8 @@ void QgsWfs3DescribeCollectionHandler::handleRequest( const QgsServerApiContext 
 
   const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
   const QString shortName { mapLayer->shortName().isEmpty() ? mapLayer->name() : mapLayer->shortName() };
-  json linksList { links( context ) };
+  json linksList = json::array( );
+  linksList = links( context );
   linksList.push_back(
   {
     { "href", href( context, QStringLiteral( "/items" ), QgsServerOgcApi::contentTypeToExtension( QgsServerOgcApi::ContentType::JSON ) )  },
@@ -975,7 +976,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
       }
     }
 
-    json data { exporter.exportFeaturesToJsonObject( featureList ) };
+    json data = exporter.exportFeaturesToJsonObject( featureList );
 
     // Add some metadata
     data["numberMatched"] = matchedFeaturesCount;
@@ -1009,7 +1010,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
     // Add prev - next links
     if ( offset != 0 )
     {
-      auto prevLink { selfLink };
+      json prevLink = selfLink;
       prevLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrl ).arg( std::max<long>( 0, limit - offset ) ).arg( limit ).toStdString();
       prevLink["rel"] = "prev";
       prevLink["name"] = "Previous page";
@@ -1017,7 +1018,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
     }
     if ( limit + offset < matchedFeaturesCount )
     {
-      auto nextLink { selfLink };
+      json nextLink = selfLink;
       nextLink["href"] = QStringLiteral( "%1&offset=%2&limit=%3" ).arg( cleanedUrl ).arg( std::min<long>( matchedFeaturesCount, limit + offset ) ).arg( limit ).toStdString();
       nextLink["rel"] = "next";
       nextLink["name"] = "Next page";
@@ -1078,7 +1079,7 @@ void QgsWfs3CollectionsFeatureHandler::handleRequest( const QgsServerApiContext 
     {
       QgsServerApiInternalServerError( QStringLiteral( "Invalid feature [%1]" ).arg( featureId ) );
     }
-    json data { exporter.exportFeatureToJsonObject( feature ) };
+    json data = exporter.exportFeatureToJsonObject( feature );
     data["links"] = links( context );
     json navigation = json::array();
     const QUrl url { context.request()->url() };


### PR DESCRIPTION
the issue:

`json j { something_returning_json_array_of_values() };`

produces a `json::array( json::array( values ) ) )`

instead of `json::array( values )`

by using the assignment all is fine:

`json j = something_returning_json_array_of_values();`

produces a `json::array( values )` as expected
