### PR TITLE
Remove QGIS version check

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -536,7 +536,6 @@ int main( int argc, char *argv[] )
 
   bool myHideSplash = false;
   bool settingsMigrationForce = false;
-  bool mySkipVersionCheck = false;
   bool hideBrowser = false;
 #if defined(ANDROID)
   QgsDebugMsg( QStringLiteral( "Android: Splash hidden" ) );
@@ -625,10 +624,6 @@ int main( int argc, char *argv[] )
         else if ( arg == QLatin1String( "--version-migration" ) )
         {
           settingsMigrationForce = true;
-        }
-        else if ( arg == QLatin1String( "--noversioncheck" ) || arg == QLatin1String( "-V" ) )
-        {
-          mySkipVersionCheck = true;
         }
         else if ( arg == QLatin1String( "--noplugins" ) || arg == QLatin1String( "-P" ) )
         {
@@ -1325,7 +1320,7 @@ int main( int argc, char *argv[] )
   // this should be done in QgsApplication::init() but it doesn't know the settings dir.
   QgsApplication::setMaxThreads( settings.value( QStringLiteral( "qgis/max_threads" ), -1 ).toInt() );
 
-  QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins, mySkipVersionCheck, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
+  QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins, rootProfileFolder, profileName ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( QStringLiteral( "QgisApp" ) );
 
   myApp.connect(

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -712,7 +712,7 @@ static bool cmpByText_( QAction *a, QAction *b )
 QgisApp *QgisApp::sInstance = nullptr;
 
 // constructor starts here
-QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCheck, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
+QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, const QString &rootProfileLocation, const QString &activeProfile, QWidget *parent, Qt::WindowFlags fl )
   : QMainWindow( parent, fl )
   , mSplash( splash )
 {
@@ -824,7 +824,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mProjOpen = settings.value( QStringLiteral( "qgis/projOpenAtLaunch" ), 0 ).toInt();
 
   startProfile( QStringLiteral( "Welcome page" ) );
-  mWelcomePage = new QgsWelcomePage( skipVersionCheck );
+  mWelcomePage = new QgsWelcomePage();
   connect( mWelcomePage, &QgsWelcomePage::projectRemoved, this, [ this ]( int row )
   {
     mRecentProjects.removeAt( row );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -181,7 +181,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Constructor
     QgisApp( QSplashScreen *splash, bool restorePlugins = true,
-             bool skipVersionCheck = false, const QString &rootProfileLocation = QString(),
+             const QString &rootProfileLocation = QString(),
              const QString &activeProfile = QString(),
              QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Window );
     //! Constructor for unit tests

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -16,7 +16,6 @@
 #include "qgswelcomepage.h"
 #include "qgsproject.h"
 #include "qgisapp.h"
-#include "qgsversioninfo.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
@@ -38,7 +37,7 @@
 
 #define FEED_URL "http://feed.qgis.org/"
 
-QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
+QgsWelcomePage::QgsWelcomePage( QWidget *parent )
   : QWidget( parent )
 {
   QgsSettings settings;
@@ -150,26 +149,6 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
   rightContainer->setLayout( rightLayout );
   mSplitter->addWidget( rightContainer );
 
-  mVersionInformation = new QTextBrowser;
-  mVersionInformation->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Maximum );
-  mVersionInformation->setReadOnly( true );
-  mVersionInformation->setOpenExternalLinks( true );
-  mVersionInformation->setStyleSheet( QStringLiteral( "QTextEdit { background-color: #dff0d8; border: 1px solid #8e998a; padding-top: 0.25em; max-height: 1.75em; min-height: 1.75em; } "
-                                      "QScrollBar { background-color: rgba(0,0,0,0); } "
-                                      "QScrollBar::add-page,QScrollBar::sub-page,QScrollBar::handle { background-color: rgba(0,0,0,0); color: rgba(0,0,0,0); } "
-                                      "QScrollBar::up-arrow,QScrollBar::down-arrow { color: rgb(0,0,0); } " ) );
-
-  mainLayout->addWidget( mVersionInformation );
-  mVersionInformation->setVisible( false );
-
-  mVersionInfo = new QgsVersionInfo();
-  if ( !QgsApplication::isRunningFromBuildDir() && settings.value( QStringLiteral( "/qgis/allowVersionCheck" ), true ).toBool()
-       && settings.value( QStringLiteral( "qgis/checkVersion" ), true ).toBool() && !skipVersionCheck )
-  {
-    connect( mVersionInfo, &QgsVersionInfo::versionInfoAvailable, this, &QgsWelcomePage::versionInfoReceived );
-    mVersionInfo->checkVersion();
-  }
-
   mSplitter->restoreState( settings.value( QStringLiteral( "Windows/WelcomePage/SplitState" ), QVariant(), QgsSettings::App ).toByteArray() );
   if ( mSplitter2 )
     mSplitter2->restoreState( settings.value( QStringLiteral( "Windows/WelcomePage/SplitState2" ), QVariant(), QgsSettings::App ).toByteArray() );
@@ -186,8 +165,6 @@ QgsWelcomePage::~QgsWelcomePage()
   settings.setValue( QStringLiteral( "Windows/WelcomePage/SplitState" ), mSplitter->saveState(), QgsSettings::App );
   if ( mSplitter2 && mNewsFeedTitle->isVisible() )
     settings.setValue( QStringLiteral( "Windows/WelcomePage/SplitState2" ), mSplitter2->saveState(), QgsSettings::App );
-
-  delete mVersionInfo;
 }
 
 void QgsWelcomePage::setRecentProjects( const QList<QgsRecentProjectItemsModel::RecentProjectData> &recentProjects )
@@ -221,20 +198,6 @@ void QgsWelcomePage::newsItemActivated( const QModelIndex &index )
 
   const QUrl link = index.data( QgsNewsFeedModel::Link ).toUrl();
   QDesktopServices::openUrl( link );
-}
-
-void QgsWelcomePage::versionInfoReceived()
-{
-  QgsVersionInfo *versionInfo = qobject_cast<QgsVersionInfo *>( sender() );
-  Q_ASSERT( versionInfo );
-
-  if ( versionInfo->newVersionAvailable() )
-  {
-    mVersionInformation->setVisible( true );
-    mVersionInformation->setText( QStringLiteral( "<style> a, a:visited, a:hover { color:#268300; } </style><b>%1</b>: %2" )
-                                  .arg( tr( "New QGIS version available" ),
-                                        QgsStringUtils::insertLinks( versionInfo->downloadInfo() ) ) );
-  }
 }
 
 void QgsWelcomePage::showContextMenuForProjects( QPoint point )

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -36,7 +36,7 @@ class QgsWelcomePage : public QWidget
     Q_OBJECT
 
   public:
-    explicit QgsWelcomePage( bool skipVersionCheck = false, QWidget *parent = nullptr );
+    explicit QgsWelcomePage( QWidget *parent = nullptr );
 
     ~QgsWelcomePage() override;
 
@@ -59,7 +59,6 @@ class QgsWelcomePage : public QWidget
     void recentProjectItemActivated( const QModelIndex &index );
     void templateProjectItemActivated( const QModelIndex &index );
     void newsItemActivated( const QModelIndex &index );
-    void versionInfoReceived();
     void showContextMenuForProjects( QPoint point );
     void showContextMenuForTemplates( QPoint point );
     void showContextMenuForNews( QPoint point );
@@ -69,8 +68,6 @@ class QgsWelcomePage : public QWidget
     void updateRecentProjectsVisibility();
 
     QgsRecentProjectItemsModel *mRecentProjectsModel = nullptr;
-    QTextBrowser *mVersionInformation = nullptr;
-    QgsVersionInfo *mVersionInfo = nullptr;
     QListView *mRecentProjectsListView = nullptr;
     QLabel *mRecentProjectsTitle = nullptr;
     QListView *mTemplateProjectsListView = nullptr;


### PR DESCRIPTION
The current way QGIS checks the version is not very convincing and there are a couple of issues with it. Very often it targets the wrong audience in bigger organisations, the people who see it do not even have the possibility to upgrade. There is also no distinction between regular releases and LTR.

So I figured it might be good to just close this chapter and remove it and maybe think of a smarter way for this in the future.

Critique and better ideas explicitly encouraged!