### PR TITLE
Export multiple themes via layout GeoPDF export

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -459,6 +459,8 @@ Moves to the next export part for a multi-layered export item, during a multi-la
       QString name;
 
       QString mapLayerId;
+
+      QString mapTheme;
     };
 
     virtual QgsLayoutItem::ExportLayerDetail exportLayerDetails() const;

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -267,6 +267,30 @@ The default is to use no simplification.
 .. versionadded:: 3.10
 %End
 
+    QStringList exportThemes() const;
+%Docstring
+Returns a list of map themes to use during the export.
+
+Items which handle layered exports (e.g. maps) may utilise this list to export different
+representations of the item as export layers, as they iterate through these included themes.
+
+.. seealso:: :py:func:`setExportThemes`
+
+.. versionadded:: 3.10
+%End
+
+    void setExportThemes( const QStringList &themes );
+%Docstring
+Sets a list of map ``themes`` to use during the export.
+
+Items which handle layered exports (e.g. maps) may utilise this list to export different
+representations of the item as export layers, as they iterate through these included themes.
+
+.. seealso:: :py:func:`exportThemes`
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void flagsChanged( QgsLayoutRenderContext::Flags flags );

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -271,7 +271,7 @@ The default is to use no simplification.
 %Docstring
 Returns a list of map themes to use during the export.
 
-Items which handle layered exports (e.g. maps) may utilise this list to export different
+Items which handle layered exports (e.g. maps) may utilize this list to export different
 representations of the item as export layers, as they iterate through these included themes.
 
 .. seealso:: :py:func:`setExportThemes`
@@ -283,7 +283,7 @@ representations of the item as export layers, as they iterate through these incl
 %Docstring
 Sets a list of map ``themes`` to use during the export.
 
-Items which handle layered exports (e.g. maps) may utilise this list to export different
+Items which handle layered exports (e.g. maps) may utilize this list to export different
 representations of the item as export layers, as they iterate through these included themes.
 
 .. seealso:: :py:func:`exportThemes`

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -556,6 +556,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
       QgsLayoutGeoPdfExporter::ComponentLayerDetail component;
       component.name = layerDetail.name;
       component.mapLayerId = layerDetail.mapLayerId;
+      component.group = layerDetail.mapTheme;
       component.sourcePdfPath = geoPdfExporter->generateTemporaryFilepath( QStringLiteral( "layer_%1.pdf" ).arg( layerId ) );
       pdfComponents << component;
       preparePrintAsPdf( mLayout, printer, component.sourcePdfPath );

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -316,6 +316,7 @@ class LayoutContextSettingsRestorer
       , mPreviousTextFormat( layout->renderContext().textRenderFormat() )
       , mPreviousExportLayer( layout->renderContext().currentExportLayer() )
       , mPreviousSimplifyMethod( layout->renderContext().simplifyMethod() )
+      , mExportThemes( layout->renderContext().exportThemes() )
     {
     }
     Q_NOWARN_DEPRECATED_POP
@@ -329,6 +330,7 @@ class LayoutContextSettingsRestorer
       mLayout->renderContext().setCurrentExportLayer( mPreviousExportLayer );
       Q_NOWARN_DEPRECATED_POP
       mLayout->renderContext().setSimplifyMethod( mPreviousSimplifyMethod );
+      mLayout->renderContext().setExportThemes( mExportThemes );
     }
 
     LayoutContextSettingsRestorer( const LayoutContextSettingsRestorer &other ) = delete;
@@ -341,6 +343,7 @@ class LayoutContextSettingsRestorer
     QgsRenderContext::TextRenderFormat mPreviousTextFormat = QgsRenderContext::TextFormatAlwaysOutlines;
     int mPreviousExportLayer = 0;
     QgsVectorSimplifyMethod mPreviousSimplifyMethod;
+    QStringList mExportThemes;
 
 };
 ///@endcond PRIVATE

--- a/src/core/layout/qgslayoutgeopdfexporter.cpp
+++ b/src/core/layout/qgslayoutgeopdfexporter.cpp
@@ -40,6 +40,7 @@ class QgsGeoPdfRenderedFeatureHandler: public QgsRenderedFeatureHandlerInterface
 
     QgsGeoPdfRenderedFeatureHandler( QgsLayoutItemMap *map, QgsLayoutGeoPdfExporter *exporter )
       : mExporter( exporter )
+      , mMap( map )
     {
       // get page size
       const QgsLayoutSize pageSize = map->layout()->pageCollection()->page( map->page() )->pageSize();
@@ -71,6 +72,7 @@ class QgsGeoPdfRenderedFeatureHandler: public QgsRenderedFeatureHandlerInterface
       // the alternative is adding a layer ID member to QgsRenderContext, and that's just asking for people to abuse it
       // and use it to retrieve QgsMapLayers mid-way through a render operation. Lesser of two evils it is!
       const QString layerId = context.renderContext.expressionContext().variable( QStringLiteral( "layer_id" ) ).toString();
+      const QString theme = ( mMap->mExportThemes.isEmpty() || mMap->mExportThemeIt == mMap->mExportThemes.end() ) ? QString() : *mMap->mExportThemeIt;
 
       // transform from pixels to map item coordinates
       QTransform pixelToMapItemTransform = QTransform::fromScale( 1.0 / context.renderContext.scaleFactor(), 1.0 / context.renderContext.scaleFactor() );
@@ -84,7 +86,7 @@ class QgsGeoPdfRenderedFeatureHandler: public QgsRenderedFeatureHandlerInterface
       // always convert to multitype, to make things consistent
       transformed.convertToMultiType();
 
-      mExporter->pushRenderedFeature( layerId, QgsLayoutGeoPdfExporter::RenderedFeature( feature, transformed ) );
+      mExporter->pushRenderedFeature( layerId, QgsLayoutGeoPdfExporter::RenderedFeature( feature, transformed ), theme );
     }
 
     QSet<QString> usedAttributes( QgsVectorLayer *, const QgsRenderContext & ) const override
@@ -96,6 +98,7 @@ class QgsGeoPdfRenderedFeatureHandler: public QgsRenderedFeatureHandlerInterface
     QTransform mMapToLayoutTransform;
     QTransform mLayoutToPdfTransform;
     QgsLayoutGeoPdfExporter *mExporter = nullptr;
+    QgsLayoutItemMap *mMap = nullptr;
 };
 ///@endcond
 

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -488,6 +488,9 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
 
       //! Associated map layer ID, or an empty string if this export layer is not associated with a map layer
       QString mapLayerId;
+
+      //! Associated map theme, or an empty string if this export layer does not need to be associated with a map theme
+      QString mapTheme;
     };
 
     /**

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1121,6 +1121,9 @@ QgsLayoutItem::ExportLayerDetail QgsLayoutItemMap::exportLayerDetails() const
       return detail;
 
     case Layer:
+      if ( !mExportThemes.empty() && mExportThemeIt != mExportThemes.end() )
+        detail.mapTheme = *mExportThemeIt;
+
       if ( mStagedRendererJob )
       {
         switch ( mStagedRendererJob->currentStage() )

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1171,7 +1171,10 @@ QgsLayoutItem::ExportLayerDetail QgsLayoutItemMap::exportLayerDetails() const
         if ( !layers.isEmpty() )
         {
           const QgsMapLayer *layer = layers.constLast();
-          detail.name = QStringLiteral( "%1: %2" ).arg( displayName(), layer->name() );
+          if ( !detail.mapTheme.isEmpty() )
+            detail.name = QStringLiteral( "%1 (%2): %3" ).arg( displayName(), detail.mapTheme, layer->name() );
+          else
+            detail.name = QStringLiteral( "%1: %2" ).arg( displayName(), layer->name() );
           detail.mapLayerId = layer->id();
         }
       }

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1007,7 +1007,8 @@ int QgsLayoutItemMap::numberExportLayers() const
 void QgsLayoutItemMap::startLayeredExport()
 {
   mCurrentExportPart = Start;
-  mExportThemes = mLayout->renderContext().exportThemes();
+  // only follow export themes if the map isn't set to follow a fixed theme
+  mExportThemes = !mFollowVisibilityPreset ? mLayout->renderContext().exportThemes() : QStringList();
   mExportThemeIt = mExportThemes.begin();
 }
 
@@ -1850,14 +1851,14 @@ QString QgsLayoutItemMap::themeToRender( const QgsExpressionContext &context ) c
 {
   QString presetName;
 
-  if ( !mExportThemes.empty() && mExportThemeIt != mExportThemes.end() )
-    presetName = *mExportThemeIt;
-  else if ( mFollowVisibilityPreset )
+  if ( mFollowVisibilityPreset )
   {
     presetName = mFollowVisibilityPresetName;
     // preset name can be overridden by data-defined one
     presetName = mDataDefinedProperties.valueAsString( QgsLayoutObject::MapStylePreset, context, presetName );
   }
+  else if ( !mExportThemes.empty() && mExportThemeIt != mExportThemes.end() )
+    presetName = *mExportThemeIt;
   return presetName;
 }
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1133,7 +1133,10 @@ QgsLayoutItem::ExportLayerDetail QgsLayoutItemMap::exportLayerDetails() const
             detail.mapLayerId  = mStagedRendererJob->currentLayerId();
             if ( const QgsMapLayer *layer = mLayout->project()->mapLayer( detail.mapLayerId ) )
             {
-              detail.name = QStringLiteral( "%1: %2" ).arg( displayName(), layer->name() );
+              if ( !detail.mapTheme.isEmpty() )
+                detail.name = QStringLiteral( "%1 (%2): %3" ).arg( displayName(), detail.mapTheme, layer->name() );
+              else
+                detail.name = QStringLiteral( "%1: %2" ).arg( displayName(), layer->name() );
             }
             return detail;
           }
@@ -1142,11 +1145,17 @@ QgsLayoutItem::ExportLayerDetail QgsLayoutItemMap::exportLayerDetails() const
             detail.mapLayerId  = mStagedRendererJob->currentLayerId();
             if ( const QgsMapLayer *layer = mLayout->project()->mapLayer( detail.mapLayerId ) )
             {
-              detail.name = tr( "%1: %2 (Labels)" ).arg( displayName(), layer->name() );
+              if ( !detail.mapTheme.isEmpty() )
+                detail.name = QStringLiteral( "%1 (%2): %3 (Labels)" ).arg( displayName(), detail.mapTheme, layer->name() );
+              else
+                detail.name = tr( "%1: %2 (Labels)" ).arg( displayName(), layer->name() );
             }
             else
             {
-              detail.name = tr( "%1: Labels" ).arg( displayName() );
+              if ( !detail.mapTheme.isEmpty() )
+                detail.name = tr( "%1 (%2): Labels" ).arg( displayName(), detail.mapTheme );
+              else
+                detail.name = tr( "%1: Labels" ).arg( displayName() );
             }
             return detail;
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1083,16 +1083,8 @@ bool QgsLayoutItemMap::nextExportPart()
       FALLTHROUGH
 
     case SelectionBoxes:
-      if ( mExportThemeIt != mExportThemes.end() && mExportThemeIt++ != mExportThemes.end() )
-      {
-        mCurrentExportPart = Start;
-        return nextExportPart();
-      }
-      else
-      {
-        mCurrentExportPart = End;
-        return false;
-      }
+      mCurrentExportPart = End;
+      return false;
 
     case End:
       return false;

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -776,6 +776,8 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
     //! Resets the item tooltip to reflect current map id
     void updateToolTip();
 
+    QString themeToRender( const QgsExpressionContext &context ) const;
+
     //! Returns current layer style overrides for this map item
     QMap<QString, QString> layerStyleOverridesToRender( const QgsExpressionContext &context ) const;
 
@@ -816,6 +818,8 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
     bool shouldDrawPart( PartType part ) const;
 
     PartType mCurrentExportPart = NotLayered;
+    QStringList mExportThemes;
+    QStringList::iterator mExportThemeIt;
 
     /**
      * Refresh the map's extents, considering data defined extent, scale and rotation

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -840,6 +840,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
     friend class QgsLayoutItemLegend;
     friend class TestQgsLayoutMap;
     friend class QgsCompositionConverter;
+    friend class QgsGeoPdfRenderedFeatureHandler;
 
 };
 

--- a/src/core/layout/qgslayoutrendercontext.cpp
+++ b/src/core/layout/qgslayoutrendercontext.cpp
@@ -110,3 +110,13 @@ void QgsLayoutRenderContext::setPagesVisible( bool visible )
 {
   mPagesVisible = visible;
 }
+
+QStringList QgsLayoutRenderContext::exportThemes() const
+{
+  return mExportThemes;
+}
+
+void QgsLayoutRenderContext::setExportThemes( const QStringList &exportThemes )
+{
+  mExportThemes = exportThemes;
+}

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -259,6 +259,28 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
      */
     const QgsVectorSimplifyMethod &simplifyMethod() const { return mSimplifyMethod; }
 
+    /**
+     * Returns a list of map themes to use during the export.
+     *
+     * Items which handle layered exports (e.g. maps) may utilise this list to export different
+     * representations of the item as export layers, as they iterate through these included themes.
+     *
+     * \see setExportThemes()
+     * \since QGIS 3.10
+     */
+    QStringList exportThemes() const;
+
+    /**
+     * Sets a list of map \a themes to use during the export.
+     *
+     * Items which handle layered exports (e.g. maps) may utilise this list to export different
+     * representations of the item as export layers, as they iterate through these included themes.
+     *
+     * \see exportThemes()
+     * \since QGIS 3.10
+     */
+    void setExportThemes( const QStringList &themes );
+
   signals:
 
     /**
@@ -290,6 +312,8 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
     bool mPagesVisible = true;
 
     QgsRenderContext::TextRenderFormat mTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
+
+    QStringList mExportThemes;
 
     QgsVectorSimplifyMethod mSimplifyMethod;
 

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -262,7 +262,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
     /**
      * Returns a list of map themes to use during the export.
      *
-     * Items which handle layered exports (e.g. maps) may utilise this list to export different
+     * Items which handle layered exports (e.g. maps) may utilize this list to export different
      * representations of the item as export layers, as they iterate through these included themes.
      *
      * \see setExportThemes()
@@ -273,7 +273,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
     /**
      * Sets a list of map \a themes to use during the export.
      *
-     * Items which handle layered exports (e.g. maps) may utilise this list to export different
+     * Items which handle layered exports (e.g. maps) may utilize this list to export different
      * representations of the item as export layers, as they iterate through these included themes.
      *
      * \see exportThemes()

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -167,8 +167,11 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
     /**
      * Called multiple times during the rendering operation, whenever a \a feature associated with the specified
      * \a layerId is rendered.
+     *
+     * The optional \a group argument can be used to differentiate features from the same layer exported
+     * multiple times as part of different layer groups.
      */
-    void pushRenderedFeature( const QString &layerId, const QgsAbstractGeoPdfExporter::RenderedFeature &feature );
+    void pushRenderedFeature( const QString &layerId, const QgsAbstractGeoPdfExporter::RenderedFeature &feature, const QString &group = QString() );
 
     struct ExportDetails
     {
@@ -264,6 +267,9 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
       //! Associated map layer ID
       QString mapLayerId;
 
+      //! Optional layer group name
+      QString group;
+
       //! Field name for display
       QString displayAttribute;
 
@@ -278,7 +284,7 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
   private:
 
     QMutex mMutex;
-    QMap< QString, QgsFeatureList > mCollatedFeatures;
+    QMap< QString, QMap< QString, QgsFeatureList > > mCollatedFeatures;
 
     /**
      * Returns the PDF output component details for the layer with given \a layerId.

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -119,6 +119,9 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
       //! Associated map layer ID, or an empty string if this component layer is not associated with a map layer
       QString mapLayerId;
 
+      //! Optional group name, for arranging layers in top-level groups
+      QString group;
+
       //! File path to the (already created) PDF to use as the source for this component layer
       QString sourcePdfPath;
 

--- a/src/core/qgsmaprendererstagedrenderjob.cpp
+++ b/src/core/qgsmaprendererstagedrenderjob.cpp
@@ -126,6 +126,7 @@ bool QgsMapRendererStagedRenderJob::renderCurrentPart( QPainter *painter )
       painter->drawImage( 0, 0, *job.img );
       painter->setOpacity( 1.0 );
     }
+    job.context.setPainter( nullptr );
   }
   else
   {
@@ -144,6 +145,8 @@ bool QgsMapRendererStagedRenderJob::renderCurrentPart( QPainter *painter )
 
       // render just the current layer's labels
       static_cast< QgsStagedRenderLabelingEngine * >( mLabelingEngineV2.get() )->renderLabelsForLayer( mLabelJob.context, *mLabelLayerIt );
+
+      mLabelJob.context.setPainter( nullptr );
     }
     else
     {
@@ -151,6 +154,7 @@ bool QgsMapRendererStagedRenderJob::renderCurrentPart( QPainter *painter )
       drawLabeling( mLabelJob.context, mLabelingEngineV2.get(), painter );
       mLabelJob.complete = true;
       mLabelJob.participatingLayers = _qgis_listRawToQPointer( mLabelingEngineV2->participatingLayers() );
+      mLabelJob.context.setPainter( nullptr );
     }
   }
   return true;

--- a/tests/src/core/testqgsgeopdfexport.cpp
+++ b/tests/src/core/testqgsgeopdfexport.cpp
@@ -58,6 +58,7 @@ class TestQgsGeoPdfExport : public QObject
     void testComposition();
     void testMetadata();
     void testGeoref();
+    void testGroups();
 
   private:
 
@@ -179,11 +180,6 @@ void TestQgsGeoPdfExport::testCollectingFeatures()
 
 void TestQgsGeoPdfExport::testComposition()
 {
-  if ( !QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() )
-  {
-    QSKIP( "This test requires GeoPDF creation abilities", SkipSingle );
-  }
-
   TestGeoPdfExporter geoPdfExporter;
   // no features, no crash
   QVERIFY( geoPdfExporter.saveTemporaryLayers() );
@@ -268,11 +264,6 @@ void TestQgsGeoPdfExport::testComposition()
 
 void TestQgsGeoPdfExport::testMetadata()
 {
-  if ( !QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() )
-  {
-    QSKIP( "This test requires GeoPDF creation abilities", SkipSingle );
-  }
-
   TestGeoPdfExporter geoPdfExporter;
   // test creation of the composition xml with metadata
 
@@ -314,11 +305,6 @@ void TestQgsGeoPdfExport::testMetadata()
 
 void TestQgsGeoPdfExport::testGeoref()
 {
-  if ( !QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() )
-  {
-    QSKIP( "This test requires GeoPDF creation abilities", SkipSingle );
-  }
-
   TestGeoPdfExporter geoPdfExporter;
   // test creation of the composition xml with georeferencing
 
@@ -364,6 +350,90 @@ void TestQgsGeoPdfExport::testGeoref()
   QVERIFY( !cp1.isNull() );
   QCOMPARE( cp1.attribute( QStringLiteral( "x" ) ), QStringLiteral( "0" ) );
   QCOMPARE( cp1.attribute( QStringLiteral( "y" ) ), QStringLiteral( "-2.83465" ) );
+}
+
+void TestQgsGeoPdfExport::testGroups()
+{
+  TestGeoPdfExporter geoPdfExporter;
+  // no features, no crash
+  QVERIFY( geoPdfExporter.saveTemporaryLayers() );
+  QCOMPARE( geoPdfExporter.mVectorComponents.count(), 0 );
+
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "a1" ), QVariant::Int ) );
+  fields.append( QgsField( QStringLiteral( "a2" ), QVariant::Int ) );
+  QgsFeature f( fields );
+
+  f.setAttributes( QgsAttributes() << 1 << 2 );
+  f.setGeometry( QgsGeometry( new QgsPoint( 1, 2 ) ) );
+  QgsGeometry renderedBounds( QgsGeometry::fromRect( QgsRectangle( 1, 10, 6, 20 ) ) );
+  geoPdfExporter.pushRenderedFeature( QStringLiteral( "layer1" ), QgsAbstractGeoPdfExporter::RenderedFeature( f, renderedBounds ) );
+  f.setAttributes( QgsAttributes() << 31 << 32 );
+  f.setGeometry( QgsGeometry( new QgsPoint( 4, 5 ) ) );
+  renderedBounds = QgsGeometry::fromWkt( QStringLiteral( "LineString(1 1, 2 2)" ) );
+  geoPdfExporter.pushRenderedFeature( QStringLiteral( "layer2" ), QgsAbstractGeoPdfExporter::RenderedFeature( f, renderedBounds ) );
+
+  QVERIFY( geoPdfExporter.saveTemporaryLayers() );
+  QgsAbstractGeoPdfExporter::VectorComponentDetail component;
+  QString layer1Path;
+  QString layer1Layer;
+  QString layer2Path;
+  QString layer2Layer;
+
+  for ( const auto &it : qgis::as_const( geoPdfExporter.mVectorComponents ) )
+  {
+    if ( it.mapLayerId == QStringLiteral( "layer1" ) )
+    {
+      layer1Path = it.sourceVectorPath;
+      layer1Layer = it.sourceVectorLayer;
+    }
+    else if ( it.mapLayerId == QStringLiteral( "layer2" ) )
+    {
+      layer2Path = it.sourceVectorPath;
+      layer2Layer = it.sourceVectorLayer;
+    }
+  }
+
+  // test creation of the composition xml
+  QList< QgsAbstractGeoPdfExporter::ComponentLayerDetail > renderedLayers; // no extra layers for now
+  QgsAbstractGeoPdfExporter::ExportDetails details;
+  QString composition = geoPdfExporter.createCompositionXml( renderedLayers, details );
+  QgsDebugMsg( composition );
+  QDomDocument doc;
+  doc.setContent( composition );
+  QDomNodeList ifLayerOnList = doc.elementsByTagName( QStringLiteral( "IfLayerOn" ) );
+  QCOMPARE( ifLayerOnList.count(), 2 );
+
+  int layer1Idx = ifLayerOnList.at( 0 ).toElement().attribute( QStringLiteral( "layerId" ) ) == QStringLiteral( "layer1" ) ? 0 : 1;
+  int layer2Idx = layer1Idx == 0 ? 1 : 0;
+  QCOMPARE( ifLayerOnList.at( layer1Idx ).toElement().attribute( QStringLiteral( "layerId" ) ), QStringLiteral( "layer1" ) );
+  QCOMPARE( ifLayerOnList.at( layer1Idx ).toElement().elementsByTagName( QStringLiteral( "Vector" ) ).at( 0 ).toElement().attribute( QStringLiteral( "dataset" ) ), layer1Path );
+  QCOMPARE( ifLayerOnList.at( layer1Idx ).toElement().elementsByTagName( QStringLiteral( "Vector" ) ).at( 0 ).toElement().attribute( QStringLiteral( "layer" ) ), layer1Layer );
+  QCOMPARE( ifLayerOnList.at( layer1Idx ).toElement().elementsByTagName( QStringLiteral( "Vector" ) ).at( 0 ).toElement().attribute( QStringLiteral( "visible" ) ), QStringLiteral( "false" ) );
+  QCOMPARE( ifLayerOnList.at( layer1Idx ).toElement().elementsByTagName( QStringLiteral( "LogicalStructure" ) ).at( 0 ).toElement().attribute( QStringLiteral( "fieldToDisplay" ) ), QStringLiteral( "attr layer1" ) );
+  QCOMPARE( ifLayerOnList.at( layer1Idx ).toElement().elementsByTagName( QStringLiteral( "LogicalStructure" ) ).at( 0 ).toElement().attribute( QStringLiteral( "displayLayerName" ) ), QStringLiteral( "name layer1" ) );
+
+  QCOMPARE( ifLayerOnList.at( layer2Idx ).toElement().attribute( QStringLiteral( "layerId" ) ), QStringLiteral( "layer2" ) );
+  QCOMPARE( ifLayerOnList.at( layer2Idx ).toElement().elementsByTagName( QStringLiteral( "Vector" ) ).at( 0 ).toElement().attribute( QStringLiteral( "dataset" ) ), layer2Path );
+  QCOMPARE( ifLayerOnList.at( layer2Idx ).toElement().elementsByTagName( QStringLiteral( "Vector" ) ).at( 0 ).toElement().attribute( QStringLiteral( "layer" ) ), layer2Layer );
+  QCOMPARE( ifLayerOnList.at( layer2Idx ).toElement().elementsByTagName( QStringLiteral( "Vector" ) ).at( 0 ).toElement().attribute( QStringLiteral( "visible" ) ), QStringLiteral( "false" ) );
+  QCOMPARE( ifLayerOnList.at( layer2Idx ).toElement().elementsByTagName( QStringLiteral( "LogicalStructure" ) ).at( 0 ).toElement().attribute( QStringLiteral( "fieldToDisplay" ) ), QStringLiteral( "attr layer2" ) );
+  QCOMPARE( ifLayerOnList.at( layer2Idx ).toElement().elementsByTagName( QStringLiteral( "LogicalStructure" ) ).at( 0 ).toElement().attribute( QStringLiteral( "displayLayerName" ) ), QStringLiteral( "name layer2" ) );
+
+
+  QDomNodeList layerTreeList = doc.elementsByTagName( QStringLiteral( "LayerTree" ) ).at( 0 ).toElement().childNodes();
+  QCOMPARE( layerTreeList.count(), 2 );
+
+  layer1Idx = layerTreeList.at( 0 ).toElement().attribute( QStringLiteral( "id" ) ) == QStringLiteral( "layer1" ) ? 0 : 1;
+  layer2Idx = layer1Idx == 0 ? 1 : 0;
+  QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "id" ) ), QStringLiteral( "layer1" ) );
+  QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "name" ) ), QStringLiteral( "name layer1" ) );
+  QCOMPARE( layerTreeList.at( layer1Idx ).toElement().attribute( QStringLiteral( "initiallyVisible" ) ), QStringLiteral( "true" ) );
+
+  QCOMPARE( layerTreeList.at( layer2Idx ).toElement().attribute( QStringLiteral( "id" ) ), QStringLiteral( "layer2" ) );
+  QCOMPARE( layerTreeList.at( layer2Idx ).toElement().attribute( QStringLiteral( "name" ) ), QStringLiteral( "name layer2" ) );
+  QCOMPARE( layerTreeList.at( layer2Idx ).toElement().attribute( QStringLiteral( "initiallyVisible" ) ), QStringLiteral( "true" ) );
+
 }
 
 QGSTEST_MAIN( TestQgsGeoPdfExport )

--- a/tests/src/core/testqgslayoutgeopdfexport.cpp
+++ b/tests/src/core/testqgslayoutgeopdfexport.cpp
@@ -23,6 +23,8 @@
 #include "qgsproject.h"
 #include "qgslayoutexporter.h"
 #include "qgslayoutgeopdfexporter.h"
+#include <gdal.h>
+
 #include <QObject>
 #include "qgstest.h"
 
@@ -77,11 +79,6 @@ void TestQgsLayoutGeoPdfExport::cleanup()
 
 void TestQgsLayoutGeoPdfExport::testCollectingFeatures()
 {
-  if ( !QgsAbstractGeoPdfExporter::geoPDFCreationAvailable() )
-  {
-    QSKIP( "This test requires GeoPDF creation abilities", SkipSingle );
-  }
-
   QgsVectorLayer *linesLayer = new QgsVectorLayer( TEST_DATA_DIR + QStringLiteral( "/lines.shp" ),
       QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
   QVERIFY( linesLayer->isValid() );
@@ -133,7 +130,7 @@ void TestQgsLayoutGeoPdfExport::testCollectingFeatures()
   exporter.exportToPdf( outputFile, settings );
 
   // check that features were collected
-  QgsFeatureList lineFeatures = geoPdfExporter.mCollatedFeatures.value( linesLayer->id() );
+  QgsFeatureList lineFeatures = geoPdfExporter.mCollatedFeatures.value( QString() ).value( linesLayer->id() );
   QCOMPARE( lineFeatures.count(), 6 );
 
   QgsFeature lineFeature1;
@@ -149,10 +146,10 @@ void TestQgsLayoutGeoPdfExport::testCollectingFeatures()
   QVERIFY( lineFeature1.isValid() );
   QCOMPARE( lineFeature1.attribute( 0 ).toString(), QStringLiteral( "Highway" ) );
   QCOMPARE( lineFeature1.attribute( 1 ).toDouble(), 1.0 );
-  QgsDebugMsg( lineGeometry1.asWkt( 1 ) );
-  QCOMPARE( lineGeometry1.asWkt( 1 ), QStringLiteral( "MultiLineString ((281.2 537.3, 283.3 532.1, 284.3 530.1, 285.3 528.5, 289 525.4, 299.3 520.2, 310.2 515.6, 313.3 513, 318.5 507.8, 319 506.8, 320 500.6, 320.5 497.5, 322.1 492.8, 322.6 490.8, 323.1 485.6, 324.1 484, 325.7 480.9, 327.2 477.8, 330.9 473.7, 331.4 472.7, 331.9 469.6, 331.9 464.9, 331.9 462.9, 332.9 458.7, 334 456.6, 338.1 453.5, 341.7 451.5, 345.4 449.4, 349 447.9, 349.5 444.8, 349.5 442.7, 347.4 439.1, 346.4 438, 344.8 434.9, 343.3 432.9, 341.7 431.3, 341.2 430.3, 340.7 427.7, 340.2 425.6, 340.2 423.6, 341.7 419.9, 342.8 417.9, 342.8 417.9, 347.9 406.5, 345.4 401.3, 343.3 399.3, 339.7 393.1, 339.7 388.9, 335 384.8, 333.5 382.2, 330.9 378.1, 330.9 376, 330.9 373.4, 330.9 371.3, 330.9 368.8, 332.4 366.7, 332.9 364.1, 334 362, 336 360, 338.1 356.9, 341.2 353.3, 346.4 343.4, 346.9 342.9, 350.5 339.3, 352.1 337.7, 355.7 332.6, 358.3 330.5, 362.9 327.4, 366 324.8, 369.7 321.2, 372.2 319.6, 375.9 316.5, 380.5 314, 384.1 311.4, 389.8 307.2, 391.9 305.2, 393.5 301.6, 393.5 298.5, 393.5 295.3, 392.9 294.3, 390.9 291.2, 387.8 286.6, 385.7 284.5, 385.2 282.4, 385.2 279.8, 385.7 277.8, 387.3 273.6, 387.8 271.6, 390.9 267.9, 392.4 266.4, 394.5 263.3, 397.6 258.6, 405.9 255))" ) );
+  QgsDebugMsg( lineGeometry1.asWkt( 0 ) );
+  QCOMPARE( lineGeometry1.asWkt( 0 ), QStringLiteral( "MultiLineString ((281 538, 283 532, 284 530, 285 529, 289 526, 299 520, 310 516, 313 513, 318 508, 319 507, 320 501, 320 498, 322 493, 323 491, 323 486, 324 484, 326 481, 327 478, 331 474, 331 473, 332 470, 332 465, 332 463, 333 459, 334 457, 338 454, 342 452, 345 450, 349 448, 349 445, 349 443, 347 439, 346 438, 345 435, 343 433, 342 432, 341 430, 341 428, 340 426, 340 424, 342 420, 343 418, 343 418, 348 407, 345 402, 343 399, 340 393, 340 389, 335 385, 333 382, 331 378, 331 376, 331 374, 331 372, 331 369, 332 367, 333 364, 334 362, 336 360, 338 357, 341 353, 346 344, 347 343, 350 339, 352 338, 356 333, 358 331, 363 328, 366 325, 370 321, 372 320, 376 317, 380 314, 384 312, 390 307, 392 305, 393 302, 393 299, 393 295, 393 294, 391 291, 388 287, 386 285, 385 283, 385 280, 386 278, 387 274, 388 272, 391 268, 392 267, 394 263, 398 259, 406 255))" ) );
 
-  QgsFeatureList  pointFeatures = geoPdfExporter.mCollatedFeatures.value( pointsLayer->id() );
+  QgsFeatureList  pointFeatures = geoPdfExporter.mCollatedFeatures.value( QString() ).value( pointsLayer->id() );
   QCOMPARE( pointFeatures.count(), 32 );
 
   QgsFeature pointFeature3;
@@ -172,10 +169,10 @@ void TestQgsLayoutGeoPdfExport::testCollectingFeatures()
   QCOMPARE( pointFeature3.attribute( 3 ).toInt(), 1 );
   QCOMPARE( pointFeature3.attribute( 4 ).toInt(), 1 );
   QCOMPARE( pointFeature3.attribute( 5 ).toInt(), 2 );
-  QCOMPARE( pointGeometry3.asWkt( 1 ), QStringLiteral( "MultiPolygon (((473.4 305.9, 505.3 305.9, 505.3 274.1, 473.4 274.1, 473.4 305.9)))" ) );
+  QCOMPARE( pointGeometry3.asWkt( 0 ), QStringLiteral( "MultiPolygon (((473 306, 505 306, 505 274, 473 274, 473 306)))" ) );
 
   // check second map
-  QgsFeatureList polyFeatures = geoPdfExporter.mCollatedFeatures.value( polygonLayer->id() );
+  QgsFeatureList polyFeatures = geoPdfExporter.mCollatedFeatures.value( QString() ).value( polygonLayer->id() );
   QCOMPARE( polyFeatures.count(), 10 );
 
   QgsFeature polyFeature3b;
@@ -191,24 +188,46 @@ void TestQgsLayoutGeoPdfExport::testCollectingFeatures()
   QVERIFY( polyFeature3b.isValid() );
   QCOMPARE( polyFeature3b.attribute( 0 ).toString(), QStringLiteral( "Dam" ) );
   QCOMPARE( polyFeature3b.attribute( 1 ).toInt(), 8 );
-  QgsDebugMsg( polyGeometry3b.asWkt( 1 ) );
-  QCOMPARE( polyGeometry3b.asWkt( 1 ), QStringLiteral( "MultiPolygon (((468.8 306.3, 468.8 305.2, 468.4 305, 467.8 305, 467.1 305, 466.4 304.2, 466.4 303.8, 466.2 303.3, 466.7 302.6, 467.2 302, 467.7 301.6, 468.6 301.5, 469.6 302.1, 470.4 302.5, 470.9 302.7, 472.1 302.7, 472.8 302.9, 473.6 302.7, 474.2 303, 474.9 303.3, 475.7 303.3, 476.5 303, 478 300.3, 478.1 299.3, 478.1 298.7, 477.8 297.5, 477.7 296.3, 477.5 296.1, 476.3 294.8, 475.6 294.4, 475.4 294.3, 473.9 294, 473.7 294.1, 473 294.4, 472.2 295, 471.6 295.6, 470.8 296.4, 469.6 297, 469.5 297.1, 467.8 296.7, 466 296.3, 463.9 296.1, 463.2 296.1, 462.3 296.7, 461.8 297.7, 461.6 298.1, 460.9 298.5, 459.8 299.3, 459.2 299.5, 458.5 300.1, 458.2 300.5, 458.3 301.2, 458.5 301.6, 458.7 302.4, 458.7 302.8, 458.3 303.6, 457.8 304.1, 457.7 305.1, 458 306, 458.2 306.6, 458.5 307.6, 458.5 307.6, 459.4 308.9, 459.7 309.2, 460.5 310, 461.1 310.4, 461.9 311, 462.4 311.4, 463.2 311.6, 464 311.7, 464.6 311.7, 465.3 311.1, 466.6 309.9, 467.3 309.1, 468.3 307.8, 468.9 306.7, 468.8 306.3)))" ) );
+  QgsDebugMsg( polyGeometry3b.asWkt( 0 ) );
+  QCOMPARE( polyGeometry3b.asWkt( 0 ), QStringLiteral( "MultiPolygon (((469 306, 469 305, 468 305, 468 305, 467 305, 466 304, 466 304, 466 303, 467 303, 467 302, 468 302, 469 302, 470 302, 470 303, 471 303, 472 303, 473 303, 474 303, 474 303, 475 303, 476 303, 476 303, 478 300, 478 299, 478 299, 478 298, 478 296, 477 296, 476 295, 476 295, 475 294, 474 294, 474 294, 473 295, 472 295, 472 296, 471 296, 470 297, 469 297, 468 297, 466 296, 464 296, 463 296, 462 297, 462 298, 462 298, 461 299, 460 299, 459 300, 458 300, 458 301, 458 301, 458 302, 459 303, 459 303, 458 304, 458 304, 458 305, 458 306, 458 307, 458 308, 458 308, 459 309, 460 309, 460 310, 461 311, 462 311, 462 312, 463 312, 464 312, 465 312, 465 311, 467 310, 467 309, 468 308, 469 307, 469 306)))" ) );
 
   // finalize and test collation
   QgsAbstractGeoPdfExporter::ExportDetails details;
-  QVERIFY( geoPdfExporter.finalize( QList<QgsAbstractGeoPdfExporter::ComponentLayerDetail>(), outputFile, details ) );
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,0,0)
+  bool expected = false;
+#else
+  bool expected = true;
+#endif
+  QCOMPARE( geoPdfExporter.finalize( QList<QgsAbstractGeoPdfExporter::ComponentLayerDetail>(), outputFile, details ), expected );
   QVERIFY( geoPdfExporter.errorMessage().isEmpty() );
 
+  QgsAbstractGeoPdfExporter::VectorComponentDetail vectorDetail;
+  for ( const auto &it :  geoPdfExporter.mVectorComponents )
+  {
+    if ( it.mapLayerId == linesLayer->id() )
+      vectorDetail = it;
+  }
+
   // read in as vector
-  std::unique_ptr< QgsVectorLayer > layer1 = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "%1|layername=lines" ).arg( outputFile ),
+  std::unique_ptr< QgsVectorLayer > layer1 = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "%1|layername=%2" ).arg( vectorDetail.sourceVectorPath, vectorDetail.sourceVectorLayer ),
       QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
   QVERIFY( layer1->isValid() );
   QCOMPARE( layer1->featureCount(), 6L );
-  std::unique_ptr< QgsVectorLayer > layer2 = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "%1|layername=points" ).arg( outputFile ),
+  for ( const auto &it :  geoPdfExporter.mVectorComponents )
+  {
+    if ( it.mapLayerId == pointsLayer->id() )
+      vectorDetail = it;
+  }
+  std::unique_ptr< QgsVectorLayer > layer2 = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "%1|layername=%2" ).arg( vectorDetail.sourceVectorPath, vectorDetail.sourceVectorLayer ),
       QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
   QVERIFY( layer2->isValid() );
   QCOMPARE( layer2->featureCount(), 32L );
-  std::unique_ptr< QgsVectorLayer > layer3 = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "%1|layername=polys" ).arg( outputFile ),
+  for ( const auto &it :  geoPdfExporter.mVectorComponents )
+  {
+    if ( it.mapLayerId == polygonLayer->id() )
+      vectorDetail = it;
+  }
+  std::unique_ptr< QgsVectorLayer > layer3 = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "%1|layername=%2" ).arg( vectorDetail.sourceVectorPath, vectorDetail.sourceVectorLayer ),
       QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
   QVERIFY( layer3->isValid() );
   QCOMPARE( layer3->featureCount(), 10L );

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -926,6 +926,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -939,6 +940,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -949,6 +951,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
@@ -956,6 +959,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -969,6 +973,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Background" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -978,6 +983,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -987,6 +993,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1010,6 +1017,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1019,6 +1027,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1027,6 +1036,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1035,6 +1045,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1050,6 +1061,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1059,6 +1071,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1067,6 +1080,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1075,6 +1089,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1083,6 +1098,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1099,6 +1115,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1107,6 +1124,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1116,6 +1134,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1124,6 +1143,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1132,6 +1152,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1140,6 +1161,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1155,6 +1177,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Background" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1163,6 +1186,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1171,6 +1195,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1180,6 +1205,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1188,6 +1214,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1196,6 +1223,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1204,6 +1232,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1237,6 +1266,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Background" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1245,6 +1275,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset2" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1253,6 +1284,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset2" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1262,6 +1294,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset2" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1272,6 +1305,7 @@ void TestQgsLayoutMap::testLayeredExport()
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1281,6 +1315,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1291,6 +1326,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // "test preset 3"
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset3" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1300,6 +1336,7 @@ void TestQgsLayoutMap::testLayeredExport()
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset3" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1308,6 +1345,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1316,6 +1354,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
@@ -1324,6 +1363,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -1380,6 +1380,75 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
   QVERIFY( !map->nextExportPart() );
   map->stopLayeredExport();
+
+  // but if map is already set to a particular map theme, it DOESN'T follow the theme iteration
+  map->setFollowVisibilityPreset( true );
+  map->setFollowVisibilityPresetName( QStringLiteral( "test preset" ) );
+  map->startLayeredExport();
+  QVERIFY( map->nextExportPart() );
+  map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Background" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  // "test preset"
+  map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
+  QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset" ) );
+  QVERIFY( map->nextExportPart() );
+  // labels
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset" ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset" ) );
+
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->exportLayerDetails().mapTheme.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( !map->nextExportPart() );
+  map->stopLayeredExport();
 }
 
 void TestQgsLayoutMap::testLayeredExportLabelsByLayer()

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -1281,6 +1281,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset2" ) );
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset2): points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
@@ -1290,6 +1291,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset2" ) );
   QVERIFY( map->nextExportPart() );
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset2): Labels" ) );
@@ -1300,6 +1302,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset2" ) );
   QVERIFY( map->nextExportPart() );
   // "test preset"
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
@@ -1311,6 +1314,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset" ) );
   QVERIFY( map->nextExportPart() );
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset): Labels" ) );
@@ -1321,6 +1325,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset" ) );
   QVERIFY( map->nextExportPart() );
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   // "test preset 3"
@@ -1332,6 +1337,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset3" ) );
   QVERIFY( map->nextExportPart() );
   // labels
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset3): Labels" ) );
@@ -1342,6 +1348,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QCOMPARE( map->themeToRender( QgsExpressionContext() ), QStringLiteral( "test preset3" ) );
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
@@ -1351,6 +1358,8 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->themeToRender( QgsExpressionContext() ).isEmpty() );
+
   QVERIFY( map->nextExportPart() );
   QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -1212,6 +1212,125 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->nextExportPart() );
   map->stopLayeredExport();
 
+  // exporting by theme
+  QgsMapThemeCollection::MapThemeRecord rec;
+  rec.setLayerRecords( QList<QgsMapThemeCollection::MapThemeLayerRecord>()
+                       << QgsMapThemeCollection::MapThemeLayerRecord( linesLayer )
+                     );
+
+  p.mapThemeCollection()->insert( QStringLiteral( "test preset" ), rec );
+  rec.setLayerRecords( QList<QgsMapThemeCollection::MapThemeLayerRecord>()
+                       << QgsMapThemeCollection::MapThemeLayerRecord( linesLayer )
+                       << QgsMapThemeCollection::MapThemeLayerRecord( pointsLayer )
+                     );
+  p.mapThemeCollection()->insert( QStringLiteral( "test preset2" ), rec );
+  rec.setLayerRecords( QList<QgsMapThemeCollection::MapThemeLayerRecord>()
+                       << QgsMapThemeCollection::MapThemeLayerRecord( pointsLayer )
+                     );
+  p.mapThemeCollection()->insert( QStringLiteral( "test preset3" ), rec );
+
+  l.renderContext().setExportThemes( QStringList() << QStringLiteral( "test preset2" ) << QStringLiteral( "test preset" ) << QStringLiteral( "test preset3" ) );
+
+
+  map->startLayeredExport();
+  QVERIFY( map->nextExportPart() );
+  map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Background" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
+  QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
+  QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  // labels
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  // "test preset"
+  map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
+  QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  // labels
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
+  // "test preset 3"
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
+  QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  // labels
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Grids" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Overviews" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( map->nextExportPart() );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Frame" ) );
+  QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::OverviewMapExtent ) );
+  QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
+  QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+  QVERIFY( !map->nextExportPart() );
+  map->stopLayeredExport();
 }
 
 void TestQgsLayoutMap::testLayeredExportLabelsByLayer()

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -1273,7 +1273,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
   QVERIFY( map->nextExportPart() );
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset2): lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset2" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
@@ -1282,7 +1282,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
   QVERIFY( map->nextExportPart() );
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset2): points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset2" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
@@ -1292,7 +1292,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
   QVERIFY( map->nextExportPart() );
   // labels
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset2): Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset2" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
@@ -1303,7 +1303,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   // "test preset"
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: lines" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset): lines" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, linesLayer->id() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
@@ -1313,7 +1313,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
   QVERIFY( map->nextExportPart() );
   // labels
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset): Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
@@ -1324,7 +1324,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->nextExportPart() );
   map->createStagedRenderJob( map->extent(), QSize( 512, 512 ), 72 );
   // "test preset 3"
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: points" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset3): points" ) );
   QCOMPARE( map->exportLayerDetails().mapLayerId, pointsLayer->id() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset3" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );
@@ -1334,7 +1334,7 @@ void TestQgsLayoutMap::testLayeredExport()
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
   QVERIFY( map->nextExportPart() );
   // labels
-  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1: Labels" ) );
+  QCOMPARE( map->exportLayerDetails().name, QStringLiteral( "Map 1 (test preset3): Labels" ) );
   QVERIFY( map->exportLayerDetails().mapLayerId.isEmpty() );
   QCOMPARE( map->exportLayerDetails().mapTheme, QStringLiteral( "test preset3" ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Grid ) );


### PR DESCRIPTION
No UI yet, but this adds the API hooks necessary to allow multiple map themes to be exported when creating a GeoPDF file from a layout.

Wait, wat?

...this screencast demonstrates the result
![Peek 2019-08-20 11-18](https://user-images.githubusercontent.com/1829991/63310102-bb56e900-c33c-11e9-8ddd-bd9434375f58.gif)

Using this api, it's possible to create a geopdf with a structure showing multiple map themes, allowing them to be toggled between. When the UI for this lands it will consist of a list of the current map themes in the project, with check boxes to select which themes to include in the geopdf output.
