### PR TITLE
GeoPDF export (last part!)

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -81,6 +81,7 @@ The root node is not transferred by the model.
       ShowLegendAsTree,
       DeferredLegendInvalidation,
       UseEmbeddedWidgets,
+      UseTextFormatting,
 
       // behavioral flags
       AllowNodeReorder,

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -187,6 +187,7 @@ SET(QGIS_APP_SRCS
 
   browser/qgsinbuiltdataitemproviders.cpp
 
+  layout/qgsgeopdflayertreemodel.cpp
   layout/qgslayoutaddpagesdialog.cpp
   layout/qgslayoutapputils.cpp
   layout/qgslayoutatlaswidget.cpp
@@ -425,6 +426,7 @@ SET (QGIS_APP_MOC_HDRS
 
   browser/qgsinbuiltdataitemproviders.h
 
+  layout/qgsgeopdflayertreemodel.h
   layout/qgslayoutaddpagesdialog.h
   layout/qgslayoutappmenuprovider.h
   layout/qgslayoutatlaswidget.h

--- a/src/app/layout/qgsgeopdflayertreemodel.cpp
+++ b/src/app/layout/qgsgeopdflayertreemodel.cpp
@@ -1,0 +1,170 @@
+/***************************************************************************
+  qgsgeopdflayertreemodel.cpp
+ ---------------------
+ begin                : August 2019
+ copyright            : (C) 2019 by Nyall Dawson
+ email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QComboBox>
+#include <QDoubleSpinBox>
+
+#include "qgsgeopdflayertreemodel.h"
+#include "qgslayertree.h"
+#include "qgsproject.h"
+#include "qgsvectorlayer.h"
+#include "qgsapplication.h"
+
+QgsGeoPdfLayerTreeModel::QgsGeoPdfLayerTreeModel( QgsLayerTree *rootNode, QObject *parent )
+  : QgsLayerTreeModel( rootNode, parent )
+{
+  setFlags( nullptr ); // ideally we'd just show embedded legend nodes - but the api doesn't exist for this
+}
+
+int QgsGeoPdfLayerTreeModel::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent )
+  return 2;
+}
+
+Qt::ItemFlags QgsGeoPdfLayerTreeModel::flags( const QModelIndex &idx ) const
+{
+  if ( idx.column() == LayerColumn )
+  {
+    return QgsLayerTreeModel::flags( idx ) | Qt::ItemIsUserCheckable;
+  }
+
+  QgsVectorLayer *vl = vectorLayer( idx );
+  if ( !vl )
+  {
+    return Qt::NoItemFlags;
+  }
+  else
+  {
+    const QModelIndex layerIndex = sibling( idx.row(), LayerColumn, idx );
+    if ( data( layerIndex, Qt::CheckStateRole ) == Qt::Checked )
+    {
+      return Qt::ItemIsEnabled | Qt::ItemIsEditable;
+    }
+  }
+  return Qt::NoItemFlags;
+}
+
+QgsVectorLayer *QgsGeoPdfLayerTreeModel::vectorLayer( const QModelIndex &idx ) const
+{
+  QgsLayerTreeNode *node = index2node( index( idx.row(), LayerColumn, idx.parent() ) );
+  if ( !node || !QgsLayerTree::isLayer( node ) )
+    return nullptr;
+
+  return qobject_cast<QgsVectorLayer *>( QgsLayerTree::toLayer( node )->layer() );
+}
+
+QVariant QgsGeoPdfLayerTreeModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  if ( orientation == Qt::Horizontal )
+  {
+    if ( role == Qt::DisplayRole )
+    {
+      switch ( section )
+      {
+        case 0:
+          return tr( "Layer" );
+        case 1:
+          return tr( "PDF Group" );
+        default:
+          return QVariant();
+      }
+    }
+  }
+  return QgsLayerTreeModel::headerData( section, orientation, role );
+}
+
+QVariant QgsGeoPdfLayerTreeModel::data( const QModelIndex &idx, int role ) const
+{
+  switch ( idx.column() )
+  {
+    case LayerColumn:
+    {
+      if ( role == Qt::CheckStateRole )
+      {
+        QgsLayerTreeNode *node = index2node( index( idx.row(), LayerColumn, idx.parent() ) );
+        QgsVectorLayer *vl = vectorLayer( idx );
+        if ( vl )
+        {
+          const QVariant v = vl->customProperty( QStringLiteral( "geopdf/includeFeatures" ) );
+          if ( v.isValid() )
+          {
+            return v.toBool() ? Qt::Checked : Qt::Unchecked;
+          }
+          else
+          {
+            // otherwise, we default to the layer's visibility
+            return node->itemVisibilityChecked() ? Qt::Checked : Qt::Unchecked;
+          }
+        }
+        return QVariant();
+      }
+      return QgsLayerTreeModel::data( idx, role );
+    }
+    case GroupColumn:
+    {
+      switch ( role )
+      {
+        case Qt::DisplayRole:
+        {
+          if ( QgsVectorLayer *vl = vectorLayer( idx ) )
+          {
+            return vl->customProperty( QStringLiteral( "geopdf/groupName" ) ).toString();
+          }
+          break;
+        }
+      }
+
+      return QVariant();
+    }
+  }
+
+  return QVariant();
+}
+
+bool QgsGeoPdfLayerTreeModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  switch ( index.column() )
+  {
+    case LayerColumn:
+    {
+      if ( role == Qt::CheckStateRole )
+      {
+        if ( QgsVectorLayer *vl = vectorLayer( index ) )
+        {
+          vl->setCustomProperty( QStringLiteral( "geopdf/includeFeatures" ), value.toInt() == Qt::Checked );
+          emit dataChanged( index, index );
+          return true;
+        }
+      }
+      break;
+    }
+
+    case GroupColumn:
+    {
+      if ( role == Qt::EditRole )
+      {
+        if ( QgsVectorLayer *vl = vectorLayer( index ) )
+        {
+          vl->setCustomProperty( QStringLiteral( "geopdf/groupName" ), value.toString() );
+          emit dataChanged( index, index );
+          return true;
+        }
+      }
+      break;
+    }
+  }
+  return false;
+}

--- a/src/app/layout/qgsgeopdflayertreemodel.h
+++ b/src/app/layout/qgsgeopdflayertreemodel.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+  qgsgeopdflayertreemodel.h
+ ---------------------
+ begin                : August 2019
+ copyright            : (C) 2019 by Nyall Dawson
+ email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSGEOPDFLAYERTREEMODEL_H
+#define QGSGEOPDFLAYERTREEMODEL_H
+
+#include <QSortFilterProxyModel>
+#include <QItemDelegate>
+
+#include "qgslayertreemodel.h"
+#include "qgis_app.h"
+
+class QgsMapCanvas;
+class QgsProject;
+
+
+class APP_EXPORT QgsGeoPdfLayerTreeModel : public QgsLayerTreeModel
+{
+    Q_OBJECT
+
+  public:
+    QgsGeoPdfLayerTreeModel( QgsLayerTree *rootNode, QObject *parent = nullptr );
+
+    int columnCount( const QModelIndex &parent ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+    Qt::ItemFlags flags( const QModelIndex &idx ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+  private:
+    enum Columns
+    {
+      LayerColumn = 0,
+      GroupColumn
+    };
+
+    QgsVectorLayer *vectorLayer( const QModelIndex &idx ) const;
+};
+
+#endif // QGSGEOPDFLAYERTREEMODEL_H

--- a/src/app/layout/qgslayoutpdfexportoptionsdialog.cpp
+++ b/src/app/layout/qgslayoutpdfexportoptionsdialog.cpp
@@ -22,6 +22,7 @@
 #include "qgsabstractgeopdfexporter.h"
 #include "qgsproject.h"
 #include "qgsmapthemecollection.h"
+#include "qgsgeopdflayertreemodel.h"
 
 #include <QCheckBox>
 #include <QPushButton>
@@ -35,9 +36,9 @@ QgsLayoutPdfExportOptionsDialog::QgsLayoutPdfExportOptionsDialog( QWidget *paren
   mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Text Objects" ), QgsRenderContext::TextFormatAlwaysText );
 
   mGeopdfAvailable = QgsAbstractGeoPdfExporter::geoPDFCreationAvailable();
-  mGeoPDFGroupBox->setEnabled( mGeopdfAvailable );
+  mGeoPDFGroupBox->setEnabled( true || mGeopdfAvailable );
   mGeoPDFGroupBox->setChecked( false );
-  if ( !mGeopdfAvailable )
+  if ( false && !mGeopdfAvailable )
   {
     mGeoPDFOptionsStackedWidget->setCurrentIndex( 0 );
     mGeoPdfUnavailableReason->setText( QgsAbstractGeoPdfExporter::geoPDFAvailabilityExplanation() );
@@ -62,6 +63,12 @@ QgsLayoutPdfExportOptionsDialog::QgsLayoutPdfExportOptionsDialog( QWidget *paren
     item->setCheckState( Qt::Unchecked );
     mThemesList->addItem( item );
   }
+
+  QgsGeoPdfLayerTreeModel *model = new QgsGeoPdfLayerTreeModel( QgsProject::instance()->layerTreeRoot(), this );
+  mGeoPdfStructureTree->setModel( model );
+  mGeoPdfStructureTree->resizeColumnToContents( 0 );
+  mGeoPdfStructureTree->header()->show();
+  mGeoPdfStructureTree->setSelectionMode( QAbstractItemView::NoSelection );
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutPdfExportOptionsDialog::showHelp );
   QgsGui::enableAutoGeometryRestore( this );

--- a/src/app/layout/qgslayoutpdfexportoptionsdialog.cpp
+++ b/src/app/layout/qgslayoutpdfexportoptionsdialog.cpp
@@ -36,9 +36,9 @@ QgsLayoutPdfExportOptionsDialog::QgsLayoutPdfExportOptionsDialog( QWidget *paren
   mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Text Objects" ), QgsRenderContext::TextFormatAlwaysText );
 
   mGeopdfAvailable = QgsAbstractGeoPdfExporter::geoPDFCreationAvailable();
-  mGeoPDFGroupBox->setEnabled( true || mGeopdfAvailable );
+  mGeoPDFGroupBox->setEnabled( mGeopdfAvailable );
   mGeoPDFGroupBox->setChecked( false );
-  if ( false && !mGeopdfAvailable )
+  if ( !mGeopdfAvailable )
   {
     mGeoPDFOptionsStackedWidget->setCurrentIndex( 0 );
     mGeoPdfUnavailableReason->setText( QgsAbstractGeoPdfExporter::geoPDFAvailabilityExplanation() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3999,6 +3999,7 @@ void QgisApp::initLayerTreeView()
   model->setFlag( QgsLayerTreeModel::AllowNodeChangeVisibility );
   model->setFlag( QgsLayerTreeModel::ShowLegendAsTree );
   model->setFlag( QgsLayerTreeModel::UseEmbeddedWidgets );
+  model->setFlag( QgsLayerTreeModel::UseTextFormatting );
   model->setAutoCollapseLegendNodes( 10 );
 
   mLayerTreeView->setModel( model );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -230,7 +230,7 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
           icon = QgsLayerItem::iconDefault();
       }
 
-      if ( vlayer && vlayer->isEditable() )
+      if ( vlayer && vlayer->isEditable() && testFlag( UseTextFormatting ) )
       {
         const int iconSize = scaleIconSize( 16 );
         QPixmap pixmap( icon.pixmap( iconSize, iconSize ) );
@@ -265,7 +265,7 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
       return nodeGroup->itemVisibilityChecked() ? Qt::Checked : Qt::Unchecked;
     }
   }
-  else if ( role == Qt::FontRole )
+  else if ( role == Qt::FontRole && testFlag( UseTextFormatting ) )
   {
     QFont f( QgsLayerTree::isLayer( node ) ? mFontLayer : ( QgsLayerTree::isGroup( node ) ? mFontGroup : QFont() ) );
     if ( index == mCurrentIndex )
@@ -280,7 +280,7 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
     }
     return f;
   }
-  else if ( role == Qt::ForegroundRole )
+  else if ( role == Qt::ForegroundRole && testFlag( UseTextFormatting ) )
   {
     QBrush brush( qApp->palette().color( QPalette::Text ), Qt::SolidPattern );
     if ( QgsLayerTree::isLayer( node ) )

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -97,6 +97,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
       ShowLegendAsTree           = 0x0004,  //!< For legends that support it, will show them in a tree instead of a list (needs also ShowLegend). Added in 2.8
       DeferredLegendInvalidation = 0x0008,  //!< Defer legend model invalidation
       UseEmbeddedWidgets         = 0x0010,  //!< Layer nodes may optionally include extra embedded widgets (if used in QgsLayerTreeView). Added in 2.16
+      UseTextFormatting          = 0x0020,  //!< Layer nodes will alter text appearance based on layer properties, such as scale based visibility
 
       // behavioral flags
       AllowNodeReorder           = 0x1000,  //!< Allow reordering with drag'n'drop

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -635,6 +635,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
       }
     }
 
+    details.customLayerTreeGroups = geoPdfExporter->customLayerTreeGroups();
     details.includeFeatures = settings.includeGeoPdfFeatures;
     details.useOgcBestPracticeFormatGeoreferencing = settings.useOgcBestPracticeFormatGeoreferencing;
     details.useIso32000ExtensionFormatGeoreferencing = settings.useIso32000ExtensionFormatGeoreferencing;

--- a/src/core/layout/qgslayoutgeopdfexporter.cpp
+++ b/src/core/layout/qgslayoutgeopdfexporter.cpp
@@ -122,6 +122,10 @@ QgsLayoutGeoPdfExporter::QgsLayoutGeoPdfExporter( QgsLayout *layout )
       {
         exportableLayerIds << vl->id();
       }
+
+      const QString groupName = vl->customProperty( QStringLiteral( "geopdf/groupName" ) ).toString();
+      if ( !groupName.isEmpty() )
+        mCustomLayerTreeGroups.insert( vl->id(), groupName );
     }
   }
 

--- a/src/core/layout/qgslayoutgeopdfexporter.h
+++ b/src/core/layout/qgslayoutgeopdfexporter.h
@@ -55,12 +55,19 @@ class CORE_EXPORT QgsLayoutGeoPdfExporter : public QgsAbstractGeoPdfExporter
 
     ~QgsLayoutGeoPdfExporter() override;
 
+    /**
+     * Returns any custom layer tree groups defined in the layer's settings.
+     */
+    QMap< QString, QString > customLayerTreeGroups() const { return mCustomLayerTreeGroups; }
+
   private:
 
     VectorComponentDetail componentDetailForLayerId( const QString &layerId ) override;
 
     QgsLayout *mLayout = nullptr;
     QHash< QgsLayoutItemMap *, QgsGeoPdfRenderedFeatureHandler * > mMapHandlers;
+
+    QMap< QString, QString > mCustomLayerTreeGroups;
 
     friend class TestQgsLayoutGeoPdfExport;
 };

--- a/src/core/qgsabstractgeopdfexporter.cpp
+++ b/src/core/qgsabstractgeopdfexporter.cpp
@@ -345,7 +345,7 @@ QString QgsAbstractGeoPdfExporter::createCompositionXml( const QList<ComponentLa
 
     QDomElement layer = doc.createElement( QStringLiteral( "Layer" ) );
     const QString id = QUuid::createUuid().toString();
-    customGroupNamesToIds[ it.key() ] == id;
+    customGroupNamesToIds[ it.key() ] = id;
     layer.setAttribute( QStringLiteral( "id" ), id );
     layer.setAttribute( QStringLiteral( "name" ), it.value() );
     layer.setAttribute( QStringLiteral( "initiallyVisible" ), QStringLiteral( "true" ) );

--- a/src/core/qgsabstractgeopdfexporter.h
+++ b/src/core/qgsabstractgeopdfexporter.h
@@ -240,6 +240,18 @@ class CORE_EXPORT QgsAbstractGeoPdfExporter
        */
       bool includeFeatures = true;
 
+      /**
+       * Optional map of map layer ID to custom logical layer tree group in created PDF file.
+       *
+       * E.g. if the map contains "layer1": "Environment", "layer2": "Environment", "layer3": "Transport"
+       * then the created PDF file will have entries in its layer tree for "Environment" and "Transport",
+       * and toggling "Environment" will toggle BOTH layer1 and layer2.
+       *
+       * Layers which are not included in this group will always have their own individual layer tree entry
+       * created for them automatically.
+       */
+      QMap< QString, QString > customLayerTreeGroups;
+
     };
 
     /**

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>563</height>
+    <height>484</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -159,6 +159,13 @@
         </widget>
        </widget>
       </item>
+      <item>
+       <widget class="QTreeView" name="mGeoPdfStructureTree">
+        <property name="headerHidden">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -195,19 +202,6 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -223,7 +217,7 @@
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -118,27 +118,7 @@
            <number>0</number>
           </property>
           <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="mExportGeoPdfFeaturesCheckBox">
-            <property name="text">
-             <string>Include vector feature information</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="mGeoPdfFormatComboBox"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QGroupBox" name="mIncludeMapThemesCheck">
+           <widget class="QgsCollapsibleGroupBoxBasic" name="mIncludeMapThemesCheck">
             <property name="title">
              <string>Include multiple map themes</string>
             </property>
@@ -155,15 +135,47 @@
             </layout>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="mGeoPdfFormatComboBox"/>
+          </item>
          </layout>
         </widget>
        </widget>
       </item>
       <item>
-       <widget class="QTreeView" name="mGeoPdfStructureTree">
-        <property name="headerHidden">
+       <widget class="QgsCollapsibleGroupBoxBasic" name="mExportGeoPdfFeaturesCheckBox">
+        <property name="title">
+         <string>Include vector feature information</string>
+        </property>
+        <property name="checkable">
          <bool>true</bool>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Uncheck layers to avoid exporting vector feature information for those layers, and optionally set the group name to allow multiple layers to be joined into a single logical PDF group</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QTreeView" name="mGeoPdfStructureTree">
+           <property name="headerHidden">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -228,7 +240,6 @@
   <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>mGeoPDFGroupBox</tabstop>
   <tabstop>mGeoPdfFormatComboBox</tabstop>
-  <tabstop>mExportGeoPdfFeaturesCheckBox</tabstop>
   <tabstop>mDisableRasterTilingCheckBox</tabstop>
   <tabstop>mSimplifyGeometriesCheckbox</tabstop>
  </tabstops>

--- a/tests/src/core/testqgslayoutgeopdfexport.cpp
+++ b/tests/src/core/testqgslayoutgeopdfexport.cpp
@@ -42,6 +42,7 @@ class TestQgsLayoutGeoPdfExport : public QObject
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
     void testCollectingFeatures();
+    void skipLayers();
 
   private:
 
@@ -350,6 +351,59 @@ void TestQgsLayoutGeoPdfExport::testCollectingFeatures()
            QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
   QVERIFY( layer3->isValid() );
   QCOMPARE( layer3->featureCount(), 10L );
+}
+
+void TestQgsLayoutGeoPdfExport::skipLayers()
+{
+  QgsVectorLayer *linesLayer = new QgsVectorLayer( TEST_DATA_DIR + QStringLiteral( "/lines.shp" ),
+      QStringLiteral( "lines" ), QStringLiteral( "ogr" ) );
+  QVERIFY( linesLayer->isValid() );
+  QgsVectorLayer *pointsLayer = new QgsVectorLayer( TEST_DATA_DIR + QStringLiteral( "/points.shp" ),
+      QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
+  QVERIFY( pointsLayer->isValid() );
+  QgsVectorLayer *polygonLayer = new QgsVectorLayer( TEST_DATA_DIR + QStringLiteral( "/polys.shp" ),
+      QStringLiteral( "polys" ), QStringLiteral( "ogr" ) );
+  QVERIFY( polygonLayer->isValid() );
+  pointsLayer->setDisplayExpression( QStringLiteral( "Staff" ) );
+
+  QgsProject p;
+  p.addMapLayer( linesLayer );
+  p.addMapLayer( pointsLayer );
+  p.addMapLayer( polygonLayer );
+  linesLayer->setCustomProperty( QStringLiteral( "geopdf/includeFeatures" ), false );
+  pointsLayer->setCustomProperty( QStringLiteral( "geopdf/includeFeatures" ), true );
+  // nothing specifically set for polygonLayer => should be included
+
+  QgsLayout l( &p );
+  l.initializeDefaults();
+  QgsLayoutItemMap *map = new QgsLayoutItemMap( &l );
+  map->attemptSetSceneRect( QRectF( 20, 20, 200, 100 ) );
+  map->setFrameEnabled( true );
+  map->setLayers( QList<QgsMapLayer *>() << linesLayer << pointsLayer << polygonLayer );
+  map->setCrs( linesLayer->crs() );
+  map->zoomToExtent( linesLayer->extent() );
+  map->setBackgroundColor( QColor( 200, 220, 230 ) );
+  map->setBackgroundEnabled( true );
+  l.addLayoutItem( map );
+
+  QgsLayoutGeoPdfExporter geoPdfExporter( &l );
+
+  // trigger render
+  QgsLayoutExporter exporter( &l );
+
+  const QString outputFile = geoPdfExporter.generateTemporaryFilepath( QStringLiteral( "test_src.pdf" ) );
+  QgsLayoutExporter::PdfExportSettings settings;
+  settings.writeGeoPdf = true;
+  settings.exportMetadata = false;
+  exporter.exportToPdf( outputFile, settings );
+
+  // check that features were collected
+  QgsFeatureList lineFeatures = geoPdfExporter.mCollatedFeatures.value( QString() ).value( linesLayer->id() );
+  QCOMPARE( lineFeatures.count(), 0 ); // should be nothing, layer is set to skip
+  QgsFeatureList  pointFeatures = geoPdfExporter.mCollatedFeatures.value( QString() ).value( pointsLayer->id() );
+  QCOMPARE( pointFeatures.count(), 15 ); // should be features, layer was set to export
+  QgsFeatureList polyFeatures = geoPdfExporter.mCollatedFeatures.value( QString() ).value( polygonLayer->id() );
+  QCOMPARE( polyFeatures.count(), 10 ); // should be features, layer did not have any setting set
 }
 
 QGSTEST_MAIN( TestQgsLayoutGeoPdfExport )


### PR DESCRIPTION
Last part of the GeoPDF package of works! This one adds a UI for configuring layer-by-layer export attributes and layer groups to GeoPDF export.

It allows users to set on a layer-by-layer basis whether layers should be identifiable and include vector features in a GeoPDF export, and optionally whether to group multiple layers together into a single logical, switchable entry in the GeoPDF layer tree.

(After this one, there's just UI cleanup work remaining....)