### PR TITLE
[ui] Improve height of save map canvas as PDF dialog

### DIFF
--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -37,6 +37,7 @@
 #include "qgsmapsettings.h"
 #include "qgsmapsettingsutils.h"
 #include "qgsmaprenderertask.h"
+#include "qgsmessageviewer.h"
 #include "qgsproject.h"
 #include "qgssettings.h"
 #include "qgsmapcanvas.h"
@@ -101,14 +102,16 @@ QgsMapSaveDialog::QgsMapSaveDialog( QWidget *parent, QgsMapCanvas *mapCanvas, co
       QStringList layers = QgsMapSettingsUtils::containsAdvancedEffects( mMapCanvas->mapSettings() );
       if ( !layers.isEmpty() )
       {
-        // Limit number of items to avoid extreme dialog height
-        if ( layers.count() >= 10 )
+        mInfoDetails = tr( "The following layer(s) use advanced effects:\n\n%1\n\nRasterizing map is recommended for proper rendering." ).arg(
+                         QChar( 0x2022 ) + QStringLiteral( " " ) + layers.join( QStringLiteral( "\n" ) + QChar( 0x2022 ) + QStringLiteral( " " ) ) );
+        connect( mInfo, &QLabel::linkActivated, [this]( const QString & )
         {
-          layers = layers.mid( 0, 9 );
-          layers << QChar( 0x2026 );
-        }
-        mInfo->setText( tr( "The following layer(s) use advanced effects:\n%1\nRasterizing map is recommended for proper rendering." ).arg(
-                          QChar( 0x2022 ) + QStringLiteral( " " ) + layers.join( QStringLiteral( "\n" ) + QChar( 0x2022 ) + QStringLiteral( " " ) ) ) );
+          QgsMessageViewer *viewer = new QgsMessageViewer( this );
+          viewer->setWindowTitle( tr( "Advanced effects warning" ) );
+          viewer->setMessageAsPlainText( mInfoDetails );
+          viewer->exec();
+        } );
+        mInfo->setText( tr( "%1A number of layers%2 use advanced effects, rasterizing map is recommended for proper rendering." ).arg( QStringLiteral( "<a href='#'>" ), QStringLiteral( "</a>" ) ) );
         mSaveAsRaster->setChecked( true );
       }
       else

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -104,6 +104,8 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
     int mDpi;
     QSize mSize;
 
+    QString mInfoDetails;
+
   private slots:
 
     void showHelp();

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -331,7 +331,10 @@ Rasterizing the map is recommended when such effects are used.</string>
      </item>
      <item row="10" column="0" colspan="2">
       <widget class="QLabel" name="mInfo">
-       <property name="enabled">
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="openExternalLinks">
         <bool>false</bool>
        </property>
       </widget>


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

The save map [canvas] as PDF dialog's height is getting out of control:
![Screenshot from 2019-08-21 11-10-20](https://user-images.githubusercontent.com/1728657/63402351-43a0c100-c405-11e9-877f-846812114c33.png)

This PR implements an alternative way to inform users of layers using advanced effects, which avoids a long vertical list in the dialog itself:
![peekKY6M6Z](https://user-images.githubusercontent.com/1728657/63402386-64691680-c405-11e9-86e9-f74891c5e608.gif)

The bonus of this alternative approach is that we can list _all_ layers using advanced effects instead of clipping the list to ten.

@nyalldawson , thoughts?

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
