### PR TITLE
New ctors for connections interface

### DIFF
--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -240,14 +240,14 @@ Creates a new connection with ``name`` by reading its configuration from the set
 If a connection with this name cannot be found, an empty connection will be returned.
 %End
 
-
-    QgsAbstractDatabaseProviderConnection( const QString &name, const QString &uri );
+    QgsAbstractDatabaseProviderConnection( const QString &uri, const QVariantMap &configuration );
 %Docstring
-Creates a new connection with ``name`` and initializes the connection from the ``uri``.
+Creates a new connection from the given ``uri`` and ``configuration``.
 The connection is not automatically stored in the settings.
 
 .. seealso:: :py:func:`store`
 %End
+
 
 
     Capabilities capabilities() const;

--- a/python/core/auto_generated/qgsabstractproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractproviderconnection.sip.in
@@ -13,9 +13,13 @@ class QgsAbstractProviderConnection
 %Docstring
 The QgsAbstractProviderConnection provides an interface for data provider connections.
 
-Connections objects can be created by passing the connection name and in this case
-they are automatically loaded from the settings, or by passing a data source URI
-in the constructor.
+Connections objects can be constructed loading them from the connections stored
+in the settings by passing the connection name.
+A new connection object can also be created by passing a data source URI in the constructor.
+
+Provider metadata keep a cache of the existing connections, to manage stored
+connections it is recommendend to call metadata methods instead of loading and
+storing the connections directly.
 
 Concrete classes must implement methods to retrieve, save and remove connections from
 the settings.
@@ -48,9 +52,9 @@ Creates a new connection with ``name`` by reading its configuration from the set
 If a connection with this name cannot be found, an empty connection will be returned.
 %End
 
-    QgsAbstractProviderConnection( const QString &name, const QString &uri );
+    QgsAbstractProviderConnection( const QString &uri, const QVariantMap &configuration );
 %Docstring
-Creates a new connection with ``name`` and initializes the connection from the ``uri``.
+Creates a new connection from the given ``uri`` and ``configuration``.
 The connection is not automatically stored in the settings.
 
 .. seealso:: :py:func:`store`
@@ -58,22 +62,16 @@ The connection is not automatically stored in the settings.
 
     virtual ~QgsAbstractProviderConnection();
 
-    virtual void store( const QVariantMap &configuration = QVariantMap() ) const = 0;
+    virtual void store( const QString &name ) const = 0;
 %Docstring
 Stores the connection in the settings.
 
-:param configuration: stores additional connection settings that are used by the
-                      source select dialog and are not part of the data source URI
+:param name: the name under which the connection will be stored
 %End
 
-    virtual void remove( ) const = 0;
+    virtual void remove( const QString &name ) const = 0;
 %Docstring
 Deletes the connection from the settings.
-%End
-
-    QString name() const;
-%Docstring
-Returns the connection name
 %End
 
     QString uri() const;
@@ -84,6 +82,16 @@ Returns the connection data source URI string representation
     void setUri( const QString &uri );
 %Docstring
 Sets the connection data source URI to ``uri``
+%End
+
+    QVariantMap configuration() const;
+%Docstring
+Returns the connection configuration parameters
+%End
+
+    void setConfiguration( const QVariantMap &configuration );
+%Docstring
+Sets the connection ``configuration``
 %End
 
 };

--- a/python/core/auto_generated/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/qgsprovidermetadata.sip.in
@@ -261,17 +261,9 @@ Raises a QgsProviderConnectionException if any errors are encountered.
 %End
 
 
-    virtual QgsAbstractProviderConnection *createConnection( const QString &name ) /Factory/;
+    virtual QgsAbstractProviderConnection *createConnection( const QString &uri, const QVariantMap &configuration ) /Factory/;
 %Docstring
-Creates a new connection by loading the connection with the given ``name`` from the settings.
-Ownership is transferred to the caller.
-
-.. versionadded:: 3.10
-%End
-
-    virtual QgsAbstractProviderConnection *createConnection( const QString &name, const QString &uri ) /Factory/;
-%Docstring
-Creates a new connection with the given ``name`` and data source ``uri``,
+Creates a new connection from ``uri`` and ``configuration``,
 the newly created connection is not automatically stored in the settings, call
 saveConnection() to save it.
 Ownership is transferred to the caller.
@@ -279,6 +271,14 @@ Ownership is transferred to the caller.
 .. seealso:: :py:func:`saveConnection`
 
 .. versionadded:: 3.10
+%End
+
+    virtual QgsAbstractProviderConnection *createConnection( const QString &name );
+%Docstring
+Creates a new connection by loading the connection with the given ``name`` from the settings.
+Ownership is transferred to the caller.
+
+.. seealso:: :py:func:`findConnection`
 %End
 
     virtual void deleteConnection( const QString &name ) throw( QgsProviderConnectionException );
@@ -291,12 +291,12 @@ Raises a QgsProviderConnectionException if any errors are encountered.
 .. versionadded:: 3.10
 %End
 
-    virtual void saveConnection( QgsAbstractProviderConnection *connection, const QVariantMap &configuration = QVariantMap() );
+    virtual void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name );
 %Docstring
 Stores the connection in the settings
 
 :param connection: the connection to be stored in the settings
-:param configuration: stores additional connection settings that not part of the data source URI
+:param name: the name under which the connection will be stored
 
 .. versionadded:: 3.10
 %End

--- a/python/plugins/db_manager/db_plugins/gpkg/plugin.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/plugin.py
@@ -85,8 +85,8 @@ class GPKGDBPlugin(DBPlugin):
     @classmethod
     def addConnection(self, conn_name, uri):
         md = QgsProviderRegistry.instance().providerMetadata(self.providerName())
-        conn = md.createConnection(conn_name, uri.database())
-        md.saveConnection(conn)
+        conn = md.createConnection(uri.database(), {})
+        md.saveConnection(conn, conn_name)
         return True
 
     @classmethod

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -35,31 +35,29 @@ QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString 
   setUri( settings.value( QStringLiteral( "path" ) ).toString() );
 }
 
-QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString &name, const QString &uri ):
-  QgsAbstractDatabaseProviderConnection( name )
+QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString &uri, const QVariantMap &configuration ):
+  QgsAbstractDatabaseProviderConnection( uri, configuration )
 {
   setDefaultCapabilities();
-  setUri( uri );
 }
 
-void QgsGeoPackageProviderConnection::store( const QVariantMap &configuration ) const
+void QgsGeoPackageProviderConnection::store( const QString &name ) const
 {
-  Q_UNUSED( configuration );
   QgsSettings settings;
   settings.beginGroup( QStringLiteral( "ogr" ), QgsSettings::Section::Providers );
   settings.beginGroup( QStringLiteral( "GPKG" ) );
   settings.beginGroup( QStringLiteral( "connections" ) );
-  settings.beginGroup( name() );
+  settings.beginGroup( name );
   settings.setValue( QStringLiteral( "path" ), uri() );
 }
 
-void QgsGeoPackageProviderConnection::remove() const
+void QgsGeoPackageProviderConnection::remove( const QString &name ) const
 {
   QgsSettings settings;
   settings.beginGroup( QStringLiteral( "ogr" ), QgsSettings::Section::Providers );
   settings.beginGroup( QStringLiteral( "GPKG" ) );
   settings.beginGroup( QStringLiteral( "connections" ) );
-  settings.remove( name() );
+  settings.remove( name );
 }
 
 
@@ -187,7 +185,7 @@ QList<QgsGeoPackageProviderConnection::TableProperty> QgsGeoPackageProviderConne
     {
       if ( row.size() != 6 )
       {
-        throw QgsProviderConnectionException( QObject::tr( "Error listing tables from %1: wrong number of columns returned by query" ).arg( name() ) );
+        throw QgsProviderConnectionException( QObject::tr( "Error listing tables from %1: wrong number of columns returned by query" ).arg( uri() ) );
       }
       QgsGeoPackageProviderConnection::TableProperty property;
       property.setTableName( row.at( 0 ).toString() );
@@ -234,7 +232,7 @@ QList<QgsGeoPackageProviderConnection::TableProperty> QgsGeoPackageProviderConne
 
   if ( ! errCause.isEmpty() )
   {
-    throw QgsProviderConnectionException( QObject::tr( "Error listing tables from %1: %2" ).arg( name() ).arg( errCause ) );
+    throw QgsProviderConnectionException( QObject::tr( "Error listing tables from %1: %2" ).arg( uri() ).arg( errCause ) );
   }
   // Filters
   if ( flags )

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -26,13 +26,13 @@ class QgsGeoPackageProviderConnection : public QgsAbstractDatabaseProviderConnec
   public:
 
     QgsGeoPackageProviderConnection( const QString &name );
-    QgsGeoPackageProviderConnection( const QString &name, const QString &uri );
+    QgsGeoPackageProviderConnection( const QString &uri, const QVariantMap &configuration );
 
 
     // QgsAbstractProviderConnection interface
   public:
-    void store( const QVariantMap &configuration ) const override;
-    void remove() const override;
+    void store( const QString &name ) const override;
+    void remove( const QString &name ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, QgsWkbTypes::Type wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -6649,7 +6649,6 @@ void QgsOgrProviderMetadata::cleanupProvider()
 
 
 
-
 QgsOgrProviderMetadata::QgsOgrProviderMetadata()
   : QgsProviderMetadata( TEXT_PROVIDER_KEY, TEXT_PROVIDER_DESCRIPTION )
 {
@@ -6678,9 +6677,9 @@ QgsAbstractProviderConnection *QgsOgrProviderMetadata::createConnection( const Q
   return new QgsGeoPackageProviderConnection( connName );
 }
 
-QgsAbstractProviderConnection *QgsOgrProviderMetadata::createConnection( const QString &connName, const QString &uri )
+QgsAbstractProviderConnection *QgsOgrProviderMetadata::createConnection( const QString &uri, const QVariantMap &configuration )
 {
-  return new QgsGeoPackageProviderConnection( connName, uri );
+  return new QgsGeoPackageProviderConnection( uri, configuration );
 }
 
 void QgsOgrProviderMetadata::deleteConnection( const QString &name )
@@ -6688,9 +6687,9 @@ void QgsOgrProviderMetadata::deleteConnection( const QString &name )
   deleteConnectionProtected<QgsGeoPackageProviderConnection>( name );
 }
 
-void QgsOgrProviderMetadata::saveConnection( QgsAbstractProviderConnection *conn, const QVariantMap &configuration )
+void QgsOgrProviderMetadata::saveConnection( const QgsAbstractProviderConnection *conn, const QString &name )
 {
-  saveConnectionProtected( conn, configuration );
+  saveConnectionProtected( conn, name );
 }
 
 ///@endcond

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -779,9 +779,12 @@ class QgsOgrProviderMetadata: public QgsProviderMetadata
   public:
     QMap<QString, QgsAbstractProviderConnection *> connections( bool cached ) override;
     QgsAbstractProviderConnection *createConnection( const QString &name ) override;
-    QgsAbstractProviderConnection *createConnection( const QString &name, const QString &uri ) override;
     void deleteConnection( const QString &name ) override;
-    void saveConnection( QgsAbstractProviderConnection *createConnection, const QVariantMap &configuration ) override;
+    void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name ) override;
+
+  protected:
+
+    QgsAbstractProviderConnection *createConnection( const QString &uri, const QVariantMap &configuration ) override;
 
 };
 

--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -24,8 +24,8 @@ QgsAbstractDatabaseProviderConnection::QgsAbstractDatabaseProviderConnection( co
 
 }
 
-QgsAbstractDatabaseProviderConnection::QgsAbstractDatabaseProviderConnection( const QString &name, const QString &uri ):
-  QgsAbstractProviderConnection( name, uri )
+QgsAbstractDatabaseProviderConnection::QgsAbstractDatabaseProviderConnection( const QString &uri, const QVariantMap &configuration ):
+  QgsAbstractProviderConnection( uri, configuration )
 {
 
 }

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -301,12 +301,12 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     QgsAbstractDatabaseProviderConnection( const QString &name );
 
     /**
-     * Creates a new connection with \a name and initializes the connection from the \a uri.
+     * Creates a new connection from the given \a uri and \a configuration.
      * The connection is not automatically stored in the settings.
      * \see store()
      */
+    QgsAbstractDatabaseProviderConnection( const QString &uri, const QVariantMap &configuration );
 
-    QgsAbstractDatabaseProviderConnection( const QString &name, const QString &uri );
 
     // Public interface
 

--- a/src/core/qgsabstractproviderconnection.cpp
+++ b/src/core/qgsabstractproviderconnection.cpp
@@ -17,22 +17,17 @@
 
 
 QgsAbstractProviderConnection::QgsAbstractProviderConnection( const QString &name )
-  : mConnectionName( name )
 {
+  Q_UNUSED( name );
   // Note: concrete classes must implement the logic to read the configuration from the settings
   //       and create mUri
 }
 
-QgsAbstractProviderConnection::QgsAbstractProviderConnection( const QString &name, const QString &uri )
-  : mConnectionName( name )
-  , mUri( uri )
+QgsAbstractProviderConnection::QgsAbstractProviderConnection( const QString &uri, const QVariantMap &configuration )
+  : mUri( uri )
+  , mConfiguration( configuration )
 {
 
-}
-
-QString QgsAbstractProviderConnection::name() const
-{
-  return mConnectionName;
 }
 
 QString QgsAbstractProviderConnection::uri() const
@@ -43,4 +38,14 @@ QString QgsAbstractProviderConnection::uri() const
 void QgsAbstractProviderConnection::setUri( const QString &uri )
 {
   mUri = uri;
+}
+
+QVariantMap QgsAbstractProviderConnection::configuration() const
+{
+  return mConfiguration;
+}
+
+void QgsAbstractProviderConnection::setConfiguration( const QVariantMap &configuration )
+{
+  mConfiguration = configuration;
 }

--- a/src/core/qgsabstractproviderconnection.h
+++ b/src/core/qgsabstractproviderconnection.h
@@ -27,12 +27,17 @@
 /**
  * The QgsAbstractProviderConnection provides an interface for data provider connections.
  *
- * Connections objects can be created by passing the connection name and in this case
- * they are automatically loaded from the settings, or by passing a data source URI
- * in the constructor.
+ * Connections objects can be constructed loading them from the connections stored
+ * in the settings by passing the connection name.
+ * A new connection object can also be created by passing a data source URI in the constructor.
+ *
+ * Provider metadata keep a cache of the existing connections, to manage stored
+ * connections it is recommendend to call metadata methods instead of loading and
+ * storing the connections directly.
  *
  * Concrete classes must implement methods to retrieve, save and remove connections from
  * the settings.
+ *
  * \ingroup core
  * \since QGIS 3.10
  */
@@ -65,30 +70,24 @@ class CORE_EXPORT QgsAbstractProviderConnection
     QgsAbstractProviderConnection( const QString &name );
 
     /**
-     * Creates a new connection with \a name and initializes the connection from the \a uri.
+     * Creates a new connection from the given \a uri and \a configuration.
      * The connection is not automatically stored in the settings.
      * \see store()
      */
-    QgsAbstractProviderConnection( const QString &name, const QString &uri );
+    QgsAbstractProviderConnection( const QString &uri, const QVariantMap &configuration );
 
     virtual ~QgsAbstractProviderConnection() = default;
 
     /**
      * Stores the connection in the settings.
-     * \param configuration stores additional connection settings that are used by the
-     * source select dialog and are not part of the data source URI
+     * \param name the name under which the connection will be stored
      */
-    virtual void store( const QVariantMap &configuration = QVariantMap() ) const = 0;
+    virtual void store( const QString &name ) const = 0;
 
     /**
      * Deletes the connection from the settings.
      */
-    virtual void remove( ) const = 0;
-
-    /**
-     * Returns the connection name
-     */
-    QString name() const;
+    virtual void remove( const QString &name ) const = 0;
 
     /**
      * Returns the connection data source URI string representation
@@ -100,10 +99,20 @@ class CORE_EXPORT QgsAbstractProviderConnection
      */
     void setUri( const QString &uri );
 
+    /**
+     * Returns the connection configuration parameters
+     */
+    QVariantMap configuration() const;
+
+    /**
+     * Sets the connection \a configuration
+     */
+    void setConfiguration( const QVariantMap &configuration );
+
   private:
 
-    QString mConnectionName;
     QString mUri;
+    QVariantMap mConfiguration;
 
 };
 

--- a/src/core/qgsprovidermetadata.cpp
+++ b/src/core/qgsprovidermetadata.cpp
@@ -176,11 +176,12 @@ QMap<QString, QgsAbstractDatabaseProviderConnection *> QgsProviderMetadata::dbCo
 QgsAbstractProviderConnection *QgsProviderMetadata::findConnection( const QString &name, bool cached )
 {
   const QMap<QString, QgsAbstractProviderConnection *> constConns { connections( cached ) };
-  for ( QgsAbstractProviderConnection *conn : constConns )
+  const QStringList constKeys { constConns.keys( ) };
+  for ( const QString &key : constKeys )
   {
-    if ( conn->name() == name )
+    if ( key == name )
     {
-      return conn;
+      return constConns.value( key );
     }
   }
   return nullptr;
@@ -193,9 +194,9 @@ QgsAbstractProviderConnection *QgsProviderMetadata::createConnection( const QStr
 }
 
 
-QgsAbstractProviderConnection *QgsProviderMetadata::createConnection( const QString &name, const QString &uri )
+QgsAbstractProviderConnection *QgsProviderMetadata::createConnection( const QString &uri, const QVariantMap &configuration )
 {
-  Q_UNUSED( name );
+  Q_UNUSED( configuration );
   Q_UNUSED( uri );
   throw QgsProviderConnectionException( QObject::tr( "Provider %1 has no %2 method" ).arg( key(), QStringLiteral( "connection" ) ) );
 }
@@ -206,17 +207,17 @@ void QgsProviderMetadata::deleteConnection( const QString &name )
   throw QgsProviderConnectionException( QObject::tr( "Provider %1 has no %2 method" ).arg( key(), QStringLiteral( "deleteConnection" ) ) );
 }
 
-void QgsProviderMetadata::saveConnection( QgsAbstractProviderConnection *connection, const QVariantMap &configuration )
+void QgsProviderMetadata::saveConnection( const QgsAbstractProviderConnection *connection, const QString &name )
 {
   Q_UNUSED( connection );
-  Q_UNUSED( configuration );
+  Q_UNUSED( name );
   throw QgsProviderConnectionException( QObject::tr( "Provider %1 has no %2 method" ).arg( key(), QStringLiteral( "saveConnection" ) ) );
 }
 
 ///@cond PRIVATE
-void QgsProviderMetadata::saveConnectionProtected( QgsAbstractProviderConnection *conn, const QVariantMap &configuration )
+void QgsProviderMetadata::saveConnectionProtected( const QgsAbstractProviderConnection *conn, const QString &name )
 {
-  conn->store( configuration );
+  conn->store( name );
   mProviderConnections.clear();
 }
 ///@endcond

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -310,21 +310,21 @@ class CORE_EXPORT QgsProviderMetadata
 #endif
 
     /**
-     * Creates a new connection by loading the connection with the given \a name from the settings.
-     * Ownership is transferred to the caller.
-     * \since QGIS 3.10
-     */
-    virtual QgsAbstractProviderConnection *createConnection( const QString &name ) SIP_FACTORY ;
-
-    /**
-     * Creates a new connection with the given \a name and data source \a uri,
+     * Creates a new connection from \a uri and \a configuration,
      * the newly created connection is not automatically stored in the settings, call
      * saveConnection() to save it.
      * Ownership is transferred to the caller.
      * \see saveConnection()
      * \since QGIS 3.10
      */
-    virtual QgsAbstractProviderConnection *createConnection( const QString &name, const QString &uri ) SIP_FACTORY;
+    virtual QgsAbstractProviderConnection *createConnection( const QString &uri, const QVariantMap &configuration ) SIP_FACTORY;
+
+    /**
+     * Creates a new connection by loading the connection with the given \a name from the settings.
+     * Ownership is transferred to the caller.
+     * \see findConnection()
+     */
+    virtual QgsAbstractProviderConnection *createConnection( const QString &name );
 
     /**
      * Removes the connection with the given \a name from the settings.
@@ -337,17 +337,17 @@ class CORE_EXPORT QgsProviderMetadata
     /**
      * Stores the connection in the settings
      * \param connection the connection to be stored in the settings
-     * \param configuration stores additional connection settings that not part of the data source URI
+     * \param name the name under which the connection will be stored
      * \since QGIS 3.10
      */
-    virtual void saveConnection( QgsAbstractProviderConnection *connection, const QVariantMap &configuration = QVariantMap() );
+    virtual void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name );
 
   protected:
 
 #ifndef SIP_RUN
 ///@cond PRIVATE
 
-    // Common functionality for connections management,to be moved into the class
+    // Common functionality for connections management, to be moved into the class
     // when all the providers are ready
     // T_provider_conn: subclass of QgsAbstractProviderConnection,
     // T_conn: provider connection class (such as QgsOgrDbConnection or QgsPostgresConn)
@@ -370,10 +370,10 @@ class CORE_EXPORT QgsProviderMetadata
     template <class T_provider_conn> void deleteConnectionProtected( const QString &name )
     {
       T_provider_conn conn( name );
-      conn.remove();
+      conn.remove( name );
       mProviderConnections.clear();
     }
-    virtual void saveConnectionProtected( QgsAbstractProviderConnection *connection, const QVariantMap &configuration = QVariantMap() );
+    virtual void saveConnectionProtected( const QgsAbstractProviderConnection *connection, const QString &name );
     //! Provider connections cache
     QMap<QString, QgsAbstractProviderConnection *> mProviderConnections;
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5038,9 +5038,9 @@ QMap<QString, QgsAbstractProviderConnection *> QgsPostgresProviderMetadata::conn
   return connectionsProtected<QgsPostgresProviderConnection, QgsPostgresConn>( cached );
 }
 
-QgsAbstractProviderConnection *QgsPostgresProviderMetadata::createConnection( const QString &name, const QString &uri )
+QgsAbstractProviderConnection *QgsPostgresProviderMetadata::createConnection( const QString &uri, const QVariantMap &configuration )
 {
-  return new QgsPostgresProviderConnection( name, uri );
+  return new QgsPostgresProviderConnection( uri, configuration );
 }
 
 void QgsPostgresProviderMetadata::deleteConnection( const QString &name )
@@ -5048,9 +5048,9 @@ void QgsPostgresProviderMetadata::deleteConnection( const QString &name )
   deleteConnectionProtected<QgsPostgresProviderConnection>( name );
 }
 
-void QgsPostgresProviderMetadata::saveConnection( QgsAbstractProviderConnection *conn, const QVariantMap &configuration )
+void QgsPostgresProviderMetadata::saveConnection( const QgsAbstractProviderConnection *conn,  const QString &name )
 {
-  saveConnectionProtected( conn, configuration );
+  saveConnectionProtected( conn, name );
 }
 
 QgsAbstractProviderConnection *QgsPostgresProviderMetadata::createConnection( const QString &name )

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -566,9 +566,9 @@ class QgsPostgresProviderMetadata: public QgsProviderMetadata
     QgsTransaction *createTransaction( const QString &connString ) override;
     QMap<QString, QgsAbstractProviderConnection *> connections( bool cached = true ) override;
     QgsAbstractProviderConnection *createConnection( const QString &name ) override;
-    QgsAbstractProviderConnection *createConnection( const QString &name, const QString &uri ) override;
+    QgsAbstractProviderConnection *createConnection( const QString &uri, const QVariantMap &configuration ) override;
     void deleteConnection( const QString &name ) override;
-    void saveConnection( QgsAbstractProviderConnection *createConnection, const QVariantMap &configuration = QVariantMap() ) override;
+    void saveConnection( const QgsAbstractProviderConnection *createConnection, const QString &name ) override;
     void initProvider() override;
     void cleanupProvider() override;
 

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -23,7 +23,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
   public:
 
     QgsPostgresProviderConnection( const QString &name );
-    QgsPostgresProviderConnection( const QString &name, const QString &uri );
+    QgsPostgresProviderConnection( const QString &uri, const QVariantMap &configuration );
 
     // QgsAbstractProviderConnection interface
 
@@ -48,8 +48,8 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema,
         const TableFlags &flags = nullptr ) const override;
     QStringList schemas( ) const override;
-    void store( const QVariantMap &configuration = QVariantMap() ) const override;
-    void remove() const override;
+    void store( const QString &name ) const override;
+    void remove( const QString &name ) const override;
 
 
   private:

--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -58,8 +58,8 @@ class TestPyQgsProviderConnectionBase():
 
     def _test_save_load(self, md, uri):
         """Common tests on connection save and load"""
-        conn = md.createConnection('qgis_test1', self.uri)
-        md.saveConnection(conn)
+        conn = md.createConnection(self.uri, {})
+        md.saveConnection(conn, 'qgis_test1')
         # Check that we retrieve the new connection
         self.assertTrue('qgis_test1' in md.connections().keys())
         self.assertTrue('qgis_test1' in md.dbConnections().keys())
@@ -253,7 +253,7 @@ class TestPyQgsProviderConnectionBase():
         self.assertTrue(isinstance(list(conns.values())[0], QgsAbstractDatabaseProviderConnection))
 
         # Remove connection
-        md.deleteConnection(conn.name())
+        md.deleteConnection('qgis_test1')
         self.assertEqual(list(md.connections().values()), [])
 
     def test_errors(self):
@@ -271,7 +271,7 @@ class TestPyQgsProviderConnectionBase():
                 conn.executeSql('DROP TABLE "notExists"')
 
         # Remove connection
-        md.deleteConnection(conn.name())
+        md.deleteConnection('qgis_test1')
         self.assertEqual(list(md.connections().values()), [])
 
     def test_connections(self):

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -59,8 +59,8 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
 
         md = QgsProviderRegistry.instance().providerMetadata('ogr')
 
-        conn = md.createConnection('qgis_test1', self.uri)
-        md.saveConnection(conn)
+        conn = md.createConnection(self.uri, {})
+        md.saveConnection(conn, 'qgis_test1')
 
         # Retrieve capabilities
         capabilities = conn.capabilities()

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -52,8 +52,8 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
 
         md = QgsProviderRegistry.instance().providerMetadata('postgres')
 
-        conn = md.createConnection('qgis_test1', self.uri)
-        md.saveConnection(conn)
+        conn = md.createConnection(self.uri, {})
+        md.saveConnection(conn, 'qgis_test1')
 
         # Retrieve capabilities
         capabilities = conn.capabilities()
@@ -96,8 +96,8 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
 
         md = QgsProviderRegistry.instance().providerMetadata('postgres')
 
-        conn = md.createConnection('qgis_test1', self.uri)
-        md.saveConnection(conn)
+        conn = md.createConnection(self.uri, {})
+        md.saveConnection(conn, 'qgis_test1')
 
         table = self._table_by_name(conn.tables('qgis_test', QgsAbstractDatabaseProviderConnection.Raster), 'Raster1')
         self.assertTrue(QgsRasterLayer("PG: %s schema='qgis_test' column='%s' table='%s'" % (conn.uri(), table.geometryColumn(), table.tableName()), 'r1', 'gdal').isValid())


### PR DESCRIPTION
Tries to make it clearer what are the use cases for the two
constructors (name and uri).

The new API:

```python
# loads an existing connection from the settings
md = QgsProviderRegistry.instance().providerMetadata('postgres')
conn = md.createConnection('qgis_test1')
# Save it back
md.saveConnection(conn, 'qgis_test1')
# Save with another name
md.saveConnection(conn, 'qgis_test2')
md.deleteConnection('qgis_test1')

# creates a "floating" connection
conn = md.createConnection(uri, { "dontResolveType": True})
# Save it in the settings
md.saveConnection(conn, 'qgis_test3')
```


```