### PR TITLE
Update warp.py

### DIFF
--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -215,9 +215,9 @@ class warp(GdalAlgorithm):
             arguments.append(extent.yMaximum())
 
             extentCrs = self.parameterAsCrs(parameters, self.TARGET_EXTENT_CRS, context)
-            if extentCrs:
+            if extentCrs.isValid():
                 arguments.append('-te_srs')
-                arguments.append(extentCrs.authid())
+                arguments.append(GdalUtils.gdal_crs_string(extentCrs))
 
         if self.parameterAsBoolean(parameters, self.MULTITHREADING, context):
             arguments.append('-multi')

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1660,13 +1660,13 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  outdir + '/check.jpg'])
 
             # with target using custom projection and user-defined extent
-            custom_crs = 'proj4: +proj=longlat +a=6378388 +b=6356912 +no_defs'
+            custom_crs2 = 'proj4: +proj=longlat +a=6378388 +b=6356912 +no_defs'
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
-                                        'SOURCE_CRS': custom_crs,
-                                        'TARGET_CRS': custom_crs,
+                                        'SOURCE_CRS': custom_crs2,
+                                        'TARGET_CRS': custom_crs2,
                                         'TARGET_EXTENT': '18.67,18.70,45.78,45.81',
-                                        'TARGET_EXTENT_CRS': custom_crs,
+                                        'TARGET_EXTENT_CRS': custom_crs2,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
                  '-s_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -t_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -of JPEG ' +

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1669,9 +1669,9 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'TARGET_EXTENT_CRS': custom_crs2,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
-                 '-s_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -t_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -of JPEG ' +
+                 '-s_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -t_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -of GTiff ' +
                  source + ' ' +
-                 outdir + '/check.jpg'])
+                 outdir + '/check.tif'])
 
             # with non-EPSG crs code
             self.assertEqual(

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1660,7 +1660,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  outdir + '/check.jpg'])
 
             # with target using custom projection and user-defined extent
-            custom_crs = 'proj4: +proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs'
+            custom_crs = 'proj4: +proj=longlat +a=6378388 +b=6356912 +no_defs'
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
                                         'SOURCE_CRS': custom_crs,
@@ -1669,7 +1669,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'TARGET_EXTENT_CRS': custom_crs,
                                         'OUTPUT': outdir + '/check.jpg'}, context, feedback),
                 ['gdalwarp',
-                 '-s_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -t_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -of JPEG ' +
+                 '-s_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -t_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
 

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1667,7 +1667,7 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'TARGET_CRS': custom_crs2,
                                         'TARGET_EXTENT': '18.67,18.70,45.78,45.81',
                                         'TARGET_EXTENT_CRS': custom_crs2,
-                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                                        'OUTPUT': outdir + '/check.tif'}, context, feedback),
                 ['gdalwarp',
                  '-s_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -t_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=longlat +a=6378388 +b=6356912 +no_defs" -of GTiff ' +
                  source + ' ' +

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -1659,6 +1659,20 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  source + ' ' +
                  outdir + '/check.jpg'])
 
+            # with target using custom projection and user-defined extent
+            custom_crs = 'proj4: +proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs'
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'SOURCE_CRS': custom_crs,
+                                        'TARGET_CRS': custom_crs,
+                                        'TARGET_EXTENT': '18.67,18.70,45.78,45.81',
+                                        'TARGET_EXTENT_CRS': custom_crs,
+                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdalwarp',
+                 '-s_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -t_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -r near -te 18.67 45.78 18.7 45.81 -te_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -of JPEG ' +
+                 source + ' ' +
+                 outdir + '/check.jpg'])
+
             # with non-EPSG crs code
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,


### PR DESCRIPTION

## Description
Changes proposed to address bug reported in https://github.com/qgis/QGIS/issues/31276. The change to line 218 addresses the case where an output extent is defined but its CRS is left blank (implicit). The change to line 220 ensures that a USER: coordinate system is translated into a Proj4 string that is recognised by GDAL.

Apologies if this pull request doesn't comply with some items on the checklist (I'm unfamiliar with this process)

Fixes #31276

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
