### PR TITLE
[needs-docs] Revise QgsPathResolver::setPathPreprocessor API

### DIFF
--- a/python/core/auto_generated/qgspathresolver.sip.in
+++ b/python/core/auto_generated/qgspathresolver.sip.in
@@ -39,7 +39,7 @@ Turn filename read from the project file to an absolute path
 %End
 
 
-    static void setPathPreprocessor( SIP_PYCALLABLE / AllowNone / );
+    static QString setPathPreprocessor( SIP_PYCALLABLE / AllowNone / );
 %Docstring
 Sets a path pre-processor function, which allows for manipulation of paths and data sources prior
 to resolving them to file references or layer sources.
@@ -85,9 +85,10 @@ Example - replace stored database credentials with new ones:
 .. versionadded:: 3.10
 %End
 %MethodCode
+    PyObject *s = 0;
     Py_BEGIN_ALLOW_THREADS
     Py_XINCREF( a0 );
-    QgsPathResolver::setPathPreprocessor( [a0]( const QString &arg )->QString
+    QString id = QgsPathResolver::setPathPreprocessor( [a0]( const QString &arg )->QString
     {
       QString res;
       SIP_BLOCK_THREADS
@@ -104,7 +105,29 @@ Example - replace stored database credentials with new ones:
       return res;
     } );
 
+    s = sipConvertFromNewType( new QString( id ), sipType_QString, 0 );
     Py_END_ALLOW_THREADS
+    return s;
+%End
+
+
+    static void removePathPreprocessor( const QString &id );
+%Docstring
+Removes the custom pre-processor function with matching ``id``.
+
+The ``id`` must correspond to a pre-processor previously added via a call to setPathPreprocessor().
+An KeyError will be raised if no processor with the specified ``id`` exists.
+
+.. seealso:: :py:func:`setPathPreprocessor`
+
+.. versionadded:: 3.10
+%End
+%MethodCode
+    if ( !QgsPathResolver::removePathPreprocessor( *a0 ) )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "No processor with id %1 exists." ).arg( *a0 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
 %End
 
 };


### PR DESCRIPTION
Allow path preprocessors to be chained and don't force replace
any existing ones.

Processors can be removed via a call to QgsPathResolver::removePathPreprocessor,
using the unique ID returned by the original call to setPathPreprocessor
