### PR TITLE
Don't try to resolve svg paths corresponding to embedded svg files

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -3770,6 +3770,9 @@ QString QgsSymbolLayerUtils::svgSymbolNameToPath( const QString &n, const QgsPat
   if ( n.isEmpty() )
     return QString();
 
+  if ( n.startsWith( QLatin1String( "base64:" ) ) )
+    return n;
+
   // we might have a full path...
   if ( QFileInfo::exists( n ) )
     return QFileInfo( n ).canonicalFilePath();
@@ -3832,6 +3835,9 @@ QString QgsSymbolLayerUtils::svgSymbolPathToName( const QString &p, const QgsPat
 {
   if ( p.isEmpty() )
     return QString();
+
+  if ( p.startsWith( QLatin1String( "base64:" ) ) )
+    return p;
 
   if ( !QFileInfo::exists( p ) )
     return p;


### PR DESCRIPTION
Big speedup when loading symbols with embedded paths