### PR TITLE
Fix massive regression in speed of editing operations 

### DIFF
--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -354,11 +354,17 @@ void QgsGeometryValidationService::invalidateTopologyChecks( QgsVectorLayer *lay
 
 void QgsGeometryValidationService::processFeature( QgsVectorLayer *layer, QgsFeatureId fid )
 {
+  if ( !mLayerChecks.contains( layer ) )
+    return;
+
+  const QList< QgsSingleGeometryCheck * > checks = mLayerChecks[layer].singleFeatureChecks;
+  if ( checks.empty() )
+    return;
+
   emit geometryCheckStarted( layer, fid );
 
   QgsGeometry geometry = layer->getGeometry( fid );
 
-  const auto &checks = mLayerChecks[layer].singleFeatureChecks;
   mLayerChecks[layer].singleFeatureCheckErrors.remove( fid );
 
   // The errors are going to be sent out via a signal. We cannot keep ownership in here (or can we?)


### PR DESCRIPTION
(E.g. pasting 100s+ features into a layer)

This was triggering multiple duplicate geometry requests from the provider
even when no validation settings were specified for a layer
