### PR TITLE
Add a fast shortcut to rectangle/geometry intersection test

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1125,6 +1125,10 @@ bool QgsGeometry::removeDuplicateNodes( double epsilon, bool useZValues )
 
 bool QgsGeometry::intersects( const QgsRectangle &r ) const
 {
+  // fast case, check bounding boxes
+  if ( !boundingBoxIntersects( r ) )
+    return false;
+
   QgsGeometry g = fromRect( r );
   return intersects( g );
 }


### PR DESCRIPTION
We can shortcut a lot of heavy lifting by first testing that the bounding boxes intersect
