### PR TITLE
Play safe, lock mutex on all QgsTileCache functions

### DIFF
--- a/src/core/qgstilecache.h
+++ b/src/core/qgstilecache.h
@@ -51,9 +51,9 @@ class CORE_EXPORT QgsTileCache
     static bool tile( const QUrl &url, QImage &image );
 
     //! how many tiles are stored in the in-memory cache
-    static int totalCost() { return sTileCache.totalCost(); }
+    static int totalCost() { QMutexLocker locker( &sTileCacheMutex ); return sTileCache.totalCost(); }
     //! how many tiles can be stored in the in-memory cache
-    static int maxCost() { return sTileCache.maxCost(); }
+    static int maxCost() { QMutexLocker locker( &sTileCacheMutex ); return sTileCache.maxCost(); }
 
   private:
     //! in-memory cache


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@nyalldawson , as discussed over google hangout.

Background: every now and then (say twice per week), my QGIS (Debug type) build crashes when zooming / panning around projects with XYZ layers. Can't figure out what's wrong for sure, but I'm thinking playing on the safe side and locking the QgsTileCache mutex for all functions won't hurt.


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
