### PR TITLE
Parallelize snap caching

### DIFF
--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -32,7 +32,8 @@ Works with one layer.
 
     explicit QgsPointLocator( QgsVectorLayer *layer, const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem(),
                               const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext(),
-                              const QgsRectangle *extent = 0 );
+                              const QgsRectangle *extent = 0,
+                              bool asynchronous = false );
 %Docstring
 Construct point locator for a ``layer``.
 
@@ -40,6 +41,11 @@ If a valid QgsCoordinateReferenceSystem is passed for ``destinationCrs`` then th
 do the searches on data reprojected to the given CRS. For accurate reprojection it is important
 to set the correct ``transformContext`` if a ``destinationCrs`` is specified. This is usually taken
 from the current :py:func:`QgsProject.transformContext()`
+
+:param asynchronous: if ``False``, point locator init() method will block until index is completely
+                     finished. if ``True``, index building will be done in another thread and init() method returns
+                     immediatly. initStarted() and initFinished() signals can be used to control current state of
+                     the point locator.
 
 If ``extent`` is not ``None``, the locator will index only a subset of the layer which falls within that extent.
 %End

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -241,7 +241,7 @@ Returns how many geometries are cached in the index
     bool isIndexing() const;
 %Docstring
 Returns ``True`` if the point locator is currently indexing the data.
-This method is usefull if constructor parameter ``asynchronous`` is ``True``
+This method is useful if constructor parameter ``asynchronous`` is ``True``
 
 .. seealso:: :py:class:`QgsPointLocator`
 %End

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -42,9 +42,9 @@ do the searches on data reprojected to the given CRS. For accurate reprojection 
 to set the correct ``transformContext`` if a ``destinationCrs`` is specified. This is usually taken
 from the current :py:func:`QgsProject.transformContext()`
 
-:param asynchronous: if ``False``, point locator init() method will block until point locator index
-                     is completely built. if ``True``, index building will be done in another thread and init() method returns
-                     immediately. initFinished() signal will be emitted once the initialization is over.
+if ``asynchronous`` is ``False``, point locator init() method will block until point locator index
+is completely built. if ``True``, index building will be done in another thread and init() method returns
+immediately. initFinished() signal will be emitted once the initialization is over.
 
 If ``extent`` is not ``None``, the locator will index only a subset of the layer which falls within that extent.
 %End

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -103,8 +103,11 @@ Configure render context  - if not ``None``, it will use to index only visible f
 Prepare the index for queries. Does nothing if the index already exists.
 If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
 to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
-This method is non blocking and index is built in another thread. Signals indexStarting and indexFinished
-are triggered to let you know when index build is started and finished.
+
+This method is either blocking or non blocking according to ``asynchronous`` parameter passed
+in the constructor
+
+.. seealso:: :py:class:`QgsPointLocator`
 %End
 
     bool hasIndex() const;
@@ -235,6 +238,14 @@ Returns how many geometries are cached in the index
 .. versionadded:: 2.14
 %End
 
+    bool isIndexing() const;
+%Docstring
+Returns ``True`` if the point locator is currently indexing the data.
+This method is usefull if constructor parameter ``asynchronous`` is ``True``
+
+.. seealso:: :py:class:`QgsPointLocator`
+%End
+
   signals:
 
     void initFinished( bool ok );
@@ -247,6 +258,14 @@ Emitted whenever index has been built and initialization is finished
 
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
+
+    bool prepare();
+%Docstring
+prepare index if need and returns ``True`` if the index is ready to be used
+
+.. versionadded:: 3.10
+%End
+
   protected slots:
     void destroyIndex();
 };

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -42,10 +42,9 @@ do the searches on data reprojected to the given CRS. For accurate reprojection 
 to set the correct ``transformContext`` if a ``destinationCrs`` is specified. This is usually taken
 from the current :py:func:`QgsProject.transformContext()`
 
-:param asynchronous: if ``False``, point locator init() method will block until index is completely
-                     finished. if ``True``, index building will be done in another thread and init() method returns
-                     immediatly. initStarted() and initFinished() signals can be used to control current state of
-                     the point locator.
+:param asynchronous: if ``False``, point locator init() method will block until point locator index
+                     is completely built. if ``True``, index building will be done in another thread and init() method returns
+                     immediately. initFinished() signal will be emitted once the initialization is over.
 
 If ``extent`` is not ``None``, the locator will index only a subset of the layer which falls within that extent.
 %End
@@ -244,11 +243,6 @@ Emitted whenever index has been built and initialization is finished
 
 :param ok: ``False`` if the creation of index has been prematurely stopped due to the limit of
            features, otherwise ``True``
-%End
-
-    void initStarted();
-%Docstring
-Emitted whenever index initialization has started
 %End
 
   protected:

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -98,7 +98,7 @@ Configure render context  - if not ``None``, it will use to index only visible f
 Prepare the index for queries. Does nothing if the index already exists.
 If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
 to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
-This method is non blocking and index is built in an other thread. Signals indexStarting and indexFinished
+This method is non blocking and index is built in another thread. Signals indexStarting and indexFinished
 are triggered to let you know when index build is started and finished.
 %End
 

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsPointLocator : QObject
 {
 %Docstring
@@ -92,12 +93,13 @@ Configure render context  - if not ``None``, it will use to index only visible f
     typedef QFlags<QgsPointLocator::Type> Types;
 
 
-    bool init( int maxFeaturesToIndex = -1 );
+    void init( int maxFeaturesToIndex = -1 );
 %Docstring
 Prepare the index for queries. Does nothing if the index already exists.
 If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
-to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used. Returns
-``False`` if the creation of index has been prematurely stopped due to the limit of features, otherwise ``True``
+to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
+This method is non blocking and index is built in an other thread. Signals indexStarting and indexFinished
+are triggered to let you know when index build is started and finished.
 %End
 
     bool hasIndex() const;
@@ -226,6 +228,21 @@ find out if the point is in any polygons
 Returns how many geometries are cached in the index
 
 .. versionadded:: 2.14
+%End
+
+  signals:
+
+    void initFinished( bool ok );
+%Docstring
+Emitted whenever index has been built and initialization is finished
+
+:param ok: ``False`` if the creation of index has been prematurely stopped due to the limit of
+           features, otherwise ``True``
+%End
+
+    void initStarted();
+%Docstring
+Emitted whenever index initialization has started
 %End
 
   protected:

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsPointLocator : QObject
 {
 %Docstring
@@ -98,14 +97,15 @@ Configure render context  - if not ``None``, it will use to index only visible f
     typedef QFlags<QgsPointLocator::Type> Types;
 
 
-    void init( int maxFeaturesToIndex = -1 );
+    bool init( int maxFeaturesToIndex = -1 );
 %Docstring
 Prepare the index for queries. Does nothing if the index already exists.
 If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
 to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
 
 This method is either blocking or non blocking according to ``asynchronous`` parameter passed
-in the constructor
+in the constructor.
+Returns false if the creation of index is blocking and has been prematurely stopped due to the limit of features, otherwise true
 
 .. seealso:: :py:class:`QgsPointLocator`
 %End
@@ -258,13 +258,6 @@ Emitted whenever index has been built and initialization is finished
 
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
-
-    bool prepare();
-%Docstring
-prepare index if need and returns ``True`` if the index is ready to be used
-
-.. versionadded:: 3.10
-%End
 
   protected slots:
     void destroyIndex();

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -177,13 +177,15 @@ Emitted when the snapping settings object changes.
 %End
 
   protected:
-    virtual void prepareIndexStarting();
+
+ virtual void prepareIndexStarting( int count );
 %Docstring
-Called when starting to index
+This methods is now deprecated and never called
 %End
-    virtual void prepareIndexFinished();
+
+ virtual void prepareIndexProgress( int index );
 %Docstring
-Called when finished indexing a layer
+This methods is now deprecated and never called
 %End
 
     void clearAllLocators();

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -35,9 +35,14 @@ which keeps the configuration in sync with map canvas (e.g. current view, active
 %End
   public:
 
-    QgsSnappingUtils( QObject *parent /TransferThis/ = 0, bool enableSnappingForInvisibleFeature = true );
+    QgsSnappingUtils( QObject *parent /TransferThis/ = 0, bool enableSnappingForInvisibleFeature = true,
+                      bool asynchronous = false );
 %Docstring
 Constructor for QgsSnappingUtils
+
+:param parent: parent object
+:param enableSnappingForInvisibleFeature: ``True`` if we want to snap feature even if there are not visible
+:param asynchronous: indicated if point locator creation has to be made asynchronously (see :py:class:`QgsPointLocator`())
 %End
     ~QgsSnappingUtils();
 

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -181,11 +181,15 @@ Emitted when the snapping settings object changes.
  virtual void prepareIndexStarting( int count );
 %Docstring
 This methods is now deprecated and never called
+
+.. deprecated:: since QGIS 3.10
 %End
 
  virtual void prepareIndexProgress( int index );
 %Docstring
 This methods is now deprecated and never called
+
+.. deprecated:: since QGIS 3.10
 %End
 
     void clearAllLocators();

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -172,13 +172,13 @@ Emitted when the snapping settings object changes.
 %End
 
   protected:
-    virtual void prepareIndexStarting( int count );
+    virtual void prepareIndexStarting();
 %Docstring
-Called when starting to index - can be overridden and e.g. progress dialog can be provided
+Called when starting to index
 %End
-    virtual void prepareIndexProgress( int index );
+    virtual void prepareIndexFinished();
 %Docstring
-Called when finished indexing a layer. When index == count the indexing is complete
+Called when finished indexing a layer
 %End
 
     void clearAllLocators();

--- a/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
@@ -26,9 +26,9 @@ Snapping utils instance that is connected to a canvas and updates the configurat
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = 0 );
 
   protected:
-    virtual void prepareIndexStarting( int count );
+    virtual void prepareIndexStarting();
 
-    virtual void prepareIndexProgress( int index );
+    virtual void prepareIndexFinished();
 
 
 };

--- a/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
@@ -23,7 +23,7 @@ Snapping utils instance that is connected to a canvas and updates the configurat
 #include "qgsmapcanvassnappingutils.h"
 %End
   public:
-    QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = 0 );
+    QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = 0, bool asynchronous = false );
 
 };
 

--- a/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
@@ -23,7 +23,16 @@ Snapping utils instance that is connected to a canvas and updates the configurat
 #include "qgsmapcanvassnappingutils.h"
 %End
   public:
+
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = 0, bool asynchronous = false );
+%Docstring
+Construct map canvas snapping utils object
+
+:param canvas: map canvas
+:param parent: parent object
+:param asynchronous: if ``True`` snapping cache index will be non blocking and done in another thread,
+                     if ``False`` it will block until indexing is done
+%End
 
 };
 

--- a/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
@@ -25,12 +25,6 @@ Snapping utils instance that is connected to a canvas and updates the configurat
   public:
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = 0 );
 
-  protected:
-    virtual void prepareIndexStarting();
-
-    virtual void prepareIndexFinished();
-
-
 };
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -937,7 +937,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   endProfile();
 
   startProfile( QStringLiteral( "Snapping utils" ) );
-  mSnappingUtils = new QgsMapCanvasSnappingUtils( mMapCanvas, this );
+  mSnappingUtils = new QgsMapCanvasSnappingUtils( mMapCanvas, this, true );
   mMapCanvas->setSnappingUtils( mSnappingUtils );
   connect( QgsProject::instance(), &QgsProject::snappingConfigChanged, mSnappingUtils, &QgsSnappingUtils::setConfig );
   connect( QgsProject::instance(), &QgsProject::collectAttachedFiles, this, &QgisApp::generateProjectAttachedFiles );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -317,6 +317,7 @@ SET(QGIS_CORE_SRCS
   qgspluginlayerregistry.cpp
   qgspointxy.cpp
   qgspointlocator.cpp
+  qgspointlocatorinittask.cpp
   qgsproject.cpp
   qgsprojectbadlayerhandler.cpp
   qgsprojectfiletransform.cpp
@@ -708,6 +709,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgspluginlayer.h
   qgspointxy.h
   qgspointlocator.h
+  qgspointlocatorinittask.h
   qgsproject.h
   qgsproxyprogresstask.h
   qgsrelationmanager.h

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * to set the correct \a transformContext if a \a destinationCrs is specified. This is usually taken
      * from the current QgsProject::transformContext().
      *
-     * \param asynchronous if FALSE, point locator init() method will block until point locator index
+     * if \a asynchronous is FALSE, point locator init() method will block until point locator index
      * is completely built. if TRUE, index building will be done in another thread and init() method returns
      * immediately. initFinished() signal will be emitted once the initialization is over.
      *

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -68,11 +68,17 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * to set the correct \a transformContext if a \a destinationCrs is specified. This is usually taken
      * from the current QgsProject::transformContext().
      *
+     * \param asynchronous if FALSE, point locator init() method will block until index is completely
+     * finished. if TRUE, index building will be done in another thread and init() method returns
+     * immediatly. initStarted() and initFinished() signals can be used to control current state of
+     * the point locator.
+     *
      * If \a extent is not NULLPTR, the locator will index only a subset of the layer which falls within that extent.
      */
     explicit QgsPointLocator( QgsVectorLayer *layer, const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem(),
                               const QgsCoordinateTransformContext &transformContext = QgsCoordinateTransformContext(),
-                              const QgsRectangle *extent = nullptr );
+                              const QgsRectangle *extent = nullptr,
+                              bool asynchronous = false );
 
     ~QgsPointLocator() override;
 
@@ -332,6 +338,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     QFuture<bool> mFuture;
     QFutureWatcher<bool> mFutureWatcher;
     int mMaxFeaturesToIndex = -1;
+    bool mAsynchronous = false;
 
     friend class QgsPointLocator_VisitorNearestVertex;
     friend class QgsPointLocator_VisitorNearestEdge;

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -24,6 +24,7 @@ class QgsVectorLayer;
 class QgsFeatureRenderer;
 class QgsRenderContext;
 class QgsRectangle;
+class QgsVectorLayerFeatureSource;
 
 #include "qgis_core.h"
 #include "qgspointxy.h"
@@ -129,9 +130,11 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * Prepare the index for queries. Does nothing if the index already exists.
      * If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
      * to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
-     * This method is non blocking and index is built in another thread. Signals indexStarting and indexFinished
-     * are triggered to let you know when index build is started and finished.
-    */
+     *
+     * This method is either blocking or non blocking according to \a asynchronous parameter passed
+     * in the constructor
+     * \see QgsPointLocator()
+     */
     void init( int maxFeaturesToIndex = -1 );
 
     //! Indicate whether the data have been already indexed
@@ -291,6 +294,14 @@ class CORE_EXPORT QgsPointLocator : public QObject
      */
     int cachedGeometryCount() const { return mGeoms.count(); }
 
+    /**
+     * Returns TRUE if the point locator is currently indexing the data.
+     * This method is usefull if constructor parameter \a asynchronous is TRUE
+     *
+     * \see QgsPointLocator()
+     */
+    bool isIndexing() const { return mIsIndexing; }
+
   signals:
 
     /**
@@ -302,6 +313,13 @@ class CORE_EXPORT QgsPointLocator : public QObject
 
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
+
+    /**
+     * prepare index if need and returns TRUE if the index is ready to be used
+     * \since 3.10
+     */
+    bool prepare();
+
   protected slots:
     void destroyIndex();
   private slots:
@@ -329,6 +347,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
 
     std::unique_ptr<QgsRenderContext> mContext;
     std::unique_ptr<QgsFeatureRenderer> mRenderer;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
     int mMaxFeaturesToIndex = -1;
     bool mAsynchronous = false;
     bool mIsIndexing = false;
@@ -341,6 +360,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     friend class QgsPointLocator_VisitorEdgesInRect;
     friend class QgsPointLocator_VisitorVerticesInRect;
     friend class QgsPointLocatorInitTask;
+    friend class TestQgsPointLocator;
 };
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -68,10 +68,9 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * to set the correct \a transformContext if a \a destinationCrs is specified. This is usually taken
      * from the current QgsProject::transformContext().
      *
-     * \param asynchronous if FALSE, point locator init() method will block until index is completely
-     * finished. if TRUE, index building will be done in another thread and init() method returns
-     * immediatly. initStarted() and initFinished() signals can be used to control current state of
-     * the point locator.
+     * \param asynchronous if FALSE, point locator init() method will block until point locator index
+     * is completely built. if TRUE, index building will be done in another thread and init() method returns
+     * immediately. initFinished() signal will be emitted once the initialization is over.
      *
      * If \a extent is not NULLPTR, the locator will index only a subset of the layer which falls within that extent.
      */
@@ -301,17 +300,12 @@ class CORE_EXPORT QgsPointLocator : public QObject
      */
     void initFinished( bool ok );
 
-    /**
-     * Emitted whenever index initialization has started
-     */
-    void initStarted();
-
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
   protected slots:
     void destroyIndex();
   private slots:
-    void onRebuildIndexFinished();
+    void onRebuildIndexFinished( bool ok );
     void onFeatureAdded( QgsFeatureId fid );
     void onFeatureDeleted( QgsFeatureId fid );
     void onGeometryChanged( QgsFeatureId fid, const QgsGeometry &geom );
@@ -335,16 +329,16 @@ class CORE_EXPORT QgsPointLocator : public QObject
 
     std::unique_ptr<QgsRenderContext> mContext;
     std::unique_ptr<QgsFeatureRenderer> mRenderer;
-    QFuture<bool> mFuture;
-    QFutureWatcher<bool> mFutureWatcher;
     int mMaxFeaturesToIndex = -1;
     bool mAsynchronous = false;
+    bool mIsIndexing = false;
 
     friend class QgsPointLocator_VisitorNearestVertex;
     friend class QgsPointLocator_VisitorNearestEdge;
     friend class QgsPointLocator_VisitorArea;
     friend class QgsPointLocator_VisitorEdgesInRect;
     friend class QgsPointLocator_VisitorVerticesInRect;
+    friend class QgsPointLocatorInitTask;
 };
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -332,6 +332,8 @@ class CORE_EXPORT QgsPointLocator : public QObject
     int mMaxFeaturesToIndex = -1;
     bool mAsynchronous = false;
     bool mIsIndexing = false;
+    QgsFeatureIds mAddedFeatures;
+    QgsFeatureIds mDeletedFeatures;
 
     friend class QgsPointLocator_VisitorNearestVertex;
     friend class QgsPointLocator_VisitorNearestEdge;

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -124,7 +124,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * Prepare the index for queries. Does nothing if the index already exists.
      * If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
      * to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
-     * This method is non blocking and index is built in an other thread. Signals indexStarting and indexFinished
+     * This method is non blocking and index is built in another thread. Signals indexStarting and indexFinished
      * are triggered to let you know when index build is started and finished.
     */
     void init( int maxFeaturesToIndex = -1 );

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -296,7 +296,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
 
     /**
      * Returns TRUE if the point locator is currently indexing the data.
-     * This method is usefull if constructor parameter \a asynchronous is TRUE
+     * This method is useful if constructor parameter \a asynchronous is TRUE
      *
      * \see QgsPointLocator()
      */

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -328,6 +328,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     std::unique_ptr< QgsRectangle > mExtent;
 
     std::unique_ptr<QgsRenderContext> mContext;
+    std::unique_ptr<QgsFeatureRenderer> mRenderer;
     QFuture<bool> mFuture;
     QFutureWatcher<bool> mFutureWatcher;
     int mMaxFeaturesToIndex = -1;

--- a/src/core/qgspointlocatorinittask.cpp
+++ b/src/core/qgspointlocatorinittask.cpp
@@ -17,6 +17,8 @@
 
 #include "qgsvectorlayer.h"
 
+/// @cond PRIVATE
+
 QgsPointLocatorInitTask::QgsPointLocatorInitTask( QgsPointLocator *loc )
   : QgsTask( tr( "Indexing %1" ).arg( loc->layer()->id() ), QgsTask::Flags() )
   , mLoc( loc )
@@ -28,3 +30,5 @@ bool QgsPointLocatorInitTask::run()
   emit rebuildIndexFinished( ok );
   return true;
 }
+
+/// @endcond

--- a/src/core/qgspointlocatorinittask.cpp
+++ b/src/core/qgspointlocatorinittask.cpp
@@ -1,0 +1,30 @@
+/***************************************************************************
+  qgspointlocatorinittask.cpp
+  --------------------------------------
+  Date                 : September 2019
+  Copyright            : (C) 2019 by Julien Cabieces
+  Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspointlocatorinittask.h"
+
+#include "qgsvectorlayer.h"
+
+QgsPointLocatorInitTask::QgsPointLocatorInitTask( QgsPointLocator *loc )
+  : QgsTask( tr( "Indexing %1" ).arg( loc->layer()->id() ), QgsTask::Flags() )
+  , mLoc( loc )
+{}
+
+bool QgsPointLocatorInitTask::run()
+{
+  const bool ok = mLoc->rebuildIndex();
+  emit rebuildIndexFinished( ok );
+  return true;
+}

--- a/src/core/qgspointlocatorinittask.h
+++ b/src/core/qgspointlocatorinittask.h
@@ -51,4 +51,6 @@ class QgsPointLocatorInitTask : public QgsTask
     QgsPointLocator *mLoc = nullptr;
 };
 
+/// @endcond
+
 #endif // QGSPOINTLOCATORINITTASK_H

--- a/src/core/qgspointlocatorinittask.h
+++ b/src/core/qgspointlocatorinittask.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+  qgspointlocatorinittask.h
+  --------------------------------------
+  Date                 : September 2019
+  Copyright            : (C) 2019 by Julien Cabieces
+  Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPOINTLOCATORINITTASK_H
+#define QGSPOINTLOCATORINITTASK_H
+
+/// @cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#define SIP_NO_FILE
+
+#include "qgstaskmanager.h"
+#include "qgspointlocator.h"
+
+class QgsPointLocatorInitTask : public QgsTask
+{
+    Q_OBJECT
+
+  public:
+
+    QgsPointLocatorInitTask( QgsPointLocator *loc );
+
+    bool run();
+
+  signals:
+
+    void rebuildIndexFinished( bool ok );
+
+  private:
+
+    QgsPointLocator *mLoc = nullptr;
+};
+
+#endif // QGSPOINTLOCATORINITTASK_H

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -91,6 +91,9 @@ bool QgsSnappingUtils::isIndexPrepared( QgsVectorLayer *vl, const QgsRectangle &
 
   QgsPointLocator *loc = locatorForLayer( vl );
 
+  if ( loc->isIndexing() )
+    return true;
+
   if ( mStrategy == IndexAlwaysFull && loc->hasIndex() )
     return true;
 

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -21,10 +21,12 @@
 #include "qgslogger.h"
 #include "qgsrenderer.h"
 
-QgsSnappingUtils::QgsSnappingUtils( QObject *parent, bool enableSnappingForInvisibleFeature )
+QgsSnappingUtils::QgsSnappingUtils( QObject *parent, bool enableSnappingForInvisibleFeature,
+                                    bool asynchronous )
   : QObject( parent )
   , mSnappingConfig( QgsProject::instance() )
   , mEnableSnappingForInvisibleFeature( enableSnappingForInvisibleFeature )
+  , mAsynchronous( asynchronous )
 {
 }
 
@@ -41,7 +43,7 @@ QgsPointLocator *QgsSnappingUtils::locatorForLayer( QgsVectorLayer *vl )
 
   if ( !mLocators.contains( vl ) )
   {
-    QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext() );
+    QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), nullptr, mAsynchronous );
     connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
     connect( vlpl, &QgsPointLocator::initStarted, this, &QgsSnappingUtils::onInitStarted );
     mLocators.insert( vl, vlpl );
@@ -76,7 +78,7 @@ QgsPointLocator *QgsSnappingUtils::temporaryLocatorForLayer( QgsVectorLayer *vl,
 
   QgsRectangle rect( pointMap.x() - tolerance, pointMap.y() - tolerance,
                      pointMap.x() + tolerance, pointMap.y() + tolerance );
-  QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), &rect );
+  QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), &rect, mAsynchronous );
   connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
   connect( vlpl, &QgsPointLocator::initStarted, this, &QgsSnappingUtils::onInitStarted );
 

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -45,7 +45,6 @@ QgsPointLocator *QgsSnappingUtils::locatorForLayer( QgsVectorLayer *vl )
   {
     QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), nullptr, mAsynchronous );
     connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
-    connect( vlpl, &QgsPointLocator::initStarted, this, &QgsSnappingUtils::onInitStarted );
     mLocators.insert( vl, vlpl );
   }
   return mLocators.value( vl );
@@ -80,7 +79,6 @@ QgsPointLocator *QgsSnappingUtils::temporaryLocatorForLayer( QgsVectorLayer *vl,
                      pointMap.x() + tolerance, pointMap.y() + tolerance );
   QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), &rect, mAsynchronous );
   connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
-  connect( vlpl, &QgsPointLocator::initStarted, this, &QgsSnappingUtils::onInitStarted );
 
   mTemporaryLocators.insert( vl, vlpl );
   return mTemporaryLocators.value( vl );
@@ -355,13 +353,6 @@ void QgsSnappingUtils::onInitFinished( bool ok )
   {
     mHybridMaxAreaPerLayer[loc->layer()->id()] /= 4;
   }
-
-  prepareIndexFinished();
-}
-
-void QgsSnappingUtils::onInitStarted()
-{
-  prepareIndexStarting();
 }
 
 void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers )

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -196,10 +196,16 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     void configChanged( const QgsSnappingConfig &snappingConfig );
 
   protected:
-    //! Called when starting to index
-    virtual void prepareIndexStarting() {}
-    //! Called when finished indexing a layer
-    virtual void prepareIndexFinished() {}
+
+    /**
+     * This methods is now deprecated and never called
+     */
+    Q_DECL_DEPRECATED virtual void prepareIndexStarting( int count ) { Q_UNUSED( count ); }
+
+    /**
+     * This methods is now deprecated and never called
+     */
+    Q_DECL_DEPRECATED virtual void prepareIndexProgress( int index ) { Q_UNUSED( index ); }
 
     //! Deletes all existing locators (e.g. when destination CRS has changed and we need to reindex)
     void clearAllLocators();
@@ -208,9 +214,6 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! called whenever a point locator has finished
     void onInitFinished( bool ok );
-
-    //! called whenever a point locator has started
-    void onInitStarted();
 
   private:
     void onIndividualLayerSettingsChanged( const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &layerSettings );
@@ -266,13 +269,11 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     //! Disable or not the snapping on all features. By default is always TRUE except for non visible features on map canvas.
     bool mEnableSnappingForInvisibleFeature = true;
 
-    //! Number of index currently being prepared
-    int mPreparingIndexCount = 0;
-
     //! true if we have to build point locator asynchronously
     bool mAsynchronous = false;
 
     friend class TestQgsVertexTool;
+    friend class TestQgsMapToolTrimExtendFeature;
 };
 
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -199,11 +199,13 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     /**
      * This methods is now deprecated and never called
+     * \deprecated since QGIS 3.10
      */
     Q_DECL_DEPRECATED virtual void prepareIndexStarting( int count ) { Q_UNUSED( count ); }
 
     /**
      * This methods is now deprecated and never called
+     * \deprecated since QGIS 3.10
      */
     Q_DECL_DEPRECATED virtual void prepareIndexProgress( int index ) { Q_UNUSED( index ); }
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -190,13 +190,21 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     void configChanged( const QgsSnappingConfig &snappingConfig );
 
   protected:
-    //! Called when starting to index - can be overridden and e.g. progress dialog can be provided
-    virtual void prepareIndexStarting( int count ) { Q_UNUSED( count ) }
-    //! Called when finished indexing a layer. When index == count the indexing is complete
-    virtual void prepareIndexProgress( int index ) { Q_UNUSED( index ) }
+    //! Called when starting to index
+    virtual void prepareIndexStarting() {}
+    //! Called when finished indexing a layer
+    virtual void prepareIndexFinished() {}
 
     //! Deletes all existing locators (e.g. when destination CRS has changed and we need to reindex)
     void clearAllLocators();
+
+  private slots:
+
+    //! called whenever a point locator has finished
+    void onInitFinished( bool ok );
+
+    //! called whenever a point locator has started
+    void onInitStarted();
 
   private:
     void onIndividualLayerSettingsChanged( const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &layerSettings );
@@ -249,12 +257,11 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     //! if using hybrid strategy, how many features of one layer may be indexed (to limit amount of consumed memory)
     int mHybridPerLayerFeatureLimit = 50000;
 
-    //! internal flag that an indexing process is going on. Prevents starting two processes in parallel.
-    bool mIsIndexing = false;
-
     //! Disable or not the snapping on all features. By default is always TRUE except for non visible features on map canvas.
     bool mEnableSnappingForInvisibleFeature = true;
 
+    //! Number of index currently being prepared
+    int mPreparingIndexCount = 0;
 };
 
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -52,8 +52,14 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
   public:
 
-    //! Constructor for QgsSnappingUtils
-    QgsSnappingUtils( QObject *parent SIP_TRANSFERTHIS = nullptr, bool enableSnappingForInvisibleFeature = true );
+    /**
+     * Constructor for QgsSnappingUtils
+     * \param parent parent object
+     * \param enableSnappingForInvisibleFeature TRUE if we want to snap feature even if there are not visible
+     * \param asynchronous indicated if point locator creation has to be made asynchronously (see QgsPointLocator())
+     */
+    QgsSnappingUtils( QObject *parent SIP_TRANSFERTHIS = nullptr, bool enableSnappingForInvisibleFeature = true,
+                      bool asynchronous = false );
     ~QgsSnappingUtils() override;
 
     // main actions
@@ -262,6 +268,11 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! Number of index currently being prepared
     int mPreparingIndexCount = 0;
+
+    //! true if we have to build point locator asynchronously
+    bool mAsynchronous = false;
+
+    friend class TestQgsVertexTool;
 };
 
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -276,6 +276,8 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     friend class TestQgsVertexTool;
     friend class TestQgsMapToolTrimExtendFeature;
+    friend class TestQgsMapToolReshape;
+    friend class TestQgsMapToolAddFeaturePoint;
 };
 
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -278,6 +278,7 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     friend class TestQgsMapToolTrimExtendFeature;
     friend class TestQgsMapToolReshape;
     friend class TestQgsMapToolAddFeaturePoint;
+    friend class TestQgsMapToolReverseLine;
 };
 
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -273,12 +273,6 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! true if we have to build point locator asynchronously
     bool mAsynchronous = false;
-
-    friend class TestQgsVertexTool;
-    friend class TestQgsMapToolTrimExtendFeature;
-    friend class TestQgsMapToolReshape;
-    friend class TestQgsMapToolAddFeaturePoint;
-    friend class TestQgsMapToolReverseLine;
 };
 
 

--- a/src/gui/qgsmapcanvassnappingutils.cpp
+++ b/src/gui/qgsmapcanvassnappingutils.cpp
@@ -22,7 +22,7 @@
 #include <QProgressDialog>
 
 QgsMapCanvasSnappingUtils::QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent )
-  : QgsSnappingUtils( parent, QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() )
+  : QgsSnappingUtils( parent, QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool(), true )
   , mCanvas( canvas )
 
 {

--- a/src/gui/qgsmapcanvassnappingutils.cpp
+++ b/src/gui/qgsmapcanvassnappingutils.cpp
@@ -21,8 +21,8 @@
 #include <QApplication>
 #include <QProgressDialog>
 
-QgsMapCanvasSnappingUtils::QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent )
-  : QgsSnappingUtils( parent, QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool(), true )
+QgsMapCanvasSnappingUtils::QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent, bool asynchronous )
+  : QgsSnappingUtils( parent, QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool(), asynchronous )
   , mCanvas( canvas )
 
 {

--- a/src/gui/qgsmapcanvassnappingutils.cpp
+++ b/src/gui/qgsmapcanvassnappingutils.cpp
@@ -58,19 +58,3 @@ void QgsMapCanvasSnappingUtils::canvasMapToolChanged()
 {
   setEnableSnappingForInvisibleFeature( QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() );
 }
-
-void QgsMapCanvasSnappingUtils::prepareIndexStarting()
-{
-  if ( !mPreparingIndexCount )
-    QApplication::setOverrideCursor( Qt::BusyCursor );
-
-  mPreparingIndexCount++;
-}
-
-void QgsMapCanvasSnappingUtils::prepareIndexFinished()
-{
-  mPreparingIndexCount--;
-
-  if ( !mPreparingIndexCount )
-    QApplication::restoreOverrideCursor();
-}

--- a/src/gui/qgsmapcanvassnappingutils.cpp
+++ b/src/gui/qgsmapcanvassnappingutils.cpp
@@ -59,23 +59,18 @@ void QgsMapCanvasSnappingUtils::canvasMapToolChanged()
   setEnableSnappingForInvisibleFeature( QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() );
 }
 
-void QgsMapCanvasSnappingUtils::prepareIndexStarting( int count )
+void QgsMapCanvasSnappingUtils::prepareIndexStarting()
 {
-  QApplication::setOverrideCursor( Qt::WaitCursor );
-  mProgress = new QProgressDialog( tr( "Indexing data…" ), QString(), 0, count, mCanvas->topLevelWidget() );
-  mProgress->setWindowModality( Qt::WindowModal );
+  if ( !mPreparingIndexCount )
+    QApplication::setOverrideCursor( Qt::BusyCursor );
+
+  mPreparingIndexCount++;
 }
 
-void QgsMapCanvasSnappingUtils::prepareIndexProgress( int index )
+void QgsMapCanvasSnappingUtils::prepareIndexFinished()
 {
-  if ( !mProgress )
-    return;
+  mPreparingIndexCount--;
 
-  mProgress->setValue( index );
-  if ( index == mProgress->maximum() )
-  {
-    delete mProgress;
-    mProgress = nullptr;
+  if ( !mPreparingIndexCount )
     QApplication::restoreOverrideCursor();
-  }
 }

--- a/src/gui/qgsmapcanvassnappingutils.h
+++ b/src/gui/qgsmapcanvassnappingutils.h
@@ -34,7 +34,7 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
 {
     Q_OBJECT
   public:
-    QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = nullptr );
+    QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = nullptr, bool asynchronous = false );
 
   private slots:
     void canvasMapSettingsChanged();

--- a/src/gui/qgsmapcanvassnappingutils.h
+++ b/src/gui/qgsmapcanvassnappingutils.h
@@ -36,10 +36,6 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
   public:
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = nullptr );
 
-  protected:
-    void prepareIndexStarting() override;
-    void prepareIndexFinished() override;
-
   private slots:
     void canvasMapSettingsChanged();
     void canvasTransformContextChanged();
@@ -49,7 +45,6 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
   private:
     QgsMapCanvas *mCanvas = nullptr;
     QProgressDialog *mProgress = nullptr;
-    int mPreparingIndexCount = 0;
 };
 
 

--- a/src/gui/qgsmapcanvassnappingutils.h
+++ b/src/gui/qgsmapcanvassnappingutils.h
@@ -34,6 +34,15 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
 {
     Q_OBJECT
   public:
+
+    /**
+     * Construct map canvas snapping utils object
+     *
+     * \param canvas map canvas
+     * \param parent parent object
+     * \param asynchronous if TRUE snapping cache index will be non blocking and done in another thread,
+     * if FALSE it will block until indexing is done
+     */
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = nullptr, bool asynchronous = false );
 
   private slots:

--- a/src/gui/qgsmapcanvassnappingutils.h
+++ b/src/gui/qgsmapcanvassnappingutils.h
@@ -37,8 +37,8 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = nullptr );
 
   protected:
-    void prepareIndexStarting( int count ) override;
-    void prepareIndexProgress( int index ) override;
+    void prepareIndexStarting() override;
+    void prepareIndexFinished() override;
 
   private slots:
     void canvasMapSettingsChanged();
@@ -49,6 +49,7 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
   private:
     QgsMapCanvas *mCanvas = nullptr;
     QProgressDialog *mProgress = nullptr;
+    int mPreparingIndexCount = 0;
 };
 
 

--- a/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
+++ b/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
@@ -115,6 +115,7 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   cfg.setType( QgsSnappingConfig::VertexAndSegment );
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
+  mCanvas->snappingUtils()->mAsynchronous = false;
 
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerPointZ << mLayerPointZSnap );
   mCanvas->setCurrentLayer( mLayerPointZ );

--- a/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
+++ b/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
@@ -115,7 +115,6 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   cfg.setType( QgsSnappingConfig::VertexAndSegment );
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
-  mCanvas->snappingUtils()->mAsynchronous = false;
 
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerPointZ << mLayerPointZSnap );
   mCanvas->setCurrentLayer( mLayerPointZ );

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -162,7 +162,6 @@ void TestQgsMapToolReshape::initTestCase()
   cfg.setType( QgsSnappingConfig::VertexAndSegment );
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
-  mCanvas->snappingUtils()->mAsynchronous = false;
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLineZ << mLayerPointZ << mLayerPolygonZ );
   mCanvas->setCurrentLayer( mLayerLineZ );
 

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -162,7 +162,7 @@ void TestQgsMapToolReshape::initTestCase()
   cfg.setType( QgsSnappingConfig::VertexAndSegment );
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
-
+  mCanvas->snappingUtils()->mAsynchronous = false;
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLineZ << mLayerPointZ << mLayerPolygonZ );
   mCanvas->setCurrentLayer( mLayerLineZ );
 

--- a/tests/src/app/testqgsmaptoolreverseline.cpp
+++ b/tests/src/app/testqgsmaptoolreverseline.cpp
@@ -60,7 +60,6 @@ void TestQgsMapToolReverseLine::initTestCase()
 
   mCanvas = new QgsMapCanvas();
   mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
-  mCanvas->snappingUtils()->mAsynchronous = false;
 }
 
 void TestQgsMapToolReverseLine::cleanupTestCase()

--- a/tests/src/app/testqgsmaptoolreverseline.cpp
+++ b/tests/src/app/testqgsmaptoolreverseline.cpp
@@ -25,7 +25,7 @@
 #include "testqgsmaptoolutils.h"
 #include "qgsmaptoolreverseline.h"
 #include "qgsmapmouseevent.h"
-
+#include "qgssnappingutils.h"
 
 class TestQgsMapToolReverseLine : public QObject
 {
@@ -60,7 +60,7 @@ void TestQgsMapToolReverseLine::initTestCase()
 
   mCanvas = new QgsMapCanvas();
   mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
-
+  mCanvas->snappingUtils()->mAsynchronous = false;
 }
 
 void TestQgsMapToolReverseLine::cleanupTestCase()

--- a/tests/src/app/testqgsmaptooltrimextendfeature.cpp
+++ b/tests/src/app/testqgsmaptooltrimextendfeature.cpp
@@ -164,7 +164,6 @@ class TestQgsMapToolTrimExtendFeature : public QObject
       mapSettings.setLayers( QList<QgsMapLayer *>() << vlPolygon.get() << vlMultiLine.get() << vlLineZ.get() << vlTopoEdit.get() << vlTopoLimit.get() );
 
       QgsSnappingUtils *mSnappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
-      mSnappingUtils->mAsynchronous = false;
       QgsSnappingConfig snappingConfig = mSnappingUtils->config();
       mSnappingUtils->setMapSettings( mapSettings );
       snappingConfig.setEnabled( true );

--- a/tests/src/app/testqgsmaptooltrimextendfeature.cpp
+++ b/tests/src/app/testqgsmaptooltrimextendfeature.cpp
@@ -164,6 +164,7 @@ class TestQgsMapToolTrimExtendFeature : public QObject
       mapSettings.setLayers( QList<QgsMapLayer *>() << vlPolygon.get() << vlMultiLine.get() << vlLineZ.get() << vlTopoEdit.get() << vlTopoLimit.get() );
 
       QgsSnappingUtils *mSnappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
+      mSnappingUtils->mAsynchronous = false;
       QgsSnappingConfig snappingConfig = mSnappingUtils->config();
       mSnappingUtils->setMapSettings( mapSettings );
       snappingConfig.setEnabled( true );

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -247,9 +247,9 @@ void TestQgsVertexTool::initTestCase()
 
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerPolygon << mLayerPoint << mLayerLineZ );
 
-  // TODO: set up snapping
-
-  mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
+  QgsMapCanvasSnappingUtils *snappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
+  snappingUtils->mAsynchronous = false;
+  mCanvas->setSnappingUtils( snappingUtils );
 
   // create vertex tool
   mVertexTool = new QgsVertexTool( mCanvas, mAdvancedDigitizingDockWidget );

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -248,7 +248,6 @@ void TestQgsVertexTool::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerPolygon << mLayerPoint << mLayerLineZ );
 
   QgsMapCanvasSnappingUtils *snappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
-  snappingUtils->mAsynchronous = false;
   mCanvas->setSnappingUtils( snappingUtils );
 
   // create vertex tool

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -358,7 +358,12 @@ class TestQgsPointLocator : public QObject
       // locator is not ready yet
       QgsPointLocator::Match m = loc.nearestVertex( pt, 999 );
       QVERIFY( !m.isValid() );
+      QVERIFY( loc.mIsIndexing );
+
+      // we block until initFinished is called from an other thread
       loop.exec();
+
+      QVERIFY( !loc.mIsIndexing );
 
       // now locator is ready
       m = loc.nearestVertex( pt, 999 );
@@ -369,6 +374,67 @@ class TestQgsPointLocator : public QObject
       QCOMPARE( m.point(), QgsPointXY( 1, 1 ) );
       QCOMPARE( m.distance(), std::sqrt( 2.0 ) );
       QCOMPARE( m.vertexIndex(), 2 );
+    }
+
+    void testLayerUpdatesAsynchronous()
+    {
+
+      QgsPointLocator loc( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr, true );
+
+      QEventLoop loop;
+      connect( &loc, &QgsPointLocator::initFinished, &loop, &QEventLoop::quit );
+
+      // trigger locator initialization
+      QgsPointLocator::Match mAddV0 = loc.nearestVertex( QgsPointXY( 12, 12 ), 999 );
+
+      // locator is not ready yet
+      QVERIFY( !mAddV0.isValid() );
+      QVERIFY( loc.mIsIndexing );
+
+      mVL->startEditing();
+
+      // add a new feature
+      QgsFeature ff( 0 );
+      QgsPolygonXY polygon;
+      QgsPolylineXY polyline;
+      polyline << QgsPointXY( 10, 11 ) << QgsPointXY( 11, 10 ) << QgsPointXY( 11, 11 ) << QgsPointXY( 10, 11 );
+      polygon << polyline;
+      QgsGeometry ffGeom = QgsGeometry::fromPolygonXY( polygon ) ;
+      ff.setGeometry( ffGeom );
+      QgsFeatureList flist;
+      flist << ff;
+      bool resA = mVL->addFeature( ff );
+      QVERIFY( resA );
+
+      // indexing is still running, change geometry
+      QgsGeometry *newGeom = new QgsGeometry( ff.geometry() );
+      newGeom->moveVertex( 10, 10, 2 ); // change 11,11 to 10,10
+      mVL->changeGeometry( ff.id(), *newGeom );
+      delete newGeom;
+
+      // we block until initFinished is called from an other thread
+      loop.exec();
+
+      QVERIFY( !loc.mIsIndexing );
+
+      // verify it is changed in the point locator
+      QgsPointLocator::Match mChV = loc.nearestVertex( QgsPointXY( 12, 12 ), 999 );
+      QVERIFY( mChV.isValid() );
+      QVERIFY( mChV.point() != QgsPointXY( 11, 11 ) ); // that point does not exist anymore
+      mChV = loc.nearestVertex( QgsPointXY( 9, 9 ), 999 );
+      QVERIFY( mChV.isValid() );
+      QVERIFY( mChV.point() == QgsPointXY( 10, 10 ) ); // updated point
+
+      // delete feature while no indexing is running
+      bool resD = mVL->deleteFeature( ff.id() );
+      QVERIFY( resD );
+
+      // verify it is deleted from the point locator
+      QgsPointLocator::Match mDelV = loc.nearestVertex( QgsPointXY( 12, 12 ), 999 );
+      QVERIFY( mDelV.isValid() );
+      QCOMPARE( mDelV.point(), QgsPointXY( 1, 1 ) );
+
+      mVL->rollBack();
     }
 };
 

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -360,7 +360,7 @@ class TestQgsPointLocator : public QObject
       QVERIFY( !m.isValid() );
       QVERIFY( loc.mIsIndexing );
 
-      // we block until initFinished is called from an other thread
+      // we block until initFinished is called from another thread
       loop.exec();
 
       QVERIFY( !loc.mIsIndexing );
@@ -412,7 +412,7 @@ class TestQgsPointLocator : public QObject
       mVL->changeGeometry( ff.id(), *newGeom );
       delete newGeom;
 
-      // we block until initFinished is called from an other thread
+      // we block until initFinished is called from another thread
       loop.exec();
 
       QVERIFY( !loc.mIsIndexing );


### PR DESCRIPTION
## Description

This PR is the main (and last) PR of the proposed GRANT [Snap Cache Improvements](https://docs.google.com/document/d/1VzgLJ-hy2GtcWrAy5geivhDDdXRGJUDcikCWUtXRe9k/edit#heading=h.uau3di2m4nvn)

For the record the 2 other PRs : #30947 and #31143. Second one is a prerequisite for this PR so it could work without seg fault and dead locks.

The idea of this PR is to parallelize for each layer the snap cache computing (sequential at the moment) using QtConcurrent API and to make it non blocking. As a consequence it is still possible to use QGIS even if snap cache is currently building. User can for instance start to edit node while the snap cache build is in progress. 

Snaping information appears for each layer as soon as they're ready, we don't wait all layers to be ready anymore.

As a consequence, there si no progress bar anymore. Indeed, the total number of snap cache to build can vary as we move the cursor in the map.

Here is 2 videos, showing the difference between actual behavior and this PR (on a worst use case).

**Actual (17 seconds to build)**

![snap_wo_thread](https://user-images.githubusercontent.com/14358135/63597695-590d1b00-c5be-11e9-80ec-d419d2ee98c8.gif)

**This PR (around 7 seconds to build in total)**

![snap_w_thread](https://user-images.githubusercontent.com/14358135/63597696-590d1b00-c5be-11e9-8d60-5731fb5a9305.gif)

## Implementation details 

Snaping informations are retrieved from QgsSnappingUtils (snapToMap) or directly from QgsPointLocator (in QgsVertexTool for instance), so I choose to parallelize in [QgsPointLocator::init method](https://github.com/troopa81/QGIS/blob/parallelize_snap_caching/src/core/qgspointlocator.cpp#L604).

If the QgsPointLocator needs to be updated (because the user move the cursor outside the index area of interest for instance) but is already being built, the modifications are discarded. The modifications will be taken into account next time (when cursor will move again) once the built is finished. A running QgsPointLocator cannot be modified (to avoid shared memory to be modified from different thread).

## TODO

Once we agree on the general behavior, I will write some unit tests and correct existing ones.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
