### PR TITLE
Prevent installation of ZIP plugins if they don't have the root folder

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -27,7 +27,7 @@ import os
 import json
 import zipfile
 
-from qgis.PyQt.QtCore import Qt, QObject, QDir, QUrl, QFileInfo, QFile
+from qgis.PyQt.QtCore import Qt, QObject, QDir, QUrl, QFileInfo, QFile, QSettings
 from qgis.PyQt.QtWidgets import QApplication, QDialog, QDialogButtonBox, QFrame, QMessageBox, QLabel, QVBoxLayout
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
@@ -556,7 +556,20 @@ class QgsPluginInstaller(QObject):
         pluginFileName = os.path.splitext(os.path.basename(filePath))[0]
 
         if not pluginName:
-            QMessageBox.warning(iface.mainWindow(), self.tr("QGIS Python Install from ZIP Plugin Installer"), self.tr('The plugin directory was not found inside the ZIP file. You should create a plugin folder, put the files inside and create the ZIP file again.'), QMessageBox.Ok)
+            import webbrowser
+            import re
+            msg_box = QMessageBox()
+            msg_box.setIcon(QMessageBox.Warning)
+            msg_box.setWindowTitle(self.tr("QGIS Python Install from ZIP Plugin Installer"))
+            msg_box.setText(self.tr("The Zip file is not a valid QGIS python plugin. No root folder was found inside."))
+            msg_box.setStandardButtons(QMessageBox.Ok)
+            more_info_btn = msg_box.addButton(self.tr("More Information"), QMessageBox.HelpRole)
+            msg_box.exec()
+            version = 'testing' if 'master' in Qgis.QGIS_VERSION.lower() else re.findall(r'^\d.[0-9]*', Qgis.QGIS_VERSION)[0]
+            locale = QSettings().value("locale/userLocale", type=str)
+            qgis_lang = str( locale[:2] )
+            if msg_box.clickedButton() == more_info_btn:
+                webbrowser.open("https://docs.qgis.org/{version}/{lang}/docs/user_manual/plugins/plugins.html#the-install-from-zip-tab".format(version=version, lang=qgis_lang))
             return
 
         pluginsDirectory = qgis.utils.home_plugin_path

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -555,6 +555,10 @@ class QgsPluginInstaller(QObject):
 
         pluginFileName = os.path.splitext(os.path.basename(filePath))[0]
 
+        if not pluginName:
+            QMessageBox.warning(iface.mainWindow(), self.tr("QGIS Python Install from ZIP Plugin Installer"), self.tr('The plugin directory was not found inside the ZIP file. You should create a plugin folder, put the files inside and create the ZIP file again.'), QMessageBox.Ok)
+            return
+
         pluginsDirectory = qgis.utils.home_plugin_path
         if not QDir(pluginsDirectory).exists():
             QDir().mkpath(pluginsDirectory)

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -27,13 +27,13 @@ import os
 import json
 import zipfile
 
-from qgis.PyQt.QtCore import Qt, QObject, QDir, QUrl, QFileInfo, QFile, QSettings
+from qgis.PyQt.QtCore import Qt, QObject, QDir, QUrl, QFileInfo, QFile
 from qgis.PyQt.QtWidgets import QApplication, QDialog, QDialogButtonBox, QFrame, QMessageBox, QLabel, QVBoxLayout
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
 import qgis
 from qgis.core import Qgis, QgsApplication, QgsNetworkAccessManager, QgsSettings, QgsNetworkRequestParameters
-from qgis.gui import QgsMessageBar, QgsPasswordLineEdit
+from qgis.gui import QgsMessageBar, QgsPasswordLineEdit, QgsHelp
 from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin,
                         reloadPlugin, updateAvailablePlugins, plugins_metadata_parser)
 from .installer_data import (repositories, plugins, officialRepo,
@@ -556,8 +556,6 @@ class QgsPluginInstaller(QObject):
         pluginFileName = os.path.splitext(os.path.basename(filePath))[0]
 
         if not pluginName:
-            import webbrowser
-            import re
             msg_box = QMessageBox()
             msg_box.setIcon(QMessageBox.Warning)
             msg_box.setWindowTitle(self.tr("QGIS Python Install from ZIP Plugin Installer"))
@@ -565,11 +563,8 @@ class QgsPluginInstaller(QObject):
             msg_box.setStandardButtons(QMessageBox.Ok)
             more_info_btn = msg_box.addButton(self.tr("More Information"), QMessageBox.HelpRole)
             msg_box.exec()
-            version = 'testing' if 'master' in Qgis.QGIS_VERSION.lower() else re.findall(r'^\d.[0-9]*', Qgis.QGIS_VERSION)[0]
-            locale = QSettings().value("locale/userLocale", type=str)
-            qgis_lang = str( locale[:2] )
             if msg_box.clickedButton() == more_info_btn:
-                webbrowser.open("https://docs.qgis.org/{version}/{lang}/docs/user_manual/plugins/plugins.html#the-install-from-zip-tab".format(version=version, lang=qgis_lang))
+                QgsHelp.openHelp("plugins/plugins.html#the-install-from-zip-tab")
             return
 
         pluginsDirectory = qgis.utils.home_plugin_path


### PR DESCRIPTION
 Fixes #30063

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Prevent installation of ZIP plugins if they don't have the root folder. This also prevent to erase all folders inside the plugin folder in this case.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
