### PR TITLE
Disables non existent projects on the recent projects list

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4271,7 +4271,25 @@ void QgisApp::updateRecentProjectPaths()
                               : QFileInfo( recentProject.path ).completeBaseName(), QDir::toNativeSeparators( recentProject.path )
                             ).replace( "&", "&&" )
                       );
-    //action->setEnabled( QFile::exists( ( recentProject.path ) ) );
+
+    QRegularExpression re_gpkg( "^(geopackage:)([^\?]+)\?(.+)$", QRegularExpression::CaseInsensitiveOption );
+    QRegularExpression re_postgres( "^postgresql:", QRegularExpression::CaseInsensitiveOption );
+
+    QRegularExpressionMatch match_gpkpg = re_gpkg.match( recentProject.path );
+    QRegularExpressionMatch match_postgres = re_postgres.match( recentProject.path );
+
+    if ( !match_postgres.hasMatch() )
+    {
+      if ( match_gpkpg.hasMatch() )
+      {
+        action->setEnabled( QFile::exists( match_gpkpg.captured( 2 ) ) );
+      }
+      else
+      {
+        action->setEnabled( QFile::exists( ( recentProject.path ) ) );
+      }
+    }
+
     action->setData( recentProject.path );
     if ( recentProject.pin )
     {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4272,22 +4272,24 @@ void QgisApp::updateRecentProjectPaths()
                             ).replace( "&", "&&" )
                       );
 
-    QRegularExpression re_gpkg( "^(geopackage:)([^\?]+)\?(.+)$", QRegularExpression::CaseInsensitiveOption );
-    QRegularExpression re_postgres( "^postgresql:", QRegularExpression::CaseInsensitiveOption );
+    QgsProjectStorage *storage = QgsApplication::projectStorageRegistry()->projectStorageFromUri( recentProject.path );
 
-    QRegularExpressionMatch match_gpkpg = re_gpkg.match( recentProject.path );
-    QRegularExpressionMatch match_postgres = re_postgres.match( recentProject.path );
-
-    if ( !match_postgres.hasMatch() )
+    if ( storage )
     {
-      if ( match_gpkpg.hasMatch() )
+      QString path = storage->filePath( recentProject.path );
+      // for geopackage projects, the path will be empty, if not valid
+      if ( storage->type() == QStringLiteral( "geopackage" ) && path.isEmpty() )
       {
-        action->setEnabled( QFile::exists( match_gpkpg.captured( 2 ) ) );
+        action->setEnabled( false );
+        action->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorBadLayer.svg" ) ) );
       }
-      else
-      {
-        action->setEnabled( QFile::exists( ( recentProject.path ) ) );
-      }
+    }
+    else
+    {
+      bool exists = QFile::exists( recentProject.path );
+      action->setEnabled( exists );
+      if ( !exists )
+        action->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorBadLayer.svg" ) ) );
     }
 
     action->setData( recentProject.path );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -258,7 +258,30 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
   connect( mButtonOpenProjectFolder, &QToolButton::clicked, this, [ = ]
   {
-    QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( QgsProject::instance()->fileName() );
+
+    /* Project name syntax:
+     *
+     * /home/qgis/projects/ortos_cim_2019.qgz
+     * geopackage:/home/qgis/projects/natural.gpkg?projectName=natural%20earth
+     * postgresql:?service=pg_geotuga&sslmode=disable&dbname=&schema=ortos&project=teste
+     */
+
+    QRegularExpression re_gpkg( "^(geopackage:)([^\?]+)\?(.+)$", QRegularExpression::CaseInsensitiveOption );
+    QRegularExpression re_postgres( "^postgresql:", QRegularExpression::CaseInsensitiveOption );
+
+    QString project = QgsProject::instance()->fileName();
+
+    QRegularExpressionMatch match_gpkpg = re_gpkg.match( project );
+    QRegularExpressionMatch match_postgres = re_postgres.match( project );
+
+    if ( !match_postgres.hasMatch() )
+    {
+      if ( match_gpkpg.hasMatch() )
+      {
+        project = match_gpkpg.captured( 2 );
+      }
+      QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( project );
+    }
   } );
 
   // get the manner in which the number of decimal places in the mouse

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -63,6 +63,8 @@
 #include "qgsmessagelog.h"
 #include "qgslayercapabilitiesmodel.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsprojectstorage.h"
+#include "qgsprojectstorageregistry.h"
 
 //qt includes
 #include <QInputDialog>
@@ -258,30 +260,19 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
   connect( mButtonOpenProjectFolder, &QToolButton::clicked, this, [ = ]
   {
-
-    /* Project name syntax:
-     *
-     * /home/qgis/projects/ortos_cim_2019.qgz
-     * geopackage:/home/qgis/projects/natural.gpkg?projectName=natural%20earth
-     * postgresql:?service=pg_geotuga&sslmode=disable&dbname=&schema=ortos&project=teste
-     */
-
-    QRegularExpression re_gpkg( "^(geopackage:)([^\?]+)\?(.+)$", QRegularExpression::CaseInsensitiveOption );
-    QRegularExpression re_postgres( "^postgresql:", QRegularExpression::CaseInsensitiveOption );
-
+    QString path;
     QString project = QgsProject::instance()->fileName();
+    QgsProjectStorage *storage = QgsProject::instance()->projectStorage();
+    if ( storage )
+      path = storage->filePath( project );
+    else
+      path = project;
 
-    QRegularExpressionMatch match_gpkpg = re_gpkg.match( project );
-    QRegularExpressionMatch match_postgres = re_postgres.match( project );
-
-    if ( !match_postgres.hasMatch() )
+    if ( !path.isEmpty() )
     {
-      if ( match_gpkpg.hasMatch() )
-      {
-        project = match_gpkpg.captured( 2 );
-      }
-      QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( project );
+      QgsGui::nativePlatformInterface()->openFileExplorerAndSelectFile( path );
     }
+
   } );
 
   // get the manner in which the number of decimal places in the mouse
@@ -2631,3 +2622,4 @@ void QgsProjectProperties::onGenerateTsFileButton() const
                             "- release to get qm file including postfix (eg. aproject_de.qm)\n"
                             "When you open it again in QGIS having set the target language (de), the project will be translated and saved with postfix (eg. aproject_de.qgs)." ).arg( l ) ) ;
 }
+

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -28,6 +28,11 @@
 #include "qgsnewsfeedmodel.h"
 #include "qgsnewsfeedparser.h"
 
+#include "qgsprojectstorage.h"
+#include "qgsprojectstorageguiprovider.h"
+#include "qgsprojectstorageguiregistry.h"
+#include "qgsprojectstorageregistry.h"
+
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QListView>
@@ -248,6 +253,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
   if ( path.isEmpty() )
     return;
 
+  QgsProjectStorage *storage = QgsApplication::projectStorageRegistry()->projectStorageFromUri( path );
   bool enabled = mRecentProjectsModel->flags( index ) & Qt::ItemIsEnabled;
 
   QMenu *menu = new QMenu( this );
@@ -274,12 +280,21 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
       } );
       menu->addAction( pinAction );
     }
-    QAction *openFolderAction = new QAction( tr( "Open Directory…" ), menu );
-    connect( openFolderAction, &QAction::triggered, this, [path]
+
+    if ( storage )
     {
-      QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( path );
-    } );
-    menu->addAction( openFolderAction );
+      path = storage->filePath( path );
+    }
+
+    if ( !path.isEmpty() )
+    {
+      QAction *openFolderAction = new QAction( tr( "Open Directory…" ), menu );
+      connect( openFolderAction, &QAction::triggered, this, [path]
+      {
+        QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( path );
+      } );
+      menu->addAction( openFolderAction );
+    }
   }
   else
   {
@@ -290,15 +305,30 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
     } );
     menu->addAction( rescanAction );
 
-    // add an entry to open the closest existing path to the original project file location
-    // to help users re-find moved/renamed projects!
-    const QString closestPath = QgsFileUtils::findClosestExistingPath( path );
-    QAction *openFolderAction = new QAction( tr( "Open “%1”…" ).arg( QDir::toNativeSeparators( closestPath ) ), menu );
-    connect( openFolderAction, &QAction::triggered, this, [closestPath]
+    bool showClosestPath = storage ? false : true;
+    if ( storage && ( storage->type() == QStringLiteral( "geopackage" ) ) )
     {
-      QDesktopServices::openUrl( QUrl::fromLocalFile( closestPath ) );
-    } );
-    menu->addAction( openFolderAction );
+      QRegularExpression reGpkg( "^(geopackage:)([^\?]+)\?(.+)$", QRegularExpression::CaseInsensitiveOption );
+      QRegularExpressionMatch matchGpkg = reGpkg.match( path );
+      if ( matchGpkg.hasMatch() )
+      {
+        path = matchGpkg.captured( 2 );
+        showClosestPath = true;
+      }
+    }
+
+    if ( showClosestPath )
+    {
+      // add an entry to open the closest existing path to the original project file or geopackage location
+      // to help users re-find moved/renamed projects!
+      const QString closestPath = QgsFileUtils::findClosestExistingPath( path );
+      QAction *openFolderAction = new QAction( tr( "Open “%1”…" ).arg( QDir::toNativeSeparators( closestPath ) ), menu );
+      connect( openFolderAction, &QAction::triggered, this, [closestPath]
+      {
+        QDesktopServices::openUrl( QUrl::fromLocalFile( closestPath ) );
+      } );
+      menu->addAction( openFolderAction );
+    }
   }
   QAction *removeProjectAction = new QAction( tr( "Remove from List" ), menu );
   connect( removeProjectAction, &QAction::triggered, this, [this, index]


### PR DESCRIPTION
## Description

This PR improves the code to be more aware of the project syntax. The project is usually a path, but it can also be a provider stored project.

Project name syntax:

```C
     /*
     * /home/qgis/projects/ortos_cim_2019.qgz
     * geopackage:/home/qgis/projects/natural.gpkg?projectName=natural%20earth
     * postgresql:?service=pg_geotuga&sslmode=disable&dbname=&schema=ortos&project=teste
     */
```

In this PR we use `QgsApplication::projectStorageRegistry()->projectStorageFromUri( )` to get the correspondent storage class.

To check if the project still exist, we check if the file is still there, for file system stored projects.

For storage based projects:
- **postgresql** - We don't check if they still exist. You may have authentication problems, can be disconnected right now, etc.
- **geopackage** We check if the file still exist. In fact, we don't have to test it, because this is already done in the provider code.

Fix #31011
Fix #31385
Fix #28655

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
