### PR TITLE
[needs-docs] Show 'template layer' constraints info in the Refactor fields algorithm's UI

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -330,6 +330,8 @@ qgis:refactorfields: >
 
   The original layer is not modified. A new layer is generated, which contains a modified attribute table, according to the provided fields mapping.
 
+  Rows in orange are not allowed to be NULL in the layer used as target. However, since the algorithm creates a new layer with no constraints, this can be taken only as a hint.
+
 qgis:regularpoints: >
   This algorithm creates a point layer with a given number of regular points, all of them within a given extent.
 

--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -330,7 +330,7 @@ qgis:refactorfields: >
 
   The original layer is not modified. A new layer is generated, which contains a modified attribute table, according to the provided fields mapping.
 
-  Rows in orange are not allowed to be NULL in the layer used as target. However, since the algorithm creates a new layer with no constraints, this can be taken only as a hint.
+  Rows in orange have constraints in the template layer from which these fields were loaded. Treat this information as a hint during configuration. No constraints will be added on an output layer nor will this be checked or enforced by the algorithm.
 
 qgis:regularpoints: >
   This algorithm creates a point layer with a given number of regular points, all of them within a given extent.

--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -330,7 +330,7 @@ qgis:refactorfields: >
 
   The original layer is not modified. A new layer is generated, which contains a modified attribute table, according to the provided fields mapping.
 
-  Rows in orange have constraints in the template layer from which these fields were loaded. Treat this information as a hint during configuration. No constraints will be added on an output layer nor will this be checked or enforced by the algorithm.
+  Rows in orange have constraints in the template layer from which these fields were loaded. Treat this information as a hint during configuration. No constraints will be added on an output layer nor will they be checked or enforced by the algorithm.
 
 qgis:regularpoints: >
   This algorithm creates a point layer with a given number of regular points, all of them within a given extent.

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -204,8 +204,6 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
                     return False
                 if 'expression' not in field_def.keys():
                     return False
-                if 'not_null' not in field_def.keys():
-                    return False
             return True
 
         def valueAsPythonString(self, value, context):

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -204,6 +204,8 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
                     return False
                 if 'expression' not in field_def.keys():
                     return False
+                if 'not_null' not in field_def.keys():
+                    return False
             return True
 
         def valueAsPythonString(self, value, context):

--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -217,7 +217,7 @@ class FieldsMappingModel(QAbstractTableModel):
 
         if role == Qt.ToolTipRole:
             if column_def['name'] == 'constraints' and 'constraints' in field:
-                return ", ".join([self.constraints[constraint] for constraint in field['constraints']])
+                return "<br>".join([self.constraints[constraint] for constraint in field['constraints']])
 
     def setData(self, index, value, role=Qt.EditRole):
         field = self._mapping[index.row()]

--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -34,6 +34,12 @@ from qgis.PyQt.QtCore import (
     pyqtSlot,
     QCoreApplication
 )
+
+from qgis.PyQt.QtGui import (
+    QBrush,
+    QColor
+)
+
 from qgis.PyQt.QtWidgets import (
     QComboBox,
     QHeaderView,
@@ -54,6 +60,7 @@ from qgis.core import (
     QgsProcessingUtils,
     QgsProject,
     QgsVectorLayer,
+    QgsFieldConstraints
 )
 from qgis.gui import QgsFieldExpressionWidget
 
@@ -109,6 +116,10 @@ class FieldsMappingModel(QAbstractTableModel):
             'name': 'precision',
             'type': QVariant.Int,
             'header': self.tr("Precision")
+        }, {
+            'name': 'not_null',
+            'type': QVariant.Bool,
+            'header': self.tr("NOT NULL")
         }]
 
     def columnIndex(self, column_name):
@@ -187,6 +198,9 @@ class FieldsMappingModel(QAbstractTableModel):
                 hAlign = Qt.AlignLeft
             return hAlign + Qt.AlignVCenter
 
+        if role == Qt.BackgroundRole:
+            return QBrush(QColor(255, 224, 178)) if 'not_null' in field and field['not_null'] else QVariant()
+
     def setData(self, index, value, role=Qt.EditRole):
         field = self._mapping[index.row()]
         column_def = self.columns[index.column()]
@@ -222,13 +236,15 @@ class FieldsMappingModel(QAbstractTableModel):
                     'type': QVariant.Invalid,
                     'length': 0,
                     'precision': 0,
-                    'expression': ''}
+                    'expression': '',
+                    'not_null': False}
 
         return {'name': field.name(),
                 'type': field.type(),
                 'length': field.length(),
                 'precision': field.precision(),
-                'expression': QgsExpression.quotedColumnRef(field.name())}
+                'expression': QgsExpression.quotedColumnRef(field.name()),
+                'not_null': bool(field.constraints().constraints() & QgsFieldConstraints.ConstraintNotNull)}
 
     def loadLayerFields(self, layer):
         self.beginResetModel()

--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -192,7 +192,7 @@ class FieldsMappingModel(QAbstractTableModel):
         column_def = self.columns[index.column()]
 
         if role == Qt.DisplayRole:
-            value = field[column_def['name']]
+            value = field[column_def['name']] if column_def['name'] in field else QVariant()
             if column_def['type'] == QVariant.Type:
                 if value == QVariant.Invalid:
                     return ''
@@ -216,9 +216,8 @@ class FieldsMappingModel(QAbstractTableModel):
             return QBrush(QColor(255, 224, 178)) if 'constraints' in field and field['constraints'] else QVariant()
 
         if role == Qt.ToolTipRole:
-            if column_def['name'] == 'constraints':
-                return ", ".join(
-                    [self.constraints[constraint] for constraint in field['constraints'] if 'constraints' in field])
+            if column_def['name'] == 'constraints' and 'constraints' in field:
+                return ", ".join([self.constraints[constraint] for constraint in field['constraints']])
 
     def setData(self, index, value, role=Qt.EditRole):
         field = self._mapping[index.row()]

--- a/python/plugins/processing/algs/qgis/ui/fieldsmappingpanelbase.ui
+++ b/python/plugins/processing/algs/qgis/ui/fieldsmappingpanelbase.ui
@@ -109,7 +109,7 @@
      <item>
       <widget class="QLabel" name="loadFromLayerLabel">
        <property name="text">
-        <string>Load fields from layer</string>
+        <string>Load fields from template layer</string>
        </property>
       </widget>
      </item>
@@ -132,7 +132,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>Load fields from selected layer</string>
+        <string>Load fields from selected template layer</string>
        </property>
        <property name="text">
         <string>Load Fields</string>


### PR DESCRIPTION
## Description
Dialog: Refactor fields algorithm's UI.
Objective: Highlight field rows when the 'template layer' field has constraints.

**TODO**
 + [x] Add an orange color (same as used in attribute form warnings) to the whole row if a template layer field has constraints.
 + [x] Adjust text in help panel to let users know why some rows are coloured. 
 + [x] Remove NOT NULL column.
 + [x] New column "Template properties."
     + Which content to show?
        + "Constraints active"?
     + What the tooltip should show?
        + Constraints, widget configuration, ...?
 + [x] Replace "Load fields from layer" by "Load fields from template layer."

**Screenshots**

![image](https://user-images.githubusercontent.com/652785/75100644-6079a500-559e-11ea-91b6-f99fa05451de.png)


Fix #34458




## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment.
