### PR TITLE
Fix docstring of QgsVectorDataProvider.empty() method.

### DIFF
--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -127,7 +127,7 @@ Number of features in the layer
 
     virtual bool empty() const;
 %Docstring
-Returns ``True`` if the layer contains at least one feature.
+Returns ``True`` if the layer does not contain any feature.
 
 .. versionadded:: 3.4
 %End

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     long featureCount() const override = 0;
 
     /**
-     * Returns TRUE if the layer contains at least one feature.
+     * Returns TRUE if the layer does not contain any feature.
      *
      * \since QGIS 3.4
      */


### PR DESCRIPTION
## Description
It's the `empty()` method. 

It says: `Returns true if the layer contains at least one feature.`
It should say: `Returns true if the layer does not contain any feature.`

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
