### PR TITLE
Sketch line symbol rendering

### DIFF
--- a/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgslinesymbollayer.sip.in
@@ -229,6 +229,16 @@ used to render polygon rings.
 .. seealso:: :py:func:`drawInsidePolygon`
 %End
 
+    bool isSketchEnabled() const;
+    float sketchRoughness() const;
+    float sketchBowing() const;
+    float sketchMaxOffset() const;
+
+    void setSketchEnabled( bool enabled );
+    void setSketchRoughness( float roughness );
+    void setSketchBowing( float bowing );
+    void setSketchMaxOffset( float maxOffset );
+
 };
 
 

--- a/src/core/symbology/qgslinesymbollayer.h
+++ b/src/core/symbology/qgslinesymbollayer.h
@@ -216,7 +216,19 @@ class CORE_EXPORT QgsSimpleLineSymbolLayer : public QgsLineSymbolLayer
      */
     void setDrawInsidePolygon( bool drawInsidePolygon ) { mDrawInsidePolygon = drawInsidePolygon; }
 
+    bool isSketchEnabled() const { return mSketchEnabled; }
+    float sketchRoughness() const { return mSketchRoughness; }
+    float sketchBowing() const { return mSketchBowing; }
+    float sketchMaxOffset() const { return mSketchMaxOffset; }
+
+    void setSketchEnabled( bool enabled ) { mSketchEnabled = enabled; }
+    void setSketchRoughness( float roughness ) { mSketchRoughness = roughness; }
+    void setSketchBowing( float bowing ) { mSketchBowing = bowing; }
+    void setSketchMaxOffset( float maxOffset ) { mSketchMaxOffset = maxOffset; }
+
   private:
+
+    void addRoughPolygon( QPainterPath &path, const QPolygonF &points );
 
     Qt::PenStyle mPenStyle = Qt::SolidLine;
     Qt::PenJoinStyle mPenJoinStyle = DEFAULT_SIMPLELINE_JOINSTYLE;
@@ -232,6 +244,11 @@ class CORE_EXPORT QgsSimpleLineSymbolLayer : public QgsLineSymbolLayer
     QVector<qreal> mCustomDashVector;
 
     bool mDrawInsidePolygon = false;
+
+    bool mSketchEnabled = false;
+    float mSketchRoughness = 1.f;
+    float mSketchBowing = 1.f;
+    float mSketchMaxOffset = 2.f;
 
     //helper functions for data defined symbology
     void applyDataDefinedSymbology( QgsSymbolRenderContext &context, QPen &pen, QPen &selPen, double &offset );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -228,6 +228,11 @@ QgsSimpleLineSymbolLayerWidget::QgsSimpleLineSymbolLayerWidget( QgsVectorLayer *
   connect( cboCapStyle, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsSimpleLineSymbolLayerWidget::penStyleChanged );
   connect( cboJoinStyle, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsSimpleLineSymbolLayerWidget::penStyleChanged );
 
+  connect( chkSketchEnabled, &QCheckBox::stateChanged, this, &QgsSimpleLineSymbolLayerWidget::sketchChanged );
+  connect( spinSketchRoughness, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSimpleLineSymbolLayerWidget::sketchChanged );
+  connect( spinSketchBowing, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSimpleLineSymbolLayerWidget::sketchChanged );
+  connect( spinSketchMaxOffset, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSimpleLineSymbolLayerWidget::sketchChanged );
+
   updatePatternIcon();
 
   connect( this, &QgsSymbolLayerWidget::changed, this, &QgsSimpleLineSymbolLayerWidget::updateAssistantSymbol );
@@ -308,6 +313,11 @@ void QgsSimpleLineSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   whileBlocking( mDrawInsideCheckBox )->setCheckState( drawInsidePolygon ? Qt::Checked : Qt::Unchecked );
 
   whileBlocking( mRingFilterComboBox )->setCurrentIndex( mRingFilterComboBox->findData( mLayer->ringFilter() ) );
+
+  whileBlocking( chkSketchEnabled )->setCheckState( mLayer->isSketchEnabled() ? Qt::Checked : Qt::Unchecked );
+  whileBlocking( spinSketchRoughness )->setValue( mLayer->sketchRoughness() );
+  whileBlocking( spinSketchBowing )->setValue( mLayer->sketchBowing() );
+  whileBlocking( spinSketchMaxOffset )->setValue( mLayer->sketchMaxOffset() );
 
   updatePatternIcon();
 
@@ -431,6 +441,16 @@ void QgsSimpleLineSymbolLayerWidget::mDrawInsideCheckBox_stateChanged( int state
 {
   bool checked = ( state == Qt::Checked );
   mLayer->setDrawInsidePolygon( checked );
+  emit changed();
+}
+
+void QgsSimpleLineSymbolLayerWidget::sketchChanged()
+{
+  mLayer->setSketchEnabled( chkSketchEnabled->isChecked() );
+  mLayer->setSketchRoughness( spinSketchRoughness->value() );
+  mLayer->setSketchBowing( spinSketchBowing->value() );
+  mLayer->setSketchMaxOffset( spinSketchMaxOffset->value() );
+  updatePatternIcon();
   emit changed();
 }
 

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -168,6 +168,7 @@ class GUI_EXPORT QgsSimpleLineSymbolLayerWidget : public QgsSymbolLayerWidget, p
     void mOffsetUnitWidget_changed();
     void mDashPatternUnitWidget_changed();
     void mDrawInsideCheckBox_stateChanged( int state );
+    void sketchChanged();
 
   private:
 

--- a/src/ui/symbollayer/widget_simpleline.ui
+++ b/src/ui/symbollayer/widget_simpleline.ui
@@ -6,14 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>384</height>
+    <width>507</width>
+    <height>807</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Bowing</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Roughness</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -107,7 +121,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="14" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -302,6 +316,29 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Max Offset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
+    <widget class="QDoubleSpinBox" name="spinSketchRoughness"/>
+   </item>
+   <item row="12" column="2">
+    <widget class="QDoubleSpinBox" name="spinSketchBowing"/>
+   </item>
+   <item row="13" column="2">
+    <widget class="QDoubleSpinBox" name="spinSketchMaxOffset"/>
+   </item>
+   <item row="10" column="0" colspan="3">
+    <widget class="QCheckBox" name="chkSketchEnabled">
+     <property name="text">
+      <string>Sketch rendering</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This is a work in progress... not ready for inclusion in core yet. 

Original (sketch lines disabled):

![image](https://user-images.githubusercontent.com/193367/63651138-1d0abf00-c752-11e9-877e-8580c9a2580f.png)

Sketch lines enabled:

![image](https://user-images.githubusercontent.com/193367/63651159-4c213080-c752-11e9-8afb-bc6e3e8678e7.png)

Sketch lines enabled - different sketch parameter values:

![image](https://user-images.githubusercontent.com/193367/63651181-7d99fc00-c752-11e9-9578-47146ea3413e.png)


Sketch line rendering - when enabled, there are three parameters to tweak for different appearance:
- roughness
- bowing
- max offset

Code ported from https://github.com/gicentre/handy/blob/master/Handy/src/org/gicentre/handy/HandyRenderer.java

Open questions / issues:
- have this as an optional feature for "simple line" symbol or shall we have a new "sketch line" symbol?
- the output is random so the rendered output changes on every map refresh
- any volunteers to implement sketch fills (hachures) ? :-)

cc @andreasneumann @timlinux @nirvn 