### PR TITLE
Fix single feature renderer symbol levels reset when changing style

### DIFF
--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -78,6 +78,11 @@ vector layers have been changed. Will request the parent dialog
 to re-synchronize with the variables.
 %End
 
+    void symbolLevelsChanged();
+%Docstring
+Emitted when the symbol levels settings have been changed.
+%End
+
   protected:
 
 

--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -72,52 +72,6 @@ Returns the symbol that is currently active in the widget. Can be ``None``.
 %End
 
 
-  protected:
-
-    void loadSymbol();
-%Docstring
-Reload the current symbol in the view.
-%End
-
-    void updateUi();
-%Docstring
-Update the state of the UI based on the currently set symbol layer.
-%End
-
-    void updateLockButton();
-%Docstring
-Update the lock button states based on the current symbol layer.
-%End
-
-
-    QgsSymbolLayer *currentLayer();
-%Docstring
-The current symbol layer that is active in the interface.
-
-:return: The active symbol layer.
-%End
-
-    void moveLayerByOffset( int offset );
-%Docstring
-Move the current active layer by a set offset in the list.
-
-:param offset: The offset to move the layer by
-%End
-
-    void setWidget( QWidget *widget );
-%Docstring
-Set the properties widget for the active symbol layer.
-
-:param widget: The widget to set to configure the active symbol layer.
-%End
-
-  signals:
-
-    void symbolModified();
-%Docstring
-Emiited when a symbol is modified in the widget.
-%End
-
   public slots:
 
     void moveLayerDown();
@@ -179,9 +133,12 @@ alters tree and sets proper widget when Layer Type is changed
 \note: The layer is received from the LayerPropertiesWidget
 %End
 
+  signals:
 
-  protected: // data
-
+    void symbolModified();
+%Docstring
+Emiited when a symbol is modified in the widget.
+%End
 
 };
 
@@ -236,6 +193,7 @@ Returns the symbol that is currently active in the widget. Can be ``None``.
 :return: The active symbol.
 %End
 
+
     QDialogButtonBox *buttonBox() const;
 %Docstring
 Returns a reference to the dialog's button box.
@@ -243,27 +201,8 @@ Returns a reference to the dialog's button box.
 .. versionadded:: 3.10
 %End
 
-  protected:
-    virtual void keyPressEvent( QKeyEvent *e );
-
-
-    void loadSymbol();
-
-
-    void updateUi();
-
-    void updateLockButton();
-
-    QgsSymbolLayer *currentLayer();
-
-    void moveLayerByOffset( int offset );
-
-    void setWidget( QWidget *widget );
-
-  signals:
-    void symbolModified();
-
   public slots:
+
     void moveLayerDown();
     void moveLayerUp();
 
@@ -294,6 +233,15 @@ Slot to update tree when a new symbol from style
 alters tree and sets proper widget when Layer Type is changed
 \note: The layer is received from the LayerPropertiesWidget
 %End
+
+  protected:
+
+    virtual void keyPressEvent( QKeyEvent *e );
+
+
+  signals:
+
+    void symbolModified();
 
 };
 

--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -71,13 +71,13 @@ Returns the symbol that is currently active in the widget. Can be ``None``.
 :return: The active symbol.
 %End
 
+
   protected:
 
     void loadSymbol();
 %Docstring
 Reload the current symbol in the view.
 %End
-
 
     void updateUi();
 %Docstring

--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -37,6 +37,10 @@ Symbol selector widget that can be used to select and build a symbol
 :param style: The style used by the widget.
 :param vl: The vector layer for the symbol.
 :param parent:
+
+.. note::
+
+   The ownership of the symbol is not transferred and must exist for the lifetime of the widget.
 %End
 
     QMenu *advancedMenu();
@@ -70,6 +74,7 @@ Returns the symbol that is currently active in the widget. Can be ``None``.
 
 :return: The active symbol.
 %End
+
 
 
   public slots:

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -320,7 +320,7 @@ void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
     QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( r, r->usingSymbolLevels(), panel );
     widget->setPanelTitle( tr( "Symbol Levels" ) );
     connect( widget, &QgsPanelWidget::widgetChanged, widget, &QgsSymbolLevelsWidget::apply );
-    connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
+    connect( widget, &QgsPanelWidget::widgetChanged, [ = ]() { emit widgetChanged(); emit symbolLevelsChanged(); } );
     panel->openPanel( widget );
     return;
   }
@@ -329,6 +329,7 @@ void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
   if ( dlg.exec() )
   {
     emit widgetChanged();
+    emit symbolLevelsChanged();
   }
 }
 

--- a/src/gui/symbology/qgsrendererwidget.h
+++ b/src/gui/symbology/qgsrendererwidget.h
@@ -88,6 +88,11 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
      */
     void layerVariablesChanged();
 
+    /**
+     * Emitted when the symbol levels settings have been changed.
+     */
+    void symbolLevelsChanged();
+
   protected:
     QgsVectorLayer *mLayer = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -57,6 +57,12 @@ QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *la
   mSelector = new QgsSymbolSelectorWidget( mSingleSymbol, mStyle, mLayer, nullptr );
   connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, &QgsSingleSymbolRendererWidget::changeSingleSymbol );
   connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
+  connect( this, &QgsRendererWidget::symbolLevelsChanged, [ = ]()
+  {
+    delete mSingleSymbol;
+    mSingleSymbol = mRenderer->symbol()->clone();
+    mSelector->loadSymbol( mSingleSymbol );
+  } );
 
   QVBoxLayout *layout = new QVBoxLayout( this );
   layout->setContentsMargins( 0, 0, 0, 0 );

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -414,7 +414,7 @@ void QgsSymbolSelectorWidget::loadSymbol( QgsSymbol *symbol, SymbolLayerItem *pa
 }
 
 
-void QgsSymbolSelectorWidget::loadSymbol()
+void QgsSymbolSelectorWidget::reloadSymbol()
 {
   model->clear();
   loadSymbol( mSymbol, static_cast<SymbolLayerItem *>( model->invisibleRootItem() ) );
@@ -553,7 +553,7 @@ void QgsSymbolSelectorWidget::symbolChanged()
   else
   {
     //it is the symbol itself
-    loadSymbol();
+    reloadSymbol();
     QModelIndex newIndex = layersTree->model()->index( 0, 0 );
     layersTree->setCurrentIndex( newIndex );
   }
@@ -824,9 +824,9 @@ void QgsSymbolSelectorDialog::keyPressEvent( QKeyEvent *e )
   }
 }
 
-void QgsSymbolSelectorDialog::loadSymbol()
+void QgsSymbolSelectorDialog::reloadSymbol()
 {
-  mSelectorWidget->loadSymbol();
+  mSelectorWidget->reloadSymbol();
 }
 
 void QgsSymbolSelectorDialog::loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent )

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -385,6 +385,13 @@ QgsSymbolWidgetContext QgsSymbolSelectorWidget::context() const
 
 void QgsSymbolSelectorWidget::loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent )
 {
+  if ( !parent )
+  {
+    mSymbol = symbol;
+    model->clear();
+    parent = static_cast<SymbolLayerItem *>( model->invisibleRootItem() );
+  }
+
   SymbolLayerItem *symbolItem = new SymbolLayerItem( symbol );
   QFont boldFont = symbolItem->font();
   boldFont.setBold( true );

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -128,57 +128,11 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
     QgsSymbol *symbol() { return mSymbol; }
 
     /**
-     * Load the given symbol into the widget.
+     * Loads the given symbol into the widget.
      * \param symbol The symbol to load.
      * \param parent The parent symbol layer item. If the parent parameter is null, the whole symbol and model will be reset.
-     * \note not available in Python bindings
      */
     void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent = nullptr ) SIP_SKIP;
-
-  protected:
-
-    /**
-     * Reload the current symbol in the view.
-     */
-    void loadSymbol();
-
-    /**
-     * Update the state of the UI based on the currently set symbol layer.
-     */
-    void updateUi();
-
-    /**
-     * Update the lock button states based on the current symbol layer.
-     */
-    void updateLockButton();
-
-    //! \note not available in Python bindings
-    SymbolLayerItem *currentLayerItem() SIP_SKIP;
-
-    /**
-     * The current symbol layer that is active in the interface.
-     * \returns The active symbol layer.
-     */
-    QgsSymbolLayer *currentLayer();
-
-    /**
-     * Move the current active layer by a set offset in the list.
-     * \param offset The offset to move the layer by
-     */
-    void moveLayerByOffset( int offset );
-
-    /**
-     * Set the properties widget for the active symbol layer.
-     * \param widget The widget to set to configure the active symbol layer.
-     */
-    void setWidget( QWidget *widget );
-
-  signals:
-
-    /**
-     * Emiited when a symbol is modified in the widget.
-     */
-    void symbolModified();
 
   public slots:
 
@@ -238,8 +192,50 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
      */
     void changeLayer( QgsSymbolLayer *layer );
 
+  signals:
 
-  protected: // data
+    /**
+     * Emiited when a symbol is modified in the widget.
+     */
+    void symbolModified();
+
+  private:
+
+    /**
+     * Reload the current symbol in the view.
+     */
+    void reloadSymbol();
+
+    /**
+     * Update the state of the UI based on the currently set symbol layer.
+     */
+    void updateUi();
+
+    /**
+     * Update the lock button states based on the current symbol layer.
+     */
+    void updateLockButton();
+
+    SymbolLayerItem *currentLayerItem();
+
+    /**
+     * The current symbol layer that is active in the interface.
+     * \returns The active symbol layer.
+     */
+    QgsSymbolLayer *currentLayer();
+
+    /**
+     * Move the current active layer by a set offset in the list.
+     * \param offset The offset to move the layer by
+     */
+    void moveLayerByOffset( int offset );
+
+    /**
+     * Set the properties widget for the active symbol layer.
+     * \param widget The widget to set to configure the active symbol layer.
+     */
+    void setWidget( QWidget *widget );
+
     QgsStyle *mStyle = nullptr;
     QgsSymbol *mSymbol = nullptr;
     QMenu *mAdvancedMenu = nullptr;
@@ -248,7 +244,6 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
     QStandardItemModel *model = nullptr;
     QWidget *mPresentWidget = nullptr;
 
-  private:
     std::unique_ptr<DataDefinedRestorer> mDataDefineRestorer;
     QgsSymbolWidgetContext mContext;
     QgsFeature mPreviewFeature;
@@ -303,36 +298,20 @@ class GUI_EXPORT QgsSymbolSelectorDialog : public QDialog
     QgsSymbol *symbol();
 
     /**
+     * Loads the given symbol into the widget.
+     * \param symbol The symbol to load.
+     * \param parent The parent symbol layer item. If the parent parameter is null, the whole symbol and model will be reset.
+     */
+    void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent = nullptr ) SIP_SKIP;
+
+    /**
      * Returns a reference to the dialog's button box.
      * \since QGIS 3.10
      */
     QDialogButtonBox *buttonBox() const;
 
-  protected:
-    // Reimplements dialog keyPress event so we can ignore it
-    void keyPressEvent( QKeyEvent *e ) override;
-
-    void loadSymbol();
-
-    //! \note not available in Python bindings
-    void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent ) SIP_SKIP;
-
-    void updateUi();
-
-    void updateLockButton();
-
-    //! \note not available in Python bindings
-    SymbolLayerItem *currentLayerItem() SIP_SKIP;
-    QgsSymbolLayer *currentLayer();
-
-    void moveLayerByOffset( int offset );
-
-    void setWidget( QWidget *widget );
-
-  signals:
-    void symbolModified();
-
   public slots:
+
     void moveLayerDown();
     void moveLayerUp();
 
@@ -361,13 +340,39 @@ class GUI_EXPORT QgsSymbolSelectorDialog : public QDialog
      */
     void changeLayer( QgsSymbolLayer *layer );
 
+  protected:
+
+    // Reimplements dialog keyPress event so we can ignore it
+    void keyPressEvent( QKeyEvent *e ) override;
+
+  private slots:
+
+    void showHelp();
+
+  signals:
+
+    void symbolModified();
+
   private:
+
+    void reloadSymbol();
+
+    void updateUi();
+
+    void updateLockButton();
+
+    SymbolLayerItem *currentLayerItem();
+
+    QgsSymbolLayer *currentLayer();
+
+    void moveLayerByOffset( int offset );
+
+    void setWidget( QWidget *widget );
+
     QgsSymbolSelectorWidget *mSelectorWidget = nullptr;
     QDialogButtonBox *mButtonBox = nullptr;
     QgsSymbolWidgetContext mContext;
 
-  private slots:
-    void showHelp();
 };
 
 #endif

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -127,20 +127,20 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
      */
     QgsSymbol *symbol() { return mSymbol; }
 
+    /**
+     * Load the given symbol into the widget.
+     * \param symbol The symbol to load.
+     * \param parent The parent symbol layer item. If the parent parameter is null, the whole symbol and model will be reset.
+     * \note not available in Python bindings
+     */
+    void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent = nullptr ) SIP_SKIP;
+
   protected:
 
     /**
      * Reload the current symbol in the view.
      */
     void loadSymbol();
-
-    /**
-     * Load the given symbol into the widget.
-     * \param symbol The symbol to load.
-     * \param parent The parent symbol layer item.
-     * \note not available in Python bindings
-     */
-    void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent ) SIP_SKIP;
 
     /**
      * Update the state of the UI based on the currently set symbol layer.

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -95,12 +95,13 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
     // TODO QGIS 4.0 - transfer ownership of symbol to widget!
 
     /**
-       * Symbol selector widget that can be used to select and build a symbol
-       * \param symbol The symbol to load into the widget as a start point.
-       * \param style The style used by the widget.
-       * \param vl The vector layer for the symbol.
-       * \param parent
-       */
+     * Symbol selector widget that can be used to select and build a symbol
+     * \param symbol The symbol to load into the widget as a start point.
+     * \param style The style used by the widget.
+     * \param vl The vector layer for the symbol.
+     * \param parent
+     * \note The ownership of the symbol is not transferred and must exist for the lifetime of the widget.
+     */
     QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *style, QgsVectorLayer *vl, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     //! Returns menu for "advanced" button - create it if doesn't exist and show the advanced button
@@ -127,10 +128,13 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
      */
     QgsSymbol *symbol() { return mSymbol; }
 
+    // TODO QGIS 4.0 - transfer ownership of symbol to widget!
+
     /**
      * Loads the given symbol into the widget.
      * \param symbol The symbol to load.
      * \param parent The parent symbol layer item. If the parent parameter is null, the whole symbol and model will be reset.
+     * \note The ownership of the symbol is not transferred and must exist for the lifetime of the widget.
      */
     void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent = nullptr ) SIP_SKIP;
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR fixes #26547, whereas the symbol levels were reset to the values set when opening the style panel / layer properties window whenever the layer symbol was modified.

I've taken the opportunity to cleanup the symbol selector {widget, dialog} class a bit.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
