### PR TITLE
Don't create an unused expression context when a layer iterator has no virtual fields

### DIFF
--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -256,6 +256,7 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QgsVectorLayerFeatureIterator( const QgsVectorLayerFeatureIterator &rhs );
 #endif
 
+    void createExpressionContext();
     std::unique_ptr<QgsExpressionContext> mExpressionContext;
 
     QgsFeedback *mInterruptionChecker = nullptr;


### PR DESCRIPTION
This adds a lot of expense to the (not recommended, but still done in parts) process of fetching a bunch of different features using multiple separate iterators
