### PR TITLE
Remove "&" character from labels in Customization dialog

### DIFF
--- a/src/app/qgscustomization.cpp
+++ b/src/app/qgscustomization.cpp
@@ -395,7 +395,8 @@ QTreeWidgetItem *QgsCustomizationDialog::readWidgetsXmlNode( const QDomNode &nod
   QString name = myElement.attribute( QStringLiteral( "objectName" ), QString() );
   QStringList data( name );
 
-  data << myElement.attribute( QStringLiteral( "label" ), name );
+  // remove '&' which are used to mark shortcut key
+  data << myElement.attribute( QStringLiteral( "label" ), name ).remove( "&" );
 
   QTreeWidgetItem *myItem = new QTreeWidgetItem( data );
 
@@ -554,7 +555,8 @@ void QgsCustomization::addTreeItemActions( QTreeWidgetItem *parentItem, const QL
     {
       // it is an ordinary action
       QStringList strs;
-      strs << action->objectName() << action->text();
+      // remove '&' which are used to mark shortcut key
+      strs << action->objectName() << action->text().remove( '&' );
       QTreeWidgetItem *item = new QTreeWidgetItem( parentItem, strs );
       item->setIcon( 0, action->icon() );
       item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable );
@@ -616,7 +618,8 @@ void QgsCustomization::createTreeItemToolbars()
     for ( QAction *act : tbWidgetActions )
     {
       QStringList actstrs;
-      actstrs << act->objectName() << act->text();
+      // remove '&' which are used to mark shortcut key
+      actstrs << act->objectName() << act->text().remove( "&" );
       QTreeWidgetItem *item = new QTreeWidgetItem( tbItem, actstrs );
       item->setIcon( 0, act->icon() );
       item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsSelectable );


### PR DESCRIPTION
This is removed from the menus so for consistency and because it looks better imho, let's remove them from the action label

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
