### PR TITLE
Fix code sample rendering in pyqgis doc

### DIFF
--- a/python/core/auto_generated/qgspathresolver.sip.in
+++ b/python/core/auto_generated/qgspathresolver.sip.in
@@ -54,6 +54,7 @@ The path pre-processor function is called before any bad layer handler.
    Setting a new ``processor`` replaces any existing processor.
 
 Example - replace an outdated folder path with a new one:
+
 .. code-block:: python
 
        def my_processor(path):
@@ -62,6 +63,7 @@ Example - replace an outdated folder path with a new one:
        QgsPathResolver.setPathPreprocessor(my_processor)
 
 Example - replace a stored database host with a new one:
+
 .. code-block:: python
 
        def my_processor(path):
@@ -71,6 +73,7 @@ Example - replace a stored database host with a new one:
 
 
 Example - replace stored database credentials with new ones:
+
 .. code-block:: python
 
        def my_processor(path):

--- a/src/core/qgspathresolver.h
+++ b/src/core/qgspathresolver.h
@@ -79,6 +79,7 @@ class CORE_EXPORT QgsPathResolver
      * \note Setting a new \a processor replaces any existing processor.
      *
      * Example - replace an outdated folder path with a new one:
+     *
      * \code{.py}
      *   def my_processor(path):
      *      return path.replace('c:/Users/ClintBarton/Documents/Projects', 'x:/Projects/')
@@ -87,6 +88,7 @@ class CORE_EXPORT QgsPathResolver
      * \endcode
      *
      * Example - replace a stored database host with a new one:
+     *
      * \code{.py}
      *   def my_processor(path):
      *      return path.replace('host=10.1.1.115', 'host=10.1.1.116')
@@ -95,6 +97,7 @@ class CORE_EXPORT QgsPathResolver
      * \endcode
      *
      * Example - replace stored database credentials with new ones:
+     *
      * \code{.py}
      *   def my_processor(path):
      *      path = path.replace("user='gis_team'", "user='team_awesome'")


### PR DESCRIPTION
Hoping that's the right way to fix how code samples are displayed at https://qgis.org/pyqgis/master/core/QgsPathResolver.html#qgis.core.QgsPathResolver.setPathPreprocessor

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
