### PR TITLE
Prevents decoding WMS capabilities requests

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -164,6 +164,24 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
   QgsDebugMsg( QStringLiteral( "exiting constructor." ) );
 }
 
+QString QgsWmsProvider::prepareUriWithoutDecode( QString uri )
+{
+  if ( uri.contains( QLatin1String( "SERVICE=WMTS" ) ) || uri.contains( QLatin1String( "/WMTSCapabilities.xml" ) ) )
+  {
+    return uri;
+  }
+
+  if ( !uri.contains( QLatin1String( "?" ) ) )
+  {
+    uri.append( '?' );
+  }
+  else if ( uri.right( 1 ) != QLatin1String( "?" ) && uri.right( 1 ) != QLatin1String( "&" ) )
+  {
+    uri.append( '&' );
+  }
+
+  return uri;
+}
 
 QString QgsWmsProvider::prepareUri( QString uri )
 {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -164,29 +164,13 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &optio
   QgsDebugMsg( QStringLiteral( "exiting constructor." ) );
 }
 
-QString QgsWmsProvider::prepareUriWithoutDecode( QString uri )
-{
-  if ( uri.contains( QLatin1String( "SERVICE=WMTS" ) ) || uri.contains( QLatin1String( "/WMTSCapabilities.xml" ) ) )
-  {
-    return uri;
-  }
-
-  if ( !uri.contains( QLatin1String( "?" ) ) )
-  {
-    uri.append( '?' );
-  }
-  else if ( uri.right( 1 ) != QLatin1String( "?" ) && uri.right( 1 ) != QLatin1String( "&" ) )
-  {
-    uri.append( '&' );
-  }
-
-  return uri;
-}
-
-QString QgsWmsProvider::prepareUri( QString uri )
+QString QgsWmsProvider::prepareUri( QString uri, bool decode )
 {
   // some services provide a percent/url encoded (legend) uri string, always decode here
-  uri = QUrl::fromPercentEncoding( uri.toUtf8() );
+  if ( decode )
+  {
+    uri = QUrl::fromPercentEncoding( uri.toUtf8() );
+  }
 
   if ( uri.contains( QLatin1String( "SERVICE=WMTS" ) ) || uri.contains( QLatin1String( "/WMTSCapabilities.xml" ) ) )
   {

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -233,6 +233,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
      * \returns prepared uri
      */
     static QString prepareUri( QString uri );
+    static QString prepareUriWithoutDecode( QString uri );
 
     int stepWidth() const override { return mSettings.mStepWidth; }
     int stepHeight() const override { return mSettings.mStepHeight; }

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -232,8 +232,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
      * \param uri uri to prepare
      * \returns prepared uri
      */
-    static QString prepareUri( QString uri );
-    static QString prepareUriWithoutDecode( QString uri );
+    static QString prepareUri( QString uri, bool decode = true );
 
     int stepWidth() const override { return mSettings.mStepWidth; }
     int stepHeight() const override { return mSettings.mStepHeight; }

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -455,7 +455,7 @@ void QgsWMSSourceSelect::btnConnect_clicked()
     return;
   }
 
-  QgsWmsCapabilitiesDownload capDownload( QgsWmsProvider::prepareUriWithoutDecode( mUri.param( "url" ) ), wmsSettings.authorization(), true );
+  QgsWmsCapabilitiesDownload capDownload( QgsWmsProvider::prepareUri( mUri.param( "url" ), false ), wmsSettings.authorization(), true );
   connect( &capDownload, &QgsWmsCapabilitiesDownload::statusChanged, this, &QgsWMSSourceSelect::showStatusMessage );
 
   QApplication::setOverrideCursor( Qt::WaitCursor );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -455,7 +455,7 @@ void QgsWMSSourceSelect::btnConnect_clicked()
     return;
   }
 
-  QgsWmsCapabilitiesDownload capDownload( wmsSettings.baseUrl(), wmsSettings.authorization(), true );
+  QgsWmsCapabilitiesDownload capDownload( QgsWmsProvider::prepareUriWithoutDecode( mUri.param( "url" ) ), wmsSettings.authorization(), true );
   connect( &capDownload, &QgsWmsCapabilitiesDownload::statusChanged, this, &QgsWMSSourceSelect::showStatusMessage );
 
   QApplication::setOverrideCursor( Qt::WaitCursor );


### PR DESCRIPTION
## Description

When a user wants to create a new WMS/WMTS connection, he must provide the WMS end point. If the end point needs any additional parameter, it is users's responsibility to provide it properly encoded.

Right now, if the user wants to provide the end point of a WMS QGIS server, adding an additional parameter MAP with a Postgresql stored project, QGIS Desktop will fail to retrieve the Capabilities document.

Fix #31192.

## Solution

To "fix" this issue, I've changed only the code related to the GetCapabilities request. I avoided more changes that might break other calls to the WMS/WMTS service.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
