### PR TITLE
Set the layer on the key and value field

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -25,6 +25,8 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
 {
   setupUi( this );
   mLayerName->setFilters( QgsMapLayerProxyModel::VectorLayer );
+  mKeyColumn->setLayer( mLayerName->currentLayer() );
+  mValueColumn->setLayer( mLayerName->currentLayer() );
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mKeyColumn, &QgsFieldComboBox::setLayer );
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mValueColumn, &QgsFieldComboBox::setLayer );
   connect( mEditExpression, &QAbstractButton::clicked, this, &QgsValueRelationConfigDlg::editExpression );


### PR DESCRIPTION
There has been the issue, that if the selected layer for the Value Relation Widget has been the one with index 0, then the depending fields lost their information.
![keyvaluesnotsaved](https://user-images.githubusercontent.com/28384354/63697452-39276280-c81d-11e9-9c62-7433d7bd34a7.gif)

This is because on setting the model in the constructor of `QgsMapLayerComboBox` the current index is set from -1 to 0 (if there are layers).

When it sets the layer to the one of index 0 when reading the configuration, it does not trigger the `setLayer` on `mKeyColumn` and `mValueColumn`. 

That's why it's adjusted to the current layer here.