### PR TITLE
[needs-docs]Set the service area algorithms speed to 50km/h

### DIFF
--- a/python/plugins/processing/algs/qgis/ServiceAreaFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ServiceAreaFromLayer.py
@@ -143,7 +143,7 @@ class ServiceAreaFromLayer(QgisAlgorithm):
         params.append(QgsProcessingParameterNumber(self.DEFAULT_SPEED,
                                                    self.tr('Default speed (km/h)'),
                                                    QgsProcessingParameterNumber.Double,
-                                                   5.0, False, 0))
+                                                   50.0, False, 0))
         params.append(QgsProcessingParameterDistance(self.TOLERANCE,
                                                      self.tr('Topology tolerance'),
                                                      0.0, self.INPUT, False, 0))

--- a/python/plugins/processing/algs/qgis/ServiceAreaFromPoint.py
+++ b/python/plugins/processing/algs/qgis/ServiceAreaFromPoint.py
@@ -140,7 +140,7 @@ class ServiceAreaFromPoint(QgisAlgorithm):
         params.append(QgsProcessingParameterNumber(self.DEFAULT_SPEED,
                                                    self.tr('Default speed (km/h)'),
                                                    QgsProcessingParameterNumber.Double,
-                                                   5.0, False, 0))
+                                                   50.0, False, 0))
         params.append(QgsProcessingParameterDistance(self.TOLERANCE,
                                                      self.tr('Topology tolerance'),
                                                      0.0, self.INPUT, False, 0))


### PR DESCRIPTION
using the same value as the "Shortest Path" algorithms
I don't know the reason of 5km/h hence assume it's a typo (50km/h?) Also 50km/h represents the mean allowed speed in urban areas here so it has some meanings to me. and it's what is used in the three other network algorithms
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
