### PR TITLE
[backport 3.4][themes] Fix night mapping widget background issues

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -1,11 +1,9 @@
-QToolTip
+QWidget
 {
-    border: 1px solid #222;
-    background-color: @itemdarkbackground;
-    color: @itembackground;
+    background: transparent;
 }
 
-QWindow, QMainWindow, QWidget
+QWindow, QMainWindow, QMdiSubWindow, QDialog, QAbstractScrollArea, QFocusFrame, QWizardPage, QDockWidget, QTabWidget, QGroupBox
 {
     color: @text;
     background-color: @background;
@@ -21,6 +19,13 @@ QWidget:item:selected
 {
     background-color: @selection;
     color: @text;
+}
+
+QToolTip
+{
+    border: 1px solid #222;
+    background-color: @itemdarkbackground;
+    color: @itembackground;
 }
 
 QMenuBar {


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This fixes stuff like:
![image](https://user-images.githubusercontent.com/1728657/63738325-9968e380-c8b3-11e9-86e6-7d5323c2cc58.png)

Or this:
![image](https://user-images.githubusercontent.com/1728657/63738332-9cfc6a80-c8b3-11e9-8b96-eaba59531a31.png)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
