### PR TITLE
[ui] Fix single feat. renderer symbol levels reset when changing style

### DIFF
--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -78,6 +78,11 @@ vector layers have been changed. Will request the parent dialog
 to re-synchronize with the variables.
 %End
 
+    void symbolLevelsChanged();
+%Docstring
+Emitted when the symbol levels settings have been changed.
+%End
+
   protected:
 
 

--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -71,13 +71,13 @@ Returns the symbol that is currently active in the widget. Can be ``None``.
 :return: The active symbol.
 %End
 
+
   protected:
 
     void loadSymbol();
 %Docstring
 Reload the current symbol in the view.
 %End
-
 
     void updateUi();
 %Docstring

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -266,7 +266,7 @@ void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
     QgsSymbolLevelsWidget *widget = new QgsSymbolLevelsWidget( r, r->usingSymbolLevels(), panel );
     widget->setPanelTitle( tr( "Symbol Levels" ) );
     connect( widget, &QgsPanelWidget::widgetChanged, widget, &QgsSymbolLevelsWidget::apply );
-    connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
+    connect( widget, &QgsPanelWidget::widgetChanged, [ = ]() { emit widgetChanged(); emit symbolLevelsChanged(); } );
     panel->openPanel( widget );
     return;
   }
@@ -275,6 +275,7 @@ void QgsRendererWidget::showSymbolLevelsDialog( QgsFeatureRenderer *r )
   if ( dlg.exec() )
   {
     emit widgetChanged();
+    emit symbolLevelsChanged();
   }
 }
 

--- a/src/gui/symbology/qgsrendererwidget.h
+++ b/src/gui/symbology/qgsrendererwidget.h
@@ -88,6 +88,11 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
      */
     void layerVariablesChanged();
 
+    /**
+     * Emitted when the symbol levels settings have been changed.
+     */
+    void symbolLevelsChanged();
+
   protected:
     QgsVectorLayer *mLayer = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.cpp
@@ -57,6 +57,12 @@ QgsSingleSymbolRendererWidget::QgsSingleSymbolRendererWidget( QgsVectorLayer *la
   mSelector = new QgsSymbolSelectorWidget( mSingleSymbol, mStyle, mLayer, nullptr );
   connect( mSelector, &QgsSymbolSelectorWidget::symbolModified, this, &QgsSingleSymbolRendererWidget::changeSingleSymbol );
   connect( mSelector, &QgsPanelWidget::showPanel, this, &QgsPanelWidget::openPanel );
+  connect( this, &QgsRendererWidget::symbolLevelsChanged, [ = ]()
+  {
+    delete mSingleSymbol;
+    mSingleSymbol = mRenderer->symbol()->clone();
+    mSelector->loadSymbol( mSingleSymbol );
+  } );
 
   QVBoxLayout *layout = new QVBoxLayout( this );
   layout->setContentsMargins( 0, 0, 0, 0 );

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -384,6 +384,13 @@ QgsSymbolWidgetContext QgsSymbolSelectorWidget::context() const
 
 void QgsSymbolSelectorWidget::loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent )
 {
+  if ( !parent )
+  {
+    mSymbol = symbol;
+    model->clear();
+    parent = static_cast<SymbolLayerItem *>( model->invisibleRootItem() );
+  }
+
   SymbolLayerItem *symbolItem = new SymbolLayerItem( symbol );
   QFont boldFont = symbolItem->font();
   boldFont.setBold( true );

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -127,20 +127,20 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
      */
     QgsSymbol *symbol() { return mSymbol; }
 
+    /**
+     * Load the given symbol into the widget.
+     * \param symbol The symbol to load.
+     * \param parent The parent symbol layer item. If the parent parameter is null, the whole symbol and model will be reset.
+     * \note not available in Python bindings
+     */
+    void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent = nullptr ) SIP_SKIP;
+
   protected:
 
     /**
      * Reload the current symbol in the view.
      */
     void loadSymbol();
-
-    /**
-     * Load the given symbol into the widget.
-     * \param symbol The symbol to load.
-     * \param parent The parent symbol layer item.
-     * \note not available in Python bindings
-     */
-    void loadSymbol( QgsSymbol *symbol, SymbolLayerItem *parent ) SIP_SKIP;
 
     /**
      * Update the state of the UI based on the currently set symbol layer.


### PR DESCRIPTION
This backports the symbol levels reset fix without the class cleanup to 3.8 (and then 3.4).