### PR TITLE
make the crash ID clickable on GitHub

### DIFF
--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -287,6 +287,18 @@ Returns a string with characters having vertical representation form substituted
 
 .. versionadded:: 3.10
 %End
+
+    static QString htmlToMarkdown( const QString &html );
+%Docstring
+Convert simple HTML to markdown. Only br, b and link are supported.
+
+:param html: HTML to convert to markdown
+
+:return: String formatted as markdown
+
+.. versionadded:: 3.10
+%End
+
 };
 
 /************************************************************************

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -448,6 +448,28 @@ QString QgsStringUtils::insertLinks( const QString &string, bool *foundLinks )
   return converted;
 }
 
+QString QgsStringUtils::htmlToMarkdown( const QString &html )
+{
+
+  QString converted = html;
+  converted.replace( QLatin1String( "<br>" ), QLatin1String( "\n" ) );
+  converted.replace( QLatin1String( "<b>" ), QLatin1String( "**" ) );
+  converted.replace( QLatin1String( "</b>" ), QLatin1String( "**" ) );
+
+  static QRegExp hrefRegEx( "<a\\s+href\\s*=\\s*([^<>]*)\\s*>([^<>]*)</a>" );
+  int offset = 0;
+  while ( hrefRegEx.indexIn( converted, offset ) != -1 )
+  {
+    QString url = hrefRegEx.cap( 1 ).replace( QStringLiteral( "\"" ), QString() );
+    QString name = hrefRegEx.cap( 2 );
+    QString anchor = QStringLiteral( "[%1](%2)" ).arg( name, url );
+    converted.replace( hrefRegEx, anchor );
+    offset = hrefRegEx.pos( 1 ) + anchor.length();
+  }
+
+  return converted;
+}
+
 QString QgsStringUtils::wordWrap( const QString &string, const int length, const bool useMaxLineLength, const QString &customDelimiter )
 {
   if ( string.isEmpty() || length == 0 )

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -283,6 +283,15 @@ class CORE_EXPORT QgsStringUtils
      * \since QGIS 3.10
      */
     static QString substituteVerticalCharacters( QString string );
+
+    /**
+     * Convert simple HTML to markdown. Only br, b and link are supported.
+     * \param html HTML to convert to markdown
+     * \returns String formatted as markdown
+     * \since QGIS 3.10
+     */
+    static QString htmlToMarkdown( const QString &html );
+
 };
 
 #endif //QGSSTRINGUTILS_H

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -16,6 +16,7 @@
 
 
 #include "qgscrashdialog.h"
+#include "qgsstringutils.h"
 
 #include <QClipboard>
 #include <QProcess>
@@ -68,7 +69,7 @@ void QgsCrashDialog::createBugReport()
   QString userText = "## User Feedback\n\n" + mUserFeedbackText->toPlainText();
   QString details = "## Report Details\n\n" + mReportData;
   QString finalText = userText + "\n\n" + details;
-  QString markdown = htmlToMarkdown( finalText );
+  QString markdown = QgsStringUtils::htmlToMarkdown( finalText );
   clipboard->setText( markdown );
 }
 
@@ -80,13 +81,3 @@ void QgsCrashDialog::reloadQGIS()
     accept();
   }
 }
-
-QString QgsCrashDialog::htmlToMarkdown( const QString &html )
-{
-  QString markdown = html;
-  markdown.replace( QLatin1String( "<br>" ), QLatin1String( "\n" ) );
-  markdown.replace( QLatin1String( "<b>" ), QLatin1String( "*" ) );
-  markdown.replace( QLatin1String( "</b>" ), QLatin1String( "*" ) );
-  return markdown;
-}
-

--- a/src/crashhandler/qgscrashdialog.h
+++ b/src/crashhandler/qgscrashdialog.h
@@ -40,8 +40,6 @@ class QgsCrashDialog : public QDialog, private Ui::QgsCrashDialog
     void setBugReport( const QString &reportData );
     void setReloadArgs( const QString &reloadArgs );
 
-    static QString htmlToMarkdown( const QString &html );
-
   private slots:
     void showReportWidget();
     void createBugReport();

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -14,6 +14,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgscrashreport.h"
+#include "qgsstringutils.h"
 
 #include <QDir>
 #include <QFile>
@@ -34,19 +35,11 @@ void QgsCrashReport::setFlags( QgsCrashReport::Flags flags )
   mFlags = flags;
 }
 
-const QString QgsCrashReport::toMarkdown()
-{
-  QString markdown = toHtml();
-  markdown.replace( QLatin1String( "<br>" ), QLatin1String( "\n" ) );
-  markdown.replace( QLatin1String( "<b>" ), QLatin1String( "*" ) );
-  markdown.replace( QLatin1String( "</b>" ), QLatin1String( "*" ) );
-  return markdown;
-}
-
 const QString QgsCrashReport::toHtml() const
 {
   QStringList reportData;
-  reportData.append( "<b>Crash ID</b>: " + crashID() );
+  QString crashID = crashID();
+  reportData.append( QStringLiteral( "<b>Crash ID</b>: <a href='https://github.com/qgis/QGIS/search?q=%1&type=Issues'>%1</a>" ).arg( crashID ) );
 
   if ( flags().testFlag( QgsCrashReport::Stack ) )
   {
@@ -161,7 +154,7 @@ void QgsCrashReport::exportToCrashFolder()
   if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
   {
     QTextStream stream( &file );
-    stream << toMarkdown() << endl;
+    stream << QgsStringUtils::htmlToMarkdown( toHtml() ) << endl;
   }
   file.close();
 }

--- a/src/crashhandler/qgscrashreport.h
+++ b/src/crashhandler/qgscrashreport.h
@@ -70,8 +70,6 @@ class QgsCrashReport
      */
     Flags flags() const { return mFlags; }
 
-    const QString toMarkdown();
-
     /**
      * Generate a string version of the report.
      * \return A formatted string including all the information from the report.

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -39,6 +39,7 @@ class TestQgsStringUtils : public QObject
     void camelCase();
     void ampersandEncode_data();
     void ampersandEncode();
+    void htmlToMarkdown();
     void wordWrap_data();
     void wordWrap();
 
@@ -198,6 +199,11 @@ void TestQgsStringUtils::camelCase()
   QCOMPARE( QgsStringUtils::capitalize( QString( "ABC DEF" ), QgsStringUtils::UpperCamelCase ), QString( "AbcDef" ) );
   QCOMPARE( QgsStringUtils::capitalize( QString( "àbc def" ), QgsStringUtils::UpperCamelCase ), QString( "ÀbcDef" ) );
   QCOMPARE( QgsStringUtils::capitalize( QString( "àbc dÉf" ), QgsStringUtils::UpperCamelCase ), QString( "ÀbcDéf" ) );
+}
+
+void TestQgsStringUtils::htmlToMarkdown()
+{
+  QCOMPARE( QgsStringUtils::htmlToMarkdown( QString( "<b>Visit</b> <a href=\"http://qgis.org\">!</a>" ) ), QString( "**Visit** [!](http://qgis.org)" ) );
 }
 
 void TestQgsStringUtils::ampersandEncode_data()


### PR DESCRIPTION
## Description

I'm trying to make the crash ID clickable on github.
For instance this report https://github.com/qgis/QGIS/issues/31443 would have a link to 
https://github.com/qgis/QGIS/search?q=62f1fcd2045780cb9f127836e6b579b8665f3e63&type=Issues

I didn't try this PR, I don't have Windows with the crash handler. Just trying to make things a little bit easier on github.

@gioman What do you think?

I was thinking about hiding this new `htmlToMarkdown` from SIP, because it's an incomplete implementation, quite simple.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
