### PR TITLE
Fix un-changed cursor when switching between 3d tool.

### DIFF
--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -135,6 +135,7 @@ void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
   if ( tool == mMapTool )
     return;
 
+  // For Camera Control tool
   if ( mMapTool && !tool )
   {
     mEngine->window()->removeEventFilter( this );
@@ -145,7 +146,6 @@ void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
   {
     mEngine->window()->installEventFilter( this );
     mScene->cameraController()->setEnabled( tool->allowsCameraControls() );
-    mEngine->window()->setCursor( tool->cursor() );
   }
 
   if ( mMapTool )
@@ -154,7 +154,11 @@ void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
   mMapTool = tool;
 
   if ( mMapTool )
+  {
     mMapTool->activate();
+    mEngine->window()->setCursor( mMapTool->cursor() );
+  }
+
 }
 
 bool Qgs3DMapCanvas::eventFilter( QObject *watched, QEvent *event )

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -119,6 +119,11 @@ void Qgs3DMapToolMeasureLine::deactivate()
   mDialog->hide();
 }
 
+QCursor Qgs3DMapToolMeasureLine::cursor() const
+{
+  return Qt::CrossCursor;
+}
+
 void Qgs3DMapToolMeasureLine::onTerrainPicked( Qt3DRender::QPickEvent *event )
 {
   handleClick( event, event->worldIntersection() );

--- a/src/app/3d/qgs3dmaptoolmeasureline.h
+++ b/src/app/3d/qgs3dmaptoolmeasureline.h
@@ -65,6 +65,8 @@ class Qgs3DMapToolMeasureLine : public Qgs3DMapTool
     void activate() override;
     void deactivate() override;
 
+    QCursor cursor() const override;
+
   private slots:
     void onTerrainPicked( Qt3DRender::QPickEvent *event );
     void onTerrainEntityChanged();


### PR DESCRIPTION
## Description
If you switch from measurement tool to identify tool in 3d map, it will keep using the cross cursor, and vice versa it will use identify-cursor.

<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
