### PR TITLE
include old project version on the initial warning message

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13695,9 +13695,9 @@ void QgisApp::oldProjectVersionWarning( const QString &oldVersion )
 
   if ( settings.value( QStringLiteral( "qgis/warnOldProjectVersion" ), QVariant( true ) ).toBool() )
   {
-    QString smalltext = tr( "This project file was saved by an older version of QGIS."
-                            " When saving this project file, QGIS will update it to the latest version, "
-                            "possibly rendering it useless for older versions of QGIS." );
+    QString smalltext = tr( "This project file was saved by QGIS version %1."
+                            " When saving this project file, QGIS will update it to version %2, "
+                            "possibly rendering it useless for older versions of QGIS." ).arg( oldVersion, Qgis::QGIS_VERSION );
 
     QString title = tr( "Project file is older" );
 


### PR DESCRIPTION
## Description

This PR adds the former and the current QGIS versions to the initial warning, f the project was saved with an older version.

The message will be like:

**This project file was saved by QGIS version 2.18.16. When saving this project file, QGIS will update it to version 3.9.0-Master, possibly rendering it useless for older versions of QGIS.**

Closes #31430 

## Screenshot

![old project warning - display QGIS version](https://user-images.githubusercontent.com/163681/63772547-31c19100-c8d1-11e9-97c0-33b6dcb7401e.png)

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
