### PR TITLE
Add support for "bbox" URI parameter in PostgreSQL provider

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/plugins/qgis_topoview/__init__.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugins/qgis_topoview/__init__.py
@@ -121,11 +121,12 @@ def run(item, action, mainwindow):
         face_extent = layerFaceMbr.extent()
 
         # face geometry
-        sql = u'SELECT face_id, topology.ST_GetFaceGeometry(%s,' \
+        sql = u'SELECT face_id, mbr, topology.ST_GetFaceGeometry(%s,' \
               'face_id)::geometry(polygon, %s) as geom ' \
               'FROM %s.face WHERE face_id > 0' % \
               (quoteStr(toponame), toposrid, quoteId(toponame))
         uri.setDataSource('', u'(%s\n)' % sql, 'geom', '', 'face_id')
+        uri.setParam('bbox', 'mbr')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.Polygon)
         layerFaceGeom = QgsVectorLayer(uri.uri(False), u'%s.face' % toponame, provider)
@@ -133,12 +134,13 @@ def run(item, action, mainwindow):
         layerFaceGeom.loadNamedStyle(os.path.join(template_dir, 'face.qml'))
 
         # face_seed
-        sql = u'SELECT face_id, ST_PointOnSurface(' \
+        sql = u'SELECT face_id, mbr, ST_PointOnSurface(' \
               'topology.ST_GetFaceGeometry(%s,' \
               'face_id))::geometry(point, %s) as geom ' \
               'FROM %s.face WHERE face_id > 0' % \
               (quoteStr(toponame), toposrid, quoteId(toponame))
         uri.setDataSource('', u'(%s)' % sql, 'geom', '', 'face_id')
+        uri.setParam('bbox', 'mbr')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.Point)
         layerFaceSeed = QgsVectorLayer(uri.uri(False), u'%s.face_seed' % toponame, provider)
@@ -151,6 +153,7 @@ def run(item, action, mainwindow):
 
         # node
         uri.setDataSource(toponame, 'node', 'geom', '', 'node_id')
+        uri.removeParam('bbox')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.Point)
         layerNode = QgsVectorLayer(uri.uri(False), u'%s.node' % toponame, provider)
@@ -161,6 +164,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'node', 'geom', '', 'node_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.Point)
+        uri.removeParam('bbox')
         layerNodeLabel = QgsVectorLayer(uri.uri(False), u'%s.node_id' % toponame, provider)
         layerNodeLabel.setExtent(node_extent)
         layerNodeLabel.loadNamedStyle(os.path.join(template_dir, 'node_label.qml'))
@@ -171,6 +175,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerEdge = QgsVectorLayer(uri.uri(False), u'%s.edge' % toponame, provider)
         edge_extent = layerEdge.extent()
 
@@ -178,6 +183,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerDirectedEdge = QgsVectorLayer(uri.uri(False), u'%s.directed_edge' % toponame, provider)
         layerDirectedEdge.setExtent(edge_extent)
         layerDirectedEdge.loadNamedStyle(os.path.join(template_dir, 'edge.qml'))
@@ -186,6 +192,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerEdgeLabel = QgsVectorLayer(uri.uri(False), u'%s.edge_id' % toponame, provider)
         layerEdgeLabel.setExtent(edge_extent)
         layerEdgeLabel.loadNamedStyle(os.path.join(template_dir, 'edge_label.qml'))
@@ -194,6 +201,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerFaceLeft = QgsVectorLayer(uri.uri(False), u'%s.face_left' % toponame, provider)
         layerFaceLeft.setExtent(edge_extent)
         layerFaceLeft.loadNamedStyle(os.path.join(template_dir, 'face_left.qml'))
@@ -202,6 +210,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerFaceRight = QgsVectorLayer(uri.uri(False), u'%s.face_right' % toponame, provider)
         layerFaceRight.setExtent(edge_extent)
         layerFaceRight.loadNamedStyle(os.path.join(template_dir, 'face_right.qml'))
@@ -210,6 +219,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerNextLeft = QgsVectorLayer(uri.uri(False), u'%s.next_left' % toponame, provider)
         layerNextLeft.setExtent(edge_extent)
         layerNextLeft.loadNamedStyle(os.path.join(template_dir, 'next_left.qml'))
@@ -218,6 +228,7 @@ def run(item, action, mainwindow):
         uri.setDataSource(toponame, 'edge_data', 'geom', '', 'edge_id')
         uri.setSrid(toposrid)
         uri.setWkbType(QgsWkbTypes.LineString)
+        uri.removeParam('bbox')
         layerNextRight = QgsVectorLayer(uri.uri(False), u'%s.next_right' % toponame, provider)
         layerNextRight.setExtent(edge_extent)
         layerNextRight.loadNamedStyle(os.path.join(template_dir, 'next_right.qml'))

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -457,7 +457,7 @@ QString QgsPostgresFeatureIterator::whereClauseRect()
                         mSource->mSpatialColType == SctPcPatch;
 
   QString whereClause = QStringLiteral( "%1%2 && %3" )
-                        .arg( QgsPostgresConn::quotedIdentifier( mSource->mGeometryColumn ),
+                        .arg( QgsPostgresConn::quotedIdentifier( mSource->mBoundingBoxColumn ),
                               castToGeometry ? "::geometry" : "",
                               qBox );
 
@@ -857,6 +857,7 @@ void QgsPostgresFeatureIterator::getFeatureAttribute( int idx, QgsPostgresResult
 QgsPostgresFeatureSource::QgsPostgresFeatureSource( const QgsPostgresProvider *p )
   : mConnInfo( p->mUri.connectionInfo( false ) )
   , mGeometryColumn( p->mGeometryColumn )
+  , mBoundingBoxColumn( p->mBoundingBoxColumn )
   , mSqlWhereClause( p->filterWhereClause() )
   , mFields( p->mAttributeFields )
   , mSpatialColType( p->mSpatialColType )

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -39,6 +39,7 @@ class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
     QString mConnInfo;
 
     QString mGeometryColumn;
+    QString mBoundingBoxColumn;
     QString mSqlWhereClause;
     QgsFields mFields;
     QgsPostgresGeometryColumnType mSpatialColType;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -105,6 +105,11 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
   mSchemaName = mUri.schema();
   mTableName = mUri.table();
   mGeometryColumn = mUri.geometryColumn();
+  mBoundingBoxColumn = mUri.param( "bbox" );
+  if ( mBoundingBoxColumn.isEmpty() )
+  {
+    mBoundingBoxColumn = mGeometryColumn;
+  }
   mSqlWhereClause = mUri.sql();
   mRequestedSrid = mUri.srid();
   mRequestedGeomType = mUri.wkbType();

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -381,6 +381,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QString mPrimaryKeyDefault;
 
     QString mGeometryColumn;          //!< Name of the geometry column
+    QString mBoundingBoxColumn;       //!< Name of the bounding box column
     mutable QgsRectangle mLayerExtent;        //!< Rectangle that contains the extent (bounding box) of the layer
 
     QgsWkbTypes::Type mDetectedGeomType = QgsWkbTypes::Unknown ;  //!< Geometry type detected in the database

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1376,6 +1376,25 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(vl.featureCount(), 4000)
         print("--- %s seconds ---" % (time.time() - start_time))
 
+    def testFilterOnCustomBbox(self):
+        extent = QgsRectangle(-68, 70, -67, 80)
+        request = QgsFeatureRequest().setFilterRect(extent)
+        dbconn = 'dbname=\'qgis_test\''
+        uri = '%s srid=4326 key="pk" sslmode=disable table="qgis_test"."some_poly_data_shift_bbox" (geom)' % (dbconn)
+
+        def _test(vl, ids):
+            values = {feat['pk']: 'x' for feat in vl.getFeatures(request)}
+            expected = {x: 'x' for x in ids}
+            self.assertEqual(values, expected)
+
+        vl = QgsVectorLayer(uri, "testgeom", "postgres")
+        self.assertTrue(vl.isValid())
+        _test(vl, [2, 3])
+
+        vl = QgsVectorLayer(uri + ' bbox=shiftbox', "testgeom", "postgres")
+        self.assertTrue(vl.isValid())
+        _test(vl, [1, 3])
+
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -638,3 +638,18 @@ INSERT INTO qgis_test.geometries_table VALUES
 CREATE VIEW qgis_test.geometries_view AS (SELECT * FROM qgis_test.geometries_table);
 
 CREATE TABLE qgis_test.geometryless_table (name VARCHAR, value INTEGER);
+
+---------------------------------------------
+--
+-- View with separate bbox field
+--
+
+CREATE VIEW qgis_test.some_poly_data_shift_bbox AS
+ SELECT pk,
+        geom,
+        ST_Translate(
+          ST_Envelope(geom),
+          ST_XMax(ST_Envelope(geom)) - ST_XMin(ST_Envelope(geom)),
+          0.0
+        ) AS shiftbox
+   FROM qgis_test.some_poly_data;

--- a/tests/testdata/provider/testdata_pg_raster.sql
+++ b/tests/testdata/provider/testdata_pg_raster.sql
@@ -1,5 +1,16 @@
 -- Table: qgis_test.raster1
 
+DO $$
+BEGIN
+  IF EXISTS ( SELECT * FROM pg_catalog.pg_available_extensions
+              WHERE name = 'postgis_raster' )
+  THEN
+    RAISE NOTICE 'Loading postgis_raster';
+    CREATE EXTENSION IF NOT EXISTS postgis_raster;
+  END IF;
+END;
+$$;
+
 CREATE TABLE qgis_test."Raster1"
 (
   pk serial NOT NULL,


### PR DESCRIPTION
.. and use it from TopoViewer DBManager plugin

Closes #18107



- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment