### PR TITLE
Add a context menu to the QgsMessageLogViewer's tab bar...

### DIFF
--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -21,6 +21,7 @@
 #include "qgsguiutils.h"
 #include "qgsmessagelog.h"
 
+#include <QMenu>
 #include <QString>
 #include "qgis_gui.h"
 #include "qgis_sip.h"
@@ -56,11 +57,13 @@ class GUI_EXPORT QgsMessageLogViewer: public QDialog, private Ui::QgsMessageLogV
     bool eventFilter( QObject *obj, QEvent *ev ) override;
 
   private slots:
+    void showContextMenuForTabBar( QPoint point );
     void closeTab( int index );
 
   private:
 
     QString mClickedAnchor;
+    QMenu *mTabBarContextMenu = nullptr;
 };
 
 #endif


### PR DESCRIPTION
…so all unwanted tabs can be closed at once. Because it's not easy to debug stuff if your plugins tend to reopen 10+ tabs ;)

![Zrzut_20190828_215349](https://user-images.githubusercontent.com/1000043/63888486-51df7600-c9df-11e9-97fc-bfb36f97f262.png)



## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
