### PR TITLE
Allow expression geometry creation functions to use array inputs

### DIFF
--- a/resources/function_help/json/collect_geometries
+++ b/resources/function_help/json/collect_geometries
@@ -1,0 +1,19 @@
+{
+  "name": "collect_geometries",
+  "type": "function",
+  "description": "Collects a set of geometries into a multi-part geometry object.",
+  "variants": [
+  { "variant": "List of arguments variant",
+      "variant_description": "Geometry parts are specified as seperate arguments to the function.",
+      "variableLenArguments": true,
+      "arguments": [ {"arg":"geometry1", "syntaxOnly": true},
+                 {"arg":"geometry2", "syntaxOnly": true},
+                 {"arg":"geometry", "descOnly": true, "description":"a geometry"}],
+      "examples": [ { "expression":"geom_to_wkt(collect_geometries(make_point(1,2), make_point(3,4), make_point(5,6)))", "returns":"'MultiPoint ((1 2),(3 4),(5 6))'"} ] },
+      {
+      "variant": "Array variant",
+      "variant_description": "Geometry parts are specified as an array of geometry parts.",
+      "arguments": [ {"arg":"array","description":"array of geometry objects"}],
+      "examples": [ { "expression":"geom_to_wkt(collect_geometries(array(make_point(1,2), make_point(3,4), make_point(5,6))))", "returns":"'MultiPoint ((1 2),(3 4),(5 6))'"} ]
+  }]
+}

--- a/resources/function_help/json/make_line
+++ b/resources/function_help/json/make_line
@@ -2,12 +2,22 @@
   "name": "make_line",
   "type": "function",
   "description": "Creates a line geometry from a series of point geometries.",
-  "variableLenArguments": true,
-  "arguments": [
+  "variants": [
+   { "variant": "List of arguments variant",
+     "variant_description": "Line vertices are specified as seperate arguments to the function.",
+     "variableLenArguments": true,
+     "arguments": [
 	{"arg":"point1", "syntaxOnly": true},
 	{"arg":"point2", "syntaxOnly": true},
-	{"arg":"point", "descOnly": true, "description":"a point geometry"}],
+	{"arg":"point", "descOnly": true, "description":"a point geometry (or array of points)"}],
   "examples": [ { "expression":"geom_to_wkt(make_line(make_point(2,4),make_point(3,5)))", "returns":"'LineString (2 4, 3 5)'"},
     { "expression":"geom_to_wkt(make_line(make_point(2,4),make_point(3,5),make_point(9,7)))", "returns":"'LineString (2 4, 3 5, 9 7)'"}
-    ]
+    ]},
+      {
+      "variant": "Array variant",
+      "variant_description": "Line vertices are specified as an array of points.",
+      "arguments": [ {"arg":"array","description":"array of points"}],
+      "examples": [ { "expression":"geom_to_wkt(make_line(array(make_point(2,4),make_point(3,5),make_point(9,7))))", "returns":"'LineString (2 4, 3 5, 9 7)'"} ]
+  }]
+
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -976,6 +976,14 @@ class TestQgsExpression: public QObject
       QTest::newRow( "is_closed multiline" ) << "is_closed(geom_from_wkt('MultiLineString ((6501338.13976828 4850981.51459331, 6501343.09036573 4850984.01453377, 6501338.13976828 4850988.96491092, 6501335.63971657 4850984.01453377, 6501338.13976828 4850981.51459331))'))" << false << QVariant( true );
       QTest::newRow( "is_closed multiline" ) << "is_closed(geom_from_wkt('MultiLineString ((6501338.13976828 4850981.51459331, 6501343.09036573 4850984.01453377, 6501338.13976828 4850988.96491092, 6501335.63971657 4850984.01453377, 6501438.13976828 4850981.51459331))'))" << false << QVariant( false );
       QTest::newRow( "is_closed multiline" ) << "is_closed(geom_from_wkt('MultiLineString EMPTY'))" << false << QVariant();
+      QTest::newRow( "collect_geometries none" ) << "geom_to_wkt(collect_geometries())" << false << QVariant( "" );
+      QTest::newRow( "collect_geometries not" ) << "geom_to_wkt(collect_geometries(45))" << true << QVariant();
+      QTest::newRow( "collect_geometries one" ) << "geom_to_wkt(collect_geometries(make_point(4,5)))" << false << QVariant( "MultiPoint ((4 5))" );
+      QTest::newRow( "collect_geometries two" ) << "geom_to_wkt(collect_geometries(make_point(4,5), make_point(6,7)))" << false << QVariant( "MultiPoint ((4 5),(6 7))" );
+      QTest::newRow( "collect_geometries mixed" ) << "geom_to_wkt(collect_geometries(make_point(4,5), 'x'))" << true << QVariant();
+      QTest::newRow( "collect_geometries array empty" ) << "geom_to_wkt(collect_geometries(array()))" << false << QVariant( "" );
+      QTest::newRow( "collect_geometries array one" ) << "geom_to_wkt(collect_geometries(array(make_point(4,5))))" << false << QVariant( "MultiPoint ((4 5))" );
+      QTest::newRow( "collect_geometries array two" ) << "geom_to_wkt(collect_geometries(array(make_point(4,5), make_point(6,7))))" << false << QVariant( "MultiPoint ((4 5),(6 7))" );
       QTest::newRow( "make_point" ) << "geom_to_wkt(make_point(2.2,4.4))" << false << QVariant( "Point (2.2 4.4)" );
       QTest::newRow( "make_point z" ) << "geom_to_wkt(make_point(2.2,4.4,5.5))" << false << QVariant( "PointZ (2.2 4.4 5.5)" );
       QTest::newRow( "make_point zm" ) << "geom_to_wkt(make_point(2.2,4.4,5.5,6.6))" << false << QVariant( "PointZM (2.2 4.4 5.5 6.6)" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -994,6 +994,11 @@ class TestQgsExpression: public QObject
       QTest::newRow( "make_line" ) << "geom_to_wkt(make_line(make_point(2,4),make_point(4,6)))" << false << QVariant( "LineString (2 4, 4 6)" );
       QTest::newRow( "make_line" ) << "geom_to_wkt(make_line(make_point(2,4),make_point(4,6),make_point(7,9)))" << false << QVariant( "LineString (2 4, 4 6, 7 9)" );
       QTest::newRow( "make_line" ) << "geom_to_wkt(make_line(make_point(2,4,1,3),make_point(4,6,9,8),make_point(7,9,3,4)))" << false << QVariant( "LineStringZM (2 4 1 3, 4 6 9 8, 7 9 3 4)" );
+      QTest::newRow( "make_line array" ) << "geom_to_wkt(make_line(array(make_point(2,4),make_point(4,6))))" << false << QVariant( "LineString (2 4, 4 6)" );
+      QTest::newRow( "make_line one" ) << "geom_to_wkt(make_line(array(make_point(2,4))))" << false << QVariant();
+      QTest::newRow( "make_line array mixed" ) << "geom_to_wkt(make_line(array(make_point(2,4),make_point(4,6)),make_point(8,9)))" << false << QVariant( "LineString (2 4, 4 6, 8 9)" );
+      QTest::newRow( "make_line array bad" ) << "geom_to_wkt(make_line(array(make_point(2,4),66)))" << true << QVariant();
+      QTest::newRow( "make_line array empty" ) << "geom_to_wkt(make_line(array()))" << false << QVariant();
       QTest::newRow( "make_polygon bad" ) << "make_polygon(make_point(2,4))" << false << QVariant();
       QTest::newRow( "make_polygon" ) << "geom_to_wkt(make_polygon(geom_from_wkt('LINESTRING( 0 0, 0 1, 1 1, 1 0, 0 0 )')))" << false << QVariant( "Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))" );
       QTest::newRow( "make_polygon rings" ) << "geom_to_wkt(make_polygon(geom_from_wkt('LINESTRING( 0 0, 0 1, 1 1, 1 0, 0 0 )'),geom_from_wkt('LINESTRING( 0.1 0.1, 0.1 0.2, 0.2 0.2, 0.2 0.1, 0.1 0.1 )'),geom_from_wkt('LINESTRING( 0.8 0.8, 0.8 0.9, 0.9 0.9, 0.9 0.8, 0.8 0.8 )')))" << false


### PR DESCRIPTION
Adds a new expression function "collect_geometries"

Collects a set of geometries into a multi-part geometry object.
Geometry parts can either be specified as seperate arguments to the
function, or (more flexibly), as an array of geometry parts.

This allows geometries to be generated using iterator based approaches,
such as transforming an array generated using generate_series, e.g:

  collect_geometries(
    array_foreach(
      generate_series( 0, 330, 30),
      project($geometry, .2, radians(@element))
    )
  )

Gives a nice radial effect of points surrounding the central feature point when used as a MultiPoint geometry generator:

![image](https://user-images.githubusercontent.com/1829991/63907352-6ca4ff80-ca5e-11e9-9b18-82a1618e1eba.png)


Also, adds a make_line expression function variant which accepts an array of points. Allows creation of lines from variable numbers of points, and from sequences from aggregates/dynamically generated sequences:

![image](https://user-images.githubusercontent.com/1829991/63907376-85adb080-ca5e-11e9-8879-b5f72b5dc4ff.png)

