### PR TITLE
[make check] Use xvfb with screen number 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,8 +466,8 @@ CONFIGURE_FILE(
   "${CMAKE_SOURCE_DIR}/cmake_templates/CTestCustom.cmake.in"
   "${CMAKE_BINARY_DIR}/CTestCustom.cmake"
   IMMEDIATE @ONLY)
-# For server side testing we have no X, we can use xfvb as a fake x
-# sudo apt-get install xfvb
+# For server side testing we have no X, we can use xvfb as a fake x
+# sudo apt-get install xvfb
 add_custom_target(check COMMAND xvfb-run --server-args=-screen\ 10\ 1024x768x24 ctest --output-on-failure)
 ENDIF(ENABLE_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ CONFIGURE_FILE(
   IMMEDIATE @ONLY)
 # For server side testing we have no X, we can use xvfb as a fake x
 # sudo apt-get install xvfb
-add_custom_target(check COMMAND xvfb-run --server-args=-screen\ 10\ 1024x768x24 ctest --output-on-failure)
+add_custom_target(check COMMAND xvfb-run --server-args=-screen\ 0\ 1024x768x24 ctest --output-on-failure)
 ENDIF(ENABLE_TESTS)
 
 IF (WITH_CORE)

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,7 @@ machine does not have an X server.  In that case you need to run the test under
 `xvfb-run`.  For example:
 
 ```
-    xvfb-run --server-args=-screen\ 10\ 1024x768x24 ctest -V -R PyQgsServerWMSGetMap
+    xvfb-run --server-args=-screen\ 0\ 1024x768x24 ctest -V -R PyQgsServerWMSGetMap
 ```
 
 # Advanced configuration

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ Make sure that you have enabled building of tests in CMake.
 # Run tests
 
 You can run all tests using `make check`.
-Note you will need `xvfb-run` for that (sudo apt-get install xfvb).
+Note you will need `xvfb-run` for that (sudo apt-get install xvfb).
 
 Individual tests can be run using `ctest`.
 


### PR DESCRIPTION
This fixes make check for me, and it is already what debian/rules uses
(and scripts/jenkins-run.sh)

Closes #31473