### PR TITLE
correct acres abbreviation to "ac"

### DIFF
--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -694,7 +694,7 @@ QString QgsUnitTypes::toAbbreviatedString( QgsUnitTypes::AreaUnit unit )
     case AreaHectares:
       return QObject::tr( "ha", "area" );
     case AreaAcres:
-      return QObject::tr( "ac²", "area" );
+      return QObject::tr( "ac", "area" );
     case AreaSquareNauticalMiles:
       return QObject::tr( "NM²", "area" );
     case AreaSquareDegrees:


### PR DESCRIPTION
## Description

This is just a trivial change to correct the abbreviation for acres that appears in the "identify results" panel.  Acres is already an area unit, so there is no need for the superscript 2.
