### PR TITLE
Revert "Moves MapTip away from the mouse cursor (revision)"

### DIFF
--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -146,18 +146,8 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   QgsDebugMsg( tipHtml );
 
-  int cursorOffset = 0;
-  // attempt to shift the tip away from the cursor.
-  if ( QgsApplication::instance() )
-  {
-    // The following calculations are taken
-    // from QgsApplication::getThemeCursor, and are used to calculate the correct cursor size
-    // for both hi-dpi and non-hi-dpi screens.
-    double scale = Qgis::UI_SCALE_FACTOR * QgsApplication::instance()->fontMetrics().height() / 32.0;
-    cursorOffset = static_cast< int >( std::ceil( scale * 32 ) );
-  }
-
-  mWidget->move( pixelPosition.x() + cursorOffset, pixelPosition.y() );
+  mWidget->move( pixelPosition.x() + Qgis::UI_SCALE_FACTOR * 15,
+                 pixelPosition.y() );
 
   mWebView->setHtml( tipHtml );
   lastTipText = tipText;

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -146,7 +146,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   QgsDebugMsg( tipHtml );
 
-  mWidget->move( pixelPosition.x() + 20,
+  mWidget->move( pixelPosition.x(),
                  pixelPosition.y() );
 
   mWebView->setHtml( tipHtml );

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -146,7 +146,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   QgsDebugMsg( tipHtml );
 
-  mWidget->move( pixelPosition.x() + Qgis::UI_SCALE_FACTOR * 15,
+  mWidget->move( pixelPosition.x() + 20,
                  pixelPosition.y() );
 
   mWebView->setHtml( tipHtml );


### PR DESCRIPTION
Reverts qgis/QGIS#30976

The improvement in the Maptip causes problems #31311 when the user tries to click hyperlinks in the Map tip. The workaround for the map tips being covered by the cursor is far easier than the needed workaround to be able to click the hyperlinks.