### PR TITLE
Show message when stack trace can't be generated from  missing symbols

### DIFF
--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -26,8 +26,8 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
   setupUi( this );
   setWindowTitle( tr( "Oh Uh!" ) );
 
-  mCrashHeaderMessage->setText( tr( ":( QGIS Crashed" ) );
-  mCrashMessage->setText( tr( "Sorry. It looks something unexpected happened that we didn't handle and QGIS crashed." ) );
+  mCrashHeaderMessage->setText( tr( "QGIS unexpectedly ended" ) );
+  mCrashMessage->setText( tr( "Sorry :( It looks something unexpected happened that we didn't handle and QGIS ended unexpectedly." ) );
   connect( mReloadQGISButton, &QPushButton::clicked, this, &QgsCrashDialog::reloadQGIS );
   connect( mCopyReportButton, &QPushButton::clicked, this, &QgsCrashDialog::createBugReport );
   mCopyReportButton->setEnabled( false );

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -34,10 +34,10 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
   mCrashMessage->setText( tr( "Sorry :( It looks something unexpected happened that we didn't handle and QGIS ended unexpectedly."
                               "<br><br>" )
                           +  tr( "Keen to help us fix bugs? "
-                                 "<a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\">Follow the steps to help our developers.</a>"
+                                 "<a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\">Follow the steps to help our developers</a>."
                                  "<br><br>"
                                  "You can also send us a helpful bug report using the Copy Report button <br>and opening a ticket at "
-                                 "<a href=\"https://github.com/qgis/QGIS/issues\">QGIS Issue Tracker</a>" ) );
+                                 "<a href=\"https://github.com/qgis/QGIS/issues\">QGIS Issue Tracker</a>." ) );
   mCrashMessage->setTextInteractionFlags( Qt::TextBrowserInteraction );
   mCrashMessage->setOpenExternalLinks( true );
 

--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -27,18 +27,19 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
   setWindowTitle( tr( "Oh Uh!" ) );
 
   mCrashHeaderMessage->setText( tr( "QGIS unexpectedly ended" ) );
-  mCrashMessage->setText( tr( "Sorry :( It looks something unexpected happened that we didn't handle and QGIS ended unexpectedly." ) );
   connect( mReloadQGISButton, &QPushButton::clicked, this, &QgsCrashDialog::reloadQGIS );
   connect( mCopyReportButton, &QPushButton::clicked, this, &QgsCrashDialog::createBugReport );
   mCopyReportButton->setEnabled( false );
 
-  mHelpLabel->setText( tr( "Keen to help us fix bugs? "
-                           "<a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\">Follow the steps to help our developers.</a>"
-                           "<br><br>"
-                           "You can also send us a helpful bug report using the Copy Report button <br>and opening a ticket at "
-                           "<a href=\"https://github.com/qgis/QGIS/issues\">QGIS Issue Tracker</a>" ) );
-  mHelpLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
-  mHelpLabel->setOpenExternalLinks( true );
+  mCrashMessage->setText( tr( "Sorry :( It looks something unexpected happened that we didn't handle and QGIS ended unexpectedly."
+                              "<br><br>" )
+                          +  tr( "Keen to help us fix bugs? "
+                                 "<a href=\"http://qgis.org/en/site/getinvolved/development/bugreporting.html#bugs-features-and-issues\">Follow the steps to help our developers.</a>"
+                                 "<br><br>"
+                                 "You can also send us a helpful bug report using the Copy Report button <br>and opening a ticket at "
+                                 "<a href=\"https://github.com/qgis/QGIS/issues\">QGIS Issue Tracker</a>" ) );
+  mCrashMessage->setTextInteractionFlags( Qt::TextBrowserInteraction );
+  mCrashMessage->setOpenExternalLinks( true );
 
 }
 

--- a/src/crashhandler/qgscrashdialog.ui
+++ b/src/crashhandler/qgscrashdialog.ui
@@ -596,13 +596,10 @@
         <font>
          <family>MS Shell Dlg 2</family>
          <pointsize>30</pointsize>
-         <weight>9</weight>
+         <weight>50</weight>
          <italic>false</italic>
          <bold>false</bold>
         </font>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">font: 75 30pt &quot;MS Shell Dlg 2&quot;;</string>
        </property>
        <property name="text">
         <string>Header</string>
@@ -622,22 +619,6 @@
        </property>
        <property name="text">
         <string>Message</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="mHelpLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Help Message</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>

--- a/src/crashhandler/qgscrashdialog.ui
+++ b/src/crashhandler/qgscrashdialog.ui
@@ -522,7 +522,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tell us something about when you got the crash.&lt;/p&gt;&lt;p&gt;Include as much info as you can as well as steps to reproduce the issue if possible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tell us something about when you got the crash.&lt;/p&gt;&lt;p&gt;Include as much information as you can as well as steps to reproduce the issue if possible.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/src/crashhandler/qgscrashdialog.ui
+++ b/src/crashhandler/qgscrashdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>707</width>
-    <height>560</height>
+    <width>645</width>
+    <height>565</height>
    </rect>
   </property>
   <property name="palette">
@@ -473,23 +473,23 @@
       </item>
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
+        <item row="1" column="2">
+         <widget class="QTextEdit" name="mReportDetailsText">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text">
-           <string>Tell us something about when you got the crash</string>
+          <property name="verticalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOn</enum>
           </property>
-          <property name="wordWrap">
+          <property name="readOnly">
            <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item row="0" column="2">
          <widget class="QLabel" name="label_3">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -505,40 +505,50 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QPlainTextEdit" name="mUserFeedbackText">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+        <item row="0" column="0" rowspan="2">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
           </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
+          <property name="topMargin">
+           <number>0</number>
           </property>
-          <property name="horizontalScrollBarPolicy">
-           <enum>Qt::ScrollBarAsNeeded</enum>
-          </property>
-          <property name="placeholderText">
-           <string>Tell us something about when you got the crash</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QTextEdit" name="mReportDetailsText">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="verticalScrollBarPolicy">
-           <enum>Qt::ScrollBarAlwaysOn</enum>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tell us something about when you got the crash.&lt;/p&gt;&lt;p&gt;Include as much info as you can as well as steps to reproduce the issue if possible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPlainTextEdit" name="mUserFeedbackText">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOn</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAsNeeded</enum>
+            </property>
+            <property name="placeholderText">
+             <string>Tell us something about when you got the crash</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -610,20 +620,27 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="mCrashMessage">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>4</number>
        </property>
-       <property name="text">
-        <string>Message</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
+       <item>
+        <widget class="QLabel" name="mCrashMessage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Message</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <spacer name="verticalSpacer_3">

--- a/src/crashhandler/qgscrashreport.cpp
+++ b/src/crashhandler/qgscrashreport.cpp
@@ -56,6 +56,10 @@ const QString QgsCrashReport::toHtml() const
     {
       reportData.append( QStringLiteral( "Stack trace could not be generated." ) );
     }
+    else if ( mStackTrace->symbolsLoaded )
+    {
+      reportData.append( QStringLiteral( "Stack trace could not be generated due to missing symbols." ) );
+    }
     else
     {
       reportData.append( QStringLiteral( "<pre>" ) );


### PR DESCRIPTION
Updates to the crash handler to not show the stack trace when the symbols can't be loaded. When symbols aren't loaded the stack trace is pretty much useless and misleading meaning people think it's caused by something it really isn't.

Other tweaks in this PR include:

- Fixing the wording to move from "Crashed" to "unexpectedly ended" as it's less aggressive 
- Fixed spacing in the message wording
- Added some more help text


![image](https://user-images.githubusercontent.com/381660/64075535-e9550980-ccfc-11e9-8be3-a0bbd7dbc51b.png)

In future, I would like to make this dialog also fetch the symbols in the background if they are not found but that is out of scope for this PR.

Should also hopefully be good for a backport into 3.4