### PR TITLE
Raster widgets, improve invalid layer handling

### DIFF
--- a/src/gui/raster/qgsrasterminmaxwidget.cpp
+++ b/src/gui/raster/qgsrasterminmaxwidget.cpp
@@ -183,6 +183,8 @@ QgsRasterMinMaxOrigin QgsRasterMinMaxWidget::minMaxOrigin()
 void QgsRasterMinMaxWidget::doComputations()
 {
   QgsDebugMsg( QStringLiteral( "Entered." ) );
+  if ( !mLayer->dataProvider() )
+    return;
 
   QgsRectangle myExtent = extent(); // empty == full
   int mySampleSize = sampleSize(); // 0 == exact

--- a/src/gui/raster/qgsrasterminmaxwidget.cpp
+++ b/src/gui/raster/qgsrasterminmaxwidget.cpp
@@ -99,7 +99,6 @@ void QgsRasterMinMaxWidget::setFromMinMaxOrigin( const QgsRasterMinMaxOrigin &mi
   switch ( minMaxOrigin.limits() )
   {
     case QgsRasterMinMaxOrigin::None:
-    default:
       mUserDefinedRadioButton->setChecked( true );
       break;
 
@@ -118,7 +117,6 @@ void QgsRasterMinMaxWidget::setFromMinMaxOrigin( const QgsRasterMinMaxOrigin &mi
 
   switch ( minMaxOrigin.extent() )
   {
-    default:
     case QgsRasterMinMaxOrigin::WholeRaster:
       mStatisticsExtentCombo->setCurrentIndex( IDX_WHOLE_RASTER );
       break;

--- a/tests/src/python/test_qgsrasterbandcombobox.py
+++ b/tests/src/python/test_qgsrasterbandcombobox.py
@@ -107,6 +107,14 @@ class TestQgsRasterBandComboBox(unittest.TestCase):
         self.assertEqual(combo.currentBand(), -1)
         self.assertEqual(len(signal_spy), 6)
 
+        combo.setLayer(layer)
+        combo.setCurrentText('bad')
+        self.assertEqual(combo.currentBand(), -1)
+        combo.setCurrentText('5')
+        self.assertEqual(combo.currentBand(), 5)
+        combo.setCurrentText('6.5')
+        self.assertEqual(combo.currentBand(), -1)
+
     def testOneBandRaster(self):
         path = os.path.join(unitTestDataPath('raster'),
                             'band1_float32_noct_epsg4326.tif')

--- a/tests/src/python/test_qgsrasterbandcombobox.py
+++ b/tests/src/python/test_qgsrasterbandcombobox.py
@@ -33,14 +33,79 @@ class TestQgsRasterBandComboBox(unittest.TestCase):
         combo = QgsRasterBandComboBox()
         self.assertFalse(combo.layer())
         self.assertEqual(combo.currentBand(), -1)
+        self.assertTrue(combo.isEditable())
 
         combo.setShowNotSetOption(True)
         self.assertEqual(combo.currentBand(), -1)
+        self.assertTrue(combo.isEditable())
 
         combo.setBand(11111)
-        self.assertEqual(combo.currentBand(), -1)
+        self.assertEqual(combo.currentBand(), 11111)
         combo.setBand(-11111)
         self.assertEqual(combo.currentBand(), -1)
+
+    def testInvalidLayer(self):
+        layer = QgsRasterLayer('blah', 'blah')
+        self.assertTrue(layer)
+        self.assertFalse(layer.isValid())
+        combo = QgsRasterBandComboBox()
+        combo.setLayer(layer)
+        self.assertEqual(combo.count(), 0)
+        self.assertTrue(combo.isEditable())
+
+        signal_spy = QSignalSpy(combo.bandChanged)
+        combo.setBand(11111)
+        self.assertEqual(len(signal_spy), 1)
+        self.assertEqual(signal_spy[-1][0], 11111)
+        self.assertEqual(combo.currentBand(), 11111)
+        combo.setBand(-11111)
+        self.assertEqual(combo.currentBand(), -1)
+        self.assertEqual(len(signal_spy), 2)
+        self.assertEqual(signal_spy[-1][0], -1)
+
+        # replace with valid layer
+        path = os.path.join(unitTestDataPath('raster'),
+                            'band3_float32_noct_epsg4326.tif')
+        info = QFileInfo(path)
+        base_name = info.baseName()
+        layer2 = QgsRasterLayer(path, base_name)
+        self.assertTrue(layer2.isValid())
+
+        combo.setBand(2)
+        self.assertEqual(combo.currentBand(), 2)
+        self.assertEqual(len(signal_spy), 3)
+        self.assertEqual(signal_spy[-1][0], 2)
+        combo.setLayer(layer2)
+        self.assertEqual(combo.count(), 3)
+        self.assertFalse(combo.isEditable())
+        self.assertEqual(combo.currentBand(), 2)
+        self.assertEqual(len(signal_spy), 3)
+
+        # back to invalid
+        combo.setLayer(layer)
+        self.assertEqual(combo.count(), 0)
+        self.assertTrue(combo.isEditable())
+        self.assertEqual(combo.currentBand(), 2)
+        self.assertEqual(len(signal_spy), 3)
+
+        # with not set option
+        combo.setShowNotSetOption(True)
+        combo.setBand(-1)
+        self.assertEqual(combo.currentBand(), -1)
+        self.assertEqual(len(signal_spy), 4)
+        self.assertEqual(signal_spy[-1][0], -1)
+        combo.setBand(3)
+        self.assertEqual(combo.currentBand(), 3)
+        self.assertEqual(len(signal_spy), 5)
+        self.assertEqual(signal_spy[-1][0], 3)
+        combo.setBand(-1)
+        self.assertEqual(combo.currentBand(), -1)
+        self.assertEqual(len(signal_spy), 6)
+        self.assertEqual(signal_spy[-1][0], -1)
+
+        combo.setLayer(layer2)
+        self.assertEqual(combo.currentBand(), -1)
+        self.assertEqual(len(signal_spy), 6)
 
     def testOneBandRaster(self):
         path = os.path.join(unitTestDataPath('raster'),


### PR DESCRIPTION
Improves the behavior of some raster widgets with invalid layer sources, avoiding loss of styling information if things are tweaked while the source is invalid....