### PR TITLE
Added batch_number variable in algorithm scope

### DIFF
--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -218,7 +218,7 @@ class BatchPanelFillWidget(QToolButton):
             alg_scope.setVariable(k, v, True)
 
         # add batchCount in the alg scope to be used in the expressions. 0 is only an example value
-        alg_scope.setVariable('row_number', 0, True)
+        alg_scope.setVariable('row_number', 0, False)
 
         expression_context.appendScope(alg_scope)
 
@@ -257,7 +257,7 @@ class BatchPanelFillWidget(QToolButton):
                     alg_scope.setVariable(k, v, True)
 
                 # add batch row number as evaluable variable in algorithm scope
-                alg_scope.setVariable('row_number', row, True)
+                alg_scope.setVariable('row_number', row, False)
 
                 expression_context.appendScope(alg_scope)
 

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -218,7 +218,7 @@ class BatchPanelFillWidget(QToolButton):
             alg_scope.setVariable(k, v, True)
 
         # add batchCount in the alg scope to be used in the expressions. 0 is only an example value
-        alg_scope.setVariable('batch_number', 0, True)
+        alg_scope.setVariable('row_number', 0, True)
 
         expression_context.appendScope(alg_scope)
 
@@ -257,7 +257,7 @@ class BatchPanelFillWidget(QToolButton):
                     alg_scope.setVariable(k, v, True)
 
                 # add batch row number as evaluable variable in algorithm scope
-                alg_scope.setVariable('batch_number', row, True)
+                alg_scope.setVariable('row_number', row, True)
 
                 expression_context.appendScope(alg_scope)
 

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -217,6 +217,9 @@ class BatchPanelFillWidget(QToolButton):
         for k, v in params.items():
             alg_scope.setVariable(k, v, True)
 
+        # add batchCount in the alg scope to be used in the expressions. 0 is only an example value
+        alg_scope.setVariable('batch_number', 0, True)
+
         expression_context.appendScope(alg_scope)
 
         # mark the parameter variables as highlighted for discoverability
@@ -252,6 +255,9 @@ class BatchPanelFillWidget(QToolButton):
 
                 for k, v in params.items():
                     alg_scope.setVariable(k, v, True)
+
+                # add batch row number as evaluable variable in algorithm scope
+                alg_scope.setVariable('batch_number', row, True)
 
                 expression_context.appendScope(alg_scope)
 


### PR DESCRIPTION
Added batch_number variable in algorithm scope to allow use it in the expression editor in Processing batch context.

In some condition, auto generation of filename with automatic numbering is not the expected one and a more complex filename format is necessary

Not sure if it's a bugfix or new feature

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
