### PR TITLE
Add _QGIS_VERSION_INT and _QGIS_VERSION #defines to qgsconfig.h

### DIFF
--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -8,6 +8,7 @@
 // <int>.<int>.<int>-<any text>.
 // or else upgrading old project file will not work
 // reliably.
+// TODO QGIS 4: remove in favor of _QGIS_VERSION
 #define VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
 #define _QGIS_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
 
@@ -17,6 +18,7 @@
 //As a short term fix I (Tim) am defining the version in top level cmake. It would be good to
 //reinstate this more generic approach below at some point though
 //#define VERSION_INT ${CPACK_PACKAGE_VERSION_MAJOR}${CPACK_PACKAGE_VERSION_MINOR}${CPACK_PACKAGE_VERSION_PATCH}
+// TODO QGIS 4: Remove in favor of _QGIS_VERSION_INT
 #define VERSION_INT ${QGIS_VERSION_INT}
 #define _QGIS_VERSION_INT ${QGIS_VERSION_INT}
 #define ABISYM(x) x ## ${QGIS_VERSION_INT}

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -9,7 +9,7 @@
 // or else upgrading old project file will not work
 // reliably.
 #define VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
-#define QGIS_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
+#define _QGIS_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
 
 //used in vim src/core/qgis.cpp
 //The way below should work but it resolves to a number like 0110 which the compiler treats as octal I think

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -18,7 +18,7 @@
 //reinstate this more generic approach below at some point though
 //#define VERSION_INT ${CPACK_PACKAGE_VERSION_MAJOR}${CPACK_PACKAGE_VERSION_MINOR}${CPACK_PACKAGE_VERSION_PATCH}
 #define VERSION_INT ${QGIS_VERSION_INT}
-#define QGIS_VERSION_INT ${QGIS_VERSION_INT}
+#define _QGIS_VERSION_INT ${QGIS_VERSION_INT}
 #define ABISYM(x) x ## ${QGIS_VERSION_INT}
 //used in main.cpp and anywhere else where the release name is needed
 #define RELEASE_NAME "${RELEASE_NAME}"

--- a/cmake_templates/qgsconfig.h.in
+++ b/cmake_templates/qgsconfig.h.in
@@ -9,6 +9,7 @@
 // or else upgrading old project file will not work
 // reliably.
 #define VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
+#define QGIS_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}-${RELEASE_NAME}"
 
 //used in vim src/core/qgis.cpp
 //The way below should work but it resolves to a number like 0110 which the compiler treats as octal I think
@@ -17,6 +18,7 @@
 //reinstate this more generic approach below at some point though
 //#define VERSION_INT ${CPACK_PACKAGE_VERSION_MAJOR}${CPACK_PACKAGE_VERSION_MINOR}${CPACK_PACKAGE_VERSION_PATCH}
 #define VERSION_INT ${QGIS_VERSION_INT}
+#define QGIS_VERSION_INT ${QGIS_VERSION_INT}
 #define ABISYM(x) x ## ${QGIS_VERSION_INT}
 //used in main.cpp and anywhere else where the release name is needed
 #define RELEASE_NAME "${RELEASE_NAME}"


### PR DESCRIPTION
Because having VERSION_INT and VERSION in public headers is just screaming for conflicts.

Those defines should be removed in QGIS 4