### PR TITLE
Allow setting layout map item extent to an existing bookmark

### DIFF
--- a/src/app/layout/qgslayoutmapwidget.h
+++ b/src/app/layout/qgslayoutmapwidget.h
@@ -27,6 +27,7 @@ class QgsMapLayer;
 class QgsLayoutItemMap;
 class QgsLayoutItemMapOverview;
 class QgsLayoutMapLabelingWidget;
+class QgsBookmarkManagerProxyModel;
 
 /**
  * \ingroup app
@@ -124,12 +125,15 @@ class QgsLayoutMapWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLayoutM
     void overviewSymbolChanged();
     void showLabelSettings();
     void switchToMoveContentTool();
+    void aboutToShowBookmarkMenu();
 
   private:
     QPointer< QgsLayoutItemMap > mMapItem;
     QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;
     QgsLayoutDesignerInterface *mInterface = nullptr;
     QPointer< QgsLayoutMapLabelingWidget > mLabelWidget;
+    QMenu *mBookmarkMenu = nullptr;
+    QgsBookmarkManagerProxyModel *mBookmarkModel = nullptr;
 
     //! Sets extent of composer map from line edits
     void updateComposerExtentFromGui();

--- a/src/core/qgsbookmarkmodel.cpp
+++ b/src/core/qgsbookmarkmodel.cpp
@@ -230,10 +230,14 @@ bool QgsBookmarkManagerModel::removeRows( int row, int count, const QModelIndex 
 {
   beginRemoveRows( parent, row, row + count );
 
-  QList< QgsBookmark > bookmarks = mManager->bookmarks();
+  QList< QgsBookmark > appBookmarks = mManager->bookmarks();
+  QList< QgsBookmark > projectBookmarks = mProjectManager->bookmarks();
   for ( int r = row + count - 1; r >= row; --r )
   {
-    mManager->removeBookmark( bookmarks.at( r ).id() );
+    if ( r >= appBookmarks.count() )
+      mProjectManager->removeBookmark( projectBookmarks.at( r - appBookmarks.size() ).id() );
+    else
+      mManager->removeBookmark( appBookmarks.at( r ).id() );
   }
   endRemoveRows();
   return true;

--- a/tests/src/python/test_qgsbookmarkmodel.py
+++ b/tests/src/python/test_qgsbookmarkmodel.py
@@ -235,6 +235,14 @@ class TestQgsBookmarkManagerModel(unittest.TestCase):
         self.assertEqual([b.name() for b in app_manager.bookmarks()], ['new name', 'new name 2'])
         self.assertFalse(model.setData(model.index(1, 7), Qt.Unchecked, Qt.CheckStateRole))
 
+        # remove rows
+        model.removeRows(0, 1)
+        self.assertEqual([b.name() for b in project_manager.bookmarks()], ['b2'])
+        self.assertEqual([b.name() for b in app_manager.bookmarks()], ['new name 2'])
+        model.removeRows(0, 2)
+        self.assertEqual([b.name() for b in project_manager.bookmarks()], [])
+        self.assertEqual([b.name() for b in app_manager.bookmarks()], [])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This new button in the map item properties toolbar shows a menu which allows directly setting a map item to the extent of that bookmark.

Fixes #20279
![bookmarks](https://user-images.githubusercontent.com/1829991/64226402-9eb4d680-cf22-11e9-90d4-428aa40242f9.gif)
