### PR TITLE
More bookmark browser functionality

### DIFF
--- a/python/gui/auto_generated/qgsbrowserguimodel.sip.in
+++ b/python/gui/auto_generated/qgsbrowserguimodel.sip.in
@@ -41,6 +41,7 @@ Constructor for QgsBrowserGuiModel, with the specified ``parent`` object.
 
      virtual bool dropMimeData( const QMimeData *data, Qt::DropAction action,
                        int row, int column, const QModelIndex &parent );
+    virtual bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole );
 
     void setMessageBar( QgsMessageBar *bar );
 %Docstring

--- a/python/gui/auto_generated/qgscustomdrophandler.sip.in
+++ b/python/gui/auto_generated/qgscustomdrophandler.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsCustomDropHandler : QObject
 {
 %Docstring
@@ -123,6 +124,49 @@ The base class implementation does nothing.
 This method is not called directly while drop handling is occurring,
 so the limitations described in handleMimeData() about returning
 quickly do not apply.
+%End
+
+    virtual bool canHandleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &uri, QgsMapCanvas *canvas );
+%Docstring
+Returns ``True`` if the handler is capable of handling the provided mime ``uri``
+when dropped onto a map ``canvas``.
+
+The base class implementation returns ``False`` regardless of mime data.
+
+This method is called when mime data is dragged over a map canvas, in order
+to determine whether any handlers are capable of handling the data and to
+determine whether the drag action should be accepted.
+
+.. warning::
+
+   Subclasses should be very careful about implementing this. If they
+   incorrectly return ``True`` to a ``uri``, it will prevent the default application
+   drop handling from occurring and will break the ability to drag and drop layers
+   and files onto QGIS.
+
+.. versionadded:: 3.10
+%End
+
+    virtual bool handleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &uri, QgsMapCanvas *canvas ) const;
+%Docstring
+Called from QGIS after a drop event with custom ``uri`` known by the handler occurs
+onto a map ``canvas``.
+
+In order for handleCustomUriCanvasDrop() to be called, subclasses must
+also implement customUriProviderKey() to indicate the providerKey
+value which the handler accepts.
+
+If the function returns ``True``, it means the handler has accepted the drop
+and it should not be further processed (e.g. by other QgsCustomDropHandlers).
+
+Subclasses which implement this must also implement corresponding versions of
+canHandleCustomUriCanvasDrop().
+
+.. seealso:: :py:func:`customUriProviderKey`
+
+.. seealso:: :py:func:`canHandleCustomUriCanvasDrop`
+
+.. versionadded:: 3.10
 %End
 };
 

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -178,6 +178,17 @@ Returns the combined extent for all layers on the map canvas
 Sets the extent of the map canvas
 %End
 
+    bool setReferencedExtent( const QgsReferencedRectangle &extent ) throw( QgsCsException );
+%Docstring
+Sets the canvas to the specified ``extent``.
+
+:return: ``True`` if the zoom was successful.
+
+:raises QgsCsException: if a transformation error occurred.
+
+.. versionadded:: 3.10
+%End
+
     double rotation() const;
 %Docstring
 Gets the current map canvas rotation in clockwise degrees

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -719,6 +719,7 @@ for the canvas.
 .. versionadded:: 3.0
 %End
 
+
   public slots:
 
     void refresh();
@@ -983,74 +984,35 @@ The ``layer`` argument indicates the associated map layer, if available.
 
     virtual bool event( QEvent *e );
 
-%Docstring
-Overridden standard event to be gestures aware
-%End
-
     virtual void keyPressEvent( QKeyEvent *e );
-
-%Docstring
-Overridden key press event
-%End
 
     virtual void keyReleaseEvent( QKeyEvent *e );
 
-%Docstring
-Overridden key release event
-%End
-
     virtual void mouseDoubleClickEvent( QMouseEvent *e );
-
-%Docstring
-Overridden mouse double-click event
-%End
 
     virtual void mouseMoveEvent( QMouseEvent *e );
 
-%Docstring
-Overridden mouse move event
-%End
-
     virtual void mousePressEvent( QMouseEvent *e );
-
-%Docstring
-Overridden mouse press event
-%End
 
     virtual void mouseReleaseEvent( QMouseEvent *e );
 
-%Docstring
-Overridden mouse release event
-%End
-
     virtual void wheelEvent( QWheelEvent *e );
-
-%Docstring
-Overridden mouse wheel event
-%End
 
     virtual void resizeEvent( QResizeEvent *e );
 
-%Docstring
-Overridden resize event
-%End
-
     virtual void paintEvent( QPaintEvent *e );
-
-%Docstring
-Overridden paint event
-%End
 
     virtual void dragEnterEvent( QDragEnterEvent *e );
 
-%Docstring
-Overridden drag enter event
-%End
 
     void moveCanvasContents( bool reset = false );
 %Docstring
 called when panning is in action, reset indicates end of panning
 %End
+
+    virtual void dropEvent( QDropEvent *event );
+
+
 
 
 

--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -678,24 +678,15 @@ void QgsLayoutMapWidget::viewExtentInCanvas()
 
   if ( !currentMapExtent.isEmpty() )
   {
-    //transform?
-    if ( QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs()
-         != mMapItem->crs() )
+    try
     {
-      try
-      {
-        QgsCoordinateTransform xForm( mMapItem->crs(),
-                                      QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(), QgsProject::instance() );
-        currentMapExtent = xForm.transformBoundingBox( currentMapExtent );
-      }
-      catch ( QgsCsException & )
-      {
-        //transform failed, better not proceed
-        return;
-      }
+      QgisApp::instance()->mapCanvas()->setReferencedExtent( QgsReferencedRectangle( currentMapExtent, mMapItem->crs() ) );
     }
-
-    QgisApp::instance()->mapCanvas()->setExtent( currentMapExtent );
+    catch ( QgsCsException & )
+    {
+      //transform failed, better not proceed
+      return;
+    }
     QgisApp::instance()->mapCanvas()->refresh();
   }
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1066,6 +1066,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsProjectItemGuiProvider() );
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsFavoritesItemGuiProvider() );
   QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsLayerItemGuiProvider() );
+  QgsGui::instance()->dataItemGuiProviderRegistry()->addProvider( new QgsBookmarksItemGuiProvider() );
 
   QShortcut *showBrowserDock = new QShortcut( QKeySequence( tr( "Ctrl+2" ) ), this );
   connect( showBrowserDock, &QShortcut::activated, mBrowserWidget, &QgsDockWidget::toggleUserVisible );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1777,11 +1777,28 @@ void QgisApp::registerCustomDropHandler( QgsCustomDropHandler *handler )
 {
   if ( !mCustomDropHandlers.contains( handler ) )
     mCustomDropHandlers << handler;
+
+  const auto canvases = mapCanvases();
+  for ( QgsMapCanvas *canvas : canvases )
+  {
+    canvas->setCustomDropHandlers( mCustomDropHandlers );
+  }
 }
 
 void QgisApp::unregisterCustomDropHandler( QgsCustomDropHandler *handler )
 {
   mCustomDropHandlers.removeOne( handler );
+
+  const auto canvases = mapCanvases();
+  for ( QgsMapCanvas *canvas : canvases )
+  {
+    canvas->setCustomDropHandlers( mCustomDropHandlers );
+  }
+}
+
+QVector<QPointer<QgsCustomDropHandler> > QgisApp::customDropHandlers() const
+{
+  return mCustomDropHandlers;
 }
 
 void QgisApp::registerCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler )
@@ -3876,6 +3893,8 @@ QgsMapCanvasDockWidget *QgisApp::createNewMapCanvasDock( const QString &name )
     QgsMapCanvasAnnotationItem *canvasItem = new QgsMapCanvasAnnotationItem( annotation, mapCanvas );
     Q_UNUSED( canvasItem ) //item is already added automatically to canvas scene
   }
+
+  mapCanvas->setCustomDropHandlers( mCustomDropHandlers );
 
   markDirty();
   connect( mapCanvasWidget, &QgsMapCanvasDockWidget::closed, this, &QgisApp::markDirty );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1190,6 +1190,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
 
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsBookmarksDataItemProvider() );
+  registerCustomDropHandler( new QgsBookmarkDropHandler() );
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQlrDataItemProvider() );
   registerCustomDropHandler( new QgsQlrDropHandler() );
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQptDataItemProvider() );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -666,6 +666,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Unregister a previously registered custom drop handler.
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler );
 
+    //! Returns a list of registered custom drop handlers.
+    QVector<QPointer<QgsCustomDropHandler >> customDropHandlers() const;
+
     //! Register a new custom layout drop handler.
     void registerCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler );
 

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -572,9 +572,8 @@ int QgsBookmarksDataItemProvider::capabilities() const
   return QgsDataProvider::Database;
 }
 
-QgsDataItem *QgsBookmarksDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
+QgsDataItem *QgsBookmarksDataItemProvider::createDataItem( const QString &, QgsDataItem *parentItem )
 {
-  Q_UNUSED( path );
   return new QgsBookmarksItem( parentItem, QObject::tr( "Spatial Bookmarks" ), QgsApplication::bookmarkManager(), QgsProject::instance()->bookmarkManager() );
 }
 
@@ -636,7 +635,7 @@ QVector<QgsDataItem *> QgsBookmarkManagerItem::createChildren()
   {
     if ( group.isEmpty() )
     {
-      for ( const QgsBookmark bookmark : mManager->bookmarksByGroup( QString() ) )
+      for ( const QgsBookmark &bookmark : mManager->bookmarksByGroup( QString() ) )
       {
         children << new QgsBookmarkItem( this, bookmark.name(), bookmark );
       }
@@ -662,19 +661,21 @@ QgsBookmarkGroupItem::QgsBookmarkGroupItem( QgsDataItem *parent, const QString &
 QVector<QgsDataItem *> QgsBookmarkGroupItem::createChildren()
 {
   QVector<QgsDataItem *> children;
-  for ( const QgsBookmark bookmark : mManager->bookmarksByGroup( mName ) )
+  const QList< QgsBookmark > bookmarks = mManager->bookmarksByGroup( mName );
+  children.reserve( bookmarks.size() );
+  for ( const QgsBookmark &bookmark : bookmarks )
   {
     children << new QgsBookmarkItem( this, bookmark.name(), bookmark );
   }
   return children;
 }
 
-QgsBookmarkItem::QgsBookmarkItem( QgsDataItem *parent, const QString &name, QgsBookmark bookmark )
+QgsBookmarkItem::QgsBookmarkItem( QgsDataItem *parent, const QString &name, const QgsBookmark &bookmark )
   : QgsDataItem( Custom, parent, name, QStringLiteral( "bookmarks:%1/%2" ).arg( bookmark.group().toLower(), bookmark.id() ) )
+  , mBookmark( bookmark )
 {
   mType = Custom;
   mCapabilities = NoCapabilities;
-  mBookmark = bookmark;
   mIconName = QStringLiteral( "/mItemBookmark.svg" );
   setState( Populated ); // no more children
 }

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -682,7 +682,7 @@ QgsBookmarkItem::QgsBookmarkItem( QgsDataItem *parent, const QString &name, cons
   , mBookmark( bookmark )
 {
   mType = Custom;
-  mCapabilities = NoCapabilities;
+  mCapabilities = Rename;
   mIconName = QStringLiteral( "/mItemBookmark.svg" );
   setState( Populated ); // no more children
 }
@@ -846,6 +846,22 @@ bool QgsBookmarksItemGuiProvider::handleDoubleClick( QgsDataItem *item, QgsDataI
     // set the extent to the bookmark and refresh
     QgisApp::instance()->mapCanvas()->setExtent( canvasExtent );
     QgisApp::instance()->mapCanvas()->refresh();
+    return true;
+  }
+  return false;
+}
+
+bool QgsBookmarksItemGuiProvider::rename( QgsDataItem *item, const QString &name, QgsDataItemGuiContext context )
+{
+  if ( QgsBookmarkItem *bookmarkItem = qobject_cast< QgsBookmarkItem * >( item ) )
+  {
+    QgsBookmark bookmark = bookmarkItem->bookmark();
+    bookmark.setName( name );
+    if ( !bookmarkItem->manager()->updateBookmark( bookmark ) )
+    {
+      context.messageBar()->pushWarning( tr( "Rename Bookmark" ), tr( "Could not rename bookmark" ) );
+      return true;
+    }
     return true;
   }
   return false;

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -263,6 +263,9 @@ class QgsBookmarksItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     QString name() override;
     bool acceptDrop( QgsDataItem *item, QgsDataItemGuiContext context ) override;
     bool handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction action ) override;
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+    bool handleDoubleClick( QgsDataItem *item, QgsDataItemGuiContext context ) override;
 
 };
 
@@ -284,8 +287,6 @@ class APP_EXPORT QgsBookmarksItem : public QgsDataCollectionItem
 
     //! Icon for boomark manager container
     static QIcon iconBookmarks();
-
-    QList< QAction * > actions( QWidget *parent ) override;
 
     QVariant sortKey() const override;
 
@@ -360,12 +361,12 @@ class APP_EXPORT QgsBookmarkItem : public QgsDataItem
      */
     QgsBookmarkItem( QgsDataItem *parent, const QString &name, const QgsBookmark &bookmark, QgsBookmarkManager *manager );
     QgsBookmarkManager *manager() { return mManager; }
+    QgsBookmark bookmark() const { return mBookmark; }
 
     //! Icon for bookmark item
     static QIcon iconBookmark();
     bool hasDragEnabled() const override;
     QgsMimeDataUtils::Uri mimeUri() const override;
-    bool handleDoubleClick() override;
 
   private:
 

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -266,6 +266,7 @@ class QgsBookmarksItemGuiProvider : public QObject, public QgsDataItemGuiProvide
     void populateContextMenu( QgsDataItem *item, QMenu *menu,
                               const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
     bool handleDoubleClick( QgsDataItem *item, QgsDataItemGuiContext context ) override;
+    bool rename( QgsDataItem *item, const QString &name, QgsDataItemGuiContext context ) override;
 
 };
 

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -336,16 +336,31 @@ class APP_EXPORT QgsBookmarkItem : public QgsDataItem
     /**
      * Constructor for QgsBookmarkGroupItem.
      */
-    QgsBookmarkItem( QgsDataItem *parent, const QString &name, QgsBookmark bookmark );
+    QgsBookmarkItem( QgsDataItem *parent, const QString &name, const QgsBookmark &bookmark );
 
     //! Icon for bookmark item
     static QIcon iconBookmark();
-
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::Uri mimeUri() const override;
     bool handleDoubleClick() override;
 
   private:
 
     QgsBookmark mBookmark;
+};
+
+/**
+ * Handles drag and drop of bookmarks files to canvases.
+ */
+class QgsBookmarkDropHandler : public QgsCustomDropHandler
+{
+    Q_OBJECT
+
+  public:
+
+    QString customUriProviderKey() const override;
+    bool canHandleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &uri, QgsMapCanvas *canvas ) override;
+    bool handleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &uri, QgsMapCanvas *canvas ) const override;
 };
 
 #endif // QGSAPPBROWSERPROVIDERS_H

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -20,6 +20,7 @@
 #include "qgsdataitemprovider.h"
 #include "qgsdataprovider.h"
 #include "qgscustomdrophandler.h"
+#include "qgsdataitemguiprovider.h"
 
 /**
  * Custom data item for QLR files.
@@ -251,6 +252,21 @@ class APP_EXPORT QgsBookmarksDataItemProvider : public QgsDataItemProvider
     QgsDataItem *createDataItem( const QString &pathIn, QgsDataItem *parentItem ) override;
 };
 
+class QgsBookmarksItemGuiProvider : public QObject, public QgsDataItemGuiProvider
+{
+    Q_OBJECT
+
+  public:
+
+    QgsBookmarksItemGuiProvider() = default;
+
+    QString name() override;
+    bool acceptDrop( QgsDataItem *item, QgsDataItemGuiContext context ) override;
+    bool handleDrop( QgsDataItem *item, QgsDataItemGuiContext context, const QMimeData *data, Qt::DropAction action ) override;
+
+};
+
+
 /**
  * Contains content of user and project bookmark managers
 */
@@ -294,6 +310,8 @@ class APP_EXPORT QgsBookmarkManagerItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QgsBookmarkManager *manager() { return mManager; }
+
     //! Icon for bookmark manager
     static QIcon iconBookmarkManager();
 
@@ -317,12 +335,16 @@ class APP_EXPORT QgsBookmarkGroupItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QString group() const { return mGroup; }
+    QgsBookmarkManager *manager() { return mManager; }
+
     //! Icon for bookmark group
     static QIcon iconBookmarkGroup();
 
   private:
 
     QgsBookmarkManager *mManager = nullptr;
+    QString mGroup;
 };
 
 /**
@@ -336,7 +358,8 @@ class APP_EXPORT QgsBookmarkItem : public QgsDataItem
     /**
      * Constructor for QgsBookmarkGroupItem.
      */
-    QgsBookmarkItem( QgsDataItem *parent, const QString &name, const QgsBookmark &bookmark );
+    QgsBookmarkItem( QgsDataItem *parent, const QString &name, const QgsBookmark &bookmark, QgsBookmarkManager *manager );
+    QgsBookmarkManager *manager() { return mManager; }
 
     //! Icon for bookmark item
     static QIcon iconBookmark();
@@ -345,6 +368,8 @@ class APP_EXPORT QgsBookmarkItem : public QgsDataItem
     bool handleDoubleClick() override;
 
   private:
+
+    QgsBookmarkManager *mManager = nullptr;
 
     QgsBookmark mBookmark;
 };

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -171,30 +171,21 @@ void QgsBookmarks::zoomToBookmark()
 void QgsBookmarks::zoomToBookmarkIndex( const QModelIndex &index )
 {
   QgsReferencedRectangle rect = index.data( QgsBookmarkManagerModel::RoleExtent ).value< QgsReferencedRectangle >();
-  QgsRectangle canvasExtent = rect;
-  if ( rect.crs() != QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs() )
+  try
   {
-    QgsCoordinateTransform ct( rect.crs(),
-                               QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(), QgsProject::instance() );
-    try
+    if ( QgisApp::instance()->mapCanvas()->setReferencedExtent( rect ) )
     {
-      canvasExtent = ct.transform( rect );
+      QgisApp::instance()->mapCanvas()->refresh();
     }
-    catch ( QgsCsException & )
-    {
-      QgisApp::instance()->messageBar()->pushWarning( tr( "Zoom to Bookmark" ), tr( "Could not reproject bookmark extent to project CRS." ) );
-      return;
-    }
-    if ( canvasExtent.isEmpty() )
+    else
     {
       QgisApp::instance()->messageBar()->pushWarning( tr( "Zoom to Bookmark" ), tr( "Bookmark extent is empty" ) );
-      return;
     }
   }
-
-  // set the extent to the bookmark and refresh
-  QgisApp::instance()->mapCanvas()->setExtent( canvasExtent );
-  QgisApp::instance()->mapCanvas()->refresh();
+  catch ( QgsCsException & )
+  {
+    QgisApp::instance()->messageBar()->pushWarning( tr( "Zoom to Bookmark" ), tr( "Could not reproject bookmark extent to project CRS." ) );
+  }
 }
 
 void QgsBookmarks::importFromXml()

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -197,7 +197,7 @@ bool QgsGeoPackageItemGuiProvider::rename( QgsDataItem *item, const QString &new
     // Checks that name does not exist yet
     if ( layerItem->tableNames().contains( newName ) )
     {
-      return false;
+      return true;
     }
     // Check if the layer(s) are in the registry
     const QList<QgsMapLayer *> layersList( layerItem->layersInProject() );
@@ -206,7 +206,7 @@ bool QgsGeoPackageItemGuiProvider::rename( QgsDataItem *item, const QString &new
       if ( QMessageBox::question( nullptr, QObject::tr( "Rename Layer" ), QObject::tr( "The layer <b>%1</b> is loaded in the current project with name <b>%2</b>,"
                                   " do you want to remove it from the project and rename it?" ).arg( layerItem->name(), layersList.at( 0 )->name() ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
       {
-        return false;
+        return true;
       }
     }
     if ( ! layersList.isEmpty() )
@@ -229,7 +229,7 @@ bool QgsGeoPackageItemGuiProvider::rename( QgsDataItem *item, const QString &new
         if ( QMessageBox::question( nullptr, QObject::tr( "Rename Layer" ), QObject::tr( "The layer <b>%1</b> exists in the current project <b>%2</b>,"
                                     " do you want to remove it from the project and rename it?" ).arg( layerItem->name(), layersList.at( 0 )->name() ), QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
         {
-          return false;
+          return true;
         }
       }
       if ( ! layersList.isEmpty() )
@@ -267,9 +267,6 @@ bool QgsGeoPackageItemGuiProvider::rename( QgsDataItem *item, const QString &new
     return errCause.isEmpty();
   }
 
-  QMessageBox::warning( nullptr, QObject::tr( "Rename layer" ),
-                        QObject::tr( "The layer <b>%1</b> cannot be renamed because this feature is not yet implemented for this kind of layers." )
-                        .arg( item->name() ) );
   return false;
 }
 

--- a/src/gui/qgsbrowserguimodel.cpp
+++ b/src/gui/qgsbrowserguimodel.cpp
@@ -97,6 +97,40 @@ bool QgsBrowserGuiModel::dropMimeData( const QMimeData *data, Qt::DropAction act
   return false;
 }
 
+bool QgsBrowserGuiModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  QgsDataItem *item = dataItem( index );
+  if ( !item )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "RENAME PROBLEM!" ), 4 );
+    return false;
+  }
+
+  if ( !( item->capabilities2() & QgsDataItem::Rename ) )
+    return false;
+
+  switch ( role )
+  {
+    case Qt::EditRole:
+    {
+      // new support
+      const QList<QgsDataItemGuiProvider *> providers = QgsGui::dataItemGuiProviderRegistry()->providers();
+      for ( QgsDataItemGuiProvider *provider : providers )
+      {
+        if ( provider->rename( item, value.toString(), createDataItemContext() ) )
+        {
+          return true;
+        }
+      }
+
+      Q_NOWARN_DEPRECATED_PUSH
+      return item->rename( value.toString() );
+      Q_NOWARN_DEPRECATED_POP
+    }
+  }
+  return false;
+}
+
 void QgsBrowserGuiModel::setMessageBar( QgsMessageBar *bar )
 {
   mMessageBar = bar;

--- a/src/gui/qgsbrowserguimodel.h
+++ b/src/gui/qgsbrowserguimodel.h
@@ -52,7 +52,7 @@ class GUI_EXPORT QgsBrowserGuiModel : public QgsBrowserModel
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     bool dropMimeData( const QMimeData *data, Qt::DropAction action,
                        int row, int column, const QModelIndex &parent ) override;
-
+    bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
     //! Sets message bar that will be passed in QgsDataItemGuiContext to data items
     void setMessageBar( QgsMessageBar *bar );
 

--- a/src/gui/qgscustomdrophandler.cpp
+++ b/src/gui/qgscustomdrophandler.cpp
@@ -45,3 +45,13 @@ bool QgsCustomDropHandler::handleFileDrop( const QString &file )
   Q_UNUSED( file )
   return false;
 }
+
+bool QgsCustomDropHandler::canHandleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &, QgsMapCanvas * )
+{
+  return false;
+}
+
+bool QgsCustomDropHandler::handleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &, QgsMapCanvas * ) const
+{
+  return false;
+}

--- a/src/gui/qgscustomdrophandler.h
+++ b/src/gui/qgscustomdrophandler.h
@@ -19,6 +19,8 @@
 #include "qgsmimedatautils.h"
 #include "qgis_gui.h"
 
+class QgsMapCanvas;
+
 /**
  * \ingroup gui
  * Abstract base class that may be implemented to handle new types of data to be dropped in QGIS.
@@ -135,6 +137,45 @@ class GUI_EXPORT QgsCustomDropHandler : public QObject
      * quickly do not apply.
      */
     virtual bool handleFileDrop( const QString &file );
+
+    /**
+     * Returns TRUE if the handler is capable of handling the provided mime \a uri
+     * when dropped onto a map \a canvas.
+     *
+     * The base class implementation returns FALSE regardless of mime data.
+     *
+     * This method is called when mime data is dragged over a map canvas, in order
+     * to determine whether any handlers are capable of handling the data and to
+     * determine whether the drag action should be accepted.
+     *
+     * \warning Subclasses should be very careful about implementing this. If they
+     * incorrectly return TRUE to a \a uri, it will prevent the default application
+     * drop handling from occurring and will break the ability to drag and drop layers
+     * and files onto QGIS.
+     *
+     * \since QGIS 3.10
+     */
+    virtual bool canHandleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &uri, QgsMapCanvas *canvas );
+
+    /**
+     * Called from QGIS after a drop event with custom \a uri known by the handler occurs
+     * onto a map \a canvas.
+     *
+     * In order for handleCustomUriCanvasDrop() to be called, subclasses must
+     * also implement customUriProviderKey() to indicate the providerKey
+     * value which the handler accepts.
+     *
+     * If the function returns TRUE, it means the handler has accepted the drop
+     * and it should not be further processed (e.g. by other QgsCustomDropHandlers).
+     *
+     * Subclasses which implement this must also implement corresponding versions of
+     * canHandleCustomUriCanvasDrop().
+     *
+     * \see customUriProviderKey()
+     * \see canHandleCustomUriCanvasDrop()
+     * \since QGIS 3.10
+     */
+    virtual bool handleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &uri, QgsMapCanvas *canvas ) const;
 };
 
 #endif // QGSCUSTOMDROPHANDLER_H

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -73,6 +73,7 @@ email                : sherman at mrcc.com
 #include "qgsexpressioncontextutils.h"
 #include "qgsmimedatautils.h"
 #include "qgscustomdrophandler.h"
+#include "qgsreferencedgeometry.h"
 
 /**
  * \ingroup gui
@@ -877,7 +878,25 @@ void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
   // update controls' enabled state
   emit zoomLastStatusChanged( mLastExtentIndex > 0 );
   emit zoomNextStatusChanged( mLastExtentIndex < mLastExtent.size() - 1 );
-} // setExtent
+}
+
+bool QgsMapCanvas::setReferencedExtent( const QgsReferencedRectangle &extent )
+{
+  QgsRectangle canvasExtent = extent;
+  if ( extent.crs() != mapSettings().destinationCrs() )
+  {
+    QgsCoordinateTransform ct( extent.crs(), mapSettings().destinationCrs(), QgsProject::instance() );
+    canvasExtent = ct.transform( extent );
+
+    if ( canvasExtent.isEmpty() )
+    {
+      return false;
+    }
+  }
+
+  setExtent( canvasExtent );
+  return true;
+}
 
 void QgsMapCanvas::setCenter( const QgsPointXY &center )
 {

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -65,6 +65,7 @@ class QgsMapTool;
 class QgsSnappingUtils;
 class QgsRubberBand;
 class QgsMapCanvasAnnotationItem;
+class QgsReferencedRectangle;
 
 /**
  * \ingroup gui
@@ -208,6 +209,16 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Sets the extent of the map canvas
     void setExtent( const QgsRectangle &r, bool magnified = false );
+
+    /**
+     * Sets the canvas to the specified \a extent.
+     *
+     * \returns TRUE if the zoom was successful.
+     *
+     * \throws QgsCsException if a transformation error occurred.
+     * \since QGIS 3.10
+     */
+    bool setReferencedExtent( const QgsReferencedRectangle &extent ) SIP_THROW( QgsCsException );
 
     /**
      * Gets the current map canvas rotation in clockwise degrees

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -25,6 +25,7 @@
 #include "qgsrectangle.h"
 #include "qgsfeatureid.h"
 #include "qgsgeometry.h"
+#include "qgscustomdrophandler.h"
 
 #include <QDomDocument>
 #include <QGraphicsView>
@@ -639,6 +640,13 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     void setPreviewJobsEnabled( bool enabled );
 
+    /**
+     * Sets a list of custom drop \a handlers to use when drop events occur on the canvas.
+     * \note Not available in Python bindings
+     * \since QGIS 3.10
+     */
+    void setCustomDropHandlers( const QVector<QPointer<QgsCustomDropHandler >> &handlers ) SIP_SKIP;
+
   public slots:
 
     //! Repaints the canvas map
@@ -863,41 +871,23 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
   protected:
 
-    //! Overridden standard event to be gestures aware
     bool event( QEvent *e ) override;
-
-    //! Overridden key press event
     void keyPressEvent( QKeyEvent *e ) override;
-
-    //! Overridden key release event
     void keyReleaseEvent( QKeyEvent *e ) override;
-
-    //! Overridden mouse double-click event
     void mouseDoubleClickEvent( QMouseEvent *e ) override;
-
-    //! Overridden mouse move event
     void mouseMoveEvent( QMouseEvent *e ) override;
-
-    //! Overridden mouse press event
     void mousePressEvent( QMouseEvent *e ) override;
-
-    //! Overridden mouse release event
     void mouseReleaseEvent( QMouseEvent *e ) override;
-
-    //! Overridden mouse wheel event
     void wheelEvent( QWheelEvent *e ) override;
-
-    //! Overridden resize event
     void resizeEvent( QResizeEvent *e ) override;
-
-    //! Overridden paint event
     void paintEvent( QPaintEvent *e ) override;
-
-    //! Overridden drag enter event
     void dragEnterEvent( QDragEnterEvent *e ) override;
 
     //! called when panning is in action, reset indicates end of panning
     void moveCanvasContents( bool reset = false );
+
+    void dropEvent( QDropEvent *event ) override;
+
 
     /// implementation struct
     class CanvasProperties;
@@ -1028,6 +1018,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     bool mUsePreviewJobs = false;
 
     QHash< QString, int > mLastLayerRenderTime;
+
+    QVector<QPointer<QgsCustomDropHandler >> mDropHandlers;
 
     /**
      * Returns the last cursor position on the canvas in geographical coordinates

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -15,13 +15,14 @@
 
 #include "qgstest.h"
 
-#include <qgsapplication.h>
-#include <qgsmapcanvas.h>
-#include <qgsvectorlayer.h>
-#include <qgsproject.h>
-#include <qgsrenderchecker.h>
-#include <qgsvectordataprovider.h>
-#include <qgsmaptoolpan.h>
+#include "qgsapplication.h"
+#include "qgsmapcanvas.h"
+#include "qgsvectorlayer.h"
+#include "qgsproject.h"
+#include "qgsrenderchecker.h"
+#include "qgsvectordataprovider.h"
+#include "qgsmaptoolpan.h"
+#include "qgscustomdrophandler.h"
 
 namespace QTest
 {
@@ -57,6 +58,7 @@ class TestQgsMapCanvas : public QObject
     void testScaleLockCanvasResize();
     void testZoomByWheel();
     void testShiftZoom();
+    void testDragDrop();
 
   private:
     QgsMapCanvas *mCanvas = nullptr;
@@ -429,6 +431,75 @@ void TestQgsMapCanvas::testShiftZoom()
 
   QGSCOMPARENEAR( mCanvas->extent().width(), originalWidth, 0.00001 );
   QGSCOMPARENEAR( mCanvas->extent().height(), originalHeight, 0.00001 );
+}
+
+class TestNoDropHandler : public QgsCustomDropHandler
+{
+    Q_OBJECT
+
+  public:
+
+    QString customUriProviderKey() const override { return QStringLiteral( "test" ); }
+    bool canHandleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &, QgsMapCanvas * ) override { return false; }
+    bool handleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &, QgsMapCanvas * ) const override { return false; }
+};
+
+class TestYesDropHandler : public QgsCustomDropHandler
+{
+    Q_OBJECT
+
+  public:
+
+    QString customUriProviderKey() const override { return QStringLiteral( "test" ); }
+    bool canHandleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &, QgsMapCanvas * ) override { return true; }
+    bool handleCustomUriCanvasDrop( const QgsMimeDataUtils::Uri &, QgsMapCanvas * ) const override { return true; }
+};
+
+void TestQgsMapCanvas::testDragDrop()
+{
+  // default drag, should not be accepted
+  std::unique_ptr< QMimeData > data = qgis::make_unique< QMimeData >();
+  std::unique_ptr< QDragEnterEvent > event = qgis::make_unique< QDragEnterEvent >( QPoint( 10, 10 ), Qt::CopyAction, data.get(), Qt::LeftButton, Qt::NoModifier );
+  mCanvas->dragEnterEvent( event.get() );
+  QVERIFY( !event->isAccepted() );
+
+  // with mime data
+  QgsMimeDataUtils::UriList list;
+  QgsMimeDataUtils::Uri uri;
+  uri.name = QStringLiteral( "name" );
+  uri.providerKey = QStringLiteral( "test" );
+  list << uri;
+  data.reset( QgsMimeDataUtils::encodeUriList( list ) );
+  event = qgis::make_unique< QDragEnterEvent >( QPoint( 10, 10 ), Qt::CopyAction, data.get(), Qt::LeftButton, Qt::NoModifier );
+  mCanvas->dragEnterEvent( event.get() );
+  // still not accepted by default
+  QVERIFY( !event->isAccepted() );
+
+  // add a custom drop handler to the canvas
+  TestNoDropHandler handler;
+  mCanvas->setCustomDropHandlers( QVector< QPointer< QgsCustomDropHandler > >() << &handler );
+  mCanvas->dragEnterEvent( event.get() );
+  // not accepted by handler
+  QVERIFY( !event->isAccepted() );
+
+  TestYesDropHandler handler2;
+  mCanvas->setCustomDropHandlers( QVector< QPointer< QgsCustomDropHandler > >() << &handler << &handler2 );
+  mCanvas->dragEnterEvent( event.get() );
+  // IS accepted by handler
+  QVERIFY( event->isAccepted() );
+
+  // check drop event logic
+  mCanvas->setCustomDropHandlers( QVector< QPointer< QgsCustomDropHandler > >() );
+  std::unique_ptr< QDropEvent > dropEvent = qgis::make_unique< QDropEvent >( QPoint( 10, 10 ), Qt::CopyAction, data.get(), Qt::LeftButton, Qt::NoModifier );
+  mCanvas->dropEvent( dropEvent.get() );
+  QVERIFY( !dropEvent->isAccepted() );
+  mCanvas->setCustomDropHandlers( QVector< QPointer< QgsCustomDropHandler > >() << &handler );
+  mCanvas->dropEvent( dropEvent.get() );
+  QVERIFY( !dropEvent->isAccepted() );
+  mCanvas->setCustomDropHandlers( QVector< QPointer< QgsCustomDropHandler > >() << &handler << &handler2 );
+  mCanvas->dropEvent( dropEvent.get() );
+  // is accepted!
+  QVERIFY( dropEvent->isAccepted() );
 }
 
 QGSTEST_MAIN( TestQgsMapCanvas )

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -23,6 +23,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsmaptoolpan.h"
 #include "qgscustomdrophandler.h"
+#include "qgsreferencedgeometry.h"
 
 namespace QTest
 {
@@ -52,6 +53,7 @@ class TestQgsMapCanvas : public QObject
     void cleanupTestCase(); // will be called after the last testfunction was executed.
 
     void testPanByKeyboard();
+    void testSetExtent();
     void testMagnification();
     void testMagnificationExtent();
     void testMagnificationScale();
@@ -107,6 +109,16 @@ void TestQgsMapCanvas::testPanByKeyboard()
     }
     QVERIFY( mCanvas->extent() == originalExtent );
   }
+}
+
+void TestQgsMapCanvas::testSetExtent()
+{
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  QVERIFY( mCanvas->setReferencedExtent( QgsReferencedRectangle( QgsRectangle( 0, 0, 10, 10 ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ) ) );
+  QCOMPARE( mCanvas->extent().toString( 0 ), QStringLiteral( "-3,-3 : 13,13" ) );
+  QVERIFY( mCanvas->setReferencedExtent( QgsReferencedRectangle( QgsRectangle( 16259461, -2477192, 16391255, -2372535 ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) ) ) );
+  QCOMPARE( mCanvas->extent().toString( 0 ), QStringLiteral( "146,-22 : 147,-21" ) );
+  mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( ) );
 }
 
 void TestQgsMapCanvas::testMagnification()


### PR DESCRIPTION
Allows:
- drag and drop of bookmarks to canvases (useful in multi-canvas projects!)
- bookmarks can be copied by drag and drop in browser
- bookmarks can be renamed or deleted in browser

![Peek 2019-09-05 11-07](https://user-images.githubusercontent.com/1829991/64307091-5657f000-cfd8-11e9-86a5-1142e229eea6.gif)
