### PR TITLE
"Reselect Features" action in Edit -> Select menu

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2360,6 +2360,21 @@ Deselects features by their ID
 Clear selection
 
 .. seealso:: :py:func:`selectByIds`
+
+.. seealso:: :py:func:`reselect`
+%End
+
+    void reselect();
+%Docstring
+Reselects the previous set of selected features. This is only applicable
+after a prior call to removeSelection().
+
+Any other modifications to the selection following a call to removeSelection() clears
+memory of the previous selection and consequently calling reselect() has no impact.
+
+.. seealso:: :py:func:`removeSelection`
+
+.. versionadded:: 3.10
 %End
 
     virtual void updateExtents( bool force = false );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2181,6 +2181,21 @@ void QgisApp::createActions()
   connect( mActionSelectRadius, &QAction::triggered, this, &QgisApp::selectByRadius );
   connect( mActionDeselectAll, &QAction::triggered, this, &QgisApp::deselectAll );
   connect( mActionSelectAll, &QAction::triggered, this, &QgisApp::selectAll );
+  connect( mActionReselect, &QAction::triggered, this, [ = ]
+  {
+    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mMapCanvas->currentLayer() );
+    if ( !vlayer )
+    {
+      visibleMessageBar()->pushMessage(
+        tr( "No active vector layer" ),
+        tr( "To reselect features, choose a vector layer in the legend." ),
+        Qgis::Info,
+        messageTimeout() );
+      return;
+    }
+
+    vlayer->reselect();
+  } );
   connect( mActionInvertSelection, &QAction::triggered, this, &QgisApp::invertSelection );
   connect( mActionSelectByExpression, &QAction::triggered, this, &QgisApp::selectByExpression );
   connect( mActionSelectByForm, &QAction::triggered, this, &QgisApp::selectByForm );
@@ -2423,6 +2438,7 @@ void QgisApp::createActionGroups()
   mMapToolGroup->addAction( mActionSelectRadius );
   mMapToolGroup->addAction( mActionDeselectAll );
   mMapToolGroup->addAction( mActionSelectAll );
+  mMapToolGroup->addAction( mActionReselect );
   mMapToolGroup->addAction( mActionInvertSelection );
   mMapToolGroup->addAction( mActionMeasure );
   mMapToolGroup->addAction( mActionMeasureArea );
@@ -2746,6 +2762,7 @@ void QgisApp::createToolBars()
       break;
     case 3:
       defSelectionAction = mActionInvertSelection;
+      break;
       break;
   }
   bt->setDefaultAction( defSelectionAction );
@@ -12665,6 +12682,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
     mActionLabeling->setEnabled( false );
     mActionOpenTable->setEnabled( false );
     mActionSelectAll->setEnabled( false );
+    mActionReselect->setEnabled( false );
     mActionInvertSelection->setEnabled( false );
     mActionOpenFieldCalc->setEnabled( false );
     mActionToggleEditing->setEnabled( false );
@@ -12799,6 +12817,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionSelectByForm->setEnabled( true );
       mActionOpenTable->setEnabled( true );
       mActionSelectAll->setEnabled( true );
+      mActionReselect->setEnabled( true );
       mActionInvertSelection->setEnabled( true );
       mActionSaveLayerDefinition->setEnabled( true );
       mActionLayerSaveAs->setEnabled( true );
@@ -13028,6 +13047,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
       mActionSelectAll->setEnabled( false );
+      mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
       mActionSelectByExpression->setEnabled( false );
       mActionSelectByForm->setEnabled( false );
@@ -13116,6 +13136,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       mActionZoomToSelected->setEnabled( false );
       mActionOpenTable->setEnabled( false );
       mActionSelectAll->setEnabled( false );
+      mActionReselect->setEnabled( false );
       mActionInvertSelection->setEnabled( false );
       mActionSelectByExpression->setEnabled( false );
       mActionSelectByForm->setEnabled( false );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -378,6 +378,7 @@ void QgsVectorLayer::drawVertexMarker( double x, double y, QPainter &p, QgsVecto
 void QgsVectorLayer::select( QgsFeatureId fid )
 {
   mSelectedFeatureIds.insert( fid );
+  mPreviousSelectedFeatureIds.clear();
 
   emit selectionChanged( QgsFeatureIds() << fid, QgsFeatureIds(), false );
 }
@@ -385,6 +386,7 @@ void QgsVectorLayer::select( QgsFeatureId fid )
 void QgsVectorLayer::select( const QgsFeatureIds &featureIds )
 {
   mSelectedFeatureIds.unite( featureIds );
+  mPreviousSelectedFeatureIds.clear();
 
   emit selectionChanged( featureIds, QgsFeatureIds(), false );
 }
@@ -392,6 +394,7 @@ void QgsVectorLayer::select( const QgsFeatureIds &featureIds )
 void QgsVectorLayer::deselect( const QgsFeatureId fid )
 {
   mSelectedFeatureIds.remove( fid );
+  mPreviousSelectedFeatureIds.clear();
 
   emit selectionChanged( QgsFeatureIds(), QgsFeatureIds() << fid, false );
 }
@@ -399,6 +402,7 @@ void QgsVectorLayer::deselect( const QgsFeatureId fid )
 void QgsVectorLayer::deselect( const QgsFeatureIds &featureIds )
 {
   mSelectedFeatureIds.subtract( featureIds );
+  mPreviousSelectedFeatureIds.clear();
 
   emit selectionChanged( QgsFeatureIds(), featureIds, false );
 }
@@ -510,6 +514,7 @@ void QgsVectorLayer::selectByIds( const QgsFeatureIds &ids, QgsVectorLayer::Sele
 
   QgsFeatureIds deselectedFeatures = mSelectedFeatureIds - newSelection;
   mSelectedFeatureIds = newSelection;
+  mPreviousSelectedFeatureIds.clear();
 
   emit selectionChanged( newSelection, deselectedFeatures, true );
 }
@@ -524,6 +529,7 @@ void QgsVectorLayer::modifySelection( const QgsFeatureIds &selectIds, const QgsF
 
   mSelectedFeatureIds -= deselectIds;
   mSelectedFeatureIds += selectIds;
+  mPreviousSelectedFeatureIds.clear();
 
   emit selectionChanged( selectIds, deselectIds - intersectingIds, false );
 }
@@ -574,7 +580,17 @@ void QgsVectorLayer::removeSelection()
   if ( mSelectedFeatureIds.isEmpty() )
     return;
 
+  const QgsFeatureIds previous = mSelectedFeatureIds;
   selectByIds( QgsFeatureIds() );
+  mPreviousSelectedFeatureIds = previous;
+}
+
+void QgsVectorLayer::reselect()
+{
+  if ( mPreviousSelectedFeatureIds.isEmpty() || !mSelectedFeatureIds.empty() )
+    return;
+
+  selectByIds( mPreviousSelectedFeatureIds );
 }
 
 QgsVectorDataProvider *QgsVectorLayer::dataProvider()

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2193,8 +2193,21 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * Clear selection
      *
      * \see selectByIds()
+     * \see reselect()
      */
     void removeSelection();
+
+    /**
+     * Reselects the previous set of selected features. This is only applicable
+     * after a prior call to removeSelection().
+     *
+     * Any other modifications to the selection following a call to removeSelection() clears
+     * memory of the previous selection and consequently calling reselect() has no impact.
+     *
+     * \see removeSelection()
+     * \since QGIS 3.10
+     */
+    void reselect();
 
     /**
      * Update the extents for the layer. This is necessary if features are
@@ -2544,6 +2557,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
         it always needs to be removed from mSelectedFeatureIds as well.
      */
     QgsFeatureIds mSelectedFeatureIds;
+
+    /**
+     * Stores the previous set of selected features, to allow for "reselect" operations.
+     */
+    QgsFeatureIds mPreviousSelectedFeatureIds;
 
     //! Field map to commit
     QgsFields mFields;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -285,6 +285,7 @@
      <addaction name="mActionSelectByForm"/>
      <addaction name="mActionSelectByExpression"/>
      <addaction name="mActionDeselectAll"/>
+     <addaction name="mActionReselect"/>
      <addaction name="mActionSelectAll"/>
      <addaction name="mActionInvertSelection"/>
     </widget>
@@ -3229,6 +3230,14 @@ Acts on the currently active layer only.</string>
    <property name="toolTip">
     <string>Toggles Display of Unplaced Labels
 Shows placeholders for labels which could not be placed, e.g. due to overlaps with other map labels.</string>
+   </property>
+  </action>
+  <action name="mActionReselect">
+   <property name="text">
+    <string>Reselect Features</string>
+   </property>
+   <property name="toolTip">
+    <string>Reselect Features from Current Layer</string>
    </property>
   </action>
  </widget>

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -2126,6 +2126,54 @@ class TestQgsVectorLayer(unittest.TestCase, FeatureSourceTestCase):
         layer.selectByRect(QgsRectangle(-112, 30, -94, 45), QgsVectorLayer.RemoveFromSelection)
         self.assertEqual(set(layer.selectedFeatureIds()), set([]))
 
+    def testReselect(self):
+        layer = QgsVectorLayer(os.path.join(unitTestDataPath(), 'points.shp'), 'Points', 'ogr')
+
+        layer.selectByIds([1, 3, 5, 7], QgsVectorLayer.SetSelection)
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5, 7])
+
+        layer.reselect() # no effect, selection has not been cleared
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5, 7])
+
+        # clear selection
+        layer.removeSelection()
+        self.assertCountEqual(layer.selectedFeatureIds(), [])
+        # reselect should bring this back
+        layer.reselect()
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5, 7])
+        layer.reselect() # no change
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5, 7])
+
+        # change an existing selection
+        layer.selectByIds([1, 3, 5], QgsVectorLayer.SetSelection)
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5])
+        layer.reselect()  # no change
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5])
+
+        layer.removeSelection()
+        self.assertCountEqual(layer.selectedFeatureIds(), [])
+        # reselect should bring this back
+        layer.reselect()
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5])
+
+        layer.select(7)
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5, 7])
+        layer.reselect()
+        self.assertCountEqual(layer.selectedFeatureIds(), [1, 3, 5, 7])
+        layer.removeSelection()
+        layer.select([3, 5])
+        self.assertCountEqual(layer.selectedFeatureIds(), [3, 5])
+        layer.reselect()
+        self.assertCountEqual(layer.selectedFeatureIds(), [3, 5])
+        layer.deselect([5])
+        self.assertCountEqual(layer.selectedFeatureIds(), [3])
+        layer.reselect()
+        self.assertCountEqual(layer.selectedFeatureIds(), [3])
+        layer.modifySelection([5], [3])
+        self.assertCountEqual(layer.selectedFeatureIds(), [5])
+        layer.reselect()
+        self.assertCountEqual(layer.selectedFeatureIds(), [5])
+
     def testAggregate(self):
         """ Test aggregate calculation """
         layer = QgsVectorLayer("Point?field=fldint:integer", "layer", "memory")


### PR DESCRIPTION
Allows restoration of a layer's selection following a selection clear operation. Handy for anyone who has ever painstakingly built a custom selection only to accidently click and clear this selection...

![Peek 2019-09-05 13-53](https://user-images.githubusercontent.com/1829991/64310739-a8067780-cfe4-11e9-940a-a6044e9b2e63.gif)
