### PR TITLE
[ui] Make the show bookmarks action focus on browser panel's bookmark node

### DIFF
--- a/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -122,6 +122,10 @@ Sets filter case sensitivity
 %Docstring
 Apply filter to the model
 %End
+    void setActiveIndex( const QModelIndex &index );
+%Docstring
+Sets the selection to ``index`` and expand it
+%End
     void updateProjectHome();
 %Docstring
 Update project home directory

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -930,7 +930,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   connect( showBookmarksDock, &QShortcut::activated, mBookMarksDockWidget, &QgsDockWidget::toggleUserVisible );
   showBookmarksDock->setObjectName( QStringLiteral( "ShowBookmarksPanel" ) );
   showBookmarksDock->setWhatsThis( tr( "Show Bookmarks Panel" ) );
-  mBookMarksDockWidget->setToggleVisibilityAction( mActionShowBookmarks );
+  mBookMarksDockWidget->setToggleVisibilityAction( mActionShowBookmarkManager );
+
+  connect( mActionShowBookmarks, &QAction::triggered, this, [ = ] { showBookmarks(); } );
 
   endProfile();
 
@@ -3524,6 +3526,7 @@ void QgisApp::setTheme( const QString &themeName )
   mActionMeasureArea->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMeasureArea.svg" ) ) );
   mActionMeasureAngle->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMeasureAngle.svg" ) ) );
   mActionMapTips->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionMapTips.svg" ) ) );
+  mActionShowBookmarkManager->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionShowBookmarks.svg" ) ) );
   mActionShowBookmarks->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionShowBookmarks.svg" ) ) );
   mActionNewBookmark->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionNewBookmark.svg" ) ) );
   mActionCustomProjection->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCustomProjection.svg" ) ) );
@@ -13767,7 +13770,14 @@ void QgisApp::newBookmark( bool inProject )
   dlg->show();
 }
 
-void QgisApp::showBookmarks( bool show )
+void QgisApp::showBookmarks()
+{
+  mBrowserWidget->setUserVisible( true );
+  QModelIndex index = browserModel()->findPath( QStringLiteral( "bookmarks:" ) );
+  mBrowserWidget->setActiveIndex( index );
+}
+
+void QgisApp::showBookmarkManager( bool show )
 {
   mBookMarksDockWidget->setUserVisible( show );
 }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -479,6 +479,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionMapTips() { return mActionMapTips; }
     QAction *actionNewBookmark() { return mActionNewBookmark; }
     QAction *actionShowBookmarks() { return mActionShowBookmarks; }
+    QAction *actionShowBookmarkManager() { return mActionShowBookmarkManager; }
     QAction *actionDraw() { return mActionDraw; }
 
     QAction *actionDataSourceManager() { return mActionDataSourceManager; }
@@ -1070,8 +1071,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Create a new file from a template project
     bool fileNewFromTemplate( const QString &fileName );
 
-    //! Show the spatial bookmarks dialog
-    void showBookmarks( bool show );
+    //! Show the spatial bookmark manager panel
+    void showBookmarkManager( bool show );
+
+    //! Show and focus the browser panel to spatial bookmarks
+    void showBookmarks();
 
     //! Create a new spatial bookmark
     void newBookmark( bool inProject = false );

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -972,10 +972,10 @@ void QgsBookmarksItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu 
       QgisApp::instance()->newBookmark();
     } );
     menu->addAction( addBookmark );
-    QAction *showBookmarksPanel = new QAction( tr( "Show Spatial Bookmarks Panel" ), menu );
+    QAction *showBookmarksPanel = new QAction( tr( "Show Spatial Bookmarks Manager" ), menu );
     connect( showBookmarksPanel, &QAction::triggered, this, [ = ]
     {
-      QgisApp::instance()->showBookmarks( true );
+      QgisApp::instance()->showBookmarkManager( true );
     } );
     menu->addAction( showBookmarksPanel );
     menu->addSeparator();

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -588,6 +588,16 @@ void QgsBrowserDockWidget::enablePropertiesWidget( bool enable )
   }
 }
 
+void QgsBrowserDockWidget::setActiveIndex( const QModelIndex &index )
+{
+  if ( index.isValid() )
+  {
+    QModelIndex proxyIndex = mProxyModel->mapFromSource( index );
+    mBrowserView->expand( proxyIndex );
+    mBrowserView->setCurrentIndex( proxyIndex );
+  }
+}
+
 void QgsBrowserDockWidget::splitterMoved()
 {
   QList<int> sizes = mSplitter->sizes();

--- a/src/gui/qgsbrowserdockwidget.h
+++ b/src/gui/qgsbrowserdockwidget.h
@@ -127,6 +127,8 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
     void setCaseSensitive( bool caseSensitive );
     //! Apply filter to the model
     void setFilter();
+    //! Sets the selection to \a index and expand it
+    void setActiveIndex( const QModelIndex &index );
     //! Update project home directory
     void updateProjectHome();
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -144,6 +144,7 @@
     <addaction name="mActionMapTips"/>
     <addaction name="mActionNewBookmark"/>
     <addaction name="mActionShowBookmarks"/>
+    <addaction name="mActionShowBookmarkManager"/>
     <addaction name="mActionDraw"/>
     <addaction name="separator"/>
     <addaction name="mActionShowAllLayers"/>
@@ -1372,13 +1373,25 @@
      <normaloff>:/images/themes/default/mActionNewBookmark.svg</normaloff>:/images/themes/default/mActionNewBookmark.svg</iconset>
    </property>
    <property name="text">
-    <string>New Bookmark…</string>
+    <string>New Spatial Bookmark…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+B</string>
    </property>
   </action>
   <action name="mActionShowBookmarks">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionShowBookmarks.svg</normaloff>:/images/themes/default/mActionShowBookmarks.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show Spatial Bookmarks</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+B</string>
+   </property>
+  </action>
+  <action name="mActionShowBookmarkManager">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -1387,10 +1400,7 @@
      <normaloff>:/images/themes/default/mActionShowBookmarks.svg</normaloff>:/images/themes/default/mActionShowBookmarks.svg</iconset>
    </property>
    <property name="text">
-    <string>Show Bookmarks</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Shift+B</string>
+    <string>Show Spatial Bookmark Manager</string>
    </property>
   </action>
   <action name="mActionDraw">

--- a/src/ui/qgsbookmarksbase.ui
+++ b/src/ui/qgsbookmarksbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Spatial Bookmarks</string>
+   <string>Spatial Bookmark Manager</string>
   </property>
   <widget class="QWidget" name="bookmarksDockContents">
    <layout class="QGridLayout" name="gridLayout">


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR essentially marks the last milestone of the great bookmarks revamp (tm) by making the show bookmarks action raise the browser panel and focus on its bookmarks root node. It remains possible to open the bookmarks panel via show spatial bookmarks manager (in the main app menu and the browser bookmarks root node's right click menu)

@nyalldawson , all good?

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
