### PR TITLE
[ui] Add decoration icon in the spatial bookmark manager list view

### DIFF
--- a/src/core/qgsbookmarkmodel.cpp
+++ b/src/core/qgsbookmarkmodel.cpp
@@ -13,8 +13,11 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsapplication.h"
 #include "qgsbookmarkmodel.h"
 #include "qgsbookmarkmanager.h"
+
+#include <QIcon>
 
 QgsBookmarkManagerModel::QgsBookmarkManagerModel( QgsBookmarkManager *manager, QgsBookmarkManager *projectManager, QObject *parent )
   : QAbstractTableModel( parent )
@@ -62,6 +65,9 @@ QVariant QgsBookmarkManagerModel::data( const QModelIndex &index, int role ) con
 
     case RoleGroup:
       return b.group();
+
+    case Qt::DecorationRole:
+      return index.column() == ColumnName ? QgsApplication::getThemeIcon( QStringLiteral( "/mItemBookmark.svg" ) ) : QIcon();
 
     case Qt::DisplayRole:
     case Qt::EditRole:


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@nyalldawson , tiny tweak to make use of the bookmark item icon in the spatial bookmark manager panel:
![image](https://user-images.githubusercontent.com/1728657/64407745-4eb74a80-d0af-11e9-859c-88c8f33f0bfb.png)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
