### PR TITLE
Fix QGIS goes super-slow in certain circumstances

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -725,6 +725,15 @@ Returns the application's bookmark manager, used for storing installation-wide b
 .. versionadded:: 3.10
 %End
 
+    static QgsStyleModel *defaultStyleModel();
+%Docstring
+Returns a shared QgsStyleModel containing the default style library (see QgsStyle.defaultStyle()).
+
+Using this shared model instead of creating a new QgsStyleModel improves performance.
+
+.. versionadded:: 3.10
+%End
+
     static QgsMessageLog *messageLog();
 %Docstring
 Returns the application's message log.

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -13,7 +13,7 @@
 
 
 
-class QgsProject : QObject, QgsExpressionContextGenerator, QgsProjectTranslator
+class QgsProject : QObject, QgsExpressionContextGenerator, QgsExpressionContextScopeGenerator, QgsProjectTranslator
 {
 %Docstring
 Reads and writes project states.
@@ -663,6 +663,8 @@ Defines if default values should be evaluated on provider side when requested an
 %End
 
     virtual QgsExpressionContext createExpressionContext() const;
+
+    virtual QgsExpressionContextScope *createExpressionContextScope() const;
 
 
     QgsSnappingConfig snappingConfig() const;
@@ -1555,6 +1557,9 @@ This will block dirtying the specified ``project`` for the lifetime of this obje
   private:
     QgsProjectDirtyBlocker( const QgsProjectDirtyBlocker &other );
 };
+
+
+
 
 
 /************************************************************************

--- a/python/core/auto_generated/symbology/qgsstylemodel.sip.in
+++ b/python/core/auto_generated/symbology/qgsstylemodel.sip.in
@@ -16,6 +16,10 @@ class QgsStyleModel: QAbstractItemModel
 A QAbstractItemModel subclass for showing symbol and color ramp entities contained
 within a QgsStyle database.
 
+If you are creating a style model for the default application style (see QgsStyle.defaultStyle()),
+consider using the shared style model available at QgsApplication.defaultStyleModel() for performance
+instead.
+
 .. seealso:: :py:class:`QgsStyleProxyModel`
 
 .. versionadded:: 3.4
@@ -46,6 +50,13 @@ within a QgsStyle database.
 Constructor for QgsStyleModel, for the specified ``style`` and ``parent`` object.
 
 The ``style`` object must exist for the lifetime of this model.
+%End
+
+    QgsStyle *style();
+%Docstring
+Returns the style managed by the model.
+
+.. versionadded:: 3.10
 %End
 
     virtual QVariant data( const QModelIndex &index, int role ) const;
@@ -96,6 +107,13 @@ A QSortFilterProxyModel subclass for showing filtered symbol and color ramps ent
 Constructor for QgsStyleProxyModel, for the specified ``style`` and ``parent`` object.
 
 The ``style`` object must exist for the lifetime of this model.
+%End
+
+    explicit QgsStyleProxyModel( QgsStyleModel *model, QObject *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsStyleProxyModel, using the specified source ``model`` and ``parent`` object.
+
+The source ``model`` object must exist for the lifetime of this model.
 %End
 
     QString filterString() const;

--- a/python/core/auto_generated/symbology/qgssymbol.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbol.sip.in
@@ -272,7 +272,7 @@ layer.
 .. seealso:: :py:func:`setColor`
 %End
 
-    void drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext *customContext = 0, bool selected = false );
+    void drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext *customContext = 0, bool selected = false, const QgsExpressionContext *expressionContext = 0 );
 %Docstring
 Draws an icon of the symbol that occupies an area given by ``size`` using the specified ``painter``.
 
@@ -283,6 +283,7 @@ matches the settings from that context.
 :param size: size of the icon
 :param customContext: the context in which the rendering happens
 :param selected: set to ``True`` to render the symbol in a selected state
+:param expressionContext: optional custom expression context
 
 .. seealso:: :py:func:`exportImage`
 

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -211,7 +211,8 @@ Returns an icon preview for a color ramp.
 .. seealso:: :py:func:`symbolPreviewPixmap`
 %End
 
-    static QPixmap symbolPreviewPixmap( const QgsSymbol *symbol, QSize size, int padding = 0, QgsRenderContext *customContext = 0, bool selected = false );
+    static QPixmap symbolPreviewPixmap( const QgsSymbol *symbol, QSize size, int padding = 0, QgsRenderContext *customContext = 0, bool selected = false,
+                                        const QgsExpressionContext *expressionContext = 0 );
 %Docstring
 Returns a pixmap preview for a color ramp.
 
@@ -220,6 +221,7 @@ Returns a pixmap preview for a color ramp.
 :param padding: space between icon edge and symbol
 :param customContext: render context to use when rendering symbol
 :param selected: set to ``True`` to render the symbol in a selected state
+:param expressionContext: optional custom expression context
 
 .. note::
 
@@ -228,6 +230,10 @@ Returns a pixmap preview for a color ramp.
 .. note::
 
    Parameter selected added in QGIS 3.10
+
+.. note::
+
+   Parameter expressionContext added in QGIS 3.10
 
 .. seealso:: :py:func:`symbolPreviewIcon`
 %End

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -57,6 +57,7 @@
 #include "qgsvaliditycheckregistry.h"
 #include "qgsnewsfeedparser.h"
 #include "qgsbookmarkmanager.h"
+#include "qgsstylemodel.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -338,6 +339,7 @@ void QgsApplication::init( QString profileFolder )
   colorSchemeRegistry()->initStyleScheme();
 
   bookmarkManager()->initialize( QgsApplication::qgisSettingsDirPath() + "/bookmarks.xml" );
+  members()->mStyleModel = new QgsStyleModel( QgsStyle::defaultStyle() );
 
   ABISYM( mInitialized ) = true;
 }
@@ -1936,6 +1938,11 @@ QgsBookmarkManager *QgsApplication::bookmarkManager()
   return members()->mBookmarkManager;
 }
 
+QgsStyleModel *QgsApplication::defaultStyleModel()
+{
+  return members()->mStyleModel;
+}
+
 QgsMessageLog *QgsApplication::messageLog()
 {
   return members()->mMessageLog;
@@ -2005,6 +2012,7 @@ QgsApplication::ApplicationMembers::ApplicationMembers()
 
 QgsApplication::ApplicationMembers::~ApplicationMembers()
 {
+  delete mStyleModel;
   delete mValidityCheckRegistry;
   delete mActionScopeRegistry;
   delete m3DRendererRegistry;

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -54,6 +54,7 @@ class QgsValidityCheckRegistry;
 class QTranslator;
 class QgsCalloutRegistry;
 class QgsBookmarkManager;
+class QgsStyleModel;
 
 /**
  * \ingroup core
@@ -652,6 +653,15 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QgsBookmarkManager *bookmarkManager();
 
     /**
+     * Returns a shared QgsStyleModel containing the default style library (see QgsStyle::defaultStyle()).
+     *
+     * Using this shared model instead of creating a new QgsStyleModel improves performance.
+     *
+     * \since QGIS 3.10
+     */
+    static QgsStyleModel *defaultStyleModel();
+
+    /**
      * Returns the application's message log.
      * \since QGIS 3.0
      */
@@ -898,6 +908,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       QgsLayoutItemRegistry *mLayoutItemRegistry = nullptr;
       QgsUserProfileManager *mUserConfigManager = nullptr;
       QgsBookmarkManager *mBookmarkManager = nullptr;
+      QgsStyleModel *mStyleModel = nullptr;
       QString mNullRepresentation;
 
       ApplicationMembers();

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -1642,6 +1642,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * created based on file name.
      */
     QString mHomePath;
+    mutable QString mCachedHomePath;
+
     mutable QgsProjectPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
     bool mAutoTransaction = false;       // transaction grouped editing
     bool mEvaluateDefaultValues = false; // evaluate default values immediately

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -796,6 +796,11 @@ QgsStyleProxyModel::QgsStyleProxyModel( QgsStyle *style, QObject *parent )
   , mStyle( style )
 {
   mModel = new QgsStyleModel( mStyle, this );
+  initialize();
+}
+
+void QgsStyleProxyModel::initialize()
+{
   setSortCaseSensitivity( Qt::CaseInsensitive );
 //  setSortLocaleAware( true );
   setSourceModel( mModel );
@@ -838,6 +843,14 @@ QgsStyleProxyModel::QgsStyleProxyModel( QgsStyle *style, QObject *parent )
     if ( mSmartGroupId >= 0 )
       setSmartGroupId( mSmartGroupId );
   } );
+}
+
+QgsStyleProxyModel::QgsStyleProxyModel( QgsStyleModel *model, QObject *parent )
+  : QSortFilterProxyModel( parent )
+  , mModel( model )
+  , mStyle( model->style() )
+{
+  initialize();
 }
 
 bool QgsStyleProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
@@ -906,6 +919,7 @@ void QgsStyleProxyModel::setFilterString( const QString &filter )
   mFilterString = filter;
   invalidateFilter();
 }
+
 
 bool QgsStyleProxyModel::favoritesOnly() const
 {

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -20,6 +20,7 @@
 #include "qgssvgcache.h"
 #include "qgsimagecache.h"
 #include "qgsproject.h"
+#include "qgsexpressioncontextutils.h"
 #include <QIcon>
 
 const double ICON_PADDING_FACTOR = 0.16;
@@ -128,7 +129,7 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
                 {
                   int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * QFontMetrics( data( index, Qt::FontRole ).value< QFont >() ).width( 'X' ) * 23 );
                   int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
-                  QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( width, height ), height / 20 );
+                  QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( width, height ), height / 20, nullptr, false, mExpressionContext.get() );
                   QByteArray data;
                   QBuffer buffer( &data );
                   pm.save( &buffer, "PNG", 100 );
@@ -185,6 +186,17 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
     {
       // Generate icons at all additional sizes specified for the model.
       // This allows the model to have size responsive icons.
+
+      if ( !mExpressionContext )
+      {
+        // build the expression context once, and keep it around. Usually this is a no-no, but in this
+        // case we want to avoid creating potentially thousands of contexts one-by-one (usually one context
+        // is created for a batch of multiple evalutions like this), and we only use a very minimal context
+        // anyway...
+        mExpressionContext = qgis::make_unique< QgsExpressionContext >();
+        mExpressionContext->appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( nullptr ) );
+      }
+
       switch ( index.column() )
       {
         case Name:
@@ -201,12 +213,11 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               if ( symbol )
               {
                 if ( mAdditionalSizes.isEmpty() )
-                  icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( 24, 24 ), 1 ) );
+                  icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( 24, 24 ), 1, nullptr, false, mExpressionContext.get() ) );
 
-                for ( const QVariant &size : mAdditionalSizes )
+                for ( const QSize &s : mAdditionalSizes )
                 {
-                  QSize s = size.toSize();
-                  icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
+                  icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ), nullptr, false, mExpressionContext.get() ) );
                 }
 
               }
@@ -225,9 +236,8 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               {
                 if ( mAdditionalSizes.isEmpty() )
                   icon.addPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( ramp.get(), QSize( 24, 24 ), 1 ) );
-                for ( const QVariant &size : mAdditionalSizes )
+                for ( const QSize &s : mAdditionalSizes )
                 {
-                  QSize s = size.toSize();
                   icon.addPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( ramp.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
                 }
 
@@ -246,9 +256,8 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               const QgsTextFormat format( mStyle->textFormat( name ) );
               if ( mAdditionalSizes.isEmpty() )
                 icon.addPixmap( QgsTextFormat::textFormatPreviewPixmap( format, QSize( 24, 24 ), QString(),  1 ) );
-              for ( const QVariant &size : mAdditionalSizes )
+              for ( const QSize &s : mAdditionalSizes )
               {
-                QSize s = size.toSize();
                 icon.addPixmap( QgsTextFormat::textFormatPreviewPixmap( format, s, QString(),  static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
               }
               mTextFormatIconCache.insert( name, icon );
@@ -265,9 +274,8 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               const QgsPalLayerSettings settings( mStyle->labelSettings( name ) );
               if ( mAdditionalSizes.isEmpty() )
                 icon.addPixmap( QgsPalLayerSettings::labelSettingsPreviewPixmap( settings, QSize( 24, 24 ), QString(),  1 ) );
-              for ( const QVariant &size : mAdditionalSizes )
+              for ( const QSize &s : mAdditionalSizes )
               {
-                QSize s = size.toSize();
                 icon.addPixmap( QgsPalLayerSettings::labelSettingsPreviewPixmap( settings, s, QString(),  static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
               }
               mLabelSettingsIconCache.insert( name, icon );
@@ -773,6 +781,7 @@ void QgsStyleModel::onTagsChanged( int entity, const QString &name, const QStrin
 void QgsStyleModel::rebuildSymbolIcons()
 {
   mSymbolIconCache.clear();
+  mExpressionContext.reset();
   emit dataChanged( index( 0, 0 ), index( mSymbolNames.count() - 1, 0 ), QVector<int>() << Qt::DecorationRole );
 }
 

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -461,6 +461,9 @@ int QgsStyleModel::columnCount( const QModelIndex & ) const
 
 void QgsStyleModel::addDesiredIconSize( QSize size )
 {
+  if ( mAdditionalSizes.contains( size ) )
+    return;
+
   mAdditionalSizes << size;
   mSymbolIconCache.clear();
   mColorRampIconCache.clear();

--- a/src/core/symbology/qgsstylemodel.h
+++ b/src/core/symbology/qgsstylemodel.h
@@ -130,6 +130,7 @@ class CORE_EXPORT QgsStyleModel: public QAbstractItemModel
     QStringList mTextFormatNames;
     QStringList mLabelSettingsNames;
     QList< QSize > mAdditionalSizes;
+    mutable std::unique_ptr< QgsExpressionContext > mExpressionContext;
 
     mutable QHash< QString, QIcon > mSymbolIconCache;
     mutable QHash< QString, QIcon > mColorRampIconCache;

--- a/src/core/symbology/qgsstylemodel.h
+++ b/src/core/symbology/qgsstylemodel.h
@@ -34,6 +34,10 @@ class QgsSymbol;
  * A QAbstractItemModel subclass for showing symbol and color ramp entities contained
  * within a QgsStyle database.
  *
+ * If you are creating a style model for the default application style (see QgsStyle::defaultStyle()),
+ * consider using the shared style model available at QgsApplication::defaultStyleModel() for performance
+ * instead.
+ *
  * \see QgsStyleProxyModel
  *
  * \since QGIS 3.4
@@ -67,6 +71,13 @@ class CORE_EXPORT QgsStyleModel: public QAbstractItemModel
      * The \a style object must exist for the lifetime of this model.
      */
     explicit QgsStyleModel( QgsStyle *style, QObject *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns the style managed by the model.
+     *
+     * \since QGIS 3.10
+     */
+    QgsStyle *style() { return mStyle; }
 
     QVariant data( const QModelIndex &index, int role ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
@@ -151,6 +162,13 @@ class CORE_EXPORT QgsStyleProxyModel: public QSortFilterProxyModel
      * The \a style object must exist for the lifetime of this model.
      */
     explicit QgsStyleProxyModel( QgsStyle *style, QObject *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Constructor for QgsStyleProxyModel, using the specified source \a model and \a parent object.
+     *
+     * The source \a model object must exist for the lifetime of this model.
+     */
+    explicit QgsStyleProxyModel( QgsStyleModel *model, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * Returns the current filter string, if set.
@@ -336,6 +354,8 @@ class CORE_EXPORT QgsStyleProxyModel: public QSortFilterProxyModel
     void setFilterString( const QString &filter );
 
   private:
+
+    void initialize();
 
     QgsStyleModel *mModel = nullptr;
     QgsStyle *mStyle = nullptr;

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -489,7 +489,7 @@ QColor QgsSymbol::color() const
   return QColor( 0, 0, 0 );
 }
 
-void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext *customContext, bool selected )
+void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext *customContext, bool selected, const QgsExpressionContext *expressionContext )
 {
   QgsRenderContext context = customContext ? *customContext : QgsRenderContext::fromQPainter( painter );
   context.setForceVectorOutput( true );
@@ -497,7 +497,11 @@ void QgsSymbol::drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext
   symbolContext.setSelected( selected );
   symbolContext.setOriginalGeometryType( mType == Fill ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::UnknownGeometry );
 
-  if ( !customContext )
+  if ( expressionContext )
+  {
+    context.setExpressionContext( *expressionContext );
+  }
+  else if ( !customContext )
   {
     // if no render context was passed, build a minimal expression context
     QgsExpressionContext expContext;

--- a/src/core/symbology/qgssymbol.h
+++ b/src/core/symbology/qgssymbol.h
@@ -326,13 +326,14 @@ class CORE_EXPORT QgsSymbol
      * \param size size of the icon
      * \param customContext the context in which the rendering happens
      * \param selected set to TRUE to render the symbol in a selected state
+     * \param expressionContext optional custom expression context
      *
      * \see exportImage()
      * \see asImage()
      * \note Parameter selected added in QGIS 3.10
      * \since QGIS 2.6
      */
-    void drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext *customContext = nullptr, bool selected = false );
+    void drawPreviewIcon( QPainter *painter, QSize size, QgsRenderContext *customContext = nullptr, bool selected = false, const QgsExpressionContext *expressionContext = nullptr );
 
     /**
      * Export the symbol as an image format, to the specified \a path and with the given \a size.

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -758,7 +758,7 @@ QIcon QgsSymbolLayerUtils::symbolPreviewIcon( const QgsSymbol *symbol, QSize siz
   return QIcon( symbolPreviewPixmap( symbol, size, padding ) );
 }
 
-QPixmap QgsSymbolLayerUtils::symbolPreviewPixmap( const QgsSymbol *symbol, QSize size, int padding, QgsRenderContext *customContext, bool selected )
+QPixmap QgsSymbolLayerUtils::symbolPreviewPixmap( const QgsSymbol *symbol, QSize size, int padding, QgsRenderContext *customContext, bool selected, const QgsExpressionContext *expressionContext )
 {
   Q_ASSERT( symbol );
   QPixmap pixmap( size );
@@ -798,12 +798,12 @@ QPixmap QgsSymbolLayerUtils::symbolPreviewPixmap( const QgsSymbol *symbol, QSize
           prop.setActive( false );
       }
     }
-    symbol_noDD->drawPreviewIcon( &painter, size, customContext, selected );
+    symbol_noDD->drawPreviewIcon( &painter, size, customContext, selected, expressionContext );
   }
   else
   {
     std::unique_ptr<QgsSymbol> symbolClone( symbol->clone( ) );
-    symbolClone->drawPreviewIcon( &painter, size, customContext, selected );
+    symbolClone->drawPreviewIcon( &painter, size, customContext, selected, expressionContext );
   }
 
   painter.end();

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -223,11 +223,14 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \param padding space between icon edge and symbol
      * \param customContext render context to use when rendering symbol
      * \param selected set to TRUE to render the symbol in a selected state
+     * \param expressionContext optional custom expression context
      * \note Parameter customContext added in QGIS 2.6
      * \note Parameter selected added in QGIS 3.10
+     * \note Parameter expressionContext added in QGIS 3.10
      * \see symbolPreviewIcon()
      */
-    static QPixmap symbolPreviewPixmap( const QgsSymbol *symbol, QSize size, int padding = 0, QgsRenderContext *customContext = nullptr, bool selected = false );
+    static QPixmap symbolPreviewPixmap( const QgsSymbol *symbol, QSize size, int padding = 0, QgsRenderContext *customContext = nullptr, bool selected = false,
+                                        const QgsExpressionContext *expressionContext = nullptr );
 
     /**
      * Draws a symbol layer preview to a QPicture

--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -21,12 +21,19 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgswindowmanagerinterface.h"
+#include "qgsapplication.h"
 
 //
 // QgsReadOnlyStyleModel
 //
 
 ///@cond PRIVATE
+QgsReadOnlyStyleModel::QgsReadOnlyStyleModel( QgsStyleModel *sourceModel, QObject *parent )
+  : QgsStyleProxyModel( sourceModel, parent )
+{
+
+}
+
 QgsReadOnlyStyleModel::QgsReadOnlyStyleModel( QgsStyle *style, QObject *parent )
   : QgsStyleProxyModel( style, parent )
 {
@@ -123,7 +130,8 @@ void QgsStyleItemsListWidget::setStyle( QgsStyle *style )
 {
   mStyle = style;
 
-  mModel = new QgsReadOnlyStyleModel( mStyle, this );
+  mModel = mStyle == QgsStyle::defaultStyle() ? new QgsReadOnlyStyleModel( QgsApplication::defaultStyleModel(), this )
+           : new QgsReadOnlyStyleModel( mStyle, this );
 
   mModel->addDesiredIconSize( viewSymbols->iconSize() );
   mModel->addDesiredIconSize( mSymbolTreeView->iconSize() );

--- a/src/gui/qgsstyleitemslistwidget.h
+++ b/src/gui/qgsstyleitemslistwidget.h
@@ -33,6 +33,7 @@ class QgsReadOnlyStyleModel : public QgsStyleProxyModel
     Q_OBJECT
   public:
 
+    explicit QgsReadOnlyStyleModel( QgsStyleModel *sourceModel, QObject *parent = nullptr );
     explicit QgsReadOnlyStyleModel( QgsStyle *style, QObject *parent = nullptr );
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     QVariant data( const QModelIndex &index, int role ) const override;

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -51,12 +51,19 @@
 //
 
 ///@cond PRIVATE
+QgsCheckableStyleModel::QgsCheckableStyleModel( QgsStyleModel *sourceModel, QObject *parent, bool readOnly )
+  : QgsStyleProxyModel( sourceModel, parent )
+  , mStyle( sourceModel->style() )
+  , mReadOnly( readOnly )
+{
+
+}
+
 QgsCheckableStyleModel::QgsCheckableStyleModel( QgsStyle *style, QObject *parent, bool readOnly )
   : QgsStyleProxyModel( style, parent )
   , mStyle( style )
   , mReadOnly( readOnly )
 {
-
 }
 
 void QgsCheckableStyleModel::setCheckable( bool checkable )
@@ -242,7 +249,8 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
   double treeIconSize = Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 2;
   mSymbolTreeView->setIconSize( QSize( static_cast< int >( treeIconSize ), static_cast< int >( treeIconSize ) ) );
 
-  mModel = new QgsCheckableStyleModel( mStyle, this, mReadOnly );
+  mModel = mStyle == QgsStyle::defaultStyle() ? new QgsCheckableStyleModel( QgsApplication::defaultStyleModel(), this, mReadOnly )
+           : new QgsCheckableStyleModel( mStyle, this, mReadOnly );
   mModel->addDesiredIconSize( listItems->iconSize() );
   mModel->addDesiredIconSize( mSymbolTreeView->iconSize() );
   listItems->setModel( mModel );
@@ -579,7 +587,7 @@ void QgsStyleManagerDialog::copyItem()
     case QgsStyle::SmartgroupEntity:
       return;
 
-  };
+  }
 }
 
 void QgsStyleManagerDialog::pasteItem()

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -37,6 +37,7 @@ class QgsCheckableStyleModel: public QgsStyleProxyModel
     Q_OBJECT
   public:
 
+    explicit QgsCheckableStyleModel( QgsStyleModel *sourceModel, QObject *parent = nullptr, bool readOnly = false );
     explicit QgsCheckableStyleModel( QgsStyle *style, QObject *parent = nullptr, bool readOnly = false );
 
     void setCheckable( bool checkable );


### PR DESCRIPTION
A bunch of optimisations related to a situation encountered today where qgis would grind to a halt when certain projects were opened.

Underlying cause was the expensive QFileInfo::canonicalFilePath() call in QgsProject::homePath() when projects were stored on a network drive. This function is called many many times, especially when project expression context scopes are created. And these are created a lot, as each call to generating a symbol preview pixmap creates a new expression context...

Accordingly, i've implemented some related optimisations here:
1. cache QgsProject::homePath, to avoid the underlying expensive call
2. move responsibility of creating project expression scopes to QgsProject, and cache these. Creating the scope from scratch is much more costly than cloning an existing one
3. use a shared QgsStyleModel for the default application style, so that there's a shared icon cache which can be used across the application (avoids duplicate generation of symbol preview icons whenever a new symbol list is created)

