### PR TITLE
appstream: include oars metadata

### DIFF
--- a/linux/org.qgis.qgis.appdata.xml.in
+++ b/linux/org.qgis.qgis.appdata.xml.in
@@ -26,6 +26,7 @@
     <release version="3.2.0" date="2018-06-22" />
   </releases>
   <launchable type="desktop-id">org.qgis.qgis.desktop</launchable>
+  <content_rating type="oars-1.1"/>
   <provides>
     <binary>qgis</binary>
   </provides>


### PR DESCRIPTION
## Description
You can read more about OARS here:
https://hughsie.github.io/oars/

This is necessary nowadays to keep builds working on flathub.org.

Fixes https://github.com/flathub/org.qgis.qgis/issues/35

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
