### PR TITLE
Address QGIS 2.x -> 3.x regression in offset features tool

### DIFF
--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -392,6 +392,9 @@ void QgsMapToolOffsetCurve::canvasMoveEvent( QgsMapMouseEvent *e )
 {
   if ( mOriginalGeometry.isNull() || !mRubberBand )
   {
+    QgsPointLocator::Match match = mCanvas->snappingUtils()->snapToCurrentLayer( e->pos(),
+                                   QgsPointLocator::Types( QgsPointLocator::Edge | QgsPointLocator::Area ) );
+    mSnapIndicator->setMatch( match );
     return;
   }
 

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -80,7 +80,7 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
     //! The layer being maniuplated
-    QgsVectorLayer *mLayer = nullptr;
+    QgsVectorLayer *mSourceLayer = nullptr;
 
     //! Geometry to manipulate
     QgsGeometry mOriginalGeometry;

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -21,6 +21,7 @@
 #include "qgis_app.h"
 #include "ui_qgsoffsetuserinputwidget.h"
 #include "qgspointlocator.h"
+#include "qgsfeature.h"
 
 class QGridLayout;
 
@@ -101,6 +102,8 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
 
     //! Forces geometry copy (no modification of geometry in current layer)
     bool mCtrlHeldOnFirstClick = false;
+
+    QgsFeature mSourceFeature;
 
     double calculateOffset( const QgsPointXY &mapPoint );
 


### PR DESCRIPTION
In QGIS 2 it was possible to offset features from a non-active layer
which would result in an offset copy of these features being inserted
into the (editable) active layer

This behavior was lost in QGIS 3, which only permits offsetting
features within the active layer.

Resurrect this behavior, with some tweaks:
- the copy-and-offset mode is activated only when ctrl is held
while offsetting. In earlier 3.x versions this also resulted in
copy-and-offset, but only for features within the current layer.
Now, copy-and-offset respects the project's snapping configuration
and potentially copies from other layers
- We use refined logic to correctly map attributes across from
the source feature layer to the destination layer, and apply
default values and provider constraints on feature copy (also
applies to copy-and-offsets where the source and destination
layer are the same)