### PR TITLE
Improve UX when a missing grid transform is desired/required

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(QGIS_APP_SRCS
   qgssourcefieldsproperties.cpp
   qgsattributesformproperties.cpp
   qgsidentifyresultsdialog.cpp
+  qgsinstallgridshiftdialog.cpp
   qgsfeatureaction.cpp
   qgslabelpropertydialog.cpp
   qgslabelengineconfigdialog.cpp
@@ -297,6 +298,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsgeometryvalidationmodel.h
   qgshtmlannotationdialog.h
   qgsidentifyresultsdialog.h
+  qgsinstallgridshiftdialog.h
   qgslabelengineconfigdialog.h
   qgslabelingwidget.h
   qgslabelpropertydialog.h

--- a/src/app/qgsinstallgridshiftdialog.cpp
+++ b/src/app/qgsinstallgridshiftdialog.cpp
@@ -68,6 +68,6 @@ void QgsInstallGridShiftFileDialog::installFromFile()
   }
   else
   {
-    QMessageBox::critical( this, tr( "Install Grid File" ), tr( "Could not copy %1 to %2. Please check folder permissions and ret" ).arg( mGridName, destPath ) );
+    QMessageBox::critical( this, tr( "Install Grid File" ), tr( "Could not copy %1 to %2. Please check folder permissions and retry." ).arg( mGridName, destPath ) );
   }
 }

--- a/src/app/qgsinstallgridshiftdialog.cpp
+++ b/src/app/qgsinstallgridshiftdialog.cpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+                         qgsinstallgridshiftdialog.cpp
+                             -------------------
+    begin                : September 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsinstallgridshiftdialog.h"
+#include "qgsgui.h"
+#include "qgssettings.h"
+#include "qgsapplication.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+QgsInstallGridShiftFileDialog::QgsInstallGridShiftFileDialog( const QString &gridName, QWidget *parent )
+  : QDialog( parent )
+  , mGridName( gridName )
+{
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mInstallButton->setText( tr( "Install %1 from Folder…" ).arg( mGridName ) );
+
+  connect( mInstallButton, &QPushButton::clicked, this, &QgsInstallGridShiftFileDialog::installFromFile );
+}
+
+void QgsInstallGridShiftFileDialog::setDescription( const QString &html )
+{
+  mSummaryLabel->setHtml( html );
+}
+
+void QgsInstallGridShiftFileDialog::setDownloadMessage( const QString &message )
+{
+  mDownloadLabel->setText( message );
+}
+
+void QgsInstallGridShiftFileDialog::installFromFile()
+{
+  QgsSettings settings;
+  const QString initialDir = settings.value( QStringLiteral( "lastTransformGridFolder" ), QDir::homePath(), QgsSettings::App ).toString();
+  const QString gridFilePath = QFileDialog::getOpenFileName( nullptr, tr( "Install %1" ).arg( mGridName ), initialDir, QStringLiteral( "%1 (%1);;" ).arg( mGridName ) + tr( "Grid Shift Files" ) + QStringLiteral( " (*.gsb *.GSB);;" ) + QObject::tr( "All files" ) + " (*)" );
+
+  if ( gridFilePath.isEmpty() )
+  {
+    return; //canceled by the user
+  }
+
+  QFileInfo fi( gridFilePath );
+  settings.setValue( QStringLiteral( "lastTransformGridFolder" ), fi.absolutePath(), QgsSettings::App );
+
+  const QString destPath = QgsApplication::qgisSettingsDirPath() + QStringLiteral( "proj/" ) + fi.fileName();
+
+  if ( QFile::copy( gridFilePath, destPath ) )
+  {
+    QMessageBox::information( this, tr( "Install Grid File" ), tr( "The %1 grid shift file has been successfully installed. Please restart QGIS for this change to take effect." ).arg( mGridName ) );
+    accept();
+  }
+  else
+  {
+    QMessageBox::critical( this, tr( "Install Grid File" ), tr( "Could not copy %1 to %2. Please check folder permissions and ret" ).arg( mGridName, destPath ) );
+  }
+}

--- a/src/app/qgsinstallgridshiftdialog.h
+++ b/src/app/qgsinstallgridshiftdialog.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+                         qgsinstallgridshiftdialog.h
+                             -------------------
+    begin                : September 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSINSTALLGRIDSHIFTDIALOG_H
+#define QGSINSTALLGRIDSHIFTDIALOG_H
+
+#include "ui_qgsinstallgridshiftdialog.h"
+#include <QDialog>
+#include "qgis_app.h"
+
+class QgsInstallGridShiftFileDialog: public QDialog, private Ui::QgsInstallGridShiftFileDialogBase
+{
+    Q_OBJECT
+  public:
+    QgsInstallGridShiftFileDialog( const QString &gridName, QWidget *parent = nullptr );
+
+    void setDescription( const QString &html );
+    void setDownloadMessage( const QString &message );
+
+  private slots:
+
+    void installFromFile();
+
+  private:
+    QString mGridName;
+
+};
+
+#endif // QGSINSTALLGRIDSHIFTDIALOG_H

--- a/src/ui/qgsinstallgridshiftdialog.ui
+++ b/src/ui/qgsinstallgridshiftdialog.ui
@@ -61,9 +61,7 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;The preferred transform between EPSG:26952 [NAD83 / Arkansas South] and EPSG:4326 [WGS 84] is not available for use on the system. This transformation requires the grid file “CHENyx06a.gsb”, which is not available for use on the system.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;Current transform “Inverse of SPCS83 Arkansas South zone (meters) + NAD83 to WGS 84 (1)” has an accuracy of 4 meters, while the preferred transformation “Inverse of SPCS83 Arkansas South zone (meters) + NAD83 to WGS 84 (12)” has accuracy 1 meters.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -80,7 +78,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;This grid is part of the proj-datumgrid-north-america package, available for download from https://download.osgeo.org/proj/proj-datumgrid-north-america-latest.zip.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -96,7 +94,7 @@ p, li { white-space: pre-wrap; }
       <item row="1" column="1">
        <widget class="QPushButton" name="mInstallButton">
         <property name="text">
-         <string>Install CHENyx06a.gsb from Folder..</string>
+         <string>Install from Folder..</string>
         </property>
        </widget>
       </item>

--- a/src/ui/qgsinstallgridshiftdialog.ui
+++ b/src/ui/qgsinstallgridshiftdialog.ui
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsInstallGridShiftFileDialogBase</class>
+ <widget class="QDialog" name="QgsInstallGridShiftFileDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>720</width>
+    <height>353</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0,0,0,0,0">
+   <item row="6" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTextEdit" name="mSummaryLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="acceptDrops">
+      <bool>false</bool>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;The preferred transform between EPSG:26952 [NAD83 / Arkansas South] and EPSG:4326 [WGS 84] is not available for use on the system. This transformation requires the grid file “CHENyx06a.gsb”, which is not available for use on the system.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;Current transform “Inverse of SPCS83 Arkansas South zone (meters) + NAD83 to WGS 84 (1)” has an accuracy of 4 meters, while the preferred transformation “Inverse of SPCS83 Arkansas South zone (meters) + NAD83 to WGS 84 (12)” has accuracy 1 meters.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Install Grid Transform File</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="mDownloadLabel">
+        <property name="text">
+         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;This grid is part of the proj-datumgrid-north-america package, available for download from https://download.osgeo.org/proj/proj-datumgrid-north-america-latest.zip.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="mInstallButton">
+        <property name="text">
+         <string>Install CHENyx06a.gsb from Folder..</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsInstallGridShiftFileDialogBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsInstallGridShiftFileDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Instead of just showing users the URL to download the grid from (and with no clues about what to DO with the downloaded file), also present them with a user-friendly dialog allowing them to install the grid to the required location:

![Peek 2019-09-09 17-05](https://user-images.githubusercontent.com/1829991/64509904-19fff900-d324-11e9-84bf-af1062f4f7bb.gif)

(ignore the messed up dialog stacking - that's the screen recorder's fault)

TODO: also expose this when the full transform selection dialog is shown