### PR TITLE
[ui] Set a sane minimum size for the symbol selector dialog

### DIFF
--- a/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgssymbolselectordialog.sip.in
@@ -203,7 +203,6 @@ Constructor for QgsSymbolSelectorDialog.
 :param parent: Parent widget
 :param embedded: ``True`` to embed in renderer properties dialog, ``False`` otherwise
 %End
-    ~QgsSymbolSelectorDialog();
 
     QMenu *advancedMenu();
 %Docstring

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -38,6 +38,7 @@
 #include "qgsimagecache.h"
 #include "qgsproject.h"
 #include "qgsguiutils.h"
+#include "qgsgui.h"
 
 #include <QColorDialog>
 #include <QPainter>
@@ -775,8 +776,9 @@ QgsSymbolSelectorDialog::QgsSymbolSelectorDialog( QgsSymbol *symbol, QgsStyle *s
   layout()->addWidget( mSelectorWidget );
   layout()->addWidget( mButtonBox );
 
-  QgsSettings settings;
-  restoreGeometry( settings.value( QStringLiteral( "Windows/SymbolSelectorWidget/geometry" ) ).toByteArray() );
+  mSelectorWidget->setMinimumSize( 460, 560 );
+  setObjectName( QStringLiteral( "SymbolSelectorDialog" ) );
+  QgsGui::instance()->enableAutoGeometryRestore( this );
 
   // can be embedded in renderer properties dialog
   if ( embedded )
@@ -789,12 +791,6 @@ QgsSymbolSelectorDialog::QgsSymbolSelectorDialog( QgsSymbol *symbol, QgsStyle *s
     setWindowTitle( tr( "Symbol Selector" ) );
   }
   mSelectorWidget->setDockMode( embedded );
-}
-
-QgsSymbolSelectorDialog::~QgsSymbolSelectorDialog()
-{
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "Windows/SymbolSelectorWidget/geometry" ), saveGeometry() );
 }
 
 QMenu *QgsSymbolSelectorDialog::advancedMenu()

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -277,7 +277,6 @@ class GUI_EXPORT QgsSymbolSelectorDialog : public QDialog
      * \param embedded TRUE to embed in renderer properties dialog, FALSE otherwise
      */
     QgsSymbolSelectorDialog( QgsSymbol *symbol, QgsStyle *style, QgsVectorLayer *vl, QWidget *parent SIP_TRANSFERTHIS = nullptr, bool embedded = false );
-    ~QgsSymbolSelectorDialog() override;
 
     //! Returns menu for "advanced" button - create it if doesn't exist and show the advanced button
     QMenu *advancedMenu();


### PR DESCRIPTION
Backport of the symbol selector dialog default size fix to 3.8 (and then 3.4)