### PR TITLE
Use floating connections from browser items

### DIFF
--- a/src/core/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.h
@@ -60,8 +60,6 @@ class CORE_EXPORT QgsGeoPackageCollectionItem : public QgsDataCollectionItem
     void addConnection();
     void deleteConnection();
 
-  protected:
-    QString mPath;
 };
 
 

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -239,15 +239,14 @@ bool QgsGeoPackageItemGuiProvider::rename( QgsDataItem *item, const QString &new
 
       // Actually rename
       QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) };
-      QgsGeoPackageProviderConnection *conn { static_cast<QgsGeoPackageProviderConnection *>( md->findConnection( layerItem->collection()->name() ) ) };
-      if ( ! conn )
+      std::unique_ptr<QgsGeoPackageProviderConnection> conn( static_cast<QgsGeoPackageProviderConnection *>( md->createConnection( layerItem->collection()->path(), QVariantMap() ) ) );
+      QString oldName = parts.value( QStringLiteral( "layerName" ) ).toString();
+      if ( ! conn->tableExists( QString(), oldName ) )
       {
         errCause = QObject::tr( "There was an error retrieving the connection %1!" ).arg( layerItem->collection()->name() );
       }
       else
       {
-        // TODO: maybe an index?
-        QString oldName = parts.value( QStringLiteral( "layerName" ) ).toString();
         try
         {
           conn->renameVectorTable( QString(), oldName, newName );
@@ -359,7 +358,7 @@ bool QgsGeoPackageItemGuiProvider::deleteLayer( QgsLayerItem *layerItem, QgsData
 
 void QgsGeoPackageItemGuiProvider::vacuumGeoPackageDbAction( const QString &path, const QString &name )
 {
-  Q_UNUSED( path );
+  Q_UNUSED( path )
   QString errCause;
   bool result = QgsGeoPackageCollectionItem::vacuumGeoPackageDb( name, errCause );
   if ( !result || !errCause.isEmpty() )


### PR DESCRIPTION
Fixes an unreported issue when deleting/renaming GPKG layers
from the browser if the connection was not stored
