### PR TITLE
Tweak widgets visibility in decorations at the opening

### DIFF
--- a/src/ui/qgsdecorationcopyrightdialog.ui
+++ b/src/ui/qgsdecorationcopyrightdialog.ui
@@ -182,9 +182,6 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item row="3" column="1" colspan="2">
          <widget class="QgsFontButton" name="mButtonFontStyle">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/src/ui/qgsdecorationlayoutextentdialog.ui
+++ b/src/ui/qgsdecorationlayoutextentdialog.ui
@@ -19,9 +19,6 @@
    </property>
    <item>
     <widget class="QGroupBox" name="grpEnable">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
      <property name="title">
       <string>Show Layout Extents</string>
      </property>
@@ -34,9 +31,6 @@
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="1">
        <widget class="QgsFontButton" name="mButtonFontStyle">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -50,9 +44,6 @@
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="mLineSymbolLabel">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
         <property name="text">
          <string>Symbol</string>
         </property>
@@ -63,9 +54,6 @@
       </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="mCheckBoxLabelExtents">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
         <property name="text">
          <string>Label extents</string>
         </property>
@@ -73,9 +61,6 @@
       </item>
       <item row="0" column="1">
        <widget class="QgsSymbolButton" name="mSymbolButton">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>

--- a/src/ui/qgsdecorationscalebardialog.ui
+++ b/src/ui/qgsdecorationscalebardialog.ui
@@ -201,9 +201,6 @@
       </item>
       <item row="4" column="1">
        <widget class="QgsFontButton" name="mButtonFontStyle">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/src/ui/qgsdecorationtitledialog.ui
+++ b/src/ui/qgsdecorationtitledialog.ui
@@ -208,9 +208,6 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item row="3" column="1" colspan="2">
          <widget class="QgsFontButton" name="mButtonFontStyle">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>


### PR DESCRIPTION
In View menu --> Decorations, the dialogs have an item that is enabled while all of them should be disabled by default (until the user hits "draw/enable.. decoration" checkbox. This PR fixes some of them but we stiil have Grid line symbol, and Image colors that would need some tweaks. @nirvn 