### PR TITLE
Parallelize snap caching

### DIFF
--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -92,12 +92,19 @@ Configure render context  - if not ``None``, it will use to index only visible f
     typedef QFlags<QgsPointLocator::Type> Types;
 
 
-    bool init( int maxFeaturesToIndex = -1 );
+    bool init( int maxFeaturesToIndex = -1, bool relaxed = false );
 %Docstring
 Prepare the index for queries. Does nothing if the index already exists.
 If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
-to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used. Returns
-``False`` if the creation of index has been prematurely stopped due to the limit of features, otherwise ``True``
+to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
+
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
+in the constructor. if ``True``, index building will be done in another thread and init() method returns
+immediately. initFinished() signal will be emitted once the initialization is over.
+
+Returns false if the creation of index is blocking and has been prematurely stopped due to the limit of features, otherwise true
+
+.. seealso:: :py:class:`QgsPointLocator`
 %End
 
     bool hasIndex() const;
@@ -176,58 +183,64 @@ interpolation of the Z value.
     };
 
 
-    Match nearestVertex( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
+    Match nearestVertex( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Find nearest vertex to the specified point - up to distance specified by tolerance
 Optional filter may discard unwanted matches.
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
 %End
 
-    Match nearestEdge( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
+    Match nearestEdge( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Find nearest edge to the specified point - up to distance specified by tolerance
 Optional filter may discard unwanted matches.
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
 %End
 
-    Match nearestArea( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
+    Match nearestArea( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Find nearest area to the specified point - up to distance specified by tolerance
 Optional filter may discard unwanted matches.
 This will first perform a pointInPolygon and return first result.
 If no match is found and tolerance is not 0, it will return nearestEdge.
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
 
 .. versionadded:: 3.0
 %End
 
-    MatchList edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = 0 );
+    MatchList edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Find edges within a specified recangle
 Optional filter may discard unwanted matches.
-%End
-    MatchList edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
-%Docstring
-Override of edgesInRect that construct rectangle from a center point and tolerance
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
 %End
 
-    MatchList verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = 0 );
+    MatchList edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
+%Docstring
+Override of edgesInRect that construct rectangle from a center point and tolerance
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
+%End
+
+    MatchList verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Find vertices within a specified recangle
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
 Optional filter may discard unwanted matches.
 
 .. versionadded:: 3.6
 %End
 
-    MatchList verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
+    MatchList verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Override of verticesInRect that construct rectangle from a center point and tolerance
+This method is either blocking or non blocking according to ``relaxed`` parameter passed
 
 .. versionadded:: 3.6
 %End
 
 
-    MatchList pointInPolygon( const QgsPointXY &point );
-%Docstring
-find out if the point is in any polygons
-%End
+
+    MatchList pointInPolygon( const QgsPointXY &point, bool relaxed = false );
 
     int cachedGeometryCount() const;
 %Docstring
@@ -236,8 +249,33 @@ Returns how many geometries are cached in the index
 .. versionadded:: 2.14
 %End
 
+    bool isIndexing() const;
+%Docstring
+Returns ``True`` if the point locator is currently indexing the data.
+This method is useful if constructor parameter ``relaxed`` is ``True``
+
+.. seealso:: :py:class:`QgsPointLocator`
+%End
+
+    void waitForFinished() const;
+%Docstring
+If the point locator has been initialized relaxedly and is currently indexing,
+this methods waits for the indexing to be finished
+%End
+
+  signals:
+
+    void initFinished( bool ok );
+%Docstring
+Emitted whenever index has been built and initialization is finished
+
+:param ok: ``False`` if the creation of index has been prematurely stopped due to the limit of
+           features, otherwise ``True``
+%End
+
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
+
   protected slots:
     void destroyIndex();
 };

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -257,7 +257,7 @@ This method is useful if constructor parameter ``relaxed`` is ``True``
 .. seealso:: :py:class:`QgsPointLocator`
 %End
 
-    void waitForFinished() const;
+    void waitForIndexingFinished();
 %Docstring
 If the point locator has been initialized relaxedly and is currently indexing,
 this methods waits for the indexing to be finished

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -38,6 +38,9 @@ which keeps the configuration in sync with map canvas (e.g. current view, active
     QgsSnappingUtils( QObject *parent /TransferThis/ = 0, bool enableSnappingForInvisibleFeature = true );
 %Docstring
 Constructor for QgsSnappingUtils
+
+:param parent: parent object
+:param enableSnappingForInvisibleFeature: ``True`` if we want to snap feature even if there are not visible
 %End
     ~QgsSnappingUtils();
 
@@ -45,6 +48,8 @@ Constructor for QgsSnappingUtils
     QgsPointLocator *locatorForLayer( QgsVectorLayer *vl );
 %Docstring
 Gets a point locator for the given layer. If such locator does not exist, it will be created
+
+:param vl: the vector layer
 %End
 
     QgsPointLocator::Match snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter = 0 );
@@ -53,6 +58,25 @@ Snap to map according to the current configuration. Optional filter allows disca
 %End
     QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0 );
 
+    QgsPointLocator::Match snapToMapRelaxed( QPoint point, QgsPointLocator::MatchFilter *filter = 0 );
+%Docstring
+Snap to map according to the current configuration.
+Unlike the snapToMap() method, this method is non blocking and return matches from point locators which
+are not currently indexing
+
+:param point: point in canvas coordinates
+:param filter: allows discarding unwanted matches.
+%End
+
+    QgsPointLocator::Match snapToMapRelaxed( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0 );
+%Docstring
+Snap to map according to the current configuration.
+Unlike the snapToMap() method, this method is non blocking and return matches from point locators which
+are not currently indexing
+
+:param pointMap: point in map coordinates
+:param filter: allows discarding unwanted matches.
+%End
 
     QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = 0 );
 %Docstring
@@ -172,13 +196,14 @@ Emitted when the snapping settings object changes.
 %End
 
   protected:
+
     virtual void prepareIndexStarting( int count );
 %Docstring
-Called when starting to index - can be overridden and e.g. progress dialog can be provided
+Called when starting to index with snapToMap - can be overridden and e.g. progress dialog can be provided
 %End
     virtual void prepareIndexProgress( int index );
 %Docstring
-Called when finished indexing a layer. When index == count the indexing is complete
+Called when finished indexing a layer with snapToMap. When index == count the indexing is complete
 %End
 
     void clearAllLocators();

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -58,16 +58,16 @@ Snap to map according to the current configuration.
 
 :param point: point in canvas coordinates
 :param filter: allows discarding unwanted matches.
-               This method is either blocking or non blocking according to ``relaxed`` parameter passed
+:param relaxed: ``True`` if this method is non blocking and the matching result can be invalid while indexing
 %End
 
     QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Snap to map according to the current configuration.
 
-:param point: point in canvas coordinates
+:param pointMap: point in map coordinates
 :param filter: allows discarding unwanted matches.
-               This method is either blocking or non blocking according to ``relaxed`` parameter passed
+:param relaxed: ``True`` if this method is non blocking and the matching result can be invalid while indexing
 %End
 
     QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = 0 );

--- a/python/core/auto_generated/qgssnappingutils.sip.in
+++ b/python/core/auto_generated/qgssnappingutils.sip.in
@@ -52,30 +52,22 @@ Gets a point locator for the given layer. If such locator does not exist, it wil
 :param vl: the vector layer
 %End
 
-    QgsPointLocator::Match snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter = 0 );
-%Docstring
-Snap to map according to the current configuration. Optional filter allows discarding unwanted matches.
-%End
-    QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0 );
-
-    QgsPointLocator::Match snapToMapRelaxed( QPoint point, QgsPointLocator::MatchFilter *filter = 0 );
+    QgsPointLocator::Match snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Snap to map according to the current configuration.
-Unlike the snapToMap() method, this method is non blocking and return matches from point locators which
-are not currently indexing
 
 :param point: point in canvas coordinates
 :param filter: allows discarding unwanted matches.
+               This method is either blocking or non blocking according to ``relaxed`` parameter passed
 %End
 
-    QgsPointLocator::Match snapToMapRelaxed( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0 );
+    QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0, bool relaxed = false );
 %Docstring
 Snap to map according to the current configuration.
-Unlike the snapToMap() method, this method is non blocking and return matches from point locators which
-are not currently indexing
 
-:param pointMap: point in map coordinates
+:param point: point in canvas coordinates
 :param filter: allows discarding unwanted matches.
+               This method is either blocking or non blocking according to ``relaxed`` parameter passed
 %End
 
     QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = 0 );

--- a/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvassnappingutils.sip.in
@@ -23,7 +23,15 @@ Snapping utils instance that is connected to a canvas and updates the configurat
 #include "qgsmapcanvassnappingutils.h"
 %End
   public:
+
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = 0 );
+%Docstring
+Construct map canvas snapping utils object
+
+:param canvas: map canvas
+:param parent: parent object
+               if ``False`` it will block until indexing is done
+%End
 
   protected:
     virtual void prepareIndexStarting( int count );

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -86,7 +86,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
   {
     case StepLimit:
 
-      match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter );
+      match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
       if ( match.isValid() )
       {
         mIs3DLayer = QgsWkbTypes::hasZ( match.layer()->wkbType() );
@@ -128,7 +128,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
       }
 
       filter.setLayer( mVlayer );
-      match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter );
+      match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
 
       if ( match.isValid() )
       {
@@ -234,7 +234,7 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
     switch ( mStep )
     {
       case StepLimit:
-        match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter );
+        match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
         if ( mRubberBandLimit && mRubberBandLimit->isVisible() )
         {
           if ( getPoints( match, pLimit1, pLimit2 ) )
@@ -248,7 +248,7 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
         if ( mIsModified )
         {
           filter.setLayer( mVlayer );
-          match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter );
+          match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
 
           if ( match.layer() )
           {
@@ -308,4 +308,3 @@ void QgsMapToolTrimExtendFeature::deactivate()
   mVlayer = nullptr;
   mLimitLayer = nullptr;
 }
-

--- a/src/app/qgsmaptooltrimextendfeature.cpp
+++ b/src/app/qgsmaptooltrimextendfeature.cpp
@@ -86,7 +86,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
   {
     case StepLimit:
 
-      match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
+      match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter, true );
       if ( match.isValid() )
       {
         mIs3DLayer = QgsWkbTypes::hasZ( match.layer()->wkbType() );
@@ -128,7 +128,7 @@ void QgsMapToolTrimExtendFeature::canvasMoveEvent( QgsMapMouseEvent *e )
       }
 
       filter.setLayer( mVlayer );
-      match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
+      match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter, true );
 
       if ( match.isValid() )
       {
@@ -234,7 +234,7 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
     switch ( mStep )
     {
       case StepLimit:
-        match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
+        match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter, true );
         if ( mRubberBandLimit && mRubberBandLimit->isVisible() )
         {
           if ( getPoints( match, pLimit1, pLimit2 ) )
@@ -248,7 +248,7 @@ void QgsMapToolTrimExtendFeature::canvasReleaseEvent( QgsMapMouseEvent *e )
         if ( mIsModified )
         {
           filter.setLayer( mVlayer );
-          match = mCanvas->snappingUtils()->snapToMapRelaxed( mMapPoint, &filter );
+          match = mCanvas->snappingUtils()->snapToMap( mMapPoint, &filter, true );
 
           if ( match.layer() )
           {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -760,7 +760,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
 
       snapUtils->setConfig( config );
       SelectedMatchFilter filter( tol, mLockedFeature.get() );
-      m = snapUtils->snapToMapRelaxed( mapPoint, &filter );
+      m = snapUtils->snapToMap( mapPoint, &filter, true );
 
       // we give priority to snap matches that are from selected features
       if ( filter.hasSelectedMatch() )
@@ -787,7 +787,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
 
     snapUtils->setConfig( config );
     SelectedMatchFilter filter( tol, mLockedFeature.get() );
-    m = snapUtils->snapToMapRelaxed( mapPoint, &filter );
+    m = snapUtils->snapToMap( mapPoint, &filter, true );
 
     // we give priority to snap matches that are from selected features
     if ( filter.hasSelectedMatch() )
@@ -802,7 +802,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   if ( mLastSnap )
   {
     OneFeatureFilter filterLast( mLastSnap->layer(), mLastSnap->featureId() );
-    QgsPointLocator::Match lastMatch = snapUtils->snapToMapRelaxed( mapPoint, &filterLast );
+    QgsPointLocator::Match lastMatch = snapUtils->snapToMap( mapPoint, &filterLast, true );
     // but skip the the previously used feature if it would only snap to segment, while now we have snap to vertex
     // so that if there is a point on a line, it gets priority (as is usual with combined vertex+segment snapping)
     bool matchHasVertexLastHasEdge = m.hasVertex() && lastMatch.hasEdge();

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -760,7 +760,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
 
       snapUtils->setConfig( config );
       SelectedMatchFilter filter( tol, mLockedFeature.get() );
-      m = snapUtils->snapToMap( mapPoint, &filter );
+      m = snapUtils->snapToMapRelaxed( mapPoint, &filter );
 
       // we give priority to snap matches that are from selected features
       if ( filter.hasSelectedMatch() )
@@ -787,7 +787,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
 
     snapUtils->setConfig( config );
     SelectedMatchFilter filter( tol, mLockedFeature.get() );
-    m = snapUtils->snapToMap( mapPoint, &filter );
+    m = snapUtils->snapToMapRelaxed( mapPoint, &filter );
 
     // we give priority to snap matches that are from selected features
     if ( filter.hasSelectedMatch() )
@@ -802,7 +802,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   if ( mLastSnap )
   {
     OneFeatureFilter filterLast( mLastSnap->layer(), mLastSnap->featureId() );
-    QgsPointLocator::Match lastMatch = snapUtils->snapToMap( mapPoint, &filterLast );
+    QgsPointLocator::Match lastMatch = snapUtils->snapToMapRelaxed( mapPoint, &filterLast );
     // but skip the the previously used feature if it would only snap to segment, while now we have snap to vertex
     // so that if there is a point on a line, it gets priority (as is usual with combined vertex+segment snapping)
     bool matchHasVertexLastHasEdge = m.hasVertex() && lastMatch.hasEdge();
@@ -834,7 +834,7 @@ QgsPointLocator::Match QgsVertexTool::snapToPolygonInterior( QgsMapMouseEvent *e
   {
     if ( currentVlayer->isEditable() && currentVlayer->geometryType() == QgsWkbTypes::PolygonGeometry )
     {
-      QgsPointLocator::MatchList matchList = snapUtils->locatorForLayer( currentVlayer )->pointInPolygon( mapPoint );
+      QgsPointLocator::MatchList matchList = snapUtils->locatorForLayer( currentVlayer )->pointInPolygon( mapPoint, true );
       if ( !matchList.isEmpty() )
       {
         m = matchList.first();
@@ -854,7 +854,7 @@ QgsPointLocator::Match QgsVertexTool::snapToPolygonInterior( QgsMapMouseEvent *e
 
       if ( vlayer->isEditable() && vlayer->geometryType() == QgsWkbTypes::PolygonGeometry )
       {
-        QgsPointLocator::MatchList matchList = snapUtils->locatorForLayer( vlayer )->pointInPolygon( mapPoint );
+        QgsPointLocator::MatchList matchList = snapUtils->locatorForLayer( vlayer )->pointInPolygon( mapPoint, true );
         if ( !matchList.isEmpty() )
         {
           m = matchList.first();
@@ -886,7 +886,7 @@ QList<QgsPointLocator::Match> QgsVertexTool::findEditableLayerMatches( const Qgs
 
   if ( layer->geometryType() == QgsWkbTypes::PolygonGeometry )
   {
-    matchList << locator->pointInPolygon( mapPoint );
+    matchList << locator->pointInPolygon( mapPoint, true );
   }
 
   double tolerance = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
@@ -1773,7 +1773,7 @@ QList<QgsPointLocator::Match> QgsVertexTool::layerVerticesSnappedToPoint( QgsVec
 {
   MatchCollectingFilter myfilter( this );
   QgsPointLocator *loc = canvas()->snappingUtils()->locatorForLayer( layer );
-  loc->nearestVertex( mapPoint, 0, &myfilter );
+  loc->nearestVertex( mapPoint, 0, &myfilter, true );
   return myfilter.matches;
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -317,6 +317,7 @@ SET(QGIS_CORE_SRCS
   qgspluginlayerregistry.cpp
   qgspointxy.cpp
   qgspointlocator.cpp
+  qgspointlocatorinittask.cpp
   qgsproject.cpp
   qgsprojectbadlayerhandler.cpp
   qgsprojectfiletransform.cpp
@@ -712,6 +713,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgspluginlayer.h
   qgspointxy.h
   qgspointlocator.h
+  qgspointlocatorinittask.h
   qgsproject.h
   qgsproxyprogresstask.h
   qgsrelationmanager.h

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -41,13 +41,13 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   res.softLockCommonAngle = -1;
 
   // try to snap to anything
-  QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMap( originalMapPoint );
+  QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMapRelaxed( originalMapPoint );
   QgsPointXY point = snapMatch.isValid() ? snapMatch.point() : originalMapPoint;
 
   // try to snap explicitly to a segment - useful for some constraints
   QgsPointXY edgePt0, edgePt1;
   EdgesOnlyFilter edgesOnlyFilter;
-  QgsPointLocator::Match edgeMatch = ctx.snappingUtils->snapToMap( originalMapPoint, &edgesOnlyFilter );
+  QgsPointLocator::Match edgeMatch = ctx.snappingUtils->snapToMapRelaxed( originalMapPoint, &edgesOnlyFilter );
   if ( edgeMatch.hasEdge() )
     edgeMatch.edgePoints( edgePt0, edgePt1 );
 

--- a/src/core/qgscadutils.cpp
+++ b/src/core/qgscadutils.cpp
@@ -41,13 +41,13 @@ QgsCadUtils::AlignMapPointOutput QgsCadUtils::alignMapPoint( const QgsPointXY &o
   res.softLockCommonAngle = -1;
 
   // try to snap to anything
-  QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMapRelaxed( originalMapPoint );
+  QgsPointLocator::Match snapMatch = ctx.snappingUtils->snapToMap( originalMapPoint, nullptr, true );
   QgsPointXY point = snapMatch.isValid() ? snapMatch.point() : originalMapPoint;
 
   // try to snap explicitly to a segment - useful for some constraints
   QgsPointXY edgePt0, edgePt1;
   EdgesOnlyFilter edgesOnlyFilter;
-  QgsPointLocator::Match edgeMatch = ctx.snappingUtils->snapToMapRelaxed( originalMapPoint, &edgesOnlyFilter );
+  QgsPointLocator::Match edgeMatch = ctx.snappingUtils->snapToMap( originalMapPoint, &edgesOnlyFilter, true );
   if ( edgeMatch.hasEdge() )
     edgeMatch.edgePoints( edgePt0, edgePt1 );
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -645,6 +645,10 @@ bool QgsPointLocator::init( int maxFeaturesToIndex, bool relaxed )
 void QgsPointLocator::waitForFinished() const
 {
   mInitTask->waitForFinished();
+
+  // force process of signal emitted from task thread
+  // so rebuildIndexFinished and taskTerminated are called
+  QCoreApplication::processEvents();
 }
 
 bool QgsPointLocator::hasIndex() const

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -22,11 +22,15 @@
 #include "qgis.h"
 #include "qgslogger.h"
 #include "qgsrenderer.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayerfeatureiterator.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgslinestring.h"
+#include "qgspointlocatorinittask.h"
 #include <spatialindex/SpatialIndex.h>
 
 #include <QLinkedListIterator>
+#include <QtConcurrent>
 
 using namespace SpatialIndex;
 
@@ -554,6 +558,10 @@ QgsCoordinateReferenceSystem QgsPointLocator::destinationCrs() const
 
 void QgsPointLocator::setExtent( const QgsRectangle *extent )
 {
+  if ( mIsIndexing )
+    // already indexing, return!
+    return;
+
   mExtent.reset( extent ? new QgsRectangle( *extent ) : nullptr );
 
   destroyIndex();
@@ -561,6 +569,10 @@ void QgsPointLocator::setExtent( const QgsRectangle *extent )
 
 void QgsPointLocator::setRenderContext( const QgsRenderContext *context )
 {
+  if ( mIsIndexing )
+    // already indexing, return!
+    return;
+
   disconnect( mLayer, &QgsVectorLayer::styleChanged, this, &QgsPointLocator::destroyIndex );
 
   destroyIndex();
@@ -574,27 +586,103 @@ void QgsPointLocator::setRenderContext( const QgsRenderContext *context )
 
 }
 
-bool QgsPointLocator::init( int maxFeaturesToIndex )
+void QgsPointLocator::onInitTaskTerminated()
 {
-  return hasIndex() ? true : rebuildIndex( maxFeaturesToIndex );
+  mIsIndexing = false;
+  mRenderer.reset();
+  mSource.reset();
 }
 
+void QgsPointLocator::onRebuildIndexFinished( bool ok )
+{
+  onInitTaskTerminated();
+
+  // treat added and deleted feature while indexing
+  for ( QgsFeatureId fid : mAddedFeatures )
+    onFeatureAdded( fid );
+
+  for ( QgsFeatureId fid : mDeletedFeatures )
+    onFeatureDeleted( fid );
+
+  emit initFinished( ok );
+}
+
+bool QgsPointLocator::init( int maxFeaturesToIndex, bool relaxed )
+{
+  const QgsWkbTypes::GeometryType geomType = mLayer->geometryType();
+  if ( geomType == QgsWkbTypes::NullGeometry // nothing to index
+       || hasIndex()
+       || mIsIndexing ) // already indexing, return!
+    return true;
+
+  mRenderer.reset( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr );
+  mSource.reset( new QgsVectorLayerFeatureSource( mLayer ) );
+
+  if ( mContext )
+  {
+    mContext->expressionContext() << QgsExpressionContextUtils::layerScope( mLayer );
+  }
+
+  mIsIndexing = true;
+
+  if ( relaxed )
+  {
+    mInitTask = new QgsPointLocatorInitTask( this );
+    connect( mInitTask, &QgsPointLocatorInitTask::rebuildIndexFinished, this, &QgsPointLocator::onRebuildIndexFinished );
+    connect( mInitTask, &QgsPointLocatorInitTask::taskTerminated, this, &QgsPointLocator::onInitTaskTerminated );
+    QgsApplication::taskManager()->addTask( mInitTask );
+    return true;
+  }
+  else
+  {
+    const bool ok = rebuildIndex( maxFeaturesToIndex );
+    mIsIndexing = false;
+    emit initFinished( ok );
+    return ok;
+  }
+}
+
+void QgsPointLocator::waitForFinished() const
+{
+  mInitTask->waitForFinished();
+}
 
 bool QgsPointLocator::hasIndex() const
 {
-  return mRTree || mIsEmptyLayer;
+  return mIsIndexing || mRTree || mIsEmptyLayer;
 }
 
+bool QgsPointLocator::prepare( bool relaxed )
+{
+  if ( mIsIndexing )
+  {
+    if ( relaxed )
+      return false;
+    else
+      waitForFinished();
+  }
+
+  if ( !mRTree )
+  {
+    init( -1, relaxed );
+    if ( ( relaxed && mIsIndexing ) || !mRTree ) // relaxed mode and currently indexing or still invalid?
+      return false;
+  }
+
+  return true;
+}
 
 bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
 {
+  QTime t;
+  t.start();
+
+  QgsDebugMsg( QStringLiteral( "RebuildIndex start : %1" ).arg( mSource->id() ) );
+
   destroyIndex();
 
   QLinkedList<RTree::Data *> dataList;
   QgsFeature f;
-  QgsWkbTypes::GeometryType geomType = mLayer->geometryType();
-  if ( geomType == QgsWkbTypes::NullGeometry )
-    return true; // nothing to index
 
   QgsFeatureRequest request;
   request.setNoAttributes();
@@ -619,22 +707,20 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
   }
 
   bool filter = false;
-  std::unique_ptr< QgsFeatureRenderer > renderer( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr );
   QgsRenderContext *ctx = nullptr;
   if ( mContext )
   {
-    mContext->expressionContext() << QgsExpressionContextUtils::layerScope( mLayer );
     ctx = mContext.get();
-    if ( renderer )
+    if ( mRenderer )
     {
       // setup scale for scale dependent visibility (rule based)
-      renderer->startRender( *ctx, mLayer->fields() );
-      filter = renderer->capabilities() & QgsFeatureRenderer::Filter;
-      request.setSubsetOfAttributes( renderer->usedAttributes( *ctx ), mLayer->fields() );
+      mRenderer->startRender( *ctx, mSource->fields() );
+      filter = mRenderer->capabilities() & QgsFeatureRenderer::Filter;
+      request.setSubsetOfAttributes( mRenderer->usedAttributes( *ctx ), mSource->fields() );
     }
   }
 
-  QgsFeatureIterator fi = mLayer->getFeatures( request );
+  QgsFeatureIterator fi = mSource->getFeatures( request );
   int indexedCount = 0;
 
   while ( fi.nextFeature( f ) )
@@ -642,10 +728,10 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
     if ( !f.hasGeometry() )
       continue;
 
-    if ( filter && ctx && renderer )
+    if ( filter && ctx && mRenderer )
     {
       ctx->expressionContext().setFeature( f );
-      if ( !renderer->willRenderFeature( f, *ctx ) )
+      if ( !mRenderer->willRenderFeature( f, *ctx ) )
       {
         continue;
       }
@@ -706,10 +792,13 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
   mRTree.reset( RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, stream, *mStorage, fillFactor, indexCapacity,
                 leafCapacity, dimension, variant, indexId ) );
 
-  if ( ctx && renderer )
+  if ( ctx && mRenderer )
   {
-    renderer->stopRender( *ctx );
+    mRenderer->stopRender( *ctx );
   }
+
+  QgsDebugMsg( QStringLiteral( "RebuildIndex end : %1 ms (%2)" ).arg( t.elapsed() ).arg( mSource->id() ) );
+
   return true;
 }
 
@@ -727,10 +816,17 @@ void QgsPointLocator::destroyIndex()
 
 void QgsPointLocator::onFeatureAdded( QgsFeatureId fid )
 {
+  if ( mIsIndexing )
+  {
+    // will modify index once current indexing is finished
+    mAddedFeatures << fid;
+    return;
+  }
+
   if ( !mRTree )
   {
     if ( mIsEmptyLayer )
-      rebuildIndex(); // first feature - let's built the index
+      init(); // first feature - let's built the index
     return; // nothing to do if we are not initialized yet
   }
 
@@ -796,6 +892,20 @@ void QgsPointLocator::onFeatureAdded( QgsFeatureId fid )
 
 void QgsPointLocator::onFeatureDeleted( QgsFeatureId fid )
 {
+  if ( mIsIndexing )
+  {
+    if ( mAddedFeatures.contains( fid ) )
+    {
+      mAddedFeatures.remove( fid );
+    }
+    else
+    {
+      // will modify index once current indexing is finished
+      mDeletedFeatures << fid;
+    }
+    return;
+  }
+
   if ( !mRTree )
     return; // nothing to do if we are not initialized yet
 
@@ -826,14 +936,10 @@ void QgsPointLocator::onAttributeValueChanged( QgsFeatureId fid, int idx, const 
 }
 
 
-QgsPointLocator::Match QgsPointLocator::nearestVertex( const QgsPointXY &point, double tolerance, MatchFilter *filter )
+QgsPointLocator::Match QgsPointLocator::nearestVertex( const QgsPointXY &point, double tolerance, MatchFilter *filter, bool relaxed )
 {
-  if ( !mRTree )
-  {
-    init();
-    if ( !mRTree ) // still invalid?
-      return Match();
-  }
+  if ( !prepare( relaxed ) )
+    return Match();
 
   Match m;
   QgsPointLocator_VisitorNearestVertex visitor( this, m, point, filter );
@@ -844,14 +950,10 @@ QgsPointLocator::Match QgsPointLocator::nearestVertex( const QgsPointXY &point, 
   return m;
 }
 
-QgsPointLocator::Match QgsPointLocator::nearestEdge( const QgsPointXY &point, double tolerance, MatchFilter *filter )
+QgsPointLocator::Match QgsPointLocator::nearestEdge( const QgsPointXY &point, double tolerance, MatchFilter *filter, bool relaxed )
 {
-  if ( !mRTree )
-  {
-    init();
-    if ( !mRTree ) // still invalid?
-      return Match();
-  }
+  if ( !prepare( relaxed ) )
+    return Match();
 
   QgsWkbTypes::GeometryType geomType = mLayer->geometryType();
   if ( geomType == QgsWkbTypes::PointGeometry )
@@ -866,14 +968,10 @@ QgsPointLocator::Match QgsPointLocator::nearestEdge( const QgsPointXY &point, do
   return m;
 }
 
-QgsPointLocator::Match QgsPointLocator::nearestArea( const QgsPointXY &point, double tolerance, MatchFilter *filter )
+QgsPointLocator::Match QgsPointLocator::nearestArea( const QgsPointXY &point, double tolerance, MatchFilter *filter, bool relaxed )
 {
-  if ( !mRTree )
-  {
-    init();
-    if ( !mRTree ) // still invalid?
-      return Match();
-  }
+  if ( !prepare( relaxed ) )
+    return Match();
 
   MatchList mlist = pointInPolygon( point );
   if ( !mlist.isEmpty() && mlist.at( 0 ).isValid() )
@@ -900,14 +998,10 @@ QgsPointLocator::Match QgsPointLocator::nearestArea( const QgsPointXY &point, do
 }
 
 
-QgsPointLocator::MatchList QgsPointLocator::edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::MatchList QgsPointLocator::edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
-  if ( !mRTree )
-  {
-    init();
-    if ( !mRTree ) // still invalid?
-      return MatchList();
-  }
+  if ( !prepare( relaxed ) )
+    return MatchList();
 
   QgsWkbTypes::GeometryType geomType = mLayer->geometryType();
   if ( geomType == QgsWkbTypes::PointGeometry )
@@ -920,20 +1014,16 @@ QgsPointLocator::MatchList QgsPointLocator::edgesInRect( const QgsRectangle &rec
   return lst;
 }
 
-QgsPointLocator::MatchList QgsPointLocator::edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::MatchList QgsPointLocator::edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
   QgsRectangle rect( point.x() - tolerance, point.y() - tolerance, point.x() + tolerance, point.y() + tolerance );
-  return edgesInRect( rect, filter );
+  return edgesInRect( rect, filter, relaxed );
 }
 
-QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
-  if ( !mRTree )
-  {
-    init();
-    if ( !mRTree ) // still invalid?
-      return MatchList();
-  }
+  if ( !prepare( relaxed ) )
+    return MatchList();
 
   MatchList lst;
   QgsPointLocator_VisitorVerticesInRect visitor( this, lst, rect, filter );
@@ -942,21 +1032,16 @@ QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsRectangle &
   return lst;
 }
 
-QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
   QgsRectangle rect( point.x() - tolerance, point.y() - tolerance, point.x() + tolerance, point.y() + tolerance );
-  return verticesInRect( rect, filter );
+  return verticesInRect( rect, filter, relaxed );
 }
 
-
-QgsPointLocator::MatchList QgsPointLocator::pointInPolygon( const QgsPointXY &point )
+QgsPointLocator::MatchList QgsPointLocator::pointInPolygon( const QgsPointXY &point, bool relaxed )
 {
-  if ( !mRTree )
-  {
-    init();
-    if ( !mRTree ) // still invalid?
-      return MatchList();
-  }
+  if ( !prepare( relaxed ) )
+    return MatchList();
 
   QgsWkbTypes::GeometryType geomType = mLayer->geometryType();
   if ( geomType == QgsWkbTypes::PointGeometry || geomType == QgsWkbTypes::LineGeometry )

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -548,6 +548,10 @@ QgsPointLocator::QgsPointLocator( QgsVectorLayer *layer, const QgsCoordinateRefe
 
 QgsPointLocator::~QgsPointLocator()
 {
+  // don't delete a locator if there is an indexing task running on it
+  if ( mIsIndexing )
+    waitForIndexingFinished();
+
   destroyIndex();
 }
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -20,6 +20,7 @@ class QgsPointXY;
 class QgsFeatureRenderer;
 class QgsRenderContext;
 class QgsRectangle;
+class QgsVectorLayerFeatureSource;
 
 #include "qgis_core.h"
 #include "qgspointxy.h"
@@ -30,6 +31,7 @@ class QgsRectangle;
 #include "qgsgeometryutils.h"
 #include "qgsvectorlayer.h"
 #include "qgslinestring.h"
+#include "qgspointlocatorinittask.h"
 #include <memory>
 
 class QgsPointLocator_VisitorNearestVertex;
@@ -122,10 +124,17 @@ class CORE_EXPORT QgsPointLocator : public QObject
     /**
      * Prepare the index for queries. Does nothing if the index already exists.
      * If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
-     * to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used. Returns
-     * FALSE if the creation of index has been prematurely stopped due to the limit of features, otherwise TRUE
-    */
-    bool init( int maxFeaturesToIndex = -1 );
+     * to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used.
+     *
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
+     * in the constructor. if TRUE, index building will be done in another thread and init() method returns
+     * immediately. initFinished() signal will be emitted once the initialization is over.
+     *
+     * Returns false if the creation of index is blocking and has been prematurely stopped due to the limit of features, otherwise true
+     *
+     * \see QgsPointLocator()
+     */
+    bool init( int maxFeaturesToIndex = -1, bool relaxed = false );
 
     //! Indicate whether the data have been already indexed
     bool hasIndex() const;
@@ -251,50 +260,65 @@ class CORE_EXPORT QgsPointLocator : public QObject
     /**
      * Find nearest vertex to the specified point - up to distance specified by tolerance
      * Optional filter may discard unwanted matches.
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      */
-    Match nearestVertex( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+    Match nearestVertex( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Find nearest edge to the specified point - up to distance specified by tolerance
      * Optional filter may discard unwanted matches.
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      */
-    Match nearestEdge( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+    Match nearestEdge( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Find nearest area to the specified point - up to distance specified by tolerance
      * Optional filter may discard unwanted matches.
      * This will first perform a pointInPolygon and return first result.
      * If no match is found and tolerance is not 0, it will return nearestEdge.
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      * \since QGIS 3.0
      */
-    Match nearestArea( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+    Match nearestArea( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Find edges within a specified recangle
      * Optional filter may discard unwanted matches.
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      */
-    MatchList edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = nullptr );
-    //! Override of edgesInRect that construct rectangle from a center point and tolerance
-    MatchList edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+    MatchList edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
+
+    /**
+     * Override of edgesInRect that construct rectangle from a center point and tolerance
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
+     */
+    MatchList edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Find vertices within a specified recangle
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      * Optional filter may discard unwanted matches.
      * \since QGIS 3.6
      */
-    MatchList verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = nullptr );
+    MatchList verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Override of verticesInRect that construct rectangle from a center point and tolerance
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      * \since QGIS 3.6
      */
-    MatchList verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+    MatchList verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     // point-in-polygon query
 
     // TODO: function to return just the first match?
-    //! find out if the point is in any polygons
-    MatchList pointInPolygon( const QgsPointXY &point );
+
+    /**
+     * find out if the \a point is in any polygons
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
+     */
+    //!
+    MatchList pointInPolygon( const QgsPointXY &point, bool relaxed = false );
 
     /**
      * Returns how many geometries are cached in the index
@@ -302,17 +326,50 @@ class CORE_EXPORT QgsPointLocator : public QObject
      */
     int cachedGeometryCount() const { return mGeoms.count(); }
 
+    /**
+     * Returns TRUE if the point locator is currently indexing the data.
+     * This method is useful if constructor parameter \a relaxed is TRUE
+     *
+     * \see QgsPointLocator()
+     */
+    bool isIndexing() const { return mIsIndexing; }
+
+    /**
+     * If the point locator has been initialized relaxedly and is currently indexing,
+     * this methods waits for the indexing to be finished
+     */
+    void waitForFinished() const;
+
+  signals:
+
+    /**
+     * Emitted whenever index has been built and initialization is finished
+     * \param ok FALSE if the creation of index has been prematurely stopped due to the limit of
+     * features, otherwise TRUE
+     */
+    void initFinished( bool ok );
+
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
+
   protected slots:
     void destroyIndex();
   private slots:
+    void onInitTaskTerminated();
+    void onRebuildIndexFinished( bool ok );
     void onFeatureAdded( QgsFeatureId fid );
     void onFeatureDeleted( QgsFeatureId fid );
     void onGeometryChanged( QgsFeatureId fid, const QgsGeometry &geom );
     void onAttributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
 
   private:
+
+    /**
+     * prepare index if need and returns TRUE if the index is ready to be used
+     * \param relaxed TRUE if index build has to be non blocking
+     */
+    bool prepare( bool relaxed );
+
     //! Storage manager
     std::unique_ptr< SpatialIndex::IStorageManager > mStorage;
 
@@ -329,12 +386,21 @@ class CORE_EXPORT QgsPointLocator : public QObject
     std::unique_ptr< QgsRectangle > mExtent;
 
     std::unique_ptr<QgsRenderContext> mContext;
+    std::unique_ptr<QgsFeatureRenderer> mRenderer;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
+    int mMaxFeaturesToIndex = -1;
+    bool mIsIndexing = false;
+    QgsFeatureIds mAddedFeatures;
+    QgsFeatureIds mDeletedFeatures;
+    QPointer<QgsPointLocatorInitTask> mInitTask;
 
     friend class QgsPointLocator_VisitorNearestVertex;
     friend class QgsPointLocator_VisitorNearestEdge;
     friend class QgsPointLocator_VisitorArea;
     friend class QgsPointLocator_VisitorEdgesInRect;
     friend class QgsPointLocator_VisitorVerticesInRect;
+    friend class QgsPointLocatorInitTask;
+    friend class TestQgsPointLocator;
 };
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -338,7 +338,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * If the point locator has been initialized relaxedly and is currently indexing,
      * this methods waits for the indexing to be finished
      */
-    void waitForFinished() const;
+    void waitForIndexingFinished();
 
   signals:
 
@@ -355,8 +355,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
   protected slots:
     void destroyIndex();
   private slots:
-    void onInitTaskTerminated();
-    void onRebuildIndexFinished( bool ok );
+    void onInitTaskFinished();
     void onFeatureAdded( QgsFeatureId fid );
     void onFeatureDeleted( QgsFeatureId fid );
     void onGeometryChanged( QgsFeatureId fid, const QgsGeometry &geom );

--- a/src/core/qgspointlocatorinittask.cpp
+++ b/src/core/qgspointlocatorinittask.cpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+  qgspointlocatorinittask.cpp
+  --------------------------------------
+  Date                 : September 2019
+  Copyright            : (C) 2019 by Julien Cabieces
+  Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspointlocatorinittask.h"
+#include "qgspointlocator.h"
+#include "qgsvectorlayer.h"
+
+/// @cond PRIVATE
+
+QgsPointLocatorInitTask::QgsPointLocatorInitTask( QgsPointLocator *loc )
+  : QgsTask( tr( "Indexing %1" ).arg( loc->layer()->id() ), QgsTask::Flags() )
+  , mLoc( loc )
+{}
+
+bool QgsPointLocatorInitTask::run()
+{
+  const bool ok = mLoc->rebuildIndex();
+  emit rebuildIndexFinished( ok );
+  return true;
+}
+
+/// @endcond

--- a/src/core/qgspointlocatorinittask.cpp
+++ b/src/core/qgspointlocatorinittask.cpp
@@ -24,10 +24,14 @@ QgsPointLocatorInitTask::QgsPointLocatorInitTask( QgsPointLocator *loc )
   , mLoc( loc )
 {}
 
+bool QgsPointLocatorInitTask::isBuildOK() const
+{
+  return mBuildOK;
+}
+
 bool QgsPointLocatorInitTask::run()
 {
-  const bool ok = mLoc->rebuildIndex();
-  emit rebuildIndexFinished( ok );
+  mBuildOK = mLoc->rebuildIndex();
   return true;
 }
 

--- a/src/core/qgspointlocatorinittask.h
+++ b/src/core/qgspointlocatorinittask.h
@@ -48,10 +48,6 @@ class QgsPointLocatorInitTask : public QgsTask
 
     bool run();
 
-  signals:
-
-    void rebuildIndexFinished( bool ok );
-
   private:
 
     QgsPointLocator *mLoc = nullptr;

--- a/src/core/qgspointlocatorinittask.h
+++ b/src/core/qgspointlocatorinittask.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+  qgspointlocatorinittask.h
+  --------------------------------------
+  Date                 : September 2019
+  Copyright            : (C) 2019 by Julien Cabieces
+  Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPOINTLOCATORINITTASK_H
+#define QGSPOINTLOCATORINITTASK_H
+
+/// @cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#define SIP_NO_FILE
+
+#include "qgstaskmanager.h"
+
+class QgsPointLocator;
+
+class QgsPointLocatorInitTask : public QgsTask
+{
+    Q_OBJECT
+
+  public:
+
+    QgsPointLocatorInitTask( QgsPointLocator *loc );
+
+    bool run();
+
+  signals:
+
+    void rebuildIndexFinished( bool ok );
+
+  private:
+
+    QgsPointLocator *mLoc = nullptr;
+};
+
+/// @endcond
+
+#endif // QGSPOINTLOCATORINITTASK_H

--- a/src/core/qgspointlocatorinittask.h
+++ b/src/core/qgspointlocatorinittask.h
@@ -41,6 +41,11 @@ class QgsPointLocatorInitTask : public QgsTask
 
     QgsPointLocatorInitTask( QgsPointLocator *loc );
 
+    /**
+     * Returns TRUE when the task has finished and the index build was ok
+     */
+    bool isBuildOK() const;
+
     bool run();
 
   signals:
@@ -50,6 +55,7 @@ class QgsPointLocatorInitTask : public QgsTask
   private:
 
     QgsPointLocator *mLoc = nullptr;
+    bool mBuildOK = false;
 };
 
 /// @endcond

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -68,7 +68,7 @@ QgsPointLocator *QgsSnappingUtils::locatorForLayerUsingStrategy( QgsVectorLayer 
 
   QgsPointLocator *loc = locatorForLayer( vl );
 
-  if ( isIndexPrepared( loc, aoi ) )
+  if ( loc->isIndexing() || isIndexPrepared( loc, aoi ) )
     return loc;
   else
     return temporaryLocatorForLayer( vl, pointMap, tolerance );
@@ -91,9 +91,6 @@ QgsPointLocator *QgsSnappingUtils::temporaryLocatorForLayer( QgsVectorLayer *vl,
 
 bool QgsSnappingUtils::isIndexPrepared( QgsPointLocator *loc, const QgsRectangle &areaOfInterest )
 {
-  if ( loc->isIndexing() )
-    return true;
-
   if ( mStrategy == IndexAlwaysFull && loc->hasIndex() )
     return true;
 
@@ -374,7 +371,7 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
 
     QgsPointLocator *loc = locatorForLayer( vl );
 
-    if ( !isIndexPrepared( loc, entry.second ) )
+    if ( !loc->isIndexing() && !isIndexPrepared( loc, entry.second ) )
       layersToIndex << entry;
   }
   if ( !layersToIndex.isEmpty() )

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -227,24 +227,9 @@ static QgsPointLocator::Types _snappingTypeToPointLocatorType( QgsSnappingConfig
   }
 }
 
-QgsPointLocator::Match QgsSnappingUtils::snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::Match QgsSnappingUtils::snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
-  return snapToMap( mMapSettings.mapToPixel().toMapCoordinates( point ), filter );
-}
-
-QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter )
-{
-  return _snapToMap( pointMap, filter, false );
-}
-
-QgsPointLocator::Match QgsSnappingUtils::snapToMapRelaxed( QPoint point, QgsPointLocator::MatchFilter *filter )
-{
-  return snapToMapRelaxed( mMapSettings.mapToPixel().toMapCoordinates( point ), filter );
-}
-
-QgsPointLocator::Match QgsSnappingUtils::snapToMapRelaxed( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter )
-{
-  return _snapToMap( pointMap, filter, true );
+  return snapToMap( mMapSettings.mapToPixel().toMapCoordinates( point ), filter, relaxed );
 }
 
 inline QgsRectangle _areaOfInterest( const QgsPointXY &point, double tolerance )
@@ -253,7 +238,7 @@ inline QgsRectangle _areaOfInterest( const QgsPointXY &point, double tolerance )
                        point.x() + tolerance, point.y() + tolerance );
 }
 
-QgsPointLocator::Match QgsSnappingUtils::_snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter, bool relaxed )
+QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
   if ( !mMapSettings.hasValidSettings() || !mSnappingConfig.enabled() )
   {

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -396,7 +396,7 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
 
       if ( loc->isIndexing() && !relaxed )
       {
-        loc->waitForFinished();
+        loc->waitForIndexingFinished();
       }
 
 

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -41,7 +41,8 @@ QgsPointLocator *QgsSnappingUtils::locatorForLayer( QgsVectorLayer *vl )
 
   if ( !mLocators.contains( vl ) )
   {
-    QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext() );
+    QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), nullptr );
+    connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
     mLocators.insert( vl, vlpl );
   }
   return mLocators.value( vl );
@@ -59,10 +60,16 @@ void QgsSnappingUtils::clearAllLocators()
 
 QgsPointLocator *QgsSnappingUtils::locatorForLayerUsingStrategy( QgsVectorLayer *vl, const QgsPointXY &pointMap, double tolerance )
 {
+  if ( vl->geometryType() == QgsWkbTypes::NullGeometry || mStrategy == IndexNeverFull )
+    return nullptr;
+
   QgsRectangle aoi( pointMap.x() - tolerance, pointMap.y() - tolerance,
                     pointMap.x() + tolerance, pointMap.y() + tolerance );
-  if ( isIndexPrepared( vl, aoi ) )
-    return locatorForLayer( vl );
+
+  QgsPointLocator *loc = locatorForLayer( vl );
+
+  if ( isIndexPrepared( loc, aoi ) )
+    return loc;
   else
     return temporaryLocatorForLayer( vl, pointMap, tolerance );
 }
@@ -74,17 +81,18 @@ QgsPointLocator *QgsSnappingUtils::temporaryLocatorForLayer( QgsVectorLayer *vl,
 
   QgsRectangle rect( pointMap.x() - tolerance, pointMap.y() - tolerance,
                      pointMap.x() + tolerance, pointMap.y() + tolerance );
+
   QgsPointLocator *vlpl = new QgsPointLocator( vl, destinationCrs(), mMapSettings.transformContext(), &rect );
+  connect( vlpl, &QgsPointLocator::initFinished, this, &QgsSnappingUtils::onInitFinished );
+
   mTemporaryLocators.insert( vl, vlpl );
   return mTemporaryLocators.value( vl );
 }
 
-bool QgsSnappingUtils::isIndexPrepared( QgsVectorLayer *vl, const QgsRectangle &areaOfInterest )
+bool QgsSnappingUtils::isIndexPrepared( QgsPointLocator *loc, const QgsRectangle &areaOfInterest )
 {
-  if ( vl->geometryType() == QgsWkbTypes::NullGeometry || mStrategy == IndexNeverFull )
-    return false;
-
-  QgsPointLocator *loc = locatorForLayer( vl );
+  if ( loc->isIndexing() )
+    return true;
 
   if ( mStrategy == IndexAlwaysFull && loc->hasIndex() )
     return true;
@@ -183,22 +191,22 @@ static void _replaceIfBetter( QgsPointLocator::Match &bestMatch, const QgsPointL
   bestMatch = candidateMatch; // the other match is better!
 }
 
-static void _updateBestMatch( QgsPointLocator::Match &bestMatch, const QgsPointXY &pointMap, QgsPointLocator *loc, QgsPointLocator::Types type, double tolerance, QgsPointLocator::MatchFilter *filter )
+static void _updateBestMatch( QgsPointLocator::Match &bestMatch, const QgsPointXY &pointMap, QgsPointLocator *loc, QgsPointLocator::Types type, double tolerance, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
   if ( type & QgsPointLocator::Vertex )
   {
-    _replaceIfBetter( bestMatch, loc->nearestVertex( pointMap, tolerance, filter ), tolerance );
+    _replaceIfBetter( bestMatch, loc->nearestVertex( pointMap, tolerance, filter, relaxed ), tolerance );
   }
   if ( bestMatch.type() != QgsPointLocator::Vertex && ( type & QgsPointLocator::Edge ) )
   {
-    _replaceIfBetter( bestMatch, loc->nearestEdge( pointMap, tolerance, filter ), tolerance );
+    _replaceIfBetter( bestMatch, loc->nearestEdge( pointMap, tolerance, filter, relaxed ), tolerance );
   }
   if ( bestMatch.type() != QgsPointLocator::Vertex && bestMatch.type() != QgsPointLocator::Edge && ( type & QgsPointLocator::Area ) )
   {
     // if edges were detected, set tolerance to 0 to only do pointInPolygon (and avoid redo nearestEdge)
     if ( type & QgsPointLocator::Edge )
       tolerance = 0;
-    _replaceIfBetter( bestMatch, loc->nearestArea( pointMap, tolerance, filter ), tolerance );
+    _replaceIfBetter( bestMatch, loc->nearestArea( pointMap, tolerance, filter, relaxed ), tolerance );
   }
 }
 
@@ -219,10 +227,24 @@ static QgsPointLocator::Types _snappingTypeToPointLocatorType( QgsSnappingConfig
   }
 }
 
-
 QgsPointLocator::Match QgsSnappingUtils::snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter )
 {
   return snapToMap( mMapSettings.mapToPixel().toMapCoordinates( point ), filter );
+}
+
+QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter )
+{
+  return _snapToMap( pointMap, filter, false );
+}
+
+QgsPointLocator::Match QgsSnappingUtils::snapToMapRelaxed( QPoint point, QgsPointLocator::MatchFilter *filter )
+{
+  return snapToMapRelaxed( mMapSettings.mapToPixel().toMapCoordinates( point ), filter );
+}
+
+QgsPointLocator::Match QgsSnappingUtils::snapToMapRelaxed( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter )
+{
+  return _snapToMap( pointMap, filter, true );
 }
 
 inline QgsRectangle _areaOfInterest( const QgsPointXY &point, double tolerance )
@@ -231,7 +253,7 @@ inline QgsRectangle _areaOfInterest( const QgsPointXY &point, double tolerance )
                        point.x() + tolerance, point.y() + tolerance );
 }
 
-QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter )
+QgsPointLocator::Match QgsSnappingUtils::_snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter, bool relaxed )
 {
   if ( !mMapSettings.hasValidSettings() || !mSnappingConfig.enabled() )
   {
@@ -247,7 +269,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     double tolerance = QgsTolerance::toleranceInProjectUnits( mSnappingConfig.tolerance(), mCurrentLayer, mMapSettings, mSnappingConfig.units() );
     QgsPointLocator::Types type = _snappingTypeToPointLocatorType( mSnappingConfig.type() );
 
-    prepareIndex( QList<LayerAndAreaOfInterest>() << qMakePair( mCurrentLayer, _areaOfInterest( pointMap, tolerance ) ) );
+    prepareIndex( QList<LayerAndAreaOfInterest>() << qMakePair( mCurrentLayer, _areaOfInterest( pointMap, tolerance ) ), relaxed );
 
     // use ad-hoc locator
     QgsPointLocator *loc = locatorForLayerUsingStrategy( mCurrentLayer, pointMap, tolerance );
@@ -255,11 +277,14 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       return QgsPointLocator::Match();
 
     QgsPointLocator::Match bestMatch;
-    _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter );
+    _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter, relaxed );
 
     if ( mSnappingConfig.intersectionSnapping() )
     {
       QgsPointLocator *locEdges = locatorForLayerUsingStrategy( mCurrentLayer, pointMap, tolerance );
+      if ( !locEdges )
+        return QgsPointLocator::Match();
+
       QgsPointLocator::MatchList edges = locEdges->edgesInRect( pointMap, tolerance );
       _replaceIfBetter( bestMatch, _findClosestSegmentIntersection( pointMap, edges ), tolerance );
     }
@@ -274,7 +299,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
       layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );
     }
-    prepareIndex( layers );
+    prepareIndex( layers, relaxed );
 
     QgsPointLocator::Match bestMatch;
     QgsPointLocator::MatchList edges; // for snap on intersection
@@ -285,7 +310,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
       if ( QgsPointLocator *loc = locatorForLayerUsingStrategy( layerConfig.layer, pointMap, tolerance ) )
       {
-        _updateBestMatch( bestMatch, pointMap, loc, layerConfig.type, tolerance, filter );
+        _updateBestMatch( bestMatch, pointMap, loc, layerConfig.type, tolerance, filter, relaxed );
 
         if ( mSnappingConfig.intersectionSnapping() )
         {
@@ -312,7 +337,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     for ( QgsMapLayer *layer : constLayers )
       if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer ) )
         layers << qMakePair( vl, aoi );
-    prepareIndex( layers );
+    prepareIndex( layers, relaxed );
 
     QgsPointLocator::MatchList edges; // for snap on intersection
     QgsPointLocator::Match bestMatch;
@@ -322,7 +347,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       QgsVectorLayer *vl = entry.first;
       if ( QgsPointLocator *loc = locatorForLayerUsingStrategy( vl, pointMap, tolerance ) )
       {
-        _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter );
+        _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter, relaxed );
 
         if ( mSnappingConfig.intersectionSnapping() )
           edges << loc->edgesInRect( pointMap, tolerance );
@@ -338,12 +363,20 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
   return QgsPointLocator::Match();
 }
 
-void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers )
+void QgsSnappingUtils::onInitFinished( bool ok )
 {
-  if ( mIsIndexing )
-    return;
-  mIsIndexing = true;
+  QgsPointLocator *loc = static_cast<QgsPointLocator *>( sender() );
 
+  // point locator init didn't work out - too many features!
+  // let's make the allowed area smaller for the next time
+  if ( !ok )
+  {
+    mHybridMaxAreaPerLayer[loc->layer()->id()] /= 4;
+  }
+}
+
+void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers, bool relaxed )
+{
   // check if we need to build any index
   QList<LayerAndAreaOfInterest> layersToIndex;
   const auto constLayers = layers;
@@ -354,24 +387,33 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
     if ( vl->geometryType() == QgsWkbTypes::NullGeometry || mStrategy == IndexNeverFull )
       continue;
 
-    if ( !isIndexPrepared( vl, entry.second ) )
+    QgsPointLocator *loc = locatorForLayer( vl );
+
+    if ( !isIndexPrepared( loc, entry.second ) )
       layersToIndex << entry;
   }
   if ( !layersToIndex.isEmpty() )
   {
     // build indexes
     QTime t;
-    t.start();
     int i = 0;
-    prepareIndexStarting( layersToIndex.count() );
-    const auto constLayersToIndex = layersToIndex;
-    for ( const LayerAndAreaOfInterest &entry : constLayersToIndex )
+
+    if ( !relaxed )
+    {
+      t.start();
+      prepareIndexStarting( layersToIndex.count() );
+    }
+
+    for ( const LayerAndAreaOfInterest &entry : layersToIndex )
     {
       QgsVectorLayer *vl = entry.first;
-      QTime tt;
-      tt.start();
-
       QgsPointLocator *loc = locatorForLayer( vl );
+
+      if ( loc->isIndexing() && !relaxed )
+      {
+        loc->waitForFinished();
+      }
+
 
       if ( !mEnableSnappingForInvisibleFeature )
       {
@@ -383,7 +425,7 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
       {
         QgsRectangle rect( mMapSettings.visibleExtent() );
         loc->setExtent( &rect );
-        loc->init();
+        loc->init( -1, relaxed );
       }
       else if ( mStrategy == IndexHybrid )
       {
@@ -410,7 +452,7 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
         if ( indexReasonableArea == -1 )
         {
           // we can safely index the whole layer
-          loc->init();
+          loc->init( -1, relaxed );
         }
         else
         {
@@ -422,24 +464,20 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
           loc->setExtent( &rect );
 
           // see if it's possible build index for this area
-          if ( !loc->init( mHybridPerLayerFeatureLimit ) )
-          {
-            // hmm that didn't work out - too many features!
-            // let's make the allowed area smaller for the next time
-            mHybridMaxAreaPerLayer[vl->id()] /= 4;
-          }
+          loc->init( mHybridPerLayerFeatureLimit, relaxed );
         }
 
       }
       else  // full index strategy
-        loc->init();
+        loc->init( relaxed );
 
-      QgsDebugMsg( QStringLiteral( "Index init: %1 ms (%2)" ).arg( tt.elapsed() ).arg( vl->id() ) );
-      prepareIndexProgress( ++i );
+      if ( !relaxed )
+        prepareIndexProgress( ++i );
     }
-    QgsDebugMsg( QStringLiteral( "Prepare index total: %1 ms" ).arg( t.elapsed() ) );
+
+    if ( !relaxed )
+      QgsDebugMsg( QStringLiteral( "Prepare index total: %1 ms" ).arg( t.elapsed() ) );
   }
-  mIsIndexing = false;
 }
 
 QgsSnappingConfig QgsSnappingUtils::config() const
@@ -484,7 +522,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToCurrentLayer( QPoint point, QgsPo
     return QgsPointLocator::Match();
 
   QgsPointLocator::Match bestMatch;
-  _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter );
+  _updateBestMatch( bestMatch, pointMap, loc, type, tolerance, filter, false );
   return bestMatch;
 }
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -72,15 +72,15 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
      * Snap to map according to the current configuration.
      * \param point point in canvas coordinates
      * \param filter allows discarding unwanted matches.
-     * This method is either blocking or non blocking according to \a relaxed parameter passed
+     * \param relaxed TRUE if this method is non blocking and the matching result can be invalid while indexing
      */
     QgsPointLocator::Match snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Snap to map according to the current configuration.
-     * \param point point in canvas coordinates
+     * \param pointMap point in map coordinates
      * \param filter allows discarding unwanted matches.
-     * This method is either blocking or non blocking according to \a relaxed parameter passed
+     * \param relaxed TRUE if this method is non blocking and the matching result can be invalid while indexing
      */
     QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -68,27 +68,21 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
      */
     QgsPointLocator *locatorForLayer( QgsVectorLayer *vl );
 
-    //! Snap to map according to the current configuration. Optional filter allows discarding unwanted matches.
-    QgsPointLocator::Match snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter = nullptr );
-    QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = nullptr );
-
     /**
      * Snap to map according to the current configuration.
-     * Unlike the snapToMap() method, this method is non blocking and return matches from point locators which
-     * are not currently indexing
      * \param point point in canvas coordinates
      * \param filter allows discarding unwanted matches.
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      */
-    QgsPointLocator::Match snapToMapRelaxed( QPoint point, QgsPointLocator::MatchFilter *filter = nullptr );
+    QgsPointLocator::Match snapToMap( QPoint point, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     /**
      * Snap to map according to the current configuration.
-     * Unlike the snapToMap() method, this method is non blocking and return matches from point locators which
-     * are not currently indexing
-     * \param pointMap point in map coordinates
+     * \param point point in canvas coordinates
      * \param filter allows discarding unwanted matches.
+     * This method is either blocking or non blocking according to \a relaxed parameter passed
      */
-    QgsPointLocator::Match snapToMapRelaxed( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = nullptr );
+    QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = nullptr, bool relaxed = false );
 
     //! Snap to current layer
     QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = nullptr );
@@ -243,14 +237,6 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     bool isIndexPrepared( QgsPointLocator *loc, const QgsRectangle &areaOfInterest );
     //! initialize index for layers where it makes sense (according to the indexing strategy)
     void prepareIndex( const QList<LayerAndAreaOfInterest> &layers, bool relaxed );
-
-    /**
-     * Internal snap to map according to given point and the current configuration.
-     * \param pointMap point in map coordinates
-     * \param filter allows discarding unwanted matches.
-     * This method is either blocking or non blocking according to \a relaxed parameter passed
-     */
-    QgsPointLocator::Match _snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter, bool relaxed );
 
   private:
     // environment

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -670,7 +670,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   // set the point coordinates in the map event
   e->setMapPoint( point );
 
-  mSnapMatch = context.snappingUtils->snapToMapRelaxed( point );
+  mSnapMatch = context.snappingUtils->snapToMap( point, nullptr, true );
 
   if ( mSnapMatch.isValid() )
   {
@@ -782,7 +782,7 @@ QList<QgsPointXY> QgsAdvancedDigitizingDockWidget::snapSegmentToAllLayers( const
   localConfig.setType( QgsSnappingConfig::Segment );
   snappingUtils->setConfig( localConfig );
 
-  match = snappingUtils->snapToMapRelaxed( originalMapPoint );
+  match = snappingUtils->snapToMap( originalMapPoint, nullptr, true );
 
   snappingUtils->setConfig( canvasConfig );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -670,7 +670,7 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   // set the point coordinates in the map event
   e->setMapPoint( point );
 
-  mSnapMatch = context.snappingUtils->snapToMap( point );
+  mSnapMatch = context.snappingUtils->snapToMapRelaxed( point );
 
   if ( mSnapMatch.isValid() )
   {
@@ -782,7 +782,7 @@ QList<QgsPointXY> QgsAdvancedDigitizingDockWidget::snapSegmentToAllLayers( const
   localConfig.setType( QgsSnappingConfig::Segment );
   snappingUtils->setConfig( localConfig );
 
-  match = snappingUtils->snapToMap( originalMapPoint );
+  match = snappingUtils->snapToMapRelaxed( originalMapPoint );
 
   snappingUtils->setConfig( canvasConfig );
 

--- a/src/gui/qgsmapcanvassnappingutils.h
+++ b/src/gui/qgsmapcanvassnappingutils.h
@@ -34,6 +34,14 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
 {
     Q_OBJECT
   public:
+
+    /**
+     * Construct map canvas snapping utils object
+     *
+     * \param canvas map canvas
+     * \param parent parent object
+     * if FALSE it will block until indexing is done
+     */
     QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent = nullptr );
 
   protected:

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -49,7 +49,7 @@ QgsPointXY QgsMapMouseEvent::snapPoint()
   mHasCachedSnapResult = true;
 
   QgsSnappingUtils *snappingUtils = mMapCanvas->snappingUtils();
-  mSnapMatch = snappingUtils->snapToMap( mMapPoint );
+  mSnapMatch = snappingUtils->snapToMapRelaxed( mMapPoint );
 
   if ( mSnapMatch.isValid() )
   {

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -49,7 +49,7 @@ QgsPointXY QgsMapMouseEvent::snapPoint()
   mHasCachedSnapResult = true;
 
   QgsSnappingUtils *snappingUtils = mMapCanvas->snappingUtils();
-  mSnapMatch = snappingUtils->snapToMapRelaxed( mMapPoint );
+  mSnapMatch = snappingUtils->snapToMap( mMapPoint, nullptr, true );
 
   if ( mSnapMatch.isValid() )
   {

--- a/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
+++ b/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
@@ -119,6 +119,9 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerPointZ << mLayerPointZSnap );
   mCanvas->setCurrentLayer( mLayerPointZ );
 
+  initPointLocator( mCanvas->snappingUtils(), mLayerPointZ );
+  initPointLocator( mCanvas->snappingUtils(), mLayerPointZSnap );
+
   // create the tool
   mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );
   mCanvas->setMapTool( mCaptureTool );

--- a/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
+++ b/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
@@ -119,8 +119,8 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerPointZ << mLayerPointZSnap );
   mCanvas->setCurrentLayer( mLayerPointZ );
 
-  initPointLocator( mCanvas->snappingUtils(), mLayerPointZ );
-  initPointLocator( mCanvas->snappingUtils(), mLayerPointZSnap );
+  mCanvas->snappingUtils()->locatorForLayer( mLayerPointZ )->init();
+  mCanvas->snappingUtils()->locatorForLayer( mLayerPointZSnap )->init();
 
   // create the tool
   mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -162,9 +162,13 @@ void TestQgsMapToolReshape::initTestCase()
   cfg.setType( QgsSnappingConfig::VertexAndSegment );
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
-
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLineZ << mLayerPointZ << mLayerPolygonZ );
   mCanvas->setCurrentLayer( mLayerLineZ );
+
+  initPointLocator( mCanvas->snappingUtils(), mLayerLineZ );
+  initPointLocator( mCanvas->snappingUtils(), mLayerPointZ );
+  initPointLocator( mCanvas->snappingUtils(), mLayerPolygonZ );
+  initPointLocator( mCanvas->snappingUtils(), mLayerTopo );
 
   // create the tool
   mCaptureTool = new QgsMapToolReshape( mCanvas );

--- a/tests/src/app/testqgsmaptoolreshape.cpp
+++ b/tests/src/app/testqgsmaptoolreshape.cpp
@@ -165,10 +165,10 @@ void TestQgsMapToolReshape::initTestCase()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLineZ << mLayerPointZ << mLayerPolygonZ );
   mCanvas->setCurrentLayer( mLayerLineZ );
 
-  initPointLocator( mCanvas->snappingUtils(), mLayerLineZ );
-  initPointLocator( mCanvas->snappingUtils(), mLayerPointZ );
-  initPointLocator( mCanvas->snappingUtils(), mLayerPolygonZ );
-  initPointLocator( mCanvas->snappingUtils(), mLayerTopo );
+  mCanvas->snappingUtils()->locatorForLayer( mLayerLineZ )->init();
+  mCanvas->snappingUtils()->locatorForLayer( mLayerPointZ )->init();
+  mCanvas->snappingUtils()->locatorForLayer( mLayerPolygonZ )->init();
+  mCanvas->snappingUtils()->locatorForLayer( mLayerTopo )->init();
 
   // create the tool
   mCaptureTool = new QgsMapToolReshape( mCanvas );

--- a/tests/src/app/testqgsmaptoolreverseline.cpp
+++ b/tests/src/app/testqgsmaptoolreverseline.cpp
@@ -25,7 +25,7 @@
 #include "testqgsmaptoolutils.h"
 #include "qgsmaptoolreverseline.h"
 #include "qgsmapmouseevent.h"
-
+#include "qgssnappingutils.h"
 
 class TestQgsMapToolReverseLine : public QObject
 {
@@ -60,7 +60,6 @@ void TestQgsMapToolReverseLine::initTestCase()
 
   mCanvas = new QgsMapCanvas();
   mCanvas->setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3946" ) ) );
-
 }
 
 void TestQgsMapToolReverseLine::cleanupTestCase()

--- a/tests/src/app/testqgsmaptooltrimextendfeature.cpp
+++ b/tests/src/app/testqgsmaptooltrimextendfeature.cpp
@@ -34,13 +34,6 @@
 #include "qgsmaptooltrimextendfeature.h"
 
 
-// initialize point locator
-void initPointLocator( QgsSnappingUtils *snappingUtils, QgsVectorLayer *layer )
-{
-  QgsPointLocator *loc = snappingUtils->locatorForLayer( layer );
-  loc->init();
-}
-
 class TestQgsMapToolTrimExtendFeature : public QObject
 {
     Q_OBJECT
@@ -181,11 +174,11 @@ class TestQgsMapToolTrimExtendFeature : public QObject
       snappingConfig.setMode( QgsSnappingConfig::AllLayers );
       mSnappingUtils->setConfig( snappingConfig );
 
-      initPointLocator( mSnappingUtils, vlPolygon.get() );
-      initPointLocator( mSnappingUtils, vlMultiLine.get() );
-      initPointLocator( mSnappingUtils, vlLineZ.get() );
-      initPointLocator( mSnappingUtils, vlTopoEdit.get() );
-      initPointLocator( mSnappingUtils, vlTopoLimit.get() );
+      mSnappingUtils->locatorForLayer( vlPolygon.get() )->init();
+      mSnappingUtils->locatorForLayer( vlMultiLine.get() )->init();
+      mSnappingUtils->locatorForLayer( vlLineZ.get() )->init();
+      mSnappingUtils->locatorForLayer( vlTopoEdit.get() )->init();
+      mSnappingUtils->locatorForLayer( vlTopoLimit.get() )->init();
 
       mCanvas->setSnappingUtils( mSnappingUtils );
     }

--- a/tests/src/app/testqgsmaptooltrimextendfeature.cpp
+++ b/tests/src/app/testqgsmaptooltrimextendfeature.cpp
@@ -29,9 +29,17 @@
 #include "qgsmapcanvas.h"
 #include "qgsmapmouseevent.h"
 #include "qgsmapcanvassnappingutils.h"
+#include "qgisapp.h"
 
 #include "qgsmaptooltrimextendfeature.h"
 
+
+// initialize point locator
+void initPointLocator( QgsSnappingUtils *snappingUtils, QgsVectorLayer *layer )
+{
+  QgsPointLocator *loc = snappingUtils->locatorForLayer( layer );
+  loc->init();
+}
 
 class TestQgsMapToolTrimExtendFeature : public QObject
 {
@@ -172,6 +180,12 @@ class TestQgsMapToolTrimExtendFeature : public QObject
       snappingConfig.setUnits( QgsTolerance::Pixels );
       snappingConfig.setMode( QgsSnappingConfig::AllLayers );
       mSnappingUtils->setConfig( snappingConfig );
+
+      initPointLocator( mSnappingUtils, vlPolygon.get() );
+      initPointLocator( mSnappingUtils, vlMultiLine.get() );
+      initPointLocator( mSnappingUtils, vlLineZ.get() );
+      initPointLocator( mSnappingUtils, vlTopoEdit.get() );
+      initPointLocator( mSnappingUtils, vlTopoLimit.get() );
 
       mCanvas->setSnappingUtils( mSnappingUtils );
     }

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -21,7 +21,14 @@
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
 #include "qgsmapmouseevent.h"
+#include "qgssnappingutils.h"
 
+// initialize point locator
+void initPointLocator( QgsSnappingUtils *snappingUtils, QgsVectorLayer *layer )
+{
+  QgsPointLocator *loc = snappingUtils->locatorForLayer( layer );
+  loc->init();
+}
 
 /**
  * \ingroup UnitTests

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -23,13 +23,6 @@
 #include "qgsmapmouseevent.h"
 #include "qgssnappingutils.h"
 
-// initialize point locator
-void initPointLocator( QgsSnappingUtils *snappingUtils, QgsVectorLayer *layer )
-{
-  QgsPointLocator *loc = snappingUtils->locatorForLayer( layer );
-  loc->init();
-}
-
 /**
  * \ingroup UnitTests
  */

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -253,10 +253,10 @@ void TestQgsVertexTool::initTestCase()
   QgsMapCanvasSnappingUtils *snappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
   mCanvas->setSnappingUtils( snappingUtils );
 
-  initPointLocator( snappingUtils, mLayerLine );
-  initPointLocator( snappingUtils, mLayerPolygon );
-  initPointLocator( snappingUtils, mLayerPoint );
-  initPointLocator( snappingUtils, mLayerLineZ );
+  snappingUtils->locatorForLayer( mLayerLine )->init();
+  snappingUtils->locatorForLayer( mLayerPolygon )->init();
+  snappingUtils->locatorForLayer( mLayerPoint )->init();
+  snappingUtils->locatorForLayer( mLayerLineZ )->init();
 
   // create vertex tool
   mVertexTool = new QgsVertexTool( mCanvas, mAdvancedDigitizingDockWidget );
@@ -875,7 +875,7 @@ void TestQgsVertexTool::testActiveLayerPriority()
 
   // make one layer active and check its vertex is used
 
-  initPointLocator( mCanvas->snappingUtils(), layerLine2 );
+  mCanvas->snappingUtils()->locatorForLayer( layerLine2 )->init();
 
   mCanvas->setCurrentLayer( mLayerLine );
 

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -26,6 +26,7 @@
 #include "qgslinestring.h"
 #include "qgssnappingconfig.h"
 #include "qgssettings.h"
+#include "testqgsmaptoolutils.h"
 
 bool operator==( const QgsGeometry &g1, const QgsGeometry &g2 )
 {
@@ -138,6 +139,7 @@ class TestQgsVertexTool : public QObject
 
   private:
     QgsMapCanvas *mCanvas = nullptr;
+    QgisApp *mQgisApp = nullptr;
     QgsAdvancedDigitizingDockWidget *mAdvancedDigitizingDockWidget = nullptr;
     QgsVertexTool *mVertexTool = nullptr;
     QgsVectorLayer *mLayerLine = nullptr;
@@ -161,6 +163,7 @@ void TestQgsVertexTool::initTestCase()
   // init QGIS's paths - true means that all path will be inited from prefix
   QgsApplication::init();
   QgsApplication::initQgis();
+  mQgisApp = new QgisApp();
 
   // Set up the QSettings environment
   QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
@@ -247,9 +250,13 @@ void TestQgsVertexTool::initTestCase()
 
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerPolygon << mLayerPoint << mLayerLineZ );
 
-  // TODO: set up snapping
+  QgsMapCanvasSnappingUtils *snappingUtils = new QgsMapCanvasSnappingUtils( mCanvas, this );
+  mCanvas->setSnappingUtils( snappingUtils );
 
-  mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
+  initPointLocator( snappingUtils, mLayerLine );
+  initPointLocator( snappingUtils, mLayerPolygon );
+  initPointLocator( snappingUtils, mLayerPoint );
+  initPointLocator( snappingUtils, mLayerLineZ );
 
   // create vertex tool
   mVertexTool = new QgsVertexTool( mCanvas, mAdvancedDigitizingDockWidget );
@@ -867,6 +874,8 @@ void TestQgsVertexTool::testActiveLayerPriority()
   mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerPolygon << mLayerPoint << layerLine2 );
 
   // make one layer active and check its vertex is used
+
+  initPointLocator( mCanvas->snappingUtils(), layerLine2 );
 
   mCanvas->setCurrentLayer( mLayerLine );
 

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -22,6 +22,13 @@
 #include "qgssnappingutils.h"
 #include "qgsvectorlayer.h"
 
+// initialize point locator
+void initPointLocator( QgsSnappingUtils *snappingUtils, QgsVectorLayer *layer )
+{
+  QgsPointLocator *loc = snappingUtils->locatorForLayer( layer );
+  loc->init();
+}
+
 /**
  * \ingroup UnitTests
  * This is a unit test for the QgsCadUtils class.
@@ -98,6 +105,8 @@ void TestQgsCadUtils::initTestCase()
   mSnappingUtils = new QgsSnappingUtils;
   mSnappingUtils->setConfig( snapConfig );
   mSnappingUtils->setMapSettings( mMapSettings );
+
+  initPointLocator( mSnappingUtils, mLayerPolygon );
 }
 
 //runs after all tests

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -22,12 +22,6 @@
 #include "qgssnappingutils.h"
 #include "qgsvectorlayer.h"
 
-// initialize point locator
-void initPointLocator( QgsSnappingUtils *snappingUtils, QgsVectorLayer *layer )
-{
-  QgsPointLocator *loc = snappingUtils->locatorForLayer( layer );
-  loc->init();
-}
 
 /**
  * \ingroup UnitTests
@@ -106,7 +100,7 @@ void TestQgsCadUtils::initTestCase()
   mSnappingUtils->setConfig( snapConfig );
   mSnappingUtils->setMapSettings( mMapSettings );
 
-  initPointLocator( mSnappingUtils, mLayerPolygon );
+  mSnappingUtils->locatorForLayer( mLayerPolygon )->init();
 }
 
 //runs after all tests

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -464,6 +464,16 @@ class TestQgsPointLocator : public QObject
       QCOMPARE( m.vertexIndex(), 2 );
     }
 
+    void testDeleteLocator()
+    {
+      QgsPointLocator *loc = new QgsPointLocator( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr );
+      QgsPointXY pt( 2, 2 );
+
+      // delete locator while we are indexing (could happend when closing project for instance)
+      loc->nearestVertex( pt, 999, nullptr, true );
+      delete loc;
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsPointLocator )

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -437,7 +437,7 @@ class TestQgsPointLocator : public QObject
       mVL->rollBack();
     }
 
-    void testWaitForFinished()
+    void testWaitForIndexingFinished()
     {
       QgsPointLocator loc( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr );
       QgsPointXY pt( 2, 2 );

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -469,7 +469,7 @@ class TestQgsPointLocator : public QObject
       QgsPointLocator *loc = new QgsPointLocator( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr );
       QgsPointXY pt( 2, 2 );
 
-      // delete locator while we are indexing (could happend when closing project for instance)
+      // delete locator while we are indexing (could happen when closing project for instance)
       loc->nearestVertex( pt, 999, nullptr, true );
       delete loc;
     }

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -436,6 +436,34 @@ class TestQgsPointLocator : public QObject
 
       mVL->rollBack();
     }
+
+    void testWaitForFinished()
+    {
+      QgsPointLocator loc( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr );
+      QgsPointXY pt( 2, 2 );
+
+      // locator is not ready yet
+      QgsPointLocator::Match m = loc.nearestVertex( pt, 999, nullptr, true );
+      QVERIFY( !m.isValid() );
+      QVERIFY( loc.mIsIndexing );
+
+      // non relaxed call, this will block until the first indexing is finished
+      // so the match point has to be valid
+      m = loc.nearestVertex( pt, 999, nullptr );
+      QVERIFY( m.isValid() );
+      QVERIFY( !loc.mIsIndexing );
+
+      // now locator is ready
+      m = loc.nearestVertex( pt, 999 );
+      QVERIFY( m.isValid() );
+      QVERIFY( m.hasVertex() );
+      QCOMPARE( m.layer(), mVL );
+      QCOMPARE( m.featureId(), ( QgsFeatureId )1 );
+      QCOMPARE( m.point(), QgsPointXY( 1, 1 ) );
+      QCOMPARE( m.distance(), std::sqrt( 2.0 ) );
+      QCOMPARE( m.vertexIndex(), 2 );
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsPointLocator )

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -401,10 +401,26 @@ class TestQgsSnappingUtils : public QObject
       QCOMPARE( m2.point(), QgsPointXY( 5.0, 2.5 ) );
 
     }
+
+    void testSnapOnCurrentLayer()
+    {
+      QgsMapSettings mapSettings;
+      mapSettings.setOutputSize( QSize( 100, 100 ) );
+      mapSettings.setExtent( QgsRectangle( 0, 0, 1, 1 ) );
+      QVERIFY( mapSettings.hasValidSettings() );
+
+      QgsSnappingUtils u( nullptr, true );
+      u.setMapSettings( mapSettings );
+      u.setCurrentLayer( mVL );
+
+      QgsPointLocator::Match m = u.snapToCurrentLayer( QPoint( 100, 100 ), QgsPointLocator::Vertex );
+      QVERIFY( m.isValid() );
+      QVERIFY( m.hasVertex() );
+      QCOMPARE( m.point(), QgsPointXY( 1, 0 ) );
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsSnappingUtils )
 
 #include "testqgssnappingutils.moc"
-
-


### PR DESCRIPTION
## Description

This PR fixes the issue related to this PR #31374.
EDIT: It now also contains PR #31374 commits because it has been reverted for 3.10.0 in #32297

The snapToCurrentLayer method doesn't prepare the index and expect to be executed synchronously. So the temporary point locator must be synchronous.

It also fixes the crashes on exit.


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
