### PR TITLE
Don't show semi-expected qt warnings in message bar

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -397,7 +397,7 @@ void myMessageOutput( QtMsgType type, const char *msg )
       // Print all warnings except setNamedColor.
       // Only seems to happen on windows
       if ( 0 != strncmp( msg, "QColor::setNamedColor: Unknown color name 'param", 48 )
-           && 0 != strncmp( msg, "Logged warning", 14 ))
+           && 0 != strncmp( msg, "Logged warning", 14 ) )
       {
         // TODO: Verify this code in action.
         dumpBacktrace( 20 );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -396,7 +396,8 @@ void myMessageOutput( QtMsgType type, const char *msg )
 #ifdef QGISDEBUG
       // Print all warnings except setNamedColor.
       // Only seems to happen on windows
-      if ( 0 != strncmp( msg, "QColor::setNamedColor: Unknown color name 'param", 48 ) )
+      if ( 0 != strncmp( msg, "QColor::setNamedColor: Unknown color name 'param", 48 )
+           && 0 != strncmp( msg, "Logged warning", 14 ))
       {
         // TODO: Verify this code in action.
         dumpBacktrace( 20 );

--- a/src/core/qgslogger.cpp
+++ b/src/core/qgslogger.cpp
@@ -121,19 +121,19 @@ void QgsLogger::debug( const QString &var, double val, int debuglevel, const cha
 void QgsLogger::warning( const QString &msg )
 {
   logMessageToFile( msg );
-  qWarning( "%s", msg.toLocal8Bit().constData() );
+  qWarning( "Logged warning: %s", msg.toLocal8Bit().constData() );
 }
 
 void QgsLogger::critical( const QString &msg )
 {
   logMessageToFile( msg );
-  qCritical( "%s", msg.toLocal8Bit().constData() );
+  qCritical( "Logged critical: %s", msg.toLocal8Bit().constData() );
 }
 
 void QgsLogger::fatal( const QString &msg )
 {
   logMessageToFile( msg );
-  qFatal( "%s", msg.toLocal8Bit().constData() );
+  qFatal( "Logged fatal: %s", msg.toLocal8Bit().constData() );
 }
 
 void QgsLogger::logMessageToFile( const QString &message )

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1186,7 +1186,6 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
     // Shows a warning when an old project file is read.
     emit oldProjectVersionWarning( fileVersion.text() );
-    QgsDebugMsg( QStringLiteral( "Emitting oldProjectVersionWarning(oldVersion)." ) );
 
     projectFile.updateRevision( thisVersion );
   }
@@ -1205,7 +1204,9 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
   QgsDebugMsg( QString::number( mProperties.count() ) + " properties read" );
 
+#if 0
   dump_( mProperties );
+#endif
 
   // get older style project title
   QString oldTitle;
@@ -2000,8 +2001,9 @@ bool QgsProject::writeProjectFile( const QString &filename )
   mLabelingEngineSettings->writeSettingsToProject( this );
 
   // now add the optional extra properties
-
+#if 0
   dump_( mProperties );
+#endif
 
   QgsDebugMsg( QStringLiteral( "there are %1 property scopes" ).arg( static_cast<int>( mProperties.count() ) ) );
 


### PR DESCRIPTION
We only want to highlight unexpected messages thrown internally from within Qt