### PR TITLE
fix simple quote in markdown URL fix #31629

### DIFF
--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -461,6 +461,7 @@ QString QgsStringUtils::htmlToMarkdown( const QString &html )
   while ( hrefRegEx.indexIn( converted, offset ) != -1 )
   {
     QString url = hrefRegEx.cap( 1 ).replace( QStringLiteral( "\"" ), QString() );
+    url.replace( QStringLiteral( "'" ), QString() );
     QString name = hrefRegEx.cap( 2 );
     QString anchor = QStringLiteral( "[%1](%2)" ).arg( name, url );
     converted.replace( hrefRegEx, anchor );

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -204,6 +204,7 @@ void TestQgsStringUtils::camelCase()
 void TestQgsStringUtils::htmlToMarkdown()
 {
   QCOMPARE( QgsStringUtils::htmlToMarkdown( QString( "<b>Visit</b> <a href=\"http://qgis.org\">!</a>" ) ), QString( "**Visit** [!](http://qgis.org)" ) );
+  QCOMPARE( QgsStringUtils::htmlToMarkdown( QString( "<b>Visit</b><br><a href='http://qgis.org'>QGIS</a>" ) ), QString( "**Visit**\n[QGIS](http://qgis.org)" ) );
 }
 
 void TestQgsStringUtils::ampersandEncode_data()


### PR DESCRIPTION
## Description
fix simple quote in markdown URL fix #31629

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
