### PR TITLE
Do not style null pixmap icon in application proxy style

### DIFF
--- a/src/gui/qgsproxystyle.cpp
+++ b/src/gui/qgsproxystyle.cpp
@@ -64,12 +64,16 @@ QPixmap QgsAppStyle::generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &p
   {
     case QIcon::Disabled:
     {
-      // override disabled icon style, with something which works better across different light/dark themes.
-      // the default Qt style here only works nicely for light themes.
-      QImage im = pixmap.toImage().convertToFormat( QImage::Format_ARGB32 );
-      QgsImageOperation::adjustHueSaturation( im, 0.2 );
-      QgsImageOperation::multiplyOpacity( im, 0.3 );
-      return QPixmap::fromImage( im );
+      if ( !pixmap.isNull() )
+      {
+        // override disabled icon style, with something which works better across different light/dark themes.
+        // the default Qt style here only works nicely for light themes.
+        QImage im = pixmap.toImage().convertToFormat( QImage::Format_ARGB32 );
+        QgsImageOperation::adjustHueSaturation( im, 0.2 );
+        QgsImageOperation::multiplyOpacity( im, 0.3 );
+        return QPixmap::fromImage( im );
+      }
+      break;
     }
 
     case QIcon::Normal:


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@nyalldawson , thanks to your recent commit increasing visibility of qt warnings / errors, I stumbled on a problem with our app proxy style, whereas prior to this PR it tried to modify null pixmap. This resulted in the following warnings:

```
Warning: QPainter::begin: Paint device returned engine == 0, type: 3
Warning: QPainter::setCompositionMode: Painter not active
Warning: QPainter::end: Painter not active, aborted
```

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
