### PR TITLE
[3d] Do not connect null objects

### DIFF
--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -63,7 +63,8 @@ void Qgs3DMapToolIdentifyPickHandler::handlePickOnVectorLayer( QgsVectorLayer *v
 Qgs3DMapToolIdentify::Qgs3DMapToolIdentify( Qgs3DMapCanvas *canvas )
   : Qgs3DMapTool( canvas )
 {
-  connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolIdentify::onTerrainEntityChanged );
+  if ( mCanvas->scene() )
+    connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolIdentify::onTerrainEntityChanged );
 
   mPickHandler.reset( new Qgs3DMapToolIdentifyPickHandler( this ) );
 }

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -50,7 +50,9 @@ void Qgs3DMapToolMeasureLinePickHandler::handlePickOnVectorLayer( QgsVectorLayer
 Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas )
   : Qgs3DMapTool( canvas )
 {
-  connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolMeasureLine::onTerrainEntityChanged );
+  if ( mCanvas->scene() )
+    connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolMeasureLine::onTerrainEntityChanged );
+
   mPickHandler.reset( new Qgs3DMapToolMeasureLinePickHandler( this ) );
 
   // Dialog
@@ -59,7 +61,8 @@ Qgs3DMapToolMeasureLine::Qgs3DMapToolMeasureLine( Qgs3DMapCanvas *canvas )
   mDialog->restorePosition();
 
   // Update scale if the terrain vertical scale changed
-  connect( mCanvas->map(), &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapToolMeasureLine::updateMeasurementLayer );
+  if ( mCanvas->map() )
+    connect( mCanvas->map(), &Qgs3DMapSettings::terrainVerticalScaleChanged, this, &Qgs3DMapToolMeasureLine::updateMeasurementLayer );
 }
 
 Qgs3DMapToolMeasureLine::~Qgs3DMapToolMeasureLine() = default;


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

A few more qt warnings popping up when creating a 3D map view, when we attempt to connect signals via a null object.

@wonder-sk , the PR gets rid of the warnings by only connecting the signals when the relevant object pointers aren't null. I tested things locally and everything functions properly. That said, I don't know if the object pointers being null is a scenario which shouldn't happen to begin with.


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
