### PR TITLE
Do not scan non existant directory

### DIFF
--- a/src/app/qgstemplateprojectsmodel.cpp
+++ b/src/app/qgstemplateprojectsmodel.cpp
@@ -39,12 +39,10 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
   for ( const QString &templatePath : paths )
   {
     const QString path = templatePath + QDir::separator() + QStringLiteral( "project_templates" );
-    scanDirectory( path );
-    mFileSystemWatcher.addPath( path );
+    addTemplateDirectory( path );
   }
 
-  scanDirectory( templateDirName );
-  mFileSystemWatcher.addPath( templateDirName );
+  addTemplateDirectory( templateDirName );
 
   connect( &mFileSystemWatcher, &QFileSystemWatcher::directoryChanged, this, &QgsTemplateProjectsModel::scanDirectory );
 
@@ -75,6 +73,15 @@ QgsTemplateProjectsModel::QgsTemplateProjectsModel( QObject *parent )
   emptyProjectItem->setData( previewImage.pixmap(), Qt::DecorationRole );
 
   appendRow( emptyProjectItem );
+}
+
+void QgsTemplateProjectsModel::addTemplateDirectory( const QString &path )
+{
+  if ( QDir().exists( path ) )
+  {
+    scanDirectory( path );
+    mFileSystemWatcher.addPath( path );
+  }
 }
 
 void QgsTemplateProjectsModel::scanDirectory( const QString &path )

--- a/src/app/qgstemplateprojectsmodel.h
+++ b/src/app/qgstemplateprojectsmodel.h
@@ -30,6 +30,7 @@ class QgsTemplateProjectsModel : public QStandardItemModel
   private slots:
 
   private:
+    void addTemplateDirectory( const QString &path );
     void scanDirectory( const QString &path );
 
     QFileSystemWatcher mFileSystemWatcher;


### PR DESCRIPTION
## Description
QFileSystemWatcher::addPath doesn't like when the path doesn't exist. Check for path existence prior to calling the method to silence the warning.

See https://github.com/qgis/QGIS/pull/31663

CC @wonder-sk 