### PR TITLE
Gpkg project storage multiple fixes

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14783,7 +14783,13 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, const bool saving )
       {
         QString uri = storageGuiProvider->showSaveGui();
         if ( !uri.isEmpty() )
+        {
           saveProjectToProjectStorage( uri );
+        }
+        else
+        {
+          messageBar()->pushCritical( tr( "Project save failed" ), tr( "The project could not be saved because the project storage URI is empty." ) );
+        }
       } );
     }
     else
@@ -14792,7 +14798,13 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, const bool saving )
       {
         QString uri = storageGuiProvider->showLoadGui();
         if ( !uri.isEmpty() )
+        {
           addProject( uri );
+        }
+        else
+        {
+          messageBar()->pushCritical( tr( "Project load failed" ), tr( "The project could not be loaded because the project storage URI is empty." ) );
+        }
       } );
     }
   }


### PR DESCRIPTION
- Shout out loudly when a project load/save failed 

GPKG prj storage: fix datetime and win shares

- fixes timestamp for last modified
- fix load/save to network storage like \\192.168.99.1\MyShare\MyDb.gpkg

Hopefully fixes #31310