### PR TITLE
Wait for threads on exit.

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1244,6 +1244,9 @@ QgsAuthManager *QgsApplication::authManager()
 
 void QgsApplication::exitQgis()
 {
+  // make sure all threads are done before exiting
+  QThreadPool::globalInstance()->waitForDone();
+
   // don't create to delete
   if ( instance() )
     delete instance()->mAuthManager;

--- a/tests/src/python/test_qgsmaprenderer.py
+++ b/tests/src/python/test_qgsmaprenderer.py
@@ -40,10 +40,6 @@ class TestQgsMapRenderer(unittest.TestCase):
     def setUp(self):
         pass
 
-    def tearDown(self):
-        # avoid crash on finish, probably related to https://bugreports.qt.io/browse/QTBUG-35760
-        QThreadPool.globalInstance().waitForDone()
-
     def checkRendererUseCachedLabels(self, job_type):
         layer = QgsVectorLayer("Point?field=fldtxt:string",
                                "layer1", "memory")

--- a/tests/src/python/test_qgspallabeling_canvas.py
+++ b/tests/src/python/test_qgspallabeling_canvas.py
@@ -51,8 +51,6 @@ class TestCanvasBase(TestQgsPalLabeling):
         TestQgsPalLabeling.tearDownClass()
         cls.removeMapLayer(cls.layer)
         cls.layer = None
-        # avoid crash on finish, probably related to https://bugreports.qt.io/browse/QTBUG-35760
-        QThreadPool.globalInstance().waitForDone()
 
     def setUp(self):
         """Run before each test."""

--- a/tests/src/python/test_qgspallabeling_layout.py
+++ b/tests/src/python/test_qgspallabeling_layout.py
@@ -95,8 +95,6 @@ class TestLayoutBase(TestQgsPalLabeling):
         TestQgsPalLabeling.tearDownClass()
         cls.removeMapLayer(cls.layer)
         cls.layer = None
-        # avoid crash on finish, probably related to https://bugreports.qt.io/browse/QTBUG-35760
-        QThreadPool.globalInstance().waitForDone()
 
     def setUp(self):
         """Run before each test."""

--- a/tests/src/python/test_qgspallabeling_placement.py
+++ b/tests/src/python/test_qgspallabeling_placement.py
@@ -43,8 +43,6 @@ class TestPlacementBase(TestQgsPalLabeling):
     @classmethod
     def tearDownClass(cls):
         TestQgsPalLabeling.tearDownClass()
-        # avoid crash on finish, probably related to https://bugreports.qt.io/browse/QTBUG-35760
-        QThreadPool.globalInstance().waitForDone()
 
     def setUp(self):
         """Run before each test."""

--- a/tests/src/python/test_qgspointdisplacementrenderer.py
+++ b/tests/src/python/test_qgspointdisplacementrenderer.py
@@ -97,11 +97,6 @@ class TestQgsPointDisplacementRenderer(unittest.TestCase):
         #QgsProject.instance().removeAllMapLayers()
         QgsProject.instance().removeMapLayer(layer)
 
-    @classmethod
-    def tearDownClass(cls):
-        # avoid crash on finish, probably related to https://bugreports.qt.io/browse/QTBUG-35760
-        QThreadPool.globalInstance().waitForDone()
-
     def _setProperties(self, r):
         """ set properties for a renderer for testing with _checkProperties"""
         r.setLabelAttributeName('name')


### PR DESCRIPTION
Move fixes that were in rendering tests to QgsApplication::exitQgis

Related to a recent segfault hunting session https://github.com/qgis/QGIS/pull/30747#issuecomment-529449636
and https://github.com/qgis/QGIS/commit/e96b204b09f71d3fd6812fb2ac3aab44335419d6#diff-61b6a0485341095d3601a93e812544c8R54

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
