### PR TITLE
[needs-docs] Do not display graduated method combobox

### DIFF
--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -522,6 +522,12 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
     minSizeSpinBox->setValue( .1 );
     maxSizeSpinBox->setValue( 2 );
   }
+  else if ( mGraduatedSymbol->type() == QgsSymbol::Fill )
+  {
+    //set button and label invisible to avoid display of a single item combobox
+    methodComboBox->hide();
+    labelMethod->hide();
+  }
   methodComboBox->blockSignals( false );
 
   connect( mExpressionWidget, static_cast < void ( QgsFieldExpressionWidget::* )( const QString & ) >( &QgsFieldExpressionWidget::fieldChanged ), this, &QgsGraduatedSymbolRendererWidget::graduatedColumnChanged );

--- a/src/ui/qgsgraduatedsymbolrendererwidget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererwidget.ui
@@ -116,7 +116,7 @@ Negative rounds to powers of 10</string>
     </layout>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="labelMethod">
      <property name="text">
       <string>Method</string>
      </property>


### PR DESCRIPTION
when the layer is of polygon geometry type to avoid a single item combobox (fixes #31638)

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
