### PR TITLE
[point displacement renderer] Fix crasher when trying to access out of bound QVector element

### DIFF
--- a/src/core/symbology/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology/qgspointdisplacementrenderer.cpp
@@ -294,7 +294,7 @@ void QgsPointDisplacementRenderer::calculateSymbolAndLabelPositions( QgsSymbolRe
 
       int featureIndex;
       double currentAngle;
-      for ( currentAngle = 0.0, featureIndex = 0; currentAngle < fullPerimeter; currentAngle += angleStep, featureIndex++ )
+      for ( currentAngle = 0.0, featureIndex = 0; currentAngle < fullPerimeter && featureIndex < diagonals.length(); currentAngle += angleStep, featureIndex++ )
       {
         double sinusCurrentAngle = std::sin( currentAngle );
         double cosinusCurrentAngle = std::cos( currentAngle );


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@nyalldawson , I stumbled on a crasher with the point displacement renderer, whereas the computing of ring displacement was trigger a QVector out of bound assert. The PR avoids doing so by adding an additional check in the appropriate loop. Not sure if there's an underlying issue that needs addressing.


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
