### PR TITLE
Add iface.pluginHelpMenu() 

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -208,6 +208,16 @@ Returns a reference to the main window "Settings" menu.
 Returns a reference to the main window "Plugin" menu.
 %End
 
+    virtual QMenu *pluginHelpMenu() = 0;
+%Docstring
+Returns a reference to the main window "Plugin Help" sub-menu.
+
+Plugins are encouraged to insert help and about actions in this submenu instead of creating
+a submenu under the pluginMenu() which solely contains Plugin Help or About actions.
+
+.. versionadded:: 3.10
+%End
+
     virtual QMenu *rasterMenu() = 0;
 %Docstring
 Returns a reference to the main window "Raster" menu.

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -565,6 +565,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMenu *addLayerMenu() { return mAddLayerMenu; }
     QMenu *settingsMenu() { return mSettingsMenu; }
     QMenu *pluginMenu() { return mPluginMenu; }
+    QMenu *pluginHelpMenu() { return mMenuPluginHelp; }
     QMenu *databaseMenu() { return mDatabaseMenu; }
     QMenu *rasterMenu() { return mRasterMenu; }
     QMenu *vectorMenu() { return mVectorMenu; }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -564,6 +564,7 @@ QMenu *QgisAppInterface::newLayerMenu() { return qgis->newLayerMenu(); }
 QMenu *QgisAppInterface::addLayerMenu() { return qgis->addLayerMenu(); }
 QMenu *QgisAppInterface::settingsMenu() { return qgis->settingsMenu(); }
 QMenu *QgisAppInterface::pluginMenu() { return qgis->pluginMenu(); }
+QMenu *QgisAppInterface::pluginHelpMenu() { return qgis->pluginHelpMenu(); }
 QMenu *QgisAppInterface::rasterMenu() { return qgis->rasterMenu(); }
 QMenu *QgisAppInterface::vectorMenu() { return qgis->vectorMenu(); }
 QMenu *QgisAppInterface::databaseMenu() { return qgis->databaseMenu(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -155,6 +155,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QMenu *addLayerMenu() override;
     QMenu *settingsMenu() override;
     QMenu *pluginMenu() override;
+    QMenu *pluginHelpMenu() override;
     QMenu *rasterMenu() override;
     QMenu *vectorMenu() override;
     QMenu *databaseMenu() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -235,6 +235,16 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual QMenu *pluginMenu() = 0;
 
     /**
+     * Returns a reference to the main window "Plugin Help" sub-menu.
+     *
+     * Plugins are encouraged to insert help and about actions in this submenu instead of creating
+     * a submenu under the pluginMenu() which solely contains Plugin Help or About actions.
+     *
+     * \since QGIS 3.10
+     */
+    virtual QMenu *pluginHelpMenu() = 0;
+
+    /**
      * Returns a reference to the main window "Raster" menu.
      */
     virtual QMenu *rasterMenu() = 0;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -2730,7 +2730,7 @@ Acts on the currently active layer only.</string>
   </action>
   <action name="mActionReportaBug">
    <property name="text">
-    <string>Report an issue</string>
+    <string>Report an Issue</string>
    </property>
   </action>
   <action name="mActionDiagramProperties">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -234,11 +234,17 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <widget class="QMenu" name="mMenuPluginHelp">
+     <property name="title">
+      <string>Plugins</string>
+     </property>
+    </widget>
     <addaction name="mActionHelpContents"/>
     <addaction name="mActionHelpAPI"/>
     <addaction name="separator"/>
-    <addaction name="mActionReportaBug"/>
+    <addaction name="mMenuPluginHelp"/>
     <addaction name="separator"/>
+    <addaction name="mActionReportaBug"/>
     <addaction name="mActionNeedSupport"/>
     <addaction name="separator"/>
     <addaction name="mActionQgisHomePage"/>


### PR DESCRIPTION
Returns a reference to the main window "Plugin Help" sub-menu.

Plugins are encouraged to insert help and about actions in this submenu instead of creating
a submenu under the pluginMenu() which solely contains Plugin Help or About actions.

For example, a tightly-integrated plugin which only implements a processing provider should not
create additional ui menus just to link to the plugin help pages. Rather, they should use this new submenu (available under the Help menu) to insert their help links.
