### PR TITLE
Gdal_translate add outsize parameter

### DIFF
--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -186,6 +186,31 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  source + ' ' +
                  outdir + '/check.jpg'])
 
+            # with 10% the size and default resampling
+            self.assertEqual(
+                translate_alg.getConsoleCommands({'INPUT': source,
+                                                  'OUTSIZE': '10% 10%',
+                                                  'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_translate',
+                 '-outsize 10% 10% ' +
+                 '-r nearest ' +
+                 '-of JPEG ' +
+                 source + ' ' +
+                 outdir + '/check.jpg'])
+
+            # with 10% the size and cubic resampling
+            self.assertEqual(
+                translate_alg.getConsoleCommands({'INPUT': source,
+                                                  'OUTSIZE': '10% 10%',
+                                                  'RESAMPLING_ALGORITHM': 2,
+                                                  'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_translate',
+                 '-outsize 10% 10% ' +
+                 '-r cubic ' +
+                 '-of JPEG ' +
+                 source + ' ' +
+                 outdir + '/check.jpg'])
+
             # with target srs
             self.assertEqual(
                 translate_alg.getConsoleCommands({'INPUT': source,


### PR DESCRIPTION
## Description
This exposes the option to change the size of the output in gdal translate.

I have also added a param for the resampling method.

This should be straighforward.

Backports could be nice.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
