### PR TITLE
[processing] quote field names in GDAL commands (fix #30878)

### DIFF
--- a/python/plugins/processing/algs/gdal/Buffer.py
+++ b/python/plugins/processing/algs/gdal/Buffer.py
@@ -119,7 +119,7 @@ class Buffer(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append(f.name())
+            other_fields.append("'{}'".format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -139,7 +139,7 @@ class Buffer(GdalAlgorithm):
             sql = "SELECT ST_Buffer({}, {}) AS {}{} FROM '{}'".format(geometry, distance, geometry, other_fields, layerName)
 
         if fieldName:
-            sql = '{} GROUP BY {}'.format(sql, fieldName)
+            sql = "{} GROUP BY '{}'".format(sql, fieldName)
 
         arguments.append(sql)
 

--- a/python/plugins/processing/algs/gdal/Buffer.py
+++ b/python/plugins/processing/algs/gdal/Buffer.py
@@ -119,7 +119,7 @@ class Buffer(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append("'{}'".format(f.name()))
+            other_fields.append('"{}"'.format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -134,12 +134,12 @@ class Buffer(GdalAlgorithm):
         arguments.append('-sql')
 
         if dissolve or fieldName:
-            sql = "SELECT ST_Union(ST_Buffer({}, {})) AS {}{} FROM '{}'".format(geometry, distance, geometry, other_fields, layerName)
+            sql = 'SELECT ST_Union(ST_Buffer({}, {})) AS {}{} FROM "{}"'.format(geometry, distance, geometry, other_fields, layerName)
         else:
-            sql = "SELECT ST_Buffer({}, {}) AS {}{} FROM '{}'".format(geometry, distance, geometry, other_fields, layerName)
+            sql = 'SELECT ST_Buffer({}, {}) AS {}{} FROM "{}"'.format(geometry, distance, geometry, other_fields, layerName)
 
         if fieldName:
-            sql = "{} GROUP BY '{}'".format(sql, fieldName)
+            sql = '{} GROUP BY "{}"'.format(sql, fieldName)
 
         arguments.append(sql)
 

--- a/python/plugins/processing/algs/gdal/Dissolve.py
+++ b/python/plugins/processing/algs/gdal/Dissolve.py
@@ -129,7 +129,7 @@ class Dissolve(GdalAlgorithm):
             if f.name() == geometry:
                 continue
 
-            other_fields.append(f.name())
+            other_fields.append("'{}'".format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -146,14 +146,14 @@ class Dissolve(GdalAlgorithm):
 
         tokens = []
         if self.parameterAsBoolean(parameters, self.COUNT_FEATURES, context):
-            tokens.append("COUNT({}) AS count".format(geometry))
+            tokens.append('COUNT({}) AS count'.format(geometry))
 
         if self.parameterAsBoolean(parameters, self.COMPUTE_AREA, context):
-            tokens.append("SUM(ST_Area({0})) AS area, ST_Perimeter(ST_Union({0})) AS perimeter".format(geometry))
+            tokens.append('SUM(ST_Area({0})) AS area, ST_Perimeter(ST_Union({0})) AS perimeter'.format(geometry))
 
         statsField = self.parameterAsString(parameters, self.STATISTICS_ATTRIBUTE, context)
         if statsField and self.parameterAsBoolean(parameters, self.COMPUTE_STATISTICS, context):
-            tokens.append("SUM({0}) AS sum, MIN({0}) AS min, MAX({0}) AS max, AVG({0}) AS avg".format(statsField))
+            tokens.append("SUM('{0}') AS sum, MIN('{0}') AS min, MAX('{0}') AS max, AVG('{0}') AS avg".format(statsField))
 
         params = ','.join(tokens)
         if params:
@@ -161,12 +161,12 @@ class Dissolve(GdalAlgorithm):
 
         group_by = ''
         if fieldName:
-            group_by = ' GROUP BY {}'.format(fieldName)
+            group_by = " GROUP BY '{}'".format(fieldName)
 
         if self.parameterAsBoolean(parameters, self.KEEP_ATTRIBUTES, context):
             sql = "SELECT ST_Union({}) AS {}{}{} FROM '{}'{}".format(geometry, geometry, other_fields, params, layerName, group_by)
         else:
-            sql = "SELECT ST_Union({}) AS {}{}{} FROM '{}'{}".format(geometry, geometry, ', ' + fieldName if fieldName else '',
+            sql = "SELECT ST_Union({}) AS {}{}{} FROM '{}'{}".format(geometry, geometry, ", '{}'".format(fieldName) if fieldName else '',
                                                                      params, layerName, group_by)
 
         arguments.append(sql)

--- a/python/plugins/processing/algs/gdal/Dissolve.py
+++ b/python/plugins/processing/algs/gdal/Dissolve.py
@@ -129,7 +129,7 @@ class Dissolve(GdalAlgorithm):
             if f.name() == geometry:
                 continue
 
-            other_fields.append("'{}'".format(f.name()))
+            other_fields.append('"{}"'.format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -153,7 +153,7 @@ class Dissolve(GdalAlgorithm):
 
         statsField = self.parameterAsString(parameters, self.STATISTICS_ATTRIBUTE, context)
         if statsField and self.parameterAsBoolean(parameters, self.COMPUTE_STATISTICS, context):
-            tokens.append("SUM('{0}') AS sum, MIN('{0}') AS min, MAX('{0}') AS max, AVG('{0}') AS avg".format(statsField))
+            tokens.append('SUM("{0}") AS sum, MIN("{0}") AS min, MAX("{0}") AS max, AVG("{0}") AS avg'.format(statsField))
 
         params = ','.join(tokens)
         if params:
@@ -161,12 +161,12 @@ class Dissolve(GdalAlgorithm):
 
         group_by = ''
         if fieldName:
-            group_by = " GROUP BY '{}'".format(fieldName)
+            group_by = ' GROUP BY "{}"'.format(fieldName)
 
         if self.parameterAsBoolean(parameters, self.KEEP_ATTRIBUTES, context):
-            sql = "SELECT ST_Union({}) AS {}{}{} FROM '{}'{}".format(geometry, geometry, other_fields, params, layerName, group_by)
+            sql = 'SELECT ST_Union({}) AS {}{}{} FROM "{}"{}'.format(geometry, geometry, other_fields, params, layerName, group_by)
         else:
-            sql = "SELECT ST_Union({}) AS {}{}{} FROM '{}'{}".format(geometry, geometry, ", '{}'".format(fieldName) if fieldName else '',
+            sql = 'SELECT ST_Union({}) AS {}{}{} FROM "{}"{}'.format(geometry, geometry, ', "{}"'.format(fieldName) if fieldName else '',
                                                                      params, layerName, group_by)
 
         arguments.append(sql)

--- a/python/plugins/processing/algs/gdal/OffsetCurve.py
+++ b/python/plugins/processing/algs/gdal/OffsetCurve.py
@@ -101,7 +101,7 @@ class OffsetCurve(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append(f.name())
+            other_fields.append("'{}'".format(f.name()))
 
         if other_fields:
             other_fields = ',*'

--- a/python/plugins/processing/algs/gdal/OffsetCurve.py
+++ b/python/plugins/processing/algs/gdal/OffsetCurve.py
@@ -101,7 +101,7 @@ class OffsetCurve(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append("'{}'".format(f.name()))
+            other_fields.append('"{}"'.format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -115,7 +115,7 @@ class OffsetCurve(GdalAlgorithm):
         arguments.append('sqlite')
         arguments.append('-sql')
 
-        sql = "SELECT ST_OffsetCurve({}, {}) AS {}{} FROM '{}'".format(geometry, distance, geometry, other_fields, layerName)
+        sql = 'SELECT ST_OffsetCurve({}, {}) AS {}{} FROM "{}"'.format(geometry, distance, geometry, other_fields, layerName)
         arguments.append(sql)
 
         if options:

--- a/python/plugins/processing/algs/gdal/OneSideBuffer.py
+++ b/python/plugins/processing/algs/gdal/OneSideBuffer.py
@@ -130,7 +130,7 @@ class OneSideBuffer(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append(f.name())
+            other_fields.append("'{}'".format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -150,7 +150,7 @@ class OneSideBuffer(GdalAlgorithm):
             sql = "SELECT ST_SingleSidedBuffer({}, {}, {}) AS {}{} FROM '{}'".format(geometry, distance, side, geometry, other_fields, layerName)
 
         if fieldName:
-            sql = '"{} GROUP BY {}"'.format(sql, fieldName)
+            sql = "{} GROUP BY '{}'".format(sql, fieldName)
 
         arguments.append(sql)
 

--- a/python/plugins/processing/algs/gdal/OneSideBuffer.py
+++ b/python/plugins/processing/algs/gdal/OneSideBuffer.py
@@ -130,7 +130,7 @@ class OneSideBuffer(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append("'{}'".format(f.name()))
+            other_fields.append('"{}"'.format(f.name()))
 
         if other_fields:
             other_fields = ',*'
@@ -145,12 +145,12 @@ class OneSideBuffer(GdalAlgorithm):
         arguments.append('-sql')
 
         if dissolve or fieldName:
-            sql = "SELECT ST_Union(ST_SingleSidedBuffer({}, {}, {})) AS {}{} FROM '{}'".format(geometry, distance, side, geometry, other_fields, layerName)
+            sql = 'SELECT ST_Union(ST_SingleSidedBuffer({}, {}, {})) AS {}{} FROM "{}"'.format(geometry, distance, side, geometry, other_fields, layerName)
         else:
-            sql = "SELECT ST_SingleSidedBuffer({}, {}, {}) AS {}{} FROM '{}'".format(geometry, distance, side, geometry, other_fields, layerName)
+            sql = 'SELECT ST_SingleSidedBuffer({}, {}, {}) AS {}{} FROM "{}"'.format(geometry, distance, side, geometry, other_fields, layerName)
 
         if fieldName:
-            sql = "{} GROUP BY '{}'".format(sql, fieldName)
+            sql = '{} GROUP BY "{}"'.format(sql, fieldName)
 
         arguments.append(sql)
 

--- a/python/plugins/processing/algs/gdal/PointsAlongLines.py
+++ b/python/plugins/processing/algs/gdal/PointsAlongLines.py
@@ -105,7 +105,7 @@ class PointsAlongLines(GdalAlgorithm):
         for f in fields:
             if f.name() == geometry:
                 continue
-            other_fields.append(f.name())
+            other_fields.append('"{}"'.format(f.name()))
 
         if other_fields:
             other_fields = ',*'

--- a/python/plugins/processing/algs/gdal/PointsAlongLines.py
+++ b/python/plugins/processing/algs/gdal/PointsAlongLines.py
@@ -119,7 +119,7 @@ class PointsAlongLines(GdalAlgorithm):
         arguments.append('sqlite')
         arguments.append('-sql')
 
-        sql = "SELECT ST_Line_Interpolate_Point({}, {}) AS {}{} FROM '{}'".format(geometry, distance, geometry, other_fields, layerName)
+        sql = 'SELECT ST_Line_Interpolate_Point({}, {}) AS {}{} FROM "{}"'.format(geometry, distance, geometry, other_fields, layerName)
         arguments.append(sql)
 
         if options:

--- a/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
@@ -158,7 +158,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -169,7 +169,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -180,7 +180,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \\"polys2\\"" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -192,7 +192,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \'polys2\' GROUP BY \'total population\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \\"polys2\\" GROUP BY \\"total population\\"" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
     def testDissolve(self):
@@ -210,7 +210,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM \'polys2\'" ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -220,8 +220,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -230,8 +230,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'total population\' FROM \'polys2\' ' +
-                 'GROUP BY \'total population\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"total population\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"total population\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source_with_space,
@@ -240,8 +240,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  '"' + source_with_space + '" ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'filename_with_spaces\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"filename_with_spaces\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -251,8 +251,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -262,8 +262,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -272,7 +272,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM \'polys2\'" ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -283,8 +283,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -explodecollections -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -294,8 +294,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\', COUNT(geometry) AS count FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\", COUNT(geometry) AS count FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -306,8 +306,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \'my_field\', COUNT(the_geom) AS count FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \\"my_field\\", COUNT(the_geom) AS count FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -317,9 +317,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\', SUM(ST_Area(geometry)) AS area, ' +
-                 'ST_Perimeter(ST_Union(geometry)) AS perimeter FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\", SUM(ST_Area(geometry)) AS area, ' +
+                 'ST_Perimeter(ST_Union(geometry)) AS perimeter FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -330,9 +330,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \'my_field\', SUM(ST_Area(the_geom)) AS area, ' +
-                 'ST_Perimeter(ST_Union(the_geom)) AS perimeter FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \\"my_field\\", SUM(ST_Area(the_geom)) AS area, ' +
+                 'ST_Perimeter(ST_Union(the_geom)) AS perimeter FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -343,9 +343,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\', ' +
-                 'SUM(\'my_val\') AS sum, MIN(\'my_val\') AS min, MAX(\'my_val\') AS max, AVG(\'my_val\') AS avg FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\", ' +
+                 'SUM(\\"my_val\\") AS sum, MIN(\\"my_val\\") AS min, MAX(\\"my_val\\") AS max, AVG(\\"my_val\\") AS avg FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -356,10 +356,10 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'test field\', ' +
-                 'SUM(\'total population\') AS sum, MIN(\'total population\') AS min, MAX(\'total population\') AS max, ' +
-                 'AVG(\'total population\') AS avg FROM \'polys2\' ' +
-                 'GROUP BY \'test field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"test field\\", ' +
+                 'SUM(\\"total population\\") AS sum, MIN(\\"total population\\") AS min, MAX(\\"total population\\") AS max, ' +
+                 'AVG(\\"total population\\") AS avg FROM \\"polys2\\" ' +
+                 'GROUP BY \\"test field\\"" -f "ESRI Shapefile"'])
 
             # compute stats without stats attribute, and vice versa (should be ignored)
             self.assertEqual(
@@ -370,8 +370,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
                                         'FIELD': 'my_field',
@@ -380,8 +380,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -391,8 +391,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
-                 'GROUP BY \'my_field\'" "my opts" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \\"my_field\\" FROM \\"polys2\\" ' +
+                 'GROUP BY \\"my_field\\"" "my opts" -f "ESRI Shapefile"'])
 
     def testOgr2PostGis(self):
         context = QgsProcessingContext()
@@ -749,7 +749,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_OffsetCurve(geometry, 5.0) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_OffsetCurve(geometry, 5.0) AS geometry,* FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
     def testOneSidedBuffer(self):
@@ -768,7 +768,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -779,7 +779,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -790,7 +790,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \\"polys2\\"" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
@@ -802,7 +802,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  outdir + '/check.shp ' +
                  source + ' ' +
                  '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* ' +
-                 'FROM \'polys2\' GROUP BY \'total population\'" -f "ESRI Shapefile"'])
+                 'FROM \\"polys2\\" GROUP BY \\"total population\\"" -f "ESRI Shapefile"'])
 
     def testPointsAlongLines(self):
         context = QgsProcessingContext()
@@ -820,7 +820,7 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-dialect sqlite -sql "SELECT ST_Line_Interpolate_Point(geometry, 0.2) AS geometry,* FROM \'polys2\'" ' +
+                 '-dialect sqlite -sql "SELECT ST_Line_Interpolate_Point(geometry, 0.2) AS geometry,* FROM \\"polys2\\"" ' +
                  '-f "ESRI Shapefile"'])
 
 

--- a/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsVectorTest.py
@@ -183,6 +183,18 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  '-dialect sqlite -sql "SELECT ST_Buffer(geometry, 5.0) AS geometry,* FROM \'polys2\'" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
 
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'DISTANCE': 5,
+                                        'FIELD': 'total population',
+                                        'EXPLODE_COLLECTIONS': True,
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['ogr2ogr',
+                 outdir + '/check.shp ' +
+                 source + ' ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_Buffer(geometry, 5.0)) AS geometry,* FROM \'polys2\' GROUP BY \'total population\'" ' +
+                 '-explodecollections -f "ESRI Shapefile"'])
+
     def testDissolve(self):
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()
@@ -208,8 +220,18 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'FIELD': 'total population',
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['ogr2ogr',
+                 outdir + '/check.shp ' +
+                 source + ' ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'total population\' FROM \'polys2\' ' +
+                 'GROUP BY \'total population\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source_with_space,
@@ -218,8 +240,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  '"' + source_with_space + '" ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'filename_with_spaces\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'filename_with_spaces\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -229,8 +251,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -240,8 +262,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -261,8 +283,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" -explodecollections -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -explodecollections -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -272,8 +294,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field, COUNT(geometry) AS count FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\', COUNT(geometry) AS count FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -284,8 +306,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, my_field, COUNT(the_geom) AS count FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \'my_field\', COUNT(the_geom) AS count FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -295,9 +317,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field, SUM(ST_Area(geometry)) AS area, ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\', SUM(ST_Area(geometry)) AS area, ' +
                  'ST_Perimeter(ST_Union(geometry)) AS perimeter FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -308,9 +330,9 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, my_field, SUM(ST_Area(the_geom)) AS area, ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(the_geom) AS the_geom, \'my_field\', SUM(ST_Area(the_geom)) AS area, ' +
                  'ST_Perimeter(ST_Union(the_geom)) AS perimeter FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -321,9 +343,23 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field, ' +
-                 'SUM(my_val) AS sum, MIN(my_val) AS min, MAX(my_val) AS max, AVG(my_val) AS avg FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\', ' +
+                 'SUM(\'my_val\') AS sum, MIN(\'my_val\') AS min, MAX(\'my_val\') AS max, AVG(\'my_val\') AS avg FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'FIELD': 'test field',
+                                        'COMPUTE_STATISTICS': True,
+                                        'STATISTICS_ATTRIBUTE': 'total population',
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['ogr2ogr',
+                 outdir + '/check.shp ' +
+                 source + ' ' +
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'test field\', ' +
+                 'SUM(\'total population\') AS sum, MIN(\'total population\') AS min, MAX(\'total population\') AS max, ' +
+                 'AVG(\'total population\') AS avg FROM \'polys2\' ' +
+                 'GROUP BY \'test field\'" -f "ESRI Shapefile"'])
 
             # compute stats without stats attribute, and vice versa (should be ignored)
             self.assertEqual(
@@ -334,8 +370,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
                                         'FIELD': 'my_field',
@@ -344,8 +380,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" -f "ESRI Shapefile"'])
 
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,
@@ -355,8 +391,8 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                 ['ogr2ogr',
                  outdir + '/check.shp ' +
                  source + ' ' +
-                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, my_field FROM \'polys2\' ' +
-                 'GROUP BY my_field" "my opts" -f "ESRI Shapefile"'])
+                 '-nlt PROMOTE_TO_MULTI -dialect sqlite -sql "SELECT ST_Union(geometry) AS geometry, \'my_field\' FROM \'polys2\' ' +
+                 'GROUP BY \'my_field\'" "my opts" -f "ESRI Shapefile"'])
 
     def testOgr2PostGis(self):
         context = QgsProcessingContext()
@@ -756,6 +792,17 @@ class TestGdalVectorAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  source + ' ' +
                  '-dialect sqlite -sql "SELECT ST_SingleSidedBuffer(geometry, 5.0, 0) AS geometry,* FROM \'polys2\'" ' +
                  '-explodecollections -f "ESRI Shapefile"'])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'DISTANCE': 5,
+                                        'FIELD': 'total population',
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['ogr2ogr',
+                 outdir + '/check.shp ' +
+                 source + ' ' +
+                 '-dialect sqlite -sql "SELECT ST_Union(ST_SingleSidedBuffer(geometry, 5.0, 0)) AS geometry,* ' +
+                 'FROM \'polys2\' GROUP BY \'total population\'" -f "ESRI Shapefile"'])
 
     def testPointsAlongLines(self):
         context = QgsProcessingContext()


### PR DESCRIPTION
## Description
Quote field names to prevent errors when field name contains spaces. Fixes #30878.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
