### PR TITLE
[processing] be safe when reading YAML file (fix #30779)

### DIFF
--- a/python/plugins/processing/algs/help/__init__.py
+++ b/python/plugins/processing/algs/help/__init__.py
@@ -43,7 +43,7 @@ def loadShortHelp():
             with codecs.open(filename, encoding='utf-8') as stream:
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=DeprecationWarning)
-                    for k, v in yaml.load(stream).items():
+                    for k, v in yaml.load(stream, Loader=yaml.SafeLoader).items():
                         if v is None:
                             continue
                         h[k] = QCoreApplication.translate("{}Algorithm".format(f[:-5].upper()), v)


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Backport fix for insecure YAML reading in Processing. These changes were applied to master and 3.8, but was not backported to LTR. Fixes #30779.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
