### PR TITLE
Aggregate calculations on empty set should return NULL (not 0)

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/aggregate_field.gml
+++ b/python/plugins/processing/tests/testdata/expected/aggregate_field.gml
@@ -24,8 +24,6 @@
       <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:4326"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6.24145873320538,-0.054510556621882 7.24145873320538,-1.05451055662188 5.24145873320538,-1.05451055662188 6.24145873320538,-0.054510556621882</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
       <ogr:fids>polys.1,polys.9</ogr:fids>
       <ogr:name>dd</ogr:name>
-      <ogr:intval>0</ogr:intval>
-      <ogr:floatval>0</ogr:floatval>
     </ogr:aggregate_field>
   </gml:featureMember>
   <gml:featureMember>

--- a/src/core/qgsstatisticalsummary.cpp
+++ b/src/core/qgsstatisticalsummary.cpp
@@ -250,6 +250,9 @@ void QgsStatisticalSummary::finalize()
 
 double QgsStatisticalSummary::statistic( QgsStatisticalSummary::Statistic stat ) const
 {
+  if ( mCount == 0 && stat != Count && stat != Variety && stat != CountMissing )
+    return std::numeric_limits<double>::quiet_NaN();
+
   switch ( stat )
   {
     case Count:

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1853,7 +1853,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "filter" ) << "aggregate('test','sum',\"col1\", \"col1\" <= 10)" << false << QVariant( 13 );
       QTest::newRow( "filter context" ) << "aggregate('test','sum',\"col1\", \"col1\" <= @test_var)" << false << QVariant( 13 );
       QTest::newRow( "filter named" ) << "aggregate(layer:='test',aggregate:='sum',expression:=\"col1\", filter:=\"col1\" <= 10)" << false << QVariant( 13 );
-      QTest::newRow( "filter no matching" ) << "aggregate('test','sum',\"col1\", \"col1\" <= -10)" << false << QVariant( 0 );
+      QTest::newRow( "filter no matching" ) << "aggregate('test','sum',\"col1\", \"col1\" <= -10)" << false << QVariant();
       QTest::newRow( "filter no matching max" ) << "aggregate('test','max',\"col1\", \"col1\" > 1000000 )" << false << QVariant();
 
       QTest::newRow( "filter by @parent attribute" ) << "aggregate(layer:='child_layer', aggregate:='min', expression:=\"col3\", filter:=\"parent\"=attribute(@parent,'col1'))" << false << QVariant( 1 );
@@ -1953,7 +1953,7 @@ class TestQgsExpression: public QObject
 
       QTest::newRow( "filter" ) << "sum(\"col1\", NULL, \"col1\" >= 5)" << false << QVariant( 32 );
       QTest::newRow( "filter named" ) << "sum(expression:=\"col1\", filter:=\"col1\" >= 5)" << false << QVariant( 32 );
-      QTest::newRow( "filter no matching" ) << "sum(expression:=\"col1\", filter:=\"col1\" <= -5)" << false << QVariant( 0 );
+      QTest::newRow( "filter no matching" ) << "sum(expression:=\"col1\", filter:=\"col1\" <= -5)" << false << QVariant();
       QTest::newRow( "filter no matching max" ) << "maximum(\"col1\", filter:=\"col1\" <= -5)" << false << QVariant();
 
       QTest::newRow( "group by" ) << "sum(\"col1\", \"col3\")" << false << QVariant( 9 );
@@ -2060,7 +2060,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "relation aggregate 1" ) << "relation_aggregate('my_rel','sum',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 4}} ) << false << QVariant( 5 );
       QTest::newRow( "relation aggregate by name" ) << "relation_aggregate('relation name','sum',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 4}} ) << false << QVariant( 5 );
       QTest::newRow( "relation aggregate 2" ) << "relation_aggregate('my_rel','sum',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 3}} ) << false << QVariant( 9 );
-      QTest::newRow( "relation aggregate 2" ) << "relation_aggregate('my_rel','sum',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 6}} ) << false << QVariant( 0 );
+      QTest::newRow( "relation aggregate no matching" ) << "relation_aggregate('my_rel','sum',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 6}} ) << false << QVariant();
       QTest::newRow( "relation aggregate count 1" ) << "relation_aggregate('my_rel','count',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 4}} ) << false << QVariant( 3 );
       QTest::newRow( "relation aggregate count 2" ) << "relation_aggregate('my_rel','count',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 3}} ) << false << QVariant( 2 );
       QTest::newRow( "relation aggregate count 2" ) << "relation_aggregate('my_rel','count',\"col3\")" << QVariantMap( {{QStringLiteral( "col1" ), 6}} ) << false << QVariant( 0 );

--- a/tests/src/core/testqgsstatisticalsummary.cpp
+++ b/tests/src/core/testqgsstatisticalsummary.cpp
@@ -317,7 +317,7 @@ void TestQgsStatisticSummary::noValues()
   QCOMPARE( s.countMissing(), 0 );
   QCOMPARE( s.statistic( QgsStatisticalSummary::CountMissing ), 0.0 );
   QCOMPARE( s.sum(), 0.0 );
-  QCOMPARE( s.statistic( QgsStatisticalSummary::Sum ), 0.0 );
+  QVERIFY( std::isnan( s.statistic( QgsStatisticalSummary::Sum ) ) );
   QVERIFY( std::isnan( s.first() ) );
   QVERIFY( std::isnan( s.statistic( QgsStatisticalSummary::First ) ) );
   QVERIFY( std::isnan( s.last() ) );

--- a/tests/src/python/test_qgsaggregatecalculator.py
+++ b/tests/src/python/test_qgsaggregatecalculator.py
@@ -427,7 +427,7 @@ class TestQgsAggregateCalculator(unittest.TestCase):
         agg.setFidsFilter(list())
         val, ok = agg.calculate(QgsAggregateCalculator.Sum, 'fldint')
         self.assertTrue(ok)
-        self.assertEqual(val, 0.0)
+        self.assertEqual(val, NULL)
 
     def testExpressionNoMatch(self):
         """ test aggregate calculation using an expression with no features """
@@ -512,6 +512,51 @@ class TestQgsAggregateCalculator(unittest.TestCase):
         self.assertFalse(ok)
         agg, ok = QgsAggregateCalculator.stringToAggregate('bad')
         self.assertFalse(ok)
+
+    def testEmptyAggregate(self):
+        """ Test calculation of aggregates on an empty list"""
+
+        layer = QgsVectorLayer("Point?field=fldint:integer&field=flddbl:double",
+                               "layer", "memory")
+        pr = layer.dataProvider()
+
+        tests = [[QgsAggregateCalculator.Count, 'fldint', 0],
+                 [QgsAggregateCalculator.Count, 'flddbl', 0],
+                 [QgsAggregateCalculator.Sum, 'fldint', NULL],
+                 [QgsAggregateCalculator.Sum, 'flddbl', NULL],
+                 [QgsAggregateCalculator.Mean, 'fldint', NULL],
+                 [QgsAggregateCalculator.Mean, 'flddbl', NULL],
+                 [QgsAggregateCalculator.StDev, 'fldint', NULL],
+                 [QgsAggregateCalculator.StDev, 'flddbl', NULL],
+                 [QgsAggregateCalculator.StDevSample, 'fldint', NULL],
+                 [QgsAggregateCalculator.StDevSample, 'flddbl', NULL],
+                 [QgsAggregateCalculator.Min, 'fldint', NULL],
+                 [QgsAggregateCalculator.Min, 'flddbl', NULL],
+                 [QgsAggregateCalculator.Max, 'fldint', NULL],
+                 [QgsAggregateCalculator.Max, 'flddbl', NULL],
+                 [QgsAggregateCalculator.Range, 'fldint', NULL],
+                 [QgsAggregateCalculator.Range, 'flddbl', NULL],
+                 [QgsAggregateCalculator.Median, 'fldint', NULL],
+                 [QgsAggregateCalculator.Median, 'flddbl', NULL],
+                 [QgsAggregateCalculator.CountDistinct, 'fldint', 0],
+                 [QgsAggregateCalculator.CountDistinct, 'flddbl', 0],
+                 [QgsAggregateCalculator.CountMissing, 'fldint', 0],
+                 [QgsAggregateCalculator.CountMissing, 'flddbl', 0],
+                 [QgsAggregateCalculator.FirstQuartile, 'fldint', NULL],
+                 [QgsAggregateCalculator.FirstQuartile, 'flddbl', NULL],
+                 [QgsAggregateCalculator.ThirdQuartile, 'fldint', NULL],
+                 [QgsAggregateCalculator.ThirdQuartile, 'flddbl', NULL],
+                 [QgsAggregateCalculator.InterQuartileRange, 'fldint', NULL],
+                 [QgsAggregateCalculator.InterQuartileRange, 'flddbl', NULL],
+                 [QgsAggregateCalculator.ArrayAggregate, 'fldint', []],
+                 [QgsAggregateCalculator.ArrayAggregate, 'flddbl', []],
+                 ]
+
+        agg = QgsAggregateCalculator(layer)
+        for t in tests:
+            val, ok = agg.calculate(t[0], t[1])
+            self.assertTrue(ok)
+            self.assertEqual(val, t[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

 Fix aggregate calculations for result size of 0

Previously:
```sql
sum([]) -> 0
```

Now:
```sql
sum([]) -> NULL
```

Detected in https://github.com/qgis/QGIS/pull/30972