### PR TITLE
fix  broken gpkg actions

### DIFF
--- a/src/core/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.cpp
@@ -211,11 +211,11 @@ void QgsGeoPackageCollectionItem::deleteConnection()
   mParent->refreshConnections();
 }
 
-bool QgsGeoPackageCollectionItem::vacuumGeoPackageDb( const QString &name, QString &errCause )
+bool QgsGeoPackageCollectionItem::vacuumGeoPackageDb( const QString &name, const QString &path, QString &errCause )
 {
   QgsScopedProxyProgressTask task( tr( "Vacuuming %1" ).arg( name ) );
   QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) ) };
-  QgsAbstractDatabaseProviderConnection *conn { static_cast<QgsAbstractDatabaseProviderConnection *>( md->findConnection( name ) ) };
+  std::unique_ptr<QgsGeoPackageProviderConnection> conn( static_cast<QgsGeoPackageProviderConnection *>( md->createConnection( path, QVariantMap() ) ) );
   if ( conn )
   {
     try

--- a/src/core/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/core/providers/ogr/qgsgeopackagedataitems.h
@@ -52,10 +52,11 @@ class CORE_EXPORT QgsGeoPackageCollectionItem : public QgsDataCollectionItem
     /**
      * Compacts (VACUUM) a geopackage database
      * \param name DB connection name
+     * \param path DB connection path
      * \param errCause contains the error message
      * \return true on success
      */
-    static bool vacuumGeoPackageDb( const QString &name, QString &errCause );
+    static bool vacuumGeoPackageDb( const QString &name, const QString &path, QString &errCause );
 
     void addConnection();
     void deleteConnection();

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -93,10 +93,23 @@ void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu
 
     // Add table to existing DB
     QAction *actionAddTable = new QAction( tr( "Create a New Layer or Table…" ), collectionItem->parent() );
-    QVariantMap data;
-    data.insert( QStringLiteral( "item" ), QVariant::fromValue( QPointer< QgsGeoPackageCollectionItem >( collectionItem ) ) );
-    actionAddTable->setData( data );
-    connect( actionAddTable, &QAction::triggered, this, &QgsGeoPackageItemGuiProvider::addTable );
+
+    connect( actionAddTable, &QAction::triggered, [ = ]
+    {
+      if ( collectionItem )
+      {
+        QgsNewGeoPackageLayerDialog dialog( nullptr );
+        dialog.setDatabasePath( item->path() );
+        dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
+        dialog.setOverwriteBehavior( QgsNewGeoPackageLayerDialog::AddNewLayer );
+        dialog.lockDatabasePath();
+        if ( dialog.exec() == QDialog::Accepted )
+        {
+          item->refreshConnections();
+        }
+      }
+    } );
+
     menu->addAction( actionAddTable );
 
     QAction *sep = new QAction( collectionItem->parent() );
@@ -167,25 +180,6 @@ void QgsGeoPackageItemGuiProvider::deleteGpkg()
     {
       QMessageBox::warning( nullptr, title, QObject::tr( "The GeoPackage '%1' cannot be deleted because it is in the current project as '%2',"
                             " remove it from the project and retry." ).arg( path, projectLayer->name() ) );
-    }
-  }
-}
-
-void QgsGeoPackageItemGuiProvider::addTable()
-{
-  QAction *s = qobject_cast<QAction *>( sender() );
-  QVariantMap data = s->data().toMap();
-  QPointer< QgsGeoPackageCollectionItem > item = data[QStringLiteral( "item" )].value<QPointer< QgsGeoPackageCollectionItem >>();
-  if ( item )
-  {
-    QgsNewGeoPackageLayerDialog dialog( nullptr );
-    dialog.setDatabasePath( item->path() );
-    dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
-    dialog.setOverwriteBehavior( QgsNewGeoPackageLayerDialog::AddNewLayer );
-    dialog.lockDatabasePath();
-    if ( dialog.exec() == QDialog::Accepted )
-    {
-      item->refreshConnections();
     }
   }
 }
@@ -360,7 +354,7 @@ void QgsGeoPackageItemGuiProvider::vacuumGeoPackageDbAction( const QString &path
 {
   Q_UNUSED( path )
   QString errCause;
-  bool result = QgsGeoPackageCollectionItem::vacuumGeoPackageDb( name, errCause );
+  bool result = QgsGeoPackageCollectionItem::vacuumGeoPackageDb( name, path, errCause );
   if ( !result || !errCause.isEmpty() )
   {
     QMessageBox::warning( nullptr, tr( "Database compact (VACUUM)" ), errCause );

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -93,19 +93,20 @@ void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu
 
     // Add table to existing DB
     QAction *actionAddTable = new QAction( tr( "Create a New Layer or Table…" ), collectionItem->parent() );
-
-    connect( actionAddTable, &QAction::triggered, [ = ]
+    QPointer<QgsGeoPackageCollectionItem>collectionItemPtr { collectionItem };
+    connect( actionAddTable, &QAction::triggered, [ collectionItemPtr ]
     {
-      if ( collectionItem )
+      if ( collectionItemPtr )
       {
         QgsNewGeoPackageLayerDialog dialog( nullptr );
-        dialog.setDatabasePath( item->path() );
+        dialog.setDatabasePath( collectionItemPtr->path() );
         dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
         dialog.setOverwriteBehavior( QgsNewGeoPackageLayerDialog::AddNewLayer );
         dialog.lockDatabasePath();
         if ( dialog.exec() == QDialog::Accepted )
         {
-          item->refreshConnections();
+          if ( collectionItemPtr )
+            collectionItemPtr->refreshConnections();
         }
       }
     } );

--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.h
@@ -57,7 +57,6 @@ class QgsGeoPackageItemGuiProvider : public QObject, public QgsDataItemGuiProvid
   protected slots:
     void vacuum();
     void renameVectorLayer();
-    void addTable( );
     void deleteGpkg();
 };
 


### PR DESCRIPTION
Fix #31730

@PeterPetrik can you please have a look to the itemguiprovider part?
I moved it into a lambda because it's simpler and because the original implementation did not work due to the fact that `data[QStringLiteral( "item" )].value<QPointer< QgsGeoPackageCollectionItem >>();` was invalid.

What was the reason for the QPointer btw? I cannot guess the reason why the data item could be destroyed when the action is triggered.