### PR TITLE
fix #30766, sip crash for QgsHighlight

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingcanvasitem.sip.in
@@ -11,6 +11,11 @@
 
 
 
+%ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsadvanceddigitizingcanvasitem.h>
+%End
+
 class QgsAdvancedDigitizingCanvasItem : QgsMapCanvasItem
 {
 %Docstring
@@ -19,6 +24,12 @@ The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CA
 
 %TypeHeaderCode
 #include "qgsadvanceddigitizingcanvasitem.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsAdvancedDigitizingCanvasItem *>( sipCpp ) )
+      sipType = sipType_QgsAdvancedDigitizingCanvasItem;
+    else
+      sipType = nullptr;
 %End
   public:
     explicit QgsAdvancedDigitizingCanvasItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );

--- a/python/gui/auto_generated/qgsgeometryrubberband.sip.in
+++ b/python/gui/auto_generated/qgsgeometryrubberband.sip.in
@@ -9,6 +9,10 @@
 
 
 
+%ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsgeometryrubberband.h>
+%End
 
 
 class QgsGeometryRubberBand: QgsMapCanvasItem
@@ -19,6 +23,12 @@ A rubberband class for QgsAbstractGeometry (considering curved geometries)*
 
 %TypeHeaderCode
 #include "qgsgeometryrubberband.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsGeometryRubberBand *>( sipCpp ) )
+      sipType = sipType_QgsGeometryRubberBand;
+    else
+      sipType = nullptr;
 %End
   public:
     enum IconType

--- a/python/gui/auto_generated/qgshighlight.sip.in
+++ b/python/gui/auto_generated/qgshighlight.sip.in
@@ -8,6 +8,11 @@
 
 
 
+%ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgshighlight.h>
+%End
+
 class QgsHighlight: QObject, QgsMapCanvasItem
 {
 %Docstring
@@ -29,9 +34,16 @@ for highlighting features or geometries on a map canvas.
 %TypeHeaderCode
 #include "qgshighlight.h"
 %End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsHighlight *>( sipCpp ) )
+      sipType = sipType_QgsHighlight;
+    else
+      sipType = nullptr;
+%End
   public:
 
-    QgsHighlight( QgsMapCanvas *mapCanvas, const QgsGeometry &geom, QgsMapLayer *layer );
+
+    QgsHighlight( QgsMapCanvas *mapCanvas /TransferThis/, const QgsGeometry &geom, QgsMapLayer *layer );
 %Docstring
 Constructor for QgsHighlight
 
@@ -40,7 +52,7 @@ Constructor for QgsHighlight
 :param layer: associated map layer
 %End
 
-    QgsHighlight( QgsMapCanvas *mapCanvas, const QgsFeature &feature, QgsVectorLayer *layer );
+    QgsHighlight( QgsMapCanvas *mapCanvas /TransferThis/, const QgsFeature &feature, QgsVectorLayer *layer );
 %Docstring
 Constructor for highlighting ``True`` feature shape using feature attributes
 and renderer.

--- a/python/gui/auto_generated/qgsmapcanvasannotationitem.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvasannotationitem.sip.in
@@ -8,6 +8,11 @@
 
 
 
+%ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsmapcanvasannotationitem.h>
+%End
+
 
 
 class QgsMapCanvasAnnotationItem: QObject, QgsMapCanvasItem
@@ -20,6 +25,12 @@ An interactive map canvas item which displays a QgsAnnotation.
 
 %TypeHeaderCode
 #include "qgsmapcanvasannotationitem.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsMapCanvasAnnotationItem *>( sipCpp ) )
+      sipType = sipType_QgsMapCanvasAnnotationItem;
+    else
+      sipType = nullptr;
 %End
   public:
 

--- a/python/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/gui/auto_generated/qgsrubberband.sip.in
@@ -10,6 +10,11 @@
 
 
 
+%ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsrubberband.h>
+%End
+
 class QgsRubberBand : QObject, QgsMapCanvasItem
 {
 %Docstring
@@ -21,6 +26,12 @@ for tracking the mouse while drawing polylines or polygons.
 
 %TypeHeaderCode
 #include "qgsrubberband.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsRubberBand *>( sipCpp ) )
+      sipType = sipType_QgsRubberBand;
+    else
+      sipType = nullptr;
 %End
   public:
 

--- a/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
@@ -9,6 +9,11 @@
 
 
 
+%ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgssnaptogridcanvasitem.h>
+%End
+
 class QgsSnapToGridCanvasItem : QObject, QgsMapCanvasItem
 {
 %Docstring
@@ -20,6 +25,12 @@ Shows a grid on the map canvas given a spatial resolution.
 
 %TypeHeaderCode
 #include "qgssnaptogridcanvasitem.h"
+%End
+%ConvertToSubClassCode
+    if ( dynamic_cast<QgsSnapToGridCanvasItem *>( sipCpp ) )
+      sipType = sipType_QgsSnapToGridCanvasItem;
+    else
+      sipType = nullptr;
 %End
   public:
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.h
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.h
@@ -24,12 +24,29 @@
 
 class QgsAdvancedDigitizingDockWidget;
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsadvanceddigitizingcanvasitem.h>
+% End
+#endif
+
 /**
  * \ingroup gui
  * \brief The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CAD tools (\see QgsAdvancedDigitizingDockWidget) on the map canvas.
  */
 class GUI_EXPORT QgsAdvancedDigitizingCanvasItem : public QgsMapCanvasItem
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsAdvancedDigitizingCanvasItem *>( sipCpp ) )
+      sipType = sipType_QgsAdvancedDigitizingCanvasItem;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
+
   public:
     explicit QgsAdvancedDigitizingCanvasItem( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget );
 

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -24,6 +24,12 @@
 #include <QPen>
 #include "qgis_gui.h"
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsgeometryrubberband.h>
+% End
+#endif
 
 class QgsAbstractGeometry;
 class QgsPoint;
@@ -34,6 +40,16 @@ struct QgsVertexId;
  * A rubberband class for QgsAbstractGeometry (considering curved geometries)*/
 class GUI_EXPORT QgsGeometryRubberBand: public QgsMapCanvasItem
 {
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsGeometryRubberBand *>( sipCpp ) )
+      sipType = sipType_QgsGeometryRubberBand;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
+
   public:
     enum IconType
     {

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -30,6 +30,13 @@ class QgsMapLayer;
 class QgsVectorLayer;
 class QgsSymbol;
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgshighlight.h>
+% End
+#endif
+
 /**
  * \ingroup gui
  * A class for highlight features on the map.
@@ -48,14 +55,22 @@ class QgsSymbol;
  */
 class GUI_EXPORT QgsHighlight: public QObject, public QgsMapCanvasItem
 {
-
     Q_OBJECT
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsHighlight *>( sipCpp ) )
+      sipType = sipType_QgsHighlight;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
+  public:
+
     Q_PROPERTY( QColor color READ color WRITE setColor )
     Q_PROPERTY( QColor fillColor READ fillColor WRITE setFillColor )
     Q_PROPERTY( int width READ width WRITE setWidth )
     Q_PROPERTY( int buffer READ buffer WRITE setBuffer )
-
-  public:
 
     /**
      * Constructor for QgsHighlight
@@ -63,7 +78,7 @@ class GUI_EXPORT QgsHighlight: public QObject, public QgsMapCanvasItem
      * \param geom initial geometry of highlight
      * \param layer associated map layer
      */
-    QgsHighlight( QgsMapCanvas *mapCanvas, const QgsGeometry &geom, QgsMapLayer *layer );
+    QgsHighlight( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS, const QgsGeometry &geom, QgsMapLayer *layer );
 
     /**
      * Constructor for highlighting TRUE feature shape using feature attributes
@@ -72,7 +87,7 @@ class GUI_EXPORT QgsHighlight: public QObject, public QgsMapCanvasItem
      * \param feature
      * \param layer vector layer
      */
-    QgsHighlight( QgsMapCanvas *mapCanvas, const QgsFeature &feature, QgsVectorLayer *layer );
+    QgsHighlight( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS, const QgsFeature &feature, QgsVectorLayer *layer );
     ~QgsHighlight() override;
 
     /**

--- a/src/gui/qgsmapcanvasannotationitem.h
+++ b/src/gui/qgsmapcanvasannotationitem.h
@@ -18,6 +18,13 @@
 #ifndef QGSMAPCANVASANNOTATIONITEM_H
 #define QGSMAPCANVASANNOTATIONITEM_H
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsmapcanvasannotationitem.h>
+% End
+#endif
+
 #include "qgsmapcanvasitem.h"
 #include "qgis_gui.h"
 
@@ -32,6 +39,15 @@ class QgsAnnotation;
 class GUI_EXPORT QgsMapCanvasAnnotationItem: public QObject, public QgsMapCanvasItem
 {
     Q_OBJECT
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsMapCanvasAnnotationItem *>( sipCpp ) )
+      sipType = sipType_QgsMapCanvasAnnotationItem;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
 
   public:
 

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -31,6 +31,13 @@
 class QgsVectorLayer;
 class QPaintEvent;
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgsrubberband.h>
+% End
+#endif
+
 /**
  * \ingroup gui
  * A class for drawing transient features (e.g. digitizing lines) on the map.
@@ -41,6 +48,15 @@ class QPaintEvent;
 class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
 {
     Q_OBJECT
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsRubberBand *>( sipCpp ) )
+      sipType = sipType_QgsRubberBand;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
   public:
 
     Q_PROPERTY( QColor fillColor READ fillColor WRITE setFillColor )

--- a/src/gui/qgssnaptogridcanvasitem.h
+++ b/src/gui/qgssnaptogridcanvasitem.h
@@ -23,6 +23,13 @@
 #include "qgsmapcanvasitem.h"
 #include "qgscoordinatetransform.h"
 
+#ifdef SIP_RUN
+% ModuleHeaderCode
+// For ConvertToSubClassCode.
+#include <qgssnaptogridcanvasitem.h>
+% End
+#endif
+
 /**
  * \ingroup gui
  *
@@ -33,6 +40,15 @@
 class GUI_EXPORT QgsSnapToGridCanvasItem : public QObject, public QgsMapCanvasItem
 {
     Q_OBJECT
+
+#ifdef SIP_RUN
+    SIP_CONVERT_TO_SUBCLASS_CODE
+    if ( dynamic_cast<QgsSnapToGridCanvasItem *>( sipCpp ) )
+      sipType = sipType_QgsSnapToGridCanvasItem;
+    else
+      sipType = nullptr;
+    SIP_END
+#endif
 
   public:
 


### PR DESCRIPTION
fixes https://github.com/qgis/QGIS/issues/30766

- looks like `SIP_TRANSFERTHIS` in constructor was the missing part. 
- added also `SIP_CONVERT_TO_SUBCLASS_CODE` to all gui classes based on ` QgsMapCanvasItem` (similarly to already existing code for `QgsVertexMarker`)