### PR TITLE
[processing] force onLayerChanged() call in the layer combobox constructor (fix #30636)

### DIFF
--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -117,6 +117,8 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   setLayout( vl );
 
   setAcceptDrops( true );
+
+  onLayerChanged( mCombo->currentLayer() );
 }
 
 QgsProcessingMapLayerComboBox::~QgsProcessingMapLayerComboBox() = default;


### PR DESCRIPTION
## Description
QgsProcessingMapLayerCombobox has a associated checkbox for handling features selection. But this checkbox gets enabled only after layer change and it is not possible to control feature selection for the layer which is selected by default.

Fixes #30636.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment