### PR TITLE
Resize not-focused tabs for datasource and options dlgs

### DIFF
--- a/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
+++ b/python/gui/auto_generated/qgsoptionsdialogbase.sip.in
@@ -66,6 +66,15 @@ Sometimes useful to do at end of subclass's constructor.
 :param title: the window title (it does not need to be defined if previously given to initOptionsBase();
 %End
 
+    void resizeAlltabs( int index );
+%Docstring
+Resizes all tabs when the dialog is resized
+
+:param index: current tab index
+
+.. versionadded:: 3.10
+%End
+
     bool iconOnly();
 %Docstring
 Determine if the options list is in icon only mode

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1648,19 +1648,7 @@ void QgsVectorLayerProperties::optionsStackedWidget_CurrentChanged( int index )
     mMetadataFilled = true;
   }
 
-  // Adjust size (GH issue #31449)
-  // make the stacked widget size to the current page only
-  for ( int i = 0; i < mOptStackedWidget->count(); ++i )
-  {
-    // determine the vertical size policy
-    QSizePolicy::Policy policy = QSizePolicy::Ignored;
-    if ( i == index )
-      policy = QSizePolicy::MinimumExpanding;
-
-    // update the size policy
-    mOptStackedWidget->widget( i )->setSizePolicy( policy, policy );
-  }
-  mOptStackedWidget->adjustSize();
+  resizeAlltabs( index );
 }
 
 void QgsVectorLayerProperties::mSimplifyDrawingGroupBox_toggled( bool checked )

--- a/src/gui/qgsdatasourcemanagerdialog.cpp
+++ b/src/gui/qgsdatasourcemanagerdialog.cpp
@@ -104,6 +104,7 @@ void QgsDataSourceManagerDialog::setCurrentPage( int index )
   mPreviousRow = ui->mOptionsStackedWidget->currentIndex();
   ui->mOptionsStackedWidget->setCurrentIndex( index );
   setWindowTitle( tr( "Data Source Manager | %1" ).arg( ui->mOptionsListWidget->currentItem()->text() ) );
+  resizeAlltabs( index );
 }
 
 void QgsDataSourceManagerDialog::setPreviousPage()

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -205,6 +205,23 @@ void QgsOptionsDialogBase::restoreOptionsBaseUi( const QString &title )
   mOptListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
 }
 
+void QgsOptionsDialogBase::resizeAlltabs( int index )
+{
+  // Adjust size (GH issue #31449)
+  // make the stacked widget size to the current page only
+  for ( int i = 0; i < mOptStackedWidget->count(); ++i )
+  {
+    // determine the vertical size policy
+    QSizePolicy::Policy policy = QSizePolicy::Ignored;
+    if ( i == index )
+      policy = QSizePolicy::MinimumExpanding;
+
+    // update the size policy
+    mOptStackedWidget->widget( i )->setSizePolicy( policy, policy );
+  }
+  mOptStackedWidget->adjustSize();
+}
+
 void QgsOptionsDialogBase::searchText( const QString &text )
 {
   const int minimumTextLength = 3;

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -92,6 +92,13 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
     void restoreOptionsBaseUi( const QString &title = QString() );
 
     /**
+     * Resizes all tabs when the dialog is resized
+     * \param index current tab index
+     * \since QGIS 3.10
+     */
+    void resizeAlltabs( int index );
+
+    /**
      * Determine if the options list is in icon only mode
      */
     bool iconOnly() {return mIconOnly;}


### PR DESCRIPTION
Moved logic into base class. I did not find any other
suclass affected.

Fixes #31732
