### PR TITLE
Fix QT font database initializing (FCGI with IIS)

### DIFF
--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -26,6 +26,7 @@
 #include <fcgi_stdio.h>
 #include <cstdlib>
 
+#include <QFontDatabase>
 #include <QString>
 
 int fcgi_accept()
@@ -71,7 +72,7 @@ int main( int argc, char *argv[] )
   // When using FCGI with IIS, environment variables (QT_QPA_FONTDIR in this case) are lost after fcgi_accept().
   QFontDatabase fontDB;
 #endif
-  
+
   // Starts FCGI loop
   while ( fcgi_accept() >= 0 )
   {

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -65,6 +65,13 @@ int main( int argc, char *argv[] )
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   server.initPython();
 #endif
+
+#ifdef Q_OS_WIN
+  // Initialize font database before fcgi_accept.
+  // When using FCGI with IIS, environment variables (QT_QPA_FONTDIR in this case) are lost after fcgi_accept().
+  QFontDatabase fontDB;
+#endif
+  
   // Starts FCGI loop
   while ( fcgi_accept() >= 0 )
   {


### PR DESCRIPTION
When using FCGI with IIS, environment variables (QT_QPA_FONTDIR in this case) are lost after fcgi_accept().

In order to specify the directory where font files are located, one must define the "QT_QPA_FONTDIR" environment variable before running qgis_mapserv.fcgi.exe. When using FCGI with IIS, you can specify environment variables to be set before starting qgis_mapserv.fcgi.exe process, but these are lost immediately after the call to fcgi_accept.
We force a QFontDatabase initialization before fcgi_accept(), in order to allow QFontDatabase to initialize the list of fonts available in "QT_QPA_FONTDIR" (this is still accessible at this time).
