### PR TITLE
Add json support to WMS GetLegendGraphic

### DIFF
--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -494,6 +494,7 @@ namespace QgsWms
     elem = doc.createElement( ( version == QLatin1String( "1.1.1" ) ? "GetLegendGraphic" : "sld:GetLegendGraphic" )/*wms:GetLegendGraphic*/ );
     appendFormat( elem, QStringLiteral( "image/jpeg" ) );
     appendFormat( elem, QStringLiteral( "image/png" ) );
+    appendFormat( elem, QStringLiteral( "application/json" ) );
     elem.appendChild( dcpTypeElem.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
     requestElem.appendChild( elem );
 

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -91,8 +91,8 @@ namespace QgsWms
 
     if ( format == QgsWmsParameters::Format::NONE )
     {
-      throw QgsServiceException( "InvalidFormat",
-                                 QStringLiteral( "Output format '%1' is not supported in the GetLegendGraphic request" ).arg( parameters.formatAsString() ) );
+      throw QgsBadRequestException( QgsServiceException::OGC_InvalidFormat,
+                                    QStringLiteral( "Output format '%1' is not supported in the GetLegendGraphic request" ).arg( parameters.formatAsString() ) );
     }
 
     // Get cached image

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -814,7 +814,11 @@ namespace QgsWms
     {
       f = Format::PDF;
     }
-
+    else if ( fStr.compare( QLatin1String( "application/json" ), Qt::CaseInsensitive ) == 0 ||
+              fStr.compare( QLatin1String( "json" ), Qt::CaseInsensitive ) == 0 )
+    {
+      f = Format::JSON;
+    }
     return f;
   }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -174,6 +174,28 @@ namespace QgsWms
     return image.release();
   }
 
+  QJsonObject QgsRenderer::getLegendGraphicsAsJson( QgsLayerTreeModel &model )
+  {
+    // get layers
+    std::unique_ptr<QgsLayerRestorer> restorer;
+    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
+
+    // configure layers
+    QList<QgsMapLayer *> layers = mContext.layersToRender();
+    configureLayers( layers );
+
+    // init renderer
+    QgsLegendSettings settings = legendSettings();
+    QgsLegendRenderer renderer( &model, settings );
+
+    // rendering
+    QJsonObject json;
+    QgsRenderContext renderContext;
+    renderer.exportLegendToJson( renderContext, json );
+
+    return json;
+  }
+
   void QgsRenderer::runHitTest( const QgsMapSettings &mapSettings, HitTest &hitTest ) const
   {
     QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -99,7 +99,7 @@ namespace QgsWms
        * of the JSON object.
        * \param model The layer tree model to use for building the legend
        * \returns the legend as a JSON object
-       * \since QGIS 3.9
+       * \since QGIS 3.12
        */
       QJsonObject getLegendGraphicsAsJson( QgsLayerTreeModel &model );
 

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -94,6 +94,15 @@ namespace QgsWms
        */
       QImage *getLegendGraphics( QgsLayerTreeModelLegendNode &nodeModel );
 
+      /**
+       * Returns the map legend as a JSON object. The caller takes the ownership
+       * of the JSON object.
+       * \param model The layer tree model to use for building the legend
+       * \returns the legend as a JSON object
+       * \since QGIS 3.9
+       */
+      QJsonObject getLegendGraphicsAsJson( QgsLayerTreeModel &model );
+
       typedef QSet<QString> SymbolSet;
       typedef QHash<QgsVectorLayer *, SymbolSet> HitTest;
 

--- a/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
@@ -29,7 +29,7 @@ from qgis.PyQt.QtCore import QSize
 
 import osgeo.gdal  # NOQA
 
-from test_qgsserver import QgsServerTestBase
+from test_qgsserver_wms import TestQgsServerWMSTestBase
 from qgis.core import QgsProject
 
 # Strip path and content length because path may vary
@@ -37,7 +37,7 @@ RE_STRIP_UNCHECKABLE = b'MAP=[^"]+|Content-Length: \d+'
 RE_ATTRIBUTES = b'[^>\s]+=[^>\s]+'
 
 
-class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
+class TestQgsServerWMSGetLegendGraphic(TestQgsServerWMSTestBase):
     """QGIS Server WMS Tests for GetLegendGraphic request"""
 
     # Set to True to re-generate reference files for this class
@@ -915,6 +915,18 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self.assertFalse(b'Exception' in r)
         self._img_diff_error(r, h, "WMS_GetLegendGraphic_Regression32020_type2_3857", max_size_diff=QSize(10, 2))
+
+    def test_wms_GetLegendGraphic_JSON(self):
+        self.wms_request_compare("GetLegendGraphic",
+                                 "&LAYERS=testlayer%20%C3%A8%C3%A9"
+                                 "&FORMAT=application/json",
+                                 "wms_getlegendgraphic_json")
+
+    def test_wms_GetLegendGraphic_JSON_multiple_layers(self):
+        self.wms_request_compare("GetLegendGraphic",
+                                 "&LAYERS=testlayer%20%C3%A8%C3%A9,testlayer3"
+                                 "&FORMAT=application/json",
+                                 "wms_getlegendgraphic_json_multiple_layers")
 
 
 if __name__ == '__main__':

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -67,6 +67,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -68,6 +68,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -67,6 +67,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -68,6 +68,7 @@ Content-Type: text/xml; charset=utf-8
    <GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -67,6 +67,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -58,6 +58,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -58,6 +58,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -60,6 +60,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>

--- a/tests/testdata/qgis_server/wms_getlegendgraphic_json.txt
+++ b/tests/testdata/qgis_server/wms_getlegendgraphic_json.txt
@@ -1,0 +1,13 @@
+*****
+Content-Type: application/json
+
+{
+   "nodes":[
+      {
+         "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAA5klEQVQ4je3QPw/BQBjH8V/LJdfKdSAXEXZhsIiBd2CyWsS7MFnF4pWY+x4MIhIDfQFYhMR/0rsy0EiqklaMvslN99wnTw7494sKz/NdmhYtM04tg9OtwemWcTojOil9mlc+IpmYWWsX40rkMSKFA7MzWm8W56p9soeBIMapVe9Vsi7iJm0H/dbA2q8uOe8b1ccpKEDKiwBAhKiAgzSAfBDoq/ygyQ3KUgrn7UJcJaBiDmAaaCNxEE2zM1pL+4WJq4TZHW8uR9kItSrRSYlxbcYSdMcSdGck9SnRSTEU4ikPn8/9F747d+tCtRm7EewAAAAASUVORK5CYII=",
+         "title":"A test vector layer",
+         "type":"layer"
+      }
+   ],
+   "title":""
+}

--- a/tests/testdata/qgis_server/wms_getlegendgraphic_json_multiple_layers.txt
+++ b/tests/testdata/qgis_server/wms_getlegendgraphic_json_multiple_layers.txt
@@ -1,0 +1,18 @@
+*****
+Content-Type: application/json
+
+{
+   "nodes":[
+      {
+         "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAA+0lEQVQ4je2RsWrCUBSG/3u5NS6ltU4Sl1MuIhazOYhP0IewfQH7MuIu+Ax9BbuULi0tIikZDG42YKckeE+HUgjkRtN29VvP/38czgGO/Bsi8ojIO5QTRYNuW/fPK2oKRgMAGFhHsbl5XS4fS4u6bd2/PK3eTwbuhRLfkdQwRvNw875Nr20yaROdVdQ0KwGAEykwHjTrNUfMbJ2ciIg8wWhkJT84UsAwXK11p9RGfyEnCoLgmYF1ajgXjncMJWXo+/5bqY0+jbkdzVebJCOLd4y7h/AjSnho6xS+/6rV6tUcMTMMFwCUlGGU8PBlsXgq6uxFa92xHffI7/kCsF1RWSlSxcoAAAAASUVORK5CYII=",
+         "title":"testlayer3",
+         "type":"layer"
+      },
+      {
+         "icon":"iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAA5klEQVQ4je3QPw/BQBjH8V/LJdfKdSAXEXZhsIiBd2CyWsS7MFnF4pWY+x4MIhIDfQFYhMR/0rsy0EiqklaMvslN99wnTw7494sKz/NdmhYtM04tg9OtwemWcTojOil9mlc+IpmYWWsX40rkMSKFA7MzWm8W56p9soeBIMapVe9Vsi7iJm0H/dbA2q8uOe8b1ccpKEDKiwBAhKiAgzSAfBDoq/ygyQ3KUgrn7UJcJaBiDmAaaCNxEE2zM1pL+4WJq4TZHW8uR9kItSrRSYlxbcYSdMcSdGck9SnRSTEU4ikPn8/9F747d+tCtRm7EewAAAAASUVORK5CYII=",
+         "title":"A test vector layer",
+         "type":"layer"
+      }
+   ],
+   "title":""
+}

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -68,6 +68,7 @@ Content-Type: text/xml; charset=utf-8
    <sld:GetLegendGraphic>
     <Format>image/jpeg</Format>
     <Format>image/png</Format>
+    <Format>application/json</Format>
     <DCPType>
      <HTTP>
       <Get>


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR adds support for GetLegendGraphic responses encoded as JSON. It builds on [previous work](https://github.com/qgis/QGIS/pull/9362) by @pblottiere, who added `QgsLegendRenderer::exportLegendToJson` for that exact purpose.

For example a GetLegendGraphic request with FORMAT=image/png producing the image


![image](https://user-images.githubusercontent.com/76594/64876231-fbb13a80-d64e-11e9-83e5-120fb1bc0ea8.png)

will produce the following with FORMAT=application/json


```json
{
  "nodes": [
    {
      "icon": "iVBORw0KGgoAAAANSUhEUgAAABoAAABuCAYAAAA5+QMZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAHaUlEQVRoge2YW4xdVRmAv3XZt3OdmdMZplPaDp1eCBUIoVwCxoxGLopTE5MmPBnEhJiqCbyYiIm+4ANvRjAxaEwTH4TURGIUY0SYqlGwlIvYaTsUpu1QOtdzzsy57XP23mv5QGeYdjqll9MXc76nk73X+r+91vrXv89egstk9+7d2SjKiiSRSWtAJRXXTQ4991z0af3EpzV4+OFvbMz15m8JUunPSiG3Bb7XC2QAnVgbxyYpEZmploneWKiUXznVaIyP7tsXXrLoW48/fq/npfYWugqfx1HrpfaIhcPJWpPFWpPEWLSW5H2HwZyHjJskrVZSrVVfCyu1/Tau//yZZ55pril68sknr6sl4meFnsJXg3RGn6wZ3jp+isb0GUR5BpJk1UNZ18cZuIG+6we47fo86SSiWJp7sxHWv/vTp5/+5yrRd773g135TPqF7p7Clsm65fXD79F6fwxhLSbI0CoMEBfWk6TzWKkRURNVX8SdOoE79yFYi01lGdx1N/dsyLBYWSgt1hYf/clTT724LPrm3ie2DmzoP5DPdw28PRcyduBVMAn1rbdR23kPUWHgomup6hW8yWNk/zOKLs1QuPNz3D9UYKFUmisWS8MKYGRkJLVxy7ZfFAqFXacbljdefpnWdZuY3f1tGkO3YlLZi0oArOMRrRugfuMdYA3J2//A27iV9Tk/1YzqPRogW+jfns/l7gM4OD5JfccuynePgPjUpFwtVA6Ld36ZuGcDh98fY+ttg9hEfkED5HLBDULiGwQNHVC+68okK6lvvZXY1hFAGNZzEqA4X7mjUW8A4N10+1VLlli36QasMYSNRkMCKJWcmZ2bLkss29wm2KsXaWO5OZomakUkURJLAISqho2wXK1UuCmaYSguXZVEGcEXmxP0JFVOTUwsaEdHcumm63iDp05OfNCq1fhKeIybo1nEZY5MWMjaFiPhET4TT/PB+8eLQsi0tRi9sqHrBFtOfDAx3r+hf/CBHuPuUPO86fZzQndhAbuWAOhOQnZGc9wST9Gcn2bsw9NF1/OzCDSAPr+T47rbp05PlednZ518d7d4MPcRSdDFpOpiXvlU8EikQBpL2kZ02QYbTAW/XsI2G5w6M4OyBtfze1Y8iV0lOivrskC5WKZYLBJZRTqTYUgrXC2wQiKFIk5iytWQ02GINDG+EEitQMhVMS8oWpoOhEQhkVha1UVa9uz0WbBYpBAIKcgoCWrNUJgkWdQACYQXW3ghBEqoNe9fDGstxpiTEsDWq3+LTVS/okiXIEqS1osSYP/+/adbcfQHa9fKqysnbNT/dfTdd/Ytr1ps9BNhK5xoqyRszEQmfPTQoUOfbNjnf/XsR2Gj+VAjrJ3gKkdmjMUkEdjk2d/s23cU4Jw8fOHXvzySJNGPPFdikgRjzWVL4jgmm/bYOrgBz9PB0vVVOZnx/c2bNw4QRTHzxTKVep0ksh/vDWEBcTb1BRaLMQZrLJ6rSQc+vb39pIOAxBi01JvWFAkphxyt8VyXTDqFMYZ6o0mtUSduJURJzFLSuI4m8D1SQYDrOkj5yQQpKdFK9Q0PD+vR0dH4HNHtjz3mOFqvX9lBSkkmHZBJB1wufuB1eb29OaB4zhoNnKnk/WBFjbpKXM9bF0QqB+clQ6xMPvC9vnaJPMfpF57NrxKlfNHtue76dom0VkHaz1y/SpRN57Zr7TjtE2lSKX/bKpHnezscvXYVvlwcrdGOM7hKpITcovSVVekLoZRCYDedI9qzZ4+rHd2v5OqX1pUihMB13e6RkZHUctQq5IM2pvYSvud1C5HJLouUMV2B5113DUR9xmnllkVC64Lruf3tFjmu06el170s6s12bXfamQln0VKpfD41tCzSrrNdO+1L7SWUVviOt0Kk1Bat2j4gHO0gtdosAYYfecT3HLdPtjG1l1BKIoUakAC5YjPvB16h7ZazBJ6Tl/Bx1dZab7lWIi8IChKg2gy/FgR+7lqJHKXWyZ179rhK6++7um1FezVCZiUzCw80olau2WpdM8/U/JyQFjO42Aj5cGr6mkjCZpPJqdlYCggBjk2eplheaKskSRLePXacE9MzB6VQ5hXATpXKvP7uYcoLi22RhM0mb40d5dD4cSw8r2YmJkq9g0PrgV2lao25UonA0WTSKa5kA0dxzPTMLAcPH+G/JyYx1h4c6+3aqwA2Fbr/HLnBXUIwVG2ETJ6ZobSwQBLHOFqhlF5Taq2l1YqoNxpMzc3xztFxDh57j5nyIhaOCKIHZ196qbL89bXj3t1Z5TReAL60dE1JSVc6RW8+Ry6dwvc8AtfFCgHW0oxiqrUq9VbEdLHMYr1ObJb/r/+2lei9x//+p1lYfV4ndg7f/3Vr7Q8RnFMpBB+/mpd/IzBYzPlfHpZ/C8mPD7/6l9+f338Vw8PDeto6I1LwkLXch2DThdqtCD4mpP1jYuzvjh7462tc4KTgUk4sxI3DD27W0gwkhj4p6MMYa4SsIMW4NM3xw6Oj1UuI06FDhw4dOnTo0KFDhw4dOnTo0KFDhw4dOvzf8D+CIQQwLMX+dAAAAABJRU5ErkJggg==",
      "title": "dwa_reservoir",
      "type": "layer"
    }
  ],
  "title": ""
}
```

The icon image is encoded in base64, and directly displayable in a web page.

Still WIP for the moment. I want to do more testing, and add unit tests. But preliminary comments are welcome.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
