### PR TITLE
[needs-docs][ui] Use ctrl+return shortcut to accept/use expression and filter text

### DIFF
--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -320,6 +320,13 @@ when text changes.
 :param enabled: ``True`` to enable auto saving.
 %End
 
+    QgsCodeEditorExpression  *expressionEditor();
+%Docstring
+Returns the expression editor widget.
+
+.. versionadded:: 3.10
+%End
+
   signals:
 
     void expressionParsed( bool isValid );

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -18,6 +18,9 @@
 #include "qgsguiutils.h"
 #include "qgsgui.h"
 
+#include <QKeySequence>
+#include <QShortcut>
+
 QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, const QString &startText, QWidget *parent, const QString &key, const QgsExpressionContext &context )
   : QDialog( parent )
   , mRecentKey( key )
@@ -33,6 +36,10 @@ QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, c
   builder->setExpressionText( startText );
   builder->loadFieldNames();
   builder->loadRecent( mRecentKey );
+
+  QShortcut *acceptShortcut = new QShortcut( QKeySequence( QStringLiteral( "Ctrl+Return" ) ), builder->expressionEditor() );
+  connect( acceptShortcut, &QShortcut::activated, this, &QgsExpressionBuilderDialog::accept );
+  buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "OK (Ctrl+Return)" ) );
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsExpressionBuilderDialog::showHelp );
 }

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -323,6 +323,12 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      */
     void setAutoSave( bool enabled ) { mAutoSave = enabled; }
 
+    /**
+     * Returns the expression editor widget.
+     * \since QGIS 3.10
+     */
+    QgsCodeEditorExpression  *expressionEditor() { return txtExpressionString; }
+
   private slots:
     void indicatorClicked( int line, int index, Qt::KeyboardModifiers state );
     void showContextMenu( QPoint );

--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -35,6 +35,10 @@ QgsExpressionSelectionDialog::QgsExpressionSelectionDialog( QgsVectorLayer *laye
 
   QgsGui::enableAutoGeometryRestore( this );
 
+  mActionSelect->setShortcut( QKeySequence( QStringLiteral( "Ctrl+Return" ) ) );
+#if QT_VERSION >= 0x051000
+  mActionSelect->setShortcutVisibleInContextMenu( true );
+#endif
   connect( mActionSelect, &QAction::triggered, this, &QgsExpressionSelectionDialog::mActionSelect_triggered );
   connect( mActionAddToSelection, &QAction::triggered, this, &QgsExpressionSelectionDialog::mActionAddToSelection_triggered );
   connect( mActionRemoveFromSelection, &QAction::triggered, this, &QgsExpressionSelectionDialog::mActionRemoveFromSelection_triggered );

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -22,10 +22,12 @@
 #include "qgshelp.h"
 #include "qgsgui.h"
 
+#include <QKeySequence>
 #include <QListView>
 #include <QMessageBox>
 #include <QRegExp>
 #include <QPushButton>
+#include <QShortcut>
 
 // constructor used when the query builder must make its own
 // connection to the database
@@ -65,6 +67,10 @@ QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
   pbn = new QPushButton( tr( "&Clear" ) );
   buttonBox->addButton( pbn, QDialogButtonBox::ActionRole );
   connect( pbn, &QAbstractButton::clicked, this, &QgsQueryBuilder::clear );
+
+  QShortcut *acceptShortcut = new QShortcut( QKeySequence( QStringLiteral( "Ctrl+Return" ) ), txtSQL );
+  connect( acceptShortcut, &QShortcut::activated, this, &QgsQueryBuilder::accept );
+  buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "OK (Ctrl+Return)" ) );
 
   setupGuiViews();
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Keyboard-based UX is broken with expression and SQL editors  as those are not focused away when hitting the Tab key. 

To fix this, this commit uses the Ctrl+Enter key sequence shortcut in the following dialogs to enable keyboard interaction:
- In the query builder (i.e. layer SQL filter), ctrl+enter will apply filter
- In the expression builder, ctrl+enter will apply the expression
- In the select by expression dialog, ctrl+enter applies the selection

This fixes the usability issue reported @ #31644. 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
