### PR TITLE
use PostgreSQL quote_ident() function to quote schema and table names when listing tables

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -639,7 +639,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
                   " LEFT JOIN pg_type b ON b.oid=t.typbasetype"
                   " WHERE c.relkind IN ('v','r','m','p')"
                   " AND has_schema_privilege( n.nspname, 'usage' )"
-                  " AND has_table_privilege( '\"' || n.nspname || '\".\"' || c.relname || '\"', 'select' )"
+                  " AND has_table_privilege( QUOTE_IDENT(n.nspname) || '.' || QUOTE_IDENT(c.relname), 'select' )"
                   " AND (t.typname IN ('geometry','geography','topogeometry') OR b.typname IN ('geometry','geography','topogeometry','pcpatch','raster'))";
 
     // user has select privilege


### PR DESCRIPTION
## Description
Found this one when working with 3rd party database with quite unusual table names like `""seksyen""`.

If table or schema name contains quotes (or even multiple quotes/other special characters) QGIS fails to get list of available tables in the PostgreSQL database. Corresponding query fails with syntax error. Only core provider affected, DB Manager works fine as it uses different queries.

Using `quote_ident()` funciton instead of manual quoting fixes this issue.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
