### PR TITLE
QgsRasterFileWriter: assorted set of fixes (might be related to refs #30937)

### DIFF
--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -335,6 +335,11 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
   return error;
 }
 
+static int qgsDivRoundUp( int a, int b )
+{
+  return a / b + ( ( ( a % b ) != 0 ) ? 1 : 0 );
+}
+
 QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const QgsRasterPipe *pipe,
     QgsRasterIterator *iter,
     int nCols, int nRows,
@@ -361,12 +366,15 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
   int iterCols = 0;
   int iterRows = 0;
 
-  QList<QgsRasterBlock *> blockList;
-  blockList.reserve( nBands );
+  std::vector< std::unique_ptr<QgsRasterBlock> > blockList;
+  std::vector< std::unique_ptr<QgsRasterBlock> > destBlockList;
+
+  blockList.resize( nBands );
+  destBlockList.resize( nBands );
+
   for ( int i = 1; i <= nBands; ++i )
   {
     iter->startRasterRead( i, nCols, nRows, outputExtent );
-    blockList.push_back( nullptr );
     if ( destProvider && destHasNoDataValueList.value( i - 1 ) ) // no tiles
     {
       destProvider->setNoDataValue( i, destNoDataValueList.value( i - 1 ) );
@@ -377,8 +385,8 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
   int fileIndex = 0;
   if ( feedback )
   {
-    int nPartsX = nCols / iter->maximumTileWidth() + 1;
-    int nPartsY = nRows / iter->maximumTileHeight() + 1;
+    int nPartsX = qgsDivRoundUp( nCols, iter->maximumTileWidth() );
+    int nPartsY = qgsDivRoundUp( nRows, iter->maximumTileHeight() );
     nParts = nPartsX * nPartsY;
   }
 
@@ -388,7 +396,8 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
   {
     for ( int i = 1; i <= nBands; ++i )
     {
-      if ( !iter->readNextRasterPart( i, iterCols, iterRows, &( blockList[i - 1] ), iterLeft, iterTop ) )
+      QgsRasterBlock *block = nullptr;
+      if ( !iter->readNextRasterPart( i, iterCols, iterRows, &block, iterLeft, iterTop ) )
       {
         // No more parts, create VRT and return
         if ( mTiledMode )
@@ -411,6 +420,7 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
         QgsDebugMsgLevel( QStringLiteral( "Done" ), 4 );
         return NoError; //reached last tile, bail out
       }
+      blockList[i - 1].reset( block );
       // TODO: verify if NoDataConflict happened, to do that we need the whole pipe or nuller interface
     }
 
@@ -419,61 +429,61 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
       feedback->setProgress( 100.0 * fileIndex / static_cast< double >( nParts ) );
       if ( feedback->isCanceled() )
       {
-        for ( int i = 0; i < nBands; ++i )
-        {
-          delete blockList[i];
-        }
         break;
       }
     }
 
     // It may happen that internal data type (dataType) is wider than destDataType
-    QList<QgsRasterBlock *> destBlockList;
     for ( int i = 1; i <= nBands; ++i )
     {
       if ( srcProvider && srcProvider->dataType( i ) == destDataType )
       {
-        destBlockList.push_back( blockList[i - 1] );
+        // nothing
       }
       else
       {
         // TODO: this conversion should go to QgsRasterDataProvider::write with additional input data type param
         blockList[i - 1]->convert( destDataType );
-        destBlockList.push_back( blockList[i - 1] );
       }
-      blockList[i - 1] = nullptr;
+      destBlockList[i - 1] = std::move( blockList[i - 1] );
     }
 
     if ( mTiledMode ) //write to file
     {
-      QgsRasterDataProvider *partDestProvider = createPartProvider( outputExtent,
+      std::unique_ptr< QgsRasterDataProvider > partDestProvider( createPartProvider( outputExtent,
           nCols, iterCols, iterRows,
           iterLeft, iterTop, mOutputUrl,
-          fileIndex, nBands, destDataType, crs );
+          fileIndex, nBands, destDataType, crs ) );
 
-      if ( partDestProvider )
+      if ( !partDestProvider || !partDestProvider->isValid() )
       {
-        //write data to output file. todo: loop over the data list
-        for ( int i = 1; i <= nBands; ++i )
-        {
-          if ( destHasNoDataValueList.value( i - 1 ) )
-          {
-            partDestProvider->setNoDataValue( i, destNoDataValueList.value( i - 1 ) );
-          }
-          partDestProvider->write( destBlockList[i - 1]->bits( 0 ), i, iterCols, iterRows, 0, 0 );
-          delete destBlockList[i - 1];
-          addToVRT( partFileName( fileIndex ), i, iterCols, iterRows, iterLeft, iterTop );
-        }
-        delete partDestProvider;
+        return DestProviderError;
       }
+
+      //write data to output file. todo: loop over the data list
+      for ( int i = 1; i <= nBands; ++i )
+      {
+        if ( destHasNoDataValueList.value( i - 1 ) )
+        {
+          partDestProvider->setNoDataValue( i, destNoDataValueList.value( i - 1 ) );
+        }
+        if ( !partDestProvider->write( destBlockList[i - 1]->bits( 0 ), i, iterCols, iterRows, 0, 0 ) )
+        {
+          return DestProviderError;
+        }
+        addToVRT( partFileName( fileIndex ), i, iterCols, iterRows, iterLeft, iterTop );
+      }
+
     }
     else if ( destProvider )
     {
       //loop over data
       for ( int i = 1; i <= nBands; ++i )
       {
-        destProvider->write( destBlockList[i - 1]->bits( 0 ), i, iterCols, iterRows, iterLeft, iterTop );
-        delete destBlockList[i - 1];
+        if ( !destProvider->write( destBlockList[i - 1]->bits( 0 ), i, iterCols, iterRows, iterLeft, iterTop ) )
+        {
+          return DestProviderError;
+        }
       }
     }
     ++fileIndex;
@@ -501,14 +511,16 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeImageRaster( QgsRaste
   {
     return SourceProviderError;
   }
+  const bool isPremultiplied = ( inputDataType == Qgis::ARGB32_Premultiplied );
 
   iter->setMaximumTileWidth( mMaxTileWidth );
   iter->setMaximumTileHeight( mMaxTileHeight );
 
-  void *redData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
-  void *greenData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
-  void *blueData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
-  void *alphaData = qgsMalloc( static_cast<size_t>( mMaxTileWidth * mMaxTileHeight ) );
+  const size_t nMaxPixels = static_cast<size_t>( mMaxTileWidth ) * mMaxTileHeight;
+  std::vector<unsigned char> redData( nMaxPixels );
+  std::vector<unsigned char> greenData( nMaxPixels );
+  std::vector<unsigned char> blueData( nMaxPixels );
+  std::vector<unsigned char> alphaData( nMaxPixels );
   int iterLeft = 0, iterTop = 0, iterCols = 0, iterRows = 0;
   int fileIndex = 0;
 
@@ -518,14 +530,18 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeImageRaster( QgsRaste
   globalOutputParameters( outputExtent, nCols, nRows, geoTransform, pixelSize );
 
   std::unique_ptr< QgsRasterDataProvider > destProvider( initOutput( nCols, nRows, crs, geoTransform, 4, Qgis::Byte ) );
+  if ( destProvider && !destProvider->isValid() )
+  {
+    return DestProviderError;
+  }
 
   iter->startRasterRead( 1, nCols, nRows, outputExtent, feedback );
 
   int nParts = 0;
   if ( feedback )
   {
-    int nPartsX = nCols / iter->maximumTileWidth() + 1;
-    int nPartsY = nRows / iter->maximumTileHeight() + 1;
+    int nPartsX = qgsDivRoundUp( nCols, iter->maximumTileWidth() );
+    int nPartsY = qgsDivRoundUp( nRows, iter->maximumTileHeight() );
     nParts = nPartsX * nPartsY;
   }
 
@@ -548,72 +564,60 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeImageRaster( QgsRaste
 
     //fill into red/green/blue/alpha channels
     qgssize nPixels = static_cast< qgssize >( iterCols ) * iterRows;
-    // TODO: should be char not int? we are then copying 1 byte
-    int red = 0;
-    int green = 0;
-    int blue = 0;
-    int alpha = 255;
     for ( qgssize i = 0; i < nPixels; ++i )
     {
       QRgb c = inputBlock->color( i );
-      alpha = qAlpha( c );
-      red = qRed( c );
-      green = qGreen( c );
-      blue = qBlue( c );
-
-      if ( inputDataType == Qgis::ARGB32_Premultiplied )
+      if ( isPremultiplied )
       {
-        double a = alpha / 255.;
-        QgsDebugMsgLevel( QStringLiteral( "red = %1 green = %2 blue = %3 alpha = %4 p = %5 a = %6" ).arg( red ).arg( green ).arg( blue ).arg( alpha ).arg( static_cast< int >( c ), 0, 16 ).arg( a ), 5 );
-        red /= a;
-        green /= a;
-        blue /= a;
+        c = qUnpremultiply( c );
       }
-      memcpy( reinterpret_cast< char * >( redData ) + i, &red, 1 );
-      memcpy( reinterpret_cast< char * >( greenData ) + i, &green, 1 );
-      memcpy( reinterpret_cast< char * >( blueData ) + i, &blue, 1 );
-      memcpy( reinterpret_cast< char * >( alphaData ) + i, &alpha, 1 );
+      redData[i] = static_cast<unsigned char>( qRed( c ) );
+      greenData[i] = static_cast<unsigned char>( qGreen( c ) );
+      blueData[i] = static_cast<unsigned char>( qBlue( c ) );
+      alphaData[i] = static_cast<unsigned char>( qAlpha( c ) );
     }
 
     //create output file
     if ( mTiledMode )
     {
-      //delete destProvider;
       std::unique_ptr< QgsRasterDataProvider > partDestProvider( createPartProvider( outputExtent,
           nCols, iterCols, iterRows,
           iterLeft, iterTop, mOutputUrl, fileIndex,
           4, Qgis::Byte, crs ) );
 
-      if ( partDestProvider )
+      if ( !partDestProvider || partDestProvider->isValid() )
       {
-        //write data to output file
-        partDestProvider->write( redData, 1, iterCols, iterRows, 0, 0 );
-        partDestProvider->write( greenData, 2, iterCols, iterRows, 0, 0 );
-        partDestProvider->write( blueData, 3, iterCols, iterRows, 0, 0 );
-        partDestProvider->write( alphaData, 4, iterCols, iterRows, 0, 0 );
-
-        addToVRT( partFileName( fileIndex ), 1, iterCols, iterRows, iterLeft, iterTop );
-        addToVRT( partFileName( fileIndex ), 2, iterCols, iterRows, iterLeft, iterTop );
-        addToVRT( partFileName( fileIndex ), 3, iterCols, iterRows, iterLeft, iterTop );
-        addToVRT( partFileName( fileIndex ), 4, iterCols, iterRows, iterLeft, iterTop );
+        return DestProviderError;
       }
+
+      //write data to output file
+      if ( !partDestProvider->write( &redData[0], 1, iterCols, iterRows, 0, 0 ) ||
+           !partDestProvider->write( &greenData[0], 2, iterCols, iterRows, 0, 0 ) ||
+           !partDestProvider->write( &blueData[0], 3, iterCols, iterRows, 0, 0 ) ||
+           !partDestProvider->write( &alphaData[0], 4, iterCols, iterRows, 0, 0 ) )
+      {
+        return DestProviderError;
+      }
+
+      addToVRT( partFileName( fileIndex ), 1, iterCols, iterRows, iterLeft, iterTop );
+      addToVRT( partFileName( fileIndex ), 2, iterCols, iterRows, iterLeft, iterTop );
+      addToVRT( partFileName( fileIndex ), 3, iterCols, iterRows, iterLeft, iterTop );
+      addToVRT( partFileName( fileIndex ), 4, iterCols, iterRows, iterLeft, iterTop );
     }
     else if ( destProvider )
     {
-      destProvider->write( redData, 1, iterCols, iterRows, iterLeft, iterTop );
-      destProvider->write( greenData, 2, iterCols, iterRows, iterLeft, iterTop );
-      destProvider->write( blueData, 3, iterCols, iterRows, iterLeft, iterTop );
-      destProvider->write( alphaData, 4, iterCols, iterRows, iterLeft, iterTop );
+      if ( !destProvider->write( &redData[0], 1, iterCols, iterRows, iterLeft, iterTop ) ||
+           !destProvider->write( &greenData[0], 2, iterCols, iterRows, iterLeft, iterTop ) ||
+           !destProvider->write( &blueData[0], 3, iterCols, iterRows, iterLeft, iterTop ) ||
+           !destProvider->write( &alphaData[0], 4, iterCols, iterRows, iterLeft, iterTop ) )
+      {
+        return DestProviderError;
+      }
     }
 
     ++fileIndex;
   }
   destProvider.reset();
-
-  qgsFree( redData );
-  qgsFree( greenData );
-  qgsFree( blueData );
-  qgsFree( alphaData );
 
   if ( feedback )
   {

--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -168,9 +168,15 @@ bool TestQgsRasterFileWriter::writeTest( const QString &rasterName )
   }
   qDebug() << "projector set";
 
-  fileWriter.writeRaster( pipe, provider->xSize(), provider->ySize(), provider->extent(), provider->crs(), provider->transformContext() );
+  auto res = fileWriter.writeRaster( pipe, provider->xSize(), provider->ySize(), provider->extent(), provider->crs(), provider->transformContext() );
 
   delete pipe;
+
+  if ( res != QgsRasterFileWriter::NoError )
+  {
+    logError( QStringLiteral( "writeRaster() returned error" ) );
+    return false;
+  }
 
   QgsRasterChecker checker;
   bool ok = checker.runTest( QStringLiteral( "gdal" ), tmpName, QStringLiteral( "gdal" ), myRasterFileInfo.filePath() );

--- a/tests/src/python/test_qgsrasterfilewriter.py
+++ b/tests/src/python/test_qgsrasterfilewriter.py
@@ -18,7 +18,8 @@ import tempfile
 
 from osgeo import gdal
 from qgis.PyQt.QtCore import QTemporaryFile, QDir
-from qgis.core import (QgsRaster,
+from qgis.core import (QgsContrastEnhancement,
+                       QgsRaster,
                        QgsRasterLayer,
                        QgsRasterChecker,
                        QgsRasterPipe,
@@ -202,6 +203,8 @@ class TestQgsRasterFileWriter(unittest.TestCase):
                                         provider.crs()), 0)
         del fw
         ds = gdal.Open(tmpName)
+        self.assertEqual(ds.RasterCount, 1)
+        self.assertEqual(ds.GetRasterBand(1).Checksum(), 4672)
         self.assertEqual(ds.GetRasterBand(1).GetOverviewCount(), 1)
         fl = ds.GetFileList()
         if pyramidFormat == QgsRaster.PyramidsGTiff:
@@ -222,6 +225,62 @@ class TestQgsRasterFileWriter(unittest.TestCase):
 
     def testGeneratePyramidsErdas(self):
         return self._testGeneratePyramids(QgsRaster.PyramidsErdas)
+
+    def testWriteAsRawInvalidOutputFile(self):
+        tmpName = "/this/is/invalid/file.tif"
+        source = QgsRasterLayer(os.path.join(self.testDataDir, 'raster', 'byte.tif'), 'my', 'gdal')
+        self.assertTrue(source.isValid())
+        provider = source.dataProvider()
+        fw = QgsRasterFileWriter(tmpName)
+
+        pipe = QgsRasterPipe()
+        self.assertTrue(pipe.set(provider.clone()))
+
+        self.assertEqual(fw.writeRaster(pipe,
+                                        provider.xSize(),
+                                        provider.ySize(),
+                                        provider.extent(),
+                                        provider.crs()), QgsRasterFileWriter.DestProviderError)
+        del fw
+
+    def testWriteAsImage(self):
+        tmpName = tempfile.mktemp(suffix='.tif')
+        source = QgsRasterLayer(os.path.join(self.testDataDir, 'raster', 'byte.tif'), 'my', 'gdal')
+        source.setContrastEnhancement(algorithm=QgsContrastEnhancement.NoEnhancement)
+        self.assertTrue(source.isValid())
+        provider = source.dataProvider()
+        fw = QgsRasterFileWriter(tmpName)
+
+        self.assertEqual(fw.writeRaster(source.pipe(),
+                                        provider.xSize(),
+                                        provider.ySize(),
+                                        provider.extent(),
+                                        provider.crs()), QgsRasterFileWriter.NoError)
+        ds = gdal.Open(tmpName)
+        self.assertEqual(ds.RasterCount, 4)
+        self.assertEqual(ds.GetRasterBand(1).Checksum(), 4672)
+        self.assertEqual(ds.GetRasterBand(2).Checksum(), 4672)
+        self.assertEqual(ds.GetRasterBand(3).Checksum(), 4672)
+        self.assertEqual(ds.GetRasterBand(4).Checksum(), 4873)
+        ds = None
+
+        del fw
+        os.unlink(tmpName)
+
+    def testWriteAsImageInvalidOutputPath(self):
+        tmpName = "/this/is/invalid/file.tif"
+        source = QgsRasterLayer(os.path.join(self.testDataDir, 'raster', 'byte.tif'), 'my', 'gdal')
+        source.setContrastEnhancement(algorithm=QgsContrastEnhancement.NoEnhancement)
+        self.assertTrue(source.isValid())
+        provider = source.dataProvider()
+        fw = QgsRasterFileWriter(tmpName)
+
+        self.assertEqual(fw.writeRaster(source.pipe(),
+                                        provider.xSize(),
+                                        provider.ySize(),
+                                        provider.extent(),
+                                        provider.crs()), QgsRasterFileWriter.DestProviderError)
+        del fw
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Lack of error checking on destination provider creation (in saveAsImage mode)
- Wrong computation of number of blocks if dimension is exactly a multiple of
  the block size
- Lack of error checking when writing blocks
- Slow computation of non-premultiplied r,g,b values, and inappropriate use
  of memcpy()
