### PR TITLE
Raster export: fix issues with multiband raster and GeoPackage (fixes #30644)

### DIFF
--- a/src/core/raster/qgsrasterblock.cpp
+++ b/src/core/raster/qgsrasterblock.cpp
@@ -236,6 +236,7 @@ bool QgsRasterBlock::setIsNoData()
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   if ( typeIsNumeric( mDataType ) )
   {
+    const size_t dataTypeSize = typeSize( mDataType );
     if ( mHasNoDataValue )
     {
       if ( !mData )
@@ -245,13 +246,18 @@ bool QgsRasterBlock::setIsNoData()
       }
 
       QgsDebugMsgLevel( QStringLiteral( "set mData to mNoDataValue" ), 4 );
-      int dataTypeSize = typeSize( mDataType );
       QByteArray noDataByteArray = valueBytes( mDataType, mNoDataValue );
-
-      char *nodata = noDataByteArray.data();
-      for ( qgssize i = 0; i < static_cast< qgssize >( mWidth )*mHeight; i++ )
+      if ( mNoDataValue == 0 )
       {
-        memcpy( reinterpret_cast< char * >( mData ) + i * dataTypeSize, nodata, dataTypeSize );
+        memset( mData, 0, dataTypeSize * mWidth * mHeight );
+      }
+      else
+      {
+        const char *nodata = noDataByteArray.data();
+        for ( qgssize i = 0; i < static_cast< qgssize >( mWidth )*mHeight; i++ )
+        {
+          memcpy( reinterpret_cast< char * >( mData ) + i * dataTypeSize, nodata, dataTypeSize );
+        }
       }
     }
     else
@@ -266,6 +272,10 @@ bool QgsRasterBlock::setIsNoData()
       }
       QgsDebugMsgLevel( QStringLiteral( "set mNoDataBitmap to 1" ), 4 );
       memset( mNoDataBitmap, 0xff, mNoDataBitmapSize );
+      if ( mData )
+      {
+        memset( mData, 0, dataTypeSize * mWidth * mHeight );
+      }
     }
     return true;
   }
@@ -297,6 +307,7 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   if ( typeIsNumeric( mDataType ) )
   {
+    const size_t dataTypeSize = typeSize( mDataType );
     if ( mHasNoDataValue )
     {
       if ( !mData )
@@ -306,7 +317,6 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
       }
 
       QgsDebugMsgLevel( QStringLiteral( "set mData to mNoDataValue" ), 4 );
-      int dataTypeSize = typeSize( mDataType );
       QByteArray noDataByteArray = valueBytes( mDataType, mNoDataValue );
 
       char *nodata = noDataByteArray.data();
@@ -347,6 +357,11 @@ bool QgsRasterBlock::setIsNoDataExcept( QRect exceptRect )
         }
       }
       QgsDebugMsgLevel( QStringLiteral( "set mNoDataBitmap to 1" ), 4 );
+
+      if ( mData )
+      {
+        memset( mData, 0, dataTypeSize * mWidth * mHeight );
+      }
 
       char *nodataRow = new char[mNoDataBitmapWidth]; // full row of no data
       // TODO: we can simply set all bytes to 11111111 (~0) I think

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -30,6 +30,8 @@
 #include <QTextStream>
 #include <QMessageBox>
 
+#include <cmath>
+
 #include <gdal.h>
 #include <cpl_string.h>
 
@@ -210,14 +212,22 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
   destHasNoDataValueList.reserve( nBands );
   destNoDataValueList.reserve( nBands );
 
+  const bool isGpkgOutput = mOutputProviderKey == "gdal" &&
+                            mOutputFormat.compare( QLatin1String( "gpkg" ), Qt::CaseInsensitive ) == 0;
+  double pixelSize;
+  double geoTransform[6];
+  globalOutputParameters( outputExtent, nCols, nRows, geoTransform, pixelSize );
+  const auto srcProviderExtent( srcProvider->extent() );
+
   for ( int bandNo = 1; bandNo <= nBands; bandNo++ )
   {
     QgsRasterNuller *nuller = pipe->nuller();
 
-    bool srcHasNoDataValue = srcProvider->sourceHasNoDataValue( bandNo );
+    const bool srcHasNoDataValue = srcProvider->sourceHasNoDataValue( bandNo );
     bool destHasNoDataValue = false;
     double destNoDataValue = std::numeric_limits<double>::quiet_NaN();
-    Qgis::DataType destDataType = srcProvider->sourceDataType( bandNo );
+    const Qgis::DataType srcDataType = srcProvider->sourceDataType( bandNo );
+    Qgis::DataType destDataType = srcDataType;
     // TODO: verify what happens/should happen if srcNoDataValue is disabled by setUseSrcNoDataValue
     QgsDebugMsgLevel( QStringLiteral( "srcHasNoDataValue = %1 srcNoDataValue = %2" ).arg( srcHasNoDataValue ).arg( srcProvider->sourceNoDataValue( bandNo ) ), 4 );
     if ( srcHasNoDataValue )
@@ -233,25 +243,32 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
       destNoDataValue = nuller->noData( bandNo ).value( 0 ).min();
       destHasNoDataValue = true;
     }
-    else
+    // GeoPackage does not support nodata for Byte output, and does not
+    // support non-Byte multiband output, so do not take the risk of an accidental
+    // data type promotion.
+    else if ( !( isGpkgOutput && destDataType == Qgis::Byte ) )
     {
       // Verify if we really need no data value, i.e.
-      QgsRectangle srcExtent = outputExtent;
+      QgsRectangle outputExtentInSrcCrs = outputExtent;
       QgsRasterProjector *projector = pipe->projector();
       if ( projector && projector->destinationCrs() != projector->sourceCrs() )
       {
         QgsCoordinateTransform ct( projector->destinationCrs(), projector->sourceCrs(), transformContext );
-        srcExtent = ct.transformBoundingBox( outputExtent );
+        outputExtentInSrcCrs = ct.transformBoundingBox( outputExtent );
       }
-      if ( !srcProvider->extent().contains( srcExtent ) )
+      if ( !srcProviderExtent.contains( outputExtentInSrcCrs ) &&
+           ( std::fabs( srcProviderExtent.xMinimum() - outputExtentInSrcCrs.xMinimum() ) > geoTransform[1] / 2 ||
+             std::fabs( srcProviderExtent.xMaximum() - outputExtentInSrcCrs.xMaximum() ) > geoTransform[1] / 2 ||
+             std::fabs( srcProviderExtent.yMinimum() - outputExtentInSrcCrs.yMinimum() ) > std::fabs( geoTransform[5] ) / 2 ||
+             std::fabs( srcProviderExtent.yMaximum() - outputExtentInSrcCrs.yMaximum() ) > std::fabs( geoTransform[5] ) / 2 ) )
       {
-        // Destination extent is larger than source extent, we need destination no data values
+        // Destination extent is (at least partially) outside of source extent, we need destination no data values
         // Get src sample statistics (estimation from sample)
-        QgsRasterBandStats stats = srcProvider->bandStatistics( bandNo, QgsRasterBandStats::Min | QgsRasterBandStats::Max, srcExtent, 250000 );
+        QgsRasterBandStats stats = srcProvider->bandStatistics( bandNo, QgsRasterBandStats::Min | QgsRasterBandStats::Max, outputExtentInSrcCrs, 250000 );
 
         // Test if we have free (not used) values
-        double typeMinValue = QgsContrastEnhancement::maximumValuePossible( static_cast< Qgis::DataType >( srcProvider->sourceDataType( bandNo ) ) );
-        double typeMaxValue = QgsContrastEnhancement::maximumValuePossible( static_cast< Qgis::DataType >( srcProvider->sourceDataType( bandNo ) ) );
+        const double typeMinValue = QgsContrastEnhancement::minimumValuePossible( srcDataType );
+        const double typeMaxValue = QgsContrastEnhancement::maximumValuePossible( srcDataType );
         if ( stats.minimumValue > typeMinValue )
         {
           destNoDataValue = typeMinValue;
@@ -293,9 +310,6 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeDataRaster( const Qgs
 
   //create destProvider for whole dataset here
   QgsRasterDataProvider *destProvider = nullptr;
-  double pixelSize;
-  double geoTransform[6];
-  globalOutputParameters( outputExtent, nCols, nRows, geoTransform, pixelSize );
 
   // initOutput() returns 0 in tile mode!
   destProvider = initOutput( nCols, nRows, crs, geoTransform, nBands, destDataType, destHasNoDataValueList, destNoDataValueList );

--- a/tests/src/python/test_qgsrasterfilewriter.py
+++ b/tests/src/python/test_qgsrasterfilewriter.py
@@ -23,7 +23,8 @@ from qgis.core import (QgsRaster,
                        QgsRasterChecker,
                        QgsRasterPipe,
                        QgsRasterFileWriter,
-                       QgsRasterProjector)
+                       QgsRasterProjector,
+                       QgsRectangle)
 
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -159,7 +160,7 @@ class TestQgsRasterFileWriter(unittest.TestCase):
 
         projector = QgsRasterProjector()
         projector.setCrs(provider.crs(), provider.crs())
-        self.assertTrue(pipe.insert(2, projector))
+        self.assertTrue(pipe.set(projector))
 
         self.assertEqual(fw.writeRaster(pipe,
                                         provider.xSize(),
@@ -171,11 +172,86 @@ class TestQgsRasterFileWriter(unittest.TestCase):
         rlayer = QgsRasterLayer('GPKG:%s:imported_table' % test_gpkg)
         self.assertTrue(rlayer.isValid())
         out_provider = rlayer.dataProvider()
-        self.assertEqual(provider.block(1, provider.extent(), source.width(), source.height()).data(),
-                         out_provider.block(1, out_provider.extent(), rlayer.width(), rlayer.height()).data())
+        for i in range(3):
+            src_data = provider.block(i + 1, provider.extent(), source.width(), source.height())
+            out_data = out_provider.block(i + 1, out_provider.extent(), rlayer.width(), rlayer.height())
+            self.assertEqual(src_data.data(), out_data.data())
 
         # remove result file
         os.unlink(test_gpkg)
+
+    def testExportToGpkgWithExtraExtent(self):
+        tmpName = tempfile.mktemp(suffix='.gpkg')
+        source = QgsRasterLayer(os.path.join(self.testDataDir, 'raster', 'band3_byte_noct_epsg4326.tif'), 'my', 'gdal')
+        self.assertTrue(source.isValid())
+        provider = source.dataProvider()
+        fw = QgsRasterFileWriter(tmpName)
+        fw.setOutputFormat('gpkg')
+
+        pipe = QgsRasterPipe()
+        self.assertTrue(pipe.set(provider.clone()))
+
+        self.assertEqual(fw.writeRaster(pipe,
+                                        provider.xSize() + 4,
+                                        provider.ySize() + 4,
+                                        QgsRectangle(-3 - 2, -4 - 2, 7 + 2, 6 + 2),
+                                        provider.crs()), 0)
+        del fw
+
+        # Check that the test geopackage contains the raster layer and compare
+        rlayer = QgsRasterLayer(tmpName)
+        self.assertTrue(rlayer.isValid())
+        out_provider = rlayer.dataProvider()
+        for i in range(3):
+            src_data = provider.block(i + 1, provider.extent(), source.width(), source.height())
+            out_data = out_provider.block(i + 1, provider.extent(), source.width(), source.height())
+            self.assertEqual(src_data.data(), out_data.data())
+        out_data = out_provider.block(1, QgsRectangle(7, -4, 7 + 2, 6), 2, 8)
+        # band3_byte_noct_epsg4326 nodata is 255
+        self.assertEqual(out_data.data().data(), b'\xff' * 2 * 8)
+        del out_provider
+        del rlayer
+
+        # remove result file
+        os.unlink(tmpName)
+
+    def testExportToGpkgWithExtraExtentNoNoData(self):
+        tmpName = tempfile.mktemp(suffix='.gpkg')
+        # Remove nodata
+        gdal.Translate('/vsimem/src.tif', os.path.join(self.testDataDir, 'raster', 'band3_byte_noct_epsg4326.tif'), options='-a_nodata none')
+        source = QgsRasterLayer('/vsimem/src.tif', 'my', 'gdal')
+        self.assertTrue(source.isValid())
+        provider = source.dataProvider()
+        fw = QgsRasterFileWriter(tmpName)
+        fw.setOutputFormat('gpkg')
+
+        pipe = QgsRasterPipe()
+        self.assertTrue(pipe.set(provider.clone()))
+
+        self.assertEqual(fw.writeRaster(pipe,
+                                        provider.xSize() + 4,
+                                        provider.ySize() + 4,
+                                        QgsRectangle(-3 - 2, -4 - 2, 7 + 2, 6 + 2),
+                                        provider.crs()), 0)
+        del fw
+
+        # Check that the test geopackage contains the raster layer and compare
+        rlayer = QgsRasterLayer(tmpName)
+        self.assertTrue(rlayer.isValid())
+        out_provider = rlayer.dataProvider()
+        for i in range(3):
+            src_data = provider.block(i + 1, provider.extent(), source.width(), source.height())
+            out_data = out_provider.block(i + 1, provider.extent(), source.width(), source.height())
+            self.assertEqual(src_data.data(), out_data.data())
+        out_data = out_provider.block(1, QgsRectangle(7, -4, 7 + 2, 6), 2, 8)
+        # No nodata: defaults to zero
+        self.assertEqual(out_data.data().data(), b'\x00' * 2 * 8)
+        del out_provider
+        del rlayer
+
+        # remove result file
+        gdal.Unlink('/vsimem/src.tif')
+        os.unlink(tmpName)
 
     def _testGeneratePyramids(self, pyramidFormat):
         tmpName = tempfile.mktemp(suffix='.tif')
@@ -193,7 +269,7 @@ class TestQgsRasterFileWriter(unittest.TestCase):
 
         projector = QgsRasterProjector()
         projector.setCrs(provider.crs(), provider.crs())
-        self.assertTrue(pipe.insert(2, projector))
+        self.assertTrue(pipe.set(projector))
 
         self.assertEqual(fw.writeRaster(pipe,
                                         provider.xSize(),


### PR DESCRIPTION
- Fix guess of appropriate nodata value when comparing stat minimum value and
  output data type minimum value (copy & paste issue)
- When exporting to GeoPackage, do not promote Byte to a larger type, as this
  is unsupported by GeoPackage
- When determining if the output extent is included in the source extent,
  use a tolerance to avoid being to sensitive to rounding issues.
- QgsRasterBlock::setIsNoData() and setIsNoDataExcept(): initialize mData to
  zero when there is no nodata value, to avoid uninitialized/old memory to
  be used when reading bits().
