### PR TITLE
[categorized renderer] When color ramp is set to random, randomize color of appended categories to pre-existing list when hitting the classify button

### DIFF
--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -831,6 +831,9 @@ void QgsCategorizedSymbolRendererWidget::addCategories()
   {
     QgsCategoryList prevCats = mRenderer->categories();
     keepExistingColors = !prevCats.isEmpty();
+    QgsRandomColorRamp randomColors;
+    if ( keepExistingColors && btnColorRamp->isRandomColorRamp() )
+      randomColors.setTotalColorCount( cats.size() );
     for ( int i = 0; i < cats.size(); ++i )
     {
       bool contains = false;
@@ -862,7 +865,14 @@ void QgsCategorizedSymbolRendererWidget::addCategories()
       }
 
       if ( !contains )
+      {
+        if ( keepExistingColors && btnColorRamp->isRandomColorRamp() )
+        {
+          // insure that append symbols have random colors
+          cats.at( i ).symbol()->setColor( randomColors.color( i ) );
+        }
         prevCats.append( cats.at( i ) );
+      }
     }
     cats = prevCats;
   }


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR address issue #31579, whereas classifying a categorized renderer on a pre-existing list  (i.e. appending new values) would not assign random colors to the appended items when the color ramp was set to random colors.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
