### PR TITLE
[Backport 3.4] [Postgresql Provider] Fix crash in discoverRelations() on invalid layer (fixes #31213)

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4418,6 +4418,11 @@ QList<QgsVectorLayer *> QgsPostgresProvider::searchLayers( const QList<QgsVector
 QList<QgsRelation> QgsPostgresProvider::discoverRelations( const QgsVectorLayer *self, const QList<QgsVectorLayer *> &layers ) const
 {
   QList<QgsRelation> result;
+  if ( !mValid )
+  {
+    QgsLogger::warning( "Error getting the foreign keys of " + mTableName + ": invalid connection" );
+    return result;
+  }
   QString sql(
     "SELECT RC.CONSTRAINT_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION "
     "FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC "

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1222,6 +1222,15 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(g.childCount(), 1)
         self.assertTrue(g.childGeometry(0).vertexCount() > 3)
 
+    def testValidLayerDiscoverRelationsNone(self):
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=', 'test', 'postgres')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(vl.dataProvider().discoverRelations(vl, []), [])
+
+    def testInvalidLayerDiscoverRelations(self):
+        vl = QgsVectorLayer('{} table="qgis_test"."invalid_layer" sql='.format(self.dbconn), "invalid_layer", "postgres")
+        self.assertFalse(vl.isValid())
+        self.assertEqual(vl.dataProvider().discoverRelations(vl, []), [])
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/31768
