### PR TITLE
[Backport 3.4] QgsRasterFileWriter: assorted set of fixes (might be related to refs #30937)

### DIFF
--- a/tests/src/core/testqgsrasterfilewriter.cpp
+++ b/tests/src/core/testqgsrasterfilewriter.cpp
@@ -168,9 +168,15 @@ bool TestQgsRasterFileWriter::writeTest( const QString &rasterName )
   }
   qDebug() << "projector set";
 
-  fileWriter.writeRaster( pipe, provider->xSize(), provider->ySize(), provider->extent(), provider->crs() );
+  auto res = fileWriter.writeRaster( pipe, provider->xSize(), provider->ySize(), provider->extent(), provider->crs() );
 
   delete pipe;
+
+  if ( res != QgsRasterFileWriter::NoError )
+  {
+    logError( QStringLiteral( "writeRaster() returned error" ) );
+    return false;
+  }
 
   QgsRasterChecker checker;
   bool ok = checker.runTest( QStringLiteral( "gdal" ), tmpName, QStringLiteral( "gdal" ), myRasterFileInfo.filePath() );


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/31766

- Lack of error checking on destination provider creation (in saveAsImage mode)
- Wrong computation of number of blocks if dimension is exactly a multiple of
  the block size
- Lack of error checking when writing blocks
- Slow computation of non-premultiplied r,g,b values, and inappropriate use
  of memcpy()
