### PR TITLE
[RPM] Fedora 31 will ship GRASS 7.8

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,9 +12,14 @@
 # py files located under /usr/share/qgis/python/plugins
 %global __python %{__python3}
 
-%if 0%{?fedora} >= 30
+# SPEC do not support elseif until very recent releases
+%if 0%{?fedora} >= 31
+%define grass grass78
+%endif
+%if 0%{?fedora} == 30
 %define grass grass76
-%else
+%endif
+%if 0%{?fedora} < 30
 %define grass grass74
 %endif
 


### PR DESCRIPTION
## Description
Fedora 31 will ship with GRASS 7.8 provided by @neteler 
This PR changes the RPM SPEC file to use it on Fedora >= 31

Needs to backported to 3.4. No need for 3.8 since 3.10 will be out soon.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
