### PR TITLE
[Backport 3.4] [GDAL provider] Be more robust to driver being disabled after provider creation (fixes #29212)

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -266,6 +266,11 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     //! Whether a per-dataset mask band is exposed as an alpha band for the point of view of the rest of the application.
     bool mMaskBandExposedAsAlpha = false;
 
+    //! \brief Driver short name.
+    // It is kept in case the driver would be de-registered after the provider has been created.
+    // Which is a very dangerous situation (see #29212)
+    QString mDriverName;
+
     //! Wrapper for GDALGetRasterBand() that takes into account mMaskBandExposedAsAlpha.
     GDALRasterBandH getBand( int bandNo ) const;
 


### PR DESCRIPTION
This is a backport of https://github.com/qgis/QGIS/pull/31772

This is still quite a dangerous practice, and this commit is more a band-aid
than a definitive fix.
In case a GDALDataset would hold and use a pointer to the GDALDriver that has
created it (which is not common in GDAL drivers though), crash would occur.
Safer but more involved fixes could be:
- to prevent disabling a driver that is in use
- to post-pone the effect of driver disabling to application restart, or when
  the last dataset using the driver has been closed
