### PR TITLE
Do not show QtSVG warnings for SVG spec implementation gaps

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -386,9 +386,13 @@ void myMessageOutput( QtMsgType type, const char *msg )
       break;
     case QtWarningMsg:
     {
-      // Ignore libpng iCPP known incorrect SRGB profile errors
-      // (which are thrown by 3rd party components we have no control over and have low value anyway).
-      if ( strncmp( msg, "libpng warning: iCCP: known incorrect sRGB profile", 50 ) == 0 )
+      /* Ignore:
+       * - libpng iCPP known incorrect SRGB profile errors (which are thrown by 3rd party components
+       *  we have no control over and have low value anyway);
+       * - QtSVG warnings with regards to lack of implementation beyond Tiny SVG 1.2
+       */
+      if ( strncmp( msg, "libpng warning: iCCP: known incorrect sRGB profile", 50 ) == 0 ||
+           strstr( msg, "Could not add child element to parent element because the types are incorrect" ) )
         break;
 
       myPrint( "Warning: %s\n", msg );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -407,7 +407,7 @@ void myMessageOutput( QtMsgType type, const char *msg )
         dumpBacktrace( 20 );
 
         // also be super obnoxious -- we DON'T want to allow these errors to be ignored!!
-        if ( QgisApp::instance() && QgisApp::instance()->thread() == QThread::currentThread() )
+        if ( QgisApp::instance() && QgisApp::instance()->messageBar() && QgisApp::instance()->thread() == QThread::currentThread() )
         {
           QgisApp::instance()->messageBar()->pushCritical( QStringLiteral( "Qt" ), msg );
         }


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@nyalldawson , all good? BTW, I've added an extra null pointer check in main.cpp to make sure that the QgisApp instance has a valid message bar object. 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
