### PR TITLE
[properties] Do not return nan values when an assistant is used with min val == max val

### DIFF
--- a/src/core/qgspropertytransformer.cpp
+++ b/src/core/qgspropertytransformer.cpp
@@ -175,6 +175,9 @@ bool QgsGenericNumericTransformer::loadVariant( const QVariant &transformer )
 
 double QgsGenericNumericTransformer::value( double input ) const
 {
+  if ( qgsDoubleNear( mMaxValue, mMinValue ) )
+    return qBound( mMinOutput, input, mMaxOutput );
+
   input = transformNumeric( input );
   if ( qgsDoubleNear( mExponent, 1.0 ) )
     return mMinOutput + ( qBound( mMinValue, input, mMaxValue ) - mMinValue ) * ( mMaxOutput - mMinOutput ) / ( mMaxValue - mMinValue );

--- a/tests/src/core/testqgsproperty.cpp
+++ b/tests/src/core/testqgsproperty.cpp
@@ -807,6 +807,13 @@ void TestQgsProperty::genericNumericTransformer()
   QGSCOMPARENEAR( t.value( 150 ), 13.5355, 0.001 );
   QCOMPARE( t.value( 200 ), 20.0 );
 
+  // invalid settings, where minValue = maxValue
+  QgsGenericNumericTransformer invalid( 1.0, 1.0, 0, 1.0 );
+  QCOMPARE( invalid.value( -1 ), 0.0 );
+  QCOMPARE( invalid.value( 0 ), 0.0 );
+  QCOMPARE( invalid.value( 1.0 ), 1.0 );
+  QCOMPARE( invalid.value( 2.0 ), 1.0 );
+
   //as expression
   QgsGenericNumericTransformer t3( 15,
                                    25,


### PR DESCRIPTION
Fixes #31242
