### PR TITLE
[layouts] Fix map rotation does not immediately restore in reports

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -662,6 +662,7 @@ bool QgsLayoutItemMap::readPropertiesFromElement( const QDomElement &itemElem, c
 
   //map rotation
   mMapRotation = itemElem.attribute( QStringLiteral( "mapRotation" ), QStringLiteral( "0" ) ).toDouble();
+  mEvaluatedMapRotation = mMapRotation;
 
   // follow map theme
   mFollowVisibilityPreset = itemElem.attribute( QStringLiteral( "followPreset" ) ).compare( QLatin1String( "true" ) ) == 0;

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -566,6 +566,15 @@ void TestQgsLayoutMap::mapRotation()
   QgsLayoutChecker checker( QStringLiteral( "composerrotation_maprotation" ), &l );
   checker.setControlPathPrefix( QStringLiteral( "composer_items" ) );
   QVERIFY( checker.testLayout( mReport, 0, 200 ) );
+
+  // test that rotation correctly applies to restored items
+  QDomDocument doc;
+  QDomElement documentElement = doc.createElement( QStringLiteral( "ComposerItemClipboard" ) );
+  map->writeXml( documentElement, doc, QgsReadWriteContext() );
+
+  QgsLayoutItemMap map2( &l );
+  QVERIFY( map2.readXml( documentElement.firstChildElement(), doc, QgsReadWriteContext() ) );
+  QCOMPARE( map2.mapRotation(), 90.0 );
 }
 
 void TestQgsLayoutMap::mapItemRotation()


### PR DESCRIPTION
Fixes #31217
