### PR TITLE
Resizing pages to content should not create empty page size if no items are present

### DIFF
--- a/src/core/layout/qgslayoutpagecollection.cpp
+++ b/src/core/layout/qgslayoutpagecollection.cpp
@@ -277,11 +277,13 @@ double QgsLayoutPageCollection::pageShadowWidth() const
 
 void QgsLayoutPageCollection::resizeToContents( const QgsMargins &margins, QgsUnitTypes::LayoutUnit marginUnits )
 {
-  if ( !mBlockUndoCommands )
-    mLayout->undoStack()->beginCommand( this, tr( "Resize to Contents" ) );
-
   //calculate current bounds
   QRectF bounds = mLayout->layoutBounds( true, 0.0 );
+  if ( bounds.isEmpty() )
+    return;
+
+  if ( !mBlockUndoCommands )
+    mLayout->undoStack()->beginCommand( this, tr( "Resize to Contents" ) );
 
   for ( int page = mPages.count() - 1; page > 0; page-- )
   {

--- a/tests/src/python/test_qgslayoutpagecollection.py
+++ b/tests/src/python/test_qgslayoutpagecollection.py
@@ -898,6 +898,19 @@ class TestQgsLayoutPageCollection(unittest.TestCase):
         p = QgsProject()
         l = QgsLayout(p)
 
+        # no items -- no crash!
+        l.pageCollection().resizeToContents(QgsMargins(1, 2, 3, 4), QgsUnitTypes.LayoutCentimeters)
+        page = QgsLayoutItemPage(l)
+        page.setPageSize("A5", QgsLayoutItemPage.Landscape)
+        l.pageCollection().addPage(page)
+        # no items, no change
+        l.pageCollection().resizeToContents(QgsMargins(1, 2, 3, 4), QgsUnitTypes.LayoutCentimeters)
+        self.assertEqual(l.pageCollection().pageCount(), 1)
+        self.assertAlmostEqual(l.pageCollection().page(0).sizeWithUnits().width(), 210.0, 2)
+        self.assertAlmostEqual(l.pageCollection().page(0).sizeWithUnits().height(), 148.0, 2)
+
+        p = QgsProject()
+        l = QgsLayout(p)
         shape1 = QgsLayoutItemShape(l)
         shape1.attemptResize(QgsLayoutSize(90, 50))
         shape1.attemptMove(QgsLayoutPoint(90, 50))


### PR DESCRIPTION
Fixes #29034
