### PR TITLE
Layout map item grids

### DIFF
--- a/src/app/layout/qgslayoutmapgridwidget.cpp
+++ b/src/app/layout/qgslayoutmapgridwidget.cpp
@@ -640,11 +640,11 @@ void QgsLayoutMapGridWidget::setGridItems()
     case QgsLayoutItemMapGrid::MapUnit:
     case QgsLayoutItemMapGrid::MM:
     case QgsLayoutItemMapGrid::CM:
-      mIntervalStackedWidget->setCurrentIndex( 0 );
+      showFixedIntervalWidth( true );
       break;
 
     case QgsLayoutItemMapGrid::DynamicPageSizeBased:
-      mIntervalStackedWidget->setCurrentIndex( 1 );
+      showFixedIntervalWidth( false );
       break;
   }
   mMinWidthSpinBox->setValue( mMapGrid->minimumIntervalWidth() );
@@ -916,6 +916,20 @@ void QgsLayoutMapGridWidget::mFrameStyleComboBox_currentIndexChanged( int )
   mMap->endCommand();
 }
 
+void QgsLayoutMapGridWidget::showFixedIntervalWidth( bool fixedWidth )
+{
+  mIntervalXSpinBox->setVisible( fixedWidth );
+  mIntervalXLabel->setVisible( fixedWidth );
+  mIntervalXDDBtn->setVisible( fixedWidth );
+  mIntervalYSpinBox->setVisible( fixedWidth );
+  mIntervalYLabel->setVisible( fixedWidth );
+  mIntervalYDDBtn->setVisible( fixedWidth );
+  mMaxWidthSpinBox->setVisible( !fixedWidth );
+  mMaxWidthLabel->setVisible( !fixedWidth );
+  mMinWidthSpinBox->setVisible( !fixedWidth );
+  mMinWidthLabel->setVisible( !fixedWidth );
+}
+
 void QgsLayoutMapGridWidget::intervalUnitChanged( int )
 {
   if ( !mMapGrid || !mMap )
@@ -929,11 +943,11 @@ void QgsLayoutMapGridWidget::intervalUnitChanged( int )
     case QgsLayoutItemMapGrid::MapUnit:
     case QgsLayoutItemMapGrid::MM:
     case QgsLayoutItemMapGrid::CM:
-      mIntervalStackedWidget->setCurrentIndex( 0 );
+      showFixedIntervalWidth( true );
       break;
 
     case QgsLayoutItemMapGrid::DynamicPageSizeBased:
-      mIntervalStackedWidget->setCurrentIndex( 1 );
+      showFixedIntervalWidth( false );
       break;
   }
 

--- a/src/app/layout/qgslayoutmapgridwidget.h
+++ b/src/app/layout/qgslayoutmapgridwidget.h
@@ -108,6 +108,8 @@ class QgsLayoutMapGridWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLay
     void intervalUnitChanged( int index );
     void minIntervalChanged( double interval );
     void maxIntervalChanged( double interval );
+    //! Sets visibility of Interval elements
+    void showFixedIntervalWidth( bool fixedWidth );
 
   private:
     QPointer< QgsLayoutItemMap > mMap;

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>423</width>
+    <width>432</width>
     <height>734</height>
    </rect>
   </property>
@@ -107,8 +107,8 @@
          <property name="title">
           <string>Appearance</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,0,0">
-          <item row="8" column="1" colspan="2">
+         <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,0,0,0">
+          <item row="8" column="2" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
             <property name="enabled">
              <bool>true</bool>
@@ -121,7 +121,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="6" column="2">
            <widget class="QgsDoubleSpinBox" name="mIntervalXSpinBox">
             <property name="prefix">
              <string/>
@@ -134,28 +134,28 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="2">
+          <item row="6" column="3">
            <widget class="QgsPropertyOverrideButton" name="mIntervalXDDBtn">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="7" column="1">
            <widget class="QLabel" name="mIntervalYLabel">
             <property name="text">
              <string>Y</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
+          <item row="3" column="2" colspan="2">
            <widget class="QPushButton" name="mMapGridCRSButton">
             <property name="text">
              <string>Change…</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="1" colspan="2">
+          <item row="10" column="2" colspan="2">
            <layout class="QGridLayout" name="gridLayout_5">
             <item row="2" column="1">
              <widget class="QgsPropertyOverrideButton" name="mOffsetYDDBtn">
@@ -199,7 +199,7 @@
             </item>
            </layout>
           </item>
-          <item row="11" column="1">
+          <item row="11" column="2">
            <widget class="QgsDoubleSpinBox" name="mCrossWidthSpinBox">
             <property name="suffix">
              <string> mm</string>
@@ -212,7 +212,7 @@
             </property>
            </widget>
           </item>
-          <item row="12" column="1" colspan="2">
+          <item row="12" column="2" colspan="2">
            <widget class="QgsSymbolButton" name="mGridLineStyleButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -225,87 +225,20 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mGridTypeLabel_2">
-            <property name="accessibleName">
-             <string extracomment="Hello translotor"/>
-            </property>
-            <property name="text">
-             <string>Grid type</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="0">
-           <widget class="QLabel" name="mLineStyleLabel">
-            <property name="text">
-             <string>Line style</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="mIntervalXLabel_2">
-            <property name="text">
-             <string>Interval</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0">
-           <widget class="QLabel" name="mCrossWidthLabel">
-            <property name="text">
-             <string>Cross width</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="0">
-           <widget class="QLabel" name="mOffsetXLabel_2">
-            <property name="text">
-             <string>Offset</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="mMapGridCRSLabel">
-            <property name="text">
-             <string>CRS</string>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="mGridBlendLabel">
-            <property name="text">
-             <string>Blend mode</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="2">
+          <item row="11" column="3">
            <widget class="QgsPropertyOverrideButton" name="mCrossWidthDDBtn">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
+          <item row="2" column="2" colspan="2">
            <widget class="QComboBox" name="mGridTypeComboBox"/>
           </item>
-          <item row="14" column="1" colspan="2">
+          <item row="14" column="2" colspan="2">
            <widget class="QgsBlendModeComboBox" name="mGridBlendComboBox"/>
           </item>
-          <item row="13" column="1" colspan="2">
+          <item row="13" column="2" colspan="2">
            <widget class="QgsSymbolButton" name="mGridMarkerStyleButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -318,34 +251,24 @@
             </property>
            </widget>
           </item>
-          <item row="13" column="0">
-           <widget class="QLabel" name="mMarkerStyleLabel">
-            <property name="text">
-             <string>Marker style</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1" colspan="2">
+          <item row="4" column="2" colspan="2">
            <widget class="QComboBox" name="mMapGridUnitComboBox"/>
           </item>
-          <item row="8" column="0">
+          <item row="8" column="1">
            <widget class="QLabel" name="mMinWidthLabel">
             <property name="text">
              <string>Minimum</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="6" column="1">
            <widget class="QLabel" name="mIntervalXLabel">
             <property name="text">
              <string>X</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="7" column="2">
            <widget class="QgsDoubleSpinBox" name="mIntervalYSpinBox">
             <property name="prefix">
              <string/>
@@ -358,14 +281,14 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="2">
+          <item row="7" column="3">
            <widget class="QgsPropertyOverrideButton" name="mIntervalYDDBtn">
             <property name="text">
              <string>…</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="1" colspan="2">
+          <item row="9" column="2" colspan="2">
            <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
             <property name="enabled">
              <bool>true</bool>
@@ -378,10 +301,103 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="9" column="1">
            <widget class="QLabel" name="mMaxWidthLabel">
             <property name="text">
              <string>Maximum</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" rowspan="4">
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>10</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QLabel" name="mIntervalXLabel_2">
+            <property name="text">
+             <string>Interval</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QLabel" name="mMapGridCRSLabel">
+            <property name="text">
+             <string>CRS</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QLabel" name="mGridTypeLabel_2">
+            <property name="accessibleName">
+             <string extracomment="Hello translotor"/>
+            </property>
+            <property name="text">
+             <string>Grid type</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0" colspan="2">
+           <widget class="QLabel" name="mOffsetXLabel_2">
+            <property name="text">
+             <string>Offset</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0" colspan="2">
+           <widget class="QLabel" name="mCrossWidthLabel">
+            <property name="text">
+             <string>Cross width</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0" colspan="2">
+           <widget class="QLabel" name="mLineStyleLabel">
+            <property name="text">
+             <string>Line style</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="13" column="0" colspan="2">
+           <widget class="QLabel" name="mMarkerStyleLabel">
+            <property name="text">
+             <string>Marker style</string>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="0" colspan="2">
+           <widget class="QLabel" name="mGridBlendLabel">
+            <property name="text">
+             <string>Blend mode</string>
             </property>
            </widget>
           </item>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -48,8 +48,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>409</width>
-        <height>1447</height>
+        <width>407</width>
+        <height>1429</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -108,6 +108,46 @@
           <string>Appearance</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,0,0">
+          <item row="8" column="1" colspan="2">
+           <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="maximum">
+             <double>999.990000000000009</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QgsDoubleSpinBox" name="mIntervalXSpinBox">
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="decimals">
+             <number>12</number>
+            </property>
+            <property name="maximum">
+             <double>9999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mIntervalXDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="mIntervalYLabel">
+            <property name="text">
+             <string>Y</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="1" colspan="2">
            <widget class="QPushButton" name="mMapGridCRSButton">
             <property name="text">
@@ -115,7 +155,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1" colspan="2">
+          <item row="10" column="1" colspan="2">
            <layout class="QGridLayout" name="gridLayout_5">
             <item row="2" column="1">
              <widget class="QgsPropertyOverrideButton" name="mOffsetYDDBtn">
@@ -159,7 +199,7 @@
             </item>
            </layout>
           </item>
-          <item row="7" column="1">
+          <item row="11" column="1">
            <widget class="QgsDoubleSpinBox" name="mCrossWidthSpinBox">
             <property name="suffix">
              <string> mm</string>
@@ -172,7 +212,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1" colspan="2">
+          <item row="12" column="1" colspan="2">
            <widget class="QgsSymbolButton" name="mGridLineStyleButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -198,140 +238,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="3">
-           <widget class="QStackedWidget" name="mIntervalStackedWidget">
-            <property name="currentIndex">
-             <number>1</number>
-            </property>
-            <widget class="QWidget" name="page">
-             <layout class="QGridLayout" name="gridLayout_7" columnstretch="0,1,0">
-              <property name="leftMargin">
-               <number>10</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="0" column="1">
-               <widget class="QgsDoubleSpinBox" name="mIntervalXSpinBox">
-                <property name="prefix">
-                 <string/>
-                </property>
-                <property name="decimals">
-                 <number>12</number>
-                </property>
-                <property name="maximum">
-                 <double>9999999.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QgsPropertyOverrideButton" name="mIntervalYDDBtn">
-                <property name="text">
-                 <string>…</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QgsDoubleSpinBox" name="mIntervalYSpinBox">
-                <property name="prefix">
-                 <string/>
-                </property>
-                <property name="decimals">
-                 <number>12</number>
-                </property>
-                <property name="maximum">
-                 <double>9999999.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QgsPropertyOverrideButton" name="mIntervalXDDBtn">
-                <property name="text">
-                 <string>…</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_2">
-                <property name="text">
-                 <string>X</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Y</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="page_2">
-             <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-              <property name="leftMargin">
-               <number>10</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="0" column="1">
-               <widget class="QgsDoubleSpinBox" name="mMinWidthSpinBox">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="suffix">
-                 <string> mm</string>
-                </property>
-                <property name="maximum">
-                 <double>999.990000000000009</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="suffix">
-                 <string> mm</string>
-                </property>
-                <property name="maximum">
-                 <double>999.990000000000009</double>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_4">
-                <property name="text">
-                 <string>Minimum</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>Maximum</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item row="8" column="0">
+          <item row="12" column="0">
            <widget class="QLabel" name="mLineStyleLabel">
             <property name="text">
              <string>Line style</string>
@@ -351,7 +258,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="11" column="0">
            <widget class="QLabel" name="mCrossWidthLabel">
             <property name="text">
              <string>Cross width</string>
@@ -361,7 +268,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="mOffsetXLabel_2">
             <property name="text">
              <string>Offset</string>
@@ -378,14 +285,14 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="0">
+          <item row="14" column="0">
            <widget class="QLabel" name="mGridBlendLabel">
             <property name="text">
              <string>Blend mode</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="2">
+          <item row="11" column="2">
            <widget class="QgsPropertyOverrideButton" name="mCrossWidthDDBtn">
             <property name="text">
              <string>…</string>
@@ -395,10 +302,10 @@
           <item row="2" column="1" colspan="2">
            <widget class="QComboBox" name="mGridTypeComboBox"/>
           </item>
-          <item row="10" column="1" colspan="2">
+          <item row="14" column="1" colspan="2">
            <widget class="QgsBlendModeComboBox" name="mGridBlendComboBox"/>
           </item>
-          <item row="9" column="1" colspan="2">
+          <item row="13" column="1" colspan="2">
            <widget class="QgsSymbolButton" name="mGridMarkerStyleButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -411,7 +318,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="13" column="0">
            <widget class="QLabel" name="mMarkerStyleLabel">
             <property name="text">
              <string>Marker style</string>
@@ -423,6 +330,60 @@
           </item>
           <item row="4" column="1" colspan="2">
            <widget class="QComboBox" name="mMapGridUnitComboBox"/>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="mMinWidthLabel">
+            <property name="text">
+             <string>Minimum</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="mIntervalXLabel">
+            <property name="text">
+             <string>X</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QgsDoubleSpinBox" name="mIntervalYSpinBox">
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="decimals">
+             <number>12</number>
+            </property>
+            <property name="maximum">
+             <double>9999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
+           <widget class="QgsPropertyOverrideButton" name="mIntervalYDDBtn">
+            <property name="text">
+             <string>…</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1" colspan="2">
+           <widget class="QgsDoubleSpinBox" name="mMaxWidthSpinBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="maximum">
+             <double>999.990000000000009</double>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="mMaxWidthLabel">
+            <property name="text">
+             <string>Maximum</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -908,20 +908,35 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>mEnabledCheckBox</tabstop>
   <tabstop>scrollArea</tabstop>
+  <tabstop>mEnabledDDBtn</tabstop>
   <tabstop>mGridTypeComboBox</tabstop>
   <tabstop>mMapGridCRSButton</tabstop>
+  <tabstop>mMapGridUnitComboBox</tabstop>
+  <tabstop>mIntervalXSpinBox</tabstop>
+  <tabstop>mIntervalXDDBtn</tabstop>
+  <tabstop>mIntervalYSpinBox</tabstop>
+  <tabstop>mIntervalYDDBtn</tabstop>
+  <tabstop>mMinWidthSpinBox</tabstop>
+  <tabstop>mMaxWidthSpinBox</tabstop>
   <tabstop>mOffsetXSpinBox</tabstop>
+  <tabstop>mOffsetXDDBtn</tabstop>
   <tabstop>mOffsetYSpinBox</tabstop>
+  <tabstop>mOffsetYDDBtn</tabstop>
   <tabstop>mCrossWidthSpinBox</tabstop>
+  <tabstop>mCrossWidthDDBtn</tabstop>
   <tabstop>mGridLineStyleButton</tabstop>
   <tabstop>mGridMarkerStyleButton</tabstop>
   <tabstop>mGridBlendComboBox</tabstop>
   <tabstop>mGridFrameGroupBox</tabstop>
   <tabstop>mFrameStyleComboBox</tabstop>
   <tabstop>mFrameWidthSpinBox</tabstop>
+  <tabstop>mFrameSizeDDBtn</tabstop>
   <tabstop>mGridFrameMarginSpinBox</tabstop>
+  <tabstop>mFrameMarginDDBtn</tabstop>
   <tabstop>mGridFramePenSizeSpinBox</tabstop>
+  <tabstop>mFrameLineThicknessDDBtn</tabstop>
   <tabstop>mGridFramePenColorButton</tabstop>
   <tabstop>mGridFrameFill1ColorButton</tabstop>
   <tabstop>mGridFrameFill2ColorButton</tabstop>
@@ -951,6 +966,7 @@
   <tabstop>mAnnotationFontButton</tabstop>
   <tabstop>mAnnotationFontColorButton</tabstop>
   <tabstop>mDistanceToMapFrameSpinBox</tabstop>
+  <tabstop>mLabelDistDDBtn</tabstop>
   <tabstop>mCoordinatePrecisionSpinBox</tabstop>
  </tabstops>
  <resources>

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -19,18 +19,18 @@
   <property name="windowTitle">
    <string>Map Options</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="6">
    <property name="spacing">
-    <number>0</number>
+    <number>9</number>
    </property>
    <property name="leftMargin">
-    <number>0</number>
+    <number>9</number>
    </property>
    <property name="topMargin">
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>9</number>
    </property>
    <property name="bottomMargin">
     <number>0</number>


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/7983394/65018812-40c4bd80-d92a-11e9-9e04-de503c081067.png)

Because the interval x/y min/max elements are put under a stackedwidget, they are not aware of the alignment of the other features in the GUI. The PR removes the stackedwidget.
After

![image](https://user-images.githubusercontent.com/7983394/65277366-0cb7eb00-db2a-11e9-81b5-b1e30d068e56.png)

The fix works. Now is it the right/best way? And not sure also about the doc and methods/parameters naming.
Also @nyalldawson is the no margin in the widget deliberate? I can see it's also the case when setting the map item labeling properties

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
