### PR TITLE
Fix endless loop on curve linearization with maxdistance tolerance higher than arc radius

### DIFF
--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -910,6 +910,8 @@ void QgsGeometryUtils::segmentizeArc( const QgsPoint &p1, const QgsPoint &p2, co
   double increment = tolerance; //one segment per degree
   if ( toleranceType == QgsAbstractGeometry::MaximumDifference )
   {
+    // Ensure tolerance is not higher than twice the radius
+    tolerance = std::min( tolerance, radius * 2 );
     double halfAngle = std::acos( -tolerance / radius + 1 );
     increment = 2 * halfAngle;
   }

--- a/tests/src/core/testqgscurve.cpp
+++ b/tests/src/core/testqgscurve.cpp
@@ -2,7 +2,7 @@
      testqgscurve.cpp
      --------------------------------------
     Date                 : 21 July 2017
-    Copyright            : (C) 2017 by Sandro Santilli
+    Copyright            : (C) 2017-2019 by Sandro Santilli
     Email                : strk @ kbt.io
  ***************************************************************************
  *                                                                         *
@@ -91,6 +91,11 @@ void TestQgsCurve::curveToLine()
   /* op: Maximum of 10 units of difference, symmetric */
   TEST_C2L( circularString, 10, QgsAbstractGeometry::MaximumDifference,
             "LineString (0 0, 29.29 70.71, 100 100, 170.71 70.71, 200 0)", 2 );
+
+  /* op: Maximum of 300 units (higher than sagitta) of difference, symmetric */
+  /* See https://github.com/qgis/QGIS/issues/31832 */
+  TEST_C2L( circularString, 300, QgsAbstractGeometry::MaximumDifference,
+            "LineString (0 0, 200 0)", 2 );
 
   /* op: Maximum of M_PI / 8 degrees of angle, (a)symmetric */
   /* See https://github.com/qgis/QGIS/issues/24616 */


### PR DESCRIPTION
See #31832


- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment