### PR TITLE
Allow allowed gap layer to be of different ZM type than main layer

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -228,7 +228,8 @@ void QgsGeometryGapCheck::fixError( const QMap<QString, QgsFeaturePool *> &featu
           else
           {
             QgsFeature feature = QgsVectorLayerUtils::createFeature( layer, error->geometry() );
-            if ( !layer->addFeature( feature ) )
+            QgsFeatureList features = QgsVectorLayerUtils::makeFeatureCompatible( feature, layer );
+            if ( !layer->addFeatures( features ) )
             {
               error->setFixFailed( tr( "Could not add feature to layer %1" ).arg( layer->name() ) );
             }


### PR DESCRIPTION
The allowed gap layer may be of different Z/M type than the "main" layer.
This will make it impossible to commit the gap (depending on the gracefulness of the underlying provider).
This will force the new feature to be compatible.