### PR TITLE
update docstring about QgsDateTimeEdit with NULL values

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsdatetimeedit.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdatetimeedit.sip.in
@@ -29,13 +29,23 @@ The QgsDateTimeEdit class is a QDateTimeEdit with the capability of setting/read
     explicit QgsDateTimeEdit( QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsDateTimeEdit
+The current date and time is used by default.
+The widget is allowing null by default.
 %End
 
     void setAllowNull( bool allowNull );
 %Docstring
 Determines if the widget allows setting null date/time.
+
+.. seealso:: :py:func:`allowNull`
 %End
+
     bool allowNull() const;
+%Docstring
+If the widget allows setting null date/time.
+
+.. seealso:: :py:func:`setAllowNull`
+%End
 
     void setDateTime( const QDateTime &dateTime );
 %Docstring
@@ -52,7 +62,11 @@ dateTime returns the date time which can eventually be a null date/time
 
 .. note::
 
-   since QDateTimeEdit.dateTime() is not virtual, dateTime must be called for QgsDateTimeEdit.
+    You mustn't call date() or time() because they can't return a NULL value.
+
+.. note::
+
+   since QDateTimeEdit.dateTime() is not virtual, dateTime must be called for QgsDateTimeEdit
 %End
 
     virtual void clear();

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -36,11 +36,23 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 
   public:
 
-    //! Constructor for QgsDateTimeEdit
+    /**
+     * Constructor for QgsDateTimeEdit
+     * The current date and time is used by default.
+     * The widget is allowing null by default.
+     */
     explicit QgsDateTimeEdit( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
-    //! Determines if the widget allows setting null date/time.
+    /**
+     * Determines if the widget allows setting null date/time.
+     * \see allowNull
+     */
     void setAllowNull( bool allowNull );
+
+    /**
+     * If the widget allows setting null date/time.
+     * \see setAllowNull
+     */
     bool allowNull() const {return mAllowNull;}
 
     /**
@@ -51,7 +63,8 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 
     /**
      * \brief dateTime returns the date time which can eventually be a null date/time
-     * \note since QDateTimeEdit::dateTime() is not virtual, dateTime must be called for QgsDateTimeEdit.
+     * \note  You mustn't call date() or time() because they can't return a NULL value.
+     * \note since QDateTimeEdit::dateTime() is not virtual, dateTime must be called for QgsDateTimeEdit
      */
     QDateTime dateTime() const;
 


### PR DESCRIPTION
## Description

If you have a QgsDateTimeEdit, you mustn't call `date()` or `time()` on it as it can't handle `NULL` values. Only `dateTime()`.

This PR needs to be backported for documentation in the API.

In a following PR, I can add `date()` and `time()` to return an empty QDateTime if needed. But I'm not sure if it can be backported.
If it is, then this PR can be updated.

It's not related to https://github.com/qgis/QGIS/issues/31849

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
