### PR TITLE
QgsCoordinateTransform: remove entries from cache when a thread exits (relates to #31762)

### DIFF
--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -536,6 +536,15 @@ class CORE_EXPORT QgsCoordinateTransform
         const QgsDatumTransform::TransformDetails &desiredOperation )> &handler );
 #endif
 
+#ifndef SIP_RUN
+#if PROJ_VERSION_MAJOR>=6
+  protected:
+    friend class QgsProjContext;
+
+    // Only meant to be called by QgsProjContext::~QgsProjContext()
+    static void removeFromCacheObjectsBelongingToCurrentThread( void *pj_context );
+#endif
+#endif
   private:
 
     mutable QExplicitlySharedDataPointer<QgsCoordinateTransformPrivate> d;

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -683,4 +683,20 @@ void QgsCoordinateTransformPrivate::freeProj()
   mProjProjections.clear();
 }
 
+#if PROJ_VERSION_MAJOR>=6
+bool QgsCoordinateTransformPrivate::removeObjectsBelongingToCurrentThread( void *pj_context )
+{
+  QgsReadWriteLocker locker( mProjLock, QgsReadWriteLocker::Write );
+
+  QMap < uintptr_t, ProjData >::iterator it = mProjProjections.find( reinterpret_cast< uintptr_t>( pj_context ) );
+  if ( it != mProjProjections.end() )
+  {
+    proj_destroy( it.value() );
+    mProjProjections.erase( it );
+  }
+
+  return mProjProjections.isEmpty();
+}
+#endif
+
 ///@endcond

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -102,6 +102,11 @@ class QgsCoordinateTransformPrivate : public QSharedData
 
     ProjData threadLocalProjData();
 
+#if PROJ_VERSION_MAJOR>=6
+    // Only meant to be called by QgsCoordinateTransform::removeFromCacheObjectsBelongingToCurrentThread()
+    bool removeObjectsBelongingToCurrentThread( void *pj_context );
+#endif
+
     /**
      * Flag to indicate whether the transform is valid (ie has a valid
      * source and destination crs)

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -16,6 +16,8 @@
  ***************************************************************************/
 #include "qgsprojutils.h"
 #include "qgis.h"
+#include "qgscoordinatetransform.h"
+
 #include <QString>
 #include <QSet>
 #include <QRegularExpression>
@@ -45,6 +47,9 @@ QgsProjContext::QgsProjContext()
 QgsProjContext::~QgsProjContext()
 {
 #if PROJ_VERSION_MAJOR>=6
+  // Call removeFromCacheObjectsBelongingToCurrentThread() before
+  // destroying the context
+  QgsCoordinateTransform::removeFromCacheObjectsBelongingToCurrentThread( mContext );
   proj_context_destroy( mContext );
 #else
   pj_ctx_free( mContext );


### PR DESCRIPTION
The first commit comes from https://github.com/qgis/QGIS/pull/31848
This PR is for the second commit "QgsCoordinateTransform: remove entries from cache when a thread exits (relates to #31762)"