### PR TITLE
[layer tree] dedicated method in QgisApp to determine insertion point

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
@@ -34,6 +34,9 @@ from the map layer registry.
     struct InsertionPoint
     {
       InsertionPoint( QgsLayerTreeGroup *parent, int position );
+%Docstring
+Construcs an insertion point as layer tree group with its corresponding position.
+%End
       QgsLayerTreeGroup *parent;
       int position;
     };
@@ -54,7 +57,7 @@ Create the instance that synchronizes given project with a layer tree root
 Set where the new layers should be inserted - can be used to follow current selection.
 By default it is root group with zero index.
 
-.. deprecated:: since QGIS 3.10
+.. deprecated:: since QGIS 3.10 use setLayerInsertionPoint( const InsertionPoint &insertionPoint ) instead
 %End
 
     void setLayerInsertionPoint( const InsertionPoint &insertionPoint );

--- a/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
@@ -30,6 +30,14 @@ from the map layer registry.
 #include "qgslayertreeregistrybridge.h"
 %End
   public:
+
+    struct InsertionPoint
+    {
+      InsertionPoint( QgsLayerTreeGroup *parent, int position );
+      QgsLayerTreeGroup *parent;
+      int position;
+    };
+
     explicit QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root, QgsProject *project, QObject *parent /TransferThis/ = 0 );
 %Docstring
 Create the instance that synchronizes given project with a layer tree root
@@ -41,10 +49,20 @@ Create the instance that synchronizes given project with a layer tree root
     void setNewLayersVisible( bool enabled );
     bool newLayersVisible() const;
 
-    void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index );
+ void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) /Deprecated/;
 %Docstring
 Set where the new layers should be inserted - can be used to follow current selection.
 By default it is root group with zero index.
+
+.. deprecated:: since QGIS 3.10
+%End
+
+    void setLayerInsertionPoint( const InsertionPoint &insertionPoint );
+%Docstring
+Set where the new layers should be inserted - can be used to follow current selection.
+By default it is root group with zero index.
+
+.. versionadded:: 3.10
 %End
 
   signals:

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -634,8 +634,8 @@ Take screenshots for user documentation
 
     virtual QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() = 0;
 %Docstring
-Returns the insertion group with its insertion index
-In Python, returns a tuple (insertionGroup, insertionIndex)
+Returns the insertion point.
+This represents the current layer tree group and index where newly added map layers should be inserted into.
 
 .. versionadded:: 3.10
 %End

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -632,6 +632,15 @@ Take screenshots for user documentation
 .. versionadded:: 3.4
 %End
 
+    virtual QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() = 0;
+%Docstring
+Returns the insertion group with its insertion index
+In Python, returns a tuple (insertionGroup, insertionIndex)
+
+.. versionadded:: 3.10
+%End
+
+
   public slots: // TODO: do these functions really need to be slots?
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4246,24 +4246,32 @@ void QgisApp::setupLayerTreeViewFromSettings()
 
 void QgisApp::updateNewLayerInsertionPoint()
 {
+  QgsLayerTreeRegistryBridge::InsertionPoint insertionPoint = layerTreeInsertionPoint();
+  QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionPoint( insertionPoint );
+}
+
+QgsLayerTreeRegistryBridge::InsertionPoint QgisApp::layerTreeInsertionPoint() const
+{
   // defaults
   QgsLayerTreeGroup *insertGroup = mLayerTreeView->layerTreeModel()->rootGroup();
   QModelIndex current = mLayerTreeView->currentIndex();
+
   int index = 0;
 
   if ( current.isValid() )
   {
     index = current.row();
 
-    if ( QgsLayerTreeNode *currentNode = mLayerTreeView->currentNode() )
+    QgsLayerTreeNode *currentNode = mLayerTreeView->currentNode();
+    if ( currentNode )
     {
       // if the insertion point is actually a group, insert new layers into the group
       if ( QgsLayerTree::isGroup( currentNode ) )
       {
         // if the group is embedded go to the first non-embedded group, at worst the top level item
         QgsLayerTreeGroup *insertGroup = QgsLayerTreeUtils::firstGroupWithoutCustomProperty( QgsLayerTree::toGroup( currentNode ), QStringLiteral( "embedded" ) );
-        QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionPoint( insertGroup, 0 );
-        return;
+
+        return QgsLayerTreeRegistryBridge::InsertionPoint( insertGroup, 0 );
       }
 
       // otherwise just set the insertion point in front of the current node
@@ -4278,8 +4286,7 @@ void QgisApp::updateNewLayerInsertionPoint()
       }
     }
   }
-
-  QgsProject::instance()->layerTreeRegistryBridge()->setLayerInsertionPoint( insertGroup, index );
+  return QgsLayerTreeRegistryBridge::InsertionPoint( insertGroup, index );
 }
 
 void QgisApp::autoSelectAddedLayer( QList<QgsMapLayer *> layers )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -153,6 +153,7 @@ class QgsNetworkRequestParameters;
 #include "qgsrecentprojectsitemsmodel.h"
 #include "qgsraster.h"
 #include "qgsrasterminmaxorigin.h"
+#include "qgslayertreeregistrybridge.h"
 #include "qgsmaplayeractionregistry.h"
 #include "qgsoptionswidgetfactory.h"
 #include "qgsattributetablefiltermodel.h"
@@ -711,6 +712,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * @param categories an int as a flag value of QgsAppScreenShots::Categories
      */
     void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 );
+
+    QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() const;
 
   public slots:
     //! save current vector layer

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -801,3 +801,8 @@ QgsBrowserGuiModel *QgisAppInterface::browserModel()
 {
   return qgis->mBrowserModel;
 }
+
+QgsLayerTreeRegistryBridge::InsertionPoint QgisAppInterface::layerTreeInsertionPoint()
+{
+  return qgis->layerTreeInsertionPoint();
+}

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -279,6 +279,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     bool askForDatumTransform( QgsCoordinateReferenceSystem sourceCrs, QgsCoordinateReferenceSystem destinationCrs ) override;
     void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 ) override;
     QgsBrowserGuiModel *browserModel() override;
+    QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() override;
+
 
   private slots:
 

--- a/src/core/layertree/qgslayertreeregistrybridge.cpp
+++ b/src/core/layertree/qgslayertreeregistrybridge.cpp
@@ -27,8 +27,7 @@ QgsLayerTreeRegistryBridge::QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root,
   , mRegistryRemovingLayers( false )
   , mEnabled( true )
   , mNewLayersVisible( true )
-  , mInsertionPointGroup( root )
-  , mInsertionPointIndex( 0 )
+  , mInsertionPoint( root, 0 )
 {
   connect( mProject, &QgsProject::legendLayersAdded, this, &QgsLayerTreeRegistryBridge::layersAdded );
   connect( mProject, static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsLayerTreeRegistryBridge::layersWillBeRemoved );
@@ -39,8 +38,13 @@ QgsLayerTreeRegistryBridge::QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root,
 
 void QgsLayerTreeRegistryBridge::setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index )
 {
-  mInsertionPointGroup = parentGroup;
-  mInsertionPointIndex = index;
+  mInsertionPoint.parent = parentGroup;
+  mInsertionPoint.position = index;
+}
+
+void QgsLayerTreeRegistryBridge::setLayerInsertionPoint( const InsertionPoint &insertionPoint )
+{
+  mInsertionPoint = insertionPoint;
 }
 
 void QgsLayerTreeRegistryBridge::layersAdded( const QList<QgsMapLayer *> &layers )
@@ -67,7 +71,7 @@ void QgsLayerTreeRegistryBridge::layersAdded( const QList<QgsMapLayer *> &layers
   }
 
   // add new layers to the right place
-  mInsertionPointGroup->insertChildNodes( mInsertionPointIndex, nodes );
+  mInsertionPoint.parent->insertChildNodes( mInsertionPoint.position, nodes );
 
   // tell other components that layers have been added - this signal is used in QGIS to auto-select the first layer
   emit addedLayersToLayerTree( layers );

--- a/src/core/layertree/qgslayertreeregistrybridge.h
+++ b/src/core/layertree/qgslayertreeregistrybridge.h
@@ -47,16 +47,18 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
   public:
 
     /**
-     * A structure to define the insertion point to the layer tree
+     * A structure to define the insertion point to the layer tree.
+     * This represents the current layer tree group and index where newly added map layers should be inserted into.
      * \since QGIS 3.10
      */
     struct InsertionPoint
     {
+      //! Construcs an insertion point as layer tree group with its corresponding position.
       InsertionPoint( QgsLayerTreeGroup *parent, int position )
         : parent( parent ), position( position ) {}
 
-      QgsLayerTreeGroup *parent;
-      int position;
+      QgsLayerTreeGroup *parent = nullptr;
+      int position = 0;
     };
 
     //! Create the instance that synchronizes given project with a layer tree root
@@ -71,7 +73,7 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     /**
      * Set where the new layers should be inserted - can be used to follow current selection.
      * By default it is root group with zero index.
-     * \deprecated since QGIS 3.10
+     * \deprecated since QGIS 3.10 use setLayerInsertionPoint( const InsertionPoint &insertionPoint ) instead
      */
     Q_DECL_DEPRECATED void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) SIP_DEPRECATED;
 

--- a/src/core/layertree/qgslayertreeregistrybridge.h
+++ b/src/core/layertree/qgslayertreeregistrybridge.h
@@ -45,6 +45,20 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
 {
     Q_OBJECT
   public:
+
+    /**
+     * A structure to define the insertion point to the layer tree
+     * \since QGIS 3.10
+     */
+    struct InsertionPoint
+    {
+      InsertionPoint( QgsLayerTreeGroup *parent, int position )
+        : parent( parent ), position( position ) {}
+
+      QgsLayerTreeGroup *parent;
+      int position;
+    };
+
     //! Create the instance that synchronizes given project with a layer tree root
     explicit QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root, QgsProject *project, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
@@ -57,8 +71,16 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     /**
      * Set where the new layers should be inserted - can be used to follow current selection.
      * By default it is root group with zero index.
+     * \deprecated since QGIS 3.10
      */
-    void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index );
+    Q_DECL_DEPRECATED void setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index ) SIP_DEPRECATED;
+
+    /**
+     * Set where the new layers should be inserted - can be used to follow current selection.
+     * By default it is root group with zero index.
+     * \since QGIS 3.10
+     */
+    void setLayerInsertionPoint( const InsertionPoint &insertionPoint );
 
   signals:
 
@@ -85,8 +107,7 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     bool mEnabled;
     bool mNewLayersVisible;
 
-    QgsLayerTreeGroup *mInsertionPointGroup = nullptr;
-    int mInsertionPointIndex;
+    InsertionPoint mInsertionPoint;
 };
 
 #endif // QGSLAYERTREEREGISTRYBRIDGE_H

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -25,6 +25,7 @@
 #include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgslayertreeregistrybridge.h"
 
 class QAction;
 class QDialog;
@@ -42,6 +43,7 @@ class QgsLayoutCustomDropHandler;
 class QgsFeature;
 class QgsLayerTreeMapCanvasBridge;
 class QgsLayerTreeView;
+class QgsLayerTreeGroup;
 class QgsLayout;
 class QgsMasterLayoutInterface;
 class QgsLayoutDesignerInterface;
@@ -560,6 +562,14 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.4
      */
     virtual void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 ) {Q_UNUSED( saveDirectory ) Q_UNUSED( categories );}
+
+    /**
+     * Returns the insertion group with its insertion index
+     * In Python, returns a tuple (insertionGroup, insertionIndex)
+     * \since QGIS 3.10
+     */
+    virtual QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() = 0;
+
 
   public slots: // TODO: do these functions really need to be slots?
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -564,8 +564,8 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 ) {Q_UNUSED( saveDirectory ) Q_UNUSED( categories );}
 
     /**
-     * Returns the insertion group with its insertion index
-     * In Python, returns a tuple (insertionGroup, insertionIndex)
+     * Returns the insertion point.
+     * This represents the current layer tree group and index where newly added map layers should be inserted into.
      * \since QGIS 3.10
      */
     virtual QgsLayerTreeRegistryBridge::InsertionPoint layerTreeInsertionPoint() = 0;

--- a/src/plugins/coordinate_capture/CMakeLists.txt
+++ b/src/plugins/coordinate_capture/CMakeLists.txt
@@ -31,6 +31,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/gui

--- a/src/plugins/evis/CMakeLists.txt
+++ b/src/plugins/evis/CMakeLists.txt
@@ -61,6 +61,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/plugins

--- a/src/plugins/geometry_checker/CMakeLists.txt
+++ b/src/plugins/geometry_checker/CMakeLists.txt
@@ -51,6 +51,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/core/providers/ogr

--- a/src/plugins/georeferencer/CMakeLists.txt
+++ b/src/plugins/georeferencer/CMakeLists.txt
@@ -77,6 +77,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/layout

--- a/src/plugins/gps_importer/CMakeLists.txt
+++ b/src/plugins/gps_importer/CMakeLists.txt
@@ -38,6 +38,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/gps
   ${CMAKE_SOURCE_DIR}/src/gui

--- a/src/plugins/topology/CMakeLists.txt
+++ b/src/plugins/topology/CMakeLists.txt
@@ -45,6 +45,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/gui

--- a/src/providers/delimitedtext/CMakeLists.txt
+++ b/src/providers/delimitedtext/CMakeLists.txt
@@ -30,6 +30,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/external

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -8,6 +8,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/auth
   ${CMAKE_SOURCE_DIR}/src/core/expression
   ${CMAKE_SOURCE_DIR}/src/core/geometry
+  ${CMAKE_SOURCE_DIR}/src/core/layertree
   ${CMAKE_SOURCE_DIR}/src/core/layout
   ${CMAKE_SOURCE_DIR}/src/core/locator
   ${CMAKE_SOURCE_DIR}/src/core/metadata


### PR DESCRIPTION
and create bindings to get the current insertion point in QgisInterface

this supersedes #31843 by keeping the code in QgisApp and making accessible through QgisInterface.
It also uses a struct instead of QPair.