### PR TITLE
Gap check ignore missing layer

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1398,6 +1398,14 @@ Sets the coordinate transform context to ``transformContext``
 
   signals:
 
+    void beforeResolveReferences( QgsProject *project );
+%Docstring
+Emitted when all layers are loaded and references can be resolved,
+just before the references of this layer are resolved.
+
+.. versionadded:: 3.10
+%End
+
     void statusChanged( const QString &status );
 %Docstring
 Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar)

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -37,10 +37,13 @@ void QgsGeometryGapCheck::prepare( const QgsGeometryCheckContext *context, const
   if ( configuration.value( QStringLiteral( "allowedGapsEnabled" ) ).toBool() )
   {
     QgsVectorLayer *layer = context->project()->mapLayer<QgsVectorLayer *>( configuration.value( "allowedGapsLayer" ).toString() );
-    mAllowedGapsLayer = layer;
-    mAllowedGapsSource = qgis::make_unique<QgsVectorLayerFeatureSource>( layer );
+    if ( layer )
+    {
+      mAllowedGapsLayer = layer;
+      mAllowedGapsSource = qgis::make_unique<QgsVectorLayerFeatureSource>( layer );
 
-    mAllowedGapsBuffer = configuration.value( QStringLiteral( "allowedGapsBuffer" ) ).toDouble();
+      mAllowedGapsBuffer = configuration.value( QStringLiteral( "allowedGapsBuffer" ) ).toDouble();
+    }
   }
   else
   {

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -99,7 +99,10 @@ void QgsGeometryValidationService::onLayersAdded( const QList<QgsMapLayer *> &la
         mLayerChecks.remove( vectorLayer );
       } );
 
-      enableLayerChecks( vectorLayer );
+      connect( vectorLayer, &QgsMapLayer::beforeResolveReferences, this, [this, vectorLayer]()
+      {
+        enableLayerChecks( vectorLayer );
+      } );
     }
   }
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -612,6 +612,7 @@ QString QgsMapLayer::decodedSource( const QString &source, const QString &dataPr
 
 void QgsMapLayer::resolveReferences( QgsProject *project )
 {
+  emit beforeResolveReferences( project );
   if ( m3DRenderer )
     m3DRenderer->resolveReferences( *project );
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1254,6 +1254,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
   signals:
 
+    /**
+     * Emitted when all layers are loaded and references can be resolved,
+     * just before the references of this layer are resolved.
+     *
+     * \since QGIS 3.10
+     */
+    void beforeResolveReferences( QgsProject *project );
+
     //! Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar)
     void statusChanged( const QString &status );
 


### PR DESCRIPTION
This

* fixes a crash when the "allowed gaps" functionality points to a missing layer (dereferenced nullptr)
* adds a new signal `beforeResolveReferences` that allows executing code on resolveReference time, when dependent layers are guaranteed to be loaded.