### PR TITLE
Fix double event fired by QSpinBox in slow graduated

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
@@ -145,6 +145,8 @@ is equal to minimum(). Typical use is to indicate that this choice has a special
 
     virtual void wheelEvent( QWheelEvent *event );
 
+    virtual void timerEvent( QTimerEvent *event );
+
 
 };
 

--- a/python/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
@@ -146,6 +146,8 @@ is equal to minimum(). Typical use is to indicate that this choice has a special
 
     virtual void wheelEvent( QWheelEvent *event );
 
+    virtual void timerEvent( QTimerEvent *event );
+
 
 };
 

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -93,6 +93,17 @@ void QgsDoubleSpinBox::wheelEvent( QWheelEvent *event )
   setSingleStep( step );
 }
 
+void QgsDoubleSpinBox::timerEvent( QTimerEvent *event )
+{
+  // Process all events, which may include a mouse release event
+  // Only allow the timer to trigger additional value changes if the user
+  // has in fact held the mouse button, rather than the timer expiry
+  // simply appearing before the mouse release in the event queue
+  qApp->processEvents();
+  if ( QApplication::mouseButtons() & Qt::LeftButton )
+    QDoubleSpinBox::timerEvent( event );
+}
+
 void QgsDoubleSpinBox::paintEvent( QPaintEvent *event )
 {
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -146,6 +146,10 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
   protected:
     void changeEvent( QEvent *event ) override;
     void wheelEvent( QWheelEvent *event ) override;
+    // This is required because private implementation of
+    // QAbstractSpinBoxPrivate may trigger a second
+    // undesired event from the auto-repeat mouse timer
+    void timerEvent( QTimerEvent *event ) override;
 
   private slots:
     void changed( double value );

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -96,6 +96,17 @@ void QgsSpinBox::wheelEvent( QWheelEvent *event )
   setSingleStep( step );
 }
 
+void QgsSpinBox::timerEvent( QTimerEvent *event )
+{
+  // Process all events, which may include a mouse release event
+  // Only allow the timer to trigger additional value changes if the user
+  // has in fact held the mouse button, rather than the timer expiry
+  // simply appearing before the mouse release in the event queue
+  qApp->processEvents();
+  if ( QApplication::mouseButtons() & Qt::LeftButton )
+    QSpinBox::timerEvent( event );
+}
+
 void QgsSpinBox::changed( int value )
 {
   mLineEdit->setShowClearButton( shouldShowClearForValue( value ) );

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -147,6 +147,10 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
     void changeEvent( QEvent *event ) override;
     void paintEvent( QPaintEvent *event ) override;
     void wheelEvent( QWheelEvent *event ) override;
+    // This is required because private implementation of
+    // QAbstractSpinBoxPrivate may trigger a second
+    // undesired event from the auto-repeat mouse timer
+    void timerEvent( QTimerEvent *event ) override;
 
   private slots:
     void changed( int value );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -486,6 +486,8 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   spinPrecision->setMinimum( QgsClassificationMethod::MIN_PRECISION );
   spinPrecision->setMaximum( QgsClassificationMethod::MAX_PRECISION );
 
+  spinGraduatedClasses->setShowClearButton( false );
+
   btnColorRamp->setShowRandomColorRamp( true );
 
   // set project default color ramp
@@ -610,14 +612,14 @@ void QgsGraduatedSymbolRendererWidget::setContext( const QgsSymbolWidgetContext 
 // Connect/disconnect event handlers which trigger updating renderer
 void QgsGraduatedSymbolRendererWidget::connectUpdateHandlers()
 {
-  connect( spinGraduatedClasses, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
-  connect( cboGraduatedMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
+  connect( spinGraduatedClasses, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
+  connect( cboGraduatedMode, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
   connect( btnColorRamp, &QgsColorRampButton::colorRampChanged, this, &QgsGraduatedSymbolRendererWidget::reapplyColorRamp );
-  connect( spinPrecision, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
+  connect( spinPrecision, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
   connect( cbxTrimTrailingZeroes, &QAbstractButton::toggled, this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
   connect( txtLegendFormat, &QLineEdit::textChanged, this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
-  connect( minSizeSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
-  connect( maxSizeSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
+  connect( minSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
+  connect( maxSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
 
   connect( mModel, &QgsGraduatedSymbolRendererModel::rowsMoved, this, &QgsGraduatedSymbolRendererWidget::rowsMoved );
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsGraduatedSymbolRendererWidget::modelDataChanged );
@@ -631,14 +633,14 @@ void QgsGraduatedSymbolRendererWidget::connectUpdateHandlers()
 // Connect/disconnect event handlers which trigger updating renderer
 void QgsGraduatedSymbolRendererWidget::disconnectUpdateHandlers()
 {
-  disconnect( spinGraduatedClasses, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
-  disconnect( cboGraduatedMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
+  disconnect( spinGraduatedClasses, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
+  disconnect( cboGraduatedMode, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsGraduatedSymbolRendererWidget::classifyGraduated );
   disconnect( btnColorRamp, &QgsColorRampButton::colorRampChanged, this, &QgsGraduatedSymbolRendererWidget::reapplyColorRamp );
-  disconnect( spinPrecision, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
+  disconnect( spinPrecision, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
   disconnect( cbxTrimTrailingZeroes, &QAbstractButton::toggled, this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
   disconnect( txtLegendFormat, &QLineEdit::textChanged, this, &QgsGraduatedSymbolRendererWidget::labelFormatChanged );
-  disconnect( minSizeSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
-  disconnect( maxSizeSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
+  disconnect( minSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
+  disconnect( maxSizeSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsGraduatedSymbolRendererWidget::reapplySizes );
 
   disconnect( mModel, &QgsGraduatedSymbolRendererModel::rowsMoved, this, &QgsGraduatedSymbolRendererWidget::rowsMoved );
   disconnect( mModel, &QAbstractItemModel::dataChanged, this, &QgsGraduatedSymbolRendererWidget::modelDataChanged );
@@ -684,7 +686,9 @@ void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
   // Only update class count if different - otherwise typing value gets very messy
   int nclasses = ranges.count();
   if ( nclasses && updateCount )
+  {
     spinGraduatedClasses->setValue( ranges.count() );
+  }
 
   // set column
   QString attrName = mRenderer->classAttribute();
@@ -906,6 +910,8 @@ void QgsGraduatedSymbolRendererWidget::symmetryPointEditingFinished( )
 
 void QgsGraduatedSymbolRendererWidget::classifyGraduated()
 {
+
+  QApplication::setOverrideCursor( Qt::WaitCursor );
   QString attrName = mExpressionWidget->currentField();
   int nclasses = spinGraduatedClasses->value();
 
@@ -948,7 +954,10 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
   if ( method && method->codeComplexity() > 1 && mLayer->featureCount() > 50000 )
   {
     if ( QMessageBox::Cancel == QMessageBox::question( this, tr( "Apply Classification" ), tr( "Natural break classification (Jenks) is O(n2) complexity, your classification may take a long time.\nPress cancel to abort breaks calculation or OK to continue." ), QMessageBox::Cancel, QMessageBox::Ok ) )
+    {
+      QApplication::restoreOverrideCursor();
       return;
+    }
   }
 
   if ( methodComboBox->currentData() == ColorMode )
@@ -957,6 +966,7 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     if ( !ramp )
     {
       QMessageBox::critical( this, tr( "Apply Classification" ), tr( "No color ramp defined." ) );
+      QApplication::restoreOverrideCursor();
       return;
     }
     mRenderer->setSourceColorRamp( ramp.release() );
@@ -965,8 +975,6 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
   {
     mRenderer->setSourceColorRamp( nullptr );
   }
-
-  QApplication::setOverrideCursor( Qt::WaitCursor );
 
   mRenderer->updateClasses( mLayer, nclasses );
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -911,7 +911,7 @@ void QgsGraduatedSymbolRendererWidget::symmetryPointEditingFinished( )
 void QgsGraduatedSymbolRendererWidget::classifyGraduated()
 {
 
-  QApplication::setOverrideCursor( Qt::WaitCursor );
+  QgsTemporaryCursorOverride override( Qt::WaitCursor );
   QString attrName = mExpressionWidget->currentField();
   int nclasses = spinGraduatedClasses->value();
 
@@ -955,7 +955,6 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
   {
     if ( QMessageBox::Cancel == QMessageBox::question( this, tr( "Apply Classification" ), tr( "Natural break classification (Jenks) is O(n2) complexity, your classification may take a long time.\nPress cancel to abort breaks calculation or OK to continue." ), QMessageBox::Cancel, QMessageBox::Ok ) )
     {
-      QApplication::restoreOverrideCursor();
       return;
     }
   }
@@ -966,7 +965,6 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     if ( !ramp )
     {
       QMessageBox::critical( this, tr( "Apply Classification" ), tr( "No color ramp defined." ) );
-      QApplication::restoreOverrideCursor();
       return;
     }
     mRenderer->setSourceColorRamp( ramp.release() );
@@ -982,7 +980,6 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
     mRenderer->setSymbolSizes( minSizeSpinBox->value(), maxSizeSpinBox->value() );
 
   mRenderer->calculateLabelPrecision();
-  QApplication::restoreOverrideCursor();
   // PrettyBreaks and StdDev calculation don't generate exact
   // number of classes - leave user interface unchanged for these
   updateUiFromRenderer( false );

--- a/src/ui/qgsgraduatedsymbolrendererwidget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererwidget.ui
@@ -329,7 +329,7 @@ Negative rounds to powers of 10</string>
           </widget>
          </item>
          <item>
-          <widget class="QSpinBox" name="spinGraduatedClasses">
+          <widget class="QgsSpinBox" name="spinGraduatedClasses">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -357,7 +357,7 @@ Negative rounds to powers of 10</string>
          <property name="checkable">
           <bool>true</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0">
+         <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
           <item row="0" column="0">
            <widget class="QLabel" name="label_2">
             <property name="text">
@@ -397,7 +397,7 @@ Negative rounds to powers of 10</string>
             <string>Add class</string>
            </property>
            <property name="icon">
-            <iconset resource="../../images/images.qrc">
+            <iconset>
              <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
            </property>
           </widget>
@@ -408,7 +408,7 @@ Negative rounds to powers of 10</string>
             <string>Delete</string>
            </property>
            <property name="icon">
-            <iconset resource="../../images/images.qrc">
+            <iconset>
              <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
            </property>
           </widget>
@@ -526,6 +526,11 @@ Negative rounds to powers of 10</string>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mExpressionWidget</tabstop>
@@ -549,8 +554,6 @@ Negative rounds to powers of 10</string>
   <tabstop>btnAdvanced</tabstop>
   <tabstop>cbxLinkBoundaries</tabstop>
  </tabstops>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
... renderer widget

Fixes #31635

For the record of the underlying issue:

https://lists.qt-project.org/pipermail/interest/2013-July/007936.html
https://forum.qt.io/topic/82181/qt-doublespin-box-value-changed-slot-has-called-twice
https://forum.qt.io/topic/96094/qspinbox-value-changed-slot-has-called-twice-on-mouse-click
https://www.qtcentre.org/threads/53709-slot-valueChanged(double)-of-doubleSpinBox-called-twice-if-breakpoint-is-set
