### PR TITLE
[feature] [mesh] fix #29326 Adding playback function for mesh datasets

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshtimesettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshtimesettings.sip.in
@@ -63,6 +63,20 @@ Returns number of offset hours for relative time formatting
 Sets number of offset hours for relative time formatting
 %End
 
+    double datasetPlaybackInterval() const;
+%Docstring
+Returns number of seconds used as interval for dataset playback
+
+.. versionadded:: 3.12
+%End
+
+    void setDatasetPlaybackInterval( double seconds );
+%Docstring
+Sets number of seconds used as interval for dataset playback
+
+.. versionadded:: 3.12
+%End
+
     QString relativeTimeFormat() const;
 %Docstring
 Returns format used for relative time

--- a/python/core/auto_generated/mesh/qgsmeshtimesettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshtimesettings.sip.in
@@ -63,20 +63,6 @@ Returns number of offset hours for relative time formatting
 Sets number of offset hours for relative time formatting
 %End
 
-    double datasetPlaybackInterval() const;
-%Docstring
-Returns number of seconds used as interval for dataset playback
-
-.. versionadded:: 3.12
-%End
-
-    void setDatasetPlaybackInterval( double seconds );
-%Docstring
-Sets number of seconds used as interval for dataset playback
-
-.. versionadded:: 3.12
-%End
-
     QString relativeTimeFormat() const;
 %Docstring
 Returns format used for relative time

--- a/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
+++ b/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
@@ -21,6 +21,7 @@
 #include "qgsmeshdataprovider.h"
 
 #include <QWidget>
+#include <QIcon>
 
 class QgsMeshLayer;
 
@@ -39,7 +40,7 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
   public:
 
     /**
-     * A widget to hold the renderer scalar settings for a mesh layer.
+    mTimeComboBox->setCurrentIndex( mTimeComboBox->count() - 1 );     * A widget to hold the renderer scalar settings for a mesh layer.
      * \param parent Parent object
      */
     QgsMeshRendererActiveDatasetWidget( QWidget *parent = nullptr );
@@ -82,7 +83,8 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
     void onPreviousTimeClicked();
     void onNextTimeClicked();
     void onLastTimeClicked();
-
+    void onDatasetPlaybackClicked();
+    void datasetPlaybackTick();
     QString metadata( QgsMeshDatasetIndex datasetIndex );
 
   private:
@@ -99,6 +101,8 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
     int mActiveVectorDatasetGroup = -1;
     QgsMeshDatasetIndex mActiveScalarDataset;
     QgsMeshDatasetIndex mActiveVectorDataset;
+    bool mDatasetIsPlaying = false;
+    QTimer *mDatasetPlaybackTimer = nullptr;
 };
 
 #endif // QGSMESHRENDERERSCALARSETTINGSWIDGET_H

--- a/src/app/mesh/qgsmeshtimeformatdialog.cpp
+++ b/src/app/mesh/qgsmeshtimeformatdialog.cpp
@@ -32,9 +32,12 @@ QgsMeshTimeFormatDialog::QgsMeshTimeFormatDialog( QgsMeshLayer *meshLayer, QWidg
 
   connect( mUseTimeComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
   connect( mReferenceDateTimeEdit, &QDateTimeEdit::timeChanged, this, &QgsMeshTimeFormatDialog::saveSettings );
-  connect( mAbsoluteTimeFormatComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );  connect( mUseTimeComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
+  connect( mAbsoluteTimeFormatComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
+  connect( mUseTimeComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
   connect( mRelativeTimeFormatComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
   connect( mOffsetHoursSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
+  connect( mPlaybackIntervalSpinBox, qgis::overload<double>::of( &QDoubleSpinBox::valueChanged ), this, &QgsMeshTimeFormatDialog::saveSettings );
+
 }
 
 void QgsMeshTimeFormatDialog::loadSettings()
@@ -71,6 +74,7 @@ void QgsMeshTimeFormatDialog::loadSettings()
   mRelativeTimeFormatComboBox->setCurrentIndex( index );
 
   mOffsetHoursSpinBox->setValue( settings.relativeTimeOffsetHours() );
+  mPlaybackIntervalSpinBox->setValue( settings.datasetPlaybackInterval() );
 }
 
 void QgsMeshTimeFormatDialog::saveSettings()
@@ -81,6 +85,7 @@ void QgsMeshTimeFormatDialog::saveSettings()
   settings.setAbsoluteTimeFormat( mAbsoluteTimeFormatComboBox->currentText() );
   settings.setRelativeTimeOffsetHours( mOffsetHoursSpinBox->value() );
   settings.setRelativeTimeFormat( mRelativeTimeFormatComboBox->currentText() );
+  settings.setDatasetPlaybackInterval( mPlaybackIntervalSpinBox->value() );
   enableGroups( settings.useAbsoluteTime() ) ;
   mLayer->setTimeSettings( settings );
 }

--- a/src/core/mesh/qgsmeshtimesettings.cpp
+++ b/src/core/mesh/qgsmeshtimesettings.cpp
@@ -74,6 +74,16 @@ void QgsMeshTimeSettings::setRelativeTimeOffsetHours( double relativeTimeOffsetH
   mRelativeTimeOffsetHours = relativeTimeOffsetHours;
 }
 
+double QgsMeshTimeSettings::datasetPlaybackInterval() const
+{
+  return mDatasetPlaybackIntervalSec;
+}
+
+void QgsMeshTimeSettings::setDatasetPlaybackInterval( double seconds )
+{
+  mDatasetPlaybackIntervalSec = seconds;
+}
+
 QString QgsMeshTimeSettings::relativeTimeFormat() const
 {
   return mRelativeTimeFormat;

--- a/src/core/mesh/qgsmeshtimesettings.h
+++ b/src/core/mesh/qgsmeshtimesettings.h
@@ -57,6 +57,18 @@ class CORE_EXPORT QgsMeshTimeSettings
     //! Sets number of offset hours for relative time formatting
     void setRelativeTimeOffsetHours( double relativeTimeOffsetHours );
 
+    /**
+     * Returns number of seconds used as interval for dataset playback
+     * \since QGIS 3.12
+     */
+    double datasetPlaybackInterval() const;
+
+    /**
+     * Sets number of seconds used as interval for dataset playback
+     * \since QGIS 3.12
+     */
+    void setDatasetPlaybackInterval( double seconds );
+
     //! Returns format used for relative time
     QString relativeTimeFormat() const;
     //! Sets format used for relative time
@@ -76,6 +88,7 @@ class CORE_EXPORT QgsMeshTimeSettings
     bool mUseAbsoluteTime = false;
 
     double mRelativeTimeOffsetHours = 0;
+    double mDatasetPlaybackIntervalSec = 3;
     QString mRelativeTimeFormat = QStringLiteral( "d hh:mm:ss" );
 
     QDateTime mAbsoluteTimeReferenceTime;

--- a/src/core/mesh/qgsmeshtimesettings.h
+++ b/src/core/mesh/qgsmeshtimesettings.h
@@ -61,13 +61,13 @@ class CORE_EXPORT QgsMeshTimeSettings
      * Returns number of seconds used as interval for dataset playback
      * \since QGIS 3.12
      */
-    double datasetPlaybackInterval() const;
+    double datasetPlaybackInterval() const; SIP_SKIP
 
     /**
      * Sets number of seconds used as interval for dataset playback
      * \since QGIS 3.12
      */
-    void setDatasetPlaybackInterval( double seconds );
+    void setDatasetPlaybackInterval( double seconds ); SIP_SKIP
 
     //! Returns format used for relative time
     QString relativeTimeFormat() const;

--- a/src/ui/mesh/qgsmeshrendereractivedatasetwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendereractivedatasetwidgetbase.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>292</width>
+    <width>296</width>
     <height>337</height>
    </rect>
   </property>
@@ -36,6 +36,29 @@
    </item>
    <item>
     <layout class="QGridLayout" name="mTimeLayout">
+     <item row="2" column="5">
+      <widget class="QToolButton" name="mFirstDatasetButton">
+       <property name="text">
+        <string>|&lt;</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="9">
+      <widget class="QSlider" name="mDatasetSlider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="tickPosition">
+        <enum>QSlider::TicksBelow</enum>
+       </property>
+       <property name="tickInterval">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="0" colspan="2">
       <widget class="QComboBox" name="mTimeComboBox">
        <property name="editable">
@@ -46,7 +69,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="5">
+     <item row="2" column="7">
       <widget class="QToolButton" name="mNextDatasetButton">
        <property name="text">
         <string>&gt;</string>
@@ -56,17 +79,24 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="4">
-      <widget class="QToolButton" name="mPreviousDatasetButton">
+     <item row="2" column="3">
+      <widget class="QToolButton" name="mTimeFormatButton">
+       <property name="toolTip">
+        <string>Time Format Options</string>
+       </property>
        <property name="text">
-        <string>&lt;</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>:/images/themes/default/console/iconSettingsConsole.svg</normaloff>:/images/themes/default/console/iconSettingsConsole.svg</iconset>
        </property>
        <property name="autoRaise">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="2" column="6">
+     <item row="2" column="8">
       <widget class="QToolButton" name="mLastDatasetButton">
        <property name="text">
         <string>&gt;|</string>
@@ -76,43 +106,23 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
-      <widget class="QToolButton" name="mFirstDatasetButton">
+     <item row="2" column="6">
+      <widget class="QToolButton" name="mPreviousDatasetButton">
        <property name="text">
-        <string>|&lt;</string>
+        <string>&lt;</string>
        </property>
        <property name="autoRaise">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
-      <widget class="QToolButton" name="mTimeFormatButton">
-       <property name="toolTip">
-        <string>Time Format Options</string>
-       </property>
+     <item row="2" column="4">
+      <widget class="QToolButton" name="mDatasetPlaybackButton">
        <property name="text">
-        <string notr="true"/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../../images/images.qrc">
-         <normaloff>:/images/themes/default/console/iconSettingsConsole.svg</normaloff>:/images/themes/default/console/iconSettingsConsole.svg</iconset>
+        <string/>
        </property>
        <property name="autoRaise">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="7">
-      <widget class="QSlider" name="mDatasetSlider">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="tickPosition">
-        <enum>QSlider::TicksBelow</enum>
-       </property>
-       <property name="tickInterval">
-        <number>1</number>
        </property>
       </widget>
      </item>
@@ -152,8 +162,6 @@
    <header>mesh/qgsmeshdatasetgrouptreeview.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/ui/mesh/qgsmeshtimeformatdialog.ui
+++ b/src/ui/mesh/qgsmeshtimeformatdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>271</width>
-    <height>382</height>
+    <height>460</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -235,6 +235,47 @@
              <string>ss</string>
             </property>
            </item>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="mDatasetPlaybackGroupBox">
+     <property name="title">
+      <string>Dataset playback</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="QWidget" name="widget_3" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Interval</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="mPlaybackIntervalSpinBox">
+           <property name="suffix">
+            <string> sec</string>
+           </property>
+           <property name="decimals">
+            <number>1</number>
+           </property>
+           <property name="minimum">
+            <double>1.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10.000000000000000</double>
+           </property>
+           <property name="value">
+            <double>3.000000000000000</double>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
![dataset_animation](https://user-images.githubusercontent.com/55395434/65317179-9bb11b80-db9b-11e9-99a0-9c1e72edb2fd.gif)
- QgsMeshRendererActiveDatasetWidget: 
1) Added Play/Stop button to start stop dataset playback.
2) Qt icons added for buttons controlling displayed dataset frame, so they match added Play/Stop button

- QgsMeshTimeFormatDialog:
1) Added double spin box to control the interval for the dataset playback

- QgsMeshTimeSettings
1) Added double interval variable to hold playback interval value + apropriate set/get functions