### PR TITLE
[processing] add default icon for scripts created using decorator (fix #31252)

### DIFF
--- a/python/processing/algfactory.py
+++ b/python/processing/algfactory.py
@@ -69,7 +69,8 @@ from qgis.core import (QgsProcessingParameterDefinition,
                        QgsProcessingOutputNumber,
                        QgsProcessingOutputRasterLayer,
                        QgsProcessingOutputVectorLayer,
-                       QgsMessageLog)
+                       QgsMessageLog,
+                       QgsApplication)
 
 
 def _log(*args, **kw):
@@ -134,7 +135,7 @@ class AlgWrapper(QgsProcessingAlgorithm):
             raise NotImplementedError()
 
     # Wrapper logic
-    def define(self, name, label, group, group_label, help=None, icon=None):
+    def define(self, name, label, group, group_label, help=None, icon=QgsApplication.iconPath("processingScript.svg")):
         self._name = name
         self._display = label
         self._group = group_label


### PR DESCRIPTION
## Description
Adds missed default icon to scripts created using decorators. Fixes #31252.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment