### PR TITLE
[layout] Fix invalid svg exports when including metadata

### DIFF
--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -635,6 +635,7 @@ class TestQgsLayoutExporter(unittest.TestCase):
             self.assertEqual('proj abstract' in open(f).read(), expected)
             self.assertEqual('kw1' in open(f).read(), expected)
             self.assertEqual('kw2' in open(f).read(), expected)
+            self.assertEqual('xmlns:cc="http://creativecommons.org/ns#"' in open(f).read(), expected)
 
         for f in [svg_file_path, svg_file_path_2]:
             checkMetadata(f, True)


### PR DESCRIPTION
The generated svgs with cc:Work elements were failing xml validation,
causing illustrator to reject them. Add the required ns for cc:Work
and also adapt the svg metadata to be compatible both with the svg
spec AND the metadata format Inkscape uses.

Fixes #28130
