### PR TITLE
Allow to collapse the GeoPdf options when exporting to pdf

### DIFF
--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -64,7 +64,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="mGeoPDFGroupBox">
+    <widget class="QgsCollapsibleGroupBoxBasic" name="mGeoPDFGroupBox">
      <property name="title">
       <string>Create Geospatial PDF (GeoPDF)</string>
      </property>

--- a/src/ui/qgsmapsavedialog.ui
+++ b/src/ui/qgsmapsavedialog.ui
@@ -57,7 +57,7 @@
       </widget>
      </item>
      <item row="9" column="0" colspan="2">
-      <widget class="QGroupBox" name="mGeoPDFGroupBox">
+      <widget class="QgsCollapsibleGroupBoxBasic" name="mGeoPDFGroupBox">
        <property name="title">
         <string>Create Geospatial PDF (GeoPDF)</string>
        </property>
@@ -369,6 +369,12 @@ Rasterizing the map is recommended when such effects are used.</string>
  <customwidgets>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>


### PR DESCRIPTION
When available these options take too much space if you do not need them. 
## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
