### PR TITLE
[categorized][graduated] Handle categorized<->graduated renderer conversion

### DIFF
--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -336,6 +336,7 @@ the categories' color.
 .. seealso:: :py:func:`sourceColorRamp`
 %End
 
+
     void setSourceSymbol( QgsSymbol *sym /Transfer/ );
 %Docstring
 Sets the source symbol for the renderer, which is the base symbol used for the each categories' symbol before applying
@@ -356,6 +357,7 @@ Returns the source color ramp, from which each categories' color is derived.
 
 .. seealso:: :py:func:`sourceSymbol`
 %End
+
 
     void setSourceColorRamp( QgsColorRamp *ramp /Transfer/ );
 %Docstring

--- a/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -347,6 +347,7 @@ the classes' color.
 .. seealso:: :py:func:`sourceColorRamp`
 %End
 
+
     void setSourceSymbol( QgsSymbol *sym /Transfer/ );
 %Docstring
 Sets the source symbol for the renderer, which is the base symbol used for the each classes' symbol before applying
@@ -367,6 +368,7 @@ Returns the source color ramp, from which each classes' color is derived.
 
 .. seealso:: :py:func:`sourceSymbol`
 %End
+
 
     void setSourceColorRamp( QgsColorRamp *ramp /Transfer/ );
 %Docstring

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -20,6 +20,7 @@
 #include "qgssymbol.h"
 #include "qgssymbollayerutils.h"
 #include "qgscolorramp.h"
+#include "qgsgraduatedsymbolrenderer.h"
 #include "qgspointdisplacementrenderer.h"
 #include "qgsinvertedpolygonrenderer.h"
 #include "qgspainteffect.h"
@@ -953,12 +954,23 @@ QgsSymbol *QgsCategorizedSymbolRenderer::sourceSymbol()
 {
   return mSourceSymbol.get();
 }
+
+const QgsSymbol *QgsCategorizedSymbolRenderer::sourceSymbol() const
+{
+  return mSourceSymbol.get();
+}
+
 void QgsCategorizedSymbolRenderer::setSourceSymbol( QgsSymbol *sym )
 {
   mSourceSymbol.reset( sym );
 }
 
 QgsColorRamp *QgsCategorizedSymbolRenderer::sourceColorRamp()
+{
+  return mSourceColorRamp.get();
+}
+
+const QgsColorRamp *QgsCategorizedSymbolRenderer::sourceColorRamp() const
 {
   return mSourceColorRamp.get();
 }
@@ -1038,22 +1050,36 @@ void QgsCategorizedSymbolRenderer::checkLegendSymbolItem( const QString &key, bo
 
 QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )
 {
-  QgsCategorizedSymbolRenderer *r = nullptr;
+  std::unique_ptr< QgsCategorizedSymbolRenderer > r;
   if ( renderer->type() == QLatin1String( "categorizedSymbol" ) )
   {
-    r = dynamic_cast<QgsCategorizedSymbolRenderer *>( renderer->clone() );
+    r.reset( static_cast<QgsCategorizedSymbolRenderer *>( renderer->clone() ) );
+  }
+  else if ( renderer->type() == QLatin1String( "graduatedSymbol" ) )
+  {
+    const QgsGraduatedSymbolRenderer *graduatedSymbolRenderer = dynamic_cast<const QgsGraduatedSymbolRenderer *>( renderer );
+    if ( graduatedSymbolRenderer )
+    {
+      r.reset( new QgsCategorizedSymbolRenderer( QString(), QgsCategoryList() ) );
+      r->setSourceSymbol( graduatedSymbolRenderer->sourceSymbol()->clone() );
+      if ( graduatedSymbolRenderer->sourceColorRamp() )
+      {
+        r->setSourceColorRamp( graduatedSymbolRenderer->sourceColorRamp()->clone() );
+      }
+      r->setClassAttribute( graduatedSymbolRenderer->classAttribute() );
+    }
   }
   else if ( renderer->type() == QLatin1String( "pointDisplacement" ) || renderer->type() == QLatin1String( "pointCluster" ) )
   {
     const QgsPointDistanceRenderer *pointDistanceRenderer = dynamic_cast<const QgsPointDistanceRenderer *>( renderer );
     if ( pointDistanceRenderer )
-      r = convertFromRenderer( pointDistanceRenderer->embeddedRenderer() );
+      r.reset( convertFromRenderer( pointDistanceRenderer->embeddedRenderer() ) );
   }
   else if ( renderer->type() == QLatin1String( "invertedPolygonRenderer" ) )
   {
     const QgsInvertedPolygonRenderer *invertedPolygonRenderer = dynamic_cast<const QgsInvertedPolygonRenderer *>( renderer );
     if ( invertedPolygonRenderer )
-      r = convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
+      r.reset( convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() ) );
   }
 
   // If not one of the specifically handled renderers, then just grab the symbol from the renderer
@@ -1061,7 +1087,7 @@ QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer(
 
   if ( !r )
   {
-    r = new QgsCategorizedSymbolRenderer( QString(), QgsCategoryList() );
+    r = qgis::make_unique< QgsCategorizedSymbolRenderer >( QString(), QgsCategoryList() );
     QgsRenderContext context;
     QgsSymbolList symbols = const_cast<QgsFeatureRenderer *>( renderer )->symbols( context );
     if ( !symbols.isEmpty() )
@@ -1073,7 +1099,7 @@ QgsCategorizedSymbolRenderer *QgsCategorizedSymbolRenderer::convertFromRenderer(
   r->setOrderBy( renderer->orderBy() );
   r->setOrderByEnabled( renderer->orderByEnabled() );
 
-  return r;
+  return r.release();
 }
 
 void QgsCategorizedSymbolRenderer::setDataDefinedSizeLegend( QgsDataDefinedSizeLegend *settings )

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -324,6 +324,15 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     QgsSymbol *sourceSymbol();
 
     /**
+     * Returns the renderer's source symbol, which is the base symbol used for the each categories' symbol before applying
+     * the categories' color.
+     * \see setSourceSymbol()
+     * \see sourceColorRamp()
+     * \note Not available in Python bindings.
+     */
+    const QgsSymbol *sourceSymbol() const SIP_SKIP;
+
+    /**
      * Sets the source symbol for the renderer, which is the base symbol used for the each categories' symbol before applying
      * the categories' color.
      * \param sym source symbol, ownership is transferred to the renderer
@@ -338,6 +347,14 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      * \see sourceSymbol()
      */
     QgsColorRamp *sourceColorRamp();
+
+    /**
+     * Returns the source color ramp, from which each categories' color is derived.
+     * \see setSourceColorRamp()
+     * \see sourceSymbol()
+     * \note Not available in Python bindings.
+     */
+    const QgsColorRamp *sourceColorRamp() const SIP_SKIP;
 
     /**
      * Sets the source color ramp.

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -301,6 +301,15 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
     QgsSymbol *sourceSymbol();
 
     /**
+     * Returns the renderer's source symbol, which is the base symbol used for the each classes' symbol before applying
+     * the classes' color.
+     * \see setSourceSymbol()
+     * \see sourceColorRamp()
+     * \note Not available in Python bindings.
+     */
+    const QgsSymbol *sourceSymbol() const SIP_SKIP;
+
+    /**
      * Sets the source symbol for the renderer, which is the base symbol used for the each classes' symbol before applying
      * the classes' color.
      * \param sym source symbol, ownership is transferred to the renderer
@@ -315,6 +324,14 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      * \see sourceSymbol()
      */
     QgsColorRamp *sourceColorRamp();
+
+    /**
+     * Returns the source color ramp, from which each classes' color is derived.
+     * \see setSourceColorRamp()
+     * \see sourceSymbol()
+     * \note Not available in Python bindings.
+     */
+    const QgsColorRamp *sourceColorRamp() const SIP_SKIP;
 
     /**
      * Sets the source color ramp.


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR fixes #31633, whereas switching from categorized<->graduated (and vice-versa) renderers was not retaining relevant information such as attribute/expression and color ramp.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
