### PR TITLE
[legends] Fix missing symbols for inverted polygon layers when using filter by map content

### DIFF
--- a/python/core/auto_generated/symbology/qgsinvertedpolygonrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsinvertedpolygonrenderer.sip.in
@@ -86,6 +86,8 @@ Features collected during renderFeature() are rendered using the embedded featur
 
     virtual QgsSymbolList originalSymbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
 
+    virtual QSet< QString > legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
+
     virtual QgsLegendSymbolList legendSymbolItems() const;
 
     virtual bool willRenderFeature( const QgsFeature &feature, QgsRenderContext &context ) const;

--- a/src/core/symbology/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.cpp
@@ -465,6 +465,13 @@ QgsSymbolList QgsInvertedPolygonRenderer::originalSymbolsForFeature( const QgsFe
   return mSubRenderer->originalSymbolsForFeature( feature, context );
 }
 
+QSet<QString> QgsInvertedPolygonRenderer::legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const
+{
+  if ( !mSubRenderer )
+    return QSet<QString>();
+  return mSubRenderer->legendKeysForFeature( feature, context );
+}
+
 QgsSymbolList QgsInvertedPolygonRenderer::symbols( QgsRenderContext &context ) const
 {
   if ( !mSubRenderer )

--- a/src/core/symbology/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology/qgsinvertedpolygonrenderer.h
@@ -84,6 +84,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRenderer
     QgsSymbol *originalSymbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
     QgsSymbolList symbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
     QgsSymbolList originalSymbolsForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
+    QSet< QString > legendKeysForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
     QgsLegendSymbolList legendSymbolItems() const override;
     bool willRenderFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
 


### PR DESCRIPTION
Fixes #22718
