### PR TITLE
[georeferencer] set target CRS when generating GDAL script (fix #31353)

### DIFF
--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1897,6 +1897,15 @@ QString QgsGeorefPluginGui::generateGDALwarpCommand( const QString &resampling, 
     gdalCommand << QStringLiteral( "-tr" ) << QString::number( targetResX, 'f' ) << QString::number( targetResY, 'f' );
   }
 
+  if ( mProjection.authid().startsWith( QStringLiteral( "EPSG:" ), Qt::CaseInsensitive ) )
+  {
+    gdalCommand << QStringLiteral( "-t_srs %1" ).arg( mProjection.authid() );
+  }
+  else
+  {
+    gdalCommand << QStringLiteral( "-t_srs \"%1\"" ).arg( mProjection.toProj4().simplified() );
+  }
+
   gdalCommand << QStringLiteral( "\"%1\"" ).arg( mTranslatedRasterFileName ) << QStringLiteral( "\"%1\"" ).arg( mModifiedRasterFileName );
 
   return gdalCommand.join( QStringLiteral( " " ) );


### PR DESCRIPTION
## Description
Georeferencer plugin does not set target CRS in the generated GDAL script. As result script produces raster without correct CRS. At the same time georeferencing raster using plugin creates raster with correct target CRS.

Fixes #31353.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
