### PR TITLE
Block the events while showing a dialog

### DIFF
--- a/python/gui/auto_generated/qgsexternalresourcewidget.sip.in
+++ b/python/gui/auto_generated/qgsexternalresourcewidget.sip.in
@@ -141,6 +141,10 @@ is set to QgsFileWidget.RelativeDefaultPath.
 emitteed as soon as the current document changes
 %End
 
+  protected:
+    virtual bool eventFilter( QObject *watched, QEvent *event );
+
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsfilewidget.sip.in
+++ b/python/gui/auto_generated/qgsfilewidget.sip.in
@@ -189,6 +189,7 @@ the appearance and behavior of the line edit portion of the widget.
 emitted as soon as the current file or directory is changed
 %End
 
+
 };
 
 

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -175,8 +175,7 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget *editor )
     }
     if ( cfg.contains( QStringLiteral( "FileWidgetButton" ) ) )
     {
-      // Prevent from showing the button in the attribute table, see https://github.com/qgis/QGIS/issues/26948
-      mQgsWidget->fileWidget()->setFileWidgetButtonVisible( cfg.value( QStringLiteral( "FileWidgetButton" ) ).toBool() && context().formMode() != QgsAttributeEditorContext::Popup );
+      mQgsWidget->fileWidget()->setFileWidgetButtonVisible( cfg.value( QStringLiteral( "FileWidgetButton" ) ).toBool() );
     }
     if ( cfg.contains( QStringLiteral( "DocumentViewer" ) ) )
     {

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -55,6 +55,17 @@ QgsExternalResourceWidget::QgsExternalResourceWidget( QWidget *parent )
 
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsExternalResourceWidget::loadDocument );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsExternalResourceWidget::valueChanged );
+  connect( mFileWidget, &QgsFileWidget::blockEvents, this, [this]( bool block )
+  {
+    if ( block )
+    {
+      installEventFilter( this );
+    }
+    else
+    {
+      removeEventFilter( this );
+    }
+  } );
 }
 
 QVariant QgsExternalResourceWidget::documentPath( QVariant::Type type ) const
@@ -194,6 +205,15 @@ void QgsExternalResourceWidget::setDefaultRoot( const QString &defaultRoot )
   mDefaultRoot = defaultRoot;
 }
 
+bool QgsExternalResourceWidget::eventFilter( QObject *watched, QEvent *event )
+{
+  if ( watched == this && event && ( event->type() == QEvent::FocusOut ||  event->type() == QEvent::FocusAboutToChange ) )
+  {
+    return true;
+  }
+  return QWidget::eventFilter( watched, event );
+}
+
 QgsFileWidget::RelativeStorage QgsExternalResourceWidget::relativeStorage() const
 {
   return mRelativeStorage;
@@ -246,5 +266,3 @@ void QgsExternalResourceWidget::loadDocument( const QString &path )
     }
   }
 }
-
-

--- a/src/gui/qgsexternalresourcewidget.h
+++ b/src/gui/qgsexternalresourcewidget.h
@@ -147,6 +147,10 @@ class GUI_EXPORT QgsExternalResourceWidget : public QWidget
     //! emitteed as soon as the current document changes
     void valueChanged( const QString & );
 
+  protected:
+    // Needed to block events when showing a dialog
+    bool eventFilter( QObject *watched, QEvent *event ) override;
+
   private slots:
     void loadDocument( const QString &path );
 

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -255,6 +255,7 @@ void QgsFileWidget::openFileDialog()
   QStringList fileNames;
   QString title;
 
+  emit blockEvents( true );
   switch ( mStorageMode )
   {
     case GetFile:
@@ -287,6 +288,7 @@ void QgsFileWidget::openFileDialog()
     }
     break;
   }
+  emit blockEvents( false );
 
   if ( fileName.isEmpty() && fileNames.isEmpty( ) )
     return;

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -184,6 +184,14 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     //! emitted as soon as the current file or directory is changed
     void fileChanged( const QString & );
 
+    /**
+     * Emitted before and after showing the file dialog.
+     *
+     * \note not available in Python bindings
+     * \since QGIS 3.10
+     */
+    void blockEvents( bool ) SIP_SKIP;
+
   private slots:
     void openFileDialog();
     void textEdited( const QString &path );


### PR DESCRIPTION
When showing a file dialog, Qt can choose to use the "system" file
dialog, which will make QgsExternalResourceWidget to loose the focus.
This patch blocks all the events that are sent to
QgsExternalResourceWidget while a dialog is shown, this way it will keep
the focus until the dialog is closed.

Fixes: #26948

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
