### PR TITLE
Do not use QString::fromAscii

### DIFF
--- a/src/core/providers/ogr/qgsgeopackageprojectstorage.cpp
+++ b/src/core/providers/ogr/qgsgeopackageprojectstorage.cpp
@@ -248,7 +248,7 @@ bool QgsGeoPackageProjectStorage::writeProject( const QString &uri, QIODevice *d
   }
   sql = sql.arg( QgsSqliteUtils::quotedIdentifier( projectUri.projectName ),
                  QgsSqliteUtils::quotedValue( metadataExpr ),
-                 QgsSqliteUtils::quotedValue( QString::fromAscii( content.toHex() ) )
+                 QgsSqliteUtils::quotedValue( QString::fromLatin1( content.toHex() ) )
                );
 
   errCause = _executeSql( projectUri.database, sql );

--- a/src/providers/postgres/qgspostgresprojectstorage.cpp
+++ b/src/providers/postgres/qgspostgresprojectstorage.cpp
@@ -183,7 +183,7 @@ bool QgsPostgresProjectStorage::writeProject( const QString &uri, QIODevice *dev
                  QgsPostgresConn::quotedValue( projectUri.projectName ),
                  metadataExpr  // no need to quote: already quoted
                );
-  sql += QString::fromAscii( content.toHex() );
+  sql += QString::fromLatin1( content.toHex() );
   sql += "') ON CONFLICT (name) DO UPDATE SET content = EXCLUDED.content, metadata = EXCLUDED.metadata;";
 
   QgsPostgresResult res( conn->PQexec( sql ) );


### PR DESCRIPTION
QString::fromAscii is obsolete.
The encoding doesn't matter, hex strings are 7-bit ascii.
