### PR TITLE
Fix Server OPENAPI validation and unreported QStringList to JSON conversion error

### DIFF
--- a/resources/server/api/ogc/schema.json
+++ b/resources/server/api/ogc/schema.json
@@ -264,7 +264,7 @@
       "limit" : {
         "name" : "limit",
         "in" : "query",
-        "description" : "The optional limit parameter limits the number of items that are presented in the response document.\\\nOnly items are counted that are on the first level of the collection in the response document.  Nested objects contained within the explicitly requested items shall not be counted.\\\nMinimum = 1.\\\nMaximum = 10000.\\\nDefault = 10.",
+        "description" : "The optional limit parameter limits the number of items that are presented in the response document.\nOnly items are counted that are on the first level of the collection in the response document.  Nested objects contained within the explicitly requested items shall not be counted.\nMinimum = 1.\nMaximum = 10000.\nDefault = 10.",
         "required" : false,
         "style" : "form",
         "explode" : false,
@@ -279,7 +279,7 @@
       "offset" : {
         "name" : "offset",
         "in" : "query",
-        "description" : "The optional offset parameter indicates the index within the result set from which the server shall begin presenting results in the response document. The first element has an index of 0.\\\nMinimum = 0.\\\nDefault = 0.",
+        "description" : "The optional offset parameter indicates the index within the result set from which the server shall begin presenting results in the response document. The first element has an index of 0.\nMinimum = 0.\nDefault = 0.",
         "required" : false,
         "style" : "form",
         "explode" : false,
@@ -320,7 +320,7 @@
       "resultType" : {
         "name" : "resultType",
         "in" : "query",
-        "description" : "This service will respond to a query in one of two ways (excluding an exception response). It may either generate a complete response document containing resources that satisfy the operation or it may simply generate an empty response container that indicates the count of the total number of resources that the operation would return. Which of these two responses is generated is determined by the value of the optional resultType parameter.\\\nThe allowed values for this parameter are \"results\" and \"hits\".\\\nIf the value of the resultType parameter is set to \"results\", the server will generate a complete response document containing resources that satisfy the operation.\\\nIf the value of the resultType attribute is set to \"hits\", the server will generate an empty response document containing no resource instances.\\\nDefault = \"results\".",
+        "description" : "This service will respond to a query in one of two ways (excluding an exception response). It may either generate a complete response document containing resources that satisfy the operation or it may simply generate an empty response container that indicates the count of the total number of resources that the operation would return. Which of these two responses is generated is determined by the value of the optional resultType parameter.\nThe allowed values for this parameter are \"results\" and \"hits\".\nIf the value of the resultType parameter is set to \"results\", the server will generate a complete response document containing resources that satisfy the operation.\nIf the value of the resultType attribute is set to \"hits\", the server will generate an empty response document containing no resource instances.\nDefault = \"results\".",
         "required" : false,
         "style" : "form",
         "explode" : false,

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -395,18 +395,18 @@ json QgsJsonUtils::jsonFromVariant( const QVariant &val )
   json j;
   if ( val.type() == QVariant::Type::Map )
   {
-    const auto vMap = val.toMap();
-    auto jMap = json::object();
+    const QVariantMap &vMap = val.toMap();
+    json jMap = json::object();
     for ( auto it = vMap.constBegin(); it != vMap.constEnd(); it++ )
     {
       jMap[ it.key().toStdString() ] = jsonFromVariant( it.value() );
     }
     j = jMap;
   }
-  else if ( val.type() == QVariant::Type::List )
+  else if ( val.type() == QVariant::Type::List || val.type() == QVariant::Type::StringList )
   {
-    const auto vList = val.toList();
-    auto jList = json::array();
+    const QVariantList &vList = val.toList();
+    json jList = json::array();
     for ( const auto &v : vList )
     {
       jList.push_back( jsonFromVariant( v ) );

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -78,7 +78,7 @@ QList<QgsServerOgcApi::ContentType> QgsServerOgcApiHandler::contentTypes() const
 
 void QgsServerOgcApiHandler::handleRequest( const QgsServerApiContext &context ) const
 {
-  Q_UNUSED( context );
+  Q_UNUSED( context )
   throw QgsServerApiNotImplementedException( QStringLiteral( "Subclasses must implement handleRequest" ) );
 }
 
@@ -170,9 +170,13 @@ std::string QgsServerOgcApiHandler::href( const QgsServerApiContext &context, co
 
 void QgsServerOgcApiHandler::jsonDump( json &data, const QgsServerApiContext &context, const QString &contentType ) const
 {
-  QDateTime time { QDateTime::currentDateTime() };
-  time.setTimeSpec( Qt::TimeSpec::UTC );
-  data["timeStamp"] = time.toString( Qt::DateFormat::ISODate ).toStdString() ;
+  // Do not append timestamp to openapi
+  if ( contentType != QgsServerOgcApi::contentTypeMimes().value( QgsServerOgcApi::ContentType::OPENAPI3 ) )
+  {
+    QDateTime time { QDateTime::currentDateTime() };
+    time.setTimeSpec( Qt::TimeSpec::UTC );
+    data["timeStamp"] = time.toString( Qt::DateFormat::ISODate ).toStdString() ;
+  }
   context.response()->setStatusCode( 200 );
   context.response()->setHeader( QStringLiteral( "Content-Type" ), contentType );
 #ifdef QGISDEBUG
@@ -184,7 +188,7 @@ void QgsServerOgcApiHandler::jsonDump( json &data, const QgsServerApiContext &co
 
 json QgsServerOgcApiHandler::schema( const QgsServerApiContext &context ) const
 {
-  Q_UNUSED( context );
+  Q_UNUSED( context )
   return nullptr;
 }
 
@@ -478,27 +482,23 @@ json QgsServerOgcApiHandler::defaultResponse()
 {
   static json defRes =
   {
+    { "description", "An error occurred." },
     {
-      "default", {
-        { "description", "An error occurred." },
+      "content", {
         {
-          "content", {
+          "application/json", {
             {
-              "application/json", {
-                {
-                  "schema", {
-                    { "$ref", "#/components/schemas/exception" }
-                  }
-                },
-                {
-                  "text/html", {
-                    {
-                      "schema", {
-                        { "type", "string" }
-                      }
-                    }
-                  }
-                }
+              "schema", {
+                { "$ref", "#/components/schemas/exception" }
+              }
+            }
+          }
+        },
+        {
+          "text/html", {
+            {
+              "schema", {
+                { "type", "string" }
               }
             }
           }

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -60,7 +60,6 @@ void QgsWfs3APIHandler::handleRequest( const QgsServerApiContext &context ) cons
   const QgsProjectMetadata metadata { context.project()->metadata() };
   json data
   {
-    { "links", links( context ) },
     { "openapi", "3.0.1" },
     {
       "tags", {{
@@ -98,8 +97,6 @@ void QgsWfs3APIHandler::handleRequest( const QgsServerApiContext &context ) cons
       }
     }
   };
-
-  assert( data.is_object() );
 
   // Gather path information from handlers
   json paths = json::array();
@@ -147,7 +144,7 @@ void QgsWfs3APIHandler::handleRequest( const QgsServerApiContext &context ) cons
 json QgsWfs3APIHandler::schema( const QgsServerApiContext &context ) const
 {
   json data;
-  const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "api" ), context.request()->url() ).toStdString() };
+  const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/api" ), context.request()->url() ).toStdString() };
   data[ path ] =
   {
     {
@@ -185,7 +182,7 @@ json QgsWfs3APIHandler::schema( const QgsServerApiContext &context ) const
                 }
               }
             },
-            defaultResponse()
+            { "default", defaultResponse() }
           }
         }
       }
@@ -326,7 +323,7 @@ json QgsWfs3LandingPageHandler::schema( const QgsServerApiContext &context ) con
                     {
                       "application/json", {
                         {
-                          "schema",  {
+                          "schema", {
                             { "$ref", "#/components/schemas/root" }
                           }
                         }
@@ -345,7 +342,7 @@ json QgsWfs3LandingPageHandler::schema( const QgsServerApiContext &context ) con
                 }
               }
             },
-            defaultResponse()
+            { "default", defaultResponse() }
           }
         }
       }
@@ -420,7 +417,7 @@ json QgsWfs3ConformanceHandler::schema( const QgsServerApiContext &context ) con
                 }
               }
             },
-            defaultResponse()
+            { "default", defaultResponse() }
           }
         }
       }
@@ -563,7 +560,7 @@ json QgsWfs3CollectionsHandler::schema( const QgsServerApiContext &context ) con
                 }
               }
             },
-            defaultResponse()
+            { "default", defaultResponse() }
           }
         }
       }
@@ -675,7 +672,7 @@ json QgsWfs3DescribeCollectionHandler::schema( const QgsServerApiContext &contex
     // Use layer id for operationId
     const QString layerId { mapLayer->id() };
     const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
-    const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "collections/%1" ).arg( shortName ), context.request()->url() ).toStdString() };
+    const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/collections/%1" ).arg( shortName ), context.request()->url() ).toStdString() };
 
     data[ path ] =
     {
@@ -714,13 +711,13 @@ json QgsWfs3DescribeCollectionHandler::schema( const QgsServerApiContext &contex
                   }
                 }
               },
-              defaultResponse()
+              { "default", defaultResponse() }
             }
           }
         }
       }
     };
-  }
+  } // end for loop
   return data;
 }
 
@@ -840,11 +837,11 @@ json QgsWfs3CollectionsItemsHandler::schema( const QgsServerApiContext &context 
     const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/collections/%1/items" ).arg( shortName ), context.request()->url() ).toStdString() };
 
     json parameters = {{
-        {{ "$ref", "#/components/parameters/limit" }},
-        {{ "$ref", "#/components/parameters/offset" }},
-        {{ "$ref", "#/components/parameters/resultType" }},
-        {{ "$ref", "#/components/parameters/bbox" }},
-        {{ "$ref", "#/components/parameters/bbox-crs" }},
+        { "$ref", "#/components/parameters/limit" },
+        { "$ref", "#/components/parameters/offset" },
+        { "$ref", "#/components/parameters/resultType" },
+        { "$ref", "#/components/parameters/bbox" },
+        { "$ref", "#/components/parameters/bbox-crs" },
         // TODO: {{ "$ref", "#/components/parameters/time" }},
       }
     };
@@ -894,13 +891,13 @@ json QgsWfs3CollectionsItemsHandler::schema( const QgsServerApiContext &context 
                   }
                 }
               },
-              defaultResponse()
+              { "default", defaultResponse() }
             }
           }
         }
       }
     };
-  }
+  } // end for loop
   return data;
 }
 
@@ -1266,7 +1263,7 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
     // Use layer id for operationId
     const QString layerId { mapLayer->id() };
     const std::string title { mapLayer->title().isEmpty() ? mapLayer->name().toStdString() : mapLayer->title().toStdString() };
-    const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "collections/%1/items/{featureId}" ).arg( shortName ), context.request()->url() ).toStdString() };
+    const std::string path { QgsServerApiUtils::appendMapParameter( context.apiRootPath() + QStringLiteral( "/collections/%1/items/{featureId}" ).arg( shortName ), context.request()->url() ).toStdString() };
 
     data[ path ] =
     {
@@ -1276,6 +1273,13 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
           { "summary", "Retrieve a single feature from the '" + title + "' feature collection"},
           { "description", description() },
           { "operationId", operationId() + '_' + layerId.toStdString() },
+          {
+            "parameters", {{ // array of objects
+                { "$ref", "#/components/parameters/featureId" }
+              }
+            }
+          },
+          // TODO: relations
           {
             "responses", {
               {
@@ -1305,13 +1309,13 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                   }
                 }
               },
-              defaultResponse()
+              { "default", defaultResponse() }
             }
           }
         }
       }
     };
-  }
+  } // end for loop
   return data;
 }
 

--- a/tests/src/core/testqgsjsonutils.cpp
+++ b/tests/src/core/testqgsjsonutils.cpp
@@ -132,6 +132,14 @@ void TestQgsJsonUtils::testParseJson()
   QCOMPARE( QString::fromStdString( QgsJsonUtils::jsonFromVariant( QgsJsonUtils::parseJson( QStringLiteral( "" ) ) ).dump() ), QString( "null" ) );
   // invalid json -> null
   QCOMPARE( QString::fromStdString( QgsJsonUtils::jsonFromVariant( QgsJsonUtils::parseJson( QStringLiteral( "invalid json" ) ) ).dump() ), QString( "null" ) );
+  // String lists
+  QCOMPARE( QString::fromStdString( QgsJsonUtils::jsonFromVariant( QStringList()
+                                    << QStringLiteral( "A string" )
+                                    << QStringLiteral( "Another string" ) ).dump() ),
+            QString( R"raw(["A string","Another string"])raw" ) );
+  QCOMPARE( QString::fromStdString( QgsJsonUtils::jsonFromVariant( QStringList()
+                                    << QStringLiteral( "A string" ) ).dump() ),
+            QString( R"raw(["A string"])raw" ) );
 
 }
 

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -63,7 +63,7 @@ Content-Type: application/openapi+json;version=3.0
         }
       },
       "limit": {
-        "description": "The optional limit parameter limits the number of items that are presented in the response document.\\\nOnly items are counted that are on the first level of the collection in the response document.  Nested objects contained within the explicitly requested items shall not be counted.\\\nMinimum = 1.\\\nMaximum = 10000.\\\nDefault = 10.",
+        "description": "The optional limit parameter limits the number of items that are presented in the response document.\nOnly items are counted that are on the first level of the collection in the response document.  Nested objects contained within the explicitly requested items shall not be counted.\nMinimum = 1.\nMaximum = 10000.\nDefault = 10.",
         "example": 10,
         "explode": false,
         "in": "query",
@@ -78,7 +78,7 @@ Content-Type: application/openapi+json;version=3.0
         "style": "form"
       },
       "offset": {
-        "description": "The optional offset parameter indicates the index within the result set from which the server shall begin presenting results in the response document. The first element has an index of 0.\\\nMinimum = 0.\\\nDefault = 0.",
+        "description": "The optional offset parameter indicates the index within the result set from which the server shall begin presenting results in the response document. The first element has an index of 0.\nMinimum = 0.\nDefault = 0.",
         "example": 0,
         "explode": false,
         "in": "query",
@@ -106,7 +106,7 @@ Content-Type: application/openapi+json;version=3.0
         "style": "form"
       },
       "resultType": {
-        "description": "This service will respond to a query in one of two ways (excluding an exception response). It may either generate a complete response document containing resources that satisfy the operation or it may simply generate an empty response container that indicates the count of the total number of resources that the operation would return. Which of these two responses is generated is determined by the value of the optional resultType parameter.\\\nThe allowed values for this parameter are \"results\" and \"hits\".\\\nIf the value of the resultType parameter is set to \"results\", the server will generate a complete response document containing resources that satisfy the operation.\\\nIf the value of the resultType attribute is set to \"hits\", the server will generate an empty response document containing no resource instances.\\\nDefault = \"results\".",
+        "description": "This service will respond to a query in one of two ways (excluding an exception response). It may either generate a complete response document containing resources that satisfy the operation or it may simply generate an empty response container that indicates the count of the total number of resources that the operation would return. Which of these two responses is generated is determined by the value of the optional resultType parameter.\nThe allowed values for this parameter are \"results\" and \"hits\".\nIf the value of the resultType parameter is set to \"results\", the server will generate a complete response document containing resources that satisfy the operation.\nIf the value of the resultType attribute is set to \"hits\", the server will generate an empty response document containing no resource instances.\nDefault = \"results\".",
         "example": "results",
         "explode": false,
         "in": "query",
@@ -478,110 +478,174 @@ Content-Type: application/openapi+json;version=3.0
     "title": "QGIS TestProject",
     "version": ""
   },
-  "links": [
-    {
-      "href": "http://server.qgis.org/wfs3/api.openapi3",
-      "rel": "self",
-      "title": "API definition as OPENAPI3",
-      "type": "application/openapi+json;version=3.0"
-    },
-    {
-      "href": "http://server.qgis.org/wfs3/api.html",
-      "rel": "alternate",
-      "title": "API definition as HTML",
-      "type": "text/html"
-    }
-  ],
   "openapi": "3.0.1",
   "paths": {
     "/wfs3": {
       "get": {
         "description": "The landing page provides links to the API definition, the Conformance statements and the metadata about the feature data in this dataset.",
         "operationId": "getLandingPage",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/root"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/root"
                 }
               },
-              "description": "The landing page provides links to the API definition, the Conformance statements and the metadata about the feature data in this dataset."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The landing page provides links to the API definition, the Conformance statements and the metadata about the feature data in this dataset."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
           }
-        ],
+        },
         "summary": "WFS 3.0 Landing Page",
-        "tags": "Capabilities"
+        "tags": [
+          "Capabilities"
+        ]
+      }
+    },
+    "/wfs3/api": {
+      "get": {
+        "description": "The formal documentation of this API according to the OpenAPI specification, version 3.0. I.e., this document.",
+        "operationId": "getApiDescription",
+        "responses": {
+          "200": {
+            "content": {
+              "application/openapi+json;version=3.0": {
+                "schema": {
+                  "type": "object"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The formal documentation of this API according to the OpenAPI specification, version 3.0. I.e., this document."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "The API definition",
+        "tags": [
+          "Capabilities"
+        ]
       }
     },
     "/wfs3/collections": {
       "get": {
         "description": "Describe the feature collections in the dataset statements and the metadata about the feature data in this dataset.",
         "operationId": "describeCollections",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/content"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/content"
                 }
               },
-              "description": "Describe the feature collections in the dataset statements and the metadata about the feature data in this dataset."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Describe the feature collections in the dataset statements and the metadata about the feature data in this dataset."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
           }
-        ],
+        },
         "summary": "Metadata about the feature collections shared by this API.",
-        "tags": "Capabilities"
+        "tags": [
+          "Capabilities"
+        ]
+      }
+    },
+    "/wfs3/collections/exclude_attribute": {
+      "get": {
+        "description": "Metadata about a feature collection.",
+        "operationId": "describeCollection_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/collectionInfo"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A test vector layer exclude attrs' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Describe the 'A test vector layer exclude attrs' feature collection",
+        "tags": [
+          "Capabilities"
+        ]
       }
     },
     "/wfs3/collections/exclude_attribute/items": {
@@ -589,23 +653,9 @@ Content-Type: application/openapi+json;version=3.0
         "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
         "operationId": "getFeatures_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de",
         "parameters": [
-          [
-            {
-              "$ref": "#/components/parameters/limit"
-            },
-            {
-              "$ref": "#/components/parameters/offset"
-            },
-            {
-              "$ref": "#/components/parameters/resultType"
-            },
-            {
-              "$ref": "#/components/parameters/bbox"
-            },
-            {
-              "$ref": "#/components/parameters/bbox-crs"
-            }
-          ],
+          {
+            "$ref": "#/components/parameters/limit"
+          },
           {
             "description": "Filter the collection by 'id'",
             "explode": false,
@@ -629,45 +679,131 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           }
         ],
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureCollectionGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureCollectionGeoJSON"
                 }
               },
-              "description": "Metadata about the collection 'A test vector layer exclude attrs' shared by this API."
-            }
-          ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A test vector layer exclude attrs' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve features of 'A test vector layer exclude attrs' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/exclude_attribute/items/{featureId}": {
+      "get": {
+        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
+        "operationId": "getFeature_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de",
+        "parameters": [
           {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
+            "$ref": "#/components/parameters/featureId"
           }
         ],
-        "summary": "Retrieve features of 'A test vector layer exclude attrs' feature collection",
-        "tags": "Features"
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureGeoJSON"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Retrieve a 'A test vector layer exclude attrs' feature by 'featureId'."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve a single feature from the 'A test vector layer exclude attrs' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/fields_alias": {
+      "get": {
+        "description": "Metadata about a feature collection.",
+        "operationId": "describeCollection_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/collectionInfo"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A test vector layer with aliases' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Describe the 'A test vector layer with aliases' feature collection",
+        "tags": [
+          "Capabilities"
+        ]
       }
     },
     "/wfs3/collections/fields_alias/items": {
@@ -675,23 +811,9 @@ Content-Type: application/openapi+json;version=3.0
         "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
         "operationId": "getFeatures_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
         "parameters": [
-          [
-            {
-              "$ref": "#/components/parameters/limit"
-            },
-            {
-              "$ref": "#/components/parameters/offset"
-            },
-            {
-              "$ref": "#/components/parameters/resultType"
-            },
-            {
-              "$ref": "#/components/parameters/bbox"
-            },
-            {
-              "$ref": "#/components/parameters/bbox-crs"
-            }
-          ],
+          {
+            "$ref": "#/components/parameters/limit"
+          },
           {
             "description": "Filter the collection by 'alias_id'",
             "explode": false,
@@ -726,45 +848,131 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           }
         ],
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureCollectionGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureCollectionGeoJSON"
                 }
               },
-              "description": "Metadata about the collection 'A test vector layer with aliases' shared by this API."
-            }
-          ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A test vector layer with aliases' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve features of 'A test vector layer with aliases' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/fields_alias/items/{featureId}": {
+      "get": {
+        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
+        "operationId": "getFeature_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
+        "parameters": [
           {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
+            "$ref": "#/components/parameters/featureId"
           }
         ],
-        "summary": "Retrieve features of 'A test vector layer with aliases' feature collection",
-        "tags": "Features"
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureGeoJSON"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Retrieve a 'A test vector layer with aliases' feature by 'featureId'."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve a single feature from the 'A test vector layer with aliases' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/layer1_with_short_name": {
+      "get": {
+        "description": "Metadata about a feature collection.",
+        "operationId": "describeCollection_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/collectionInfo"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A Layer1 with a short name' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Describe the 'A Layer1 with a short name' feature collection",
+        "tags": [
+          "Capabilities"
+        ]
       }
     },
     "/wfs3/collections/layer1_with_short_name/items": {
@@ -772,23 +980,9 @@ Content-Type: application/openapi+json;version=3.0
         "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
         "operationId": "getFeatures_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a",
         "parameters": [
-          [
-            {
-              "$ref": "#/components/parameters/limit"
-            },
-            {
-              "$ref": "#/components/parameters/offset"
-            },
-            {
-              "$ref": "#/components/parameters/resultType"
-            },
-            {
-              "$ref": "#/components/parameters/bbox"
-            },
-            {
-              "$ref": "#/components/parameters/bbox-crs"
-            }
-          ],
+          {
+            "$ref": "#/components/parameters/limit"
+          },
           {
             "description": "Filter the collection by 'id'",
             "explode": false,
@@ -823,45 +1017,131 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           }
         ],
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureCollectionGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureCollectionGeoJSON"
                 }
               },
-              "description": "Metadata about the collection 'A Layer1 with a short name' shared by this API."
-            }
-          ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A Layer1 with a short name' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve features of 'A Layer1 with a short name' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/layer1_with_short_name/items/{featureId}": {
+      "get": {
+        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
+        "operationId": "getFeature_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a",
+        "parameters": [
           {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
+            "$ref": "#/components/parameters/featureId"
           }
         ],
-        "summary": "Retrieve features of 'A Layer1 with a short name' feature collection",
-        "tags": "Features"
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureGeoJSON"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Retrieve a 'A Layer1 with a short name' feature by 'featureId'."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve a single feature from the 'A Layer1 with a short name' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/testlayer èé": {
+      "get": {
+        "description": "Metadata about a feature collection.",
+        "operationId": "describeCollection_testlayer20150528120452665",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/collectionInfo"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A test vector layer èé' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Describe the 'A test vector layer èé' feature collection",
+        "tags": [
+          "Capabilities"
+        ]
       }
     },
     "/wfs3/collections/testlayer èé/items": {
@@ -869,23 +1149,9 @@ Content-Type: application/openapi+json;version=3.0
         "description": "Every feature in a dataset belongs to a collection. A dataset may consist of multiple feature collections. A feature collection is often a collection of features of a similar type, based on a common schema. Use content negotiation or specify a file extension to request HTML (.html) or GeoJSON (.json).",
         "operationId": "getFeatures_testlayer20150528120452665",
         "parameters": [
-          [
-            {
-              "$ref": "#/components/parameters/limit"
-            },
-            {
-              "$ref": "#/components/parameters/offset"
-            },
-            {
-              "$ref": "#/components/parameters/resultType"
-            },
-            {
-              "$ref": "#/components/parameters/bbox"
-            },
-            {
-              "$ref": "#/components/parameters/bbox-crs"
-            }
-          ],
+          {
+            "$ref": "#/components/parameters/limit"
+          },
           {
             "description": "Filter the collection by 'id'",
             "explode": false,
@@ -920,495 +1186,131 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           }
         ],
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureCollectionGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureCollectionGeoJSON"
                 }
               },
-              "description": "Metadata about the collection 'A test vector layer èé' shared by this API."
-            }
-          ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Metadata about the collection 'A test vector layer èé' shared by this API."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve features of 'A test vector layer èé' feature collection",
+        "tags": [
+          "Features"
+        ]
+      }
+    },
+    "/wfs3/collections/testlayer èé/items/{featureId}": {
+      "get": {
+        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
+        "operationId": "getFeature_testlayer20150528120452665",
+        "parameters": [
           {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
+            "$ref": "#/components/parameters/featureId"
           }
         ],
-        "summary": "Retrieve features of 'A test vector layer èé' feature collection",
-        "tags": "Features"
+        "responses": {
+          "200": {
+            "content": {
+              "application/geo+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/featureGeoJSON"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Retrieve a 'A test vector layer èé' feature by 'featureId'."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
+                }
+              },
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
+        "summary": "Retrieve a single feature from the 'A test vector layer èé' feature collection",
+        "tags": [
+          "Features"
+        ]
       }
     },
     "/wfs3/conformance": {
       "get": {
         "description": "List all requirements classes specified in a standard (e.g., WFS 3.0 Part 1: Core) that the server conforms to",
         "operationId": "getRequirementClasses",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/root"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/root"
                 }
               },
-              "description": "List all requirements classes specified in a standard (e.g., WFS 3.0 Part 1: Core) that the server conforms to"
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "List all requirements classes specified in a standard (e.g., WFS 3.0 Part 1: Core) that the server conforms to"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
           }
-        ],
+        },
         "summary": "Information about standards that this API conforms to",
-        "tags": "Capabilities"
-      }
-    },
-    "/wfs3api": {
-      "get": {
-        "description": "The formal documentation of this API according to the OpenAPI specification, version 3.0. I.e., this document.",
-        "operationId": "getApiDescription",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/openapi+json;version=3.0": {
-                  "schema": {
-                    "type": "object"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "The formal documentation of this API according to the OpenAPI specification, version 3.0. I.e., this document."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "The API definition",
-        "tags": "Capabilities"
-      }
-    },
-    "/wfs3collections/exclude_attribute": {
-      "get": {
-        "description": "Metadata about a feature collection.",
-        "operationId": "describeCollection_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/collectionInfo"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Metadata about the collection 'A test vector layer exclude attrs' shared by this API."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Describe the 'A test vector layer exclude attrs' feature collection",
-        "tags": "Capabilities"
-      }
-    },
-    "/wfs3collections/exclude_attribute/items/{featureId}": {
-      "get": {
-        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
-        "operationId": "getFeature_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Retrieve a 'A test vector layer exclude attrs' feature by 'featureId'."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Retrieve a single feature from the 'A test vector layer exclude attrs' feature collection",
-        "tags": "Features"
-      }
-    },
-    "/wfs3collections/fields_alias": {
-      "get": {
-        "description": "Metadata about a feature collection.",
-        "operationId": "describeCollection_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/collectionInfo"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Metadata about the collection 'A test vector layer with aliases' shared by this API."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Describe the 'A test vector layer with aliases' feature collection",
-        "tags": "Capabilities"
-      }
-    },
-    "/wfs3collections/fields_alias/items/{featureId}": {
-      "get": {
-        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
-        "operationId": "getFeature_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Retrieve a 'A test vector layer with aliases' feature by 'featureId'."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Retrieve a single feature from the 'A test vector layer with aliases' feature collection",
-        "tags": "Features"
-      }
-    },
-    "/wfs3collections/layer1_with_short_name": {
-      "get": {
-        "description": "Metadata about a feature collection.",
-        "operationId": "describeCollection_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/collectionInfo"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Metadata about the collection 'A Layer1 with a short name' shared by this API."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Describe the 'A Layer1 with a short name' feature collection",
-        "tags": "Capabilities"
-      }
-    },
-    "/wfs3collections/layer1_with_short_name/items/{featureId}": {
-      "get": {
-        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
-        "operationId": "getFeature_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Retrieve a 'A Layer1 with a short name' feature by 'featureId'."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Retrieve a single feature from the 'A Layer1 with a short name' feature collection",
-        "tags": "Features"
-      }
-    },
-    "/wfs3collections/testlayer èé": {
-      "get": {
-        "description": "Metadata about a feature collection.",
-        "operationId": "describeCollection_testlayer20150528120452665",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/collectionInfo"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Metadata about the collection 'A test vector layer èé' shared by this API."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Describe the 'A test vector layer èé' feature collection",
-        "tags": "Capabilities"
-      }
-    },
-    "/wfs3collections/testlayer èé/items/{featureId}": {
-      "get": {
-        "description": "Retrieve a feature; use content negotiation or specify a file extension to request HTML (.html or GeoJSON (.json)",
-        "operationId": "getFeature_testlayer20150528120452665",
-        "responses": [
-          [
-            "200",
-            {
-              "content": {
-                "application/geo+json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/featureGeoJSON"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": "Retrieve a 'A test vector layer èé' feature by 'featureId'."
-            }
-          ],
-          {
-            "default": {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  },
-                  "text/html": {
-                    "schema": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "description": "An error occurred."
-            }
-          }
-        ],
-        "summary": "Retrieve a single feature from the 'A test vector layer èé' feature collection",
-        "tags": "Features"
+        "tags": [
+          "Capabilities"
+        ]
       }
     }
   },
@@ -1426,6 +1328,5 @@ Content-Type: application/openapi+json;version=3.0
       "description": "Access to data (features).",
       "name": "Features"
     }
-  ],
-  "timeStamp": "2019-09-10T18:18:14Z"
+  ]
 }


### PR DESCRIPTION
- Fix JSON unreported issue with QStringList to json conversion
-  Fix some OPENAPI validation issues.

Swagger is happy now, except for the MAP=/...
in the query string: no query string parameters
are allowed in the endpoint, but we can
fix this in the web server configuration.

