### PR TITLE
[dbmanager] don't ignore field modifiers when updating it (fix #27613)

### DIFF
--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -1179,7 +1179,6 @@ class TableField(TableSubItemObject):
         if self.default2String() == new_default_str:
             new_default_str = None
         if self.comment == new_comment:
-            # Update also a new_comment
             new_comment = None
         ret = self.table().database().connector.updateTableColumn((self.table().schemaName(), self.table().name),
                                                                   self.name, new_name, new_type_str,

--- a/python/plugins/db_manager/dlg_field_properties.py
+++ b/python/plugins/db_manager/dlg_field_properties.py
@@ -71,15 +71,13 @@ class DlgFieldProperties(QDialog, Ui_Dialog):
         fld.notNull = not self.chkNull.isChecked()
         fld.default = self.editDefault.text()
         fld.hasDefault = fld.default != ""
-        # Get the comment from the LineEdit
         fld.comment = self.editCom.text()
-        try:
-            modifier = int(self.editLength.text())
-        except ValueError:
-            ok = False
+        # length field also used for geometry definition, so we should
+        # not cast its value to int
+        if self.editLength.text() != "":
+            fld.modifier = self.editLength.text()
         else:
-            ok = True
-        fld.modifier = modifier if ok else None
+            fld.modifier = None
         return fld
 
     def onOK(self):


### PR DESCRIPTION
## Description
When updating field via DB Manager (Table → Edit table → Edit column) column modifiers like length or geometry definition details were used only if they are numbers representing field length. This causes loss of the geometry definitions (like `Multipoint,4326`) when renaming/editing geometry columns.

Fixes #27613.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment