### PR TITLE
[georeferencer] clear canvas cache and layers when resetting (fix #26700)

### DIFF
--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1113,6 +1113,8 @@ void QgsGeorefPluginGui::removeOldLayer()
       ( QStringList() << mLayer->id() ) );
     mLayer = nullptr;
   }
+  mCanvas->setLayers( QList<QgsMapLayer *>() );
+  mCanvas->clearCache();
   mCanvas->refresh();
 }
 


### PR DESCRIPTION
## Description
Clear georeferencer canvas cache and layers when georeferenced layer removed. Fixes #26700.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
