### PR TITLE
Avoid touching unchanged sip files in prepare commit script

### DIFF
--- a/python/gui/auto_generated/qgsfilewidget.sip.in
+++ b/python/gui/auto_generated/qgsfilewidget.sip.in
@@ -184,9 +184,10 @@ the appearance and behavior of the line edit portion of the widget.
 %End
 
   signals:
-    void fileChanged( const QString & );
+
+    void fileChanged( const QString &path );
 %Docstring
-emitted as soon as the current file or directory is changed
+Emitted whenever the current file or directory ``path`` is changed.
 %End
 
 

--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -120,11 +120,15 @@ for f in $MODIFIED; do
     if grep -Fq "$sip_file" "${TOPLEVEL}"/python/"${module}"/"${module}"_auto.sip; then
       sip_file=$(${GP}sed -r 's@^src/(core|gui|analysis|server|3d)@\1/auto_generated@; s@\.h$@.sip.in@' <<<"$f" )
       m=python/$sip_file.$REV.prepare
-      touch python/"$sip_file"
+      if [ ! -f python/"$sip_file" ]; then
+        touch python/"$sip_file"
+      fi
       cp python/"$sip_file" "$m"
-      "${TOPLEVEL}"/scripts/sipify.pl -s python/"$sip_file" -p python/"${module}"/auto_additions/"${pyfile}" "$f"
-      if ! diff -u "$m" python/"$sip_file" >>"$SIPIFYDIFF"; then
+      "${TOPLEVEL}"/scripts/sipify.pl -s $m -p python/"${module}"/auto_additions/"${pyfile}" "$f"
+      # only replace sip files if they have changed
+      if ! diff -u python/"$sip_file" "$m" >>"$SIPIFYDIFF"; then
         echo "python/$sip_file is not up to date"
+        cp "$m" python/"$sip_file"
       fi
       rm "$m"
     fi

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -181,8 +181,11 @@ class GUI_EXPORT QgsFileWidget : public QWidget
     QgsFilterLineEdit *lineEdit();
 
   signals:
-    //! emitted as soon as the current file or directory is changed
-    void fileChanged( const QString & );
+
+    /**
+     * Emitted whenever the current file or directory \a path is changed.
+     */
+    void fileChanged( const QString &path );
 
     /**
      * Emitted before and after showing the file dialog.


### PR DESCRIPTION
Since any modification to these files triggers a new cmake run and rebuilding of the sip bindings (slow!), we want to avoid touching the sip files in any way if there's no actual changes to push.

Speeds up rebuilding in some circumstances by avoiding needless rebuilding of sip bindings.