### PR TITLE
Avoid using expensive geos polygon overlap calculation for two horizontal labels

### DIFF
--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -274,6 +274,12 @@ bool LabelPosition::isInConflict( LabelPosition *lp )
 
 bool LabelPosition::isInConflictSinglePart( LabelPosition *lp )
 {
+  if ( qgsDoubleNear( alpha, 0 ) && qgsDoubleNear( lp->alpha, 0 ) )
+  {
+    // simple case -- both candidates are oriented to axis, so shortcut with easy calculation
+    return boundingBoxIntersects( lp );
+  }
+
   if ( !mGeos )
     createGeosGeom();
 

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -858,6 +858,17 @@ void PointSet::getCentroid( double &px, double &py, bool forceInside ) const
   }
 }
 
+bool PointSet::boundingBoxIntersects( const PointSet *other ) const
+{
+  double x1 = ( xmin > other->xmin ? xmin : other->xmin );
+  double x2 = ( xmax < other->xmax ? xmax : other->xmax );
+  if ( x1 > x2 )
+    return false;
+  double y1 = ( ymin > other->ymin ? ymin : other->ymin );
+  double y2 = ( ymax < other->ymax ? ymax : other->ymax );
+  return y1 <= y2;
+}
+
 void PointSet::getPointByDistance( double *d, double *ad, double dl, double *px, double *py )
 {
   int i;

--- a/src/core/pal/pointset.h
+++ b/src/core/pal/pointset.h
@@ -148,6 +148,12 @@ namespace pal
         max[1] = ymax;
       }
 
+      /**
+       * Returns TRUE if the bounding box of this pointset intersects the bounding box
+       * of another pointset.
+       */
+      bool boundingBoxIntersects( const PointSet *other ) const;
+
       //! Returns NULLPTR if this isn't a hole. Otherwise returns pointer to parent pointset.
       PointSet *getHoleOf() { return holeOf; }
 


### PR DESCRIPTION
We can dramatically speed up label overlap detection on this common case, since
it reduces to overlap of two axis-aligned rectangles.

Speeds up rendering of labels on complex maps
