### PR TITLE
Show color button style "Pick color" and "Choose Color" actions

### DIFF
--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -145,6 +145,20 @@ Returns the platform's HIG flags.
 
     ~QgsGui();
 
+    static QColor sampleColor( QPoint point );
+%Docstring
+Samples the color on screen at the specified global ``point`` (pixel).
+
+.. versionadded:: 3.10
+%End
+
+    static QScreen *findScreenAt( QPoint point );
+%Docstring
+Returns the screen at the given global ``point`` (pixel).
+
+.. versionadded:: 3.10
+%End
+
   private:
     QgsGui( const QgsGui &other );
 };

--- a/python/gui/auto_generated/qgssymbolbutton.sip.in
+++ b/python/gui/auto_generated/qgssymbolbutton.sip.in
@@ -203,6 +203,10 @@ Emitted when the symbol's settings are changed.
 
     virtual void mouseMoveEvent( QMouseEvent *e );
 
+    virtual void mouseReleaseEvent( QMouseEvent *e );
+
+    virtual void keyPressEvent( QKeyEvent *e );
+
     virtual void dragEnterEvent( QDragEnterEvent *e );
 
 

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -24,6 +24,7 @@
 #include "qgssettings.h"
 #include "qgsproject.h"
 #include "qgsguiutils.h"
+#include "qgsgui.h"
 
 #include <QPainter>
 #include <QMouseEvent>
@@ -282,7 +283,7 @@ void QgsColorButton::mouseMoveEvent( QMouseEvent *e )
 {
   if ( mPickingColor )
   {
-    setButtonBackground( sampleColor( e->globalPos() ) );
+    setButtonBackground( QgsGui::sampleColor( e->globalPos() ) );
     e->accept();
     return;
   }
@@ -343,7 +344,7 @@ void QgsColorButton::stopPicking( QPoint eventPos, bool samplingColor )
     return;
   }
 
-  setColor( sampleColor( eventPos ) );
+  setColor( QgsGui::sampleColor( eventPos ) );
   addRecentColor( mColor );
 }
 
@@ -422,30 +423,6 @@ void QgsColorButton::dropEvent( QDropEvent *e )
     setColor( mimeColor );
     addRecentColor( mimeColor );
   }
-}
-
-QColor QgsColorButton::sampleColor( QPoint point ) const
-{
-  QScreen *screen = findScreenAt( point );
-  if ( ! screen )
-  {
-    return QColor();
-  }
-  QPixmap snappedPixmap = screen->grabWindow( QApplication::desktop()->winId(), point.x(), point.y(), 1, 1 );
-  QImage snappedImage = snappedPixmap.toImage();
-  return snappedImage.pixel( 0, 0 );
-}
-
-QScreen *QgsColorButton::findScreenAt( QPoint pos )
-{
-  for ( QScreen *screen : QGuiApplication::screens() )
-  {
-    if ( screen->geometry().contains( pos ) )
-    {
-      return screen;
-    }
-  }
-  return nullptr;
 }
 
 void QgsColorButton::setValidColor( const QColor &newColor )

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -453,10 +453,6 @@ class GUI_EXPORT QgsColorButton : public QToolButton
 
   private:
 
-
-    QColor sampleColor( QPoint point ) const;
-
-    static QScreen *findScreenAt( QPoint pos );
     Behavior mBehavior = QgsColorButton::ShowDialog;
     QString mColorDialogTitle;
     QColor mColor;

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -50,6 +50,9 @@
 #include "qgsproviderguiregistry.h"
 #include "qgsprojectstorageguiregistry.h"
 
+#include <QScreen>
+#include <QDesktopWidget>
+
 QgsGui *QgsGui::instance()
 {
   static QgsGui *sInstance( new QgsGui() );
@@ -163,6 +166,31 @@ QgsGui::~QgsGui()
   delete mWidgetStateHelper;
   delete mProjectStorageGuiRegistry;
   delete mProviderGuiRegistry;
+}
+
+QColor QgsGui::sampleColor( QPoint point )
+{
+  QScreen *screen = findScreenAt( point );
+  if ( ! screen )
+  {
+    return QColor();
+  }
+  QPixmap snappedPixmap = screen->grabWindow( QApplication::desktop()->winId(), point.x(), point.y(), 1, 1 );
+  QImage snappedImage = snappedPixmap.toImage();
+  return snappedImage.pixel( 0, 0 );
+}
+
+QScreen *QgsGui::findScreenAt( QPoint point )
+{
+  const QList< QScreen * > screens = QGuiApplication::screens();
+  for ( QScreen *screen : screens )
+  {
+    if ( screen->geometry().contains( point ) )
+    {
+      return screen;
+    }
+  }
+  return nullptr;
 }
 
 QgsGui::QgsGui()

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -178,6 +178,20 @@ class GUI_EXPORT QgsGui : public QObject
 
     ~QgsGui();
 
+    /**
+     * Samples the color on screen at the specified global \a point (pixel).
+     *
+     * \since QGIS 3.10
+     */
+    static QColor sampleColor( QPoint point );
+
+    /**
+     * Returns the screen at the given global \a point (pixel).
+     *
+     * \since QGIS 3.10
+     */
+    static QScreen *findScreenAt( QPoint point );
+
   private:
 
     QgsGui();

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -27,6 +27,8 @@
 #include "qgsapplication.h"
 #include "qgsguiutils.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsgui.h"
+#include "qgscolordialog.h"
 
 #include <QMenu>
 #include <QClipboard>
@@ -236,6 +238,13 @@ void QgsSymbolButton::pasteColor()
 
 void QgsSymbolButton::mousePressEvent( QMouseEvent *e )
 {
+  if ( mPickingColor )
+  {
+    //don't show dialog if in color picker mode
+    e->accept();
+    return;
+  }
+
   if ( e->button() == Qt::RightButton )
   {
     QToolButton::showMenu();
@@ -250,6 +259,13 @@ void QgsSymbolButton::mousePressEvent( QMouseEvent *e )
 
 void QgsSymbolButton::mouseMoveEvent( QMouseEvent *e )
 {
+  if ( mPickingColor )
+  {
+    updatePreview( QgsGui::sampleColor( e->globalPos() ) );
+    e->accept();
+    return;
+  }
+
   //handle dragging colors/symbols from button
 
   if ( !( e->buttons() & Qt::LeftButton ) )
@@ -272,6 +288,32 @@ void QgsSymbolButton::mouseMoveEvent( QMouseEvent *e )
   drag->setPixmap( QgsColorWidget::createDragIcon( mSymbol->color() ) );
   drag->exec( Qt::CopyAction );
   setDown( false );
+}
+
+void QgsSymbolButton::mouseReleaseEvent( QMouseEvent *e )
+{
+  if ( mPickingColor )
+  {
+    //end color picking operation by sampling the color under cursor
+    stopPicking( e->globalPos() );
+    e->accept();
+    return;
+  }
+
+  QToolButton::mouseReleaseEvent( e );
+}
+
+void QgsSymbolButton::keyPressEvent( QKeyEvent *e )
+{
+  if ( !mPickingColor )
+  {
+    //if not picking a color, use default tool button behavior
+    QToolButton::keyPressEvent( e );
+    return;
+  }
+
+  //cancel picking, sampling the color if space was pressed
+  stopPicking( QCursor::pos(), e->key() == Qt::Key_Space );
 }
 
 void QgsSymbolButton::dragEnterEvent( QDragEnterEvent *e )
@@ -405,11 +447,29 @@ void QgsSymbolButton::prepareMenu()
   }
   mMenu->addAction( pasteColorAction );
   connect( pasteColorAction, &QAction::triggered, this, &QgsSymbolButton::pasteColor );
+
+  QAction *pickColorAction = new QAction( tr( "Pick Color" ), this );
+  mMenu->addAction( pickColorAction );
+  connect( pickColorAction, &QAction::triggered, this, &QgsSymbolButton::activatePicker );
+
+  QAction *chooseColorAction = new QAction( tr( "Choose Color…" ), this );
+  mMenu->addAction( chooseColorAction );
+  connect( chooseColorAction, &QAction::triggered, this, &QgsSymbolButton::showColorDialog );
 }
 
 void QgsSymbolButton::addRecentColor( const QColor &color )
 {
   QgsRecentColorScheme::addRecentColor( color );
+}
+
+void QgsSymbolButton::activatePicker()
+{
+  //activate picker color
+  QApplication::setOverrideCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Sampler ) );
+  grabMouse();
+  grabKeyboard();
+  mPickingColor = true;
+  setMouseTracking( true );
 }
 
 
@@ -533,6 +593,68 @@ QPixmap QgsSymbolButton::createColorIcon( const QColor &color ) const
   p.drawRect( 0, 0, iconSize - 1, iconSize - 1 );
   p.end();
   return pixmap;
+}
+
+void QgsSymbolButton::stopPicking( QPoint eventPos, bool samplingColor )
+{
+  //release mouse and keyboard, and reset cursor
+  releaseMouse();
+  releaseKeyboard();
+  QgsApplication::restoreOverrideCursor();
+  setMouseTracking( false );
+  mPickingColor = false;
+
+  if ( !samplingColor )
+  {
+    //not sampling color, restore old icon
+    updatePreview();
+    return;
+  }
+
+  const QColor newColor = QgsGui::sampleColor( eventPos );
+  setColor( newColor );
+  addRecentColor( newColor );
+}
+
+void QgsSymbolButton::showColorDialog()
+{
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QColor currentColor = mSymbol->color();
+    QgsCompoundColorWidget *colorWidget = new QgsCompoundColorWidget( panel, currentColor, QgsCompoundColorWidget::LayoutVertical );
+    colorWidget->setPanelTitle( tr( "Symbol Color" ) );
+    colorWidget->setAllowOpacity( true );
+
+    if ( currentColor.isValid() )
+    {
+      colorWidget->setPreviousColor( currentColor );
+    }
+
+    connect( colorWidget, &QgsCompoundColorWidget::currentColorChanged, this, [ = ]( const QColor & newColor )
+    {
+      if ( newColor.isValid() )
+      {
+        setColor( newColor );
+      }
+    } );
+    panel->openPanel( colorWidget );
+    return;
+  }
+
+  QColor newColor;
+
+  QgsColorDialog dialog( this, nullptr, mSymbol->color() );
+  dialog.setTitle( tr( "Symbol Color" ) );
+  dialog.setAllowOpacity( true );
+
+  if ( dialog.exec() && dialog.color().isValid() )
+  {
+    setColor( dialog.color() );
+  }
+
+  // reactivate button's window
+  activateWindow();
 }
 
 void QgsSymbolButton::setDialogTitle( const QString &title )

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -219,6 +219,8 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
     void mousePressEvent( QMouseEvent *e ) override;
     // Reimplemented to allow dragging colors/symbols from button
     void mouseMoveEvent( QMouseEvent *e ) override;
+    void mouseReleaseEvent( QMouseEvent *e ) override;
+    void keyPressEvent( QKeyEvent *e ) override;
     // Reimplemented to accept dragged colors
     void dragEnterEvent( QDragEnterEvent *e ) override;
 
@@ -240,6 +242,11 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
     void prepareMenu();
 
     void addRecentColor( const QColor &color );
+
+    /**
+     * Activates the color picker tool, which allows for sampling a color from anywhere on the screen
+     */
+    void activatePicker();
 
   private:
 
@@ -264,6 +271,8 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
 
     QgsExpressionContextGenerator *mExpressionContextGenerator = nullptr;
 
+    bool mPickingColor = false;
+
     /**
      * Regenerates the text preview. If \a color is specified, a temporary color preview
      * is shown instead.
@@ -285,6 +294,16 @@ class GUI_EXPORT QgsSymbolButton : public QToolButton
      * Create a \a color icon for display in the drop-down menu.
      */
     QPixmap createColorIcon( const QColor &color ) const;
+
+    /**
+     * Ends a color picking operation
+     * \param eventPos global position of pixel to sample color from
+     * \param samplingColor set to TRUE to actually sample the color, FALSE to just cancel
+     * the color picking operation
+     */
+    void stopPicking( QPoint eventPos, bool samplingColor = true );
+
+    void showColorDialog();
 
 };
 


### PR DESCRIPTION
in symbol button menu

Synchronizes the behavior of the color and symbol buttons

Fixes #25696