### PR TITLE
Fix inconsistent use of QgsLayoutAtlas::changed signal

### DIFF
--- a/src/app/layout/qgslayoutatlaswidget.cpp
+++ b/src/app/layout/qgslayoutatlaswidget.cpp
@@ -110,6 +110,7 @@ void QgsLayoutAtlasWidget::changeCoverageLayer( QgsMapLayer *layer )
 void QgsLayoutAtlasWidget::mAtlasFilenamePatternEdit_editingFinished()
 {
   QString error;
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Filename" ) );
   if ( !mAtlas->setFilenameExpression( mAtlasFilenamePatternEdit->text(), error ) )
   {
@@ -120,6 +121,7 @@ void QgsLayoutAtlasWidget::mAtlasFilenamePatternEdit_editingFinished()
                                     error ) );
   }
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
 }
 
 void QgsLayoutAtlasWidget::mAtlasFilenameExpressionButton_clicked()
@@ -141,6 +143,7 @@ void QgsLayoutAtlasWidget::mAtlasFilenameExpressionButton_clicked()
       //set atlas filename expression
       mAtlasFilenamePatternEdit->setText( expression );
       QString error;
+      mBlockUpdates = true;
       mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Filename" ) );
       if ( !mAtlas->setFilenameExpression( expression, error ) )
       {
@@ -149,6 +152,7 @@ void QgsLayoutAtlasWidget::mAtlasFilenameExpressionButton_clicked()
                                   .arg( expression,
                                         error ) );
       }
+      mBlockUpdates = false;
       mLayout->undoStack()->endCommand();
     }
   }
@@ -156,9 +160,11 @@ void QgsLayoutAtlasWidget::mAtlasFilenameExpressionButton_clicked()
 
 void QgsLayoutAtlasWidget::mAtlasHideCoverageCheckBox_stateChanged( int state )
 {
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Toggle Atlas Layer" ) );
   mAtlas->setHideCoverage( state == Qt::Checked );
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
 }
 
 void QgsLayoutAtlasWidget::mAtlasSingleFileCheckBox_stateChanged( int state )
@@ -189,17 +195,21 @@ void QgsLayoutAtlasWidget::mAtlasSortFeatureCheckBox_stateChanged( int state )
     mAtlasSortFeatureDirectionButton->setEnabled( false );
     mAtlasSortExpressionWidget->setEnabled( false );
   }
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Toggle Atlas Sorting" ) );
   mAtlas->setSortFeatures( state == Qt::Checked );
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
   updateAtlasFeatures();
 }
 
 void QgsLayoutAtlasWidget::changesSortFeatureExpression( const QString &expression, bool )
 {
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Sort" ) );
   mAtlas->setSortExpression( expression );
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
   updateAtlasFeatures();
 }
 
@@ -228,9 +238,11 @@ void QgsLayoutAtlasWidget::mAtlasFeatureFilterCheckBox_stateChanged( int state )
     mAtlasFeatureFilterEdit->setEnabled( false );
     mAtlasFeatureFilterButton->setEnabled( false );
   }
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Filter" ) );
   mAtlas->setFilterFeatures( state == Qt::Checked );
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
   updateAtlasFeatures();
 }
 
@@ -242,9 +254,11 @@ void QgsLayoutAtlasWidget::pageNameExpressionChanged( const QString &, bool vali
     return;
   }
 
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Name" ) );
   mAtlas->setPageNameExpression( expression );
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
 }
 
 void QgsLayoutAtlasWidget::mAtlasFeatureFilterEdit_editingFinished()
@@ -252,6 +266,7 @@ void QgsLayoutAtlasWidget::mAtlasFeatureFilterEdit_editingFinished()
   QString error;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Filter" ) );
 
+  mBlockUpdates = true;
   if ( !mAtlas->setFilterExpression( mAtlasFeatureFilterEdit->text(), error ) )
   {
     //expression could not be set
@@ -259,7 +274,7 @@ void QgsLayoutAtlasWidget::mAtlasFeatureFilterEdit_editingFinished()
                               .arg( mAtlasFeatureFilterEdit->text(),
                                     error ) );
   }
-
+  mBlockUpdates = false;
   mLayout->undoStack()->endCommand();
   updateAtlasFeatures();
 }
@@ -285,6 +300,7 @@ void QgsLayoutAtlasWidget::mAtlasFeatureFilterButton_clicked()
       mAtlasFeatureFilterEdit->setText( expression );
       QString error;
       mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Filter" ) );
+      mBlockUpdates = true;
       if ( !mAtlas->setFilterExpression( mAtlasFeatureFilterEdit->text(), error ) )
       {
         //expression could not be set
@@ -294,6 +310,7 @@ void QgsLayoutAtlasWidget::mAtlasFeatureFilterButton_clicked()
                                         error )
                                 );
       }
+      mBlockUpdates = false;
       mLayout->undoStack()->endCommand();
       updateAtlasFeatures();
     }
@@ -306,9 +323,11 @@ void QgsLayoutAtlasWidget::mAtlasSortFeatureDirectionButton_clicked()
   at = ( at == Qt::UpArrow ) ? Qt::DownArrow : Qt::UpArrow;
   mAtlasSortFeatureDirectionButton->setArrowType( at );
 
+  mBlockUpdates = true;
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Sort" ) );
   mAtlas->setSortAscending( at == Qt::UpArrow );
   mLayout->undoStack()->endCommand();
+  mBlockUpdates = false;
   updateAtlasFeatures();
 }
 
@@ -319,6 +338,9 @@ void QgsLayoutAtlasWidget::changeFileFormat()
 
 void QgsLayoutAtlasWidget::updateGuiElements()
 {
+  if ( mBlockUpdates )
+    return;
+
   blockAllSignals( true );
   mUseAtlasCheckBox->setCheckState( mAtlas->enabled() ? Qt::Checked : Qt::Unchecked );
   mConfigurationGroup->setEnabled( mAtlas->enabled() );

--- a/src/app/layout/qgslayoutatlaswidget.h
+++ b/src/app/layout/qgslayoutatlaswidget.h
@@ -53,6 +53,7 @@ class QgsLayoutAtlasWidget: public QWidget, private Ui::QgsLayoutAtlasWidgetBase
     QgsPrintLayout *mLayout = nullptr;
     QgsLayoutAtlas *mAtlas = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
+    bool mBlockUpdates = false;
 
     void blockAllSignals( bool b );
     void checkLayerType( QgsVectorLayer *layer );

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -162,6 +162,15 @@ void QgsLayoutAtlas::setCoverageLayer( QgsVectorLayer *layer )
   emit coverageLayerChanged( layer );
 }
 
+void QgsLayoutAtlas::setPageNameExpression( const QString &expression )
+{
+  if ( mPageNameExpression == expression )
+    return;
+
+  mPageNameExpression = expression;
+  emit changed();
+}
+
 QString QgsLayoutAtlas::nameForPage( int pageNumber ) const
 {
   if ( pageNumber < 0 || pageNumber >= mFeatureIds.count() )
@@ -170,12 +179,51 @@ QString QgsLayoutAtlas::nameForPage( int pageNumber ) const
   return mFeatureIds.at( pageNumber ).second;
 }
 
+void QgsLayoutAtlas::setSortFeatures( bool enabled )
+{
+  if ( mSortFeatures == enabled )
+    return;
+
+  mSortFeatures = enabled;
+  emit changed();
+}
+
+void QgsLayoutAtlas::setSortAscending( bool ascending )
+{
+  if ( mSortAscending == ascending )
+    return;
+
+  mSortAscending = ascending;
+  emit changed();
+}
+
+void QgsLayoutAtlas::setSortExpression( const QString &expression )
+{
+  if ( mSortExpression == expression )
+    return;
+
+  mSortExpression = expression;
+  emit changed();
+}
+
+void QgsLayoutAtlas::setFilterFeatures( bool filtered )
+{
+  if ( mFilterFeatures == filtered )
+    return;
+
+  mFilterFeatures = filtered;
+  emit changed();
+}
+
 bool QgsLayoutAtlas::setFilterExpression( const QString &expression, QString &errorString )
 {
   errorString.clear();
+  const bool hasChanged = mFilterExpression != expression;
   mFilterExpression = expression;
 
   QgsExpression filterExpression( mFilterExpression );
+  if ( hasChanged )
+    emit changed();
   if ( filterExpression.hasParserError() )
   {
     errorString = filterExpression.parserErrorString();
@@ -422,15 +470,23 @@ void QgsLayoutAtlas::refreshCurrentFeature()
 
 void QgsLayoutAtlas::setHideCoverage( bool hide )
 {
-  mHideCoverage = hide;
-
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagHideCoverageLayer, hide );
+  if ( hide == mHideCoverage )
+    return;
+
+  mHideCoverage = hide;
   mLayout->refresh();
+  emit changed();
 }
 
 bool QgsLayoutAtlas::setFilenameExpression( const QString &pattern, QString &errorString )
 {
+  const bool hasChanged = mFilenameExpressionString != pattern;
   mFilenameExpressionString = pattern;
+
+  if ( hasChanged )
+    emit changed();
+
   return updateFilenameExpression( errorString );
 }
 

--- a/src/core/layout/qgslayoutatlas.h
+++ b/src/core/layout/qgslayoutatlas.h
@@ -132,7 +132,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
      * Sets the \a expression (or field name) used for calculating the page name.
      * \see pageNameExpression()
      */
-    void setPageNameExpression( const QString &expression ) { mPageNameExpression = expression; }
+    void setPageNameExpression( const QString &expression );
 
     /**
      * Returns the calculated name for a specified atlas \a page number. Page numbers start at 0.
@@ -154,7 +154,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
      * \see setSortAscending()
      * \see setSortExpression()
      */
-    void setSortFeatures( bool enabled ) { mSortFeatures = enabled; }
+    void setSortFeatures( bool enabled );
 
     /**
      * Returns TRUE if features should be sorted in an ascending order.
@@ -176,7 +176,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
      * \see sortAscending()
      * \see setSortExpression()
      */
-    void setSortAscending( bool ascending ) { mSortAscending = ascending; }
+    void setSortAscending( bool ascending );
 
     /**
      * Returns the expression (or field name) to use for sorting features.
@@ -198,7 +198,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
      * \see setSortAscending()
      * \see sortExpression()
      */
-    void setSortExpression( const QString &expression ) { mSortExpression = expression; }
+    void setSortExpression( const QString &expression );
 
     /**
      * Returns TRUE if features should be filtered in the coverage layer.
@@ -212,7 +212,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
      * \see filterFeatures()
      * \see setFilterExpression()
      */
-    void setFilterFeatures( bool filtered ) { mFilterFeatures = filtered; }
+    void setFilterFeatures( bool filtered );
 
     /**
      * Returns the expression used for filtering features in the coverage layer.

--- a/tests/src/python/test_qgslayoutatlas.py
+++ b/tests/src/python/test_qgslayoutatlas.py
@@ -675,6 +675,51 @@ class TestQgsLayoutAtlas(unittest.TestCase):
 
         QgsProject.instance().removeMapLayer(polygonLayer)
 
+    def testChangedSignal(self):
+        layout = QgsPrintLayout(QgsProject.instance())
+        atlas = layout.atlas()
+        s = QSignalSpy(atlas.changed)
+
+        atlas.setPageNameExpression('1+2')
+        self.assertEqual(len(s), 1)
+        atlas.setPageNameExpression('1+2')
+        self.assertEqual(len(s), 1)
+
+        atlas.setSortFeatures(True)
+        self.assertEqual(len(s), 2)
+        atlas.setSortFeatures(True)
+        self.assertEqual(len(s), 2)
+
+        atlas.setSortAscending(False)
+        self.assertEqual(len(s), 3)
+        atlas.setSortAscending(False)
+        self.assertEqual(len(s), 3)
+
+        atlas.setSortExpression('1+2')
+        self.assertEqual(len(s), 4)
+        atlas.setSortExpression('1+2')
+        self.assertEqual(len(s), 4)
+
+        atlas.setFilterFeatures(True)
+        self.assertEqual(len(s), 5)
+        atlas.setFilterFeatures(True)
+        self.assertEqual(len(s), 5)
+
+        atlas.setFilterExpression('1+2')
+        self.assertEqual(len(s), 6)
+        atlas.setFilterExpression('1+2')
+        self.assertEqual(len(s), 6)
+
+        atlas.setHideCoverage(True)
+        self.assertEqual(len(s), 7)
+        atlas.setHideCoverage(True)
+        self.assertEqual(len(s), 7)
+
+        atlas.setFilenameExpression('1+2')
+        self.assertEqual(len(s), 8)
+        atlas.setFilenameExpression('1+2')
+        self.assertEqual(len(s), 8)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes GUI is not updated when layout atlas is set to use the
default filename expression

Fixes #20786
