### PR TITLE
Feature update layer selection relation widgets

### DIFF
--- a/src/gui/attributetable/qgsvectorlayerselectionmanager.cpp
+++ b/src/gui/attributetable/qgsvectorlayerselectionmanager.cpp
@@ -21,7 +21,7 @@ QgsVectorLayerSelectionManager::QgsVectorLayerSelectionManager( QgsVectorLayer *
   : QgsIFeatureSelectionManager( parent )
   , mLayer( layer )
 {
-  connect( mLayer, &QgsVectorLayer::selectionChanged, this, &QgsVectorLayerSelectionManager::selectionChanged );
+  connect( mLayer, &QgsVectorLayer::selectionChanged, this, &QgsVectorLayerSelectionManager::onSelectionChanged );
 }
 
 int QgsVectorLayerSelectionManager::selectedFeatureCount()
@@ -47,4 +47,14 @@ void QgsVectorLayerSelectionManager::setSelectedFeatures( const QgsFeatureIds &i
 const QgsFeatureIds &QgsVectorLayerSelectionManager::selectedFeatureIds() const
 {
   return mLayer->selectedFeatureIds();
+}
+
+QgsVectorLayer *QgsVectorLayerSelectionManager::layer() const
+{
+  return mLayer;
+}
+
+void QgsVectorLayerSelectionManager::onSelectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect )
+{
+  emit selectionChanged( selected, deselected, clearAndSelect );
 }

--- a/src/gui/attributetable/qgsvectorlayerselectionmanager.h
+++ b/src/gui/attributetable/qgsvectorlayerselectionmanager.h
@@ -48,6 +48,14 @@ class GUI_EXPORT QgsVectorLayerSelectionManager : public QgsIFeatureSelectionMan
     QgsVectorLayer *layer() const;
 
   private slots:
+
+    /**
+     * Called whenever layer selection was changed
+     *
+     * \param selected        Newly selected feature ids
+     * \param deselected      Ids of all features which have previously been selected but are not any more
+     * \param clearAndSelect  In case this is set to TRUE, the old selection was dismissed and the new selection corresponds to selected
+     */
     virtual void onSelectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 
   private:

--- a/src/gui/attributetable/qgsvectorlayerselectionmanager.h
+++ b/src/gui/attributetable/qgsvectorlayerselectionmanager.h
@@ -41,6 +41,10 @@ class GUI_EXPORT QgsVectorLayerSelectionManager : public QgsIFeatureSelectionMan
     void deselect( const QgsFeatureIds &ids ) override;
     void setSelectedFeatures( const QgsFeatureIds &ids ) override;
     const QgsFeatureIds &selectedFeatureIds() const override;
+    QgsVectorLayer *layer() const;
+
+  protected slots:
+    virtual void onSelectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 
   private:
     QgsVectorLayer *mLayer = nullptr;

--- a/src/gui/attributetable/qgsvectorlayerselectionmanager.h
+++ b/src/gui/attributetable/qgsvectorlayerselectionmanager.h
@@ -41,9 +41,13 @@ class GUI_EXPORT QgsVectorLayerSelectionManager : public QgsIFeatureSelectionMan
     void deselect( const QgsFeatureIds &ids ) override;
     void setSelectedFeatures( const QgsFeatureIds &ids ) override;
     const QgsFeatureIds &selectedFeatureIds() const override;
+
+    /**
+     * Returns the vector layer
+     */
     QgsVectorLayer *layer() const;
 
-  protected slots:
+  private slots:
     virtual void onSelectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 
   private:

--- a/src/gui/qgsfeatureselectiondlg.cpp
+++ b/src/gui/qgsfeatureselectiondlg.cpp
@@ -15,7 +15,7 @@
 
 #include "qgsfeatureselectiondlg.h"
 
-#include "qgsgenericfeatureselectionmanager.h"
+#include "qgsvectorlayerselectionmanager.h"
 #include "qgsdistancearea.h"
 #include "qgsfeaturerequest.h"
 #include "qgsattributeeditorcontext.h"
@@ -29,7 +29,7 @@ QgsFeatureSelectionDlg::QgsFeatureSelectionDlg( QgsVectorLayer *vl, QgsAttribute
 {
   setupUi( this );
 
-  mFeatureSelection = new QgsGenericFeatureSelectionManager( mDualView );
+  mFeatureSelection = new QgsVectorLayerSelectionManager( vl, mDualView );
 
   mDualView->setFeatureSelectionManager( mFeatureSelection );
 
@@ -72,5 +72,3 @@ void QgsFeatureSelectionDlg::showEvent( QShowEvent *event )
 
   QDialog::showEvent( event );
 }
-
-

--- a/src/gui/qgsfeatureselectiondlg.h
+++ b/src/gui/qgsfeatureselectiondlg.h
@@ -16,7 +16,7 @@
 #ifndef QGSFEATURESELECTIONDLG_H
 #define QGSFEATURESELECTIONDLG_H
 
-class QgsGenericFeatureSelectionManager;
+class QgsVectorLayerSelectionManager;
 
 #include "ui_qgsfeatureselectiondlg.h"
 #include "qgis_sip.h"
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
     void setSelectedFeatures( const QgsFeatureIds &ids );
 
   private:
-    QgsGenericFeatureSelectionManager *mFeatureSelection = nullptr;
+    QgsVectorLayerSelectionManager *mFeatureSelection = nullptr;
     QgsVectorLayer *mVectorLayer = nullptr;
 
     // QWidget interface

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -272,6 +272,7 @@ void QgsRelationEditorWidget::initDualView( QgsVectorLayer *layer, const QgsFeat
   mFeatureSelectionMgr = new QgsFilteredSelectionManager( layer, request, mDualView );
   mDualView->setFeatureSelectionManager( mFeatureSelectionMgr );
   connect( mFeatureSelectionMgr, &QgsIFeatureSelectionManager::selectionChanged, this, &QgsRelationEditorWidget::updateButtons );
+  updateButtons();
 }
 
 void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const QgsRelation &nmrelation )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -38,6 +38,10 @@
 
 /// @cond PRIVATE
 
+/**
+ * This class is used to filter the current vector layer selection to features matching the given request.
+ * Relation editor widget use it in order to get selected feature for the current relation.
+ */
 class QgsFilteredSelectionManager : public QgsVectorLayerSelectionManager
 {
   public:

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -64,7 +64,7 @@ class QgsFilteredSelectionManager : public QgsVectorLayerSelectionManager
       return mSelectedFeatureIds.count();
     }
 
-  public slots:
+  private slots:
 
     void onSelectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect ) override
     {

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -49,12 +49,9 @@ class QgsFilteredSelectionManager : public QgsVectorLayerSelectionManager
       : QgsVectorLayerSelectionManager( layer, parent )
       , mRequest( request )
     {
-      QgsFeature feature;
-      QgsFeatureIterator it = layer->getSelectedFeatures( mRequest );
-      while ( it.nextFeature( feature ) )
-      {
-        mSelectedFeatureIds << feature.id();
-      }
+      for ( auto fid : layer->selectedFeatureIds() )
+        if ( mRequest.acceptFeature( layer->getFeature( fid ) ) )
+          mSelectedFeatureIds << fid;
 
       connect( layer, &QgsVectorLayer::selectionChanged, this, &QgsFilteredSelectionManager::onSelectionChanged );
     }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -36,6 +36,8 @@
 #include <QLabel>
 #include <QMessageBox>
 
+/// @cond PRIVATE
+
 class QgsFilteredSelectionManager : public QgsVectorLayerSelectionManager
 {
   public:
@@ -93,6 +95,8 @@ class QgsFilteredSelectionManager : public QgsVectorLayerSelectionManager
     QgsFeatureRequest mRequest;
     QgsFeatureIds mSelectedFeatureIds;
 };
+
+/// @endcond
 
 QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget *parent )
   : QgsCollapsibleGroupBox( parent )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -517,9 +517,6 @@ void QgsRelationEditorWidget::linkFeature()
       for ( const QgsFeature &f : constNewFeatures )
         ids << f.id();
       mRelation.referencingLayer()->selectByIds( ids );
-
-
-      updateUi();
     }
     else
     {
@@ -543,6 +540,8 @@ void QgsRelationEditorWidget::linkFeature()
         }
       }
     }
+
+    updateUi();
   }
 }
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -28,7 +28,7 @@
 #include "qgis_gui.h"
 
 class QgsFeature;
-class QgsGenericFeatureSelectionManager;
+class QgsVectorLayerSelectionManager;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
 
@@ -160,10 +160,11 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
 
   private:
     void updateUi();
+    void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
 
     QgsDualView *mDualView = nullptr;
     QgsDualView::ViewMode mViewMode = QgsDualView::AttributeEditor;
-    QgsGenericFeatureSelectionManager *mFeatureSelectionMgr = nullptr;
+    QgsVectorLayerSelectionManager *mFeatureSelectionMgr = nullptr;
     QgsAttributeEditorContext mEditorContext;
     QgsRelation mRelation;
     QgsRelation mNmRelation;

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -255,6 +255,37 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         self.assertEqual([2, 3], relation.referencingFields())
         self.assertEqual([0, 1], relation.referencedFields())
 
+    def test_selection(self):
+
+        fbook = QgsFeature(self.vl_books.fields())
+        fbook.setAttributes([self.vl_books.dataProvider().defaultValueClause(0), 'The Hitchhiker\'s Guide to the Galaxy', 'Sputnik Editions', 1961])
+        self.vl_books.addFeature(fbook)
+
+        flink = QgsFeature(self.vl_link_books_authors.fields())
+        flink.setAttributes([fbook.id(), 5])
+        self.vl_link_books_authors.addFeature(flink)
+
+        self.createWrapper(self.vl_authors, '"name"=\'Douglas Adams\'')
+
+        self.zoomToButton = self.widget.findChild(QToolButton, "mDeleteFeatureButton")
+        self.assertTrue(self.zoomToButton)
+        self.assertTrue(not self.zoomToButton.isEnabled())
+
+        selectionMgr = self.widget.featureSelectionManager()
+        self.assertTrue(selectionMgr)
+
+        self.vl_books.select(fbook.id())
+        self.assertEqual([fbook.id()], selectionMgr.selectedFeatureIds())
+        self.assertTrue(self.zoomToButton.isEnabled())
+
+        selectionMgr.deselect([fbook.id()])
+        self.assertEqual([], selectionMgr.selectedFeatureIds())
+        self.assertTrue(not self.zoomToButton.isEnabled())
+
+        self.vl_books.select([1, fbook.id()])
+        self.assertEqual([fbook.id()], selectionMgr.selectedFeatureIds())
+        self.assertTrue(self.zoomToButton.isEnabled())
+
     def startTransaction(self):
         """
         Start a new transaction and set all layers into transaction mode.


### PR DESCRIPTION
## Description

Before this PR, selected features in relation widget and feature selection dialog for link existing child was not connected to layer selection. 

This is problematic because you cannot use map selection if you want to choose child to create a relation with a given parent. This is what it looks like with the PR. 

![selection2](https://user-images.githubusercontent.com/14358135/65410406-90076400-ddea-11e9-8c3c-fb05c50b6e91.gif)

The existing behaviour seems to be made on purposed using the `QgsGenericFeatureSelectionManager`. This class was only used for this 2 widgets. So, I would like to know if the behavior is OK. Once we agree, I will complete the PR with some unit test.

To be complete, I plan to add the feature selection widget ![widget_sel1](https://user-images.githubusercontent.com/14358135/65410788-89c5b780-ddeb-11e9-921e-18d170f14b0f.png) and ![widget_sel2](https://user-images.githubusercontent.com/14358135/65410787-892d2100-ddeb-11e9-8fa3-f6fec9af0b9a.png) to the feature selection dialog and make it non modal. But, it would be the object of a separate PR.

cc @haubourg 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
