### PR TITLE
[dbmanager] use CRS selector in the Create table dialog (fix #25535)

### DIFF
--- a/python/plugins/db_manager/ui/DlgCreateTable.ui
+++ b/python/plugins/db_manager/ui/DlgCreateTable.ui
@@ -202,19 +202,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2" rowspan="2">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>50</width>
-         <height>51</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
@@ -226,9 +213,9 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QLineEdit" name="editGeomSrid">
-       <property name="text">
-        <string notr="true">0</string>
+      <widget class="QgsProjectionSelectionWidget" name="widgetTargetSrid" native="true">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -263,6 +250,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>cboSchema</tabstop>
   <tabstop>editName</tabstop>
@@ -276,7 +271,6 @@
   <tabstop>cboGeomType</tabstop>
   <tabstop>editGeomColumn</tabstop>
   <tabstop>spinGeomDim</tabstop>
-  <tabstop>editGeomSrid</tabstop>
   <tabstop>chkSpatialIndex</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>


### PR DESCRIPTION
## Description
Create table dialog still used plain line edit for SRID, this PR replaces it with QGIS CRS selector. Also reset dialog UI to the initial state on successful table creation. Fixes #25535.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
