### PR TITLE
Fix browser crash when adding (broken) WMTS

### DIFF
--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -202,7 +202,14 @@ Qt::ItemFlags QgsBrowserModel::flags( const QModelIndex &index ) const
 
   Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 
-  QgsDataItem *ptr = reinterpret_cast< QgsDataItem * >( index.internalPointer() );
+  QgsDataItem *ptr = dataItem( index );
+
+  if ( !ptr )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "FLAGS PROBLEM!" ), 4 );
+    return Qt::ItemFlags();
+  }
+
   if ( ptr->hasDragEnabled() )
     flags |= Qt::ItemIsDragEnabled;
 
@@ -498,7 +505,6 @@ QModelIndex QgsBrowserModel::findItem( QgsDataItem *item, QgsDataItem *parent ) 
     if ( childIndex.isValid() )
       return childIndex;
   }
-
   return QModelIndex();
 }
 

--- a/src/gui/qgsbrowserguimodel.cpp
+++ b/src/gui/qgsbrowserguimodel.cpp
@@ -37,7 +37,13 @@ Qt::ItemFlags QgsBrowserGuiModel::flags( const QModelIndex &index ) const
     return Qt::ItemFlags();
 
   Qt::ItemFlags flags = QgsBrowserModel::flags( index );
-  QgsDataItem *ptr = reinterpret_cast< QgsDataItem * >( index.internalPointer() );
+  QgsDataItem *ptr = dataItem( index );
+
+  if ( !ptr )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "FLAGS PROBLEM!" ), 4 );
+    return Qt::ItemFlags();
+  }
 
   Q_NOWARN_DEPRECATED_PUSH
   bool legacyAcceptDrop = ptr->acceptDrop();

--- a/src/gui/qgsbrowsertreeview.cpp
+++ b/src/gui/qgsbrowsertreeview.cpp
@@ -143,7 +143,7 @@ bool QgsBrowserTreeView::treeExpanded( const QModelIndex &index )
 
 bool QgsBrowserTreeView::hasExpandedDescendant( const QModelIndex &index ) const
 {
-  if ( !model() )
+  if ( !model() || !index.isValid() )
     return false;
 
   for ( int i = 0; i < model()->rowCount( index ); i++ )


### PR DESCRIPTION
The crash was caused by duplicated paths in data items.

While in theory identifiers should be unique, a broken
getCapabilities might serve duplicated (or empty)
identifiers.

Fixes #31927 

