### PR TITLE
replace old extension when changing output format (fix #26054)

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -397,6 +397,20 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
   mFilename->setEnabled( true );
   mFilename->setFilter( QgsVectorFileWriter::filterForDriver( format() ) );
 
+  // if output filename already defined we need to replace old suffix
+  // to avoid double extensions like .gpkg.shp
+  if ( !mFilename->filePath().isEmpty() )
+  {
+    QRegularExpression rx( "\\.(.*?)[\\s]" );
+    QString ext;
+    ext = rx.match( QgsVectorFileWriter::filterForDriver( format() ) ).captured( 1 );
+    if ( !ext.isEmpty() )
+    {
+      QFileInfo fi( mFilename->filePath() );
+      mFilename->setFilePath( QStringLiteral( "%1/%2.%3" ).arg( fi.path() ).arg( fi.baseName() ).arg( ext ) );
+    }
+  }
+
   bool selectAllFields = true;
   bool fieldsAsDisplayedValues = false;
 


### PR DESCRIPTION
## Description
If user changes output format the vector "Save as" dialog when output file already selected, extension of the file is not updated and resulting file has double extension like `.gpkg.shp`.

Fixes #26054.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
