### PR TITLE
fix false boolean not shown as so in attribute table

### DIFF
--- a/python/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
@@ -1,0 +1,43 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/fieldformatter/qgscheckboxfieldformatter.h                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsCheckBoxFieldFormatter : QgsFieldFormatter
+{
+%Docstring
+Field formatter for a check box field.
+
+.. versionadded:: 3.10
+%End
+
+%TypeHeaderCode
+#include "qgscheckboxfieldformatter.h"
+%End
+  public:
+
+    QgsCheckBoxFieldFormatter();
+%Docstring
+Constructor for QgsCheckBoxFieldFormatter.
+%End
+
+    virtual QString id() const;
+
+
+    virtual QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const;
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/fieldformatter/qgscheckboxfieldformatter.h                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgscheckboxfieldformatter.sip.in
@@ -11,7 +11,7 @@
 class QgsCheckBoxFieldFormatter : QgsFieldFormatter
 {
 %Docstring
-Field formatter for a check box field.
+Field formatter for a checkbox field.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgsfieldformatter.sip.in
+++ b/python/core/auto_generated/qgsfieldformatter.sip.in
@@ -29,7 +29,11 @@ This is an abstract base class and will always need to be subclassed.
 #include "qgsfieldformatter.h"
 %End
   public:
+
     QgsFieldFormatter();
+%Docstring
+Default constructor
+%End
 
     virtual ~QgsFieldFormatter();
 

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -321,6 +321,7 @@
 %Include auto_generated/geometry/qgswkbptr.sip
 %Include auto_generated/./3d/qgs3drendererregistry.sip
 %Include auto_generated/./3d/qgsabstract3drenderer.sip
+%Include auto_generated/fieldformatter/qgscheckboxfieldformatter.sip
 %Include auto_generated/fieldformatter/qgsrangefieldformatter.sip
 %Include auto_generated/fieldformatter/qgsdatetimefieldformatter.sip
 %Include auto_generated/fieldformatter/qgsfallbackfieldformatter.sip

--- a/scripts/astyle.options
+++ b/scripts/astyle.options
@@ -7,7 +7,7 @@
 --indent-labels
 --indent-namespaces
 --indent-switches
---max-instatement-indent=40
+--max-instatement-indent=80
 --min-conditional-indent=-1
 --suffix=none
 --break-after-logical

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -569,6 +569,7 @@ SET(QGIS_CORE_SRCS
   3d/qgs3drendererregistry.cpp
   3d/qgsabstract3drenderer.cpp
 
+  fieldformatter/qgscheckboxfieldformatter.cpp
   fieldformatter/qgsrangefieldformatter.cpp
   fieldformatter/qgsdatetimefieldformatter.cpp
   fieldformatter/qgsfallbackfieldformatter.cpp
@@ -1290,6 +1291,7 @@ SET(QGIS_CORE_HDRS
   3d/qgs3drendererregistry.h
   3d/qgsabstract3drenderer.h
 
+  fieldformatter/qgscheckboxfieldformatter.h
   fieldformatter/qgsrangefieldformatter.h
   fieldformatter/qgsdatetimefieldformatter.h
   fieldformatter/qgsfallbackfieldformatter.h

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
@@ -31,7 +31,7 @@ QString QgsCheckBoxFieldFormatter::representValue( QgsVectorLayer *layer, int fi
   Q_UNUSED( cache )
 
   /*
-  This foillows this logic:
+  This follows this logic:
 
   if field type is bool:
     NULL => nullRepresentation

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+  qgscheckboxfieldformatter.cpp - QgsCheckBoxFieldFormatter
+
+ ---------------------
+ begin                : 23.09.2019
+ copyright            : (C) 2019 by Denis Rouzaud
+ email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QObject>
+
+#include "qgscheckboxfieldformatter.h"
+#include "qgsapplication.h"
+
+
+QString QgsCheckBoxFieldFormatter::id() const
+{
+  return QStringLiteral( "CheckBox" );
+}
+
+QString QgsCheckBoxFieldFormatter::representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const
+{
+  Q_UNUSED( layer )
+  Q_UNUSED( fieldIndex )
+  Q_UNUSED( cache )
+  Q_UNUSED( config )
+
+
+  if ( value.isNull() || !value.canConvert<bool>() )
+  {
+    return QgsApplication::nullRepresentation();
+  }
+
+  const bool boolValue = value.toBool();
+
+  if ( boolValue )
+    return QObject::tr( "true" );
+  else
+    return QObject::tr( "false" );
+}

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.cpp
@@ -30,6 +30,19 @@ QString QgsCheckBoxFieldFormatter::representValue( QgsVectorLayer *layer, int fi
 {
   Q_UNUSED( cache )
 
+  /*
+  This foillows this logic:
+
+  if field type is bool:
+    NULL => nullRepresentation
+    true => tr("true")
+    false => tr("false")
+  else
+    if cannot convert to string (like json integer list) => (invalid)
+    if == checkedstate => tr("true")
+    if == uncheckedstate => tr("false")
+    else (value.toString)
+  */
 
   bool isNull = value.isNull();
   bool boolValue = false;

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.h
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+  qgscheckboxfieldformatter.h - QgsCheckBoxFieldFormatter
+
+ ---------------------
+ begin                : 23.09.2019
+ copyright            : (C) 2019 by Denis Rouzaud
+ email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCHECKBOXFIELDFORMATTER_H
+#define QGSCHECKBOXFIELDFORMATTER_H
+
+#include "qgis_core.h"
+#include "qgsfieldformatter.h"
+
+
+/**
+ * \ingroup core
+ * Field formatter for a check box field.
+ *
+ * \since QGIS 3.10
+ */
+class CORE_EXPORT QgsCheckBoxFieldFormatter : public QgsFieldFormatter
+{
+  public:
+
+    /**
+     * Constructor for QgsCheckBoxFieldFormatter.
+     */
+    QgsCheckBoxFieldFormatter() = default;
+
+    QString id() const override;
+
+    QString representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const override;
+};
+
+
+#endif // QGSCHECKBOXFIELDFORMATTER_H

--- a/src/core/fieldformatter/qgscheckboxfieldformatter.h
+++ b/src/core/fieldformatter/qgscheckboxfieldformatter.h
@@ -22,7 +22,7 @@
 
 /**
  * \ingroup core
- * Field formatter for a check box field.
+ * Field formatter for a checkbox field.
  *
  * \since QGIS 3.10
  */

--- a/src/core/qgsfieldformatter.cpp
+++ b/src/core/qgsfieldformatter.cpp
@@ -20,9 +20,6 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 
-QgsFieldFormatter::QgsFieldFormatter() //NOLINT
-{
-}
 
 QString QgsFieldFormatter::representValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const
 {

--- a/src/core/qgsfieldformatter.h
+++ b/src/core/qgsfieldformatter.h
@@ -40,6 +40,10 @@ class QgsVectorLayer;
 class CORE_EXPORT QgsFieldFormatter
 {
   public:
+
+    /**
+      * Default constructor
+      */
     QgsFieldFormatter() = default;
 
     virtual ~QgsFieldFormatter() = default;

--- a/src/core/qgsfieldformatter.h
+++ b/src/core/qgsfieldformatter.h
@@ -40,7 +40,7 @@ class QgsVectorLayer;
 class CORE_EXPORT QgsFieldFormatter
 {
   public:
-    QgsFieldFormatter();
+    QgsFieldFormatter() = default;
 
     virtual ~QgsFieldFormatter() = default;
 

--- a/src/core/qgsfieldformatterregistry.cpp
+++ b/src/core/qgsfieldformatterregistry.cpp
@@ -23,6 +23,7 @@
 #include "qgskeyvaluefieldformatter.h"
 #include "qgslistfieldformatter.h"
 #include "qgsrangefieldformatter.h"
+#include "qgscheckboxfieldformatter.h"
 #include "qgsfallbackfieldformatter.h"
 
 
@@ -36,6 +37,7 @@ QgsFieldFormatterRegistry::QgsFieldFormatterRegistry( QObject *parent )
   addFieldFormatter( new QgsListFieldFormatter() );
   addFieldFormatter( new QgsDateTimeFieldFormatter() );
   addFieldFormatter( new QgsRangeFieldFormatter() );
+  addFieldFormatter( new QgsCheckBoxFieldFormatter() );
 
   mFallbackFieldFormatter = new QgsFallbackFieldFormatter();
 }

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -689,8 +689,11 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
   {
     case Qt::DisplayRole:
     case Qt::ToolTipRole:
-      return mFieldFormatters.at( index.column() )->representValue( layer(), fieldId, mWidgetConfigs.at( index.column() ),
-             mAttributeWidgetCaches.at( index.column() ), val );
+      return mFieldFormatters.at( index.column() )->representValue( layer(),
+                                                                    fieldId,
+                                                                    mWidgetConfigs.at( index.column() ),
+                                                                    mAttributeWidgetCaches.at( index.column() ),
+                                                                    val );
 
     case Qt::EditRole:
       return val;

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -380,7 +380,7 @@ class TestQgsCheckBoxFieldFormatter(unittest.TestCase):
         # normal case
         self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 1), 'true')
         self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 0), 'false')
-        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 10), null_value)
+        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 10), "(10)")
         # invert true/false
         self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 1, 'CheckedState': 0}, None, 0), 'true')
         self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 1, 'CheckedState': 0}, None, 1), 'false')
@@ -388,7 +388,7 @@ class TestQgsCheckBoxFieldFormatter(unittest.TestCase):
         # test with string
         self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'yeah'), 'true')
         self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'nooh'), 'false')
-        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'oops'), null_value)
+        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'oops'), ("oops"))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -388,7 +388,7 @@ class TestQgsCheckBoxFieldFormatter(unittest.TestCase):
         # test with string
         self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'yeah'), 'true')
         self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'nooh'), 'false')
-        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'oops'), ("oops"))
+        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'oops'), "(oops)")
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -15,7 +15,7 @@ import qgis  # NOQA
 from qgis.core import (QgsFeature, QgsProject, QgsRelation, QgsVectorLayer,
                        QgsValueMapFieldFormatter, QgsValueRelationFieldFormatter,
                        QgsRelationReferenceFieldFormatter, QgsRangeFieldFormatter,
-                       QgsSettings, QgsGeometry, QgsPointXY)
+                       QgsCheckBoxFieldFormatter, QgsSettings, QgsGeometry, QgsPointXY)
 
 from qgis.PyQt.QtCore import QCoreApplication, QLocale
 from qgis.testing import start_app, unittest
@@ -355,6 +355,40 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123000'), '123000.00')
 
         QgsProject.instance().removeAllMapLayers()
+
+
+class TestQgsCheckBoxFieldFormatter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        QCoreApplication.setOrganizationName("QGIS_Test")
+        QCoreApplication.setOrganizationDomain("QGIS_TestPyQgsCheckBoxFieldFormatter.com")
+        QCoreApplication.setApplicationName("QGIS_TestPyQgsCheckBoxFieldFormatter")
+        QgsSettings().clear()
+        start_app()
+
+    def test_representValue(self):
+        null_value = "NULL"
+        QgsSettings().setValue("qgis/nullValue", null_value)
+        layer = QgsVectorLayer("point?field=int:integer&field=str:string", "layer", "memory")
+        self.assertTrue(layer.isValid())
+
+        field_formatter = QgsCheckBoxFieldFormatter()
+
+        # test with integer
+        # normal case
+        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 1), 'true')
+        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 0), 'false')
+        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 0, 'CheckedState': 1}, None, 10), null_value)
+        # invert true/false
+        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 1, 'CheckedState': 0}, None, 0), 'true')
+        self.assertEqual(field_formatter.representValue(layer, 0, {'UncheckedState': 1, 'CheckedState': 0}, None, 1), 'false')
+
+        # test with string
+        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'yeah'), 'true')
+        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'nooh'), 'false')
+        self.assertEqual(field_formatter.representValue(layer, 1, {'UncheckedState': 'nooh', 'CheckedState': 'yeah'}, None, 'oops'), null_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If an attribute is of type boolean, QGIS does not display `false` in the attribute table while `true` is written.

![image](https://user-images.githubusercontent.com/127259/65437519-3d4a9e00-de24-11e9-9cea-d12f55a44c89.png)

![image](https://user-images.githubusercontent.com/127259/65437533-4471ac00-de24-11e9-97d1-42136f37e0ff.png)


before => after
![image](https://user-images.githubusercontent.com/127259/65437699-8f8bbf00-de24-11e9-9b7d-158e019fddce.png)



***
also small astyle improvement for a better alignments of multilines