### PR TITLE
Fix warning in external resource widget

### DIFF
--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -261,7 +261,10 @@ void QgsExternalResourceWidget::loadDocument( const QString &path )
       QImageReader ir( resolvedPath );
       ir.setAutoTransform( true );
       QPixmap pm = QPixmap::fromImage( ir.read() );
-      mPixmapLabel->setPixmap( pm );
+      if ( !pm.isNull() )
+        mPixmapLabel->setPixmap( pm );
+      else
+        mPixmapLabel->clear();
       updateDocumentViewer();
     }
   }


### PR DESCRIPTION
Would trigger an internal warning when loading an inexistant image in the attribute table. Foremost `$projectPath/NULL` for me here.