### PR TITLE
Respect user set default vector output format in vector split algorithm

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -386,6 +386,84 @@ from a context.
 .. seealso:: :py:func:`getMapLayer`
 %End
 
+    QString preferredVectorFormat() const;
+%Docstring
+Returns the preferred vector format to use for vector outputs.
+
+This method returns a file extension to use when creating vector outputs (e.g. "shp"). Generally,
+it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()` However, in some cases, a specific parameter
+may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+and which creates multiple output layers in that folder). In this case, the format returned by this
+function should be used when creating these outputs.
+
+It is the algorithm's responsibility to check whether the returned format is acceptable for the algorithm,
+and to provide an appropriate fallback when the returned format is not usable.
+
+.. seealso:: :py:func:`setPreferredVectorFormat`
+
+.. seealso:: :py:func:`preferredRasterFormat`
+
+.. versionadded:: 3.10
+%End
+
+    void setPreferredVectorFormat( const QString &format );
+%Docstring
+Sets the preferred vector ``format`` to use for vector outputs.
+
+This method sets a file extension to use when creating vector outputs (e.g. "shp"). Generally,
+it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()` However, in some cases, a specific parameter
+may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+and which creates multiple output layers in that folder). In this case, the format set by this
+function will be used when creating these outputs.
+
+.. seealso:: :py:func:`preferredVectorFormat`
+
+.. seealso:: :py:func:`setPreferredRasterFormat`
+
+.. versionadded:: 3.10
+%End
+
+    QString preferredRasterFormat() const;
+%Docstring
+Returns the preferred raster format to use for vector outputs.
+
+This method returns a file extension to use when creating raster outputs (e.g. "tif"). Generally,
+it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()` However, in some cases, a specific parameter
+may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+and which creates multiple output layers in that folder). In this case, the format returned by this
+function should be used when creating these outputs.
+
+It is the algorithm's responsibility to check whether the returned format is acceptable for the algorithm,
+and to provide an appropriate fallback when the returned format is not usable.
+
+.. seealso:: :py:func:`setPreferredRasterFormat`
+
+.. seealso:: :py:func:`preferredVectorFormat`
+
+.. versionadded:: 3.10
+%End
+
+    void setPreferredRasterFormat( const QString &format );
+%Docstring
+Sets the preferred raster ``format`` to use for vector outputs.
+
+This method sets a file extension to use when creating raster outputs (e.g. "tif"). Generally,
+it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+:py:func:`QgsProcessingDestinationParameter.defaultFileExtension()` However, in some cases, a specific parameter
+may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+and which creates multiple output layers in that folder). In this case, the format set by this
+function will be used when creating these outputs.
+
+.. seealso:: :py:func:`preferredRasterFormat`
+
+.. seealso:: :py:func:`setPreferredVectorFormat`
+
+.. versionadded:: 3.10
+%End
+
   private:
     QgsProcessingContext( const QgsProcessingContext &other );
 };

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -273,6 +273,32 @@ Returns a subset of fields based on the indices of desired fields.
 .. versionadded:: 3.2
 %End
 
+    static QString defaultVectorExtension();
+%Docstring
+Returns the default vector extension to use, in the absence of all other constraints (e.g.
+provider based support for extensions).
+
+This method returns the user-set default extension from the processing settings, or
+a fallback value of "gpkg".
+
+.. seealso:: :py:func:`defaultRasterExtension`
+
+.. versionadded:: 3.10
+%End
+
+    static QString defaultRasterExtension();
+%Docstring
+Returns the default raster extension to use, in the absence of all other constraints (e.g.
+provider based support for extensions).
+
+This method returns the user-set default extension from the processing settings, or
+a fallback value of "tif".
+
+.. seealso:: :py:func:`defaultVectorExtension`
+
+.. versionadded:: 3.10
+%End
+
 };
 
 class QgsProcessingFeatureSource : QgsFeatureSource

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -58,6 +58,8 @@ class ProcessingConfig:
     SHOW_PROVIDERS_TOOLTIP = 'SHOW_PROVIDERS_TOOLTIP'
     SHOW_ALGORITHMS_KNOWN_ISSUES = 'SHOW_ALGORITHMS_KNOWN_ISSUES'
     MAX_THREADS = 'MAX_THREADS'
+    DEFAULT_OUTPUT_RASTER_LAYER_EXT = 'DefaultOutputRasterLayerExt'
+    DEFAULT_OUTPUT_VECTOR_LAYER_EXT = 'DefaultOutputVectorLayerExt'
 
     settings = {}
     settingIcons = {}
@@ -144,6 +146,24 @@ class ProcessingConfig:
             ProcessingConfig.MAX_THREADS,
             ProcessingConfig.tr('Max Threads'), threads,
             valuetype=Setting.INT))
+
+        extensions = QgsVectorFileWriter.supportedFormatExtensions()
+        ProcessingConfig.addSetting(Setting(
+            ProcessingConfig.tr('General'),
+            ProcessingConfig.DEFAULT_OUTPUT_VECTOR_LAYER_EXT,
+            ProcessingConfig.tr('Default output vector layer extension'),
+            'gpkg',
+            valuetype=Setting.SELECTION,
+            options=extensions))
+
+        extensions = QgsRasterFileWriter.supportedFormatExtensions()
+        ProcessingConfig.addSetting(Setting(
+            ProcessingConfig.tr('General'),
+            ProcessingConfig.DEFAULT_OUTPUT_RASTER_LAYER_EXT,
+            ProcessingConfig.tr('Default output raster layer extension'),
+            'tif',
+            valuetype=Setting.SELECTION,
+            options=extensions))
 
     @staticmethod
     def setGroupIcon(group, icon):

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -40,7 +40,8 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingOutputLayerDefinition,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingParameterFolderDestination)
+                       QgsProcessingParameterFolderDestination,
+                       QgsProcessingParameterVectorDestination)
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.tools.dataobjects import createContext
 from processing.gui.PostgisTableSelector import PostgisTableSelector
@@ -231,12 +232,12 @@ class DestinationSelectionPanel(BASE, WIDGET):
     def selectFile(self):
         file_filter = getFileFilter(self.parameter)
         settings = QgsSettings()
-        if isinstance(self.parameter, QgsProcessingParameterFeatureSink):
+        if isinstance(self.parameter, (QgsProcessingParameterFeatureSink, QgsProcessingParameterVectorDestination)):
             last_ext_path = '/Processing/LastVectorOutputExt'
-            last_ext = settings.value(last_ext_path, '.gpkg')
+            last_ext = settings.value(last_ext_path, '.{}'.format(self.parameter.defaultFileExtension()))
         elif isinstance(self.parameter, QgsProcessingParameterRasterDestination):
             last_ext_path = '/Processing/LastRasterOutputExt'
-            last_ext = settings.value(last_ext_path, '.tif')
+            last_ext = settings.value(last_ext_path, '.{}'.format(self.parameter.defaultFileExtension()))
         else:
             last_ext_path = None
             last_ext = None
@@ -245,7 +246,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
         filters = file_filter.split(';;')
         try:
             last_filter = [f for f in filters if '*{}'.format(last_ext) in f.lower()][0]
-        except:
+        except IndexError:
             last_filter = None
 
         if settings.contains('/Processing/LastOutputPath'):

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -18,6 +18,18 @@
 #include "qgsprocessingcontext.h"
 #include "qgsprocessingutils.h"
 
+QgsProcessingContext::QgsProcessingContext()
+  : mPreferredVectorFormat( QgsProcessingUtils::defaultVectorExtension() )
+  , mPreferredRasterFormat( QgsProcessingUtils::defaultRasterExtension() )
+{
+  auto callback = [ = ]( const QgsFeature & feature )
+  {
+    if ( mFeedback )
+      mFeedback->reportError( QObject::tr( "Encountered a transform error when reprojecting feature with id %1." ).arg( feature.id() ) );
+  };
+  mTransformErrorCallback = callback;
+}
+
 QgsProcessingContext::~QgsProcessingContext()
 {
   for ( auto it = mLayersToLoadOnCompletion.constBegin(); it != mLayersToLoadOnCompletion.constEnd(); ++it )

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -54,15 +54,7 @@ class CORE_EXPORT QgsProcessingContext
     /**
      * Constructor for QgsProcessingContext.
      */
-    QgsProcessingContext()
-    {
-      auto callback = [ = ]( const QgsFeature & feature )
-      {
-        if ( mFeedback )
-          mFeedback->reportError( QObject::tr( "Encountered a transform error when reprojecting feature with id %1." ).arg( feature.id() ) );
-      };
-      mTransformErrorCallback = callback;
-    }
+    QgsProcessingContext();
 
     //! QgsProcessingContext cannot be copied
     QgsProcessingContext( const QgsProcessingContext &other ) = delete;
@@ -441,6 +433,80 @@ class CORE_EXPORT QgsProcessingContext
      * \see getMapLayer()
      */
     QgsMapLayer *takeResultLayer( const QString &id ) SIP_TRANSFERBACK;
+
+    /**
+     * Returns the preferred vector format to use for vector outputs.
+     *
+     * This method returns a file extension to use when creating vector outputs (e.g. "shp"). Generally,
+     * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+     * QgsProcessingDestinationParameter::defaultFileExtension(). However, in some cases, a specific parameter
+     * may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+     * and which creates multiple output layers in that folder). In this case, the format returned by this
+     * function should be used when creating these outputs.
+     *
+     * It is the algorithm's responsibility to check whether the returned format is acceptable for the algorithm,
+     * and to provide an appropriate fallback when the returned format is not usable.
+     *
+     * \see setPreferredVectorFormat()
+     * \see preferredRasterFormat()
+     *
+     * \since QGIS 3.10
+     */
+    QString preferredVectorFormat() const { return mPreferredVectorFormat; }
+
+    /**
+     * Sets the preferred vector \a format to use for vector outputs.
+     *
+     * This method sets a file extension to use when creating vector outputs (e.g. "shp"). Generally,
+     * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+     * QgsProcessingDestinationParameter::defaultFileExtension(). However, in some cases, a specific parameter
+     * may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+     * and which creates multiple output layers in that folder). In this case, the format set by this
+     * function will be used when creating these outputs.
+     *
+     * \see preferredVectorFormat()
+     * \see setPreferredRasterFormat()
+     *
+     * \since QGIS 3.10
+     */
+    void setPreferredVectorFormat( const QString &format ) { mPreferredVectorFormat = format; }
+
+    /**
+     * Returns the preferred raster format to use for vector outputs.
+     *
+     * This method returns a file extension to use when creating raster outputs (e.g. "tif"). Generally,
+     * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+     * QgsProcessingDestinationParameter::defaultFileExtension(). However, in some cases, a specific parameter
+     * may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+     * and which creates multiple output layers in that folder). In this case, the format returned by this
+     * function should be used when creating these outputs.
+     *
+     * It is the algorithm's responsibility to check whether the returned format is acceptable for the algorithm,
+     * and to provide an appropriate fallback when the returned format is not usable.
+     *
+     * \see setPreferredRasterFormat()
+     * \see preferredVectorFormat()
+     *
+     * \since QGIS 3.10
+     */
+    QString preferredRasterFormat() const { return mPreferredRasterFormat; }
+
+    /**
+     * Sets the preferred raster \a format to use for vector outputs.
+     *
+     * This method sets a file extension to use when creating raster outputs (e.g. "tif"). Generally,
+     * it is preferable to use the extension associated with a particular parameter, which can be retrieved through
+     * QgsProcessingDestinationParameter::defaultFileExtension(). However, in some cases, a specific parameter
+     * may not be available to call this method on (e.g. for an algorithm which has only an output folder parameter
+     * and which creates multiple output layers in that folder). In this case, the format set by this
+     * function will be used when creating these outputs.
+     *
+     * \see preferredRasterFormat()
+     * \see setPreferredVectorFormat()
+     *
+     * \since QGIS 3.10
+     */
+    void setPreferredRasterFormat( const QString &format ) { mPreferredRasterFormat = format; }
 
   private:
 

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -458,6 +458,9 @@ class CORE_EXPORT QgsProcessingContext
 
     QPointer< QgsProcessingFeedback > mFeedback;
 
+    QString mPreferredVectorFormat;
+    QString mPreferredRasterFormat;
+
 #ifdef SIP_RUN
     QgsProcessingContext( const QgsProcessingContext &other );
 #endif

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -4491,10 +4491,9 @@ QString QgsProcessingParameterFeatureSink::defaultFileExtension() const
   }
   else
   {
-    QgsSettings settings;
     if ( hasGeometry() )
     {
-      return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+      return QgsProcessingUtils::defaultVectorExtension();
     }
     else
     {
@@ -4712,8 +4711,7 @@ QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
   }
   else
   {
-    QgsSettings settings;
-    return settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "tif" ), QgsSettings::Core ).toString();
+    return QgsProcessingUtils::defaultRasterExtension();
   }
 }
 
@@ -5128,10 +5126,9 @@ QString QgsProcessingParameterVectorDestination::defaultFileExtension() const
   }
   else
   {
-    QgsSettings settings;
     if ( hasGeometry() )
     {
-      return settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "shp" ), QgsSettings::Core ).toString();
+      return QgsProcessingUtils::defaultVectorExtension();
     }
     else
     {

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -189,8 +189,7 @@ bool QgsProcessingProvider::isSupportedOutputValue( const QVariant &outputValue,
 QString QgsProcessingProvider::defaultVectorFileExtension( bool hasGeometry ) const
 {
   QgsSettings settings;
-  const QString defaultExtension = hasGeometry ? QStringLiteral( "shp" ) : QStringLiteral( "dbf" );
-  const QString userDefault = settings.value( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), defaultExtension, QgsSettings::Core ).toString();
+  const QString userDefault = QgsProcessingUtils::defaultVectorExtension();
 
   const QStringList supportedExtensions = supportedOutputVectorLayerExtensions();
   if ( supportedExtensions.contains( userDefault, Qt::CaseInsensitive ) )
@@ -206,15 +205,14 @@ QString QgsProcessingProvider::defaultVectorFileExtension( bool hasGeometry ) co
   {
     // who knows? provider says it has no file support at all...
     // let's say shp. even MapInfo supports shapefiles.
-    return defaultExtension;
+    return hasGeometry ? QStringLiteral( "shp" ) : QStringLiteral( "dbf" );
   }
 }
 
 QString QgsProcessingProvider::defaultRasterFileExtension() const
 {
   QgsSettings settings;
-  const QString defaultExtension = QStringLiteral( "tif" );
-  const QString userDefault = settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), defaultExtension, QgsSettings::Core ).toString();
+  const QString userDefault = QgsProcessingUtils::defaultRasterExtension();
 
   const QStringList supportedExtensions = supportedOutputRasterLayerExtensions();
   if ( supportedExtensions.contains( userDefault, Qt::CaseInsensitive ) )
@@ -229,7 +227,7 @@ QString QgsProcessingProvider::defaultRasterFileExtension() const
   else
   {
     // who knows? provider says it has no file support at all...
-    return defaultExtension;
+    return QStringLiteral( "tif" );
   }
 }
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -32,6 +32,7 @@
 #include "qgsproviderregistry.h"
 #include "qgsmeshlayer.h"
 #include "qgsreferencedgeometry.h"
+#include "qgsrasterfilewriter.h"
 
 QList<QgsRasterLayer *> QgsProcessingUtils::compatibleRasterLayers( QgsProject *project, bool sort )
 {
@@ -913,6 +914,24 @@ QgsFields QgsProcessingUtils::indicesToFields( const QList<int> &indices, const 
   for ( int i : indices )
     fieldsSubset.append( fields.at( i ) );
   return fieldsSubset;
+}
+
+QString QgsProcessingUtils::defaultVectorExtension()
+{
+  QgsSettings settings;
+  const int setting = settings.value( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ), -1 ).toInt();
+  if ( setting == -1 )
+    return QStringLiteral( "gpkg" );
+  return QgsVectorFileWriter::supportedFormatExtensions().value( setting, QStringLiteral( "gpkg" ) );
+}
+
+QString QgsProcessingUtils::defaultRasterExtension()
+{
+  QgsSettings settings;
+  const int setting = settings.value( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ), -1 ).toInt();
+  if ( setting == -1 )
+    return QStringLiteral( "tif" );
+  return QgsRasterFileWriter::supportedFormatExtensions().value( setting, QStringLiteral( "tif" ) );
 }
 
 //

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -302,6 +302,30 @@ class CORE_EXPORT QgsProcessingUtils
      */
     static QgsFields indicesToFields( const QList<int> &indices, const QgsFields &fields );
 
+    /**
+     * Returns the default vector extension to use, in the absence of all other constraints (e.g.
+     * provider based support for extensions).
+     *
+     * This method returns the user-set default extension from the processing settings, or
+     * a fallback value of "gpkg".
+     *
+     * \see defaultRasterExtension()
+     * \since QGIS 3.10
+     */
+    static QString defaultVectorExtension();
+
+    /**
+     * Returns the default raster extension to use, in the absence of all other constraints (e.g.
+     * provider based support for extensions).
+     *
+     * This method returns the user-set default extension from the processing settings, or
+     * a fallback value of "tif".
+     *
+     * \see defaultVectorExtension()
+     * \since QGIS 3.10
+     */
+    static QString defaultRasterExtension();
+
   private:
     static bool canUseLayer( const QgsRasterLayer *layer );
     static bool canUseLayer( const QgsMeshLayer *layer );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -45,6 +45,7 @@
 #include "qgslayoutmanager.h"
 #include "qgslayoutitemlabel.h"
 #include "qgscoordinatetransformcontext.h"
+#include "qgsrasterfilewriter.h"
 
 class DummyAlgorithm : public QgsProcessingAlgorithm
 {
@@ -143,11 +144,11 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
 
       // default vector format extension
       QgsProcessingParameterFeatureSink *sinkParam = new QgsProcessingParameterFeatureSink( "sink" );
-      QCOMPARE( sinkParam->defaultFileExtension(), QStringLiteral( "shp" ) ); // before alg is accessible
+      QCOMPARE( sinkParam->defaultFileExtension(), QStringLiteral( "gpkg" ) ); // before alg is accessible
       QVERIFY( !sinkParam->algorithm() );
       QVERIFY( !sinkParam->provider() );
       QVERIFY( addParameter( sinkParam ) );
-      QCOMPARE( sinkParam->defaultFileExtension(), QStringLiteral( "shp" ) );
+      QCOMPARE( sinkParam->defaultFileExtension(), QStringLiteral( "gpkg" ) );
       QCOMPARE( sinkParam->algorithm(), this );
       QVERIFY( !sinkParam->provider() );
 
@@ -171,7 +172,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
     {
       // default vector format extension, taken from provider
       QgsProcessingParameterFeatureSink *sinkParam = new QgsProcessingParameterFeatureSink( "sink2" );
-      QCOMPARE( sinkParam->defaultFileExtension(), QStringLiteral( "shp" ) ); // before alg is accessible
+      QCOMPARE( sinkParam->defaultFileExtension(), QStringLiteral( "gpkg" ) ); // before alg is accessible
       QVERIFY( !sinkParam->algorithm() );
       QVERIFY( !sinkParam->provider() );
       QVERIFY( addParameter( sinkParam ) );
@@ -439,7 +440,7 @@ class DummyProvider3 : public QgsProcessingProvider
 
     QStringList supportedOutputRasterLayerExtensions() const override
     {
-      return QStringList() << QStringLiteral( "mig" ) << QStringLiteral( "asc" );
+      return QStringList() << QStringLiteral( "mig" ) << QStringLiteral( "sdat" );
     }
 
     void loadAlgorithms() override
@@ -612,8 +613,7 @@ void TestQgsProcessing::initTestCase()
   QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
 
   QgsSettings settings;
-  settings.remove( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QgsSettings::Core );
-  settings.remove( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QgsSettings::Core );
+  settings.clear();
 
   QgsApplication::processingRegistry()->addProvider( new QgsNativeAlgorithms( QgsApplication::processingRegistry() ) );
 }
@@ -5287,10 +5287,10 @@ void TestQgsProcessing::parameterFeatureSink()
   QCOMPARE( def->valueAsPythonString( "uri='complex' username=\"complex\"", context ), QStringLiteral( "'uri=\\'complex\\' username=\\\"complex\\\"'" ) );
   QCOMPARE( def->valueAsPythonString( QStringLiteral( "c:\\test\\new data\\test.dat" ), context ), QStringLiteral( "'c:\\\\test\\\\new data\\\\test.dat'" ) );
 
-  QCOMPARE( def->defaultFileExtension(), QStringLiteral( "shp" ) );
+  QCOMPARE( def->defaultFileExtension(), QStringLiteral( "gpkg" ) );
   QCOMPARE( def->generateTemporaryDestination(), QStringLiteral( "memory:" ) );
   def->setSupportsNonFileBasedOutput( false );
-  QVERIFY( def->generateTemporaryDestination().endsWith( QLatin1String( ".shp" ) ) );
+  QVERIFY( def->generateTemporaryDestination().endsWith( QLatin1String( ".gpkg" ) ) );
   QVERIFY( def->generateTemporaryDestination().startsWith( QgsProcessingUtils::tempFolder() ) );
 
   QVariantMap map = def->toVariantMap();
@@ -5453,8 +5453,8 @@ void TestQgsProcessing::parameterVectorOut()
   QCOMPARE( def->valueAsPythonString( "uri='complex' username=\"complex\"", context ), QStringLiteral( "'uri=\\'complex\\' username=\\\"complex\\\"'" ) );
   QCOMPARE( def->valueAsPythonString( QStringLiteral( "c:\\test\\new data\\test.dat" ), context ), QStringLiteral( "'c:\\\\test\\\\new data\\\\test.dat'" ) );
 
-  QCOMPARE( def->defaultFileExtension(), QStringLiteral( "shp" ) );
-  QVERIFY( def->generateTemporaryDestination().endsWith( QLatin1String( ".shp" ) ) );
+  QCOMPARE( def->defaultFileExtension(), QStringLiteral( "gpkg" ) );
+  QVERIFY( def->generateTemporaryDestination().endsWith( QLatin1String( ".gpkg" ) ) );
   QVERIFY( def->generateTemporaryDestination().startsWith( QgsProcessingUtils::tempFolder() ) );
 
   QVariantMap map = def->toVariantMap();
@@ -5563,12 +5563,12 @@ void TestQgsProcessing::parameterVectorOut()
 
   QgsProcessingContext context3;
   params.insert( QStringLiteral( "x" ), QgsProcessing::TEMPORARY_OUTPUT );
-  QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context3 ).right( 6 ), QStringLiteral( "/x.shp" ) );
+  QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context3 ).right( 6 ), QStringLiteral( "x.gpkg" ) );
 
   QgsProcessingContext context4;
   fs.sink = QgsProperty::fromValue( QgsProcessing::TEMPORARY_OUTPUT );
   params.insert( QStringLiteral( "x" ), QVariant::fromValue( fs ) );
-  QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context4 ).right( 6 ), QStringLiteral( "/x.shp" ) );
+  QCOMPARE( QgsProcessingParameters::parameterAsOutputLayer( def.get(), params, context4 ).right( 6 ), QStringLiteral( "x.gpkg" ) );
 
   // test supported output vector layer extensions
 
@@ -8451,14 +8451,16 @@ void TestQgsProcessing::defaultExtensionsForProvider()
   QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "mig" ) );
   // unless the user has set a default format, which IS supported by that provider
   QgsSettings settings;
-  settings.setValue( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "tab" ), QgsSettings::Core );
-  settings.setValue( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "asc" ), QgsSettings::Core );
+
+  settings.setValue( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ), QgsVectorFileWriter::supportedFormatExtensions().indexOf( QStringLiteral( "tab" ) ) );
+  settings.setValue( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ), QgsRasterFileWriter::supportedFormatExtensions().indexOf( QStringLiteral( "sdat" ) ) );
+
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "tab" ) );
-  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "asc" ) );
+  QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "sdat" ) );
 
   // but if default is not supported by provider, we use a supported format
-  settings.setValue( QStringLiteral( "Processing/DefaultOutputVectorLayerExt" ), QStringLiteral( "gpkg" ), QgsSettings::Core );
-  settings.setValue( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "ecw" ), QgsSettings::Core );
+  settings.setValue( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ), QgsVectorFileWriter::supportedFormatExtensions().indexOf( QStringLiteral( "gpkg" ) ) );
+  settings.setValue( QStringLiteral( "Processing/Configuration/DefaultOutputRasterLayerExt" ), QgsRasterFileWriter::supportedFormatExtensions().indexOf( QStringLiteral( "ecw" ) ) );
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "mif" ) );
   QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "mig" ) );
 }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8449,6 +8449,12 @@ void TestQgsProcessing::defaultExtensionsForProvider()
   // default implementation should return first supported format for provider
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "mif" ) );
   QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "mig" ) );
+
+  // a default context should use reasonable defaults
+  QgsProcessingContext context;
+  QCOMPARE( context.preferredVectorFormat(), QStringLiteral( "gpkg" ) );
+  QCOMPARE( context.preferredRasterFormat(), QStringLiteral( "tif" ) );
+
   // unless the user has set a default format, which IS supported by that provider
   QgsSettings settings;
 
@@ -8457,6 +8463,11 @@ void TestQgsProcessing::defaultExtensionsForProvider()
 
   QCOMPARE( provider.defaultVectorFileExtension( true ), QStringLiteral( "tab" ) );
   QCOMPARE( provider.defaultRasterFileExtension(), QStringLiteral( "sdat" ) );
+
+  // context should respect these as preferred formats
+  QgsProcessingContext context2;
+  QCOMPARE( context2.preferredVectorFormat(), QStringLiteral( "tab" ) );
+  QCOMPARE( context2.preferredRasterFormat(), QStringLiteral( "sdat" ) );
 
   // but if default is not supported by provider, we use a supported format
   settings.setValue( QStringLiteral( "Processing/Configuration/DefaultOutputVectorLayerExt" ), QgsVectorFileWriter::supportedFormatExtensions().indexOf( QStringLiteral( "gpkg" ) ) );


### PR DESCRIPTION
The created outputs will now be created using the format specified from the Processing setting default vector format setting.