### PR TITLE
[processing] Add API support for algorithm aliases

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingregistry.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingregistry.sip.in
@@ -107,6 +107,19 @@ according to some user configuration.
 .. seealso:: :py:func:`algorithmById`
 %End
 
+    void addAlgorithmAlias( const QString &aliasId, const QString &actualId );
+%Docstring
+Adds a new alias to an existing algorithm.
+
+This allows algorithms to be referred to by a different provider ID and algorithm name to their actual underlying provider and algorithm name.
+It provides a mechanism to allow algorithms to be moved between providers without breaking existing scripts or plugins.
+
+The ``aliasId`` argument specifies the "fake" algorithm id (eg "fake_provider:fake_alg") by which the algorithm can
+be referred to, and the ``actualId`` argument specifies the real algorithm ID for the algorithm.
+
+.. versionadded:: 3.10
+%End
+
     bool addParameterType( QgsProcessingParameterType *type /Transfer/ );
 %Docstring
 Register a new parameter type for processing.

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -134,8 +134,11 @@ QList< const QgsProcessingAlgorithm * > QgsProcessingRegistry::algorithms() cons
   return algs;
 }
 
-const QgsProcessingAlgorithm *QgsProcessingRegistry::algorithmById( const QString &id ) const
+const QgsProcessingAlgorithm *QgsProcessingRegistry::algorithmById( const QString &constId ) const
 {
+  // allow mapping of algorithm via registered algorithm aliases
+  QString id = mAlgorithmAliases.value( constId, constId );
+
   QMap<QString, QgsProcessingProvider *>::const_iterator it = mProviders.constBegin();
   for ( ; it != mProviders.constEnd(); ++it )
   {
@@ -164,6 +167,11 @@ QgsProcessingAlgorithm *QgsProcessingRegistry::createAlgorithmById( const QStrin
 
   std::unique_ptr< QgsProcessingAlgorithm > creation( alg->create( configuration ) );
   return creation.release();
+}
+
+void QgsProcessingRegistry::addAlgorithmAlias( const QString &aliasId, const QString &actualId )
+{
+  mAlgorithmAliases.insert( aliasId, actualId );
 }
 
 bool QgsProcessingRegistry::addParameterType( QgsProcessingParameterType *type )

--- a/src/core/processing/qgsprocessingregistry.h
+++ b/src/core/processing/qgsprocessingregistry.h
@@ -134,6 +134,19 @@ class CORE_EXPORT QgsProcessingRegistry : public QObject
     QgsProcessingAlgorithm *createAlgorithmById( const QString &id, const QVariantMap &configuration = QVariantMap() ) const SIP_TRANSFERBACK;
 
     /**
+     * Adds a new alias to an existing algorithm.
+     *
+     * This allows algorithms to be referred to by a different provider ID and algorithm name to their actual underlying provider and algorithm name.
+     * It provides a mechanism to allow algorithms to be moved between providers without breaking existing scripts or plugins.
+     *
+     * The \a aliasId argument specifies the "fake" algorithm id (eg "fake_provider:fake_alg") by which the algorithm can
+     * be referred to, and the \a actualId argument specifies the real algorithm ID for the algorithm.
+     *
+     * \since QGIS 3.10
+     */
+    void addAlgorithmAlias( const QString &aliasId, const QString &actualId );
+
+    /**
      * Register a new parameter type for processing.
      * Ownership is transferred to the registry.
      * Will emit parameterTypeAdded.
@@ -199,6 +212,8 @@ class CORE_EXPORT QgsProcessingRegistry : public QObject
 
     //! Hash of available parameter types by id. This object owns the pointers.
     QMap<QString, QgsProcessingParameterType *> mParameterTypes;
+
+    QMap< QString, QString > mAlgorithmAliases;
 
 #ifdef SIP_RUN
     QgsProcessingRegistry( const QgsProcessingRegistry &other );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1253,6 +1253,13 @@ void TestQgsProcessing::algorithm()
   QVERIFY( !r.algorithmById( "p1:alg3" ) );
   QVERIFY( !r.algorithmById( "px:alg1" ) );
 
+  // alias support
+  QVERIFY( !r.algorithmById( QStringLiteral( "fake:fakealg" ) ) );
+  r.addAlgorithmAlias( QStringLiteral( "fake:fakealg" ), QStringLiteral( "nope:none" ) );
+  QVERIFY( !r.algorithmById( QStringLiteral( "fake:fakealg" ) ) );
+  r.addAlgorithmAlias( QStringLiteral( "fake:fakealg" ), QStringLiteral( "p1:alg1" ) );
+  QCOMPARE( r.algorithmById( QStringLiteral( "fake:fakealg" ) ), p->algorithm( "alg1" ) );
+
   // test that algorithmById can transparently map 'qgis' algorithms across to matching 'native' algorithms
   // this allows us the freedom to convert qgis python algs to c++ without breaking api or existing models
   QCOMPARE( QgsApplication::processingRegistry()->algorithmById( QStringLiteral( "qgis:dissolve" ) )->id(), QStringLiteral( "native:dissolve" ) );


### PR DESCRIPTION
Allows us to freely move algorithms between providers without breaking existing scripts
