### PR TITLE
Limit number of label candidates for large layers

### DIFF
--- a/src/core/pal/layer.h
+++ b/src/core/pal/layer.h
@@ -86,6 +86,69 @@ namespace pal
        */
       int featureCount() { return mHashtable.size(); }
 
+      /**
+       * Returns the maximum number of point label candidates to generate for features
+       * in this layer.
+       */
+      int maximumPointLabelCandidates() const
+      {
+        // when an extreme number of features exist in the layer, we limit the number of candidates
+        // to avoid the engine processing endlessly...
+        const int size = mHashtable.size();
+        if ( size > 1000 )
+          return std::min( pal->point_p, 4 );
+        else if ( size > 500 )
+          return std::min( pal->point_p, 6 );
+        else if ( size > 200 )
+          return std::min( pal->point_p, 8 );
+        else if ( size > 100 )
+          return std::min( pal->point_p, 12 );
+        else
+          return pal->point_p;
+      }
+
+      /**
+       * Returns the maximum number of line label candidates to generate for features
+       * in this layer.
+       */
+      int maximumLineLabelCandidates() const
+      {
+        // when an extreme number of features exist in the layer, we limit the number of candidates
+        // to avoid the engine processing endlessly...
+        const int size = mHashtable.size();
+        if ( size > 1000 )
+          return std::min( pal->line_p, 5 );
+        else if ( size > 500 )
+          return std::min( pal->line_p, 10 );
+        else if ( size > 200 )
+          return std::min( pal->line_p, 20 );
+        else if ( size > 100 )
+          return std::min( pal->line_p, 40 );
+        else
+          return pal->line_p;
+      }
+
+      /**
+       * Returns the maximum number of polygon label candidates to generate for features
+       * in this layer.
+       */
+      int maximumPolygonLabelCandidates() const
+      {
+        // when an extreme number of features exist in the layer, we limit the number of candidates
+        // to avoid the engine processing endlessly...
+        const int size = mHashtable.size();
+        if ( size > 1000 )
+          return std::min( pal->poly_p, 5 );
+        else if ( size > 500 )
+          return std::min( pal->poly_p, 15 );
+        else if ( size > 200 )
+          return std::min( pal->poly_p, 20 );
+        else if ( size > 100 )
+          return std::min( pal->poly_p, 25 );
+        else
+          return pal->poly_p;
+      }
+
       //! Returns pointer to the associated provider
       QgsAbstractLabelProvider *provider() const { return mProvider; }
 

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -331,13 +331,13 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
       switch ( feat->feature->getGeosType() )
       {
         case GEOS_POINT:
-          max_p = point_p;
+          max_p = feat->feature->layer()->maximumPointLabelCandidates();
           break;
         case GEOS_LINESTRING:
-          max_p = line_p;
+          max_p = feat->feature->layer()->maximumLineLabelCandidates();
           break;
         case GEOS_POLYGON:
-          max_p = poly_p;
+          max_p = feat->feature->layer()->maximumPolygonLabelCandidates();
           break;
       }
 


### PR DESCRIPTION
When an extreme number of features are being labeled from a single layer, place additional limits on the maximum number of labeling candidates to generate for features in this layer

Helps avoid extreme labeling times (e.g. on my test project with
some 3000 point features being registered for labeling, the labeling
time cuts from 30 seconds to 3 seconds). There should be no loss
in quality here either, given that the labeling placement solution
for any map with this many labels is always going to be quasi-random
anyway (and is likely never going to be a cartographic masterpiece....)
