### PR TITLE
[ui] Insure color widgets are only enabled when image decoration enabled

### DIFF
--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -62,6 +62,7 @@ QgsDecorationImageDialog::QgsDecorationImageDialog( QgsDecorationImage &deco, QW
 
   // enabled
   grpEnable->setChecked( mDeco.enabled() );
+  connect( grpEnable, &QGroupBox::toggled, this, [ = ] { updateEnabledColorButtons(); } );
 
   wgtImagePath->setFilePath( mDeco.imagePath() );
   connect( wgtImagePath, &QgsFileWidget::fileChanged, this, &QgsDecorationImageDialog::updateImagePath );
@@ -110,6 +111,36 @@ void QgsDecorationImageDialog::apply()
   mDeco.update();
 }
 
+void QgsDecorationImageDialog::updateEnabledColorButtons()
+{
+  QColor defaultFill, defaultStroke;
+  double defaultStrokeWidth, defaultFillOpacity, defaultStrokeOpacity;
+  bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultStrokeColor, hasDefaultStrokeWidth, hasDefaultStrokeOpacity;
+  bool hasFillParam, hasFillOpacityParam, hasStrokeParam, hasStrokeWidthParam, hasStrokeOpacityParam;
+  QgsApplication::svgCache()->containsParams( mDeco.imagePath(), hasFillParam, hasDefaultFillColor, defaultFill,
+      hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
+      hasStrokeParam, hasDefaultStrokeColor, defaultStroke,
+      hasStrokeWidthParam, hasDefaultStrokeWidth, defaultStrokeWidth,
+      hasStrokeOpacityParam, hasDefaultStrokeOpacity, defaultStrokeOpacity );
+
+  pbnChangeColor->setEnabled( grpEnable->isChecked() && hasFillParam );
+  pbnChangeColor->setAllowOpacity( hasFillOpacityParam );
+  if ( hasFillParam )
+  {
+    QColor fill = hasDefaultFillColor ? defaultFill : pbnChangeColor->color();
+    fill.setAlphaF( hasFillOpacityParam && hasDefaultFillOpacity ? defaultFillOpacity : 1.0 );
+    pbnChangeColor->setColor( fill );
+  }
+  pbnChangeOutlineColor->setEnabled( grpEnable->isChecked() && hasStrokeParam );
+  pbnChangeOutlineColor->setAllowOpacity( hasStrokeOpacityParam );
+  if ( hasStrokeParam )
+  {
+    QColor stroke = hasDefaultStrokeColor ? defaultStroke : pbnChangeOutlineColor->color();
+    stroke.setAlphaF( hasStrokeOpacityParam && hasDefaultStrokeOpacity ? defaultStrokeOpacity : 1.0 );
+    pbnChangeOutlineColor->setColor( stroke );
+  }
+}
+
 void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
 {
   if ( mDeco.imagePath() != imagePath )
@@ -117,32 +148,7 @@ void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
 
   if ( mDeco.mImageFormat == QgsDecorationImage::FormatSVG )
   {
-    QColor defaultFill, defaultStroke;
-    double defaultStrokeWidth, defaultFillOpacity, defaultStrokeOpacity;
-    bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultStrokeColor, hasDefaultStrokeWidth, hasDefaultStrokeOpacity;
-    bool hasFillParam, hasFillOpacityParam, hasStrokeParam, hasStrokeWidthParam, hasStrokeOpacityParam;
-    QgsApplication::svgCache()->containsParams( imagePath, hasFillParam, hasDefaultFillColor, defaultFill,
-        hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
-        hasStrokeParam, hasDefaultStrokeColor, defaultStroke,
-        hasStrokeWidthParam, hasDefaultStrokeWidth, defaultStrokeWidth,
-        hasStrokeOpacityParam, hasDefaultStrokeOpacity, defaultStrokeOpacity );
-
-    pbnChangeColor->setEnabled( hasFillParam );
-    pbnChangeColor->setAllowOpacity( hasFillOpacityParam );
-    if ( hasFillParam )
-    {
-      QColor fill = hasDefaultFillColor ? defaultFill : pbnChangeColor->color();
-      fill.setAlphaF( hasFillOpacityParam && hasDefaultFillOpacity ? defaultFillOpacity : 1.0 );
-      pbnChangeColor->setColor( fill );
-    }
-    pbnChangeOutlineColor->setEnabled( hasStrokeParam );
-    pbnChangeOutlineColor->setAllowOpacity( hasStrokeOpacityParam );
-    if ( hasStrokeParam )
-    {
-      QColor stroke = hasDefaultStrokeColor ? defaultStroke : pbnChangeOutlineColor->color();
-      stroke.setAlphaF( hasStrokeOpacityParam && hasDefaultStrokeOpacity ? defaultStrokeOpacity : 1.0 );
-      pbnChangeOutlineColor->setColor( stroke );
-    }
+    updateEnabledColorButtons();
   }
   else
   {

--- a/src/app/decorations/qgsdecorationimagedialog.h
+++ b/src/app/decorations/qgsdecorationimagedialog.h
@@ -30,6 +30,7 @@ class APP_EXPORT QgsDecorationImageDialog : public QDialog, private Ui::QgsDecor
 
   private:
     void drawImage();
+    void updateEnabledColorButtons();
     void updateImagePath( const QString &imagePath );
     void resizeEvent( QResizeEvent * ) override; //overloads qwidget
 


### PR DESCRIPTION

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This fixes #31962. 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
