### PR TITLE
[processing] Extend api for retrieving a layer in a compatible format

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -661,6 +661,43 @@ in a temporary location. The function will then return the path to that temporar
 
 The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
 layer export is required.
+
+When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
+to use parameterAsCompatibleSourceLayerPathAndLayerName() which may avoid conversion in more situations.
+%End
+
+    QString parameterAsCompatibleSourceLayerPathAndLayerName( const QVariantMap &parameters, const QString &name,
+        QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = 0, QString *layerName /Out/ = 0 );
+%Docstring
+Evaluates the parameter with matching ``name`` to a source vector layer file path and layer name of compatible format.
+
+If the parameter is evaluated to an existing layer, and that layer is not of the format listed in the
+``compatibleFormats`` argument, then the layer will first be exported to a compatible format
+in a temporary location. The function will then return the path to that temporary file.
+
+``compatibleFormats`` should consist entirely of lowercase file extensions, e.g. 'shp'.
+
+The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
+layer export is required. This defaults to shapefiles, because shapefiles are the future (don't believe the geopackage hype!).
+
+This method should be preferred over parameterAsCompatibleSourceLayerPath() when an algorithm is able
+to correctly handle files with multiple layers. Unlike parameterAsCompatibleSourceLayerPath(), it will not force
+a conversion in this case and will return the target layer name in the ``layerName`` argument.
+
+:param parameters: input parameter value map
+:param name: name of target parameter
+:param context: processing context
+:param compatibleFormats: a list of lowercase file extensions compatible with the algorithm
+:param preferredFormat: preferred format extension to use if conversion if required
+:param feedback: feedback object
+
+:return: - path to source layer, or nearly converted compatible layer
+         - layerName: will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+
+
+.. seealso:: :py:func:`parameterAsCompatibleSourceLayerPath`
+
+.. versionadded:: 3.10
 %End
 
     QgsMapLayer *parameterAsLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -732,6 +732,43 @@ in a temporary location. The function will then return the path to that temporar
 
 The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
 layer export is required. This defaults to shapefiles, because shapefiles are the future (don't believe the geopackage hype!).
+
+When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
+to use parameterAsCompatibleSourceLayerPathAndLayerName() which may avoid conversion in more situations.
+%End
+
+    static QString parameterAsCompatibleSourceLayerPathAndLayerName( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters,
+        QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = 0, QString *layerName /Out/ = 0 );
+%Docstring
+Evaluates the parameter with matching ``definition`` to a source vector layer file path and layer name of compatible format.
+
+If the parameter is evaluated to an existing layer, and that layer is not of the format listed in the
+``compatibleFormats`` argument, then the layer will first be exported to a compatible format
+in a temporary location. The function will then return the path to that temporary file.
+
+``compatibleFormats`` should consist entirely of lowercase file extensions, e.g. 'shp'.
+
+The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
+layer export is required. This defaults to shapefiles, because shapefiles are the future (don't believe the geopackage hype!).
+
+This method should be preferred over parameterAsCompatibleSourceLayerPath() when an algorithm is able
+to correctly handle files with multiple layers. Unlike parameterAsCompatibleSourceLayerPath(), it will not force
+a conversion in this case and will return the target layer name in the ``layerName`` argument.
+
+:param definition: associated parameter definition
+:param parameters: input parameter value map
+:param context: processing context
+:param compatibleFormats: a list of lowercase file extensions compatible with the algorithm
+:param preferredFormat: preferred format extension to use if conversion if required
+:param feedback: feedback object
+
+:return: - path to source layer, or nearly converted compatible layer
+         - layerName: will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+
+
+.. seealso:: :py:func:`parameterAsCompatibleSourceLayerPath`
+
+.. versionadded:: 3.10
 %End
 
     static QgsMapLayer *parameterAsLayer( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context );

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -232,7 +232,7 @@ a specified ``algorithm``.
         QgsProcessingContext &context,
         QgsProcessingFeedback *feedback );
 %Docstring
-Converts a source vector ``layer`` to a file path to a vector layer of compatible format.
+Converts a source vector ``layer`` to a file path of a vector layer of compatible format.
 
 If the specified ``layer`` is not of the format listed in the
 ``compatibleFormats`` argument, then the layer will first be exported to a compatible format
@@ -242,6 +242,52 @@ in a temporary location using ``baseName``. The function will then return the pa
 
 The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
 layer export is required. This defaults to shapefiles.
+
+When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
+to use convertToCompatibleFormatAndLayerName() which may avoid conversion in more situations.
+
+.. seealso:: :py:func:`convertToCompatibleFormatAndLayerName`
+%End
+
+    static QString convertToCompatibleFormatAndLayerName( const QgsVectorLayer *layer,
+        bool selectedFeaturesOnly,
+        const QString &baseName,
+        const QStringList &compatibleFormats,
+        const QString &preferredFormat,
+        QgsProcessingContext &context,
+        QgsProcessingFeedback *feedback,
+        QString &layerName /Out/ );
+%Docstring
+Converts a source vector ``layer`` to a file path and layer name of a vector layer of compatible format.
+
+If the specified ``layer`` is not of the format listed in the
+``compatibleFormats`` argument, then the layer will first be exported to a compatible format
+in a temporary location using ``baseName``. The function will then return the path to that temporary file.
+
+``compatibleFormats`` should consist entirely of lowercase file extensions, e.g. 'shp'.
+
+The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
+layer export is required. This defaults to shapefiles.
+
+This method should be preferred over convertToCompatibleFormat() when an algorithm is able
+to correctly handle files with multiple layers. Unlike convertToCompatibleFormat(), it will not force
+a conversion in this case and will return the target layer name in the ``layerName`` argument.
+
+:param layer: source layer to convert (if required)
+:param selectedFeaturesOnly: ``True`` if only selected features from the layer should be used
+:param baseName: base file name for converted layer, if required
+:param compatibleFormats: a list of lowercase file extensions compatible with the algorithm
+:param preferredFormat: preferred format extension to use if conversion if required
+:param context: processing context
+:param feedback: feedback object
+
+:return: - path to source layer, or nearly converted compatible layer
+         - layerName: will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+
+
+.. seealso:: :py:func:`convertToCompatibleFormat`
+
+.. versionadded:: 3.10
 %End
 
     static QgsFields combineFields( const QgsFields &fieldsA, const QgsFields &fieldsB, const QString &fieldsBPrefix = QString() );

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -612,6 +612,11 @@ QString QgsProcessingAlgorithm::parameterAsCompatibleSourceLayerPath( const QVar
   return QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( parameterDefinition( name ), parameters, context, compatibleFormats, preferredFormat, feedback );
 }
 
+QString QgsProcessingAlgorithm::parameterAsCompatibleSourceLayerPathAndLayerName( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat, QgsProcessingFeedback *feedback, QString *layerName )
+{
+  return QgsProcessingParameters::parameterAsCompatibleSourceLayerPathAndLayerName( parameterDefinition( name ), parameters, context, compatibleFormats, preferredFormat, feedback, layerName );
+}
+
 QgsMapLayer *QgsProcessingAlgorithm::parameterAsLayer( const QVariantMap &parameters, const QString &name, QgsProcessingContext &context ) const
 {
   return QgsProcessingParameters::parameterAsLayer( parameterDefinition( name ), parameters, context );

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -653,9 +653,44 @@ class CORE_EXPORT QgsProcessingAlgorithm
      *
      * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
      * layer export is required.
+     *
+     * When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
+     * to use parameterAsCompatibleSourceLayerPathAndLayerName() which may avoid conversion in more situations.
      */
     QString parameterAsCompatibleSourceLayerPath( const QVariantMap &parameters, const QString &name,
         QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = nullptr );
+
+    /**
+     * Evaluates the parameter with matching \a name to a source vector layer file path and layer name of compatible format.
+     *
+     * If the parameter is evaluated to an existing layer, and that layer is not of the format listed in the
+     * \a compatibleFormats argument, then the layer will first be exported to a compatible format
+     * in a temporary location. The function will then return the path to that temporary file.
+     *
+     * \a compatibleFormats should consist entirely of lowercase file extensions, e.g. 'shp'.
+     *
+     * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
+     * layer export is required. This defaults to shapefiles, because shapefiles are the future (don't believe the geopackage hype!).
+     *
+     * This method should be preferred over parameterAsCompatibleSourceLayerPath() when an algorithm is able
+     * to correctly handle files with multiple layers. Unlike parameterAsCompatibleSourceLayerPath(), it will not force
+     * a conversion in this case and will return the target layer name in the \a layerName argument.
+     *
+     * \param parameters input parameter value map
+     * \param name name of target parameter
+     * \param context processing context
+     * \param compatibleFormats a list of lowercase file extensions compatible with the algorithm
+     * \param preferredFormat preferred format extension to use if conversion if required
+     * \param feedback feedback object
+     * \param layerName will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+     *
+     * \returns path to source layer, or nearly converted compatible layer
+     *
+     * \see parameterAsCompatibleSourceLayerPath()
+     * \since QGIS 3.10
+     */
+    QString parameterAsCompatibleSourceLayerPathAndLayerName( const QVariantMap &parameters, const QString &name,
+        QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = nullptr, QString *layerName SIP_OUT = nullptr );
 
     /**
      * Evaluates the parameter with matching \a name to a map layer.

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -480,7 +480,7 @@ QgsProcessingFeatureSource *QgsProcessingParameters::parameterAsSource( const Qg
   return QgsProcessingUtils::variantToSource( value, context, definition->defaultValue() );
 }
 
-QString QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat, QgsProcessingFeedback *feedback )
+QString parameterAsCompatibleSourceLayerPathInternal( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat, QgsProcessingFeedback *feedback, QString *layerName )
 {
   if ( !definition )
     return QString();
@@ -544,8 +544,29 @@ QString QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( const Qgs
   if ( !vl )
     return QString();
 
-  return QgsProcessingUtils::convertToCompatibleFormat( vl, selectedFeaturesOnly, definition->name(),
-         compatibleFormats, preferredFormat, context, feedback );
+  if ( layerName )
+    return QgsProcessingUtils::convertToCompatibleFormatAndLayerName( vl, selectedFeaturesOnly, definition->name(),
+           compatibleFormats, preferredFormat, context, feedback, *layerName );
+  else
+    return QgsProcessingUtils::convertToCompatibleFormat( vl, selectedFeaturesOnly, definition->name(),
+           compatibleFormats, preferredFormat, context, feedback );
+}
+
+QString QgsProcessingParameters::parameterAsCompatibleSourceLayerPath( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat, QgsProcessingFeedback *feedback )
+{
+  return parameterAsCompatibleSourceLayerPathInternal( definition, parameters, context, compatibleFormats, preferredFormat, feedback, nullptr );
+}
+
+QString QgsProcessingParameters::parameterAsCompatibleSourceLayerPathAndLayerName( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat, QgsProcessingFeedback *feedback, QString *layerName )
+{
+  QString *destLayer = layerName;
+  QString tmp;
+  if ( destLayer )
+    destLayer->clear();
+  else
+    destLayer = &tmp;
+
+  return parameterAsCompatibleSourceLayerPathInternal( definition, parameters, context, compatibleFormats, preferredFormat, feedback, destLayer );
 }
 
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -793,9 +793,44 @@ class CORE_EXPORT QgsProcessingParameters
      *
      * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
      * layer export is required. This defaults to shapefiles, because shapefiles are the future (don't believe the geopackage hype!).
+     *
+     * When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
+     * to use parameterAsCompatibleSourceLayerPathAndLayerName() which may avoid conversion in more situations.
      */
     static QString parameterAsCompatibleSourceLayerPath( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters,
         QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = nullptr );
+
+    /**
+     * Evaluates the parameter with matching \a definition to a source vector layer file path and layer name of compatible format.
+     *
+     * If the parameter is evaluated to an existing layer, and that layer is not of the format listed in the
+     * \a compatibleFormats argument, then the layer will first be exported to a compatible format
+     * in a temporary location. The function will then return the path to that temporary file.
+     *
+     * \a compatibleFormats should consist entirely of lowercase file extensions, e.g. 'shp'.
+     *
+     * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
+     * layer export is required. This defaults to shapefiles, because shapefiles are the future (don't believe the geopackage hype!).
+     *
+     * This method should be preferred over parameterAsCompatibleSourceLayerPath() when an algorithm is able
+     * to correctly handle files with multiple layers. Unlike parameterAsCompatibleSourceLayerPath(), it will not force
+     * a conversion in this case and will return the target layer name in the \a layerName argument.
+     *
+     * \param definition associated parameter definition
+     * \param parameters input parameter value map
+     * \param context processing context
+     * \param compatibleFormats a list of lowercase file extensions compatible with the algorithm
+     * \param preferredFormat preferred format extension to use if conversion if required
+     * \param feedback feedback object
+     * \param layerName will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+     *
+     * \returns path to source layer, or nearly converted compatible layer
+     *
+     * \see parameterAsCompatibleSourceLayerPath()
+     * \since QGIS 3.10
+     */
+    static QString parameterAsCompatibleSourceLayerPathAndLayerName( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters,
+        QgsProcessingContext &context, const QStringList &compatibleFormats, const QString &preferredFormat = QString( "shp" ), QgsProcessingFeedback *feedback = nullptr, QString *layerName SIP_OUT = nullptr );
 
     /**
      * Evaluates the parameter with matching \a definition to a map layer.

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -258,7 +258,7 @@ class CORE_EXPORT QgsProcessingUtils
     static QString formatHelpMapAsHtml( const QVariantMap &map, const QgsProcessingAlgorithm *algorithm );
 
     /**
-     * Converts a source vector \a layer to a file path to a vector layer of compatible format.
+     * Converts a source vector \a layer to a file path of a vector layer of compatible format.
      *
      * If the specified \a layer is not of the format listed in the
      * \a compatibleFormats argument, then the layer will first be exported to a compatible format
@@ -268,6 +268,11 @@ class CORE_EXPORT QgsProcessingUtils
      *
      * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
      * layer export is required. This defaults to shapefiles.
+     *
+     * When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
+     * to use convertToCompatibleFormatAndLayerName() which may avoid conversion in more situations.
+     *
+     * \see convertToCompatibleFormatAndLayerName()
      */
     static QString convertToCompatibleFormat( const QgsVectorLayer *layer,
         bool selectedFeaturesOnly,
@@ -276,6 +281,45 @@ class CORE_EXPORT QgsProcessingUtils
         const QString &preferredFormat,
         QgsProcessingContext &context,
         QgsProcessingFeedback *feedback );
+
+    /**
+     * Converts a source vector \a layer to a file path and layer name of a vector layer of compatible format.
+     *
+     * If the specified \a layer is not of the format listed in the
+     * \a compatibleFormats argument, then the layer will first be exported to a compatible format
+     * in a temporary location using \a baseName. The function will then return the path to that temporary file.
+     *
+     * \a compatibleFormats should consist entirely of lowercase file extensions, e.g. 'shp'.
+     *
+     * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
+     * layer export is required. This defaults to shapefiles.
+     *
+     * This method should be preferred over convertToCompatibleFormat() when an algorithm is able
+     * to correctly handle files with multiple layers. Unlike convertToCompatibleFormat(), it will not force
+     * a conversion in this case and will return the target layer name in the \a layerName argument.
+     *
+     * \param layer source layer to convert (if required)
+     * \param selectedFeaturesOnly TRUE if only selected features from the layer should be used
+     * \param baseName base file name for converted layer, if required
+     * \param compatibleFormats a list of lowercase file extensions compatible with the algorithm
+     * \param preferredFormat preferred format extension to use if conversion if required
+     * \param context processing context
+     * \param feedback feedback object
+     * \param layerName will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+     *
+     * \returns path to source layer, or nearly converted compatible layer
+     *
+     * \see convertToCompatibleFormat()
+     * \since QGIS 3.10
+     */
+    static QString convertToCompatibleFormatAndLayerName( const QgsVectorLayer *layer,
+        bool selectedFeaturesOnly,
+        const QString &baseName,
+        const QStringList &compatibleFormats,
+        const QString &preferredFormat,
+        QgsProcessingContext &context,
+        QgsProcessingFeedback *feedback,
+        QString &layerName SIP_OUT );
 
     /**
      * Combines two field lists, avoiding duplicate field names (in a case-insensitive manner).


### PR DESCRIPTION
A few releases ago a bug fix was implemented which forced conversions of multi-layer sources. This was a valid bug fix, but the consequence was that any algorithm using this api with a source file containing multiple layers (e.g. gpkg) performed a complete copy of the target layer to a new file, severely impacting performance.

This commit adds new API to retrieve a compatible layer path in the case when an algorithm CAN correctly handle specific target layer names. In this case, the forced copy of the source layer is avoided when using multi-layer inputs like geopackage.

Allows fix for performance regression in processing R provider 