### PR TITLE
A few canvas decoration dialog UI fixes

### DIFF
--- a/src/app/decorations/qgsdecorationgrid.h
+++ b/src/app/decorations/qgsdecorationgrid.h
@@ -40,9 +40,8 @@ class APP_EXPORT QgsDecorationGrid: public QgsDecorationItem
 
     enum GridStyle
     {
-      Line = 0, //solid lines
-      //      Cross = 1, //only draw line crossings
-      Marker = 1 //user-defined marker
+      Line = 0, // lines
+      Marker //markers
     };
 
     enum GridAnnotationPosition

--- a/src/app/decorations/qgsdecorationgriddialog.cpp
+++ b/src/app/decorations/qgsdecorationgriddialog.cpp
@@ -38,7 +38,7 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidg
 
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsDecorationGridDialog::buttonBox_accepted );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsDecorationGridDialog::buttonBox_rejected );
-  connect( mGridTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsDecorationGridDialog::mGridTypeComboBox_currentIndexChanged );
+  connect( mGridTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, [ = ]( int ) { updateSymbolButtons(); } );
   connect( mPbtnUpdateFromExtents, &QPushButton::clicked, this, &QgsDecorationGridDialog::mPbtnUpdateFromExtents_clicked );
   connect( mPbtnUpdateFromLayer, &QPushButton::clicked, this, &QgsDecorationGridDialog::mPbtnUpdateFromLayer_clicked );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationGridDialog::showHelp );
@@ -49,12 +49,12 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid &deco, QWidg
   mAnnotationFontButton->setMode( QgsFontButton::ModeQFont );
 
   grpEnable->setChecked( mDeco.enabled() );
+  connect( grpEnable, &QGroupBox::toggled, this, [ = ] { updateSymbolButtons(); } );
 
   // mXMinLineEdit->setValidator( new QDoubleValidator( mXMinLineEdit ) );
 
-  mGridTypeComboBox->insertItem( QgsDecorationGrid::Line, tr( "Line" ) );
-  // mGridTypeComboBox->insertItem( QgsDecorationGrid::Cross, tr( "Cross" ) );
-  mGridTypeComboBox->insertItem( QgsDecorationGrid::Marker, tr( "Marker" ) );
+  mGridTypeComboBox->addItem( tr( "Line" ), QgsDecorationGrid::Line );
+  mGridTypeComboBox->addItem( tr( "Marker" ), QgsDecorationGrid::Marker );
 
   // mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::InsideMapFrame, tr( "Inside frame" ) );
   // mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::OutsideMapFrame, tr( "Outside frame" ) );
@@ -90,7 +90,7 @@ void QgsDecorationGridDialog::updateGuiElements()
   mOffsetXEdit->setText( QString::number( mDeco.gridOffsetX() ) );
   mOffsetYEdit->setText( QString::number( mDeco.gridOffsetY() ) );
 
-  mGridTypeComboBox->setCurrentIndex( static_cast< int >( mDeco.gridStyle() ) );
+  mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findData( mDeco.gridStyle() ) );
   mDrawAnnotationCheckBox->setChecked( mDeco.showGridAnnotation() );
   mAnnotationDirectionComboBox->setCurrentIndex( static_cast< int >( mDeco.gridAnnotationDirection() ) );
   mCoordinatePrecisionSpinBox->setValue( mDeco.gridAnnotationPrecision() );
@@ -119,15 +119,9 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   mDeco.setGridIntervalY( mIntervalYEdit->text().toDouble() );
   mDeco.setGridOffsetX( mOffsetXEdit->text().toDouble() );
   mDeco.setGridOffsetY( mOffsetYEdit->text().toDouble() );
-  if ( mGridTypeComboBox->currentText() == tr( "Marker" ) )
-  {
-    mDeco.setGridStyle( QgsDecorationGrid::Marker );
-  }
-  else if ( mGridTypeComboBox->currentText() == tr( "Line" ) )
-  {
-    mDeco.setGridStyle( QgsDecorationGrid::Line );
-  }
+  mDeco.setGridStyle( static_cast< QgsDecorationGrid::GridStyle >( mGridTypeComboBox->currentData().toInt() ) );
   mDeco.setAnnotationFrameDistance( mDistanceToMapFrameSpinBox->value() );
+
   // if ( mAnnotationPositionComboBox->currentText() == tr( "Inside frame" ) )
   // {
   //   mDeco.setGridAnnotationPosition( QgsDecorationGrid::InsideMapFrame );
@@ -136,6 +130,7 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   // {
   //   mDeco.setGridAnnotationPosition( QgsDecorationGrid::OutsideMapFrame );
   // }
+
   mDeco.setShowGridAnnotation( mDrawAnnotationCheckBox->isChecked() );
   QString text = mAnnotationDirectionComboBox->currentText();
   if ( text == tr( "Horizontal" ) )
@@ -183,31 +178,31 @@ void QgsDecorationGridDialog::buttonBox_rejected()
   reject();
 }
 
-void QgsDecorationGridDialog::mGridTypeComboBox_currentIndexChanged( int index )
+void QgsDecorationGridDialog::updateSymbolButtons()
 {
-  switch ( index )
+  switch ( mGridTypeComboBox->currentData().toInt() )
   {
     case ( QgsDecorationGrid::Marker ):
     {
       mMarkerSymbolButton->setVisible( true );
-      mMarkerSymbolButton->setEnabled( true );
+      mMarkerSymbolButton->setEnabled( grpEnable->isChecked() );
       mMarkerSymbolLabel->setVisible( true );
       mLineSymbolButton->setVisible( false );
+      mLineSymbolButton->setEnabled( false );
       mLineSymbolLabel->setVisible( false );
       break;
     }
     case ( QgsDecorationGrid::Line ):
     {
       mLineSymbolButton->setVisible( true );
-      mLineSymbolButton->setEnabled( true );
+      mLineSymbolButton->setEnabled( grpEnable->isChecked() );
       mLineSymbolLabel->setVisible( true );
       mMarkerSymbolButton->setVisible( false );
+      mMarkerSymbolButton->setEnabled( false );
       mMarkerSymbolLabel->setVisible( false );
       break;
     }
   }
-
-  // mCrossWidthSpinBox->setEnabled( index == QgsDecorationGrid::Cross );
 }
 
 void QgsDecorationGridDialog::mPbtnUpdateFromExtents_clicked()

--- a/src/app/decorations/qgsdecorationgriddialog.h
+++ b/src/app/decorations/qgsdecorationgriddialog.h
@@ -39,7 +39,7 @@ class APP_EXPORT QgsDecorationGridDialog : public QDialog, private Ui::QgsDecora
     void buttonBox_accepted();
     void buttonBox_rejected();
     void showHelp();
-    void mGridTypeComboBox_currentIndexChanged( int index );
+    void updateSymbolButtons();
     void mPbtnUpdateFromExtents_clicked();
     void mPbtnUpdateFromLayer_clicked();
 

--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -62,6 +62,7 @@ QgsDecorationImageDialog::QgsDecorationImageDialog( QgsDecorationImage &deco, QW
 
   // enabled
   grpEnable->setChecked( mDeco.enabled() );
+  connect( grpEnable, &QGroupBox::toggled, this, [ = ] { updateEnabledColorButtons(); } );
 
   wgtImagePath->setFilePath( mDeco.imagePath() );
   connect( wgtImagePath, &QgsFileWidget::fileChanged, this, &QgsDecorationImageDialog::updateImagePath );
@@ -110,10 +111,8 @@ void QgsDecorationImageDialog::apply()
   mDeco.update();
 }
 
-void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
+void QgsDecorationImageDialog::updateEnabledColorButtons()
 {
-  if ( mDeco.imagePath() != imagePath )
-    mDeco.setImagePath( imagePath );
 
   if ( mDeco.mImageFormat == QgsDecorationImage::FormatSVG )
   {
@@ -121,13 +120,13 @@ void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
     double defaultStrokeWidth, defaultFillOpacity, defaultStrokeOpacity;
     bool hasDefaultFillColor, hasDefaultFillOpacity, hasDefaultStrokeColor, hasDefaultStrokeWidth, hasDefaultStrokeOpacity;
     bool hasFillParam, hasFillOpacityParam, hasStrokeParam, hasStrokeWidthParam, hasStrokeOpacityParam;
-    QgsApplication::svgCache()->containsParams( imagePath, hasFillParam, hasDefaultFillColor, defaultFill,
+    QgsApplication::svgCache()->containsParams( mDeco.imagePath(), hasFillParam, hasDefaultFillColor, defaultFill,
         hasFillOpacityParam, hasDefaultFillOpacity, defaultFillOpacity,
         hasStrokeParam, hasDefaultStrokeColor, defaultStroke,
         hasStrokeWidthParam, hasDefaultStrokeWidth, defaultStrokeWidth,
         hasStrokeOpacityParam, hasDefaultStrokeOpacity, defaultStrokeOpacity );
 
-    pbnChangeColor->setEnabled( hasFillParam );
+    pbnChangeColor->setEnabled( grpEnable->isChecked() && hasFillParam );
     pbnChangeColor->setAllowOpacity( hasFillOpacityParam );
     if ( hasFillParam )
     {
@@ -135,7 +134,7 @@ void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
       fill.setAlphaF( hasFillOpacityParam && hasDefaultFillOpacity ? defaultFillOpacity : 1.0 );
       pbnChangeColor->setColor( fill );
     }
-    pbnChangeOutlineColor->setEnabled( hasStrokeParam );
+    pbnChangeOutlineColor->setEnabled( grpEnable->isChecked() && hasStrokeParam );
     pbnChangeOutlineColor->setAllowOpacity( hasStrokeOpacityParam );
     if ( hasStrokeParam )
     {
@@ -149,7 +148,14 @@ void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
     pbnChangeColor->setEnabled( false );
     pbnChangeOutlineColor->setEnabled( false );
   }
+}
 
+void QgsDecorationImageDialog::updateImagePath( const QString &imagePath )
+{
+  if ( mDeco.imagePath() != imagePath )
+    mDeco.setImagePath( imagePath );
+
+  updateEnabledColorButtons();
   drawImage();
 }
 

--- a/src/app/decorations/qgsdecorationimagedialog.h
+++ b/src/app/decorations/qgsdecorationimagedialog.h
@@ -30,6 +30,7 @@ class APP_EXPORT QgsDecorationImageDialog : public QDialog, private Ui::QgsDecor
 
   private:
     void drawImage();
+    void updateEnabledColorButtons();
     void updateImagePath( const QString &imagePath );
     void resizeEvent( QResizeEvent * ) override; //overloads qwidget
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR fixes the (only?) two remaining widgets-enabled-when-it-shouldn't cases with our canvas decoration dialogs. 


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
