### PR TITLE
Add active python plugins in the about dialog

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4724,6 +4724,15 @@ void QgisApp::about()
     versionString += "<td colspan=2>" + tr( "This copy of QGIS writes debugging output." ) + "</td>";
 #endif
 
+#ifdef WITH_BINDINGS
+    if ( mPythonUtils && mPythonUtils->isEnabled() )
+    {
+      versionString += tr( "</tr><tr><td>Active python plugins</td><td colspan=3>" );
+      const QStringList activePlugins = mPythonUtils->listActivePlugins();
+      versionString += activePlugins.join( "; <br>" ) + "</td>";
+    }
+#endif
+
     versionString += QLatin1String( "</tr></table></div></body></html>" );
 
     sAbt->setVersion( versionString );

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -66,7 +66,7 @@
 #define ERR(message) QgsError(message,"GDAL provider")
 
 static QString PROVIDER_KEY = QStringLiteral( "gdal" );
-static QString PROVIDER_DESCRIPTION = QStringLiteral( "GDAL provider" );
+static QString PROVIDER_DESCRIPTION = QStringLiteral( "GDAL data provider" );
 
 // To avoid potential races when destroying related instances ("main" and clones)
 static QMutex gGdaProviderMutex( QMutex::Recursive );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -83,13 +83,7 @@ email                : sherman at mrcc.com
 #endif
 
 static const QString TEXT_PROVIDER_KEY = QStringLiteral( "ogr" );
-static const QString TEXT_PROVIDER_DESCRIPTION =
-  QStringLiteral( "OGR data provider" )
-  + " (compiled against GDAL/OGR library version "
-  + GDAL_RELEASE_NAME
-  + ", running against GDAL/OGR library version "
-  + GDALVersionInfo( "RELEASE_NAME" )
-  + ')';
+static const QString TEXT_PROVIDER_DESCRIPTION = QStringLiteral( "OGR data provider" );
 
 static OGRwkbGeometryType ogrWkbGeometryTypeFromName( const QString &typeName );
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This extra information is added with the hope it'll add value to issues reporting when people are pasting the content of the about dialog's text box.

Specifically, it'll allow people reviewing newly filed issues to know whether 3rd-party plugins were active or not without the need of asking: "did you deactivate plugins?".

This is how it looks when pasting the content of the about box into github:


QGIS version | 3.9.0-Master | QGIS code revision | 511826d502
-- | -- | -- | --
Compiled against Qt | 5.12.4 | Running against Qt | 5.12.4
Compiled against GDAL/OGR | 2.4.2 | Running against GDAL/OGR | 2.4.2
Compiled against GEOS | 3.7.2-CAPI-1.11.2 | Running against GEOS | 3.7.2-CAPI-1.11.2 b55d2125
Compiled against SQLite | 3.29.0 | Running against SQLite | 3.29.0
PostgreSQL Client Version | 11.5 (Ubuntu 11.5-1) | SpatiaLite Version | 4.3.0a
QWT Version | 6.1.4 | QScintilla2 Version | 2.10.4
Compiled against PROJ | 5.2.0 | Running against PROJ | Rel. 5.2.0, September 15th, 2018
OS Version | Ubuntu Eoan Ermine (development branch) | This copy of QGIS writes debugging output.
Active python plugins | go2streetview; timemanager; GroupStats; slyr; MemoryLayerSaver; DataPlotly; processing_r; processing; db_manager



## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
