### PR TITLE
Decoration fixes

### DIFF
--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -221,7 +221,7 @@ void QgsDecorationImageDialog::drawImage()
   if ( !missing )
   {
     QPixmap  px( maxLength, maxLength );
-    px.fill();
+    px.fill( Qt::transparent );
 
     QPainter painter;
     painter.begin( &px );
@@ -245,7 +245,7 @@ void QgsDecorationImageDialog::drawImage()
   else
   {
     QPixmap  px( 200, 200 );
-    px.fill();
+    px.fill( Qt::transparent );
     QPainter painter;
     painter.begin( &px );
     QFont font( QStringLiteral( "time" ), 12, QFont::Bold );

--- a/src/app/decorations/qgsdecorationnortharrow.cpp
+++ b/src/app/decorations/qgsdecorationnortharrow.cpp
@@ -79,6 +79,7 @@ void QgsDecorationNorthArrow::saveToProject()
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Size" ), mSize );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/SvgPath" ), mSvgPath );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Rotation" ), mRotationInt );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Automatic" ), mAutomatic );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );

--- a/src/app/decorations/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/decorations/qgsdecorationnortharrowdialog.cpp
@@ -190,7 +190,7 @@ void QgsDecorationNorthArrowDialog::drawNorthArrow()
     }
 
     QPixmap  myPainterPixmap( maxLength, maxLength );
-    myPainterPixmap.fill();
+    myPainterPixmap.fill( Qt::transparent );
 
     QPainter myQPainter;
     myQPainter.begin( &myPainterPixmap );
@@ -230,7 +230,7 @@ void QgsDecorationNorthArrowDialog::drawNorthArrow()
   else
   {
     QPixmap  myPainterPixmap( 200, 200 );
-    myPainterPixmap.fill();
+    myPainterPixmap.fill( Qt::transparent );
     QPainter myQPainter;
     myQPainter.begin( &myPainterPixmap );
     QFont myQFont( QStringLiteral( "time" ), 12, QFont::Bold );


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

A few additional canvas decoration-related fixes.

Before vs. PR for the north arrow / image decoration preview fill fix:
![image](https://user-images.githubusercontent.com/1728657/65585632-f6d47b00-dfac-11e9-95d5-50fd0818eee8.png)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
