### PR TITLE
Fix crash when exporting layout with no pages

### DIFF
--- a/src/app/layout/qgslayoutappmenuprovider.cpp
+++ b/src/app/layout/qgslayoutappmenuprovider.cpp
@@ -141,6 +141,8 @@ QMenu *QgsLayoutAppMenuProvider::createContextMenu( QWidget *parent, QgsLayout *
         layout->pageCollection()->deletePage( page );
       }
     } );
+    if ( layout->pageCollection()->pageCount() < 2 )
+      removePageAction->setEnabled( false );
     menu->addAction( removePageAction );
 
     menu->addSeparator();

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -506,7 +506,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToImage( QgsAbstractLay
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &filePath, const QgsLayoutExporter::PdfExportSettings &s )
 {
-  if ( !mLayout )
+  if ( !mLayout || mLayout->pageCollection()->pageCount() == 0 )
     return PrintError;
 
   PdfExportSettings settings = s;
@@ -1186,6 +1186,9 @@ void QgsLayoutExporter::preparePrint( QgsLayout *layout, QPrinter &printer, bool
 
 QgsLayoutExporter::ExportResult QgsLayoutExporter::print( QPrinter &printer )
 {
+  if ( mLayout->pageCollection()->pageCount() == 0 )
+    return PrintError;
+
   preparePrint( mLayout, printer, true );
   QPainter p;
   if ( !p.begin( &printer ) )


### PR DESCRIPTION
And prevent this situation arising by blocking removal of the last remaining page in a layout