### PR TITLE
rename QgsLayerTreeRegistryBridge.InsertionPoint.parent to group

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeregistrybridge.sip.in
@@ -33,11 +33,11 @@ from the map layer registry.
 
     struct InsertionPoint
     {
-      InsertionPoint( QgsLayerTreeGroup *parent, int position );
+      InsertionPoint( QgsLayerTreeGroup *group, int position );
 %Docstring
 Construcs an insertion point as layer tree group with its corresponding position.
 %End
-      QgsLayerTreeGroup *parent;
+      QgsLayerTreeGroup *group;
       int position;
     };
 

--- a/src/core/layertree/qgslayertreeregistrybridge.cpp
+++ b/src/core/layertree/qgslayertreeregistrybridge.cpp
@@ -38,7 +38,7 @@ QgsLayerTreeRegistryBridge::QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root,
 
 void QgsLayerTreeRegistryBridge::setLayerInsertionPoint( QgsLayerTreeGroup *parentGroup, int index )
 {
-  mInsertionPoint.parent = parentGroup;
+  mInsertionPoint.group = parentGroup;
   mInsertionPoint.position = index;
 }
 
@@ -71,7 +71,7 @@ void QgsLayerTreeRegistryBridge::layersAdded( const QList<QgsMapLayer *> &layers
   }
 
   // add new layers to the right place
-  mInsertionPoint.parent->insertChildNodes( mInsertionPoint.position, nodes );
+  mInsertionPoint.group->insertChildNodes( mInsertionPoint.position, nodes );
 
   // tell other components that layers have been added - this signal is used in QGIS to auto-select the first layer
   emit addedLayersToLayerTree( layers );

--- a/src/core/layertree/qgslayertreeregistrybridge.h
+++ b/src/core/layertree/qgslayertreeregistrybridge.h
@@ -54,10 +54,10 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     struct InsertionPoint
     {
       //! Construcs an insertion point as layer tree group with its corresponding position.
-      InsertionPoint( QgsLayerTreeGroup *parent, int position )
-        : parent( parent ), position( position ) {}
+      InsertionPoint( QgsLayerTreeGroup *group, int position )
+        : group( group ), position( position ) {}
 
-      QgsLayerTreeGroup *parent = nullptr;
+      QgsLayerTreeGroup *group = nullptr;
       int position = 0;
     };
 


### PR DESCRIPTION
because I find it confusing to do `insertionPoint.parent.insertLayer()`
better do `insertionPoint.group.insertLayer()`

