### PR TITLE
use an enum for enable macros possibilities

### DIFF
--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1,0 +1,9 @@
+# The following has been generated automatically from src/core/qgis.h
+# monkey patching scoped based enum
+Qgis.PythonMacroMode.Never.__doc__ = "Macros are never run"
+Qgis.PythonMacroMode.Ask.__doc__ = "User is prompt before runnning"
+Qgis.PythonMacroMode.SessionOnly.__doc__ = "Only during this session"
+Qgis.PythonMacroMode.Always.__doc__ = "Macros are always run"
+Qgis.PythonMacroMode.__doc__ = 'Authorisation to run Python Macros\n\n.. versionadded:: 3.10\n\n' + '* ``Never``: ' + Qgis.PythonMacroMode.Never.__doc__ + '\n' + '* ``Ask``: ' + Qgis.PythonMacroMode.Ask.__doc__ + '\n' + '* ``SessionOnly``: ' + Qgis.PythonMacroMode.SessionOnly.__doc__ + '\n' + '* ``Always``: ' + Qgis.PythonMacroMode.Always.__doc__
+# --
+Qgis.PythonMacroMode.baseClass = Qgis

--- a/python/core/auto_additions/qgis.py
+++ b/python/core/auto_additions/qgis.py
@@ -1,7 +1,7 @@
 # The following has been generated automatically from src/core/qgis.h
 # monkey patching scoped based enum
 Qgis.PythonMacroMode.Never.__doc__ = "Macros are never run"
-Qgis.PythonMacroMode.Ask.__doc__ = "User is prompt before runnning"
+Qgis.PythonMacroMode.Ask.__doc__ = "User is prompt before running"
 Qgis.PythonMacroMode.SessionOnly.__doc__ = "Only during this session"
 Qgis.PythonMacroMode.Always.__doc__ = "Macros are always run"
 Qgis.PythonMacroMode.__doc__ = 'Authorisation to run Python Macros\n\n.. versionadded:: 3.10\n\n' + '* ``Never``: ' + Qgis.PythonMacroMode.Never.__doc__ + '\n' + '* ``Ask``: ' + Qgis.PythonMacroMode.Ask.__doc__ + '\n' + '* ``SessionOnly``: ' + Qgis.PythonMacroMode.SessionOnly.__doc__ + '\n' + '* ``Always``: ' + Qgis.PythonMacroMode.Always.__doc__

--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -29,6 +29,9 @@ The Qgis class provides global constants for use throughout the application.
 #include "qgis.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
     static const QString QGIS_VERSION;
     static const int QGIS_VERSION_INT;
     static const QString QGIS_RELEASE_NAME;
@@ -60,6 +63,14 @@ The Qgis class provides global constants for use throughout the application.
       CFloat64,
       ARGB32,
       ARGB32_Premultiplied
+    };
+
+    enum class PythonMacroMode
+    {
+      Never,
+      Ask,
+      SessionOnly,
+      Always
     };
 
     static const double DEFAULT_SEARCH_RADIUS_MM;

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -5,7 +5,6 @@
 %Include auto_generated/expression/qgsexpressionnodeimpl.sip
 %Include auto_generated/expression/qgsexpressionfunction.sip
 %Include auto_generated/qgstessellator.sip
-%Include auto_generated/qgis.sip
 %Include auto_generated/qgsabstractproviderconnection.sip
 %Include auto_generated/qgsabstractdatabaseproviderconnection.sip
 %Include auto_generated/qgsaction.sip
@@ -335,6 +334,7 @@
 %Include auto_generated/validity/qgsvaliditycheckregistry.sip
 %Include auto_generated/gps/qgsqtlocationconnection.sip
 %Include auto_generated/gps/qgsgpsconnectionregistry.sip
+%Include auto_generated/qgis.sip
 %Include auto_generated/qgsabstractcontentcache.sip
 %Include auto_generated/qgsapplication.sip
 %Include auto_generated/qgsactionscoperegistry.sip

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -179,7 +179,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 {
     Q_OBJECT
   public:
-
     //! Constructor
     QgisApp( QSplashScreen *splash, bool restorePlugins = true,
              bool skipVersionCheck = false, const QString &rootProfileLocation = QString(),
@@ -2275,7 +2274,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     bool cmpByText( QAction *a, QAction *b );
 
     //! the user has trusted the project macros
-    bool mTrustedMacros = false;
+    bool mPythonMacrosEnabled = false;
 
     //! a bar to display warnings in a non-blocker manner
     QgsMessageBar *mInfoBar = nullptr;

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -150,6 +150,11 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   // non-default themes are best rendered using the Fusion style, therefore changing themes must require a restart to
   lblUITheme->setText( QStringLiteral( "%1 <i>(%2)</i>" ).arg( lblUITheme->text(), tr( "QGIS restart required" ) ) );
 
+  mEnableMacrosComboBox->addItem( tr( "Never" ), QVariant::fromValue( Qgis::PythonMacroMode::Never ) );
+  mEnableMacrosComboBox->addItem( tr( "Ask" ), QVariant::fromValue( Qgis::PythonMacroMode::Ask ) );
+  mEnableMacrosComboBox->addItem( tr( "For this session only" ), QVariant::fromValue( Qgis::PythonMacroMode::SessionOnly ) );
+  mEnableMacrosComboBox->addItem( tr( "Always (not recommended)" ), QVariant::fromValue( Qgis::PythonMacroMode::Always ) );
+
   mIdentifyHighlightColorButton->setColorDialogTitle( tr( "Identify Highlight Color" ) );
   mIdentifyHighlightColorButton->setAllowOpacity( true );
   mIdentifyHighlightColorButton->setContext( QStringLiteral( "gui" ) );
@@ -759,7 +764,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   chbAskToSaveProjectChanges->setChecked( mSettings->value( QStringLiteral( "qgis/askToSaveProjectChanges" ), QVariant( true ) ).toBool() );
   mLayerDeleteConfirmationChkBx->setChecked( mSettings->value( QStringLiteral( "qgis/askToDeleteLayers" ), true ).toBool() );
   chbWarnOldProjectVersion->setChecked( mSettings->value( QStringLiteral( "/qgis/warnOldProjectVersion" ), QVariant( true ) ).toBool() );
-  cmbEnableMacros->setCurrentIndex( mSettings->value( QStringLiteral( "/qgis/enableMacros" ), 1 ).toInt() );
+  Qgis::PythonMacroMode pyMacroMode = mSettings->enumValue( QStringLiteral( "/qgis/enableMacros" ), Qgis::PythonMacroMode::Ask );
+  mEnableMacrosComboBox->setCurrentIndex( mEnableMacrosComboBox->findData( QVariant::fromValue( pyMacroMode ) ) );
 
   // templates
   cbxProjectDefaultNew->setChecked( mSettings->value( QStringLiteral( "/qgis/newProjectDefault" ), QVariant( false ) ).toBool() );
@@ -1524,7 +1530,7 @@ void QgsOptions::saveOptions()
     mSettings->setValue( QStringLiteral( "/qgis/projectTemplateDir" ), leTemplateFolder->text() );
     QgisApp::instance()->updateProjectFromTemplates();
   }
-  mSettings->setValue( QStringLiteral( "/qgis/enableMacros" ), cmbEnableMacros->currentIndex() );
+  mSettings->setEnumValue( QStringLiteral( "/qgis/enableMacros" ), mEnableMacrosComboBox->currentData().value<Qgis::PythonMacroMode>() );
 
   QgsApplication::setNullRepresentation( leNullValue->text() );
   mSettings->setValue( QStringLiteral( "/qgis/style" ), cmbStyle->currentText() );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -648,6 +648,7 @@ ELSE(NOT MSVC)
 ENDIF(NOT MSVC)
 
 SET(QGIS_CORE_MOC_HDRS
+  qgis.h
   qgsabstractcontentcache.h
   qgsabstractdatabaseproviderconnection.h
   qgsapplication.h
@@ -909,7 +910,6 @@ SET(QGIS_CORE_HDRS
 
   qgstessellator.h
 
-  qgis.h
   qgis_sip.h
   qgsabstractgeopdfexporter.h
   qgsabstractproviderconnection.h

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -44,6 +44,7 @@ int QgisEvent = QEvent::User + 1;
  */
 class CORE_EXPORT Qgis
 {
+    Q_GADGET
   public:
     // Version constants
     //
@@ -93,6 +94,19 @@ class CORE_EXPORT Qgis
       ARGB32 = 12, //!< Color, alpha, red, green, blue, 4 bytes the same as QImage::Format_ARGB32
       ARGB32_Premultiplied = 13 //!< Color, alpha, red, green, blue, 4 bytes  the same as QImage::Format_ARGB32_Premultiplied
     };
+
+    /**
+     * Authorisation to run Python Macros
+     * \since QGIS 3.10
+     */
+    enum class PythonMacroMode
+    {
+      Never = 0, //!< Macros are never run
+      Ask = 1, //!< User is prompt before runnning
+      SessionOnly = 2, //!< Only during this session
+      Always = 3 //!< Macros are always run
+    };
+    Q_ENUM( PythonMacroMode )
 
     /**
      * Identify search radius in mm
@@ -437,7 +451,7 @@ template<class T> QString qgsEnumValueToKey( const T &value ) SIP_SKIP
 {
   QMetaEnum metaEnum = QMetaEnum::fromType<T>();
   Q_ASSERT( metaEnum.isValid() );
-  return QString::fromUtf8( metaEnum.valueToKey( value ) );
+  return QString::fromUtf8( metaEnum.valueToKey( static_cast<int>( value ) ) );
 }
 
 /**

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -102,7 +102,7 @@ class CORE_EXPORT Qgis
     enum class PythonMacroMode
     {
       Never = 0, //!< Macros are never run
-      Ask = 1, //!< User is prompt before runnning
+      Ask = 1, //!< User is prompt before running
       SessionOnly = 2, //!< Only during this session
       Always = 3 //!< Macros are always run
     };

--- a/src/core/qgssettings.h
+++ b/src/core/qgssettings.h
@@ -257,7 +257,7 @@ class CORE_EXPORT QgsSettings : public QObject
       if ( metaEnum.isValid() )
       {
         // read as string
-        QByteArray ba = value( key, metaEnum.valueToKey( defaultValue ), section ).toString().toUtf8();
+        QByteArray ba = value( key, metaEnum.valueToKey( static_cast<int>( defaultValue ) ), section ).toString().toUtf8();
         const char *vs = ba.data();
         v = static_cast<T>( metaEnum.keyToValue( vs, &ok ) );
         if ( ok )
@@ -300,7 +300,7 @@ class CORE_EXPORT QgsSettings : public QObject
       Q_ASSERT( metaEnum.isValid() );
       if ( metaEnum.isValid() )
       {
-        setValue( key, metaEnum.valueToKey( value ), section );
+        setValue( key, metaEnum.valueToKey( static_cast<int>( value ) ), section );
       }
       else
       {

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -103,7 +103,7 @@
            <string>General</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/general.svg</normaloff>:/images/themes/default/propertyicons/general.svg</iconset>
           </property>
          </item>
@@ -115,7 +115,7 @@
            <string>System</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
           </property>
          </item>
@@ -127,7 +127,7 @@
            <string>CRS</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/CRS.svg</normaloff>:/images/themes/default/propertyicons/CRS.svg</iconset>
           </property>
          </item>
@@ -139,7 +139,7 @@
            <string>Data sources</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/attributes.svg</normaloff>:/images/themes/default/propertyicons/attributes.svg</iconset>
           </property>
          </item>
@@ -151,7 +151,7 @@
            <string>Rendering</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/rendering.svg</normaloff>:/images/themes/default/propertyicons/rendering.svg</iconset>
           </property>
          </item>
@@ -163,7 +163,7 @@
            <string>Canvas and legend</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/overlay.svg</normaloff>:/images/themes/default/propertyicons/overlay.svg</iconset>
           </property>
          </item>
@@ -175,7 +175,7 @@
            <string>Map tools</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/map_tools.svg</normaloff>:/images/themes/default/propertyicons/map_tools.svg</iconset>
           </property>
          </item>
@@ -187,7 +187,7 @@
            <string>Colors</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/colors.svg</normaloff>:/images/themes/default/propertyicons/colors.svg</iconset>
           </property>
          </item>
@@ -199,7 +199,7 @@
            <string>Digitizing</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/digitizing.svg</normaloff>:/images/themes/default/propertyicons/digitizing.svg</iconset>
           </property>
          </item>
@@ -211,7 +211,7 @@
            <string>Print layouts</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mIconLayout.svg</normaloff>:/images/themes/default/mIconLayout.svg</iconset>
           </property>
          </item>
@@ -223,7 +223,7 @@
            <string>GDAL</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/gdal.svg</normaloff>:/images/themes/default/propertyicons/gdal.svg</iconset>
           </property>
          </item>
@@ -235,7 +235,7 @@
            <string>Variables</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
           </property>
          </item>
@@ -247,7 +247,7 @@
            <string>Authentication</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/locked.svg</normaloff>:/images/themes/default/locked.svg</iconset>
           </property>
          </item>
@@ -259,7 +259,7 @@
            <string>Network</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/network_and_proxy.svg</normaloff>:/images/themes/default/propertyicons/network_and_proxy.svg</iconset>
           </property>
          </item>
@@ -271,7 +271,7 @@
            <string>Locator</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/search.svg</normaloff>:/images/themes/default/search.svg</iconset>
           </property>
          </item>
@@ -283,7 +283,7 @@
            <string>Advanced</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mIconWarning.svg</normaloff>:/images/themes/default/mIconWarning.svg</iconset>
           </property>
          </item>
@@ -295,7 +295,7 @@
            <string>Configure GPU for processing algorithms</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mIconGPU.svg</normaloff>:/images/themes/default/mIconGPU.svg</iconset>
           </property>
          </item>
@@ -361,8 +361,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>832</height>
+                <width>848</width>
+                <height>943</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -815,7 +815,7 @@
                        <string/>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
                       </property>
                      </widget>
@@ -953,7 +953,7 @@
                        <string/>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
                       </property>
                      </widget>
@@ -967,7 +967,7 @@
                        <string/>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                       </property>
                      </widget>
@@ -1005,33 +1005,13 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QComboBox" name="cmbEnableMacros">
+                     <widget class="QComboBox" name="mEnableMacrosComboBox">
                       <property name="currentIndex">
-                       <number>0</number>
+                       <number>-1</number>
                       </property>
                       <property name="sizeAdjustPolicy">
                        <enum>QComboBox::AdjustToContents</enum>
                       </property>
-                      <item>
-                       <property name="text">
-                        <string>Never</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Ask</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>For this session only</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Always (not recommended)</string>
-                       </property>
-                      </item>
                      </widget>
                     </item>
                     <item>
@@ -1098,8 +1078,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>541</width>
-                <height>1072</height>
+                <width>545</width>
+                <height>1114</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1138,7 +1118,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -1152,7 +1132,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -1205,7 +1185,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -1219,7 +1199,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -1252,7 +1232,7 @@
                      <string>…</string>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
                     </property>
                    </widget>
@@ -1286,7 +1266,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -1300,7 +1280,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -1332,7 +1312,7 @@
                      <string>…</string>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionArrowUp.svg</normaloff>:/images/themes/default/mActionArrowUp.svg</iconset>
                     </property>
                    </widget>
@@ -1368,7 +1348,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                     </property>
                    </widget>
@@ -1410,7 +1390,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -1430,7 +1410,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -1446,10 +1426,10 @@
                     <property name="title">
                      <string>Current environment variables (read-only - bold indicates modified at startup)</string>
                     </property>
-                    <property name="collapsed">
+                    <property name="collapsed" stdset="0">
                      <bool>false</bool>
                     </property>
-                    <property name="saveCollapsedState">
+                    <property name="saveCollapsedState" stdset="0">
                      <bool>true</bool>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1634,8 +1614,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>552</width>
-                <height>398</height>
+                <width>561</width>
+                <height>421</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1662,7 +1642,7 @@
                    </widget>
                   </item>
                   <item row="2" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leProjectGlobalCrs">
+                   <widget class="QgsProjectionSelectionWidget" name="leProjectGlobalCrs" native="true">
                     <property name="minimumSize">
                      <size>
                       <width>0</width>
@@ -1748,7 +1728,7 @@
                    </widget>
                   </item>
                   <item row="3" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs">
+                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs" native="true">
                     <property name="enabled">
                      <bool>false</bool>
                     </property>
@@ -1833,8 +1813,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>830</height>
+                <width>533</width>
+                <height>678</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2092,7 +2072,7 @@
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -2149,8 +2129,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>674</width>
-                <height>965</height>
+                <width>702</width>
+                <height>1139</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -2935,8 +2915,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>501</width>
-                <height>298</height>
+                <width>532</width>
+                <height>309</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3246,8 +3226,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>604</width>
-                <height>609</height>
+                <width>611</width>
+                <height>652</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3537,7 +3517,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     <property name="value">
                      <number>200</number>
                     </property>
-                    <property name="showClearButton">
+                    <property name="showClearButton" stdset="0">
                      <bool>true</bool>
                     </property>
                    </widget>
@@ -3565,7 +3545,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <string>…</string>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                       </property>
                      </widget>
@@ -3579,7 +3559,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <string>…</string>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                       </property>
                      </widget>
@@ -3593,7 +3573,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <string>…</string>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                       </property>
                      </widget>
@@ -3620,7 +3600,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <string>…</string>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
                       </property>
                      </widget>
@@ -3634,7 +3614,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                        <string>…</string>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
                       </property>
                      </widget>
@@ -3690,8 +3670,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>157</width>
-                <height>265</height>
+                <width>181</width>
+                <height>318</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -3723,7 +3703,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
                     </property>
                    </widget>
@@ -3744,7 +3724,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionEditPaste.svg</normaloff>:/images/themes/default/mActionEditPaste.svg</iconset>
                     </property>
                    </widget>
@@ -3758,7 +3738,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -3772,7 +3752,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -3786,7 +3766,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
                     </property>
                    </widget>
@@ -3807,7 +3787,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
                     </property>
                    </widget>
@@ -3858,8 +3838,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>830</height>
+                <width>574</width>
+                <height>827</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4467,8 +4447,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>480</width>
-                <height>543</height>
+                <width>472</width>
+                <height>572</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -4658,7 +4638,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -4672,7 +4652,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -4736,8 +4716,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>412</width>
-                <height>372</height>
+                <width>509</width>
+                <height>367</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4905,8 +4885,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>830</height>
+                <width>640</width>
+                <height>753</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5064,7 +5044,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                          <string/>
                         </property>
                         <property name="icon">
-                         <iconset resource="../../images/images.qrc">
+                         <iconset>
                           <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
                         </property>
                        </widget>
@@ -5078,7 +5058,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                          <string/>
                         </property>
                         <property name="icon">
-                         <iconset resource="../../images/images.qrc">
+                         <iconset>
                           <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
                         </property>
                        </widget>
@@ -5125,10 +5105,10 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <property name="checkable">
                   <bool>true</bool>
                  </property>
-                 <property name="collapsed">
+                 <property name="collapsed" stdset="0">
                   <bool>false</bool>
                  </property>
-                 <property name="saveCollapsedState">
+                 <property name="saveCollapsedState" stdset="0">
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_1">
@@ -5148,7 +5128,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                     </property>
                    </widget>
@@ -5162,7 +5142,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                      <string/>
                     </property>
                     <property name="icon">
-                     <iconset resource="../../images/images.qrc">
+                     <iconset>
                       <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                     </property>
                    </widget>
@@ -5407,7 +5387,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Noto Sans'; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
@@ -5627,7 +5607,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>chbAskToSaveProjectChanges</tabstop>
   <tabstop>mLayerDeleteConfirmationChkBx</tabstop>
   <tabstop>chbWarnOldProjectVersion</tabstop>
-  <tabstop>cmbEnableMacros</tabstop>
+  <tabstop>mEnableMacrosComboBox</tabstop>
   <tabstop>mOptionsScrollArea_03</tabstop>
   <tabstop>mBtnAddSVGPath</tabstop>
   <tabstop>mBtnRemoveSVGPath</tabstop>
@@ -5806,9 +5786,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mOpenClDevicesCombo</tabstop>
   <tabstop>mGPUInfoTextBrowser</tabstop>
  </tabstops>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>mOptionsListWidget</sender>


### PR DESCRIPTION
This creates a scoped enum as `Qgis::PythonMacroMode`

for whoever is interested, there is no implicit casting to int for scoped enums.
This is why I introduced static casting when using `QMetaEnum::valueToKey`.

Since this is fixed, we could move the enums to `Qgis` class as scoped enums. We would/could have `Qgis::LayerType::VectorLayer`. 

For reference to the topic: https://github.com/qgis/QGIS/pull/9734
Last question is, can we forward declare by doing `namespace Qgis {class LayerType;}`. But that's out of scope for this PR.

