### PR TITLE
[bugfix] Fix plugin manager not working with QT < 5.6

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -23,7 +23,7 @@
  ***************************************************************************/
 """
 
-from qgis.PyQt.QtCore import (pyqtSignal, QObject, QCoreApplication, QFile,
+from qgis.PyQt.QtCore import (pyqtSignal, qVersion, QObject, QCoreApplication, QFile,
                               QDir, QDirIterator, QDate, QUrl, QFileInfo,
                               QLocale, QByteArray)
 from qgis.PyQt.QtXml import QDomDocument
@@ -324,7 +324,10 @@ class Repositories(QObject):
 
         self.mRepositories[key]["QRequest"] = QNetworkRequest(url)
         self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorClass), "Relay")
-        self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
+        qtVersion = [int(v) for v in qVersion().split('.')]
+        if qtVersion >= [5, 6, 0]:
+            # QNetworkRequest.FollowRedirectsAttribute has been introduced in QT 5.6
+            self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
         authcfg = self.mRepositories[key]["authcfg"]
         if authcfg and isinstance(authcfg, str):
             if not QgsApplication.authManager().updateNetworkRequest(


### PR DESCRIPTION
Bring back Plugin Manager not working with QT < 5.6 (e.g. Xenial).

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
