### PR TITLE
Improvements and big optimisations for QgsTessellator

### DIFF
--- a/python/core/auto_generated/qgstessellator.sip.in
+++ b/python/core/auto_generated/qgstessellator.sip.in
@@ -32,11 +32,13 @@ Optionally provides extrusion by adding triangles that serve as walls when extru
 Creates tessellator with a specified origin point of the world (in map coordinates)
 %End
 
-    QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
+    QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false, bool noZ = false );
 %Docstring
 Creates tessellator with a specified ``bounds`` of input geometry coordinates.
 This constructor allows the tessellator to map input coordinates to a desirable range for numerically
 stability during calculations.
+
+If ``noZ`` is ``True``, then a 2-dimensional tesselation only will be performed and all z coordinates will be ignored.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgstessellator.sip.in
+++ b/python/core/auto_generated/qgstessellator.sip.in
@@ -35,7 +35,7 @@ Creates tessellator with a specified origin point of the world (in map coordinat
     QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false, bool noZ = false );
 %Docstring
 Creates tessellator with a specified ``bounds`` of input geometry coordinates.
-This constructor allows the tessellator to map input coordinates to a desirable range for numerically
+This constructor allows the tessellator to map input coordinates to a desirable range for numerical
 stability during calculations.
 
 If ``noZ`` is ``True``, then a 2-dimensional tessellation only will be performed and all z coordinates will be ignored.

--- a/python/core/auto_generated/qgstessellator.sip.in
+++ b/python/core/auto_generated/qgstessellator.sip.in
@@ -38,7 +38,7 @@ Creates tessellator with a specified ``bounds`` of input geometry coordinates.
 This constructor allows the tessellator to map input coordinates to a desirable range for numerically
 stability during calculations.
 
-If ``noZ`` is ``True``, then a 2-dimensional tesselation only will be performed and all z coordinates will be ignored.
+If ``noZ`` is ``True``, then a 2-dimensional tessellation only will be performed and all z coordinates will be ignored.
 
 .. versionadded:: 3.10
 %End

--- a/python/core/auto_generated/qgstessellator.sip.in
+++ b/python/core/auto_generated/qgstessellator.sip.in
@@ -32,6 +32,15 @@ Optionally provides extrusion by adding triangles that serve as walls when extru
 Creates tessellator with a specified origin point of the world (in map coordinates)
 %End
 
+    QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
+%Docstring
+Creates tessellator with a specified ``bounds`` of input geometry coordinates.
+This constructor allows the tesselator to map input coordinates to a desirable range for numerically
+stability during calculations.
+
+.. versionadded:: 3.10
+%End
+
     void addPolygon( const QgsPolygon &polygon, float extrusionHeight );
 %Docstring
 Tessellates a triangle and adds its vertex entries to the output data array

--- a/python/core/auto_generated/qgstessellator.sip.in
+++ b/python/core/auto_generated/qgstessellator.sip.in
@@ -35,7 +35,7 @@ Creates tessellator with a specified origin point of the world (in map coordinat
     QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
 %Docstring
 Creates tessellator with a specified ``bounds`` of input geometry coordinates.
-This constructor allows the tesselator to map input coordinates to a desirable range for numerically
+This constructor allows the tessellator to map input coordinates to a desirable range for numerically
 stability during calculations.
 
 .. versionadded:: 3.10

--- a/src/3d/processing/qgsalgorithmtessellate.cpp
+++ b/src/3d/processing/qgsalgorithmtessellate.cpp
@@ -89,7 +89,7 @@ QgsFeatureList QgsTessellateAlgorithm::processFeature( const QgsFeature &feature
     else
     {
       QgsRectangle bounds = f.geometry().boundingBox();
-      QgsTessellator t( bounds.xMinimum(), bounds.yMinimum(), false );
+      QgsTessellator t( bounds, false );
 
       if ( f.geometry().isMultipart() )
       {

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -1084,19 +1084,25 @@ void QgsLineString::transform( const QTransform &t, double zTranslate, double zS
   int nPoints = numPoints();
   bool hasZ = is3D();
   bool hasM = isMeasure();
+  double *x = mX.data();
+  double *y = mY.data();
+  double *z = hasZ ? mZ.data() : nullptr;
+  double *m = hasM ? mM.data() : nullptr;
   for ( int i = 0; i < nPoints; ++i )
   {
-    qreal x, y;
-    t.map( mX.at( i ), mY.at( i ), &x, &y );
-    mX[i] = x;
-    mY[i] = y;
+    double xOut, yOut;
+    t.map( *x, *y, &xOut, &yOut );
+    *x++ = xOut;
+    *y++ = yOut;
     if ( hasZ )
     {
-      mZ[i] = mZ.at( i ) * zScale + zTranslate;
+      *z = *z * zScale + zTranslate;
+      z++;
     }
     if ( hasM )
     {
-      mM[i] = mM.at( i ) * mScale + mTranslate;
+      *m = *m * mScale + mTranslate;
+      m++;
     }
   }
   clearCache();

--- a/src/core/geometry/qgstriangle.cpp
+++ b/src/core/geometry/qgstriangle.cpp
@@ -31,21 +31,27 @@ QgsTriangle::QgsTriangle( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint
 {
   mWkbType = QgsWkbTypes::Triangle;
 
-  std::unique_ptr<QgsLineString> ext( new QgsLineString() );
-
-  ext->setPoints( QgsPointSequence() << p1 << p2 << p3 );
-
-  setExteriorRing( ext.release() );
+  QVector< double > x { p1.x(), p2.x(), p3.x(), p1.x() };
+  QVector< double > y { p1.y(), p2.y(), p3.y(), p1.y() };
+  QVector< double > z;
+  if ( p1.is3D() )
+  {
+    z = { p1.z(), p2.z(), p3.z(), p1.z() };
+  }
+  QVector< double > m;
+  if ( p1.isMeasure() )
+  {
+    m = {p1.m(), p2.m(), p3.m(), p1.m() };
+  }
+  setExteriorRing( new QgsLineString( x, y, z, m ) );
 }
 
 QgsTriangle::QgsTriangle( const QgsPointXY &p1, const QgsPointXY &p2, const QgsPointXY &p3 )
 {
   mWkbType = QgsWkbTypes::Triangle;
 
-  QVector< double > x;
-  x << p1.x() << p2.x() << p3.x();
-  QVector< double > y;
-  y << p1.y() << p2.y() << p3.y();
+  QVector< double > x { p1.x(), p2.x(), p3.x(), p1.x() };
+  QVector< double > y {p1.y(), p2.y(), p3.y(), p1.y() };
   QgsLineString *ext = new QgsLineString( x, y );
   setExteriorRing( ext );
 }
@@ -54,10 +60,8 @@ QgsTriangle::QgsTriangle( const QPointF p1, const QPointF p2, const QPointF p3 )
 {
   mWkbType = QgsWkbTypes::Triangle;
 
-  QVector< double > x;
-  x << p1.x() << p2.x() << p3.x();
-  QVector< double > y;
-  y << p1.y() << p2.y() << p3.y();
+  QVector< double > x{ p1.x(), p2.x(), p3.x(), p1.x() };
+  QVector< double > y{ p1.y(), p2.y(), p3.y(), p1.y() };
   QgsLineString *ext = new QgsLineString( x, y );
   setExteriorRing( ext );
 }

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -231,7 +231,7 @@ static void _ringToPoly2tri( const QgsLineString *ring, std::vector<p2t::Point *
     const float y = *srcYData++;
     const float z = *srcZData++;
 
-    const bool found = std::find_if( polyline.begin(), polyline.end(), [x, y]( p2t::Point *&p ) { return *p == p2t::Point( x, y ); } ) != polyline.end();
+    const bool found = std::find_if( polyline.begin(), polyline.end(), [x, y]( p2t::Point *&p ) { return p->x == x && p->y == y; } ) != polyline.end();
 
     if ( found )
     {

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -346,7 +346,7 @@ static bool _check_intersecting_rings( const QgsPolygon &polygon )
 
   if ( ringEngines.size() > 1 )
   {
-    for ( auto i = 0; i < ringEngines.size(); ++i )
+    for ( size_t i = 0; i < ringEngines.size(); ++i )
     {
       std::unique_ptr< QgsGeometryEngine > &first = ringEngines.at( i );
       if ( polygon.numInteriorRings() > 1 )
@@ -357,7 +357,7 @@ static bool _check_intersecting_rings( const QgsPolygon &polygon )
       // representations available in ringEngines
       // This needs addressing by extending the QgsGeometryEngine relation tests to allow testing against
       // another QgsGeometryEngine object.
-      for ( int interiorRing = i; interiorRing < polygon.numInteriorRings(); ++interiorRing )
+      for ( int interiorRing = static_cast< int >( i ); interiorRing < polygon.numInteriorRings(); ++interiorRing )
       {
         if ( first->intersects( polygon.interiorRing( interiorRing ) ) )
           return false;

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -534,6 +534,7 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
 
       std::vector<p2t::Triangle *> triangles = cdt->GetTriangles();
 
+      mData.reserve( mData.size() + triangles.size() * ( ( mAddNormals ? 6 : 3 ) * ( mAddBackFaces ? 2 : 1 ) ) );
       for ( size_t i = 0; i < triangles.size(); ++i )
       {
         p2t::Triangle *t = triangles[i];

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -346,7 +346,7 @@ static bool _check_intersecting_rings( const QgsPolygon &polygon )
 
   if ( ringEngines.size() > 1 )
   {
-    for ( int i = 0; i < ringEngines.size(); ++i )
+    for ( auto i = 0; i < ringEngines.size(); ++i )
     {
       std::unique_ptr< QgsGeometryEngine > &first = ringEngines.at( i );
       if ( polygon.numInteriorRings() > 1 )

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsTessellator
 
     /**
      * Creates tessellator with a specified \a bounds of input geometry coordinates.
-     * This constructor allows the tesselator to map input coordinates to a desirable range for numerically
+     * This constructor allows the tessellator to map input coordinates to a desirable range for numerically
      * stability during calculations.
      * \since QGIS 3.10
      */

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsTessellator
      * This constructor allows the tessellator to map input coordinates to a desirable range for numerically
      * stability during calculations.
      *
-     * If \a noZ is TRUE, then a 2-dimensional tesselation only will be performed and all z coordinates will be ignored.
+     * If \a noZ is TRUE, then a 2-dimensional tessellation only will be performed and all z coordinates will be ignored.
      *
      * \since QGIS 3.10
      */

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -47,9 +47,12 @@ class CORE_EXPORT QgsTessellator
      * Creates tessellator with a specified \a bounds of input geometry coordinates.
      * This constructor allows the tessellator to map input coordinates to a desirable range for numerically
      * stability during calculations.
+     *
+     * If \a noZ is TRUE, then a 2-dimensional tesselation only will be performed and all z coordinates will be ignored.
+     *
      * \since QGIS 3.10
      */
-    QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
+    QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false, bool noZ = false );
 
     //! Tessellates a triangle and adds its vertex entries to the output data array
     void addPolygon( const QgsPolygon &polygon, float extrusionHeight );
@@ -82,6 +85,7 @@ class CORE_EXPORT QgsTessellator
     bool mAddBackFaces = false;
     QVector<float> mData;
     int mStride;
+    bool mNoZ = false;
 };
 
 #endif // QGSTESSELLATOR_H

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsTessellator
 
     /**
      * Creates tessellator with a specified \a bounds of input geometry coordinates.
-     * This constructor allows the tessellator to map input coordinates to a desirable range for numerically
+     * This constructor allows the tessellator to map input coordinates to a desirable range for numerical
      * stability during calculations.
      *
      * If \a noZ is TRUE, then a 2-dimensional tessellation only will be performed and all z coordinates will be ignored.

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -18,6 +18,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsrectangle.h"
 
 class QgsPolygon;
 class QgsMultiPolygon;
@@ -42,6 +43,14 @@ class CORE_EXPORT QgsTessellator
     //! Creates tessellator with a specified origin point of the world (in map coordinates)
     QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
 
+    /**
+     * Creates tessellator with a specified \a bounds of input geometry coordinates.
+     * This constructor allows the tesselator to map input coordinates to a desirable range for numerically
+     * stability during calculations.
+     * \since QGIS 3.10
+     */
+    QgsTessellator( const QgsRectangle &bounds, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
+
     //! Tessellates a triangle and adds its vertex entries to the output data array
     void addPolygon( const QgsPolygon &polygon, float extrusionHeight );
 
@@ -64,6 +73,9 @@ class CORE_EXPORT QgsTessellator
     std::unique_ptr< QgsMultiPolygon > asMultiPolygon() const SIP_SKIP;
 
   private:
+    void init();
+
+    QgsRectangle mBounds;
     double mOriginX = 0, mOriginY = 0;
     bool mAddNormals = false;
     bool mInvertNormals = false;

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -101,6 +101,7 @@ bool checkTriangleOutput( const QVector<float> &data, bool withNormals, const QL
     TriangleCoords out( dataRaw, withNormals );
     if ( exp != out )
     {
+      qDebug() << i;
       qDebug() << "expected:";
       exp.dump();
       qDebug() << "got:";
@@ -136,6 +137,7 @@ class TestQgsTessellator : public QObject
     void testCrashSelfIntersection();
     void testCrashEmptyPolygon();
     void testBoundsScaling();
+    void testNoZ();
 
   private:
 };
@@ -367,6 +369,21 @@ void TestQgsTessellator::testBoundsScaling()
   QgsTessellator t2( polygon.boundingBox(), true );
   t2.addPolygon( polygon, 0 );
   QVERIFY( checkTriangleOutput( t2.data(), true, tc ) );
+}
+
+void TestQgsTessellator::testNoZ()
+{
+  // test tessellation with no z support
+  QgsPolygon polygonZ;
+  polygonZ.fromWkt( "POLYGONZ((1 1 1, 2 1 1, 3 2 1, 1 2 1, 1 1 1))" );
+
+  QList<TriangleCoords> tc;
+  tc << TriangleCoords( QVector3D( 0, 1, 0 ), QVector3D( 1, 0, 0 ), QVector3D( 2, 1, 0 ) );
+  tc << TriangleCoords( QVector3D( 0, 1, 0 ), QVector3D( 0, 0, 0 ), QVector3D( 1, 0, 0 ) );
+
+  QgsTessellator t( polygonZ.boundingBox(), false, false, false, true );
+  t.addPolygon( polygonZ, 0 );
+  QVERIFY( checkTriangleOutput( t.data(), false, tc ) );
 }
 
 


### PR DESCRIPTION
This PR optimises QgsTesselator, by using the knowledge that the tesellator only operates on QgsPolygon geometries and accordingly all rings are QgsLineStrings. In this case we can use heavily optimised point getters and setters and avoid the generic, inefficient virtual methods.

It also adds a new constructor which takes a geometry bounds, and scales coordinates using these bounds. This avoids numerical instability with very small coordinate differences, e.g. when tesellating a geometry in geographic coordinates. 