### PR TITLE
Processing Modeler: set default action to Export as Script Algorithm button

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -281,6 +281,7 @@ class ModelerDialog(BASE, WIDGET):
         self.toolbutton_export_to_script.setPopupMode(QToolButton.InstantPopup)
         self.export_to_script_algorithm_action = QAction(QCoreApplication.translate('ModelerDialog', 'Export as Script Algorithm…'))
         self.toolbutton_export_to_script.addActions([self.export_to_script_algorithm_action])
+        self.toolbutton_export_to_script.setDefaultAction(self.export_to_script_algorithm_action)
         self.mToolbar.insertWidget(self.mActionExportImage, self.toolbutton_export_to_script)
         self.export_to_script_algorithm_action.triggered.connect(self.export_as_script_algorithm)
 


### PR DESCRIPTION
## Description
In Processing Modeler, set default action to Export as Script Algorithm button otherwise the button tooltip is not shown.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
