### PR TITLE
Address implentation gaps for decorations' center placement

### DIFF
--- a/src/app/decorations/qgsdecorationcopyright.cpp
+++ b/src/app/decorations/qgsdecorationcopyright.cpp
@@ -185,12 +185,12 @@ void QgsDecorationCopyright::render( const QgsMapSettings &mapSettings, QgsRende
       break;
     case TopCenter: // Top Center
       yOffset = yOffset + textHeight - textDescent;
-      xOffset = deviceWidth / 2;
+      xOffset = deviceWidth / 2 + xOffset;
       horizontalAlignment = QgsTextRenderer::AlignCenter;
       break;
     case BottomCenter: // Bottom Center
       yOffset = deviceHeight - yOffset - textDescent;
-      xOffset = deviceWidth / 2;
+      xOffset = deviceWidth / 2 + xOffset;
       horizontalAlignment = QgsTextRenderer::AlignCenter;
       break;
     default:

--- a/src/app/decorations/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/decorations/qgsdecorationcopyrightdialog.cpp
@@ -66,7 +66,12 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
   cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
+  connect( cboPlacement, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    spnHorizontal->setMinimum( cboPlacement->currentData() == QgsDecorationItem::TopCenter || cboPlacement->currentData() == QgsDecorationItem::BottomCenter ? -100 : 0 );
+  } );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
+
   spnHorizontal->setValue( mDeco.mMarginHorizontal );
   spnVertical->setValue( mDeco.mMarginVertical );
   wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );

--- a/src/app/decorations/qgsdecorationimagedialog.cpp
+++ b/src/app/decorations/qgsdecorationimagedialog.cpp
@@ -54,7 +54,12 @@ QgsDecorationImageDialog::QgsDecorationImageDialog( QgsDecorationImage &deco, QW
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
   cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
+  connect( cboPlacement, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    spinHorizontal->setMinimum( cboPlacement->currentData() == QgsDecorationItem::TopCenter || cboPlacement->currentData() == QgsDecorationItem::BottomCenter ? -100 : 0 );
+  } );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
+
   spinHorizontal->setValue( mDeco.mMarginHorizontal );
   spinVertical->setValue( mDeco.mMarginVertical );
   wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );

--- a/src/app/decorations/qgsdecorationnortharrow.cpp
+++ b/src/app/decorations/qgsdecorationnortharrow.cpp
@@ -220,7 +220,12 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
                                       deviceHeight - yOffset - maxLength + ( maxLength - size.height() ) / 2 );
         break;
       case TopCenter:
+        context.painter()->translate( deviceWidth / 2 - size.width() / 2 + xOffset, yOffset );
+        break;
       case BottomCenter:
+        context.painter()->translate( deviceWidth / 2 - size.width() / 2 + xOffset,
+                                      deviceHeight - yOffset - size.height() );
+        break;
       default:
         QgsDebugMsg( QStringLiteral( "Unsupported placement index of %1" ).arg( static_cast<int>( mPlacement ) ) );
     }

--- a/src/app/decorations/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/decorations/qgsdecorationnortharrowdialog.cpp
@@ -62,8 +62,10 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
 
   // placement
   cboPlacement->addItem( tr( "Top Left" ), QgsDecorationItem::TopLeft );
+  cboPlacement->addItem( tr( "Top Center" ), QgsDecorationItem::TopCenter );
   cboPlacement->addItem( tr( "Top Right" ), QgsDecorationItem::TopRight );
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
+  cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
   spinHorizontal->setValue( mDeco.mMarginHorizontal );

--- a/src/app/decorations/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/decorations/qgsdecorationnortharrowdialog.cpp
@@ -67,7 +67,12 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
   cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
+  connect( cboPlacement, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    spinHorizontal->setMinimum( cboPlacement->currentData() == QgsDecorationItem::TopCenter || cboPlacement->currentData() == QgsDecorationItem::BottomCenter ? -100 : 0 );
+  } );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
+
   spinHorizontal->setValue( mDeco.mMarginHorizontal );
   spinVertical->setValue( mDeco.mMarginVertical );
   wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );

--- a/src/app/decorations/qgsdecorationscalebar.cpp
+++ b/src/app/decorations/qgsdecorationscalebar.cpp
@@ -310,7 +310,10 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
   mSettings.setNumberOfSegments( mStyleIndex == 3 ? 2 : 1 );
   mSettings.setUnitsPerSegment( mStyleIndex == 3 ? unitsPerSegment / 2 : unitsPerSegment );
   mSettings.setUnitLabel( scaleBarUnitLabel );
-
+  if ( mPlacement == TopCenter || mPlacement == BottomCenter )
+  {
+    mSettings.setLabelHorizontalPlacement( QgsScaleBarSettings::LabelCenteredSegment );
+  }
   QgsScaleBarRenderer::ScaleBarContext scaleContext;
   scaleContext.segmentWidth = mStyleIndex == 3 ? segmentSize / 2 : segmentSize;
   scaleContext.scale = mapSettings.scale();
@@ -370,7 +373,12 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
       originY = deviceHeight - originY - size.height();
       break;
     case TopCenter:
+      originX = deviceWidth / 2 - size.width() / 2 + originX;
+      break;
     case BottomCenter:
+      originX = deviceWidth / 2 - size.width() / 2 + originX;
+      originY = deviceHeight - originY - size.height();
+      break;
     default:
       QgsDebugMsg( QStringLiteral( "Unsupported placement index of %1" ).arg( static_cast<int>( mPlacement ) ) );
   }

--- a/src/app/decorations/qgsdecorationscalebardialog.cpp
+++ b/src/app/decorations/qgsdecorationscalebardialog.cpp
@@ -62,7 +62,12 @@ QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar 
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
   cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
+  connect( cboPlacement, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    spnHorizontal->setMinimum( cboPlacement->currentData() == QgsDecorationItem::TopCenter || cboPlacement->currentData() == QgsDecorationItem::BottomCenter ? -100 : 0 );
+  } );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
+
   spnHorizontal->setValue( mDeco.mMarginHorizontal );
   spnVertical->setValue( mDeco.mMarginVertical );
   wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );

--- a/src/app/decorations/qgsdecorationscalebardialog.cpp
+++ b/src/app/decorations/qgsdecorationscalebardialog.cpp
@@ -57,8 +57,10 @@ QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar 
 
   // placement
   cboPlacement->addItem( tr( "Top Left" ), QgsDecorationItem::TopLeft );
+  cboPlacement->addItem( tr( "Top Center" ), QgsDecorationItem::TopCenter );
   cboPlacement->addItem( tr( "Top Right" ), QgsDecorationItem::TopRight );
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
+  cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
   spnHorizontal->setValue( mDeco.mMarginHorizontal );

--- a/src/app/decorations/qgsdecorationtitle.cpp
+++ b/src/app/decorations/qgsdecorationtitle.cpp
@@ -196,7 +196,7 @@ void QgsDecorationTitle::render( const QgsMapSettings &mapSettings, QgsRenderCon
                     << QPointF( deviceWidth, yOffset * 2 + textHeight )
                     << QPointF( 0, yOffset * 2 + textHeight );
       yOffset = yOffset + textHeight - textDescent;
-      xOffset = deviceWidth / 2;
+      xOffset = deviceWidth / 2 + xOffset;
       horizontalAlignment = QgsTextRenderer::AlignCenter;
       break;
     case BottomCenter: // Bottom Center
@@ -205,7 +205,7 @@ void QgsDecorationTitle::render( const QgsMapSettings &mapSettings, QgsRenderCon
                     << QPointF( deviceWidth, deviceHeight - ( yOffset * 2 + textHeight ) )
                     << QPointF( 0, deviceHeight - ( yOffset * 2 + textHeight ) );
       yOffset = deviceHeight - yOffset - textDescent;
-      xOffset = deviceWidth / 2;
+      xOffset = deviceWidth / 2 + xOffset;
       horizontalAlignment = QgsTextRenderer::AlignCenter;
       break;
     default:

--- a/src/app/decorations/qgsdecorationtitledialog.cpp
+++ b/src/app/decorations/qgsdecorationtitledialog.cpp
@@ -76,7 +76,12 @@ QgsDecorationTitleDialog::QgsDecorationTitleDialog( QgsDecorationTitle &deco, QW
   cboPlacement->addItem( tr( "Bottom Left" ), QgsDecorationItem::BottomLeft );
   cboPlacement->addItem( tr( "Bottom Center" ), QgsDecorationItem::BottomCenter );
   cboPlacement->addItem( tr( "Bottom Right" ), QgsDecorationItem::BottomRight );
+  connect( cboPlacement, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, [ = ]( int )
+  {
+    spnHorizontal->setMinimum( cboPlacement->currentData() == QgsDecorationItem::TopCenter || cboPlacement->currentData() == QgsDecorationItem::BottomCenter ? -100 : 0 );
+  } );
   cboPlacement->setCurrentIndex( cboPlacement->findData( mDeco.placement() ) );
+
   spnHorizontal->setValue( mDeco.mMarginHorizontal );
   spnVertical->setValue( mDeco.mMarginVertical );
   wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR fixes an ongoing implementation gap with top/bottom center placement, whereas the scale bar and north arrow decorations were missing those options. Here's how centered placement looks like:
![image](https://user-images.githubusercontent.com/1728657/65852686-11c63700-e381-11e9-815a-da9ddb6ce955.png)

The PR also addresses the current lack of ability to move centered decorations _leftward_ by allowing negative horizontal margin when a decoration is set to top/bottom center placement.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
