### PR TITLE
[quick] Insure project background color is respected in map settings

### DIFF
--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -185,6 +185,14 @@ void QgsQuickMapSettings::setLayers( const QList<QgsMapLayer *> &layers )
 
 void QgsQuickMapSettings::onReadProject( const QDomDocument &doc )
 {
+  if ( mProject )
+  {
+    int red = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), 255 );
+    int green = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 );
+    int blue = mProject->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 );
+    mMapSettings.setBackgroundColor( QColor( red, green, blue ) );
+  }
+
   QDomNodeList nodes = doc.elementsByTagName( "mapcanvas" );
   if ( nodes.count() )
   {
@@ -214,4 +222,18 @@ void QgsQuickMapSettings::setRotation( double rotation )
 {
   if ( !qgsDoubleNear( rotation, 0 ) )
     QgsMessageLog::logMessage( tr( "Map Canvas rotation is not supported. Resetting from %1 to 0." ).arg( rotation ) );
+}
+
+QColor QgsQuickMapSettings::backgroundColor() const
+{
+  return mMapSettings.backgroundColor();
+}
+
+void QgsQuickMapSettings::setBackgroundColor( const QColor &color )
+{
+  if ( mMapSettings.backgroundColor() == color )
+    return;
+
+  mMapSettings.setBackgroundColor( color );
+  emit backgroundColorChanged();
 }

--- a/src/quickgui/qgsquickmapsettings.h
+++ b/src/quickgui/qgsquickmapsettings.h
@@ -77,6 +77,13 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
     Q_PROPERTY( double rotation READ rotation WRITE setRotation NOTIFY rotationChanged )
 
     /**
+     * The background color used to render the map
+     *
+     * The value is set to the project's bacckground color setting on QgsProject::readProject
+     */
+    Q_PROPERTY( QColor backgroundColor READ backgroundColor WRITE setBackgroundColor NOTIFY backgroundColorChanged )
+
+    /**
      * The size of the resulting map image
      *
      * Automatically loaded from project on QgsProject::readProject
@@ -167,6 +174,12 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
     //! \copydoc QgsQuickMapSettings::rotation
     void setRotation( double rotation );
 
+    //! \copydoc QgsQuickMapSettings::backgroundColor
+    QColor backgroundColor() const;
+
+    //! \copydoc QgsQuickMapSettings::backgroundColor
+    void setBackgroundColor( const QColor &color );
+
     //! \copydoc QgsMapSettings::outputSize()
     QSize outputSize() const;
 
@@ -206,6 +219,9 @@ class QUICK_EXPORT QgsQuickMapSettings : public QObject
 
     //! \copydoc QgsQuickMapSettings::rotation
     void rotationChanged();
+
+    //! \copydoc QgsQuickMapSettings::backgroundColor
+    void backgroundColorChanged();
 
     //! \copydoc QgsQuickMapSettings::visibleExtent
     void visibleExtentChanged();


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR insures that the project background color is attached to the QgsQuickMapSettings object for the quick map canvas to draw using the expected background color.

Sponsored by QField.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
