### PR TITLE
Do not assume PostGIS 2.0+ has raster

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1023,8 +1023,12 @@ QString QgsPostgresConn::postgisVersion()
   QgsDebugMsg( QStringLiteral( "Checking for raster support" ) );
   if ( mPostgisVersionMajor >= 2 )
   {
-    mRasterAvailable = true;
-    QgsDebugMsg( QStringLiteral( "Raster support available!" ) );
+    QgsPostgresResult result( PQexec( QStringLiteral( "SELECT oid FROM pg_catalog.pg_type WHERE typname='raster'" ) ) );
+    if ( result.PQntuples() >= 1 )
+    {
+      mRasterAvailable = true;
+      QgsDebugMsg( QStringLiteral( "Raster support available!" ) );
+    }
   }
 
   return mPostgisVersionInfo;


### PR DESCRIPTION
People installing PostGIS via scripts do not necessarely install
raster support, even after PostGIS 2.0.
Starting with PostGIS 3.0 the raster support is not enforced as
active even when installing via extension.

This change detects raster support by the presence of a "raster"
named custom type.