### PR TITLE
Disappearing Null representation in Range Widget on QgsDoubleSpinBox 

### DIFF
--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -175,7 +175,7 @@ void QgsDoubleSpinBox::setSpecialValueText( const QString &txt )
   else
   {
     QDoubleSpinBox::setSpecialValueText( txt );
-    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+    mLineEdit->setNullValue( txt );
   }
 }
 

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -349,9 +349,6 @@ void TestQgsRangeWidgetWrapper::test_focus()
   QVERIFY( editor2 );
   widget2->initWidget( editor2 );
 
-  editor1->mLineEdit->setNullValue( QgsApplication::nullRepresentation() );
-  editor2->mLineEdit->setNullValue( QgsApplication::nullRepresentation() );
-
   QVERIFY( widget1->value().isNull() );
   QVERIFY( widget2->value().isNull() );
   QVERIFY( !editor1->mLineEdit->hasFocus() );

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -352,20 +352,24 @@ void TestQgsRangeWidgetWrapper::test_focus()
   editor1->mLineEdit->setNullValue( QgsApplication::nullRepresentation() );
   editor2->mLineEdit->setNullValue( QgsApplication::nullRepresentation() );
 
-  QVERIFY( editor1->mLineEdit->isNull() );
-  QVERIFY( editor2->mLineEdit->isNull() );
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
   QVERIFY( !editor1->mLineEdit->hasFocus() );
   QVERIFY( !editor2->mLineEdit->hasFocus() );
   QCOMPARE( editor1->mLineEdit->text(), QStringLiteral( "nope" ) );
   QCOMPARE( editor2->mLineEdit->text(), QStringLiteral( "nope" ) );
 
   editor1->mLineEdit->setFocus();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
   QVERIFY( editor1->mLineEdit->hasFocus() );
   QVERIFY( !editor2->mLineEdit->hasFocus() );
   QCOMPARE( editor1->mLineEdit->text(), QStringLiteral( "" ) );
   QCOMPARE( editor2->mLineEdit->text(), QStringLiteral( "nope" ) );
 
   editor2->mLineEdit->setFocus();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
   QVERIFY( !editor1->mLineEdit->hasFocus() );
   QVERIFY( editor2->mLineEdit->hasFocus() );
   QCOMPARE( editor1->mLineEdit->text(), QStringLiteral( "nope" ) );
@@ -373,14 +377,16 @@ void TestQgsRangeWidgetWrapper::test_focus()
 
   editor1->mLineEdit->setFocus();
   editor1->mLineEdit->setText( QString( "151.000000000" ) );
-  QVERIFY( !editor1->mLineEdit->isNull() );
-  QVERIFY( editor2->mLineEdit->isNull() );
+  QVERIFY( !widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
   QVERIFY( editor1->mLineEdit->hasFocus() );
   QVERIFY( !editor2->mLineEdit->hasFocus() );
   QCOMPARE( editor1->mLineEdit->text(), QStringLiteral( "151.000000000" ) );
   QCOMPARE( editor2->mLineEdit->text(), QStringLiteral( "nope" ) );
 
   editor2->mLineEdit->setFocus();
+  QVERIFY( !widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
   QVERIFY( !editor1->mLineEdit->hasFocus() );
   QVERIFY( editor2->mLineEdit->hasFocus() );
   QCOMPARE( editor1->mLineEdit->text(), QStringLiteral( "151.000000000" ) );


### PR DESCRIPTION
Compared to the `QgsSpinBox` used for int values the Null representation did not disappear on `QgsDoubleSpinBox` used for double values:
Before:
![before](https://user-images.githubusercontent.com/28384354/65883260-f82fea00-e396-11e9-9302-a42cf4d039a5.gif)
After:
![after](https://user-images.githubusercontent.com/28384354/65883259-f82fea00-e396-11e9-8a8f-fb13d33d87c6.gif)

The feature has been implemented by me back then #8442 but obviously it contained a bug for `QgsDoubleSpinBox`.

I improved the tests for these cases.

This fixes #22883