### PR TITLE
 [needs-docs] revive the GDAL 'rasterize over' tool that was available in the old ltr and for some reason not activated/added in QGIS 3

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -67,6 +67,7 @@ from .tpi import tpi
 from .tri import tri
 from .warp import warp
 from .pansharp import pansharp
+from .rasterize_over_fixed_value import rasterize_over_fixed_value
 
 from .extractprojection import ExtractProjection
 from .rasterize_over import rasterize_over
@@ -175,6 +176,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             # rasterize(),
             ExtractProjection(),
             rasterize_over(),
+            rasterize_over_fixed_value(),
             # ----- OGR tools -----
             Buffer(),
             ClipVectorByExtent(),

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -69,7 +69,7 @@ from .warp import warp
 from .pansharp import pansharp
 
 from .extractprojection import ExtractProjection
-# from .rasterize_over import rasterize_over
+from .rasterize_over import rasterize_over
 
 from .Buffer import Buffer
 from .ClipVectorByExtent import ClipVectorByExtent
@@ -174,7 +174,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             pansharp(),
             # rasterize(),
             ExtractProjection(),
-            # rasterize_over(),
+            rasterize_over(),
             # ----- OGR tools -----
             Buffer(),
             ClipVectorByExtent(),

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -46,6 +46,7 @@ class rasterize_over(GdalAlgorithm):
     INPUT_RASTER = 'INPUT_RASTER'
     ADD = 'ADD'
     EXTRA = 'EXTRA'
+    BURN = 'BURN'
 
     def __init__(self):
         super().__init__()
@@ -64,7 +65,13 @@ class rasterize_over(GdalAlgorithm):
                                                       None,
                                                       self.INPUT,
                                                       QgsProcessingParameterField.Numeric,
-                                                      optional=False))
+                                                      optional=True))
+
+        self.addParameter(QgsProcessingParameterNumber(self.BURN,
+                                                       self.tr('A fixed value to burn'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       defaultValue=0.0,
+                                                       optional=True))
 
         add_param = QgsProcessingParameterBoolean(self.ADD,
                                                      self.tr('Add burn in values to existing raster values'),
@@ -108,6 +115,9 @@ class rasterize_over(GdalAlgorithm):
         if fieldName:
             arguments.append('-a')
             arguments.append(fieldName)
+        else:
+            arguments.append('-burn')
+            arguments.append(self.parameterAsDouble(parameters, self.BURN, context))
 
         if self.parameterAsBool(parameters, self.ADD, context):
             arguments.append('-add')

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -83,7 +83,7 @@ class rasterize_over(GdalAlgorithm):
         return 'rasterize_over'
 
     def displayName(self):
-        return self.tr('Rasterize (write attribute value over existing raster)')
+        return self.tr('Rasterize (overwrite with attribute)')
 
     def group(self):
         return self.tr('Vector conversion')

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -39,13 +39,13 @@ from processing.algs.gdal.GdalUtils import GdalUtils
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
 
-class rasterize_over(GdalAlgorithm):
+class rasterize_over_fixed_value(GdalAlgorithm):
 
     INPUT = 'INPUT'
-    FIELD = 'FIELD'
     INPUT_RASTER = 'INPUT_RASTER'
     ADD = 'ADD'
     EXTRA = 'EXTRA'
+    BURN = 'BURN'
 
     def __init__(self):
         super().__init__()
@@ -59,12 +59,11 @@ class rasterize_over(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT_RASTER, self.tr('Input raster layer')))
 
-        self.addParameter(QgsProcessingParameterField(self.FIELD,
-                                                      self.tr('Field to use for burn in value'),
-                                                      None,
-                                                      self.INPUT,
-                                                      QgsProcessingParameterField.Numeric,
-                                                      optional=False))
+        self.addParameter(QgsProcessingParameterNumber(self.BURN,
+                                                       self.tr('A fixed value to burn'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       defaultValue=0.0,
+                                                       optional=False))
 
         add_param = QgsProcessingParameterBoolean(self.ADD,
                                                      self.tr('Add burn in values to existing raster values'),
@@ -80,10 +79,10 @@ class rasterize_over(GdalAlgorithm):
         self.addParameter(extra_param)
 
     def name(self):
-        return 'rasterize_over'
+        return 'rasterize_over_fixed_value'
 
     def displayName(self):
-        return self.tr('Rasterize (write attribute value over existing raster)')
+        return self.tr('Rasterize (write fixed value over existing raster)')
 
     def group(self):
         return self.tr('Vector conversion')
@@ -106,8 +105,8 @@ class rasterize_over(GdalAlgorithm):
 
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
 
-        arguments.append('-a')
-        arguments.append(fieldName)
+        arguments.append('-burn')
+        arguments.append(self.parameterAsDouble(parameters, self.BURN, context))
 
         if self.parameterAsBool(parameters, self.ADD, context):
             arguments.append('-add')

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -82,7 +82,7 @@ class rasterize_over_fixed_value(GdalAlgorithm):
         return 'rasterize_over_fixed_value'
 
     def displayName(self):
-        return self.tr('Rasterize (write fixed value over existing raster)')
+        return self.tr('Rasterize (overwrite with fixed value)')
 
     def group(self):
         return self.tr('Vector conversion')


### PR DESCRIPTION
This implementation/set of options for GDAL rasterize is very valuable for a number of GIS analysis (i.e. adding a physical barrier over a digital elevation model and then modelling its consequences).

I argue that this would need to be backported to LTR, as this tool was available in the old LTR.

fixes https://github.com/qgis/QGIS/issues/27298