### PR TITLE
Makes GPKG prefered input format for OGR algs #Fixes 29097

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -89,6 +89,7 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
                 # and extract selection if required
                 ogr_data_path = self.parameterAsCompatibleSourceLayerPath(parameters, parameter_name, context,
                                                                           QgsVectorFileWriter.supportedFormatExtensions(),
+                                                                          'gpkg',
                                                                           feedback=feedback)
                 ogr_layer_name = GdalUtils.ogrLayerName(ogr_data_path)
             else:

--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -87,9 +87,13 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
             if executing:
                 # parameter is not a vector layer - try to convert to a source compatible with OGR
                 # and extract selection if required
+                if 'gpkg' in QgsVectorFileWriter.supportedFormatExtensions():
+                    preferred_format = 'gpkg'
+                else:
+                    preferred_format = 'shp'
                 ogr_data_path = self.parameterAsCompatibleSourceLayerPath(parameters, parameter_name, context,
                                                                           QgsVectorFileWriter.supportedFormatExtensions(),
-                                                                          'gpkg',
+                                                                          preferred_format,
                                                                           feedback=feedback)
                 ogr_layer_name = GdalUtils.ogrLayerName(ogr_data_path)
             else:

--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -87,13 +87,9 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
             if executing:
                 # parameter is not a vector layer - try to convert to a source compatible with OGR
                 # and extract selection if required
-                if 'gpkg' in QgsVectorFileWriter.supportedFormatExtensions():
-                    preferred_format = 'gpkg'
-                else:
-                    preferred_format = 'shp'
                 ogr_data_path = self.parameterAsCompatibleSourceLayerPath(parameters, parameter_name, context,
                                                                           QgsVectorFileWriter.supportedFormatExtensions(),
-                                                                          preferred_format,
+                                                                          QgsVectorFileWriter.supportedFormatExtensions()[0],
                                                                           feedback=feedback)
                 ogr_layer_name = GdalUtils.ogrLayerName(ogr_data_path)
             else:

--- a/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
@@ -109,11 +109,11 @@ class TestGdalAlgorithms(unittest.TestCase):
         self.assertIsNotNone(alg)
         parameters = {'INPUT': 'testmem'}
         feedback = QgsProcessingFeedback()
-        # check that memory layer is automatically saved out to shape when required by GDAL algorithms
+        # check that memory layer is automatically saved out to geopackage when required by GDAL algorithms
         ogr_data_path, ogr_layer_name = alg.getOgrCompatibleSource('INPUT', parameters, context, feedback,
                                                                    executing=True)
         self.assertTrue(ogr_data_path)
-        self.assertTrue(ogr_data_path.endswith('.shp'))
+        self.assertTrue(ogr_data_path.endswith('.gpkg'))
         self.assertTrue(os.path.exists(ogr_data_path))
         self.assertTrue(ogr_layer_name)
 
@@ -198,11 +198,11 @@ class TestGdalAlgorithms(unittest.TestCase):
         self.assertIsNotNone(alg)
         parameters = {'INPUT': QgsProcessingFeatureSourceDefinition('testmem', True)}
         feedback = QgsProcessingFeedback()
-        # check that memory layer is automatically saved out to shape when required by GDAL algorithms
+        # check that memory layer is automatically saved out to geopackage when required by GDAL algorithms
         ogr_data_path, ogr_layer_name = alg.getOgrCompatibleSource('INPUT', parameters, context, feedback,
                                                                    executing=True)
         self.assertTrue(ogr_data_path)
-        self.assertTrue(ogr_data_path.endswith('.shp'))
+        self.assertTrue(ogr_data_path.endswith('.gpkg'))
         self.assertTrue(os.path.exists(ogr_data_path))
         self.assertTrue(ogr_layer_name)
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Currently, when a GDAL algorithm uses a memory layer (or runs from the temporary output in a processing model) the input layer is converted to a shapefile, with all its drawbacks. The bigger one being that the names of the columns get truncated.

This makes the default transaction format Geopackage.

Fixes #29097

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
