### PR TITLE
makes the A_SRS parameter optional

### DIFF
--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
@@ -96,7 +96,7 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
                                                      self.tr('Output geometry type'), options=self.GEOMTYPE,
                                                      defaultValue=0))
         self.addParameter(QgsProcessingParameterCrs(self.A_SRS,
-                                                    self.tr('Assign an output CRS'), defaultValue='', optional=False))
+                                                    self.tr('Assign an output CRS'), defaultValue='', optional=True))
         self.addParameter(QgsProcessingParameterCrs(self.T_SRS,
                                                     self.tr('Reproject to this CRS on output '), defaultValue='',
                                                     optional=True))


### PR DESCRIPTION
The A_SRS parameter in the ogr based tool to import in PostGIS is not mandatory and there is no need to leave it so. Moreover setting this as it should be (optional) also helps with https://github.com/qgis/QGIS/issues/31753