### PR TITLE
change confusing parameter name in DB Manager

### DIFF
--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -208,7 +208,7 @@
       <item row="7" column="0" colspan="2">
        <widget class="QCheckBox" name="chkSinglePart">
         <property name="text">
-         <string>Create single-part geometries instead of multi-part</string>
+         <string>Do not promote to multi-part</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Explanation:

https://lists.osgeo.org/pipermail/qgis-developer/2019-October/058742.html

The new option name has been chosen to be consistent with a similar option used in OGR ("promote_to_multi").