### PR TITLE
monkey patch sys.argv if AttributeError  in tests

### DIFF
--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -394,6 +394,11 @@ def start_app(cleanup=True):
     except NameError:
         myGuiFlag = True  # All test will run qgis in gui mode
 
+        try:
+            sys.argv
+        except AttributeError:
+            sys.argv = ['']
+
         # In python3 we need to convert to a bytes object (or should
         # QgsApplication accept a QString instead of const char* ?)
         try:


### PR DESCRIPTION
## Description

In QGIS Master, there is already this fix:
https://github.com/qgis/QGIS/blob/master/python/testing/__init__.py#L408
which is not present in QGIS 3.4.

Can we add it in QGIS 3.4?

When I launch tests using the QGIS docker image, tests are passing on master, but not 3.4.

@elpaso Related commit in master: https://github.com/qgis/QGIS/commit/ed9709b4faa7b565ee75b7298e4b02069bcaf994

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
