### PR TITLE
C++ API for generating random points inside geometry

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1450,6 +1450,41 @@ by calling `error()` on the returned geometry.
 Returns an extruded version of this geometry.
 %End
 
+
+    SIP_PYOBJECT randomPointsInPolygon( int count, unsigned long seed = 0 ) /TypeHint="QgsPolylineXY"/;
+%Docstring
+Returns a list of ``count`` random points generated inside a (multi)polygon geometry.
+
+Optionally, a specific random ``seed`` can be used when generating points. If ``seed``
+is 0, then a completely random sequence of points will be generated.
+
+This method works only with (multi)polygon geometry types. If the geometry
+is not a polygon type, a TypeError will be raised. If the geometry
+is null, a ValueError will be raised.
+
+.. versionadded:: 3.10
+%End
+%MethodCode
+    const QgsWkbTypes::GeometryType type = sipCpp->type();
+    if ( sipCpp->isNull() )
+    {
+      PyErr_SetString( PyExc_ValueError, QStringLiteral( "Cannot generate points inside a null geometry." ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else if ( type != QgsWkbTypes::PolygonGeometry )
+    {
+      PyErr_SetString( PyExc_TypeError, QStringLiteral( "Cannot generate points inside a %1 geometry. Only Polygon types are permitted." ).arg( QgsWkbTypes::displayString( sipCpp->wkbType() ) ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QgsPointXY>" );
+      sipRes = sipConvertFromNewType( new QVector< QgsPointXY >( sipCpp->randomPointsInPolygon( a0, a1 ) ), qvector_type, Py_None );
+    }
+%End
+
+
+
     QByteArray asWkb() const;
 %Docstring
 Export the geometry to WKB

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2325,6 +2325,22 @@ QgsGeometry QgsGeometry::extrude( double x, double y )
   return engine.extrude( x, y );
 }
 
+QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, const std::function<bool( const QgsPointXY & )> &acceptPoint, unsigned long seed, QgsFeedback *feedback )
+{
+  if ( type() != QgsWkbTypes::PolygonGeometry )
+    return QVector< QgsPointXY >();
+
+  return QgsInternalGeometryEngine::randomPointsInPolygon( *this, count, acceptPoint, seed, feedback );
+}
+
+QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, unsigned long seed, QgsFeedback *feedback )
+{
+  if ( type() != QgsWkbTypes::PolygonGeometry )
+    return QVector< QgsPointXY >();
+
+  return QgsInternalGeometryEngine::randomPointsInPolygon( *this, count, []( const QgsPointXY & ) { return true; }, seed, feedback );
+}
+
 QByteArray QgsGeometry::asWkb() const
 {
   return d->geometry ? d->geometry->asWkb() : QByteArray();

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2325,7 +2325,8 @@ QgsGeometry QgsGeometry::extrude( double x, double y )
   return engine.extrude( x, y );
 }
 
-QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, const std::function<bool( const QgsPointXY & )> &acceptPoint, unsigned long seed, QgsFeedback *feedback )
+///@cond PRIVATE // avoid dox warning
+QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, const std::function< bool( const QgsPointXY & ) > &acceptPoint, unsigned long seed, QgsFeedback *feedback )
 {
   if ( type() != QgsWkbTypes::PolygonGeometry )
     return QVector< QgsPointXY >();
@@ -2340,6 +2341,7 @@ QVector<QgsPointXY> QgsGeometry::randomPointsInPolygon( int count, unsigned long
 
   return QgsInternalGeometryEngine::randomPointsInPolygon( *this, count, []( const QgsPointXY & ) { return true; }, seed, feedback );
 }
+///@endcond
 
 QByteArray QgsGeometry::asWkb() const
 {

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -47,6 +47,7 @@ class QgsMapToPixel;
 class QPainter;
 class QgsPolygon;
 class QgsLineString;
+class QgsFeedback;
 
 /**
  * Polyline as represented as a vector of two-dimensional points.
@@ -1435,6 +1436,79 @@ class CORE_EXPORT QgsGeometry
 
     //! Returns an extruded version of this geometry.
     QgsGeometry extrude( double x, double y );
+
+#ifndef SIP_RUN
+
+    /**
+     * Returns a list of \a count random points generated inside a (multi)polygon geometry.
+     *
+     * Optionally, a specific random \a seed can be used when generating points. If \a seed
+     * is 0, then a completely random sequence of points will be generated.
+     *
+     * If the source geometry is not a (multi)polygon, an empty list will be returned.
+     *
+     * The \a acceptPoint function is used to filter result candidates. If the function returns
+     * FALSE, then the point will not be accepted and another candidate generated.
+     *
+     * The optional \a feedback argument can be used to provide cancellation support during
+     * the point generation.
+     *
+     * \since QGIS 3.10
+     */
+    QVector< QgsPointXY > randomPointsInPolygon( int count, const std::function< bool( const QgsPointXY & ) > &acceptPoint, unsigned long seed = 0, QgsFeedback *feedback = nullptr );
+
+    /**
+     * Returns a list of \a count random points generated inside a (multi)polygon geometry.
+     *
+     * Optionally, a specific random \a seed can be used when generating points. If \a seed
+     * is 0, then a completely random sequence of points will be generated.
+     *
+     * If the source geometry is not a (multi)polygon, an empty list will be returned.
+     *
+     * The optional \a feedback argument can be used to provide cancellation support during
+     * the point generation.
+     *
+     * \since QGIS 3.10
+     */
+    QVector< QgsPointXY > randomPointsInPolygon( int count, unsigned long seed = 0, QgsFeedback *feedback = nullptr );
+    ///@cond PRIVATE
+#else
+
+    /**
+     * Returns a list of \a count random points generated inside a (multi)polygon geometry.
+     *
+     * Optionally, a specific random \a seed can be used when generating points. If \a seed
+     * is 0, then a completely random sequence of points will be generated.
+     *
+     * This method works only with (multi)polygon geometry types. If the geometry
+     * is not a polygon type, a TypeError will be raised. If the geometry
+     * is null, a ValueError will be raised.
+     *
+     * \since QGIS 3.10
+     */
+    SIP_PYOBJECT randomPointsInPolygon( int count, unsigned long seed = 0 ) SIP_TYPEHINT( QgsPolylineXY );
+    % MethodCode
+    const QgsWkbTypes::GeometryType type = sipCpp->type();
+    if ( sipCpp->isNull() )
+    {
+      PyErr_SetString( PyExc_ValueError, QStringLiteral( "Cannot generate points inside a null geometry." ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else if ( type != QgsWkbTypes::PolygonGeometry )
+    {
+      PyErr_SetString( PyExc_TypeError, QStringLiteral( "Cannot generate points inside a %1 geometry. Only Polygon types are permitted." ).arg( QgsWkbTypes::displayString( sipCpp->wkbType() ) ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const sipMappedType *qvector_type = sipFindMappedType( "QVector<QgsPointXY>" );
+      sipRes = sipConvertFromNewType( new QVector< QgsPointXY >( sipCpp->randomPointsInPolygon( a0, a1 ) ), qvector_type, Py_None );
+    }
+    % End
+
+
+#endif
+///@endcond
 
     /**
      * Export the geometry to WKB

--- a/src/core/geometry/qgsinternalgeometryengine.h
+++ b/src/core/geometry/qgsinternalgeometryengine.h
@@ -26,6 +26,7 @@ class QgsGeometry;
 class QgsAbstractGeometry;
 class QgsLineString;
 class QgsLineSegment2D;
+class QgsFeedback;
 
 /**
  * \ingroup core
@@ -147,6 +148,23 @@ class QgsInternalGeometryEngine
      * \since QGIS 3.2
      */
     QgsGeometry variableWidthBufferByM( int segments ) const;
+
+    /**
+     * Returns a list of \a count random points generated inside a \a polygon geometry.
+     *
+     * Optionally, a specific random \a seed can be used when generating points. If \a seed
+     * is 0, then a completely random sequence of points will be generated.
+     *
+     * The \a acceptPoint function is used to filter result candidates. If the function returns
+     * FALSE, then the point will not be accepted and another candidate generated.
+     *
+     * The optional \a feedback argument can be used to provide cancellation support during
+     * the point generation.
+     *
+     * \since QGIS 3.10
+     */
+    static QVector< QgsPointXY > randomPointsInPolygon( const QgsGeometry &polygon, int count,
+        const std::function< bool( const QgsPointXY & ) > &acceptPoint, unsigned long seed = 0, QgsFeedback *feedback = nullptr );
 
   private:
     const QgsAbstractGeometry *mGeometry = nullptr;

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -5229,6 +5229,36 @@ class TestQgsGeometry(unittest.TestCase):
             self.assertEqual(res, t[3],
                              "mismatch for {}, expected:\n{}\nGot:\n{}\n".format(t[0], t[3], res[0].where() if res else ''))
 
+    def testRandomPoints(self):
+        """
+        Test QgsGeometry.randomPointsInPolygon.
+
+        This just test the Python operation of this function -- more tests in testqgsgeometry.cpp
+        """
+
+        # no random points inside null geometry
+        g = QgsGeometry()
+        with self.assertRaises(ValueError):
+            res = g.randomPointsInPolygon(100)
+        # no random points inside linestring
+        g = QgsGeometry.fromWkt('LineString(4 5, 6 6)')
+        with self.assertRaises(TypeError):
+            res = g.randomPointsInPolygon(100)
+        # good!
+        g = QgsGeometry.fromWkt('Polygon(( 5 15, 10 15, 10 20, 5 20, 5 15 ), (6 16, 8 16, 8 18, 6 16 ))')
+        res = g.randomPointsInPolygon(100)
+        self.assertEqual(len(res), 100)
+        g = QgsGeometry.fromWkt('MultiPolygon((( 5 15, 10 15, 10 20, 5 20, 5 15 ), (6 16, 8 16, 8 18, 6 16 )), (( 105 115, 110 115, 110 120, 105 120, 105 115 ), (106 116, 108 116, 108 118, 106 116 )))')
+        res = g.randomPointsInPolygon(100)
+        self.assertEqual(len(res), 100)
+        res2 = g.randomPointsInPolygon(100)
+        self.assertNotEqual(res, res2)
+
+        # with seed
+        res = g.randomPointsInPolygon(100, seed=123123)
+        res2 = g.randomPointsInPolygon(100, seed=123123)
+        self.assertEqual(res, res2)
+
     def renderGeometry(self, geom, use_pen, as_polygon=False, as_painter_path=False):
         image = QImage(200, 200, QImage.Format_RGB32)
         image.fill(QColor(0, 0, 0))


### PR DESCRIPTION
Adds an optimised c++ method for generating random points inside
a polygon geometry, using a tessellation based approach to
avoid the inefficiencies of the brute force filtered-random-points-within-extent
approach.
