### PR TITLE
[Plugin installer] Fix handling zip file names with a dash as a version suffix separator

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -397,7 +397,11 @@ class Repositories(QObject):
                     fileName = pluginNodes.item(i).firstChildElement("file_name").text().strip()
                     if not fileName:
                         fileName = QFileInfo(pluginNodes.item(i).firstChildElement("download_url").text().strip().split("?")[0]).fileName()
-                    name = fileName.partition(".")[0]
+                    match = re.match('(.*?)[.-]', fileName)
+                    if match:
+                        name = match.groups()[0]
+                    else:
+                        name = fileName
                     experimental = False
                     if pluginNodes.item(i).firstChildElement("experimental").text().strip().upper() in ["TRUE", "YES"]:
                         experimental = True


### PR DESCRIPTION
Currently, the zip files can be named either package_name.zip or package_name.version_suffix.zip, i.e. the optional suffix must be delimited with a dot. However, there is a recurrent confusion when people use dash instead (e.g. my_plugin-1.2.3.zip). In that case the plugin installer unzips the package without any warning and then fails to localize it.

See e.g. https://lists.osgeo.org/pipermail/qgis-developer/2019-October/058747.html

As both characters can't be used in Python package name anyway, I'd simply accept them both as a version delimiter.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
