### PR TITLE
Don't load print layouts when opening project browser items 

### DIFF
--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -238,6 +238,7 @@ Clears the project, removing all settings and resetting it back to an empty, def
     enum ReadFlag
     {
       FlagDontResolveLayers,
+      FlagDontLoadLayouts,
     };
     typedef QFlags<QgsProject::ReadFlag> ReadFlags;
 

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -473,7 +473,7 @@ QVector<QgsDataItem *> QgsProjectRootDataItem::createChildren()
   QVector<QgsDataItem *> childItems;
 
   QgsProject p;
-  if ( !p.read( mPath, QgsProject::FlagDontResolveLayers ) )
+  if ( !p.read( mPath, QgsProject::FlagDontResolveLayers | QgsProject::FlagDontLoadLayouts ) )
   {
     childItems.append( new QgsErrorItem( nullptr, p.error(), mPath + "/error" ) );
     return childItems;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1416,7 +1416,8 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   emit labelingEngineSettingsChanged();
 
   mAnnotationManager->readXml( doc->documentElement(), context );
-  mLayoutManager->readXml( doc->documentElement(), *doc );
+  if ( !( flags & QgsProject::FlagDontLoadLayouts ) )
+    mLayoutManager->readXml( doc->documentElement(), *doc );
   mBookmarkManager->readXml( doc->documentElement(), *doc );
 
   // reassign change dependencies now that all layers are loaded

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -275,6 +275,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     enum ReadFlag
     {
       FlagDontResolveLayers = 1 << 0, //!< Don't resolve layer paths (i.e. don't load any layer content). Dramatically improves project read time if the actual data from the layers is not required.
+      FlagDontLoadLayouts = 1 << 1, //!< Don't load print layouts. Improves project read time if layouts are not required, and allows projects to be safely read in background threads (since print layouts are not thread safe).
     };
     Q_DECLARE_FLAGS( ReadFlags, ReadFlag )
 

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -25,6 +25,7 @@
 #include "qgsunittypes.h"
 #include "qgsvectorlayer.h"
 #include "qgssymbollayerutils.h"
+#include "qgslayoutmanager.h"
 
 class TestQgsProject : public QObject
 {
@@ -457,6 +458,12 @@ void TestQgsProject::testReadFlags()
   QVERIFY( !layers.value( QStringLiteral( "polys20170310142652234" ) )->isValid() );
   QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "lines20170310142652255" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
   QCOMPARE( qobject_cast< QgsVectorLayer * >( layers.value( QStringLiteral( "polys20170310142652234" ) ) )->renderer()->type(), QStringLiteral( "categorizedSymbol" ) );
+
+
+  QString project3Path = QString( TEST_DATA_DIR ) + QStringLiteral( "/layouts/layout_casting.qgs" );
+  QgsProject p3;
+  QVERIFY( p3.read( project3Path, QgsProject::FlagDontLoadLayouts ) );
+  QCOMPARE( p3.layoutManager()->layouts().count(), 0 );
 }
 
 void TestQgsProject::testSetGetCrs()


### PR DESCRIPTION
This can cause crashes, e.g. if the layouts use HTML based items (since QWebPage cannot be used on background threads)