### PR TITLE
Fix layer exporter force to single-part

### DIFF
--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -418,7 +418,7 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
       QgsGeometry singlePartGeometry { fet.geometry() };
       // We want a failure if the geometry cannot be converted to single-part without data loss!
       // check if there are more than one part
-      const QgsGeometryCollection *c = qgsgeometry_cast<QgsGeometryCollection *>( singlePartGeometry.constGet() );
+      const QgsGeometryCollection *c = qgsgeometry_cast<const QgsGeometryCollection *>( singlePartGeometry.constGet() );
       if ( ( c && c->partCount() > 1 ) || ! singlePartGeometry.convertToSingleType() )
       {
         delete writer;

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -19,7 +19,18 @@ import osgeo.gdal
 import osgeo.ogr
 import sys
 
-from qgis.core import QgsApplication, QgsSettings, QgsFeature, QgsField, QgsGeometry, QgsVectorLayer, QgsFeatureRequest, QgsVectorDataProvider, QgsWkbTypes
+from qgis.core import (
+    QgsApplication,
+    QgsSettings,
+    QgsFeature,
+    QgsField,
+    QgsGeometry,
+    QgsVectorLayer,
+    QgsFeatureRequest,
+    QgsVectorDataProvider,
+    QgsWkbTypes,
+    QgsVectorLayerExporter,
+)
 from qgis.PyQt.QtCore import QVariant
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -813,6 +824,96 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
         gdalprovider = next(provider for provider in registry.providers() if provider.name() == 'GDAL')
         item = gdalprovider.createDataItem(tmpfile, None)
         assert not item
+
+    def testWriteShapefileWithSingleConversion(self):
+        """Check writing geometries from a POLYGON ESRI shapefile does not
+        convert to multi when "forceSinglePartGeometryType" options is TRUE
+        also checks failing cases.
+
+        OGR provider always report MULTI for POLYGON and LINESTRING, but if we set
+        the import option "forceSinglePartGeometryType" the writer must respect the
+        actual single-part type if the features in the data provider are actually single
+        and not multi.
+        """
+
+        ml = QgsVectorLayer(
+            ('Polygon?crs=epsg:4326&field=id:int'),
+            'test',
+            'memory')
+
+        provider = ml.dataProvider()
+        ft = QgsFeature()
+        ft.setGeometry(QgsGeometry.fromWkt('Polygon ((0 0, 0 1, 1 1, 1 0, 0 0))'))
+        ft.setAttributes([1])
+        res, features = provider.addFeatures([ft])
+
+        dest_file_name = os.path.join(self.basetestpath, 'multipart.shp')
+        write_result, error_message = QgsVectorLayerExporter.exportLayer(ml,
+                                                                         dest_file_name,
+                                                                         'ogr',
+                                                                         ml.crs(),
+                                                                         False,
+                                                                         {"driverName": "ESRI Shapefile"}
+                                                                         )
+        self.assertEqual(write_result, QgsVectorLayerExporter.NoError, error_message)
+
+        # Open the newly created layer
+        shapefile_layer = QgsVectorLayer(dest_file_name)
+
+        dest_singlepart_file_name = os.path.join(self.basetestpath, 'singlepart.gpkg')
+        write_result, error_message = QgsVectorLayerExporter.exportLayer(shapefile_layer,
+                                                                         dest_singlepart_file_name,
+                                                                         'ogr',
+                                                                         shapefile_layer.crs(),
+                                                                         False,
+                                                                         {
+                                                                             "forceSinglePartGeometryType": True,
+                                                                             "driverName": "GPKG",
+                                                                         })
+        self.assertEqual(write_result, QgsVectorLayerExporter.NoError, error_message)
+
+        # Load result layer and check that it's NOT MULTI
+        single_layer = QgsVectorLayer(dest_singlepart_file_name)
+        self.assertTrue(single_layer.isValid())
+        self.assertTrue(QgsWkbTypes.isSingleType(single_layer.wkbType()))
+
+        # Now save the shapfile layer into a gpkg with no force options
+        dest_multipart_file_name = os.path.join(self.basetestpath, 'multipart.gpkg')
+        write_result, error_message = QgsVectorLayerExporter.exportLayer(shapefile_layer,
+                                                                         dest_multipart_file_name,
+                                                                         'ogr',
+                                                                         shapefile_layer.crs(),
+                                                                         False,
+                                                                         {
+                                                                             "forceSinglePartGeometryType": False,
+                                                                             "driverName": "GPKG",
+                                                                         })
+        self.assertEqual(write_result, QgsVectorLayerExporter.NoError, error_message)
+        # Load result layer and check that it's MULTI
+        multi_layer = QgsVectorLayer(dest_multipart_file_name)
+        self.assertTrue(multi_layer.isValid())
+        self.assertTrue(QgsWkbTypes.isMultiType(multi_layer.wkbType()))
+
+        # Failing case: add a real multi to the shapefile and try to force to single
+        self.assertTrue(shapefile_layer.startEditing())
+        ft = QgsFeature()
+        ft.setGeometry(QgsGeometry.fromWkt('MultiPolygon (((0 0, 0 1, 1 1, 1 0, 0 0)), ((0 0, 0 1.5, 1 1.5, 1 0, 0 0)))'))
+        ft.setAttributes([2])
+        self.assertTrue(shapefile_layer.addFeatures([ft]))
+        self.assertTrue(shapefile_layer.commitChanges())
+
+        dest_multipart_failure_file_name = os.path.join(self.basetestpath, 'multipart_failure.gpkg')
+        write_result, error_message = QgsVectorLayerExporter.exportLayer(shapefile_layer,
+                                                                         dest_multipart_failure_file_name,
+                                                                         'ogr',
+                                                                         shapefile_layer.crs(),
+                                                                         False,
+                                                                         {
+                                                                             "forceSinglePartGeometryType": True,
+                                                                             "driverName": "GPKG",
+                                                                         })
+        self.assertTrue(QgsWkbTypes.isMultiType(multi_layer.wkbType()))
+        self.assertEqual(write_result, QgsVectorLayerExporter.ErrFeatureWriteFailed, "Failed to transform a feature with ID '1' to single part. Writing stopped.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Try to respect the option and fails if is there
any real MULTI geometry in the input layer.

Fixes #32089
