### PR TITLE
CMakeLists.txt: bump minimum cmake version to 3.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #############################################################
 # CMake settings
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 SET(CMAKE_COLOR_MAKEFILE ON)
 # set path to additional CMake modules
 SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
Commit 869ee9bc666fb939f3052047c54719d2a60575fa added the use of
VERSION_GREATER_EQUAL which is a 3.7 addition. So bump to it
