### PR TITLE
[db_manager] Allow selecting geometry type in context menu

### DIFF
--- a/python/plugins/db_manager/db_plugins/gpkg/connector.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/connector.py
@@ -62,6 +62,7 @@ class GPKGDBConnector(DBConnector):
         DBConnector.__init__(self, uri)
         self.dbname = uri.database()
         self.connection = connection
+        self._current_thread = None
         md = QgsProviderRegistry.instance().providerMetadata(connection.providerName())
         # QgsAbstractDatabaseProviderConnection instance
         self.core_connection = md.findConnection(connection.connectionName())

--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -1158,7 +1158,7 @@ class VectorTable(Table):
         def selectedCrs():
             return crsSelector.crs()
 
-        addButton = QPushButton(self.tr('Load layer'))
+        addButton = QPushButton(self.tr('Load Layer'))
         addButton.clicked.connect(lambda: self.addLayer(selectedGeometryType(), selectedCrs()))
         btns = QDialogButtonBox(QDialogButtonBox.Cancel)
         btns.addButton(addButton, QDialogButtonBox.ActionRole)

--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -52,7 +52,8 @@ from qgis.core import (
     QgsVectorLayer,
     QgsRasterLayer,
     QgsProject,
-    QgsMessageLog
+    QgsMessageLog,
+    QgsCoordinateReferenceSystem
 )
 
 from qgis.gui import (
@@ -745,6 +746,11 @@ class Table(DbItemObject):
         uri.setDataSource(schema, self.name, geomCol if geomCol else None, None, uniqueCol.name if uniqueCol else "")
         return uri
 
+    def crs(self):
+        """Returns the CRS of this table or an invalid CRS if this is not a spatial table
+        This should be overwritten by any additional db plugins"""
+        return QgsCoordinateReferenceSystem()
+
     def mimeUri(self):
         layerType = "raster" if self.type == Table.RasterType else "vector"
         return u"%s:%s:%s:%s" % (layerType, self.database().dbplugin().providerName(), self.name, self.uri().uri(False))
@@ -1144,6 +1150,7 @@ class VectorTable(Table):
         layout.addRow(zCheckBox)
         layout.addRow(mCheckBox)
         crsSelector = QgsProjectionSelectionWidget()
+        crsSelector.setCrs(self.crs())
         layout.addRow(self.tr('CRS'), crsSelector)
 
         def selectedGeometryType():

--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -1178,7 +1178,7 @@ class VectorTable(Table):
         """Called whenever a context menu is shown for this table. Can be used to add additional actions to the menu."""
 
         if self.geomType == 'GEOMETRY':
-            menu.addAction(self.tr("Advanced add layer…"), self.showAdvancedVectorDialog)
+            menu.addAction(self.tr("Add Layer (Advanced)…"), self.showAdvancedVectorDialog)
 
 
 class RasterTable(Table):

--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -1139,7 +1139,7 @@ class VectorTable(Table):
         dlg.restoreGeometry(settings.value("/DB_Manager/advancedAddDialog/geometry", QByteArray(), type=QByteArray))
         layout = QFormLayout()
         dlg.setLayout(layout)
-        dlg.setWindowTitle(self.tr('Add layer {}').format(self.name))
+        dlg.setWindowTitle(self.tr('Add Layer {}').format(self.name))
         geometryTypeComboBox = QComboBox()
         geometryTypeComboBox.addItem(self.tr('Point'), 'POINT')
         geometryTypeComboBox.addItem(self.tr('Line'), 'LINESTRING')

--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -269,6 +269,9 @@ class PGTable(Table):
 
         return PGTableInfo(self)
 
+    def crs(self):
+        return self.database().connector.getCrs(self.srid)
+
     def tableDataModel(self, parent):
         from .data_model import PGTableDataModel
 

--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -350,7 +350,7 @@ class PGRasterTable(PGTable, RasterTable):
 
     def mimeUri(self):
         # QGIS has no provider for PGRasters, let's use GDAL
-        uri = u"raster:gdal:%s:%s" % (self.name, re.sub(":", "\:", self.gdalUri()))
+        uri = u"raster:gdal:{}:{}".format(self.name, re.sub(":", r"\:", self.gdalUri()))
         return uri
 
     def toMapLayer(self):

--- a/python/plugins/db_manager/db_tree.py
+++ b/python/plugins/db_manager/db_tree.py
@@ -88,8 +88,6 @@ class DBTree(QTreeView):
 
     def currentTable(self):
         item = self.currentItem()
-        if item is None:
-            return
 
         if isinstance(item, Table):
             return item
@@ -131,6 +129,7 @@ class DBTree(QTreeView):
             if isinstance(item, Table) and item.canBeAddedToCanvas():
                 menu.addSeparator()
                 menu.addAction(self.tr("Add to Canvas"), self.addLayer)
+                item.addExtraContextMenuEntries(menu)
 
         elif isinstance(item, DBPlugin):
             if item.database() is not None:


### PR DESCRIPTION
![Peek 2019-10-05 11-12](https://user-images.githubusercontent.com/588407/66252953-b66dbd80-e761-11e9-9c31-c49669e0496b.gif)

When a layer has a generic "GEOMETRY" type, it will only be listed once in the db_manager
but with an additional context menu entry for advanced properties, where one can select
the geometry type and the CRS.

Fix #32119
References #30787

Edge case for feature vs bugfix

CC @gioman @jgrocha 