### PR TITLE
Ensure polygon rings generated for rendering are always closed

### DIFF
--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -207,6 +207,9 @@ QPolygonF QgsSymbol::_getPolygonRing( QgsRenderContext &context, const QgsCurve 
     mtp.transformInPlace( ptr->rx(), ptr->ry() );
   }
 
+  if ( !poly.empty() && !poly.isClosed() )
+    poly << poly.at( 0 );
+
   return poly;
 }
 


### PR DESCRIPTION
Avoids issues with unclosed rings and use of spatial algorithms
during rendering (e.g. GEOS routines)
