### PR TITLE
Get the username from current_user to fill layer_styles' owner field for Postgresql based connections

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4728,7 +4728,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                                          ",styleSLD xml"
                                          ",useAsDefault boolean"
                                          ",description text"
-                                         ",owner varchar(63)"
+                                         ",owner varchar(63) DEFAULT CURRENT_USER"
                                          ",ui xml"
                                          ",update_time timestamp DEFAULT CURRENT_TIMESTAMP"
                                          ")" ) );
@@ -4759,9 +4759,9 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
   // two values are both replaced in the final .arg call of the string construction.
 
   QString sql = QString( "INSERT INTO layer_styles("
-                         "f_table_catalog,f_table_schema,f_table_name,f_geometry_column,styleName,styleQML,styleSLD,useAsDefault,description,owner%11"
+                         "f_table_catalog,f_table_schema,f_table_name,f_geometry_column,styleName,styleQML,styleSLD,useAsDefault,description%11"
                          ") VALUES ("
-                         "%1,%2,%3,%4,%5,XMLPARSE(DOCUMENT %16),XMLPARSE(DOCUMENT %17),%8,%9,%10%12"
+                         "%1,%2,%3,%4,%5,XMLPARSE(DOCUMENT %16),XMLPARSE(DOCUMENT %17),%8,%9%12"
                          ")" )
                 .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
                 .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
@@ -4770,7 +4770,6 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                 .arg( QgsPostgresConn::quotedValue( styleName.isEmpty() ? dsUri.table() : styleName ) )
                 .arg( useAsDefault ? "true" : "false" )
                 .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
-                .arg( QgsPostgresConn::quotedValue( dsUri.username() ) )
                 .arg( uiFileColumn )
                 .arg( uiFileValue )
                 // Must be the final .arg replacement - see above
@@ -4808,7 +4807,6 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                    ",styleQML=XMLPARSE(DOCUMENT %12)"
                    ",styleSLD=XMLPARSE(DOCUMENT %13)"
                    ",description=%4"
-                   ",owner=%5"
                    " WHERE f_table_catalog=%6"
                    " AND f_table_schema=%7"
                    " AND f_table_name=%8"
@@ -4816,7 +4814,6 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                    " AND styleName=%10" )
           .arg( useAsDefault ? "true" : "false" )
           .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
-          .arg( QgsPostgresConn::quotedValue( dsUri.username() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.table() ) )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4759,9 +4759,9 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
   // two values are both replaced in the final .arg call of the string construction.
 
   QString sql = QString( "INSERT INTO layer_styles("
-                         "f_table_catalog,f_table_schema,f_table_name,f_geometry_column,styleName,styleQML,styleSLD,useAsDefault,description%11"
+                         "f_table_catalog,f_table_schema,f_table_name,f_geometry_column,styleName,styleQML,styleSLD,useAsDefault,description,owner%11"
                          ") VALUES ("
-                         "%1,%2,%3,%4,%5,XMLPARSE(DOCUMENT %16),XMLPARSE(DOCUMENT %17),%8,%9%12"
+                         "%1,%2,%3,%4,%5,XMLPARSE(DOCUMENT %16),XMLPARSE(DOCUMENT %17),%8,%9,%10%12"
                          ")" )
                 .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
                 .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
@@ -4770,6 +4770,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                 .arg( QgsPostgresConn::quotedValue( styleName.isEmpty() ? dsUri.table() : styleName ) )
                 .arg( useAsDefault ? "true" : "false" )
                 .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
+                .arg( "CURRENT_USER" )
                 .arg( uiFileColumn )
                 .arg( uiFileValue )
                 // Must be the final .arg replacement - see above
@@ -4807,6 +4808,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                    ",styleQML=XMLPARSE(DOCUMENT %12)"
                    ",styleSLD=XMLPARSE(DOCUMENT %13)"
                    ",description=%4"
+                   ",owner=%5"
                    " WHERE f_table_catalog=%6"
                    " AND f_table_schema=%7"
                    " AND f_table_name=%8"
@@ -4814,6 +4816,7 @@ bool QgsPostgresProviderMetadata::saveStyle( const QString &uri, const QString &
                    " AND styleName=%10" )
           .arg( useAsDefault ? "true" : "false" )
           .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
+          .arg( "CURRENT_USER" )
           .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.table() ) )


### PR DESCRIPTION
## Description

Fix #32133.

For connections using pg_services the connection's username can be retrieved using `CURRENT_USER` on the server side. This works for any kind of Postgresql connection, since it is managed on the Postgresql server side.

The DDL changed to:

```sql
    QgsPostgresResult res( conn->PQexec( "CREATE TABLE layer_styles("
                                         "id SERIAL PRIMARY KEY"
                                         ",f_table_catalog varchar"
                                         ",f_table_schema varchar"
                                         ",f_table_name varchar"
                                         ",f_geometry_column varchar"
                                         ",styleName text"
                                         ",styleQML xml"
                                         ",styleSLD xml"
                                         ",useAsDefault boolean"
                                         ",description text"
                                         ",owner varchar(63) DEFAULT CURRENT_USER"
                                         ",ui xml"
                                         ",update_time timestamp DEFAULT CURRENT_TIMESTAMP"
                                         ")" ) );
```

Both INSERT and UPDATE queries will set `owner` to `CURRENT_USER`. This supports previous lay_styles tables without the `owner` default value set.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
