### PR TITLE
Improve layer unknown CRS handling

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -88,6 +88,8 @@ Constructor for LayerOptions with optional ``transformContext``.
 %End
 
       QgsCoordinateTransformContext transformContext;
+
+      bool allowInvalidCrs;
     };
 
     explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = QStringLiteral( "mesh_memory" ),

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -89,7 +89,7 @@ Constructor for LayerOptions with optional ``transformContext``.
 
       QgsCoordinateTransformContext transformContext;
 
-      bool allowInvalidCrs;
+      bool skipCrsValidation;
     };
 
     explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = QStringLiteral( "mesh_memory" ),

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1679,6 +1679,7 @@ this method is now deprecated and always return false, because circular dependen
 
 
 
+
 };
 
 QFlags<QgsMapLayer::LayerFlag> operator|(QgsMapLayer::LayerFlag f1, QFlags<QgsMapLayer::LayerFlag> f2);

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -352,7 +352,7 @@ Constructor for LayerOptions.
 
       QgsCoordinateReferenceSystem fallbackCrs;
 
-      bool allowInvalidCrs;
+      bool skipCrsValidation;
 
     };
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -352,6 +352,8 @@ Constructor for LayerOptions.
 
       QgsCoordinateReferenceSystem fallbackCrs;
 
+      bool allowInvalidCrs;
+
     };
 
     explicit QgsVectorLayer( const QString &path = QString(), const QString &baseName = QString(),

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -114,6 +114,8 @@ Constructor for LayerOptions.
 
       QgsCoordinateTransformContext transformContext;
 
+      bool allowInvalidCrs;
+
     };
 
     explicit QgsRasterLayer( const QString &uri,

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -114,7 +114,7 @@ Constructor for LayerOptions.
 
       QgsCoordinateTransformContext transformContext;
 
-      bool allowInvalidCrs;
+      bool skipCrsValidation;
 
     };
 

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -119,7 +119,7 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
 
     if isRaster:
         options = QgsRasterLayer.LayerOptions()
-        options.allowInvalidCrs = True
+        options.skipCrsValidation = True
         qgslayer = QgsRasterLayer(fileName, name, 'gdal', options)
         if qgslayer.isValid():
             if crs is not None and qgslayer.crs() is None:
@@ -134,7 +134,7 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
                 fileName))
     else:
         options = QgsVectorLayer.LayerOptions()
-        options.allowInvalidCrs = True
+        options.skipCrsValidation = True
         qgslayer = QgsVectorLayer(fileName, name, 'ogr', options)
         if qgslayer.isValid():
             if crs is not None and qgslayer.crs() is None:

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -113,16 +113,14 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
 
     if fileName is None:
         return
-    prjSetting = None
-    settings = QgsSettings()
-    if crs is not None:
-        prjSetting = settings.value('/Projections/defaultBehavior')
-        settings.setValue('/Projections/defaultBehavior', '')
+
     if name is None:
         name = os.path.split(fileName)[1]
 
     if isRaster:
-        qgslayer = QgsRasterLayer(fileName, name)
+        options = QgsRasterLayer.LayerOptions()
+        options.allowInvalidCrs = True
+        qgslayer = QgsRasterLayer(fileName, name, 'gdal', options)
         if qgslayer.isValid():
             if crs is not None and qgslayer.crs() is None:
                 qgslayer.setCrs(crs, False)
@@ -131,13 +129,13 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
             qgslayer.loadNamedStyle(style)
             QgsProject.instance().addMapLayers([qgslayer])
         else:
-            if prjSetting:
-                settings.setValue('/Projections/defaultBehavior', prjSetting)
             raise RuntimeError(QCoreApplication.translate('dataobject',
                                                           'Could not load layer: {0}\nCheck the processing framework log to look for errors.').format(
                 fileName))
     else:
-        qgslayer = QgsVectorLayer(fileName, name, 'ogr')
+        options = QgsVectorLayer.LayerOptions()
+        options.allowInvalidCrs = True
+        qgslayer = QgsVectorLayer(fileName, name, 'ogr', options)
         if qgslayer.isValid():
             if crs is not None and qgslayer.crs() is None:
                 qgslayer.setCrs(crs, False)
@@ -150,9 +148,6 @@ def load(fileName, name=None, crs=None, style=None, isRaster=False):
                     style = ProcessingConfig.getSetting(ProcessingConfig.VECTOR_POLYGON_STYLE)
             qgslayer.loadNamedStyle(style)
             QgsProject.instance().addMapLayers([qgslayer])
-
-    if prjSetting:
-        settings.setValue('/Projections/defaultBehavior', prjSetting)
 
     return qgslayer
 

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -70,6 +70,13 @@ projections\defaultProjectCrs=EPSG:4326
 # "UsePresetCrs" - always use a preset CRS, see projections\defaultProjectCrs
 projections\newProjectCrsBehavior=UseCrsOfFirstLayerAdded
 
+# Specifies the behavior when adding a layer with unknown/invalid CRS to a project
+# "NoAction" - take no action and leave as unknown CRS
+# "PromptUserForCrs" - user is prompted for a CRS choice
+# "UseProjectCrs" - copy the current project's CRS
+# "UseDefaultCrs" - use the default layer CRS set via QGIS options
+projections\unknownCrsBehavior=NoAction
+
 [core]
 # Whether or not to anonymize newly created projects
 # If set to 1, then project metadata items like AUTHOR and CREATION DATE

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -62,6 +62,7 @@ SET(QGIS_APP_SRCS
   qgslayertreeviewembeddedindicator.cpp
   qgslayertreeviewfilterindicator.cpp
   qgslayertreeviewmemoryindicator.cpp
+  qgslayertreeviewnocrsindicator.cpp
   qgslayertreeviewnonremovableindicator.cpp
   qgslayertreeviewbadlayerindicator.cpp
   qgsmapcanvasdockwidget.cpp
@@ -309,6 +310,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslayertreeviewembeddedindicator.h
   qgslayertreeviewmemoryindicator.h
   qgslayertreeviewfilterindicator.h
+  qgslayertreeviewnocrsindicator.h
   qgslayertreeviewnonremovableindicator.h
   qgslayertreeviewbadlayerindicator.h
   qgsmapcanvasdockwidget.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -224,6 +224,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewmemoryindicator.h"
 #include "qgslayertreeviewbadlayerindicator.h"
 #include "qgslayertreeviewnonremovableindicator.h"
+#include "qgslayertreeviewnocrsindicator.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"
 #include "qgslayoutcustomdrophandler.h"
@@ -4160,6 +4161,7 @@ void QgisApp::initLayerTreeView()
   new QgsLayerTreeViewFilterIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewEmbeddedIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewMemoryIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
+  new QgsLayerTreeViewNoCrsIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   QgsLayerTreeViewBadLayerIndicatorProvider *badLayerIndicatorProvider = new QgsLayerTreeViewBadLayerIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   connect( badLayerIndicatorProvider, &QgsLayerTreeViewBadLayerIndicatorProvider::requestChangeDataSource, this, &QgisApp::changeDataSource );
   new QgsLayerTreeViewNonRemovableIndicatorProvider( mLayerTreeView );  // gets parented to the layer view

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -702,9 +702,7 @@ void QgisApp::validateCrs( QgsCoordinateReferenceSystem &srs )
         mySelector->setCrs( defaultCrs );
       }
 
-      bool waiting = QApplication::overrideCursor() && QApplication::overrideCursor()->shape() == Qt::WaitCursor;
-      if ( waiting )
-        QApplication::setOverrideCursor( Qt::ArrowCursor );
+      QgsTemporaryCursorRestoreOverride cursorOverride;
 
       if ( mySelector->exec() )
       {
@@ -712,9 +710,6 @@ void QgisApp::validateCrs( QgsCoordinateReferenceSystem &srs )
         srs = mySelector->crs();
         sAuthId = srs.authid();
       }
-
-      if ( waiting )
-        QApplication::restoreOverrideCursor();
 
       delete mySelector;
       break;

--- a/src/app/qgslayertreeviewnocrsindicator.cpp
+++ b/src/app/qgslayertreeviewnocrsindicator.cpp
@@ -20,6 +20,7 @@
 #include "qgslayertreeutils.h"
 #include "qgsvectorlayer.h"
 #include "qgisapp.h"
+#include "qgsprojectionselectiondialog.h"
 
 QgsLayerTreeViewNoCrsIndicatorProvider::QgsLayerTreeViewNoCrsIndicatorProvider( QgsLayerTreeView *view )
   : QgsLayerTreeViewIndicatorProvider( view )
@@ -32,7 +33,19 @@ void QgsLayerTreeViewNoCrsIndicatorProvider::onIndicatorClicked( const QModelInd
   if ( !QgsLayerTree::isLayer( node ) )
     return;
 
-  // TODO
+  QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer();
+  if ( !layer )
+    return;
+
+  QgsProjectionSelectionDialog selector( QgisApp::instance() );
+  selector.setMessage( QString() );
+  if ( selector.exec() )
+  {
+    QgsCoordinateReferenceSystem crs = selector.crs();
+    layer->setCrs( selector.crs() );
+    layer->triggerRepaint();
+    updateLayerIndicator( layer );
+  }
 }
 
 bool QgsLayerTreeViewNoCrsIndicatorProvider::acceptLayer( QgsMapLayer *layer )

--- a/src/app/qgslayertreeviewnocrsindicator.cpp
+++ b/src/app/qgslayertreeviewnocrsindicator.cpp
@@ -37,7 +37,7 @@ void QgsLayerTreeViewNoCrsIndicatorProvider::onIndicatorClicked( const QModelInd
 
 bool QgsLayerTreeViewNoCrsIndicatorProvider::acceptLayer( QgsMapLayer *layer )
 {
-  return layer &&  layer->isSpatial() && !layer->crs().isValid();
+  return layer && layer->isValid() && layer->isSpatial() && !layer->crs().isValid();
 }
 
 QString QgsLayerTreeViewNoCrsIndicatorProvider::iconName( QgsMapLayer *layer )

--- a/src/app/qgslayertreeviewnocrsindicator.cpp
+++ b/src/app/qgslayertreeviewnocrsindicator.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+  qgslayertreeviewnocrsindicator.h
+  --------------------------------------
+  Date                 : October 2019
+  Copyright            : (C) 2019 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertreeviewnocrsindicator.h"
+#include "qgslayertreeview.h"
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
+#include "qgsvectorlayer.h"
+#include "qgisapp.h"
+
+QgsLayerTreeViewNoCrsIndicatorProvider::QgsLayerTreeViewNoCrsIndicatorProvider( QgsLayerTreeView *view )
+  : QgsLayerTreeViewIndicatorProvider( view )
+{
+}
+
+void QgsLayerTreeViewNoCrsIndicatorProvider::onIndicatorClicked( const QModelIndex &index )
+{
+  QgsLayerTreeNode *node = mLayerTreeView->layerTreeModel()->index2node( index );
+  if ( !QgsLayerTree::isLayer( node ) )
+    return;
+
+  // TODO
+}
+
+bool QgsLayerTreeViewNoCrsIndicatorProvider::acceptLayer( QgsMapLayer *layer )
+{
+  return layer &&  layer->isSpatial() && !layer->crs().isValid();
+}
+
+QString QgsLayerTreeViewNoCrsIndicatorProvider::iconName( QgsMapLayer *layer )
+{
+  Q_UNUSED( layer )
+  return QStringLiteral( "/mIconProjectionDisabled.svg" );
+}
+
+QString QgsLayerTreeViewNoCrsIndicatorProvider::tooltipText( QgsMapLayer *layer )
+{
+  Q_UNUSED( layer )
+  return tr( "<b>Layer has no coordinate reference system set!</b><br>This layer is not georeferenced and has no geographic location available." );
+}
+
+void QgsLayerTreeViewNoCrsIndicatorProvider::connectSignals( QgsMapLayer *layer )
+{
+  QgsLayerTreeViewIndicatorProvider::connectSignals( layer );
+  connect( layer, &QgsMapLayer::crsChanged, this, &QgsLayerTreeViewNoCrsIndicatorProvider::onLayerChanged );
+}
+
+void QgsLayerTreeViewNoCrsIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
+{
+  QgsLayerTreeViewIndicatorProvider::disconnectSignals( layer );
+  disconnect( layer, &QgsMapLayer::crsChanged, this, &QgsLayerTreeViewNoCrsIndicatorProvider::onLayerChanged );
+}

--- a/src/app/qgslayertreeviewnocrsindicator.h
+++ b/src/app/qgslayertreeviewnocrsindicator.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+  qgslayertreeviewnocrsindicator.h
+  --------------------------------------
+  Date                 : October 2019
+  Copyright            : (C) 2019 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERTREEVIEWNOCRSINDICATOR_H
+#define QGSLAYERTREEVIEWNOCRSINDICATOR_H
+
+#include "qgslayertreeviewindicatorprovider.h"
+
+//! Adds indicators showing whether layers have an unknown/not set CRS
+class QgsLayerTreeViewNoCrsIndicatorProvider : public QgsLayerTreeViewIndicatorProvider
+{
+    Q_OBJECT
+  public:
+    explicit QgsLayerTreeViewNoCrsIndicatorProvider( QgsLayerTreeView *view );
+
+  protected:
+
+    void connectSignals( QgsMapLayer *layer ) override;
+    void disconnectSignals( QgsMapLayer *layer ) override;
+
+  protected slots:
+
+    void onIndicatorClicked( const QModelIndex &index ) override;
+
+  private:
+    bool acceptLayer( QgsMapLayer *layer ) override;
+    QString iconName( QgsMapLayer *layer ) override;
+    QString tooltipText( QgsMapLayer *layer ) override;
+};
+
+#endif // QGSLAYERTREEVIEWNOCRSINDICATOR_H

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -44,6 +44,20 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
   public:
 
     /**
+     * Behavior to use when encountering a layer with an unknown CRS
+     * \since QGIS 3.10
+     */
+    enum UnknownLayerCrsBehavior
+    {
+      NoAction = 0, //!< Take no action and leave as unknown CRS
+      PromptUserForCrs = 1, //!< User is prompted for a CRS choice
+      UseProjectCrs = 2, //!< Copy the current project's CRS
+      UseDefaultCrs = 3, //!< Use the default layer CRS set via QGIS options
+    };
+    Q_ENUM( UnknownLayerCrsBehavior )
+
+
+    /**
      * Constructor
      * \param parent Parent widget (usually a QgisApp)
      * \param name name for the widget

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -42,6 +42,8 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QgsMeshLayer::LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::MeshLayer, baseName, meshLayerPath )
 {
+  mShouldValidateCrs = !options.allowInvalidCrs;
+
   setProviderType( providerKey );
   // if we’re given a provider type, try to create and bind one to this layer
   if ( !meshLayerPath.isEmpty() && !providerKey.isEmpty() )

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -42,7 +42,7 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QgsMeshLayer::LayerOptions &options )
   : QgsMapLayer( QgsMapLayerType::MeshLayer, baseName, meshLayerPath )
 {
-  mShouldValidateCrs = !options.allowInvalidCrs;
+  mShouldValidateCrs = !options.skipCrsValidation;
 
   setProviderType( providerKey );
   // if we’re given a provider type, try to create and bind one to this layer

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
        *
        * \since QGIS 3.10
        */
-      bool allowInvalidCrs = false;
+      bool skipCrsValidation = false;
     };
 
     /**

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -107,6 +107,21 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       {}
 
       QgsCoordinateTransformContext transformContext;
+
+      /**
+       * Controls whether the layer is allowed to have an invalid/unknown CRS.
+       *
+       * If TRUE, then no validation will be performed on the layer's CRS and the layer
+       * layer's crs() may be invalid() (i.e. the layer will have no georeferencing available
+       * and will be treated as having purely numerical coordinates).
+       *
+       * If FALSE (the default), the layer's CRS will be validated using QgsCoordinateReferenceSystem::validate(),
+       * which may cause a blocking, user-facing dialog asking users to manually select the correct CRS for the
+       * layer.
+       *
+       * \since QGIS 3.10
+       */
+      bool allowInvalidCrs = false;
     };
 
     /**

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -214,7 +214,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
   {
     QgsVectorLayer::LayerOptions options { transformContext };
     options.loadDefaultStyle = false;
-    options.allowInvalidCrs = true;
+    options.skipCrsValidation = true;
     std::unique_ptr< QgsVectorLayer > layer = qgis::make_unique<QgsVectorLayer>( string, name, QStringLiteral( "ogr" ), options );
     if ( layer->isValid() )
     {
@@ -225,7 +225,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
   {
     QgsRasterLayer::LayerOptions rasterOptions;
     rasterOptions.loadDefaultStyle = false;
-    rasterOptions.allowInvalidCrs = true;
+    rasterOptions.skipCrsValidation = true;
     std::unique_ptr< QgsRasterLayer > rasterLayer( new QgsRasterLayer( string, name, QStringLiteral( "gdal" ), rasterOptions ) );
     if ( rasterLayer->isValid() )
     {
@@ -235,7 +235,7 @@ QgsMapLayer *QgsProcessingUtils::loadMapLayerFromString( const QString &string, 
   if ( typeHint == LayerHint::UnknownType || typeHint == LayerHint::Mesh )
   {
     QgsMeshLayer::LayerOptions meshOptions;
-    meshOptions.allowInvalidCrs = true;
+    meshOptions.skipCrsValidation = true;
     std::unique_ptr< QgsMeshLayer > meshLayer( new QgsMeshLayer( string, name, QStringLiteral( "mdal" ), meshOptions ) );
     if ( meshLayer->isValid() )
     {

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -61,6 +61,12 @@ QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions 
     QString crsDef = url.queryItemValue( QStringLiteral( "crs" ) );
     mCrs.createFromString( crsDef );
   }
+  else
+  {
+    // TODO - remove in QGIS 4.0. Layers without an explicit CRS set SHOULD have an invalid CRS. But in order to maintain
+    // 3.x api, we have to be tolerant/shortsighted(?) here and fallback to EPSG:4326
+    mCrs = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) );
+  }
 
   mNextFeatureId = 1;
 

--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -75,6 +75,6 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
 
   QString uri = geomType + '?' + parts.join( '&' );
   QgsVectorLayer::LayerOptions options{ QgsCoordinateTransformContext() };
-  options.allowInvalidCrs = true;
+  options.skipCrsValidation = true;
   return new QgsVectorLayer( uri, name, QStringLiteral( "memory" ), options );
 }

--- a/src/core/providers/memory/qgsmemoryproviderutils.cpp
+++ b/src/core/providers/memory/qgsmemoryproviderutils.cpp
@@ -74,5 +74,7 @@ QgsVectorLayer *QgsMemoryProviderUtils::createMemoryLayer( const QString &name, 
   }
 
   QString uri = geomType + '?' + parts.join( '&' );
-  return new QgsVectorLayer( uri, name, QStringLiteral( "memory" ), QgsVectorLayer::LayerOptions( QgsCoordinateTransformContext() ) );
+  QgsVectorLayer::LayerOptions options{ QgsCoordinateTransformContext() };
+  options.allowInvalidCrs = true;
+  return new QgsVectorLayer( uri, name, QStringLiteral( "memory" ), options );
 }

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -487,7 +487,7 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
 
 void QgsCoordinateReferenceSystem::validate()
 {
-  if ( d->mIsValid )
+  if ( d->mIsValid || !sCustomSrsValidation )
     return;
 
   d.detach();

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -59,7 +59,7 @@
 //! The length of the string "+lat_1="
 const int LAT_PREFIX_LEN = 7;
 
-CUSTOM_CRS_VALIDATION QgsCoordinateReferenceSystem::mCustomSrsValidation = nullptr;
+CUSTOM_CRS_VALIDATION QgsCoordinateReferenceSystem::sCustomSrsValidation = nullptr;
 
 QReadWriteLock QgsCoordinateReferenceSystem::sSrIdCacheLock;
 QHash< long, QgsCoordinateReferenceSystem > QgsCoordinateReferenceSystem::sSrIdCache;
@@ -493,8 +493,8 @@ void QgsCoordinateReferenceSystem::validate()
   d.detach();
 
   // try to validate using custom validation routines
-  if ( mCustomSrsValidation )
-    mCustomSrsValidation( *this );
+  if ( sCustomSrsValidation )
+    sCustomSrsValidation( *this );
 
   if ( !d->mIsValid )
   {
@@ -2037,12 +2037,12 @@ int QgsCoordinateReferenceSystem::openDatabase( const QString &path, sqlite3_dat
 
 void QgsCoordinateReferenceSystem::setCustomCrsValidation( CUSTOM_CRS_VALIDATION f )
 {
-  mCustomSrsValidation = f;
+  sCustomSrsValidation = f;
 }
 
 CUSTOM_CRS_VALIDATION QgsCoordinateReferenceSystem::customCrsValidation()
 {
-  return mCustomSrsValidation;
+  return sCustomSrsValidation;
 }
 
 void QgsCoordinateReferenceSystem::debugPrint()

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -495,11 +495,6 @@ void QgsCoordinateReferenceSystem::validate()
   // try to validate using custom validation routines
   if ( sCustomSrsValidation )
     sCustomSrsValidation( *this );
-
-  if ( !d->mIsValid )
-  {
-    *this = QgsCoordinateReferenceSystem::fromOgcWmsCrs( GEO_EPSG_CRS_AUTHID );
-  }
 }
 
 bool QgsCoordinateReferenceSystem::createFromSrid( const long id )

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -844,7 +844,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     QExplicitlySharedDataPointer<QgsCoordinateReferenceSystemPrivate> d;
 
     //! Function for CRS validation. May be NULLPTR.
-    static CUSTOM_CRS_VALIDATION mCustomSrsValidation;
+    static CUSTOM_CRS_VALIDATION sCustomSrsValidation;
 
 
     // cache

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -120,6 +120,7 @@ void QgsMapLayer::clone( QgsMapLayer *layer ) const
   layer->setLegendUrl( legendUrl() );
   layer->setLegendUrlFormat( legendUrlFormat() );
   layer->setDependencies( dependencies() );
+  layer->mShouldValidateCrs = mShouldValidateCrs;
   layer->setCrs( crs() );
   layer->setCustomProperties( mCustomProperties );
 }
@@ -764,7 +765,7 @@ void QgsMapLayer::setCrs( const QgsCoordinateReferenceSystem &srs, bool emitSign
 {
   mCRS = srs;
 
-  if ( isSpatial() && !mCRS.isValid() )
+  if ( mShouldValidateCrs && isSpatial() && !mCRS.isValid() )
   {
     mCRS.setValidationHint( tr( "Specify CRS for layer %1" ).arg( name() ) );
     mCRS.validate();

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1533,6 +1533,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
     //! Read flags. It's up to the subclass to respect these when restoring state from XML
     QgsMapLayer::ReadFlags mReadFlags = nullptr;
 
+    /**
+     * TRUE if the layer's CRS should be validated and invalid CRSes are not permitted.
+     *
+     * \since QGIS 3.10
+     */
+    bool mShouldValidateCrs = true;
+
   private:
 
     virtual QString baseURI( PropertyType type ) const;

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -3079,11 +3079,13 @@ QgsCoordinateReferenceSystem QgsProject::defaultCrsForNewLayers() const
 {
   QgsSettings settings;
   QgsCoordinateReferenceSystem defaultCrs;
-  if ( settings.value( QStringLiteral( "/Projections/defaultBehavior" ), QStringLiteral( "prompt" ) ).toString() == QStringLiteral( "useProject" )
-       || settings.value( QStringLiteral( "/Projections/defaultBehavior" ), QStringLiteral( "prompt" ) ).toString() == QStringLiteral( "prompt" ) )
+
+  // TODO QGIS 4.0 -- remove this method, and place it somewhere in app (where it belongs)
+  // in the meantime, we have a slightly hacky way to read the settings key using an enum which isn't available (since it lives in app)
+  if ( settings.value( QStringLiteral( "/projections/unknownCrsBehavior" ), QStringLiteral( "NoAction" ), QgsSettings::App ).toString() == QStringLiteral( "UseProjectCrs" )
+       || settings.value( QStringLiteral( "/projections/unknownCrsBehavior" ), 0, QgsSettings::App ).toString() == 2 )
   {
     // for new layers if the new layer crs method is set to either prompt or use project, then we use the project crs
-    // (since "prompt" has no meaning here - the prompt will always be shown, it's just deciding on the default choice in the prompt!)
     defaultCrs = crs();
   }
   else

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -150,6 +150,8 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   , mAuxiliaryLayerKey( QString() )
   , mReadExtentFromXml( options.readExtentFromXml )
 {
+  mShouldValidateCrs = !options.allowInvalidCrs;
+
   if ( options.fallbackCrs.isValid() )
     setCrs( options.fallbackCrs, false );
   mWkbType = options.fallbackWkbType;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -150,7 +150,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   , mAuxiliaryLayerKey( QString() )
   , mReadExtentFromXml( options.readExtentFromXml )
 {
-  mShouldValidateCrs = !options.allowInvalidCrs;
+  mShouldValidateCrs = !options.skipCrsValidation;
 
   if ( options.fallbackCrs.isValid() )
     setCrs( options.fallbackCrs, false );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -478,7 +478,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        *
        * \since QGIS 3.10
        */
-      bool allowInvalidCrs = false;
+      bool skipCrsValidation = false;
 
     };
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -465,6 +465,21 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
        */
       QgsCoordinateReferenceSystem fallbackCrs;
 
+      /**
+       * Controls whether the layer is allowed to have an invalid/unknown CRS.
+       *
+       * If TRUE, then no validation will be performed on the layer's CRS and the layer
+       * layer's crs() may be invalid() (i.e. the layer will have no georeferencing available
+       * and will be treated as having purely numerical coordinates).
+       *
+       * If FALSE (the default), the layer's CRS will be validated using QgsCoordinateReferenceSystem::validate(),
+       * which may cause a blocking, user-facing dialog asking users to manually select the correct CRS for the
+       * layer.
+       *
+       * \since QGIS 3.10
+       */
+      bool allowInvalidCrs = false;
+
     };
 
     /**

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -117,6 +117,8 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
   , QSTRING_NOT_SET( QStringLiteral( "Not Set" ) )
   , TRSTRING_NOT_SET( tr( "Not Set" ) )
 {
+  mShouldValidateCrs = !options.allowInvalidCrs;
+
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   setProviderType( providerKey );
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -117,7 +117,7 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
   , QSTRING_NOT_SET( QStringLiteral( "Not Set" ) )
   , TRSTRING_NOT_SET( tr( "Not Set" ) )
 {
-  mShouldValidateCrs = !options.allowInvalidCrs;
+  mShouldValidateCrs = !options.skipCrsValidation;
 
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   setProviderType( providerKey );

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -188,6 +188,21 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
        */
       QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext();
 
+      /**
+       * Controls whether the layer is allowed to have an invalid/unknown CRS.
+       *
+       * If TRUE, then no validation will be performed on the layer's CRS and the layer
+       * layer's crs() may be invalid() (i.e. the layer will have no georeferencing available
+       * and will be treated as having purely numerical coordinates).
+       *
+       * If FALSE (the default), the layer's CRS will be validated using QgsCoordinateReferenceSystem::validate(),
+       * which may cause a blocking, user-facing dialog asking users to manually select the correct CRS for the
+       * layer.
+       *
+       * \since QGIS 3.10
+       */
+      bool allowInvalidCrs = false;
+
     };
 
     /**

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -201,7 +201,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
        *
        * \since QGIS 3.10
        */
-      bool allowInvalidCrs = false;
+      bool skipCrsValidation = false;
 
     };
 

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -185,7 +185,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
       QgsDebugMsg( QStringLiteral( "creating raster layer" ) );
       // should copy code from addLayer() to split uri ?
       QgsRasterLayer::LayerOptions options;
-      options.allowInvalidCrs = true;
+      options.skipCrsValidation = true;
       mLayer = qgis::make_unique< QgsRasterLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey(), options );
       break;
     }
@@ -194,7 +194,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     {
       QgsDebugMsg( QStringLiteral( "creating mesh layer" ) );
       QgsMeshLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      options.allowInvalidCrs = true;
+      options.skipCrsValidation = true;
       mLayer = qgis::make_unique < QgsMeshLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey(), options );
       break;
     }
@@ -203,7 +203,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     {
       QgsDebugMsg( QStringLiteral( "creating vector layer" ) );
       QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
-      options.allowInvalidCrs = true;
+      options.skipCrsValidation = true;
       mLayer = qgis::make_unique < QgsVectorLayer>( layerItem->uri(), layerItem->name(), layerItem->providerKey(), options );
       break;
     }

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -304,7 +304,7 @@ QString QgsRasterFormatSaveOptionsWidget::validateOptions( bool gui, bool report
   {
     tmpLayer = true;
     QgsRasterLayer::LayerOptions options;
-    options.allowInvalidCrs = true;
+    options.skipCrsValidation = true;
     rasterLayer = new QgsRasterLayer( mRasterFileName, QFileInfo( mRasterFileName ).baseName(), QStringLiteral( "gdal" ), options );
   }
 

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -302,22 +302,10 @@ QString QgsRasterFormatSaveOptionsWidget::validateOptions( bool gui, bool report
   bool tmpLayer = false;
   if ( !( mRasterLayer && rasterLayer->dataProvider() ) && ! mRasterFileName.isNull() )
   {
-    // temporarily override /Projections/defaultBehavior to avoid dialog prompt
-    // this is taken from qgsbrowserdockwidget.cpp
-    // TODO - integrate this into qgis core
-    QgsSettings settings;
-    QString defaultProjectionOption = settings.value( QStringLiteral( "Projections/defaultBehavior" ), "prompt" ).toString();
-    if ( settings.value( QStringLiteral( "Projections/defaultBehavior" ), "prompt" ).toString() == QLatin1String( "prompt" ) )
-    {
-      settings.setValue( QStringLiteral( "Projections/defaultBehavior" ), "useProject" );
-    }
     tmpLayer = true;
-    rasterLayer = new QgsRasterLayer( mRasterFileName, QFileInfo( mRasterFileName ).baseName(), QStringLiteral( "gdal" ) );
-    // restore /Projections/defaultBehavior
-    if ( defaultProjectionOption == QLatin1String( "prompt" ) )
-    {
-      settings.setValue( QStringLiteral( "Projections/defaultBehavior" ), defaultProjectionOption );
-    }
+    QgsRasterLayer::LayerOptions options;
+    options.allowInvalidCrs = true;
+    rasterLayer = new QgsRasterLayer( mRasterFileName, QFileInfo( mRasterFileName ).baseName(), QStringLiteral( "gdal" ), options );
   }
 
   if ( mProvider == QLatin1String( "gdal" ) && mPyramids )

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1614,15 +1614,55 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>561</width>
-                <height>421</height>
+                <width>857</width>
+                <height>827</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
+               <item row="4" column="0">
+                <widget class="QgsCollapsibleGroupBox" name="mDefaultDatumTransformGroupBox">
+                 <property name="title">
+                  <string>Default Datum Transformations</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_10">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_40">
+                    <property name="text">
+                     <string>Enter default datum transformations which will be used in any newly created project</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QCheckBox" name="mShowDatumTransformDialogCheckBox">
+                    <property name="text">
+                     <string>Ask for datum transformation if several are available</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="Line" name="line_2">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QgsDatumTransformTableWidget" name="mDefaultDatumTransformTableWidget" native="true"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="5" column="0">
+                <widget class="QCheckBox" name="mPlanimetricMeasurementsComboBox">
+                 <property name="text">
+                  <string>Planimetric measurements</string>
+                 </property>
+                </widget>
+               </item>
                <item row="2" column="0">
                 <widget class="QgsCollapsibleGroupBox" name="grpProjectProjection">
                  <property name="title">
-                  <string>CRS for New Projects</string>
+                  <string>CRS for Projects</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_27" columnstretch="0,1">
                   <item row="0" column="0" colspan="2">
@@ -1671,26 +1711,23 @@
                  </layout>
                 </widget>
                </item>
-               <item row="6" column="0">
-                <spacer name="verticalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
                <item row="3" column="0">
                 <widget class="QgsCollapsibleGroupBox" name="grpProjectionBehavior">
                  <property name="title">
-                  <string>CRS for New Layers</string>
+                  <string>CRS for Layers</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_14" columnstretch="0,1">
-                  <item row="0" column="0" colspan="2">
+                  <item row="0" column="1">
+                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs" native="true">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0" colspan="2">
                    <widget class="QLabel" name="label_8">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -1706,7 +1743,28 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="0">
+                  <item row="4" column="0" colspan="2">
+                   <widget class="QRadioButton" name="radUseProjectProjection">
+                    <property name="text">
+                     <string>Use pro&amp;ject CRS</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_16">
+                    <property name="text">
+                     <string>Default CRS for layers</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="5" column="0" colspan="2">
+                   <widget class="QRadioButton" name="radUseGlobalProjection">
+                    <property name="text">
+                     <string>&amp;Use default layer CRS</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0" colspan="2">
                    <widget class="QRadioButton" name="radPromptForProjection">
                     <property name="text">
                      <string>Pro&amp;mpt for CRS</string>
@@ -1714,71 +1772,27 @@
                    </widget>
                   </item>
                   <item row="2" column="0">
-                   <widget class="QRadioButton" name="radUseProjectProjection">
+                   <widget class="QRadioButton" name="radCrsNoAction">
                     <property name="text">
-                     <string>Use pro&amp;ject CRS</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QRadioButton" name="radUseGlobalProjection">
-                    <property name="text">
-                     <string>&amp;Use a default CRS</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QgsProjectionSelectionWidget" name="leLayerGlobalCrs" native="true">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="focusPolicy">
-                     <enum>Qt::StrongFocus</enum>
+                     <string>Leave as an unknown CRS (take no action)</string>
                     </property>
                    </widget>
                   </item>
                  </layout>
                 </widget>
                </item>
-               <item row="4" column="0">
-                <widget class="QgsCollapsibleGroupBox" name="mDefaultDatumTransformGroupBox">
-                 <property name="title">
-                  <string>Default Datum Transformations</string>
+               <item row="6" column="0">
+                <spacer name="verticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_10">
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="label_40">
-                    <property name="text">
-                     <string>Enter default datum transformations which will be used in any newly created project</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QCheckBox" name="mShowDatumTransformDialogCheckBox">
-                    <property name="text">
-                     <string>Ask for datum transformation if several are available</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="Line" name="line_2">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QgsDatumTransformTableWidget" name="mDefaultDatumTransformTableWidget" native="true"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QCheckBox" name="mPlanimetricMeasurementsComboBox">
-                 <property name="text">
-                  <string>Planimetric measurements</string>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
                  </property>
-                </widget>
+                </spacer>
                </item>
               </layout>
              </widget>
@@ -5631,11 +5645,13 @@ p, li { white-space: pre-wrap; }
   <tabstop>radProjectUseCrsOfFirstLayer</tabstop>
   <tabstop>radProjectUseDefaultCrs</tabstop>
   <tabstop>leProjectGlobalCrs</tabstop>
+  <tabstop>leLayerGlobalCrs</tabstop>
+  <tabstop>radCrsNoAction</tabstop>
   <tabstop>radPromptForProjection</tabstop>
   <tabstop>radUseProjectProjection</tabstop>
   <tabstop>radUseGlobalProjection</tabstop>
-  <tabstop>leLayerGlobalCrs</tabstop>
   <tabstop>mShowDatumTransformDialogCheckBox</tabstop>
+  <tabstop>mPlanimetricMeasurementsComboBox</tabstop>
   <tabstop>mOptionsScrollArea_11</tabstop>
   <tabstop>cbxAttributeTableDocked</tabstop>
   <tabstop>mComboCopyFeatureFormat</tabstop>
@@ -5817,22 +5833,6 @@ p, li { white-space: pre-wrap; }
     <hint type="destinationlabel">
      <x>753</x>
      <y>126</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>radUseGlobalProjection</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>leLayerGlobalCrs</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>290</x>
-     <y>295</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>367</x>
-     <y>315</y>
     </hint>
    </hints>
   </connection>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -223,7 +223,7 @@ class DummyAlgorithm : public QgsProcessingAlgorithm
       p.addMapLayer( layer3111 );
 
       QString testDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
-      QString raster1 = testDataDir + "tenbytenraster.asc";
+      QString raster1 = testDataDir + "landsat_4326.tif";
       QFileInfo fi1( raster1 );
       QgsRasterLayer *r1 = new QgsRasterLayer( fi1.filePath(), "R1" );
       QVERIFY( r1->isValid() );
@@ -2219,7 +2219,7 @@ void TestQgsProcessing::parameterCrs()
   QgsProject p;
   p.setCrs( QgsCoordinateReferenceSystem::fromEpsgId( 28353 ) );
   QString testDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
-  QString raster1 = testDataDir + "tenbytenraster.asc";
+  QString raster1 = testDataDir + "landsat_4326.tif";
   QString raster2 = testDataDir + "landsat.tif";
   QFileInfo fi1( raster1 );
   QgsRasterLayer *r1 = new QgsRasterLayer( fi1.filePath(), "R1" );
@@ -2296,8 +2296,8 @@ void TestQgsProcessing::parameterCrs()
   QCOMPARE( def->valueAsPythonString( "EPSG:12003", context ), QStringLiteral( "'EPSG:12003'" ) );
   QCOMPARE( def->valueAsPythonString( "ProjectCrs", context ), QStringLiteral( "'ProjectCrs'" ) );
   QCOMPARE( def->valueAsPythonString( QStringLiteral( "c:\\test\\new data\\test.dat" ), context ), QStringLiteral( "'c:\\\\test\\\\new data\\\\test.dat'" ) );
-  QCOMPARE( def->valueAsPythonString( raster1, context ), QString( "'" ) + testDataDir + QStringLiteral( "tenbytenraster.asc'" ) );
-  QCOMPARE( def->valueAsPythonString( r1->id(), context ), QString( "'" ) + testDataDir + QStringLiteral( "tenbytenraster.asc'" ) );
+  QCOMPARE( def->valueAsPythonString( raster1, context ), QString( "'" ) + testDataDir + QStringLiteral( "landsat_4326.tif'" ) );
+  QCOMPARE( def->valueAsPythonString( r1->id(), context ), QString( "'" ) + testDataDir + QStringLiteral( "landsat_4326.tif'" ) );
   QCOMPARE( def->valueAsPythonString( QVariant::fromValue( QgsProperty::fromExpression( "\"a\"=1" ) ), context ), QStringLiteral( "QgsProperty.fromExpression('\"a\"=1')" ) );
   QCOMPARE( def->valueAsPythonString( "uri='complex' username=\"complex\"", context ), QStringLiteral( "'uri=\\'complex\\' username=\\\"complex\\\"'" ) );
 
@@ -2492,7 +2492,7 @@ void TestQgsProcessing::parameterExtent()
   // setup a context
   QgsProject p;
   QString testDataDir = QStringLiteral( TEST_DATA_DIR ) + '/'; //defined in CmakeLists.txt
-  QString raster1 = testDataDir + "tenbytenraster.asc";
+  QString raster1 = testDataDir + "landsat_4326.tif";
   QString raster2 = testDataDir + "landsat.tif";
   QFileInfo fi1( raster1 );
   QgsRasterLayer *r1 = new QgsRasterLayer( fi1.filePath(), "R1" );
@@ -2550,10 +2550,10 @@ void TestQgsProcessing::parameterExtent()
   QCOMPARE( QgsProcessingParameters::parameterAsExtent( def.get(), params, context ),  r1->extent() );
   QCOMPARE( QgsProcessingParameters::parameterAsExtentCrs( def.get(), params, context ).authid(), QStringLiteral( "EPSG:4326" ) );
   ext = QgsProcessingParameters::parameterAsExtent( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
 
   // layer as parameter
   params.insert( "non_optional", QVariant::fromValue( r1 ) );
@@ -2561,63 +2561,63 @@ void TestQgsProcessing::parameterExtent()
   QCOMPARE( QgsProcessingParameters::parameterAsExtent( def.get(), params, context ),  r1->extent() );
   QCOMPARE( QgsProcessingParameters::parameterAsExtentCrs( def.get(), params, context ).authid(), QStringLiteral( "EPSG:4326" ) );
   ext = QgsProcessingParameters::parameterAsExtent( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
   QgsGeometry gExt = QgsProcessingParameters::parameterAsExtentGeometry( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
   QCOMPARE( gExt.constGet()->vertexCount(), 5 );
   ext = gExt.boundingBox();
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
 
   // using feature source definition
   params.insert( "non_optional",  QgsProcessingFeatureSourceDefinition( r1->id() ) );
   QCOMPARE( QgsProcessingParameters::parameterAsExtentCrs( def.get(), params, context ).authid(), QStringLiteral( "EPSG:4326" ) );
   ext = QgsProcessingParameters::parameterAsExtent( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
   gExt = QgsProcessingParameters::parameterAsExtentGeometry( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
   QCOMPARE( gExt.constGet()->vertexCount(), 5 );
   ext = gExt.boundingBox();
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
   params.insert( "non_optional",  QgsProcessingFeatureSourceDefinition( QgsProperty::fromValue( QVariant::fromValue( r1 ) ) ) );
   QCOMPARE( QgsProcessingParameters::parameterAsExtentCrs( def.get(), params, context ).authid(), QStringLiteral( "EPSG:4326" ) );
   ext = QgsProcessingParameters::parameterAsExtent( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
   gExt = QgsProcessingParameters::parameterAsExtentGeometry( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
   QCOMPARE( gExt.constGet()->vertexCount(), 5 );
   ext = gExt.boundingBox();
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
 
   // using output layer definition, e.g. from a previous model child algorithm
   params.insert( "non_optional",  QgsProcessingOutputLayerDefinition( r1->id() ) );
   QCOMPARE( QgsProcessingParameters::parameterAsExtentCrs( def.get(), params, context ).authid(), QStringLiteral( "EPSG:4326" ) );
   ext = QgsProcessingParameters::parameterAsExtent( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
   gExt = QgsProcessingParameters::parameterAsExtentGeometry( def.get(), params, context, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
   QCOMPARE( gExt.constGet()->vertexCount(), 5 );
   ext = gExt.boundingBox();
-  QGSCOMPARENEAR( ext.xMinimum(), 1535375, 100 );
-  QGSCOMPARENEAR( ext.xMaximum(), 1535475, 100 );
-  QGSCOMPARENEAR( ext.yMinimum(),  5083255, 100 );
-  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 100 );
+  QGSCOMPARENEAR( ext.xMinimum(), 17.942777, 0.001 );
+  QGSCOMPARENEAR( ext.xMaximum(), 17.944704, 0.001 );
+  QGSCOMPARENEAR( ext.yMinimum(),  30.229681, 0.001 );
+  QGSCOMPARENEAR( ext.yMaximum(), 30.231616, 0.001 );
 
   // string representing a non-project layer source
   params.insert( "non_optional", raster2 );
@@ -2730,8 +2730,8 @@ void TestQgsProcessing::parameterExtent()
 
   QCOMPARE( def->valueAsPythonString( QVariant(), context ), QStringLiteral( "None" ) );
   QCOMPARE( def->valueAsPythonString( "1,2,3,4", context ), QStringLiteral( "'1,2,3,4'" ) );
-  QCOMPARE( def->valueAsPythonString( r1->id(), context ), QString( "'" ) + testDataDir + QStringLiteral( "tenbytenraster.asc'" ) );
-  QCOMPARE( def->valueAsPythonString( QVariant::fromValue( r1 ), context ), QString( "'" ) + testDataDir + QStringLiteral( "tenbytenraster.asc'" ) );
+  QCOMPARE( def->valueAsPythonString( r1->id(), context ), QString( "'" ) + testDataDir + QStringLiteral( "landsat_4326.tif'" ) );
+  QCOMPARE( def->valueAsPythonString( QVariant::fromValue( r1 ), context ), QString( "'" ) + testDataDir + QStringLiteral( "landsat_4326.tif'" ) );
   QCOMPARE( def->valueAsPythonString( raster2, context ), QString( "'" ) + testDataDir + QStringLiteral( "landsat.tif'" ) );
   QCOMPARE( def->valueAsPythonString( QVariant::fromValue( QgsProperty::fromExpression( "\"a\"=1" ) ), context ), QStringLiteral( "QgsProperty.fromExpression('\"a\"=1')" ) );
   QCOMPARE( def->valueAsPythonString( QgsRectangle( 11, 12, 13, 14 ), context ), QStringLiteral( "'11, 13, 12, 14'" ) );
@@ -6546,10 +6546,10 @@ void TestQgsProcessing::combineLayerExtent()
 
   // with reprojection
   ext = QgsProcessingUtils::combineLayerExtents( QList< QgsMapLayer *>() << r1.get() << r2.get(), QgsCoordinateReferenceSystem::fromEpsgId( 3785 ), context );
-  QGSCOMPARENEAR( ext.xMinimum(), 1995320, 10 );
+  QGSCOMPARENEAR( ext.xMinimum(), 1535375.0, 10 );
   QGSCOMPARENEAR( ext.xMaximum(), 2008833, 10 );
   QGSCOMPARENEAR( ext.yMinimum(), 3523084, 10 );
-  QGSCOMPARENEAR( ext.yMaximum(), 3536664, 10 );
+  QGSCOMPARENEAR( ext.yMaximum(), 5083355, 10 );
 }
 
 void TestQgsProcessing::processingFeatureSource()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -99,8 +99,23 @@ class TestQgsCoordinateReferenceSystem: public QObject
     QStringList myAuthIdStrings;
     QString mTempFolder;
     QString testESRIWkt( int i, QgsCoordinateReferenceSystem &crs );
+
+    static bool sValidateCalled;
+
+    static void testValidationCrs( QgsCoordinateReferenceSystem &crs )
+    {
+      sValidateCalled = true;
+
+      crs.createFromString( QStringLiteral( "EPSG:3111" ) );
+    }
+
+    static void testNoActionValidationCrs( QgsCoordinateReferenceSystem & )
+    {
+      sValidateCalled = true;
+    }
 };
 
+bool TestQgsCoordinateReferenceSystem::sValidateCalled = false;
 
 void TestQgsCoordinateReferenceSystem::initTestCase()
 {
@@ -625,6 +640,7 @@ void TestQgsCoordinateReferenceSystem::fromStringCache()
   QgsCoordinateReferenceSystem::invalidateCache();
   QVERIFY( !QgsCoordinateReferenceSystem::sStringCache.contains( "EPSG:3113" ) );
 }
+
 void TestQgsCoordinateReferenceSystem::isValid()
 {
   QgsCoordinateReferenceSystem myCrs;
@@ -632,14 +648,36 @@ void TestQgsCoordinateReferenceSystem::isValid()
   QVERIFY( myCrs.isValid() );
   debugPrint( myCrs );
 }
+
 void TestQgsCoordinateReferenceSystem::validate()
 {
-  QgsCoordinateReferenceSystem myCrs;
-  myCrs.createFromSrid( GEOSRID );
+  // no validator set
+  QgsCoordinateReferenceSystem::setCustomCrsValidation( nullptr );
+  QgsCoordinateReferenceSystem myCrs( QStringLiteral( "EPSG:28356" ) );
   myCrs.validate();
   QVERIFY( myCrs.isValid() );
-  debugPrint( myCrs );
+  QCOMPARE( myCrs.authid(), QStringLiteral( "EPSG:28356" ) );
+  myCrs = QgsCoordinateReferenceSystem();
+  myCrs.validate();
+  // no change, no custom function
+  QVERIFY( !myCrs.isValid() );
+
+  QgsCoordinateReferenceSystem::setCustomCrsValidation( &TestQgsCoordinateReferenceSystem::testValidationCrs );
+  myCrs.validate();
+  QVERIFY( myCrs.isValid() );
+  QCOMPARE( myCrs.authid(), QStringLiteral( "EPSG:3111" ) );
+  QVERIFY( sValidateCalled );
+  sValidateCalled = false;
+
+  myCrs = QgsCoordinateReferenceSystem();
+  QgsCoordinateReferenceSystem::setCustomCrsValidation( &TestQgsCoordinateReferenceSystem::testNoActionValidationCrs );
+  myCrs.validate();
+  QVERIFY( !myCrs.isValid() );
+  QVERIFY( sValidateCalled );
+
+  QgsCoordinateReferenceSystem::setCustomCrsValidation( nullptr );
 }
+
 void TestQgsCoordinateReferenceSystem::equality()
 {
   QgsCoordinateReferenceSystem myCrs;

--- a/tests/src/core/testqgstracer.cpp
+++ b/tests/src/core/testqgstracer.cpp
@@ -69,7 +69,7 @@ static QgsFeature make_feature( const QString &wkt )
 
 static QgsVectorLayer *make_layer( const QStringList &wkts )
 {
-  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "LineString" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:4326" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
   Q_ASSERT( vl->isValid() );
 
   vl->startEditing();

--- a/tests/src/python/test_qgsextentgroupbox.py
+++ b/tests/src/python/test_qgsextentgroupbox.py
@@ -125,7 +125,7 @@ class TestQgsExtentGroupBox(unittest.TestCase):
         self.assertEqual(w.outputExtent().toString(20), QgsRectangle(1, 2, 3, 4).toString(20))
 
         # repeat, this time using layer extent
-        layer = QgsVectorLayer("Polygon?crs=4326", 'memory', 'memory')
+        layer = QgsVectorLayer("Polygon?crs=epsg:4326", 'memory', 'memory')
         self.assertTrue(layer.isValid())
         f = QgsFeature()
         f.setGeometry(QgsGeometry.fromWkt('Polygon((1 2, 3 2, 3 4, 1 4, 1 2))'))

--- a/tests/src/python/test_qgsfeaturesource.py
+++ b/tests/src/python/test_qgsfeaturesource.py
@@ -27,7 +27,7 @@ start_app()
 
 
 def createLayerWithFivePoints():
-    layer = QgsVectorLayer("Point?field=id:integer&field=fldtxt:string&field=fldint:integer",
+    layer = QgsVectorLayer("Point?crs=EPSG:4326&field=id:integer&field=fldtxt:string&field=fldint:integer",
                            "addfeat", "memory")
     pr = layer.dataProvider()
     f = QgsFeature()


### PR DESCRIPTION
The current approach taken for handling layers with invalid/unknown CRS is horrible UX. By defaulting to a blocking dialog forcing users to make a CRS choice, we create situations resulting in effective application hangs. E.g.

- loading 100 layers from a folder into QGIS can result in 100 unknown CRS prompts. This is effectively a hang, since users either have to patiently click through 100 dialogs one by one or force kill QGIS
- running a lengthy script can be paused with a blocking dialog asking users to pick a CRS, even when the script does not require a valid CRS for a layer to proceed. Very frustrating after leaving QGIS running overnight and hoping for completed results in the morning!
- by forcing users to make CRS choices upfront, we don't allow them to do useful things like explore the layer's metadata or the coordinate ranges contained within the layer in order to make this choice. Deferring the choice allows users to do these steps at a later stage and make a better informed choice of CRS.
- By forcing users to make the choice upfront, we run the risk that users will click anything in the dialog just to get rid of it. And then the random choice is remembered and treated as the canonical value for the lifetime of that project, leaving no hints to the user that they should really investigate and fix the situation...
- Even worse, we have logic in place which falls back to a forced WGS84 CRS when a user cancels the dialog. This is very bad, since it's almost always the incorrect choice yet gives users NO visual indication of this. WGS84 is also bad(tm), and we, as knowledgeable members of the geospatial community, need to be guiding users AWAY from this CRS as quickly as possible.
- Plugins (and even core QGIS code) have been hacking around this situation by temporarily overriding user settings and forcing unknown layers to load in some random CRS choice. This is a horrible and fragile development practice (but with no choice other choice, it was the only available option for developers).

So this PR adds a new option for handling invalid layer CRS: "Leave as an unknown CRS (take no action)". It's now the default, with a new settings key created so that ALL users will be moved initially to this new default value.

When set, no validation of layer CRS is performed upfront. Instead, layers are loaded with no crs set. They gain a new indicator icon showing that the layer has no CRS (better icon needed!), and any coordinates in the layer are treated as purely raw coordinate values (just like if a project itself has no crs set). Users can click the indicator at a later stage to set the layer's CRS, OR can highlight multiple layers in the tree and set 100 layer's CRSes at once. Phew!

Additionally, new API hooks have been added to allow plugins to indicate that all CRS validation should be skipped when loading a particular layer, regardless of the user's actual settings. This avoids the need for the hacky temporary settings overrides used to date...

