### PR TITLE
[ui] Fix overview panel's extent polygon red-on-red visibility issue

### DIFF
--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -296,7 +296,8 @@ void QgsPanningWidget::setPolygon( const QPolygon &p )
   if ( mPoly.at( 0 ) != mPoly.at( mPoly.length() - 1 ) )
     mPoly.append( mPoly.at( 0 ) );
 
-  setGeometry( p.boundingRect() );
+  QRect rect = p.boundingRect() + QMargins( 1, 1, 1, 1 );
+  setGeometry( rect );
   update();
 }
 
@@ -305,14 +306,24 @@ void QgsPanningWidget::paintEvent( QPaintEvent *pe )
   Q_UNUSED( pe )
 
   QPainter p;
+
   p.begin( this );
-  p.setPen( Qt::red );
-  QPolygonF t = mPoly.translated( -mPoly.boundingRect().left(), -mPoly.boundingRect().top() );
+  QPolygonF t = mPoly.translated( -mPoly.boundingRect().left() + 1, -mPoly.boundingRect().top() + 1 );
 
   // drawPolygon causes issues on windows - corners of path may be missing resulting in triangles being drawn
   // instead of rectangles! (Same cause as #13343)
   QPainterPath path;
   path.addPolygon( t );
+
+  QPen pen;
+  pen.setJoinStyle( Qt::MiterJoin );
+  pen.setColor( Qt::white );
+  pen.setWidth( 3 );
+  p.setPen( pen );
+  p.drawPath( path );
+  pen.setColor( Qt::red );
+  pen.setWidth( 1 );
+  p.setPen( pen );
   p.drawPath( path );
 
   p.end();


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Because red-on-red is hard to read:
![image](https://user-images.githubusercontent.com/1728657/66304094-a94dfb80-e926-11e9-83a9-7f0c7d6856c1.png)
_Spot the extent polygon! Current (left) vs. PR (right)_

The PR insures that the overview panel's extent rectangle will never end up being red-on-red by adding a secondary white outline. 

While it's about fixing the red-on-red issue, it also delivers better visibility in all scenarios:
![image](https://user-images.githubusercontent.com/1728657/66304143-c1be1600-e926-11e9-98ed-6bb3e1b1ddd9.png)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
