### PR TITLE
Uh-oh misspelling

### DIFF
--- a/src/crashhandler/qgscrashdialog.cpp
+++ b/src/crashhandler/qgscrashdialog.cpp
@@ -26,7 +26,7 @@ QgsCrashDialog::QgsCrashDialog( QWidget *parent )
   : QDialog( parent )
 {
   setupUi( this );
-  setWindowTitle( tr( "Oh Uh!" ) );
+  setWindowTitle( tr( "Uh-oh!" ) );
 
   mCrashHeaderMessage->setText( tr( "QGIS unexpectedly ended" ) );
   connect( mReloadQGISButton, &QPushButton::clicked, this, &QgsCrashDialog::reloadQGIS );


### PR DESCRIPTION
## Description

When QGIS crashes, _misspellings_ happens. This was reported as #32117.

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment

Fix #32117