### PR TITLE
Fix memory layers cannot use non-EPSG CRS codes

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -271,18 +271,29 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
   locker.unlock();
 
   bool result = false;
-  QRegularExpression reCrsId( "^(epsg|postgis|internal|user)\\:(\\d+)$", QRegularExpression::CaseInsensitiveOption );
+  QRegularExpression reCrsId( QStringLiteral( "^(epsg|esri|osgeo|ignf|zangi|iau2000|postgis|internal|user)\\:(\\w+)$" ), QRegularExpression::CaseInsensitiveOption );
   QRegularExpressionMatch match = reCrsId.match( definition );
   if ( match.capturedStart() == 0 )
   {
     QString authName = match.captured( 1 ).toLower();
-    CrsType type = InternalCrsId;
     if ( authName == QLatin1String( "epsg" ) )
-      type = EpsgCrsId;
-    if ( authName == QLatin1String( "postgis" ) )
-      type = PostgisCrsId;
-    long id = match.captured( 2 ).toLong();
-    result = createFromId( id, type );
+    {
+      result = createFromOgcWmsCrs( definition );
+    }
+    else if ( authName == QLatin1String( "postgis" ) )
+    {
+      const long id = match.captured( 2 ).toLong();
+      result = createFromId( id, PostgisCrsId );
+    }
+    else if ( authName == QLatin1String( "esri" ) || authName == QLatin1String( "osgeo" ) || authName == QLatin1String( "ignf" ) || authName == QLatin1String( "zangi" ) || authName == QLatin1String( "iau2000" ) )
+    {
+      result = createFromOgcWmsCrs( definition );
+    }
+    else
+    {
+      const long id = match.captured( 2 ).toLong();
+      result = createFromId( id, InternalCrsId );
+    }
   }
   else
   {

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -59,6 +59,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void createFromProj4();
     void fromProj4();
     void proj4Cache();
+    void fromString();
     void fromStringCache();
     void isValid();
     void validate();
@@ -567,6 +568,34 @@ void TestQgsCoordinateReferenceSystem::proj4Cache()
 
   QgsCoordinateReferenceSystem::invalidateCache();
   QVERIFY( !QgsCoordinateReferenceSystem::sProj4Cache.contains( GEOPROJ4 ) );
+}
+
+void TestQgsCoordinateReferenceSystem::fromString()
+{
+  QgsCoordinateReferenceSystem crs;
+  crs.createFromString( QStringLiteral( "woohooo" ) );
+  QVERIFY( !crs.isValid() );
+  crs.createFromString( QStringLiteral( "EPSG:3111" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.authid(), QStringLiteral( "EPSG:3111" ) );
+  crs.createFromString( QStringLiteral( "epsg:3111" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.authid(), QStringLiteral( "EPSG:3111" ) );
+
+#if PROJ_VERSION_MAJOR>=6
+  crs.createFromString( QStringLiteral( "esri:102499" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.authid(), QStringLiteral( "ESRI:102499" ) );
+  crs.createFromString( QStringLiteral( "OSGEO:41001" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.authid(), QStringLiteral( "OSGEO:41001" ) );
+  crs.createFromString( QStringLiteral( "IGNF:LAMB1" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.authid(), QStringLiteral( "IGNF:LAMB1" ) );
+  crs.createFromString( QStringLiteral( "IAU2000:69918" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.authid(), QStringLiteral( "IAU2000:69918" ) );
+#endif
 }
 
 void TestQgsCoordinateReferenceSystem::fromStringCache()


### PR DESCRIPTION
Likely also fixes other bugs relating to use of non-EPSG authorities, by making QgsCoordinateReferenceSystem::createFromString correctly handle other authorities and avoid forced conversion of the identifier to a number.
