### PR TITLE
Null representation in QgsDateTimeEdit on getting focus

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsdatetimeedit.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdatetimeedit.sip.in
@@ -115,6 +115,8 @@ Signal emitted whenever the value changes.
 
     virtual void focusOutEvent( QFocusEvent *event );
 
+    virtual void focusInEvent( QFocusEvent *event );
+
     virtual void wheelEvent( QWheelEvent *event );
 
     virtual void showEvent( QShowEvent *event );

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -161,10 +161,8 @@ void QgsDateTimeEdit::focusInEvent( QFocusEvent *event )
   if ( mAllowNull && mIsNull && !mCurrentPressEvent )
   {
     QAbstractSpinBox::focusInEvent( event );
-    if ( mAllowNull && mIsNull )
-    {
-      displayCurrentDate();
-    }
+
+    displayCurrentDate();
   }
   else
   {

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -60,7 +60,7 @@ void QgsDateTimeEdit::clear()
 {
   if ( mAllowNull )
   {
-    displayNull();
+    displayCurrentDate();
 
     // Check if it's really changed or crash, see GH #29937
     if ( ! dateTime().isNull() )
@@ -76,10 +76,6 @@ void QgsDateTimeEdit::clear()
     disconnect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
     emit dateTimeChanged( QDateTime() );
     connect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
-
-    // otherwise, NULL is not displayed in the line edit
-    // this might not be the right way to do it
-    clearFocus();
   }
 }
 
@@ -280,6 +276,7 @@ void QgsDateTimeEdit::setDateTime( const QDateTime &dateTime )
   if ( !dateTime.isValid() || dateTime.isNull() )
   {
     clear();
+    displayNull();
   }
   // Check if it's really changed or crash, see GH #29937
   else if ( dateTime != QgsDateTimeEdit::dateTime() )

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -165,7 +165,6 @@ void QgsDateTimeEdit::focusInEvent( QFocusEvent *event )
     {
       displayCurrentDate();
     }
-    emit editingFinished();
   }
   else
   {

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -165,7 +165,7 @@ void QgsDateTimeEdit::focusInEvent( QFocusEvent *event )
   if ( mAllowNull && mIsNull && !mCurrentPressEvent )
   {
     QAbstractSpinBox::focusInEvent( event );
-    if ( lineEdit()->text() == QgsApplication::nullRepresentation() )
+    if ( mAllowNull && mIsNull )
     {
       displayCurrentDate();
     }

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -160,6 +160,23 @@ void QgsDateTimeEdit::focusOutEvent( QFocusEvent *event )
   }
 }
 
+void QgsDateTimeEdit::focusInEvent( QFocusEvent *event )
+{
+  if ( mAllowNull && mIsNull && !mCurrentPressEvent )
+  {
+    QAbstractSpinBox::focusInEvent( event );
+    if ( lineEdit()->text() == QgsApplication::nullRepresentation() )
+    {
+      displayCurrentDate();
+    }
+    emit editingFinished();
+  }
+  else
+  {
+    QDateTimeEdit::focusInEvent( event );
+  }
+}
+
 void QgsDateTimeEdit::wheelEvent( QWheelEvent *event )
 {
   // dateTime might have been set to minimum in calendar mode
@@ -216,6 +233,13 @@ void QgsDateTimeEdit::displayNull( bool updateCalendar )
     QDateTimeEdit::setDateTime( minimumDateTime() );
   }
   lineEdit()->setText( QgsApplication::nullRepresentation() );
+  connect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
+}
+
+void QgsDateTimeEdit::displayCurrentDate()
+{
+  disconnect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
+  QDateTimeEdit::setDateTime( QDateTime::currentDateTime() );
   connect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
 }
 

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -232,6 +232,7 @@ void QgsDateTimeEdit::displayNull( bool updateCalendar )
     // a date selected in calendar widget
     QDateTimeEdit::setDateTime( minimumDateTime() );
   }
+  lineEdit()->setCursorPosition( lineEdit()->text().length() );
   lineEdit()->setText( QgsApplication::nullRepresentation() );
   connect( this, &QDateTimeEdit::dateTimeChanged, this, &QgsDateTimeEdit::changed );
 }

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -120,7 +120,15 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     QString mOriginalStyleSheet = QString();
     QAction *mClearAction;
 
+    /**
+    * write the null value representation to the line edit without changing the value
+    * \param updateCalendar Flag if calendar is open and minimum date needs to be set
+    */
     void displayNull( bool updateCalendar = false );
+
+    /**
+    * write the current date into the line edit without changing the value
+    */
     void displayCurrentDate();
 
     //! reset the value to current date time

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -104,6 +104,7 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
   protected:
     void mousePressEvent( QMouseEvent *event ) override;
     void focusOutEvent( QFocusEvent *event ) override;
+    void focusInEvent( QFocusEvent *event ) override;
     void wheelEvent( QWheelEvent *event ) override;
     void showEvent( QShowEvent *event ) override;
 
@@ -120,6 +121,7 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     QAction *mClearAction;
 
     void displayNull( bool updateCalendar = false );
+    void displayCurrentDate();
 
     //! reset the value to current date time
     void resetBeforeChange( int delta );

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -149,6 +149,8 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
     {
       setMinimumDateTime( QDateTime::fromString( QStringLiteral( "0100-01-01" ), Qt::ISODate ) );
     }
+
+    friend class TestQgsDateTimeEdit;
 };
 
 #endif // QGSDATETIMEEDIT_H

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -24,6 +24,7 @@
 SIP_NO_FILE
 
 class QgsDateTimeEdit;
+class TestQgsDateTimeEdit;
 
 /**
  * \ingroup gui
@@ -77,6 +78,9 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
 
   private:
     void updateValues( const QVariant &value, const QVariantList  & = QVariantList() ) override;
+
+
+    friend class TestQgsDateTimeEdit;
 };
 
 #endif // QGSDATETIMEEDITWRAPPER_H

--- a/tests/src/gui/testqgsdatetimeedit.cpp
+++ b/tests/src/gui/testqgsdatetimeedit.cpp
@@ -18,6 +18,8 @@
 #include "qdatetime.h"
 
 #include <qgsdatetimeedit.h>
+#include <qgsdatetimeeditwrapper.h>
+#include <qgsdatetimefieldformatter.h>
 
 class TestQgsDateTimeEdit: public QObject
 {
@@ -29,6 +31,13 @@ class TestQgsDateTimeEdit: public QObject
     void cleanup(); // will be called after every testfunction.
 
     void nullValues();
+    void focus();
+
+  private:
+    std::unique_ptr<QgsDateTimeEditWrapper> widget1; // For field 0
+    std::unique_ptr<QgsDateTimeEditWrapper> widget2; // For field 1
+    std::unique_ptr<QgsDateTimeEditWrapper> widget3; // For field 2
+    std::unique_ptr<QgsVectorLayer> vl;
 
 };
 
@@ -42,6 +51,27 @@ void TestQgsDateTimeEdit::cleanupTestCase()
 
 void TestQgsDateTimeEdit::init()
 {
+
+  vl = qgis::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=epsg:4326" ),
+                                          QStringLiteral( "myvl" ),
+                                          QLatin1Literal( "memory" ) );
+
+  // add fields
+  QList<QgsField> fields;
+  fields.append( QgsField( "date1", QVariant::Date ) );
+  fields.append( QgsField( "date2", QVariant::Date ) );
+  fields.append( QgsField( "date3", QVariant::Date ) );
+  vl->dataProvider()->addAttributes( fields );
+  vl->updateFields();
+  QVERIFY( vl.get() );
+  QVERIFY( vl->isValid() );
+
+  widget1 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 0, nullptr, nullptr );
+  widget2 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 1, nullptr, nullptr );
+  widget3 = qgis::make_unique<QgsDateTimeEditWrapper>( vl.get(), 2, nullptr, nullptr );
+  QVERIFY( widget1.get() );
+  QVERIFY( widget2.get() );
+  QVERIFY( widget3.get() );
 }
 
 void TestQgsDateTimeEdit::cleanup()
@@ -77,6 +107,123 @@ void TestQgsDateTimeEdit::nullValues()
   QCOMPARE( timeEdit->date(), date.date() );
 
   delete timeEdit;
+}
+
+void TestQgsDateTimeEdit::focus()
+{
+  QgsApplication::setNullRepresentation( QString( "nope" ) );
+  QWidget *w = new QWidget(); //required for focus events
+  QApplication::setActiveWindow( w );
+
+  QVariantMap cfg;
+  cfg.insert( QStringLiteral( "AllowNull" ), true );
+
+  widget1->setConfig( cfg );
+  QgsDateTimeEdit *dateedit1 = qobject_cast<QgsDateTimeEdit *>( widget1->createWidget( w ) );
+  QVERIFY( dateedit1 );
+  widget1->initWidget( dateedit1 );
+  widget1->setValue( QVariant::Date );
+
+  widget2->setConfig( cfg );
+  QgsDateTimeEdit *dateedit2 = qobject_cast<QgsDateTimeEdit *>( widget2->createWidget( w ) );
+  QVERIFY( dateedit2 );
+  widget2->initWidget( dateedit2 );
+  widget2->setValue( QVariant::Date );
+
+  widget3->setConfig( cfg );
+  QgsDateTimeEdit *dateedit3 = qobject_cast<QgsDateTimeEdit *>( widget3->createWidget( w ) );
+  QVERIFY( dateedit3 );
+  widget3->initWidget( dateedit3 );
+  widget3->setValue( QVariant::Date );
+
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( !dateedit1->hasFocus() );
+  QVERIFY( !dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit2->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
+
+  dateedit1->setFocus();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( dateedit1->hasFocus() );
+  QVERIFY( !dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QDateTime::currentDateTime().toString( QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+  QCOMPARE( dateedit2->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
+
+  dateedit2->setFocus();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( !dateedit1->hasFocus() );
+  QVERIFY( dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit2->text(), QDateTime::currentDateTime().toString( QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
+
+  dateedit3->setFocus();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( !dateedit1->hasFocus() );
+  QVERIFY( !dateedit2->hasFocus() );
+  QVERIFY( dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit2->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit3->text(), QDateTime::currentDateTime().toString( QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+
+  dateedit1->setFocus();
+  dateedit1->setDateTime( QDateTime::fromString( QStringLiteral( "1955-11-12" ), QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+  QVERIFY( !widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( dateedit1->hasFocus() );
+  QVERIFY( !dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QStringLiteral( "1955-11-12" ) );
+  QCOMPARE( dateedit2->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
+
+  dateedit2->setFocus();
+  QVERIFY( !widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( !dateedit1->hasFocus() );
+  QVERIFY( dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QStringLiteral( "1955-11-12" ) );
+  QCOMPARE( dateedit2->text(), QDateTime::currentDateTime().toString( QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
+
+  dateedit1->setFocus();
+  dateedit1->clear();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( dateedit1->hasFocus() );
+  QVERIFY( !dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QDateTime::currentDateTime().toString( QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+  QCOMPARE( dateedit2->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
+
+  dateedit2->setFocus();
+  QVERIFY( widget1->value().isNull() );
+  QVERIFY( widget2->value().isNull() );
+  QVERIFY( widget3->value().isNull() );
+  QVERIFY( !dateedit1->hasFocus() );
+  QVERIFY( dateedit2->hasFocus() );
+  QVERIFY( !dateedit3->hasFocus() );
+  QCOMPARE( dateedit1->text(), QStringLiteral( "nope" ) );
+  QCOMPARE( dateedit2->text(), QDateTime::currentDateTime().toString( QgsDateTimeFieldFormatter::DATE_FORMAT ) );
+  QCOMPARE( dateedit3->text(), QStringLiteral( "nope" ) );
 }
 
 QGSTEST_MAIN( TestQgsDateTimeEdit )

--- a/tests/src/gui/testqgsrangewidgetwrapper.cpp
+++ b/tests/src/gui/testqgsrangewidgetwrapper.cpp
@@ -348,14 +348,14 @@ void TestQgsRangeWidgetWrapper::test_focus()
   QgsDoubleSpinBox *editor1 = qobject_cast<QgsDoubleSpinBox *>( widget1->createWidget( w ) );
   QVERIFY( editor1 );
   widget1->initWidget( editor1 );
-  widget3->setValue( QVariant( QVariant::Double ) );
+  widget1->setValue( QVariant( QVariant::Double ) );
 
   //QgsDoubleSpinBox
   widget2->setConfig( cfg );
   QgsDoubleSpinBox *editor2 = qobject_cast<QgsDoubleSpinBox *>( widget2->createWidget( w ) );
   QVERIFY( editor2 );
   widget2->initWidget( editor2 );
-  widget3->setValue( QVariant( QVariant::Double ) );
+  widget2->setValue( QVariant( QVariant::Double ) );
 
   //QgsSpinBox
   widget3->setConfig( cfg );


### PR DESCRIPTION
There has been several issues in the behavior of getting and leaving focus on the `QgsDateTimeEditWidget` (`QgsDateTimeEdit`). 

This is definitely a bug fix and in my opinion it should be in the 3.10. But please, if you see any risks or inputs how it could be solved better, than tell me. I'm very open on that, since I have to confess that I did possibly not see through all the ideas, how it should have worked before.

### Issues (before)
![datetimenull](https://user-images.githubusercontent.com/28384354/66373658-6f720900-e9a9-11e9-815a-f8cec9f6cf31.gif)

#### 1. On getting focus
On mouse click on null representing text it changes to current date text in gray, what can be edited and that's fine. But when clicking outside the null representing text it keeps the null representing text, what has been not nice.

#### 2. On leaving focus
On leaving focus it set back the null representing text when the cursor has been on the end of the text. If the cursor has been inside the text, it did not change back to the null representing text, what has been not nice.

#### 3. On clear button
On clear button it set back the null representing text and leaves the focus. This has been not nice at all, since the user is most probably still editing the field when he presses the clear button.

The issue report for it is this: https://github.com/qgis/QGIS/issues/22883

### Solutions (now)
![datetimenull-after](https://user-images.githubusercontent.com/28384354/66374059-6e8da700-e9aa-11e9-9492-ddd0bdf12afa.gif)

#### 1. On getting focus
I could not find out the logic that it changes the text on cursor inside the null representing text and otherwise not. But I decided that it's anyway more consistent, when it changes the text to the current date on getting focus (on `FocusInEvent` calling function `displayCurrentDate`).

#### 2. On leaving focus
On off Focus it calls the function `displayNull` and there it set's the cursor to the end of the text. I did not found out why the setting of the null representation text had no effect if the cursor has not been at the end. But like this it works and I see no danger in it.

#### 3. On clear button
On clear button it does not set the null representing text, but the current date instead (and the value NULL of course like before). It does not leave the focus anymore.

**Added some tests for that...**