### PR TITLE
Application options: defer disabling of drivers after application restart (relates to #29212)

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -587,6 +587,32 @@ Apply the skipped drivers list to gdal
 .. seealso:: :py:func:`skippedGdalDrivers`
 %End
 
+    static void registerGdalDriversFromSettings();
+%Docstring
+Register gdal drivers, excluding the ones mentioned in "gdal/skipList" setting.
+
+.. versionadded:: 3.10
+%End
+
+    static QStringList deferredSkippedGdalDrivers();
+%Docstring
+Returns the list of gdal drivers that have been disabled in the current session,
+and thus, for safety, should not be disabled right now, but at the
+next application restart.
+
+.. versionadded:: 3.10
+%End
+
+    static void setSkippedGdalDrivers( const QStringList &skippedGdalDrivers,
+                                       const QStringList &deferredSkippedGdalDrivers );
+%Docstring
+Sets the list of gdal drivers that should be disabled (``skippedGdalDrivers``),
+but excludes for now the ones defines in ``deferredSkippedGdalDrivers``.
+This writes the "gdal/skipList" setting.
+
+.. versionadded:: 3.10
+%End
+
     static int maxThreads();
 %Docstring
 Gets maximum concurrent thread count

--- a/src/core/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/core/providers/gdal/qgsgdalproviderbase.cpp
@@ -26,6 +26,8 @@
 #include "qgsgdalproviderbase.h"
 #include "qgssettings.h"
 
+#include <mutex>
+
 QgsGdalProviderBase::QgsGdalProviderBase()
 {
 
@@ -219,18 +221,8 @@ int QgsGdalProviderBase::colorInterpretationFromGdal( const GDALColorInterp gdal
 
 void QgsGdalProviderBase::registerGdalDrivers()
 {
-  GDALAllRegister();
-  QgsSettings mySettings;
-  QString myJoinedList = mySettings.value( QStringLiteral( "gdal/skipList" ), "" ).toString();
-  if ( !myJoinedList.isEmpty() )
-  {
-    QStringList myList = myJoinedList.split( ' ' );
-    for ( int i = 0; i < myList.size(); ++i )
-    {
-      QgsApplication::skipGdalDriver( myList.at( i ) );
-    }
-    QgsApplication::applyGdalSkippedDrivers();
-  }
+  static std::once_flag initialized;
+  std::call_once( initialized, QgsApplication::registerGdalDriversFromSettings );
 }
 
 QgsRectangle QgsGdalProviderBase::extent( GDALDatasetH gdalDataset )const

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -128,6 +128,7 @@ QString ABISYM( QgsApplication::mCfgIntDir );
 #endif
 QString ABISYM( QgsApplication::mBuildOutputPath );
 QStringList ABISYM( QgsApplication::mGdalSkipList );
+QStringList QgsApplication::sDeferredSkippedGdalDrivers;
 int ABISYM( QgsApplication::mMaxThreads );
 QString ABISYM( QgsApplication::mAuthDbDirPath );
 
@@ -1555,10 +1556,41 @@ void QgsApplication::restoreGdalDriver( const QString &driver )
   applyGdalSkippedDrivers();
 }
 
+void QgsApplication::setSkippedGdalDrivers( const QStringList &skippedGdalDrivers,
+    const QStringList &deferredSkippedGdalDrivers )
+{
+  ABISYM( mGdalSkipList ) = skippedGdalDrivers;
+  sDeferredSkippedGdalDrivers = deferredSkippedGdalDrivers;
+
+  QgsSettings settings;
+  settings.setValue( QStringLiteral( "gdal/skipList" ), skippedGdalDrivers.join( QStringLiteral( " " ) ) );
+
+  applyGdalSkippedDrivers();
+}
+
+void QgsApplication::registerGdalDriversFromSettings()
+{
+  QgsSettings settings;
+  QString joinedList = settings.value( QStringLiteral( "gdal/skipList" ), QString() ).toString();
+  QStringList myList;
+  if ( !joinedList.isEmpty() )
+  {
+    myList = joinedList.split( ' ' );
+  }
+  ABISYM( mGdalSkipList ) = myList;
+  applyGdalSkippedDrivers();
+}
+
 void QgsApplication::applyGdalSkippedDrivers()
 {
   ABISYM( mGdalSkipList ).removeDuplicates();
-  QString myDriverList = ABISYM( mGdalSkipList ).join( QStringLiteral( " " ) );
+  QStringList realDisabledDriverList;
+  for ( const auto &driverName : ABISYM( mGdalSkipList ) )
+  {
+    if ( !sDeferredSkippedGdalDrivers.contains( driverName ) )
+      realDisabledDriverList << driverName;
+  }
+  QString myDriverList = realDisabledDriverList.join( ' ' );
   QgsDebugMsg( QStringLiteral( "Gdal Skipped driver list set to:" ) );
   QgsDebugMsg( myDriverList );
   CPLSetConfigOption( "GDAL_SKIP", myDriverList.toUtf8() );

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -515,7 +515,7 @@ class CORE_EXPORT QgsApplication : public QApplication
      * Sets the GDAL_SKIP environment variable to exclude the specified driver
      * and then calls GDALDriverManager::AutoSkipDrivers() to unregister it. The
      * driver name should be the short format of the Gdal driver name e.g. GTIFF.
-     */
+    */
     static void restoreGdalDriver( const QString &driver );
 
     /**
@@ -528,8 +528,32 @@ class CORE_EXPORT QgsApplication : public QApplication
      * Apply the skipped drivers list to gdal
      * \see skipGdalDriver
      * \see restoreGdalDriver
-     * \see skippedGdalDrivers */
+     * \see skippedGdalDrivers
+     */
     static void applyGdalSkippedDrivers();
+
+    /**
+     * Register gdal drivers, excluding the ones mentioned in "gdal/skipList" setting.
+     * \since QGIS 3.10
+     */
+    static void registerGdalDriversFromSettings();
+
+    /**
+     * Returns the list of gdal drivers that have been disabled in the current session,
+     * and thus, for safety, should not be disabled right now, but at the
+     * next application restart.
+     * \since QGIS 3.10
+     */
+    static QStringList deferredSkippedGdalDrivers() { return sDeferredSkippedGdalDrivers; }
+
+    /**
+     * Sets the list of gdal drivers that should be disabled (\a skippedGdalDrivers),
+     * but excludes for now the ones defines in \a deferredSkippedGdalDrivers.
+     * This writes the "gdal/skipList" setting.
+     * \since QGIS 3.10
+     */
+    static void setSkippedGdalDrivers( const QStringList &skippedGdalDrivers,
+                                       const QStringList &deferredSkippedGdalDrivers );
 
     /**
      * Gets maximum concurrent thread count
@@ -857,6 +881,12 @@ class CORE_EXPORT QgsApplication : public QApplication
      * List of gdal drivers to be skipped. Uses GDAL_SKIP to exclude them.
      * \see skipGdalDriver, restoreGdalDriver */
     static QStringList ABISYM( mGdalSkipList );
+
+    /**
+     * List of gdal drivers that have been disabled in the current session,
+     * and thus, for safety, should not be disabled right now, but at the
+     * next application restart */
+    static QStringList sDeferredSkippedGdalDrivers;
 
     /**
      * \since QGIS 2.4 */


### PR DESCRIPTION
This is a follow-up of #31772

Driver de-registration is now defered after application restart to avoid
any risk of potential crashes if a dataset using a disabled driver was
already in use.

(revives https://github.com/qgis/QGIS/pull/31801 that was forgotten and address its review comments)