### PR TITLE
do not stop package layer algo when an error occured with one layer

### DIFF
--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -169,7 +169,7 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
   }
 
   if ( errored )
-    throw QgsProcessingException( QObject::tr( "Error obtained while packaging one or more layers." ) );
+    feedback->reportError( QObject::tr( "Error obtained while packaging one or more layers." ) );
 
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), packagePath );


### PR DESCRIPTION
## Description

Some layers can fail to be imported into the geopackage.
Before, the algorithm would continue until the end with other layers. And only at the end an exception is raised.

@nyalldawson I know this has been discussed before, and I saw your comment: https://github.com/qgis/QGIS/blob/master/src/analysis/processing/qgsalgorithmpackage.cpp#L129

Let's not raise an exception, just report errors. Users can have the list of layers packaged in the output.
I'm using this algorithm in a python plugin so I need to programmatically know layers which haven't been imported. Ideally, we should have another output with not packaged layers ID?

Before:
```
Packaging layer 1/24: _val_raepa_etat_canal_ass
Packaging layer 2/24: _val_raepa_forme_canal_ass
Packaging layer 3/24: _val_raepa_precision_annee
Packaging layer 4/24: _val_raepa_type_intervention_ass
Packaging layer 5/24: Appareils
Packaging layer failed: Unsupported type for field _temp_data
Packaging layer 6/24: Canalisations
Packaging layer failed: Unsupported type for field _temp_data
Packaging layer 7/24: raepa_canalass_l
Packaging layer failed: Unsupported type for field _temp_data
Packaging layer 8/24: Ouvrages
Packaging layer failed: Unsupported type for field _temp_data
Packaging layer 9/24: sys_organisme_gestionnaire
Packaging layer 10/24: val_raepa_cat_canal_ae
Packaging layer 11/24: val_raepa_cat_canal_ass
Packaging layer 12/24: val_raepa_fonc_app_ae
Packaging layer 13/24: val_raepa_fonc_app_ass
Packaging layer 14/24: val_raepa_fonc_canal_ae
Packaging layer 15/24: val_raepa_fonc_canal_ass
Packaging layer 16/24: val_raepa_fonc_ouv_ae
Packaging layer 17/24: val_raepa_fonc_ouv_ass
Packaging layer 18/24: val_raepa_materiau
Packaging layer 19/24: val_raepa_mode_circulation
Packaging layer 20/24: val_raepa_qualite_anpose
Packaging layer 21/24: val_raepa_qualite_geoloc
Packaging layer 22/24: val_raepa_support_reparation
Packaging layer 23/24: val_raepa_typ_reseau_ass
Packaging layer 24/24: val_raepa_type_defaillance
Error obtained while packaging one or more layers.
Execution failed after 1.84 seconds

Loading resulting layers
Algorithm 'Package layers' finished
```

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
