### PR TITLE
Format legend name for remote rasters added via http/https/ftp

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13430,12 +13430,12 @@ QgsRasterLayer *QgisApp::addRasterLayerPrivate(
   }
 
   QString shortName = name;
-  QRegularExpression reRasterFile( "^/vsi(.+/)*([^ ]+)( .+)?$", QRegularExpression::CaseInsensitiveOption );
+  QRegularExpression reRasterFile( QStringLiteral( "^/vsi(.+/)*([^ ]+)( .+)?$" ), QRegularExpression::CaseInsensitiveOption );
   QRegularExpressionMatch matchRasterFile = reRasterFile.match( name );
 
   if ( matchRasterFile.hasMatch() )
   {
-    if ( matchRasterFile.captured( 2 ).length() > 5 )
+    if ( matchRasterFile.captured( 2 ).length() > 0 )
     {
       shortName = matchRasterFile.captured( 2 );
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13429,8 +13429,20 @@ QgsRasterLayer *QgisApp::addRasterLayerPrivate(
     refreshBlocker = qgis::make_unique< QgsCanvasRefreshBlocker >();
   }
 
+  QString shortName = name;
+  QRegularExpression reRasterFile( "^/vsi(.+/)*([^ ]+)( .+)?$", QRegularExpression::CaseInsensitiveOption );
+  QRegularExpressionMatch matchRasterFile = reRasterFile.match( name );
+
+  if ( matchRasterFile.hasMatch() )
+  {
+    if ( matchRasterFile.captured( 2 ).length() > 5 )
+    {
+      shortName = matchRasterFile.captured( 2 );
+    }
+  }
+
   QgsSettings settings;
-  QString baseName =  settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() ? QgsMapLayer::formatLayerName( name ) : name;
+  QString baseName =  settings.value( QStringLiteral( "qgis/formatLayerName" ), false ).toBool() ? QgsMapLayer::formatLayerName( shortName ) : shortName;
 
   QgsDebugMsg( "Creating new raster layer using " + uri
                + " with baseName of " + baseName );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13435,7 +13435,7 @@ QgsRasterLayer *QgisApp::addRasterLayerPrivate(
 
   if ( matchRasterFile.hasMatch() )
   {
-    if ( matchRasterFile.captured( 2 ).length() > 0 )
+    if ( !matchRasterFile.captured( 2 ).isEmpty() )
     {
       shortName = matchRasterFile.captured( 2 );
     }


### PR DESCRIPTION
## Description

As described in the issue #31636, legend names can became quite huge and **expose the user credentials**. This PR tries to get the filename from the _uri_, discarding anything until the last slash and everything after the first space. It is based on the regular expression:

```cpp
QRegularExpression reRasterFile( "^/vsi(.+/)*([^ ]+)( .+)?$", QRegularExpression::CaseInsensitiveOption );
```

On the screenshot below, we can see the names before this PR and after the PR. For both names, we toggle the _formatLayerName_ advanced setting (so the legend gets capitalized).

![remote raster legend name](https://user-images.githubusercontent.com/163681/66443308-6e3aed80-ea36-11e9-9902-7416b694deb3.png)

Fix #31636

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
