### PR TITLE
Qgs quick/external widget update #2

### DIFF
--- a/src/quickgui/images/ic_back.svg
+++ b/src/quickgui/images/ic_back.svg
@@ -1,10 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="30px" height="30px" viewBox="0 0 30 30" enable-background="new 0 0 30 30" xml:space="preserve">
-<path d="M18.125,3.047C18.49,2.683,18.934,2.5,19.453,2.5c0.521,0,0.965,0.183,1.328,0.547L22.5,4.844
-	c0.365,0.364,0.547,0.808,0.547,1.328s-0.182,0.938-0.547,1.25L15,15l7.5,7.5c0.365,0.364,0.547,0.808,0.547,1.328
-	s-0.182,0.964-0.547,1.328l-1.719,1.797c-0.363,0.364-0.807,0.547-1.328,0.547c-0.52,0-0.963-0.183-1.328-0.547L7.5,16.328
-	C7.137,15.964,6.953,15.521,6.953,15s0.184-0.964,0.547-1.328L18.125,3.047z"/>
-</svg>
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24"><path d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z" /></svg>

--- a/src/quickgui/images/ic_back.svg
+++ b/src/quickgui/images/ic_back.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="30px" height="30px" viewBox="0 0 30 30" enable-background="new 0 0 30 30" xml:space="preserve">
+<path d="M18.125,3.047C18.49,2.683,18.934,2.5,19.453,2.5c0.521,0,0.965,0.183,1.328,0.547L22.5,4.844
+	c0.365,0.364,0.547,0.808,0.547,1.328s-0.182,0.938-0.547,1.25L15,15l7.5,7.5c0.365,0.364,0.547,0.808,0.547,1.328
+	s-0.182,0.964-0.547,1.328l-1.719,1.797c-0.363,0.364-0.807,0.547-1.328,0.547c-0.52,0-0.963-0.183-1.328-0.547L7.5,16.328
+	C7.137,15.964,6.953,15.521,6.953,15s0.184-0.964,0.547-1.328L18.125,3.047z"/>
+</svg>

--- a/src/quickgui/images/images.qrc
+++ b/src/quickgui/images/images.qrc
@@ -12,5 +12,6 @@
         <file>ic_camera.svg</file>
         <file>ic_gallery.svg</file>
         <file>ic_today.svg</file>
+        <file>ic_back.svg</file>
     </qresource>
 </RCC>

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -138,6 +138,13 @@ Item {
     }
   ]
 
+  onVisibleChanged: {
+    if (visible) {
+      image.currentValue = value
+      image.source = image.getSource()
+    }
+  }
+
   Loader {
     id: photoCapturePanelLoader
   }

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -139,13 +139,6 @@ Item {
     }
   ]
 
-  onVisibleChanged: {
-    if (visible) {
-      image.currentValue = value
-      image.source = image.getSource()
-    }
-  }
-
   Loader {
     id: photoCapturePanelLoader
   }
@@ -182,8 +175,6 @@ Item {
       onCurrentValueChanged: {
         image.source = image.getSource()
       }
-
-      Component.onCompleted: image.source = getSource()
 
       function getSource() {
         var absolutePath = getAbsolutePath(prefixToRelativePath, image.currentValue)

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -61,6 +61,7 @@ Item {
   property var galleryIcon: customStyle.icons.gallery
   property var brokenImageIcon: customStyle.icons.brokenImage
   property var notAvailableImageIcon: customStyle.icons.notAvailable
+  property var backIcon: customStyle.icons.back
   property real iconSize:  customStyle.fields.height
   property real textMargin: QgsQuick.Utils.dp * 10
   /**
@@ -275,6 +276,7 @@ Item {
               photoCapturePanelLoader.item.width = window.width
               photoCapturePanelLoader.item.edge = Qt.RightEdge
               photoCapturePanelLoader.item.imageButtonSize = fieldItem.iconSize
+              photoCapturePanelLoader.item.backButtonSource = fieldItem.backIcon
             }
             photoCapturePanelLoader.item.visible = true
             photoCapturePanelLoader.item.targetDir = targetDir

--- a/src/quickgui/plugin/qgsquickfeatureformstyling.qml
+++ b/src/quickgui/plugin/qgsquickfeatureformstyling.qml
@@ -79,6 +79,7 @@ QtObject {
     property var brokenImage: QgsQuick.Utils.getThemeIcon("ic_broken_image_black")
     property var notAvailable: QgsQuick.Utils.getThemeIcon("ic_photo_notavailable_white")
     property var today: QgsQuick.Utils.getThemeIcon("ic_today")
+    property var back: QgsQuick.Utils.getThemeIcon("ic_back")
   }
 
 }

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -61,7 +61,7 @@ Drawer {
 
   background: Rectangle {
     color: photoPanel.bgColor
-    //opacity: photoPanel.bgOpacity
+    opacity: photoPanel.bgOpacity
   }
 
   onVisibleChanged: {

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -229,18 +229,12 @@ Drawer {
       }
     }
 
-    Rectangle {
+    Item {
       id: backButton
 
-      property int borderWidth: 5 * QgsQuick.Utils.dp
-      property real scaleRatio: 0.7
-      width: buttonSize * scaleRatio
-      height: buttonSize * scaleRatio
-      color: "white"
-      opacity: 0.5
-      border.color: photoPanel.borderColor
-      border.width: borderWidth
-      radius: width*0.5
+      property int borderWidth: 50 * QgsQuick.Utils.dp
+      width: imageButtonSize * 0.7
+      height: width
       antialiasing: true
 
       MouseArea {
@@ -251,12 +245,21 @@ Drawer {
       }
 
       Image {
+        id: backBtnIcon
         fillMode: Image.PreserveAspectFit
         anchors.centerIn: parent
-        sourceSize.height: imageButtonSize * backButton.scaleRatio
-        sourceSize.width: imageButtonSize * backButton.scaleRatio
-        height: imageButtonSize * backButton.scaleRatio
+        sourceSize.height: backButton.width
+        sourceSize.width: backButton.width
+        height: backButton.width
         source: photoPanel.backButtonSource
+      }
+
+      ColorOverlay {
+        anchors.fill: backBtnIcon
+        anchors.centerIn: parent
+        source: backBtnIcon
+        color: "white"
+        smooth: true
       }
     }
   }

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -38,11 +38,20 @@ Drawer {
   property var captureButtonIcon: QgsQuick.Utils.getThemeIcon("ic_camera_alt_border")
   property var confirmButtonIcon: QgsQuick.Utils.getThemeIcon("ic_check_black")
   property var cancelButtonIcon: QgsQuick.Utils.getThemeIcon("ic_clear_black")
+  property var backButtonSource: QgsQuick.Utils.getThemeIcon("ic_back")
   property real imageButtonSize: 45 * QgsQuick.Utils.dp
   property real buttonSize: imageButtonSize * 1.2
   property var buttonsPosition
 
   signal confirmButtonClicked(string path, string filename)
+
+  function cancelEvent() {
+    captureItem.saveImage = false
+    photoPreview.visible = false
+    if (camera.imageCapture.capturedImagePath != "") {
+      QgsQuick.Utils.removeFile(camera.imageCapture.capturedImagePath)
+    }
+  }
 
   id: photoPanel
   visible: false
@@ -52,7 +61,7 @@ Drawer {
 
   background: Rectangle {
     color: photoPanel.bgColor
-    opacity: photoPanel.bgOpacity
+    //opacity: photoPanel.bgOpacity
   }
 
   onVisibleChanged: {
@@ -63,6 +72,7 @@ Drawer {
       camera.stop()
       photoPreview.visible = false
     }
+    photoPreview.source = ""
   }
 
   // PhotoCapture item
@@ -165,13 +175,7 @@ Drawer {
 
           MouseArea {
             anchors.fill: parent
-            onClicked: {
-              captureItem.saveImage = false
-              photoPreview.visible = false
-              if (camera.imageCapture.capturedImagePath != "") {
-                QgsQuick.Utils.removeFile(camera.imageCapture.capturedImagePath)
-              }
-            }
+            onClicked: photoPanel.cancelEvent()
           }
 
           Image {
@@ -220,6 +224,37 @@ Drawer {
             source: photoPanel.confirmButtonIcon
           }
         }
+      }
+    }
+
+    Rectangle {
+      id: backButton
+
+      property int borderWidth: 5 * QgsQuick.Utils.dp
+      property real scaleRatio: 0.7
+      width: buttonSize * scaleRatio
+      height: buttonSize * scaleRatio
+      color: "white"
+      opacity: 0.5
+      border.color: photoPanel.borderColor
+      border.width: borderWidth
+      radius: width*0.5
+      antialiasing: true
+
+      MouseArea {
+        anchors.fill: parent
+        onClicked: {
+          cancelButton.visible ? photoPanel.cancelEvent() : photoPanel.close()
+        }
+      }
+
+      Image {
+        fillMode: Image.PreserveAspectFit
+        anchors.centerIn: parent
+        sourceSize.height: imageButtonSize * backButton.scaleRatio
+        sourceSize.width: imageButtonSize * backButton.scaleRatio
+        height: imageButtonSize * backButton.scaleRatio
+        source: photoPanel.backButtonSource
       }
     }
   }

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -45,7 +45,7 @@ Drawer {
 
   signal confirmButtonClicked(string path, string filename)
 
-  function cancelEvent() {
+  function discardCapturedImage() {
     captureItem.saveImage = false
     photoPreview.visible = false
     if (camera.imageCapture.capturedImagePath != "") {
@@ -72,7 +72,6 @@ Drawer {
       camera.stop()
       photoPreview.visible = false
     }
-    photoPreview.source = ""
   }
 
   // PhotoCapture item
@@ -178,7 +177,7 @@ Drawer {
 
         MouseArea {
           anchors.fill: parent
-          onClicked:photoPanel.cancelEvent()
+          onClicked:photoPanel.discardCapturedImage()
         }
 
         Image {
@@ -240,7 +239,7 @@ Drawer {
       MouseArea {
         anchors.fill: parent
         onClicked: {
-          cancelButton.visible ? photoPanel.cancelEvent() : photoPanel.close()
+          cancelButton.visible ? photoPanel.discardCapturedImage() : photoPanel.close()
         }
       }
 

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -233,7 +233,7 @@ Drawer {
       id: backButton
 
       property int borderWidth: 50 * QgsQuick.Utils.dp
-      width: imageButtonSize * 0.7
+      width: imageButtonSize * 1.5
       height: width
       antialiasing: true
 
@@ -248,9 +248,9 @@ Drawer {
         id: backBtnIcon
         fillMode: Image.PreserveAspectFit
         anchors.centerIn: parent
-        sourceSize.height: backButton.width
-        sourceSize.width: backButton.width
-        height: backButton.width
+        height: imageButtonSize / 2
+        sourceSize.height: height
+        sourceSize.width: height
         source: photoPanel.backButtonSource
       }
 

--- a/src/quickgui/plugin/qgsquickphotopanel.qml
+++ b/src/quickgui/plugin/qgsquickphotopanel.qml
@@ -112,6 +112,7 @@ Drawer {
     VideoOutput {
       id: videoOutput
       source: camera
+      visible: !photoPreview.visible
       focus : visible // to receive focus and capture key events when visible
       anchors.fill: parent
       autoOrientation: true
@@ -149,80 +150,81 @@ Drawer {
         }
 
       }
+    }
 
-      Image {
-        id: photoPreview
-        width: parent.width
-        height: parent.height
-        fillMode: Image.PreserveAspectFit
-        onVisibleChanged: if (!photoPreview.visible) photoPreview.source = ""
+    Image {
+      id: photoPreview
+      width: parent.width
+      height: parent.height
+      fillMode: Image.PreserveAspectFit
+      visible: false
+      onVisibleChanged: if (!photoPreview.visible) photoPreview.source = ""
 
-        // Cancel button
-        Rectangle {
-          id: cancelButton
-          visible: camera.imageCapture.capturedImagePath != ""
+      // Cancel button
+      Rectangle {
+        id: cancelButton
+        visible: camera.imageCapture.capturedImagePath != ""
 
-          property int borderWidth: 5 * QgsQuick.Utils.dp
-          width: buttonSize
-          height: buttonSize
-          color: "white"
-          border.color: photoPanel.borderColor
-          anchors.right: parent.right
-          anchors.top: confirmButton.bottom
-          border.width: borderWidth
-          radius: width*0.5
-          antialiasing: true
+        property int borderWidth: 5 * QgsQuick.Utils.dp
+        width: buttonSize
+        height: buttonSize
+        color: "white"
+        border.color: photoPanel.borderColor
+        anchors.right: parent.right
+        anchors.top: confirmButton.bottom
+        border.width: borderWidth
+        radius: width*0.5
+        antialiasing: true
 
-          MouseArea {
-            anchors.fill: parent
-            onClicked: photoPanel.cancelEvent()
-          }
+        MouseArea {
+          anchors.fill: parent
+          onClicked:photoPanel.cancelEvent()
+        }
 
-          Image {
-            fillMode: Image.PreserveAspectFit
-            anchors.centerIn: parent
-            sourceSize.height: imageButtonSize
-            sourceSize.width: imageButtonSize
-            height: imageButtonSize
-            source: photoPanel.cancelButtonIcon
+        Image {
+          fillMode: Image.PreserveAspectFit
+          anchors.centerIn: parent
+          sourceSize.height: imageButtonSize
+          sourceSize.width: imageButtonSize
+          height: imageButtonSize
+          source: photoPanel.cancelButtonIcon
+        }
+      }
+
+      // Confirm button
+      Rectangle {
+        id: confirmButton
+        visible: camera.imageCapture.capturedImagePath != ""
+
+        property int borderWidth: 5 * QgsQuick.Utils.dp
+        width: buttonSize
+        height: buttonSize
+        color: "white"
+        border.color: photoPanel.borderColor
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        border.width: borderWidth
+        radius: width*0.5
+        antialiasing: true
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: {
+            captureItem.saveImage = true
+            photoPanel.visible = false
+            photoPanel.lastPhotoName = QgsQuick.Utils.getRelativePath(camera.imageCapture.capturedImagePath, photoPanel.prefixToRelativePath)
+            confirmButtonClicked(photoPanel.prefixToRelativePath, photoPanel.lastPhotoName)
           }
         }
 
-        // Confirm button
-        Rectangle {
-          id: confirmButton
-          visible: camera.imageCapture.capturedImagePath != ""
-
-          property int borderWidth: 5 * QgsQuick.Utils.dp
-          width: buttonSize
-          height: buttonSize
-          color: "white"
-          border.color: photoPanel.borderColor
-          anchors.right: parent.right
-          anchors.verticalCenter: parent.verticalCenter
-          border.width: borderWidth
-          radius: width*0.5
-          antialiasing: true
-
-          MouseArea {
-            anchors.fill: parent
-            onClicked: {
-              captureItem.saveImage = true
-              photoPanel.visible = false
-              photoPanel.lastPhotoName = QgsQuick.Utils.getRelativePath(camera.imageCapture.capturedImagePath, photoPanel.prefixToRelativePath)
-              confirmButtonClicked(photoPanel.prefixToRelativePath, photoPanel.lastPhotoName)
-            }
-          }
-
-          Image {
-            fillMode: Image.PreserveAspectFit
-            anchors.centerIn: parent
-            sourceSize.height: imageButtonSize
-            sourceSize.width: imageButtonSize
-            height: imageButtonSize
-            width: imageButtonSize
-            source: photoPanel.confirmButtonIcon
-          }
+        Image {
+          fillMode: Image.PreserveAspectFit
+          anchors.centerIn: parent
+          sourceSize.height: imageButtonSize
+          sourceSize.width: imageButtonSize
+          height: imageButtonSize
+          width: imageButtonSize
+          source: photoPanel.confirmButtonIcon
         }
       }
     }


### PR DESCRIPTION
Some improvements related to external resource widget and photopanel

- Added back button on PhotoPanel
- Split preview and camera output - preview's dimension depends on captured image and if the image doesn't fill a whole screen, camera output is still visible on the background (fixed by this PR)

Back button looks like this:
![Screenshot_2019-10-09-14-23-48-257_uk co lutraconsulting](https://user-images.githubusercontent.com/6735606/66481458-446ae080-eaa1-11e9-8a89-216cfdbe78ef.png)
