### PR TITLE
prevent clearing selection in QgsFeatureListView

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -135,8 +135,10 @@ void QgsFeatureListView::mousePressEvent( QMouseEvent *event )
 
     if ( QgsFeatureListViewDelegate::EditElement == mItemDelegate->positionToElement( event->pos() ) )
     {
+
       mEditSelectionDrag = true;
-      setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
+      if ( index.isValid() )
+        setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
     }
     else
     {
@@ -236,7 +238,8 @@ void QgsFeatureListView::mouseMoveEvent( QMouseEvent *event )
 
   if ( mEditSelectionDrag )
   {
-    setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
+    if ( index.isValid() )
+      setEditSelection( mModel->mapToMaster( index ), QItemSelectionModel::ClearAndSelect );
   }
   else
   {


### PR DESCRIPTION
this removes warning in debug mode about invalid model

currently, the unselection is not used in the dual view and the signal (currentEditSelectionChanged) is only emitted when the selection count is 1 (so never emitted when clearing the selection)

it might makes sense to implement a clear selection in the feature list view but it has to emit proper signals and the dual view must be adapted to clear the form on the right

