### PR TITLE
When using estimated metadata, skip NULL geometries

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1656,10 +1656,11 @@ void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &l
       // our estimatation ignores that a where clause might restrict the feature type or srid
       if ( useEstimatedMetadata )
       {
-        table = QStringLiteral( "(SELECT %1 FROM %2%3 LIMIT %4) AS t" )
+        table = QStringLiteral( "(SELECT %1 FROM %2%3 WHERE %4 IS NOT NULL LIMIT %5) AS t" )
                 .arg( quotedIdentifier( layerProperty.geometryColName ),
                       table,
                       layerProperty.sql.isEmpty() ? QString() : QStringLiteral( " WHERE %1" ).arg( layerProperty.sql ) )
+                .arg( layerProperty.geometryColName )
                 .arg( GEOM_TYPE_SELECT_LIMIT );
       }
       else if ( !layerProperty.sql.isEmpty() )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -2112,7 +2112,7 @@ QgsDataSourceUri QgsPostgresConn::connUri( const QString &connName )
   }
   QString database = settings.value( key + "/database" ).toString();
 
-  bool useEstimatedMetadata = settings.value( key + "/estimatedMetadata", false ).toBool();
+  bool estimatedMetadata = useEstimatedMetadata( connName );
   QgsDataSourceUri::SslMode sslmode = settings.enumValue( key + "/sslmode", QgsDataSourceUri::SslPrefer );
 
   QString username;
@@ -2149,7 +2149,7 @@ QgsDataSourceUri QgsPostgresConn::connUri( const QString &connName )
   {
     uri.setConnection( host, port, database, username, password, sslmode, authcfg );
   }
-  uri.setUseEstimatedMetadata( useEstimatedMetadata );
+  uri.setUseEstimatedMetadata( estimatedMetadata );
 
   return uri;
 }
@@ -2173,6 +2173,14 @@ bool QgsPostgresConn::dontResolveType( const QString &connName )
 
   return settings.value( "/PostgreSQL/connections/" + connName + "/dontResolveType", false ).toBool();
 }
+
+bool QgsPostgresConn::useEstimatedMetadata( const QString &connName )
+{
+  QgsSettings settings;
+
+  return settings.value( "/PostgreSQL/connections/" + connName + "/estimatedMetadata", false ).toBool();
+}
+
 
 bool QgsPostgresConn::allowGeometrylessTables( const QString &connName )
 {

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -376,6 +376,7 @@ class QgsPostgresConn : public QObject
     static bool publicSchemaOnly( const QString &connName );
     static bool geometryColumnsOnly( const QString &connName );
     static bool dontResolveType( const QString &connName );
+    static bool useEstimatedMetadata( const QString &connName );
     static bool allowGeometrylessTables( const QString &connName );
     static bool allowProjectsInDatabase( const QString &connName );
     static void deleteConnection( const QString &connName );

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -400,6 +400,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
   }
 
   bool dontResolveType = QgsPostgresConn::dontResolveType( mConnectionName );
+  bool estimatedMetadata = QgsPostgresConn::useEstimatedMetadata( mConnectionName );
   const auto constLayerProperties = layerProperties;
   for ( QgsPostgresLayerProperty layerProperty : constLayerProperties )
   {
@@ -415,8 +416,7 @@ QVector<QgsDataItem *> QgsPGSchemaItem::createChildren()
         //QgsDebugMsg( QStringLiteral( "skipping column %1.%2 without type constraint" ).arg( layerProperty.schemaName ).arg( layerProperty.tableName ) );
         continue;
       }
-
-      conn->retrieveLayerTypes( layerProperty, true /* useEstimatedMetadata */ );
+      conn->retrieveLayerTypes( layerProperty, estimatedMetadata );
     }
 
     for ( int i = 0; i < layerProperty.size(); i++ )

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -324,6 +324,7 @@ QList<QgsPostgresProviderConnection::TableProperty> QgsPostgresProviderConnectio
       const bool aspatial { ! flags || flags.testFlag( TableFlag::Aspatial ) };
       conn->supportedLayers( properties, false, schema == QStringLiteral( "public" ), aspatial, schema );
       bool dontResolveType = configuration().value( QStringLiteral( "dontResolveType" ), false ).toBool();
+      bool useEstimatedMetadata = configuration().value( QStringLiteral( "estimatedMetadata" ), false ).toBool();
 
       // Cannot be const:
       for ( auto &pr : properties )
@@ -359,7 +360,7 @@ QList<QgsPostgresProviderConnection::TableProperty> QgsPostgresProviderConnectio
                                       ( pr.types.value( 0, QgsWkbTypes::Unknown ) == QgsWkbTypes::Unknown ||
                                         pr.srids.value( 0, std::numeric_limits<int>::min() ) == std::numeric_limits<int>::min() ) ) )
           {
-            conn->retrieveLayerTypes( pr, true /* useEstimatedMetadata */ );
+            conn->retrieveLayerTypes( pr, useEstimatedMetadata );
           }
           QgsPostgresProviderConnection::TableProperty property;
           property.setFlags( prFlags );


### PR DESCRIPTION
This allows determining srid/type of columns having a NULL
geometries in the first 1000 records, at the cost of possibly
scanning whole tables when geometries are ALL nulls.

References #32053