### PR TITLE
[Backport release-3_4][server] Fix crach on WFS Insert

### DIFF
--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -241,7 +241,7 @@ namespace QgsWfs
       for ( int i = 0; i < wfsLayerIds.size(); ++i )
       {
         QgsMapLayer *layer = project->mapLayer( wfsLayerIds.at( i ) );
-        if ( layer->type() != QgsMapLayer::LayerType::VectorLayer )
+        if ( !layer || layer->type() != QgsMapLayer::LayerType::VectorLayer )
         {
           continue;
         }


### PR DESCRIPTION
## Description

When I want to save a geometry from QGIS client on QGIS server WFS transaction QGIS will crach.

Server logs:
```
08:39:46 INFO Server[71]: Qgis Server Settings: 
08:39:46 INFO Server[71]:   - QGIS_OPTIONS_PATH / '' (Override the default path for user configuration): '' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_PARALLEL_RENDERING / '/qgis/parallel_rendering' (Activate/Deactivate parallel rendering for WMS getMap request): 'false' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_MAX_THREADS / '/qgis/max_threads' (Number of threads to use when parallel rendering is activated): '-1' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_LOG_LEVEL / '' (Log level): '0' (read from ENVIRONMENT_VARIABLE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_LOG_FILE / '' (Log file): '' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_LOG_STDERR / '' (Activate/Deactivate logging to stderr): '1' (read from ENVIRONMENT_VARIABLE)
08:39:46 INFO Server[71]:   - QGIS_PROJECT_FILE / '' (QGIS project file): '' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - MAX_CACHE_LAYERS / '' (Specify the maximum number of cached layers): '100' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_CACHE_DIRECTORY / '/cache/directory' (Specify the cache directory): '/tmp/profiles/default/cache' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_CACHE_SIZE / '/cache/size' (Specify the cache size): '52428800' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_SHOW_GROUP_SEPARATOR / '/locale/showGroupSeparator' (Show group (thousands) separator): 'false' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]:   - QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE / '/locale/userLocale' (Override system locale): '' (read from DEFAULT_VALUE)
08:39:46 INFO Server[71]: Ini file used to initialize settings: /tmp/profiles/default/QGIS/QGIS3.ini
08:39:46 INFO Server[71]: cacheDirectory: /tmp/profiles/default/cache/
08:39:46 INFO Server[71]: maximumCacheSize: 52428800
08:39:46 INFO Server[71]: Prefix  PATH: /usr/local
08:39:46 INFO Server[71]: Plugin  PATH: /usr/local/lib/qgis/plugins
08:39:46 INFO Server[71]: PkgData PATH: /usr/local/share/qgis
08:39:46 INFO Server[71]: User DB PATH: /tmp/profiles/default/qgis.db
08:39:46 INFO Server[71]: Auth DB PATH: /tmp/profiles/default/qgis-auth.db
08:39:46 INFO Server[71]: SVG PATHS: /usr/local/share/qgis/svg/:/tmp/profiles/default/svg/
Initializing server modules from  "/usr/local/lib/qgis/server" 

"Checking /usr/local/lib/qgis/server for native services modules"
"Loading native module /usr/local/lib/qgis/server/libdummy.so"
08:39:46 WARNING [71]: Adding service SampleService 1.0
"Loading native module /usr/local/lib/qgis/server/libwcs.so"
08:39:46 WARNING [71]: Adding service WCS 1.0.0
"Loading native module /usr/local/lib/qgis/server/libwfs.so"
08:39:47 WARNING [71]: Adding service WFS 1.1.0
"Loading native module /usr/local/lib/qgis/server/libwms.so"
08:39:47 WARNING [71]: Adding service WMS 1.3.0
"Loading native module /usr/local/lib/qgis/server/libwmts.so"
08:39:47 WARNING [71]: Adding service WMTS 1.0.0
08:39:47 INFO Server[71]: Server initialized
08:39:47 INFO /src/src/server/qgsserverplugins.cpp[71]: load library /usr/local/lib/qgispython (3.4.12)
08:39:47 INFO /src/src/server/qgsserverplugins.cpp[71]: Python support library loaded successfully.
08:39:48 WARNING [71]: Starting GeoMapFish access restriction...
08:39:48 WARNING [71]: Use config '/etc/qgisserver/accesscontrol_config.yaml'.
08:39:48 INFO Server[71]: Server plugin geomapfish_qgisserver loaded!
08:39:48 INFO Server[71]: Server python plugins loaded
08:39:48 INFO Server[71]: ******************** New request ***************
08:39:48 INFO Server[71]: SERVER_NAMEqgisserver
08:39:48 INFO Server[71]: REQUEST_URI/docker/mapserv_proxy/?map=%2Fvar%2Fsig%2Fqgis%2Fmontreuxnoel.qgs&transparent=true&ogcserver=qgis%2Fmontreuxnoel&authentication_required=true&SERVICE=WFS&role_ids=58&user_id=1079
08:39:48 INFO Server[71]: REMOTE_ADDR172.23.0.2
08:39:48 INFO Server[71]: CONTENT_TYPEtext/xml
08:39:48 INFO Server[71]: HTTP_USER_AGENTMozilla/5.0 QGIS/3.4.6-Madeira
08:39:48 INFO Server[71]: AUTHENTICATION_REQUIRED:true
08:39:48 INFO Server[71]: MAP:/var/sig/qgis/montreuxnoel.qgs
08:39:48 INFO Server[71]: OGCSERVER:qgis/montreuxnoel
08:39:48 INFO Server[71]: REQUEST:Transaction
08:39:48 INFO Server[71]: REQUEST_BODY:<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.qgis.org/gml https://preprod.cartoriviera.ch/mapserv_proxy?ogcserver=qgis/montreuxnoel&amp;authentication_required=true&amp;SERVICE=WFS&amp;REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=chalets_gestion" xmlns:gml="http://www.opengis.net/gml"><Insert xmlns="http://www.opengis.net/wfs"><chalets_gestion xmlns="http://www.qgis.org/gml"><geometry xmlns="http://www.qgis.org/gml"><gml:Polygon srsName="EPSG:2056"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates cs="," ts=" ">2557933.86268808972090483,1143042.43758319853805006 2558091.59036501403898001,1142980.42499227100051939 2558052.4954707333818078,1142888.75420568254776299 2558052.4954707333818078,1142888.75420568254776299 2557932.5145882866345346,1142927.84909996297210455 2557933.86268808972090483,1142927.84909996297210455 2557933.86268808972090483,1142927.84909996297210455 2557933.86268808972090483,1142927.84909996297210455 2557933.86268808972090483,1142927.84909996297210455 2557896.11589361215010285,1142968.29209404601715505 2557896.11589361215010285,1142968.29209404601715505 2557933.86268808972090483,1143042.43758319853805006</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></geometry></chalets_gestion></Insert></Transaction>
08:39:48 INFO Server[71]: ROLE_IDS:58
08:39:48 INFO Server[71]: SCHEMALOCATION:http://www.qgis.org/gml https://preprod.cartoriviera.ch/mapserv_proxy?ogcserver=qgis/montreuxnoel&authentication_required=true&SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=1.0.0&TYPENAME=chalets_gestion
08:39:48 INFO Server[71]: SERVICE:WFS
08:39:48 INFO Server[71]: TRANSPARENT:true
08:39:48 INFO Server[71]: USER_ID:1079
08:39:48 INFO Server[71]: VERSION:1.0.0
08:39:48 WARNING [71]: Service WFS 1.0.0 not found, returning default
[Fri Oct 11 08:39:48.860551 2019] [fcgid:warn] [pid 16:tid 140378109097728] [client 172.23.0.2:42298] mod_fcgid: error reading data, FastCGI server closed connection
```

The dump informations:
```
gdb /usr/local/bin/qgis_mapserv.fcgi /tmp/core
GNU gdb (Ubuntu 8.1-0ubuntu3.1) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/local/bin/qgis_mapserv.fcgi...(no debugging symbols found)...done.

warning: core file may not match specified executable file.
[New LWP 85]
[New LWP 95]
[New LWP 96]
[New LWP 88]
[New LWP 87]
[New LWP 86]
[New LWP 89]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/local/bin/qgis_mapserv.fcgi'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f33103fca70 in QgsMapLayer::type() const () from /usr/local/lib/libqgis_core.so.3.4.12
[Current thread is 1 (Thread 0x7f3311ceb380 (LWP 85))]
(gdb) bt
#0  0x00007f33103fca70 in QgsMapLayer::type() const () from /usr/local/lib/libqgis_core.so.3.4.12
#1  0x00007f32dad665da in QgsWfs::v1_0_0::performTransaction(QgsWfs::v1_0_0::transactionRequest&, QgsServerInterface*, QgsProject const*) () from /usr/local/lib/qgis/server/libwfs.so
#2  0x00007f32dad6064e in QgsWfs::v1_0_0::createTransactionDocument(QgsServerInterface*, QgsProject const*, QString const&, QgsServerRequest const&) () from /usr/local/lib/qgis/server/libwfs.so
#3  0x00007f32dad60193 in QgsWfs::v1_0_0::writeTransaction(QgsServerInterface*, QgsProject const*, QString const&, QgsServerRequest const&, QgsServerResponse&) () from /usr/local/lib/qgis/server/libwfs.so
#4  0x00007f32dad21fc0 in QgsWfs::Service::executeRequest(QgsServerRequest const&, QgsServerResponse&, QgsProject const*) () from /usr/local/lib/qgis/server/libwfs.so
#5  0x00007f33118f008c in QgsServer::handleRequest(QgsServerRequest&, QgsServerResponse&, QgsProject const*) () from /usr/local/lib/libqgis_server.so.3.4.12
#6  0x00000000004019f2 in main ()
```

For me it's that layer can be null, Probably the layer is in the project but he isn't loaded...

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
