### PR TITLE
[Server] WFS Service: force Geometry to Multi in GML to be compliant with XML schema provided by DescribeFeatureType

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1307,32 +1307,23 @@ namespace QgsWfs
 
         QDomElement geomElem = doc.createElement( QStringLiteral( "qgs:geometry" ) );
         QDomElement gmlElem;
+        QgsGeometry cloneGeom( geom );
         if ( params.geometryName == QLatin1String( "EXTENT" ) )
         {
-          QgsGeometry bbox = QgsGeometry::fromRect( geom.boundingBox() );
-          gmlElem = QgsOgcUtils::geometryToGML( bbox, doc, prec );
+          cloneGeom = QgsGeometry::fromRect( geom.boundingBox() );
         }
         else if ( params.geometryName == QLatin1String( "CENTROID" ) )
         {
-          QgsGeometry centroid = geom.centroid();
-          gmlElem = QgsOgcUtils::geometryToGML( centroid, doc, prec );
+          cloneGeom = geom.centroid();
         }
-        else
+        else if ( params.forceGeomToMulti && ! QgsWkbTypes::isMultiType( geom.wkbType() ) )
         {
-          if ( params.forceGeomToMulti && ! QgsWkbTypes::isMultiType( geom.wkbType() ) )
-          {
-            QgsGeometry multiGeom = geom;
-            multiGeom.convertToMultiType();
-            gmlElem = QgsOgcUtils::geometryToGML( multiGeom, doc, prec );
-          }
-          else
-          {
-            const QgsAbstractGeometry *abstractGeom = geom.constGet();
-            if ( abstractGeom )
-            {
-              gmlElem = abstractGeom->asGml2( doc, prec, "http://www.opengis.net/gml" );
-            }
-          }
+          cloneGeom.convertToMultiType();
+        }
+        const QgsAbstractGeometry *abstractGeom = cloneGeom.constGet();
+        if ( abstractGeom )
+        {
+          gmlElem = abstractGeom->asGml2( doc, prec, "http://www.opengis.net/gml" );
         }
 
         if ( !gmlElem.isNull() )
@@ -1418,32 +1409,23 @@ namespace QgsWfs
 
         QDomElement geomElem = doc.createElement( QStringLiteral( "qgs:geometry" ) );
         QDomElement gmlElem;
+        QgsGeometry cloneGeom( geom );
         if ( params.geometryName == QLatin1String( "EXTENT" ) )
         {
-          QgsGeometry bbox = QgsGeometry::fromRect( geom.boundingBox() );
-          gmlElem = QgsOgcUtils::geometryToGML( bbox, doc, QStringLiteral( "GML3" ), prec );
+          cloneGeom = QgsGeometry::fromRect( geom.boundingBox() );
         }
         else if ( params.geometryName == QLatin1String( "CENTROID" ) )
         {
-          QgsGeometry centroid = geom.centroid();
-          gmlElem = QgsOgcUtils::geometryToGML( centroid, doc, QStringLiteral( "GML3" ), prec );
+          cloneGeom = geom.centroid();
         }
-        else
+        else if ( params.forceGeomToMulti && ! QgsWkbTypes::isMultiType( geom.wkbType() ) )
         {
-          if ( params.forceGeomToMulti && ! QgsWkbTypes::isMultiType( geom.wkbType() ) )
-          {
-            QgsGeometry multiGeom = geom;
-            multiGeom.convertToMultiType();
-            gmlElem = QgsOgcUtils::geometryToGML( multiGeom, doc, QStringLiteral( "GML3" ), prec );
-          }
-          else
-          {
-            const QgsAbstractGeometry *abstractGeom = geom.constGet();
-            if ( abstractGeom )
-            {
-              gmlElem = abstractGeom->asGml3( doc, prec, "http://www.opengis.net/gml" );
-            }
-          }
+          cloneGeom.convertToMultiType();
+        }
+        const QgsAbstractGeometry *abstractGeom = cloneGeom.constGet();
+        if ( abstractGeom )
+        {
+          gmlElem = abstractGeom->asGml3( doc, prec, "http://www.opengis.net/gml" );
         }
 
         if ( !gmlElem.isNull() )


### PR DESCRIPTION
## Description
It's an adapted to QGIS 3 forward porting of https://github.com/qgis/QGIS/pull/8243

If in the layer level, the geometry is defined as multi, in the GML all the geometry has to be converted to multi. It's needed to validate GML with schema provided by DescribeFeatureType request.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
