### PR TITLE
Abstract content cache: delete task later

### DIFF
--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -378,12 +378,12 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
         {
           if ( mRemoteContentCache.contains( path ) )
           {
-            delete task;
+            task->deleteLater();
             // We got the file!
             return *mRemoteContentCache[ path ];
           }
         }
-        delete task;
+        task->deleteLater();
       }
       else
       {


### PR DESCRIPTION
## Description
Try to fix travis segfault by replacing the `delete task` calls with `task->deleteLater()` in `QgsAbstractContentCache`

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
