### PR TITLE
Wait for finished in abstract content cache when fetching with blocking

### DIFF
--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -372,22 +372,18 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
         QMetaObject::invokeMethod( const_cast< QgsAbstractContentCacheBase * >( qobject_cast< const QgsAbstractContentCacheBase * >( this ) ), "onRemoteContentFetched", Qt::QueuedConnection, Q_ARG( QString, path ), Q_ARG( bool, true ) );
       } );
 
+      QgsApplication::taskManager()->addTask( task );
+
+      // if blocking, wait for finished
+      // arbitrary setting maximum wait to 5 seconds
       if ( blocking )
       {
-        if ( task->run() )
+        task->waitForFinished( 5000 );
+        if ( mRemoteContentCache.contains( path ) )
         {
-          if ( mRemoteContentCache.contains( path ) )
-          {
-            task->deleteLater();
-            // We got the file!
-            return *mRemoteContentCache[ path ];
-          }
+          // We got the file!
+          return *mRemoteContentCache[ path ];
         }
-        task->deleteLater();
-      }
-      else
-      {
-        QgsApplication::taskManager()->addTask( task );
       }
       return fetchingContent;
     }

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -311,9 +311,44 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
       QMutexLocker locker( &mMutex );
 
       // already a request in progress for this url
-      // force requesting remote url if blocking mode
-      if ( mPendingRemoteUrls.contains( path ) && !blocking )
-        return fetchingContent;
+      if ( mPendingRemoteUrls.contains( path ) )
+      {
+        // it's a non blocking request so return fetching content
+        if ( !blocking )
+        {
+          return fetchingContent;
+        }
+
+        // it's a blocking request so try to find the task and wait for task finished
+        const auto constActiveTasks = QgsApplication::taskManager()->activeTasks();
+        for ( QgsTask *task : constActiveTasks )
+        {
+          // the network content fetcher task's description ends with the path
+          if ( !task->description().endsWith( path ) )
+          {
+            continue;
+          }
+
+          // cast task to network content fetcher task
+          QgsNetworkContentFetcherTask *ncfTask = qobject_cast<QgsNetworkContentFetcherTask *>( task );
+          if ( ncfTask )
+          {
+            // wait for task finished
+            if ( waitForTaskFinished( ncfTask ) )
+            {
+              if ( mRemoteContentCache.contains( path ) )
+              {
+                // We got the file!
+                return *mRemoteContentCache[ path ];
+              }
+            }
+          }
+          // task found, no needs to continue
+          break;
+        }
+        // if no content returns the content is probably in remote content cache
+        // or a new task will be created
+      }
 
       if ( mRemoteContentCache.contains( path ) )
       {
@@ -332,7 +367,6 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
       connect( task, &QgsNetworkContentFetcherTask::fetched, this, [this, task, path, missingContent]
       {
         QMutexLocker locker( &mMutex );
-        QgsMessageLog::logMessage( tr( "%2 fetched: %1" ).arg( path, mTypeString ), mTypeString );
 
         QNetworkReply *reply = task->reply();
         if ( !reply )
@@ -373,39 +407,19 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
         QMetaObject::invokeMethod( const_cast< QgsAbstractContentCacheBase * >( qobject_cast< const QgsAbstractContentCacheBase * >( this ) ), "onRemoteContentFetched", Qt::QueuedConnection, Q_ARG( QString, path ), Q_ARG( bool, true ) );
       } );
 
+      QgsApplication::taskManager()->addTask( task );
+
       // if blocking, wait for finished
-      // arbitrary setting maximum wait to 5 seconds
       if ( blocking )
       {
-        // First step, waiting for task running
-        QEventLoop loop;
-        connect( task, &QgsNetworkContentFetcherTask::begun, &loop, &QEventLoop::quit );
-        QgsApplication::taskManager()->addTask( task );
-        if ( task->status() != QgsTask::Running )
+        if ( waitForTaskFinished( task ) )
         {
-          loop.exec();
-        }
-
-        // Second step, wait 5 seconds for task finished
-        if ( task->waitForFinished( 5000 ) )
-        {
-          // The wait did not time out
-          // Third step, check status as complete
-          if ( task->status() == QgsTask::Complete )
+          if ( mRemoteContentCache.contains( path ) )
           {
-            // Fourth step, force the signal fetched to be sure reply has been checked
-            task->fetched();
-            if ( mRemoteContentCache.contains( path ) )
-            {
-              // We got the file!
-              return *mRemoteContentCache[ path ];
-            }
+            // We got the file!
+            return *mRemoteContentCache[ path ];
           }
         }
-      }
-      else
-      {
-        QgsApplication::taskManager()->addTask( task );
       }
       return fetchingContent;
     }
@@ -430,6 +444,42 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
 
       if ( success )
         emit remoteContentFetched( url );
+    }
+
+    /**
+     * Blocks the current thread until the \a task finishes or an arbitrary setting maximum wait to 5 seconds
+     *
+     * \warning this method must NEVER be used from GUI based applications (like the main QGIS application)
+     * or crashes will result. Only for use in external scripts or QGIS server.
+     *
+     * The result will be FALSE if the wait timed out and TRUE in any other case.
+     *
+     * \since QGIS 3.10
+     */
+    bool waitForTaskFinished( QgsNetworkContentFetcherTask *task ) const
+    {
+      // First step, waiting for task running
+      if ( task->status() != QgsTask::Running )
+      {
+        QEventLoop loop;
+        connect( task, &QgsNetworkContentFetcherTask::begun, &loop, &QEventLoop::quit );
+        if ( task->status() != QgsTask::Running )
+          loop.exec();
+      }
+
+      // Second step, wait 5 seconds for task finished
+      if ( task->waitForFinished( 5000 ) )
+      {
+        // The wait did not time out
+        // Third step, check status as complete
+        if ( task->status() == QgsTask::Complete )
+        {
+          // Fourth step, force the signal fetched to be sure reply has been checked
+          task->fetched();
+          return true;
+        }
+      }
+      return false;
     }
 
     /**


### PR DESCRIPTION
## Description
After trying to fix travis segfault with Abstract content cache: delete task later #32218
The commit uses `waitForFinished` with arbitrary setting maximum wait to 5 seconds.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
