### PR TITLE
Change help answer to what is actually shown in the preview

### DIFF
--- a/resources/function_help/json/scale_linear
+++ b/resources/function_help/json/scale_linear
@@ -10,8 +10,8 @@
 	{"arg":"range_max", "description":"Specifies the maximum value in the output range, the largest value which should be output by the function."}
   ],
   "examples": [
-	{ "expression":"scale_linear(5,0,10,0,100)", "returns":"72"},
+	{ "expression":"scale_linear(5,0,10,0,100)", "returns":"50"},
 	{ "expression":"scale_linear(0.2,0,1,0,360)", "returns":"72", "note": "scaling a value between 0 and 1 to an angle between 0 and 360"},
-	{ "expression":"scale_linear(1500,1000,10000,9,20)", "returns":"10.22", "note": "scaling a population which varies between 1000 and 10000 to a font size between 9 and 20"}
+	{ "expression":"scale_linear(1500,1000,10000,9,20)", "returns":"9.6111111", "note": "scaling a population which varies between 1000 and 10000 to a font size between 9 and 20"}
   ]
 }


### PR DESCRIPTION
## Description

Not 100% sure, but I was emailed by Mariëlle that the result in the help text is not in line with the outcome as you see in the Output preview:
I'm not familiar myself with the calculation of it, but from the 3 examples you see in the help window to the right, the first one and the third one differ in result in what is shown there:

![Screenshot-20191012181147-1260x645](https://user-images.githubusercontent.com/731673/66704421-307ee300-ed1c-11e9-9326-927488c91a85.png)

If I just copy "scale_linear(5,0,10,0,100)" (first example) then the "Output review" shows '50'
And the last example "scale_linear(1500,1000,10000,9,20)" shows '9.6111111'

Given the 'Output preview' is ok (please check, I'm not familiar with the calculation), the help text is brought inline with that.
