### PR TITLE
Sort translations in desktop file

### DIFF
--- a/scripts/ts2appinfo.py
+++ b/scripts/ts2appinfo.py
@@ -57,7 +57,7 @@ except AttributeError:
 
 app = QCoreApplication(argvb)
 
-for qm in glob(sys.argv[1] + "/output/i18n/qgis_*.qm"):
+for qm in sorted(glob(sys.argv[1] + "/output/i18n/qgis_*.qm")):
     translator = QTranslator()
     translator.load(qm)
 


### PR DESCRIPTION
## Description

Desktop file generation is non-deterministic - translation positions may vary across builds. This makes the build non-reproducible.

The cause is the use of [`glob()`](https://docs.python.org/3/library/glob.html) which collects qm file paths in a random order, depending on the filesystem. To ensure the translations are written in a fixed order the list returned by `glob()` must be sorted.

See also:
- [reproducible-builds.org](https://reproducible-builds.org/) for context on reproducible builds
- [Issue 25616](https://bugs.python.org/issue25615) in Python's bug tracker, documenting the randomness of `glob()`
- [This page](https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/readdir) for more details for the underlying source of randomness (`readdir()`)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message _=> no existing issue found_
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes _=> not applicable_
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
