### PR TITLE
commenting noisy warnings

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -204,12 +204,12 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
 {
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
-
+/*
 #ifdef QGISDEBUG
   if ( index.model() != mModel->masterModel() )
     qWarning() << "Index from wrong model passed in";
 #endif
-
+*/
   if ( ok )
     mCurrentEditSelectionModel->select( index, command );
 }

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -204,9 +204,9 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
 {
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
-  
-  Q_ASSERT( index.model() == mModel->masterModel() || !index.isValid() )
-    
+
+  Q_ASSERT( index.model() == mModel->masterModel() || !index.isValid() );
+
   if ( ok )
     mCurrentEditSelectionModel->select( index, command );
 }

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -205,19 +205,10 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
   
-  if ( index.isValid() && index.model() != mModel->masterModel() )
-  {
-#ifdef QGISDEBUG 
-    qWarning() << "Index from wrong model passed in";
-#endif
-    if ( ok )
-      mCurrentEditSelectionModel->select( QModelIndex(), command );
-  }
-  else
-  {
-    if ( ok )
-      mCurrentEditSelectionModel->select( index, command );
-  }
+  Q_ASSERT( index.model() == mModel->masterModel() || !index.isValid() )
+    
+  if ( ok )
+    mCurrentEditSelectionModel->select( index, command );
 }
 
 void QgsFeatureListView::repaintRequested( const QModelIndexList &indexes )

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -204,14 +204,20 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
 {
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
-
-#ifdef QGISDEBUG
+  
   if ( index.isValid() && index.model() != mModel->masterModel() )
+  {
+#ifdef QGISDEBUG 
     qWarning() << "Index from wrong model passed in";
 #endif
-
-  if ( ok )
-    mCurrentEditSelectionModel->select( index, command );
+    if ( ok )
+      mCurrentEditSelectionModel->select( QModelIndex(), command );
+  }
+  else
+  {
+    if ( ok )
+      mCurrentEditSelectionModel->select( index, command );
+  }
 }
 
 void QgsFeatureListView::repaintRequested( const QModelIndexList &indexes )

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -204,12 +204,12 @@ void QgsFeatureListView::setEditSelection( const QModelIndex &index, QItemSelect
 {
   bool ok = true;
   emit aboutToChangeEditSelection( ok );
-/*
+
 #ifdef QGISDEBUG
-  if ( index.model() != mModel->masterModel() )
+  if ( index.isValid() && index.model() != mModel->masterModel() )
     qWarning() << "Index from wrong model passed in";
 #endif
-*/
+
   if ( ok )
     mCurrentEditSelectionModel->select( index, command );
 }


### PR DESCRIPTION
These are annoying and prevent from correctly testing QGIS nightlies.
Will be reverted when #32176 is merged

