### PR TITLE
OracleDBConnector: Prevent AttributeError

### DIFF
--- a/python/plugins/db_manager/db_plugins/oracle/connector.py
+++ b/python/plugins/db_manager/db_plugins/oracle/connector.py
@@ -108,6 +108,8 @@ class OracleDBConnector(DBConnector):
                 self.cache_connection = sqlite3.connect(sqlite_cache_file)
             except sqlite3.Error:
                 self.cache_connection = False
+        else:
+            self.cache_connection = False
 
         # Find if there is cache for our connection:
         if self.cache_connection:


### PR DESCRIPTION
In some cases, If os.path.isfile(sqlite_cache_file) is False, the attribute cache_connection was not assigned and so an AttributeError occured in the following lines.