### PR TITLE
[docker] fix cache and enable timeouts for Docker images (on cron jobs)

### DIFF
--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -22,11 +22,13 @@ mkdir -p "${CCACHE_DIR}"
 # copy ccache dir within QGIS source so it can be accessed from docker
 cp -r ${CCACHE_DIR} ${TRAVIS_BUILD_DIR}/.ccache_image_build
 
+echo "Cache directory size: "$( du -h -d=0 ${TRAVIS_BUILD_DIR}/.ccache_image_build)
+
 # calculate timeouts
 CURRENT_TIME=$(date +%s)
 TIMEOUT=$((( TRAVIS_AVAILABLE_TIME - TRAVIS_UPLOAD_TIME ) * 60 - CURRENT_TIME + TRAVIS_TIMESTAMP))
 TIMEOUT=$(( TIMEOUT < 300 ? 300 : TIMEOUT ))
-
+echo "Timeout: ${TIMEOUT}s"
 
 # building docker images
 DIR=$(git rev-parse --show-toplevel)/.docker

--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -42,14 +42,13 @@ docker build --build-arg DOCKER_TAG="${DOCKER_TAG}" \
              -f qgis.dockerfile ..
 
 docker run --name qgis_container qgis/qgis:${DOCKER_TAG} /bin/true
-CONTAINER_ID=$(docker ps -aqf "name=qgis_container")
 
 echo "Copy build cache from Docker container to Travis cache directory"
 rm -rf "${CCACHE_DIR:?}/"*
-docker cp ${CONTAINER_ID}:/usr/src/QGIS/.ccache_image_build ${CCACHE_DIR}
+docker cp qgis_container:/usr/src/QGIS/.ccache_image_build ${CCACHE_DIR}
 popd
 
-docker cp ${CONTAINER_ID}:/usr/src/build_exit_value ${HOME}/build_exit_value
+docker cp qgis_container:/usr/src/build_exit_value ${HOME}/build_exit_value
 if [[ $(cat ${HOME}/build_exit_value) -eq 124 ]]; then
   echo "Build timeout, not pushing image or triggering PyQGIS docs"
   exit 1

--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -17,12 +17,13 @@
 
 set -e
 
-mkdir -p "${CCACHE_DIR}"
+# test if ccache dir exists (coming from Travis cache)
+[[ -d ${{CCACHE_DIR}}]] && echo "cache directory (${CCACHE_DIR}) exists" || mkdir -p "${CCACHE_DIR}"
 
 # copy ccache dir within QGIS source so it can be accessed from docker
 cp -r ${CCACHE_DIR} ${TRAVIS_BUILD_DIR}/.ccache_image_build
 
-echo "Cache directory size: "$( du -h -d=0 ${TRAVIS_BUILD_DIR}/.ccache_image_build)
+echo "Cache directory size: "$(du -h --max-depth=0 ${TRAVIS_BUILD_DIR}/.ccache_image_build)
 
 # calculate timeouts
 CURRENT_TIME=$(date +%s)
@@ -31,8 +32,7 @@ TIMEOUT=$(( TIMEOUT < 300 ? 300 : TIMEOUT ))
 echo "Timeout: ${TIMEOUT}s"
 
 # building docker images
-DIR=$(git rev-parse --show-toplevel)/.docker
-pushd "${DIR}"
+pushd "${TRAVIS_BUILD_DIR}/.docker"
 echo "${bold}Building QGIS Docker image '${DOCKER_TAG}'...${endbold}"
 docker build --build-arg DOCKER_TAG="${DOCKER_TAG}" \
              --build-arg BUILD_TIMEOUT="${TIMEOUT}" \

--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -21,43 +21,55 @@ set -e
 [[ -d ${CCACHE_DIR} ]] && echo "cache directory (${CCACHE_DIR}) exists" || mkdir -p "${CCACHE_DIR}"
 
 # copy ccache dir within QGIS source so it can be accessed from docker
-cp -r ${CCACHE_DIR} ${TRAVIS_BUILD_DIR}/.ccache_image_build
+cp -r ${CCACHE_DIR}/. ${TRAVIS_BUILD_DIR}/.ccache_image_build
 
 echo "Cache directory size: "$(du -h --max-depth=0 ${TRAVIS_BUILD_DIR}/.ccache_image_build)
 
 # calculate timeouts
 CURRENT_TIME=$(date +%s)
 TIMEOUT=$((( TRAVIS_AVAILABLE_TIME - TRAVIS_UPLOAD_TIME ) * 60 - CURRENT_TIME + TRAVIS_TIMESTAMP))
-TIMEOUT=$(( TIMEOUT < 300 ? 300 : TIMEOUT ))
+#TIMEOUT=$(( TIMEOUT < 300 ? 300 : TIMEOUT ))
+TIMEOUT=10
 echo "Timeout: ${TIMEOUT}s"
 
 # building docker images
 pushd "${TRAVIS_BUILD_DIR}/.docker"
 echo "${bold}Building QGIS Docker image '${DOCKER_TAG}'...${endbold}"
-docker build --build-arg DOCKER_TAG="${DOCKER_TAG}" \
-             --build-arg BUILD_TIMEOUT="${TIMEOUT}" \
-             --build-arg CC --build-arg CXX \
+DOCKER_BUILD_ARGS="--build-arg DOCKER_TAG=${DOCKER_TAG} \
+                   --build-arg BUILD_TIMEOUT=${TIMEOUT} \
+                   --build-arg CC --build-arg CXX"
+docker build ${DOCKER_BUILD_ARGS} \
              --cache-from "qgis/qgis:${DOCKER_TAG}" \
-             -t "qgis/qgis:${DOCKER_TAG}" \
+             -t "qgis/qgis:BUILDER" \
              -f qgis.dockerfile ..
 
-docker run --name qgis_container qgis/qgis:${DOCKER_TAG} /bin/true
+docker run --name qgis_container qgis/qgis:BUILDER /bin/true
 
 echo "Copy build cache from Docker container to Travis cache directory"
 rm -rf "${CCACHE_DIR:?}/"*
-docker cp qgis_container:/usr/src/QGIS/.ccache_image_build ${CCACHE_DIR}
-popd
+mkdir -p ${CCACHE_DIR}
+docker cp qgis_container:/QGIS/.ccache_image_build/. ${CCACHE_DIR}
 
-docker cp qgis_container:/usr/src/build_exit_value ${HOME}/build_exit_value
-if [[ $(cat ${HOME}/build_exit_value) -eq 124 ]]; then
+docker cp qgis_container:/QGIS/build_exit_value ${HOME}/build_exit_value
+
+if [[ $(cat ${HOME}/build_exit_value) == "TIMEOUT" ]]; then
   echo "Build timeout, not pushing image or triggering PyQGIS docs"
   exit 1
 else
-  echo "${bold}Pushing image to docker hub...${endbold}"
+  echo "${bold}Finalize image…${endbold}"
+  # enable experimental features in Docker to squash
+  echo '{ "experimental": true}' | sudo tee /etc/docker/daemon.json
+  docker build ${DOCKER_BUILD_ARGS} \
+             --cache-from "qgis/qgis:BUILDER" \
+             --squash \
+             -t "qgis/qgis:${DOCKER_TAG}" \
+             -f qgis.dockerfile ..
+
+  echo "${bold}Pushing image to docker hub…${endbold}"
   docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   docker push "qgis/qgis:${DOCKER_TAG}"
 
-  echo "Trigger build of PyQGIS Documentation"
+  echo "Trigger build of PyQGIS Documentation…"
   if [[ ${TRIGGER_PYQGIS_DOC} =~ ^TRUE$ ]]; then
     body='{
       "request": {

--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -29,7 +29,6 @@ echo "Cache directory size: "$(du -h --max-depth=0 ${TRAVIS_BUILD_DIR}/.ccache_i
 CURRENT_TIME=$(date +%s)
 TIMEOUT=$((( TRAVIS_AVAILABLE_TIME - TRAVIS_UPLOAD_TIME ) * 60 - CURRENT_TIME + TRAVIS_TIMESTAMP))
 #TIMEOUT=$(( TIMEOUT < 300 ? 300 : TIMEOUT ))
-TIMEOUT=10
 echo "Timeout: ${TIMEOUT}s"
 
 # building docker images

--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -58,6 +58,7 @@ else
   echo "${bold}Finalize image…${endbold}"
   # enable experimental features in Docker to squash
   echo '{ "experimental": true}' | sudo tee /etc/docker/daemon.json
+  sudo service docker restart
   docker build ${DOCKER_BUILD_ARGS} \
              --cache-from "qgis/qgis:BUILDER" \
              --squash \

--- a/.ci/travis/docker_image/script.sh
+++ b/.ci/travis/docker_image/script.sh
@@ -18,7 +18,7 @@
 set -e
 
 # test if ccache dir exists (coming from Travis cache)
-[[ -d ${{CCACHE_DIR}}]] && echo "cache directory (${CCACHE_DIR}) exists" || mkdir -p "${CCACHE_DIR}"
+[[ -d ${CCACHE_DIR} ]] && echo "cache directory (${CCACHE_DIR}) exists" || mkdir -p "${CCACHE_DIR}"
 
 # copy ccache dir within QGIS source so it can be accessed from docker
 cp -r ${CCACHE_DIR} ${TRAVIS_BUILD_DIR}/.ccache_image_build

--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -47,8 +47,8 @@ RUN cmake \
   -DWITH_APIDOC=OFF \
   -DWITH_ASTYLE=OFF \
   -DQT5_3DEXTRA_LIBRARY="/usr/lib/x86_64-linux-gnu/libQt53DExtras.so" \
-  -DQT5_3DEXTRA_INCLUDE_DIR="/usr/src/QGIS/external/qt3dextra-headers" \
-  -DCMAKE_PREFIX_PATH="/usr/src/QGIS/external/qt3dextra-headers/cmake" \
+  -DQT5_3DEXTRA_INCLUDE_DIR="/QGIS/external/qt3dextra-headers" \
+  -DCMAKE_PREFIX_PATH="/QGIS/external/qt3dextra-headers/cmake" \
  .. \
  && echo "Timeout: ${BUILD_TIMEOUT}s" \
  && SUCCESS=OK \

--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -1,8 +1,9 @@
 
-# CACHE_TAG is provided by Docker cloud
 # see https://docs.docker.com/docker-cloud/builds/advanced/
 # using ARG in FROM requires min v17.05.0-ce
 ARG DOCKER_TAG=latest
+# build timeout in seconds, so no timeout by default
+ARG BUILD_TIMEOUT=360000
 
 FROM  qgis/qgis3-build-deps:${DOCKER_TAG}
 MAINTAINER Denis Rouzaud <denis@opengis.ch>
@@ -45,7 +46,8 @@ RUN cmake \
   -DQT5_3DEXTRA_INCLUDE_DIR="/usr/src/QGIS/external/qt3dextra-headers" \
   -DCMAKE_PREFIX_PATH="/usr/src/QGIS/external/qt3dextra-headers/cmake" \
  .. \
- && ninja install \
+ && echo "Timeout: ${BUILD_TIMEOUT}s" \
+ && timeout ${BUILD_TIMEOUT}s ninja install \
  && rm -rf /usr/src/QGIS
 
 ################################################################################

--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -18,10 +18,12 @@ ENV LANG=C.UTF-8
 COPY . /usr/src/QGIS
 
 # If this directory is changed, also adapt script.sh which copies the directory
-RUN mkdir -p /usr/src/.ccache_image_build
-ENV CCACHE_DIR=/usr/src/.ccache_image_build
+RUN mkdir -p /usr/src/QGIS/.ccache_image_build
+ENV CCACHE_DIR=/usr/src/QGIS/.ccache_image_build
 RUN ccache -M 1G
 RUN ccache -s
+
+RUN echo "ccache_dir: "$(du -h --max-depth=0 ${CCACHE_DIR})
 
 WORKDIR /usr/src/QGIS/build
 
@@ -49,7 +51,9 @@ RUN cmake \
  .. \
  && echo "Timeout: ${BUILD_TIMEOUT}s" \
  && timeout ${BUILD_TIMEOUT}s ninja install \
- && rm -rf /usr/src/QGIS
+ && rm -rf /usr/src/QGIS \
+ && rv=$? \
+ && echo "$rv" > /usr/src/build_exit_value
 
 ################################################################################
 # Python testing environment setup

--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -2,13 +2,14 @@
 # see https://docs.docker.com/docker-cloud/builds/advanced/
 # using ARG in FROM requires min v17.05.0-ce
 ARG DOCKER_TAG=latest
-# build timeout in seconds, so no timeout by default
-ARG BUILD_TIMEOUT=360000
 
 FROM  qgis/qgis3-build-deps:${DOCKER_TAG}
 MAINTAINER Denis Rouzaud <denis@opengis.ch>
 
 LABEL Description="Docker container with QGIS" Vendor="QGIS.org" Version="1.1"
+
+# build timeout in seconds, so no timeout by default
+ARG BUILD_TIMEOUT=360000
 
 ARG CC=/usr/lib/ccache/clang
 ARG CXX=/usr/lib/ccache/clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - TRAVIS_TIMESTAMP=$(date +%s)
     - TRAVIS_AVAILABLE_TIME=150 # in minutes
     - TRAVIS_UPLOAD_TIME=5 # time considered to start the machine and the container (minutes)
-    # Docker hub username and passowrd
+    # Docker hub username and password
     - secure: "b7eMDIolaAnq1voGKC1ez7Kcf+/A0WZDJEHBvNwk2KubBfrGOE83GMDrFNF4NqjIprqIAvVKj+TrX1ckCvs24re3IqUJo71TaF1IgxzDDPwSsmNh5UMmvZkeiJys9bWjqDO9wYR5ietNmIE18qyMc8ToJk8oKm6AXuAG2n6znmM="
     - secure: "PHCp7F3nApp38Mz6b4/OLxgfBiikRGzPQDHg3R5LX+SQOll24c/DMtwpPwizNuFEiCFcRmJ9uc1t0HWEerIZe5uqm7AtE/nMXBsvDZ+hj4Tz/fEBF98a1k4WLYheN1exFidVkJgdAeiwMOOUQXw5KuIX62bxBdzsdcd0QGwxiXo="
     # Travis Token to create PyQGIS Documentation Travis build after Docker push
@@ -60,7 +60,7 @@ matrix:
       addons:
         apt:
           sources:
-           # - sourceline: 'ppa:jonathonf/backports'  # silversearcher-ag backport
+          # - sourceline: 'ppa:jonathonf/backports'  # silversearcher-ag backport
           packages:
             - doxygen
             - graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ matrix:
       name: bionic docker build 🐳
       if: repo = qgis/QGIS AND (tag IS PRESENT OR type = cron)
       services: docker
+      sudo: required # required to restart Docker Daemon with experimental features
       env:
         - TRAVIS_CONFIG=docker_image
         - CCACHE_DIR=${HOME}/.ccache_docker_build_bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ matrix:
       name: disco docker build 💃
       if: repo = qgis/QGIS AND (tag IS PRESENT OR type = cron)
       services: docker
+      sudo: required # required to restart Docker Daemon with experimental features
       env:
         - TRAVIS_CONFIG=docker_image
         - CCACHE_DIR=${HOME}/.ccache_docker_build_disco


### PR DESCRIPTION
This allows faster builds of the Docker images on cron jobs by fixing the caching on Travis (it has a distinct cache than the standard testing builds)
To get the cache, it has to be stored on some point in a docker image. To avoid image size increase, a second build is done with removing the cache and build information and using squash builds (currently an experimental feature of Docker).