### PR TITLE
Fix assert with negative QVector size in transformBoundingBox

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -517,19 +517,18 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
 
   // 64 points (<=2.12) is not enough, see #13665, for EPSG:4326 -> EPSG:3574 (say that it is a hard one),
   // are decent result from about 500 points and more. This method is called quite often, but
-  // even with 1000 points it takes < 1ms
+  // even with 1000 points it takes < 1ms.
   // TODO: how to effectively and precisely reproject bounding box?
   const int nPoints = 1000;
   double d = std::sqrt( ( rect.width() * rect.height() ) / std::pow( std::sqrt( static_cast< double >( nPoints ) ) - 1, 2.0 ) );
-  int nXPoints = static_cast< int >( std::ceil( rect.width() / d ) ) + 1;
-  int nYPoints = static_cast< int >( std::ceil( rect.height() / d ) ) + 1;
+  int nXPoints = std::min( static_cast< int >( std::ceil( rect.width() / d ) ) + 1, 1000 );
+  int nYPoints = std::min( static_cast< int >( std::ceil( rect.height() / d ) ) + 1, 1000 );
 
   QgsRectangle bb_rect;
   bb_rect.setMinimal();
 
   // We're interfacing with C-style vectors in the
   // end, so let's do C-style vectors here too.
-
   QVector<double> x( nXPoints * nYPoints );
   QVector<double> y( nXPoints * nYPoints );
   QVector<double> z( nXPoints * nYPoints );

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -48,6 +48,13 @@ class TestQgsCoordinateTransform(unittest.TestCase):
         self.assertAlmostEqual(myExpectedValues[2], myProjectedExtent.xMaximum(), msg=myMessage)
         self.assertAlmostEqual(myExpectedValues[3], myProjectedExtent.yMaximum(), msg=myMessage)
 
+    def testTransformBoundingBoxSizeOverflowProtection(self):
+        """Test transform bounding box size overflow protection (github issue #32302)"""
+        extent = QgsRectangle(-176.0454709164556562, 89.9999999999998153, 180.0000000000000000, 90.0000000000000000)
+        transform = d = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:4236'), QgsCoordinateReferenceSystem('EPSG:3031'), QgsProject.instance())
+        # this test checks that the line below doesn't assert and crash
+        transformedExtent = transform.transformBoundingBox(extent)
+
     def testTransformQgsRectangle_Regression17600(self):
         """Test that rectangle transform is in the bindings"""
         myExtent = QgsRectangle(-1797107, 4392148, 6025926, 6616304)


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This fixes #32302 by insuring that the multilication of nXPoints and nYPoints doesn't result in overflown (and therefore negative) int value.

The gdb output of the crash was:

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff2fa9899 in __GI_abort () at abort.c:79
#2  0x0000555555565c55 in qgisCrash(int) (signal=-1) at /home/webmaster/dev/cpp/QGIS/src/app/main.cpp:360
#3  0x000055555556608d in myMessageOutput(QtMsgType, char const*)
    (type=QtFatalMsg, msg=0x55555d0e2d78 "ASSERT failure in QVector::QVector: \"Size must be greater than or equal to 0.\", file /usr/include/x86_64-linux-gnu/qt5/QtCore/qvector.h, line 487") at /home/webmaster/dev/cpp/QGIS/src/app/main.cpp:436
#4  0x00007ffff3433508 in  () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#5  0x00007ffff3433599 in  () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#6  0x00007ffff3402a80 in QMessageLogger::fatal(char const*, ...) const () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#7  0x00007ffff3401f46 in  () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#8  0x00007ffff4cc0060 in QVector<double>::QVector(int) (this=0x7fffffffc3b8, asize=-1606247658) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qvector.h:487
#9  0x00007ffff51ea03a in QgsCoordinateTransform::transformBoundingBox(QgsRectangle const&, QgsCoordinateTransform::TransformDirection, bool) const
    (this=0x7fffffffc570, rect=..., direction=QgsCoordinateTransform::ForwardTransform, handle180Crossover=false)
    at /home/webmaster/dev/cpp/QGIS/src/core/qgscoordinatetransform.cpp:533
#10 0x00007ffff57de52b in QgsRasterLayerRenderer::QgsRasterLayerRenderer(QgsRasterLayer*, QgsRenderContext&) (this=0x55555cf92120, layer=
    0x55555993b190, rendererContext=...) at /home/webmaster/dev/cpp/QGIS/src/core/raster/qgsrasterlayerrenderer.cpp:105
#11 0x00007ffff57c26f5 in QgsRasterLayer::createMapRenderer(QgsRenderContext&) (this=0x55555993b190, rendererContext=...)
    at /home/webmaster/dev/cpp/QGIS/src/core/raster/qgsrasterlayer.cpp:245
#12 0x00007ffff5333c7a in QgsMapRendererJob::prepareJobs(QPainter*, QgsLabelingEngine*, bool) (this=0x55555cd4ea20, painter=0x0, labelingEngine2=
    0x7fffc2346e70, deferredPainterSet=false) at /home/webmaster/dev/cpp/QGIS/src/core/qgsmaprendererjob.cpp:359
#13 0x00007ffff5339a4a in QgsMapRendererParallelJob::start() (this=0x55555cd4ea20) at /home/webmaster/dev/cpp/QGIS/src/core/qgsmaprendererparalleljob.cpp:61
#14 0x00007ffff69c2422 in QgsMapCanvas::refreshMap() (this=0x5555565f41f0) at /home/webmaster/dev/cpp/QGIS/src/gui/qgsmapcanvas.cpp:563
#15 0x00007ffff69d640c in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (QgsMapCanvas::*)()>::call(void (QgsMapCanvas::*)(), QgsMapCanvas*, void**) (f=(void (QgsMapCanvas::*)(class QgsMapCanvas * const)) 0x7ffff69c20bc <QgsMapCanvas::refreshMap()>, o=0x5555565f41f0, arg=0x7fffffffcfa0)
    at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:152
#16 0x00007ffff69d5bbc in QtPrivate::FunctionPointer<void (QgsMapCanvas::*)()>::call<QtPrivate::List<>, void>(void (QgsMapCanvas::*)(), QgsMapCanvas*, void**)
    (f=(void (QgsMapCanvas::*)(class QgsMapCanvas * const)) 0x7ffff69c20bc <QgsMapCanvas::refreshMap()>, o=0x5555565f41f0, arg=0x7fffffffcfa0)
    at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:185
#17 0x00007ffff69d49da in QtPrivate::QSlotObject<void (QgsMapCanvas::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (which=1, this_=0x555556719dc0, r=0x5555565f41f0, a=0x7fffffffcfa0, ret=0x0) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qobjectdefs_impl.h:414
#18 0x00007ffff362e5c8 in QMetaObject::activate(QObject*, int, int, void**) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#19 0x00007ffff363b66b in QTimer::timeout(QTimer::QPrivateSignal) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#20 0x00007ffff362ee55 in QObject::event(QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#21 0x00007ffff4016a86 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#22 0x00007ffff401fe00 in QApplication::notify(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5
#23 0x00007ffff515b6ff in QgsApplication::notify(QObject*, QEvent*) (this=0x7fffffffd8c0, receiver=0x5555563d2190, event=0x7fffffffd340)
    at /home/webmaster/dev/cpp/QGIS/src/core/qgsapplication.cpp:418
#24 0x00007ffff3602a9a in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#25 0x00007ffff3659a00 in QTimerInfoList::activateTimers() () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#26 0x00007ffff365a2dc in  () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#27 0x00007fffec30084d in g_main_context_dispatch () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
```

@nyalldawson , it'd be great if you could look into this. The fix is mostly a bandaid, the underlying series of events leading to insanely large nXPoints / nYPoints values aren't fully understood by yours truly :wink: 


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
