### PR TITLE
[raster renderer] Fix freeze/crash by not rendering negative width/height raster viewport

### DIFF
--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -238,6 +238,12 @@ bool QgsRasterLayerRenderer::render()
   if ( !mRasterViewPort )
     return true; // outside of layer extent - nothing to do
 
+  if ( mRasterViewPort->mWidth <= 0 || mRasterViewPort->mHeight <= 0 )
+  {
+    QgsDebugMsg( QStringLiteral( "Negative raster viewport width and/or height values, rendering stopped" ) );
+    return true; // likely a reprojection issue leading to negative values, bail out instead of freezing
+  }
+
   //R->draw( mPainter, mRasterViewPort, &mMapToPixel );
 
   QTime time;


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This is part 2 of properly fixing #32302 . While the crasher is gone, it merely led to QGIS freezing altogether due to reprojected raster viewport ending up with negative width and height values. 

The PR adds a negative width / height check, and bails out from rendering if either of these values are negative.



## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
