### PR TITLE
fix SAGA Slope, Aspect, Curvature

### DIFF
--- a/python/plugins/processing/algs/saga/description/Slope,Aspect,Curvature.txt
+++ b/python/plugins/processing/algs/saga/description/Slope,Aspect,Curvature.txt
@@ -1,7 +1,7 @@
 Slope, Aspect, Curvature
 ta_morphometry
 QgsProcessingParameterRasterLayer|ELEVATION|Elevation|None|False
-QgsProcessingParameterEnum|METHOD|Method|[0] Maximum Slope (Travis et al. 1975);[1] Maximum Triangle Slope (Tarboton 1997);[2] Least Squares Fitted Plane (Horn 1981, Costa-Cabral & Burgess 1996);[$
+QgsProcessingParameterEnum|METHOD|Method|[0] Maximum Slope (Travis et al. 1975);[1] Maximum Triangle Slope (Tarboton 1997);[2] Least Squares Fitted Plane (Horn 1981, Costa-Cabral & Burgess 1996);[3] 6 parameter 2nd order polynom (Evans 1979);[4] 6 parameter 2nd order polynom (Heerdegen & Beran 1982);[5] 6 parameter 2nd order polynom (Bauer, Rohdenburg, Bork 1985);[6] 9 parameter 2nd order polynom (Zevenbergen & Thorne 1987);[7]10 parameter 3rd order polynom (Haralick 1983)|False|6
 QgsProcessingParameterEnum|UNIT_SLOPE|Slope Units|[0] radians;[1] degree;[2] percent|False|1
 QgsProcessingParameterEnum|UNIT_ASPECT|Aspect Units|[0] radians;[1] degree|False|1
 QgsProcessingParameterRasterDestination|SLOPE|Slope

--- a/python/plugins/processing/algs/saga/description/Slope,Aspect,Curvature.txt
+++ b/python/plugins/processing/algs/saga/description/Slope,Aspect,Curvature.txt
@@ -1,18 +1,18 @@
 Slope, Aspect, Curvature
 ta_morphometry
 QgsProcessingParameterRasterLayer|ELEVATION|Elevation|None|False
-QgsProcessingParameterEnum|METHOD|Method|[0] Maximum Slope (Travis et al. 1975);[1] Maximum Triangle Slope (Tarboton 1997);[2] Least Squares Fitted Plane (Horn 1981, Costa-Cabral & Burgess 1996);[3] 6 parameter 2nd order polynom (Evans 1979);[4] 6 parameter 2nd order polynom (Heerdegen & Beran 1982);[5] 6 parameter 2nd order polynom (Bauer, Rohdenburg, Bork 1985);[6] 9 parameter 2nd order polynom (Zevenbergen & Thorne 1987);[7]10 parameter 3rd order polynom (Haralick 1983)|False|6
+QgsProcessingParameterEnum|METHOD|Method|[0] Maximum Slope (Travis et al. 1975);[1] Maximum Triangle Slope (Tarboton 1997);[2] Least Squares Fitted Plane (Horn 1981, Costa-Cabral & Burgess 1996);[$
 QgsProcessingParameterEnum|UNIT_SLOPE|Slope Units|[0] radians;[1] degree;[2] percent|False|1
 QgsProcessingParameterEnum|UNIT_ASPECT|Aspect Units|[0] radians;[1] degree|False|1
 QgsProcessingParameterRasterDestination|SLOPE|Slope
 QgsProcessingParameterRasterDestination|ASPECT|Aspect
-QgsProcessingParameterRasterDestination|C_GENE|General Curvature|None|True
-QgsProcessingParameterRasterDestination|C_PLAN|Plan Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_PROF|Profile Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_TANG|Tangential Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_LONG|Longitudinal Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_CROS|Cross-Sectional Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_MINI|Minimal Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_MAXI|Maximal Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_TOTA|Total Curvature|None|True|False
-QgsProcessingParameterRasterDestination|C_ROTO|Flow-Line Curvature|None|True|False
+QgsProcessingParameterRasterDestination|C_GENE|General Curvature
+QgsProcessingParameterRasterDestination|C_PLAN|Plan Curvature
+QgsProcessingParameterRasterDestination|C_PROF|Profile Curvature
+QgsProcessingParameterRasterDestination|C_TANG|Tangential Curvature
+QgsProcessingParameterRasterDestination|C_LONG|Longitudinal Curvature
+QgsProcessingParameterRasterDestination|C_CROS|Cross-Sectional Curvature
+QgsProcessingParameterRasterDestination|C_MINI|Minimal Curvature
+QgsProcessingParameterRasterDestination|C_MAXI|Maximal Curvature
+QgsProcessingParameterRasterDestination|C_TOTA|Total Curvature
+QgsProcessingParameterRasterDestination|C_ROTO|Flow-Line Curvature


### PR DESCRIPTION
Some output layers had parameters that for some reason did not allowed to select the checkbox to have them loaded after the tool run.