### PR TITLE
[geonode] fix data item context menu

### DIFF
--- a/src/core/geocms/geonode/qgsgeonodeconnection.cpp
+++ b/src/core/geocms/geonode/qgsgeonodeconnection.cpp
@@ -102,10 +102,7 @@ QStringList QgsGeoNodeConnectionUtils::connectionList()
 
 void QgsGeoNodeConnectionUtils::deleteConnection( const QString &name )
 {
-  QgsSettings settings;
-  // Add Section manually
-  settings.remove( QStringLiteral( "qgis/connections-geonode/" ) + name );
-  settings.remove( QStringLiteral( "qgis/geonode/" ) + name );
+  QgsOwsConnection::deleteConnection( QStringLiteral( "GEONODE" ), name );
 }
 
 QString QgsGeoNodeConnectionUtils::pathGeoNodeConnection()

--- a/src/providers/geonode/qgsgeonodedataitemguiprovider.cpp
+++ b/src/providers/geonode/qgsgeonodedataitemguiprovider.cpp
@@ -17,6 +17,8 @@
 #include "qgsgeonodedataitems.h"
 #include "qgsgeonodenewconnection.h"
 
+#include <QMessageBox>
+
 void QgsGeoNodeDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
 {
   if ( QgsGeoNodeRootItem *rootItem = qobject_cast< QgsGeoNodeRootItem * >( item ) )
@@ -25,7 +27,7 @@ void QgsGeoNodeDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMen
     connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
     menu->addAction( actionNew );
   }
-  else if ( QgsGeoNodeRootItem *connItem = qobject_cast< QgsGeoNodeRootItem * >( item ) )
+  else if ( QgsGeoNodeConnectionItem *connItem = qobject_cast< QgsGeoNodeConnectionItem * >( item ) )
   {
     QAction *actionEdit = new QAction( tr( "Edit Connection…" ), menu );
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
@@ -61,6 +63,10 @@ void QgsGeoNodeDataItemGuiProvider::editConnection( QgsDataItem *item )
 
 void QgsGeoNodeDataItemGuiProvider::deleteConnection( QgsDataItem *item )
 {
+  if ( QMessageBox::question( nullptr, tr( "Delete Connection" ), tr( "Are you sure you want to delete the connection “%1”?" ).arg( item->name() ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
   QgsGeoNodeConnectionUtils::deleteConnection( item->name() );
   item->parent()->refresh();
 }


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->
This PR will fix the bug on geonode data item in the browser tree where the context menu didn't show up when we right click on the connection item. Also I put an update to use OWS delete connection method and dialog box before deleting connection. 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
