### PR TITLE
[API/feature?] make fids caching optional

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1042,12 +1042,14 @@ if the geometry type of the new data source matches the current geometry type of
     virtual QString loadDefaultStyle( bool &resultFlag /Out/ ) ${SIP_FINAL};
 
 
-    QgsVectorLayerFeatureCounter *countSymbolFeatures();
+    QgsVectorLayerFeatureCounter *countSymbolFeatures( bool storeSymbolFids = false );
 %Docstring
 Count features for symbols.
 The method will return the feature counter task. You will need to
 connect to the symbolFeatureCountMapChanged() signal to be
 notified when the freshly updated feature counts are ready.
+
+:param storeSymbolFids: If ``True`` will gather the feature ids (fids) per symbol, otherwise only the count. Default ``False``.
 
 .. note::
 

--- a/python/core/auto_generated/qgsvectorlayerfeaturecounter.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerfeaturecounter.sip.in
@@ -24,9 +24,13 @@ QgsVectorLayer.countSymbolFeatures() and connect to the signal
 %End
   public:
 
-    QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext() );
+    QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), bool storeSymbolFids = false );
 %Docstring
 Create a new feature counter for ``layer``.
+
+:param layer: Target QgsVectorLayer to perform counting on.
+:param context: Specific QgsExpressionContext to use during the rendering step.
+:param storeSymbolFids: If ``True`` will store the feature ids (fids), otherwise will only count the number of features per symbol. Default ``False``.
 %End
 
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1082,13 +1082,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * connect to the symbolFeatureCountMapChanged() signal to be
      * notified when the freshly updated feature counts are ready.
      *
+     * \param storeSymbolFids If TRUE will gather the feature ids (fids) per symbol, otherwise only the count. Default FALSE.
      * \note If the count features for symbols has been already done a
      *       NULLPTR is returned. If you need to wait for the results,
      *       you can call waitForFinished() on the feature counter.
      *
      * \since This is asynchronous since QGIS 3.0
      */
-    QgsVectorLayerFeatureCounter *countSymbolFeatures();
+    QgsVectorLayerFeatureCounter *countSymbolFeatures( bool storeSymbolFids = false );
 
     /**
      * Sets the string (typically sql) used to define a subset of the layer

--- a/src/core/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/qgsvectorlayerfeaturecounter.cpp
@@ -17,11 +17,12 @@
 #include "qgsvectorlayer.h"
 #include "qgsfeatureid.h"
 
-QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context )
+QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context, bool storeSymbolFids )
   : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel )
   , mSource( new QgsVectorLayerFeatureSource( layer ) )
   , mRenderer( layer->renderer()->clone() )
   , mExpressionContext( context )
+  , mWithFids( storeSymbolFids )
   , mFeatureCount( layer->featureCount() )
 {
   if ( !mExpressionContext.scopeCount() )
@@ -40,7 +41,8 @@ bool QgsVectorLayerFeatureCounter::run()
   for ( ; symbolIt != symbolList.constEnd(); ++symbolIt )
   {
     mSymbolFeatureCountMap.insert( symbolIt->label(), 0 );
-    mSymbolFeatureIdMap.insert( symbolIt->label(), QgsFeatureIds() );
+    if ( mWithFids )
+      mSymbolFeatureIdMap.insert( symbolIt->label(), QgsFeatureIds() );
   }
 
   // If there are no features to be counted, we can spare us the trouble
@@ -74,7 +76,8 @@ bool QgsVectorLayerFeatureCounter::run()
       for ( const QString &key : featureKeyList )
       {
         mSymbolFeatureCountMap[key] += 1;
-        mSymbolFeatureIdMap[key].insert( f.id() );
+        if ( mWithFids )
+          mSymbolFeatureIdMap[key].insert( f.id() );
       }
       ++featuresCounted;
 

--- a/src/core/qgsvectorlayerfeaturecounter.h
+++ b/src/core/qgsvectorlayerfeaturecounter.h
@@ -38,8 +38,11 @@ class CORE_EXPORT QgsVectorLayerFeatureCounter : public QgsTask
 
     /**
      * Create a new feature counter for \a layer.
+     * \param layer Target QgsVectorLayer to perform counting on.
+     * \param context Specific QgsExpressionContext to use during the rendering step.
+     * \param storeSymbolFids If TRUE will store the feature ids (fids), otherwise will only count the number of features per symbol. Default FALSE.
      */
-    QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext() );
+    QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), bool storeSymbolFids = false );
 
 
     /**
@@ -92,6 +95,7 @@ class CORE_EXPORT QgsVectorLayerFeatureCounter : public QgsTask
     QgsExpressionContext mExpressionContext;
     QHash<QString, long> mSymbolFeatureCountMap;
     QHash<QString, QgsFeatureIds> mSymbolFeatureIdMap;
+    bool mWithFids = false;
     int mFeatureCount;
 
 };


### PR DESCRIPTION
## Description
This is a follow up PR to #31061 that enabled caching of fids per symbol during the counting procedure.

This PR aims to make fids caching optional, as it is not necessary to have the have the fids in most cases, especially until #30297 is merged.

This should prevent for useless memory usage.

If this is merged after 3.10 is published, backporting is highly recommended to prevent extra memory usage.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
