### PR TITLE
[geonode] a generic way to consume geonode api. fixes #31376

### DIFF
--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -269,111 +269,106 @@ QList<QgsGeoNodeRequest::ServiceLayerDetail> QgsGeoNodeRequest::parseLayers( con
   const QJsonObject jsonObject = jsonDocument.object();
   const QVariantMap jsonVariantMap = jsonObject.toVariantMap();
   const QVariantList layerList = jsonVariantMap.value( QStringLiteral( "objects" ) ).toList();
-  qint16 majorVersion;
-  qint16 minorVersion;
-  if ( jsonVariantMap.contains( QStringLiteral( "geonode_version" ) ) )
+
+  QString wmsURLFormat, wfsURLFormat, xyzURLFormat;
+
+  for ( const QVariant &layer : qgis::as_const( layerList ) )
   {
-    QRegularExpression re( "((\\d+)(\\.\\d+))" );
-    QRegularExpressionMatch match = re.match( jsonVariantMap.value( QStringLiteral( "geonode_version" ) ).toString() );
-    if ( match.hasMatch() )
+    QgsGeoNodeRequest::ServiceLayerDetail layerStruct;
+    const QVariantMap layerMap = layer.toMap();
+    QVariantList layerLinks = layerMap.value( QStringLiteral( "links" ) ).toList();
+
+    if ( layerMap.value( QStringLiteral( "typename" ) ).toString().isEmpty() )
     {
-      const QStringList geonodeVersionSplit = match.captured( 0 ).split( '.' );
-      majorVersion = geonodeVersionSplit.at( 0 ).toInt();
-      minorVersion = geonodeVersionSplit.at( 1 ).toInt();
+      const QStringList splitURL = layerMap.value( QStringLiteral( "detail_url" ) ).toString().split( '/' );
+      layerStruct.typeName = splitURL.at( splitURL.length() - 1 );
     }
-    else
+    layerStruct.uuid = layerMap.value( QStringLiteral( "uuid" ) ).toString();
+    layerStruct.id = layerMap.value( QStringLiteral( "id" ) ).toString();
+    layerStruct.name = layerMap.value( QStringLiteral( "name" ) ).toString();
+    layerStruct.typeName = layerMap.value( QStringLiteral( "typename" ) ).toString();
+    layerStruct.title = layerMap.value( QStringLiteral( "title" ) ).toString();
+
+    layerStruct = parseOWSUrl( layerStruct, layerLinks );
+
+    if ( layerStruct.wmsURL.isEmpty() && layerStruct.wfsURL.isEmpty() && layerStruct.xyzURL.isEmpty() )
     {
-      return layers;
-    }
-  }
-  else
-  {
-    majorVersion = 2;
-    minorVersion = 6;
-  }
-
-  if ( majorVersion == 2 && minorVersion == 6 )
-  {
-    for ( const QVariant &layer : qgis::as_const( layerList ) )
-    {
-      QgsGeoNodeRequest::ServiceLayerDetail layerStruct;
-      const QVariantMap layerMap = layer.toMap();
-      // Find WMS and WFS. XYZ is not available
-      // Trick to get layer's typename from distribution_url or detail_url
-      QString layerTypeName = layerMap.value( QStringLiteral( "detail_url" ) ).toString().split( '/' ).last();
-      if ( layerTypeName.isEmpty() )
+      if ( wmsURLFormat.isEmpty() && wfsURLFormat.isEmpty() && xyzURLFormat.isEmpty() )
       {
-        layerTypeName = layerMap.value( QStringLiteral( "distribution_url" ) ).toString().split( '/' ).last();
-      }
-      // On this step, layerTypeName is in WORKSPACE%3ALAYERNAME or WORKSPACE:LAYERNAME format
-      if ( layerTypeName.contains( QStringLiteral( "%3A" ) ) )
-      {
-        layerTypeName.replace( QStringLiteral( "%3A" ), QStringLiteral( ":" ) );
-      }
-      // On this step, layerTypeName is in WORKSPACE:LAYERNAME format
-      const QStringList splitURL = layerTypeName.split( ':' );
-      QString layerWorkspace = splitURL.at( 0 );
-      QString layerName = splitURL.at( 1 );
-
-      layerStruct.name = layerName;
-      layerStruct.typeName = layerTypeName;
-      layerStruct.uuid = layerMap.value( QStringLiteral( "uuid" ) ).toString();
-      layerStruct.title = layerMap.value( QStringLiteral( "title" ) ).toString();
-
-      // WMS url : BASE_URI/geoserver/WORKSPACE/wms
-      layerStruct.wmsURL = mBaseUrl + QStringLiteral( "/geoserver/" ) + layerWorkspace + QStringLiteral( "/wms" );
-      // WFS url : BASE_URI/geoserver/WORKSPACE/wfs
-      layerStruct.wfsURL = mBaseUrl + QStringLiteral( "/geoserver/" ) + layerWorkspace + QStringLiteral( "/wfs" );
-      // XYZ url : set to empty string
-      layerStruct.xyzURL.clear();
-
-      layers.append( layerStruct );
-    }
-  }
-  // Geonode version 2.7 or newer
-  else if ( ( majorVersion == 2 && minorVersion >= 7 ) || ( majorVersion >= 3 ) )
-  {
-    for ( const QVariant &layer : qgis::as_const( layerList ) )
-    {
-      QgsGeoNodeRequest::ServiceLayerDetail layerStruct;
-      const QVariantMap layerMap = layer.toMap();
-      // Find WMS, WFS, and XYZ link
-      const QVariantList layerLinks = layerMap.value( QStringLiteral( "links" ) ).toList();
-      for ( const QVariant &link : layerLinks )
-      {
-        const QVariantMap linkMap = link.toMap();
-        if ( linkMap.contains( QStringLiteral( "link_type" ) ) )
+        bool success = requestBlocking( QStringLiteral( "/api/layers/" ) + layerStruct.id );
+        if ( success )
         {
-          if ( linkMap.value( QStringLiteral( "link_type" ) ) == QStringLiteral( "OGC:WMS" ) )
+          const QJsonDocument resourceUriDocument = QJsonDocument::fromJson( this->lastResponse() );
+          const QJsonObject resourceUriObject = resourceUriDocument.object();
+          const QVariantMap resourceUriMap = resourceUriObject.toVariantMap();
+          QVariantList resourceUriLinks = resourceUriMap.value( QStringLiteral( "links" ) ).toList();
+          QgsGeoNodeRequest::ServiceLayerDetail tempLayerStruct;
+          tempLayerStruct = parseOWSUrl( tempLayerStruct, resourceUriLinks );
+
+          // Avoid iterating all the layers to get the service url. Instead, generate a string format once we found one service url
+          // for every service (wms, wfs, xyz). And then use the string format for the other layers since they are identical.
+          if ( tempLayerStruct.server == "qgis-server" )
           {
-            layerStruct.wmsURL = linkMap.value( QStringLiteral( "url" ) ).toString();
+            wmsURLFormat = !tempLayerStruct.wmsURL.isEmpty() ? tempLayerStruct.wmsURL.replace( layerStruct.name, "%1" ) : "";
+            wfsURLFormat = !tempLayerStruct.wfsURL.isEmpty() ? tempLayerStruct.wfsURL.replace( layerStruct.name, "%1" ) : "";
+            xyzURLFormat = !tempLayerStruct.xyzURL.isEmpty() ? tempLayerStruct.xyzURL.replace( layerStruct.name, "%1" ) : "";
           }
-          else if ( linkMap.value( QStringLiteral( "link_type" ) ) == QStringLiteral( "OGC:WFS" ) )
+          else if ( tempLayerStruct.server == "geoserver" )
           {
-            layerStruct.wfsURL = linkMap.value( QStringLiteral( "url" ) ).toString();
-          }
-          else if ( linkMap.value( QStringLiteral( "link_type" ) ) == QStringLiteral( "image" ) )
-          {
-            if ( linkMap.contains( QStringLiteral( "name" ) ) && linkMap.value( QStringLiteral( "name" ) ) == QStringLiteral( "Tiles" ) )
-            {
-              layerStruct.xyzURL = linkMap.value( QStringLiteral( "url" ) ).toString();
-            }
+            wmsURLFormat = !tempLayerStruct.wmsURL.isEmpty() ? tempLayerStruct.wmsURL : "";
+            wfsURLFormat = !tempLayerStruct.wfsURL.isEmpty() ? tempLayerStruct.wfsURL : "";
+            xyzURLFormat = !tempLayerStruct.xyzURL.isEmpty() ? tempLayerStruct.xyzURL.replace( layerStruct.name, "%1" ) : "";
           }
         }
+        else
+        {
+          layers.append( layerStruct );
+          continue;
+        }
       }
-      if ( layerMap.value( QStringLiteral( "typename" ) ).toString().isEmpty() )
-      {
-        const QStringList splitURL = layerMap.value( QStringLiteral( "detail_url" ) ).toString().split( '/' );
-        layerStruct.typeName = splitURL.at( splitURL.length() - 1 );
-      }
-      layerStruct.uuid = layerMap.value( QStringLiteral( "uuid" ) ).toString();
-      layerStruct.name = layerMap.value( QStringLiteral( "name" ) ).toString();
-      layerStruct.typeName = layerMap.value( QStringLiteral( "typename" ) ).toString();
-      layerStruct.title = layerMap.value( QStringLiteral( "title" ) ).toString();
-      layers.append( layerStruct );
+
+      // Replace string argument with the layer id.
+      layerStruct.wmsURL = wmsURLFormat.contains( "%1" ) ? wmsURLFormat.arg( layerStruct.name ) : wmsURLFormat;
+      layerStruct.wfsURL = wfsURLFormat.contains( "%1" ) ? wfsURLFormat.arg( layerStruct.name ) : wfsURLFormat;
+      layerStruct.xyzURL = xyzURLFormat.contains( "%1" ) ? xyzURLFormat.arg( layerStruct.name ) : xyzURLFormat;
     }
+
+    layers.append( layerStruct );
   }
+
   return layers;
+}
+
+QgsGeoNodeRequest::ServiceLayerDetail QgsGeoNodeRequest::parseOWSUrl( QgsGeoNodeRequest::ServiceLayerDetail &layerStruct, const QVariantList &layerLinks )
+{
+  QString urlFound;
+  for ( const QVariant &link : layerLinks )
+  {
+    const QVariantMap linkMap = link.toMap();
+    if ( linkMap.contains( QStringLiteral( "link_type" ) ) )
+    {
+      if ( linkMap.value( QStringLiteral( "link_type" ) ) == QStringLiteral( "OGC:WMS" ) )
+      {
+        urlFound = layerStruct.wmsURL = linkMap.value( QStringLiteral( "url" ) ).toString();
+      }
+      else if ( linkMap.value( QStringLiteral( "link_type" ) ) == QStringLiteral( "OGC:WFS" ) )
+      {
+        urlFound = layerStruct.wfsURL = linkMap.value( QStringLiteral( "url" ) ).toString();
+      }
+      else if ( linkMap.value( QStringLiteral( "link_type" ) ) == QStringLiteral( "image" ) )
+      {
+        if ( linkMap.contains( QStringLiteral( "name" ) ) && linkMap.value( QStringLiteral( "name" ) ) == QStringLiteral( "Tiles" ) )
+        {
+          urlFound = layerStruct.xyzURL = linkMap.value( QStringLiteral( "url" ) ).toString();
+        }
+      }
+    }
+
+    if ( layerStruct.server.isEmpty() )
+      layerStruct.server = urlFound.contains( QStringLiteral( "qgis-server" ) ) ? QStringLiteral( "qgis-server" ) : QStringLiteral( "geoserver" );
+  }
+
+  return layerStruct;
 }
 
 QgsGeoNodeStyle QgsGeoNodeRequest::retrieveStyle( const QString &styleUrl )
@@ -529,6 +524,8 @@ bool QgsGeoNodeRequest::requestBlocking( const QString &endPoint )
 QNetworkReply *QgsGeoNodeRequest::requestUrl( const QString &url )
 {
   QNetworkRequest request( url );
+  request.setAttribute( QNetworkRequest::FollowRedirectsAttribute, true );
+
   QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsGeoNodeRequest" ) );
   // Add authentication check here
 

--- a/src/core/geocms/geonode/qgsgeonoderequest.h
+++ b/src/core/geocms/geonode/qgsgeonoderequest.h
@@ -74,6 +74,8 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
     {
       //! Unique identifier (generate on the client side, not at the GeoNode server)
       QUuid uuid;
+      //! Layer id
+      QString id;
       //! Layer name
       QString name;
       //! Layer type name
@@ -86,6 +88,8 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
       QString wfsURL;
       //! XYZ tileserver URL for layer
       QString xyzURL;
+      //! Backend server (geoserver or qgis-server)
+      QString server;
     };
 
     /**
@@ -212,6 +216,11 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
      * \see protocol()
      */
     void setProtocol( const QString &protocol );
+
+    /**
+     * Returns the updated ServiceLayerDetail struct with WMS/WFS/XYZ url.
+     */
+    QgsGeoNodeRequest::ServiceLayerDetail parseOWSUrl( QgsGeoNodeRequest::ServiceLayerDetail &layerStruct, const QVariantList &layerLinks );
 
   public slots:
 

--- a/src/core/geocms/geonode/qgsgeonoderequest.h
+++ b/src/core/geocms/geonode/qgsgeonoderequest.h
@@ -68,6 +68,16 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
   public:
 
     /**
+     * GeoNode backend server type.
+     */
+    typedef enum
+    {
+      UNKNOWN,
+      QGIS_SERVER,
+      GEOSERVER
+    } BackendServer;
+
+    /**
      * Service layer details for an individual layer from a GeoNode connection.
      */
     struct ServiceLayerDetail
@@ -89,7 +99,7 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
       //! XYZ tileserver URL for layer
       QString xyzURL;
       //! Backend server (geoserver or qgis-server)
-      QString server;
+      BackendServer server{};
     };
 
     /**
@@ -220,7 +230,7 @@ class CORE_EXPORT QgsGeoNodeRequest : public QObject
     /**
      * Returns the updated ServiceLayerDetail struct with WMS/WFS/XYZ url.
      */
-    QgsGeoNodeRequest::ServiceLayerDetail parseOWSUrl( QgsGeoNodeRequest::ServiceLayerDetail &layerStruct, const QVariantList &layerLinks );
+    QgsGeoNodeRequest::ServiceLayerDetail parseOwsUrl( QgsGeoNodeRequest::ServiceLayerDetail &layerStruct, const QVariantList &layerLinks );
 
   public slots:
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->
fix #31376 
  -  Remove the geonode version checking. Because I just found out that the geonode version has nothing to do with the format of the returned data.
  -  Redo the logic to construct OWS endpoint of layers.


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
