### PR TITLE
[Release-3_4][Server] WMS: Use QGIS Style instead of SLD to restore layer style

### DIFF
--- a/src/server/services/wms/qgslayerrestorer.cpp
+++ b/src/server/services/wms/qgslayerrestorer.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgslayerrestorer.h"
+#include "qgsmessagelog.h"
 #include "qgsmaplayer.h"
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
@@ -41,7 +42,10 @@ QgsLayerRestorer::QgsLayerRestorer( const QList<QgsMapLayer *> &layers )
     QDomDocument styleDoc( QStringLiteral( "style" ) );
     QDomElement styleXml = styleDoc.createElement( QStringLiteral( "style" ) );
     styleDoc.appendChild( styleXml );
-    layer->writeStyle( styleXml, styleDoc, errMsg, QgsReadWriteContext() );
+    if ( !layer->writeStyle( styleXml, styleDoc, errMsg, QgsReadWriteContext() ) )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "QGIS Style has not been added to layer restorer for layer %1: %2" ).arg( layer->name(), errMsg ) );
+    }
     ( void )settings.mQgisStyle.setContent( styleDoc.toString() );
 
     if ( layer->type() == QgsMapLayer::LayerType::VectorLayer )
@@ -83,7 +87,10 @@ QgsLayerRestorer::~QgsLayerRestorer()
       QString errMsg;
       QDomElement root = settings.mQgisStyle.documentElement();
       QgsReadWriteContext context = QgsReadWriteContext();
-      layer->readStyle( root, errMsg, context );
+      if ( !layer->readStyle( root, errMsg, context ) )
+      {
+        QgsMessageLog::logMessage( QStringLiteral( "QGIS Style has not been read from layer restorer for layer %1: %2" ).arg( layer->name(), errMsg ) );
+      }
     }
     layer->removeCustomProperty( "readSLD" );
 

--- a/src/server/services/wms/qgslayerrestorer.h
+++ b/src/server/services/wms/qgslayerrestorer.h
@@ -56,7 +56,7 @@ class QgsLayerRestorer
       QString name;
       double mOpacity;
       QString mNamedStyle;
-      QDomDocument mSldStyle;
+      QDomDocument mQgisStyle;
       QString mFilter;
       QgsFeatureIds mSelectedFeatureIds;
     };

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -1340,6 +1340,43 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetMap_SLDRestored")
 
+    def test_wms_getmap_sld_restore_labeling(self):
+        """QGIS Server has to restore all the style. This test is not done
+        to evaluate the SLD application but the style restoration and
+        specifically the labeling."""
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetMap",
+            "LAYERS": "pointlabel",
+            "STYLES": "",
+            "SLD_BODY": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><StyledLayerDescriptor xmlns=\"http://www.opengis.net/sld\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:ogc=\"http://www.opengis.net/ogc\" xsi:schemaLocation=\"http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd\" version=\"1.1.0\" xmlns:se=\"http://www.opengis.net/se\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"> <NamedLayer> <se:Name>pointlabel</se:Name> <UserStyle> <se:Name>pointlabel_style</se:Name> <se:FeatureTypeStyle> <se:Rule> <se:Name>Single symbol</se:Name> <se:PointSymbolizer uom=\"http://www.opengeospatial.org/se/units/metre\"> <se:Graphic> <se:Mark> <se:WellKnownName>square</se:WellKnownName> <se:Fill> <se:SvgParameter name=\"fill\">5e86a1</se:SvgParameter> </se:Fill> <se:Stroke> <se:SvgParameter name=\"stroke\">000000</se:SvgParameter> </se:Stroke> </se:Mark> <se:Size>0.007</se:Size> </se:Graphic> </se:PointSymbolizer> </se:Rule> </se:FeatureTypeStyle> </UserStyle> </NamedLayer> </StyledLayerDescriptor>",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-4710778,5696513,14587125",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "CRS": "EPSG:3857"
+        }.items())])
+        r, h = self._result(self._execute_request(qs))
+
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetMap",
+            "LAYERS": "pointlabel",
+            "STYLES": "",
+            "FORMAT": "image/png",
+            "BBOX": "-16817707,-4710778,5696513,14587125",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "CRS": "EPSG:3857"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetMap_Labeling_Complex")
+
     def test_wms_getmap_group(self):
         """A WMS shall render the requested layers by drawing the leftmost in the list
         bottommost, the next one over that, and so on."""


### PR DESCRIPTION
## Description
To save default style, QGIS Server used the SLD style. In SLD style, labeling is not saved so when style is restored with SLD style, labeling was lost.

To be sure to restore layer style, QGIS style is used.

Manually backport #32342

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
