### PR TITLE
[Release-3_4]Fix featureCount on postgres view when flag estimatedmetadata is set

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3186,7 +3186,9 @@ long QgsPostgresProvider::featureCount() const
   // use estimated metadata even when there is a where clause,
   // although we get an incorrect feature count for the subset
   // - but make huge dataset usable.
-  if ( !mIsQuery && mUseEstimatedMetadata )
+  // don't use it on view because it will always return 0 (view as no rows)
+  const QgsPostgresProvider::Relkind type = relkind();
+  if ( !mIsQuery && mUseEstimatedMetadata && type != Relkind::View )
   {
     sql = QStringLiteral( "SELECT reltuples::bigint FROM pg_catalog.pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
   }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3186,7 +3186,7 @@ long QgsPostgresProvider::featureCount() const
   // use estimated metadata even when there is a where clause,
   // although we get an incorrect feature count for the subset
   // - but make huge dataset usable.
-  // don't use it on view because it will always return 0 (view as no rows)
+  // don't use it on view because it will always return 0 (view has no rows)
   const QgsPostgresProvider::Relkind type = relkind();
   if ( !mIsQuery && mUseEstimatedMetadata && type != Relkind::View )
   {

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1232,6 +1232,16 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertFalse(vl.isValid())
         self.assertEqual(vl.dataProvider().discoverRelations(vl, []), [])
 
+    def testFeatureCountOnView(self):
+        """
+        Test feature count on view when with estimatedmetadata = true
+        """
+        self.execSQLCommand('CREATE VIEW qgis_test.somedataview AS SELECT * FROM qgis_test."someData"')
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'pk\' estimatedmetadata=true srid=4326 type=POINT table="qgis_test"."somedataview" (geom) sql=', 'test', 'postgres')
+        self.assertTrue(vl.isValid())
+        self.assertEqual(self.source.featureCount(), vl.dataProvider().featureCount())
+
+
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 
     @classmethod


### PR DESCRIPTION
We [can't estimate rows on postgres view](https://stackoverflow.com/questions/28157246/how-estimate-row-count-of-a-postgresql-view). 

Manually backport  #32114

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
