### PR TITLE
[Release-3_4] Server: fix pointer errors when plugins are of f

### DIFF
--- a/src/server/services/wcs/qgswcsdescribecoverage.cpp
+++ b/src/server/services/wcs/qgswcsdescribecoverage.cpp
@@ -46,7 +46,6 @@ namespace QgsWcs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       describeDocument = &doc;
@@ -61,7 +60,10 @@ namespace QgsWcs
       }
       describeDocument = &doc;
     }
-
+#else
+    doc = createDescribeCoverageDocument( serverIface, project, version, request );
+    describeDocument = &doc;
+#endif
     response.setHeader( "Content-Type", "text/xml; charset=utf-8" );
     response.write( describeDocument->toByteArray() );
   }

--- a/src/server/services/wcs/qgswcsdescribecoverage.cpp
+++ b/src/server/services/wcs/qgswcsdescribecoverage.cpp
@@ -36,16 +36,14 @@ namespace QgsWcs
   void writeDescribeCoverage( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
                               const QgsServerRequest &request, QgsServerResponse &response )
   {
-    QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
+    QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
     QDomDocument doc;
     const QDomDocument *describeDocument = nullptr;
 
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    cacheManager = serverIface->cacheManager();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       describeDocument = &doc;
@@ -80,6 +78,8 @@ namespace QgsWcs
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
 #endif
 
     //wcs:WCS_Capabilities element

--- a/src/server/services/wcs/qgswcsgetcapabilities.cpp
+++ b/src/server/services/wcs/qgswcsgetcapabilities.cpp
@@ -37,16 +37,14 @@ namespace QgsWcs
   void writeGetCapabilities( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
                              const QgsServerRequest &request, QgsServerResponse &response )
   {
-    QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
+    QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
     QDomDocument doc;
     const QDomDocument *capabilitiesDocument = nullptr;
 
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    cacheManager = serverIface->cacheManager();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -280,6 +278,8 @@ namespace QgsWcs
   {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
 #endif
     /*
      * Adding layer list in ContentMetadata

--- a/src/server/services/wcs/qgswcsgetcapabilities.cpp
+++ b/src/server/services/wcs/qgswcsgetcapabilities.cpp
@@ -47,7 +47,6 @@ namespace QgsWcs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -62,7 +61,10 @@ namespace QgsWcs
       }
       capabilitiesDocument = &doc;
     }
-
+#else
+    doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+    capabilitiesDocument = &doc;
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( capabilitiesDocument->toByteArray() );
   }

--- a/src/server/services/wcs/qgswcsgetcoverage.cpp
+++ b/src/server/services/wcs/qgswcsgetcoverage.cpp
@@ -52,6 +52,8 @@ namespace QgsWcs
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
 #endif
     //defining coverage name
     QString coveName;

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -42,16 +42,14 @@ namespace QgsWfs
   void writeDescribeFeatureType( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
                                  const QgsServerRequest &request, QgsServerResponse &response )
   {
-    QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
+    QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
     QDomDocument doc;
     const QDomDocument *describeDocument = nullptr;
 
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    cacheManager = serverIface->cacheManager();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       describeDocument = &doc;
@@ -91,7 +89,11 @@ namespace QgsWfs
       throw QgsBadRequestException( QStringLiteral( "Invalid WFS Parameter" ),
                                     QStringLiteral( "OUTPUTFORMAT %1 is not supported" ).arg( wfsParameters.outputFormatAsString() ) );
 
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
+#endif
 
     //xsd:schema
     QDomElement schemaElement = doc.createElement( QStringLiteral( "schema" )/*xsd:schema*/ );

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -52,7 +52,6 @@ namespace QgsWfs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       describeDocument = &doc;
@@ -67,7 +66,10 @@ namespace QgsWfs
       }
       describeDocument = &doc;
     }
-
+#else
+    doc = createDescribeFeatureTypeDocument( serverIface, project, version, request );
+    describeDocument = &doc;
+#endif
     response.setHeader( "Content-Type", "text/xml; charset=utf-8" );
     response.write( describeDocument->toByteArray() );
   }

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -51,7 +51,6 @@ namespace QgsWfs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -66,7 +65,10 @@ namespace QgsWfs
       }
       capabilitiesDocument = &doc;
     }
-
+#else
+    doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+    capabilitiesDocument = &doc;
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( capabilitiesDocument->toByteArray() );
   }

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -41,16 +41,14 @@ namespace QgsWfs
   void writeGetCapabilities( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
                              const QgsServerRequest &request, QgsServerResponse &response )
   {
-    QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
+    QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
     QDomDocument doc;
     const QDomDocument *capabilitiesDocument = nullptr;
 
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    cacheManager = serverIface->cacheManager();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -435,7 +433,11 @@ namespace QgsWfs
 
   QDomElement getFeatureTypeListElement( QDomDocument &doc, QgsServerInterface *serverIface, const QgsProject *project )
   {
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
+#endif
 
     //wfs:FeatureTypeList element
     QDomElement featureTypeListElement = doc.createElement( QStringLiteral( "FeatureTypeList" )/*wfs:FeatureTypeList*/ );

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
@@ -53,7 +53,6 @@ namespace QgsWfs
       QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
       cacheManager = serverIface->cacheManager();
-#endif
       if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
       {
         capabilitiesDocument = &doc;
@@ -68,7 +67,10 @@ namespace QgsWfs
         }
         capabilitiesDocument = &doc;
       }
-
+#else
+      doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+      capabilitiesDocument = &doc;
+#endif
       response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
       response.write( capabilitiesDocument->toByteArray() );
     }

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
@@ -43,16 +43,14 @@ namespace QgsWfs
     void writeGetCapabilities( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
                                const QgsServerRequest &request, QgsServerResponse &response )
     {
-      QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-      accessControl = serverIface->accessControls();
+      QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
       QDomDocument doc;
       const QDomDocument *capabilitiesDocument = nullptr;
 
-      QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-      cacheManager = serverIface->cacheManager();
+      QgsServerCacheManager *cacheManager = serverIface->cacheManager();
       if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
       {
         capabilitiesDocument = &doc;
@@ -274,7 +272,11 @@ namespace QgsWfs
 
     QDomElement getFeatureTypeListElement( QDomDocument &doc, QgsServerInterface *serverIface, const QgsProject *project )
     {
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+      ( void )serverIface;
+#endif
 
       //wfs:FeatureTypeList element
       QDomElement featureTypeListElement = doc.createElement( QStringLiteral( "FeatureTypeList" )/*wfs:FeatureTypeList*/ );

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -217,6 +217,9 @@ namespace QgsWfs
 
   void performTransaction( transactionRequest &aRequest, QgsServerInterface *serverIface, const QgsProject *project )
   {
+#ifndef HAVE_SERVER_PYTHON_PLUGINS
+    ( void )serverIface;
+#endif
     // store typeName
     QStringList typeNameList;
 
@@ -242,8 +245,10 @@ namespace QgsWfs
         typeNameList << name;
     }
 
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
     // get access controls
     QgsAccessControl *accessControl = serverIface->accessControls();
+#endif
 
     //scoped pointer to restore all original layer filters (subsetStrings) when pointer goes out of scope
     //there's LOTS of potential exit paths here, so we avoid having to restore the filters manually

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -225,8 +225,12 @@ namespace QgsWfs
           typeNameList << name;
       }
 
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       // get access controls
       QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+      ( void )serverIface;
+#endif
 
       //scoped pointer to restore all original layer filters (subsetStrings) when pointer goes out of scope
       //there's LOTS of potential exit paths here, so we avoid having to restore the filters manually

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -107,6 +107,8 @@ namespace QgsWms
     // access control
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
 #endif
     // Use layer ids
     bool useLayerIds = QgsServerProjectUtils::wmsUseLayerIds( *project );

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -55,17 +55,15 @@ namespace QgsWms
                         const QString &version, const QgsServerRequest &request,
                         QgsServerResponse &response )
   {
-    QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
+    QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
 
     QDomDocument doc;
     const QDomDocument *contextDocument = nullptr;
 
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    cacheManager = serverIface->cacheManager();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       contextDocument = &doc;

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -66,7 +66,6 @@ namespace QgsWms
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       contextDocument = &doc;
@@ -81,7 +80,10 @@ namespace QgsWms
       }
       contextDocument = &doc;
     }
-
+#else
+    doc = getContext( serverIface, project, version, request );
+    contextDocument = &doc;
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( contextDocument->toByteArray() );
   }

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -39,12 +39,9 @@ namespace QgsWms
     QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
 
     // Get cached image
-    QgsAccessControl *accessControl = nullptr;
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
-    cacheManager = serverIface->cacheManager();
-#endif
+    QgsAccessControl *accessControl = serverIface->accessControls();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager )
     {
       ImageOutputFormat outputFormat = parseImageFormat( format );
@@ -78,6 +75,7 @@ namespace QgsWms
         return;
       }
     }
+#endif
 
     QgsRenderer renderer( serverIface, project, wmsParameters );
 
@@ -86,12 +84,14 @@ namespace QgsWms
     if ( result )
     {
       writeImage( response, *result,  format, renderer.getImageQuality() );
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( cacheManager )
       {
         QByteArray content = response.data();
         if ( !content.isEmpty() )
           cacheManager->setCachedImage( &content, project, request, accessControl );
       }
+#endif
     }
     else
     {

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -131,7 +131,11 @@ namespace QgsWms
       myDocument.appendChild( root );
 
       // access control
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+      ( void )serverIface;
+#endif
       // Use layer ids
       bool useLayerIds = QgsServerProjectUtils::wmsUseLayerIds( *project );
       // WMS restricted layers

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -56,7 +56,6 @@ namespace QgsWmts
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -71,7 +70,10 @@ namespace QgsWmts
       }
       capabilitiesDocument = &doc;
     }
-
+#else
+    doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+    capabilitiesDocument = &doc;
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( capabilitiesDocument->toByteArray() );
   }

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -46,16 +46,14 @@ namespace QgsWmts
   void writeGetCapabilities( QgsServerInterface *serverIface, const QgsProject *project, const QString &version,
                              const QgsServerRequest &request, QgsServerResponse &response )
   {
-    QgsAccessControl *accessControl = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
+    QgsAccessControl *accessControl = serverIface->accessControls();
 #endif
     QDomDocument doc;
     const QDomDocument *capabilitiesDocument = nullptr;
 
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    cacheManager = serverIface->cacheManager();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;

--- a/src/server/services/wmts/qgswmtsgettile.cpp
+++ b/src/server/services/wmts/qgswmtsgettile.cpp
@@ -34,12 +34,9 @@ namespace QgsWmts
     QUrlQuery query = translateWmtsParamToWmsQueryItem( QStringLiteral( "GetMap" ), params, project, serverIface );
 
     // Get cached image
-    QgsAccessControl *accessControl = nullptr;
-    QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    accessControl = serverIface->accessControls();
-    cacheManager = serverIface->cacheManager();
-#endif
+    QgsAccessControl *accessControl = serverIface->accessControls();
+    QgsServerCacheManager *cacheManager = serverIface->cacheManager();
     if ( cacheManager )
     {
       QgsWmtsParameters::Format f = params.format();
@@ -67,18 +64,20 @@ namespace QgsWmts
         return;
       }
     }
-
+#endif
 
     QgsServerParameters wmsParams( query );
     QgsServerRequest wmsRequest( "?" + query.query( QUrl::FullyDecoded ) );
     QgsService *service = serverIface->serviceRegistry()->getService( wmsParams.service(), wmsParams.version() );
     service->executeRequest( wmsRequest, response, project );
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
     if ( cacheManager )
     {
       QByteArray content = response.data();
       if ( !content.isEmpty() )
         cacheManager->setCachedImage( &content, project, request, accessControl );
     }
+#endif
   }
 
 } // namespace QgsWmts

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -254,6 +254,8 @@ namespace QgsWmts
     QList< layerDef > wmtsLayers;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     QgsAccessControl *accessControl = serverIface->accessControls();
+#else
+    ( void )serverIface;
 #endif
 
     // WMTS Project configuration
@@ -507,6 +509,10 @@ namespace QgsWmts
   QUrlQuery translateWmtsParamToWmsQueryItem( const QString &request, const QgsWmtsParameters &params,
       const QgsProject *project, QgsServerInterface *serverIface )
   {
+#ifndef HAVE_SERVER_PYTHON_PLUGINS
+    ( void )serverIface;
+#endif
+
     //defining Layer
     QString layer = params.layer();
     //read Layer


### PR DESCRIPTION
## Description
Manually backport:
* #32345 Server fix getCapabilities crash when plugins are off
* #32351 Server: fix more pointer errors when plugins are off
* #9755 Fix warnings when building without HAVE_SERVER_PYTHON_PLUGINS

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
