### PR TITLE
Fixes invalid renderer type after loading qml style

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -614,6 +614,14 @@ void QgsRasterLayerProperties::setRendererWidget( const QString &rendererName )
     }
   }
 
+  const int widgetIndex = mRenderTypeComboBox->findData( rendererName );
+  if ( widgetIndex != -1 )
+  {
+    mDisableRenderTypeComboBoxCurrentIndexChanged = true;
+    mRenderTypeComboBox->setCurrentIndex( widgetIndex );
+    mDisableRenderTypeComboBoxCurrentIndexChanged = false;
+  }
+
   if ( mRendererWidget != oldWidget )
     delete oldWidget;
 


### PR DESCRIPTION
## Description

The renderer type combobox is not updated after loading a QML style file.
