### PR TITLE
Connections db api tables table uri

### DIFF
--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -256,6 +256,14 @@ Returns connection capabilities
 %End
 
 
+    virtual QString tableUri( const QString &schema, const QString &name ) const throw( QgsProviderConnectionException );
+%Docstring
+Returns the URI string for the given ``table`` and ``schema``.
+Raises a QgsProviderConnectionException if any errors are encountered.
+
+:raises :: py:class:`QgsProviderConnectionException`
+%End
+
     virtual void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, QgsWkbTypes::Type wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const throw( QgsProviderConnectionException );
 %Docstring
 Creates an empty table with ``name`` in the given ``schema`` (schema is ignored  if not supported by the backend).

--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -262,6 +262,8 @@ Returns the URI string for the given ``table`` and ``schema``.
 Raises a QgsProviderConnectionException if any errors are encountered.
 
 :raises :: py:class:`QgsProviderConnectionException`
+
+.. versionadded:: 3.12
 %End
 
     virtual void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, QgsWkbTypes::Type wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const throw( QgsProviderConnectionException );
@@ -389,6 +391,8 @@ Raises a QgsProviderConnectionException if any errors are encountered or if the 
 .. note::
 
    Not available in Python bindings
+
+.. versionadded:: 3.12
 %End
 
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tablesInt( const QString &schema = QString(), const int flags = 0 ) const throw( QgsProviderConnectionException ) /PyName=tables/;

--- a/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
+++ b/python/core/auto_generated/qgsabstractdatabaseproviderconnection.sip.in
@@ -379,6 +379,18 @@ Raises a QgsProviderConnectionException if any errors are encountered.
 %End
 
 
+    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const;
+%Docstring
+Returns information on a ``table`` in the given ``schema``.
+Raises a QgsProviderConnectionException if any errors are encountered or if the table does not exist.
+
+:raises :: py:class:`QgsProviderConnectionException`
+
+.. note::
+
+   Not available in Python bindings
+%End
+
     QList<QgsAbstractDatabaseProviderConnection::TableProperty> tablesInt( const QString &schema = QString(), const int flags = 0 ) const throw( QgsProviderConnectionException ) /PyName=tables/;
 %Docstring
 Returns information on the tables in the given schema.

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -67,11 +67,15 @@ void QgsGeoPackageProviderConnection::remove( const QString &name ) const
 
 QString QgsGeoPackageProviderConnection::tableUri( const QString &schema, const QString &name ) const
 {
-  if ( ! tableExists( schema, name ) )
+  const auto tableInfo { table( schema, name ) };
+  if ( tableInfo.flags().testFlag( QgsAbstractDatabaseProviderConnection::TableFlag::Raster ) )
   {
-    throw QgsProviderConnectionException( QObject::tr( "Table '%1' does not exists" ).arg( name ) );
+    return QStringLiteral( "GPKG:%1:%2" ).arg( uri() ).arg( name );
   }
-  return uri() + QStringLiteral( "|layername=%1" ).arg( name );
+  else
+  {
+    return uri() + QStringLiteral( "|layername=%1" ).arg( name );
+  }
 }
 
 void QgsGeoPackageProviderConnection::createVectorTable( const QString &schema,

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -65,6 +65,14 @@ void QgsGeoPackageProviderConnection::remove( const QString &name ) const
   settings.remove( name );
 }
 
+QString QgsGeoPackageProviderConnection::tableUri( const QString &schema, const QString &name ) const
+{
+  if ( ! tableExists( schema, name ) )
+  {
+    throw QgsProviderConnectionException( QObject::tr( "Table '%1' does not exists" ).arg( name ) );
+  }
+  return uri() + QStringLiteral( "|layername=%1" ).arg( name );
+}
 
 void QgsGeoPackageProviderConnection::createVectorTable( const QString &schema,
     const QString &name,

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.cpp
@@ -38,6 +38,11 @@ QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString 
 QgsGeoPackageProviderConnection::QgsGeoPackageProviderConnection( const QString &uri, const QVariantMap &configuration ):
   QgsAbstractDatabaseProviderConnection( uri, configuration )
 {
+  // Cleanup the URI in case it contains other information other than the file path
+  if ( uri.contains( '|' ) )
+  {
+    setUri( uri.left( uri.indexOf( '|' ) ).trimmed() );
+  }
   setDefaultCapabilities();
 }
 

--- a/src/core/providers/ogr/qgsgeopackageproviderconnection.h
+++ b/src/core/providers/ogr/qgsgeopackageproviderconnection.h
@@ -33,6 +33,7 @@ class QgsGeoPackageProviderConnection : public QgsAbstractDatabaseProviderConnec
   public:
     void store( const QString &name ) const override;
     void remove( const QString &name ) const override;
+    QString tableUri( const QString &schema, const QString &name ) const override;
     void createVectorTable( const QString &schema, const QString &name, const QgsFields &fields, QgsWkbTypes::Type wkbType, const QgsCoordinateReferenceSystem &srs, bool overwrite, const QMap<QString, QVariant> *options ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;

--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -34,6 +34,13 @@ QgsAbstractDatabaseProviderConnection::Capabilities QgsAbstractDatabaseProviderC
   return mCapabilities;
 }
 
+QString QgsAbstractDatabaseProviderConnection::tableUri( const QString &schema, const QString &name ) const
+{
+  Q_UNUSED( schema )
+  Q_UNUSED( name )
+  throw QgsProviderConnectionException( QObject::tr( "Operation 'tableUri' is not supported" ) );
+}
+
 ///@cond PRIVATE
 void QgsAbstractDatabaseProviderConnection::checkCapability( QgsAbstractDatabaseProviderConnection::Capability capability ) const
 {

--- a/src/core/qgsabstractdatabaseproviderconnection.cpp
+++ b/src/core/qgsabstractdatabaseproviderconnection.cpp
@@ -138,6 +138,23 @@ QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsAbstractDatabaseP
   return QList<QgsAbstractDatabaseProviderConnection::TableProperty>();
 }
 
+
+QgsAbstractDatabaseProviderConnection::TableProperty QgsAbstractDatabaseProviderConnection::table( const QString &schema, const QString &name ) const
+{
+  checkCapability( Capability::Tables );
+  const QList<QgsAbstractDatabaseProviderConnection::TableProperty> constTables { tables( schema ) };
+  for ( const auto &t : constTables )
+  {
+    if ( t.tableName() == name )
+    {
+      return t;
+    }
+  }
+  throw QgsProviderConnectionException( QObject::tr( "Table '%1' was not found in schema '%2'" )
+                                        .arg( name )
+                                        .arg( schema ) );
+}
+
 QList<QgsAbstractDatabaseProviderConnection::TableProperty> QgsAbstractDatabaseProviderConnection::tablesInt( const QString &schema, const int flags ) const
 {
   return tables( schema, static_cast<QgsAbstractDatabaseProviderConnection::TableFlags>( flags ) );

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -409,7 +409,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     virtual void vacuum( const QString &schema, const QString &name ) const SIP_THROW( QgsProviderConnectionException );
 
     /**
-     * Returns information on the tables in the given schema .
+     * Returns information on the tables in the given schema.
      * Raises a QgsProviderConnectionException if any errors are encountered.
      * \param schema name of the schema (ignored if not supported by the backend)
      * \param flags filter tables by flags, this option completely overrides search options stored in the connection
@@ -417,6 +417,14 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * \note Not available in Python bindings
      */
     virtual QList<QgsAbstractDatabaseProviderConnection::TableProperty> tables( const QString &schema = QString(), const QgsAbstractDatabaseProviderConnection::TableFlags &flags = nullptr ) const SIP_SKIP;
+
+    /**
+     * Returns information on a \a table in the given \a schema.
+     * Raises a QgsProviderConnectionException if any errors are encountered or if the table does not exist.
+     * \throws QgsProviderConnectionException
+     * \note Not available in Python bindings
+     */
+    virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const;
 
     /**
      * Returns information on the tables in the given schema.

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -318,6 +318,13 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
     // Operations interface
 
     /**
+     * Returns the URI string for the given \a table and \a schema.
+     * Raises a QgsProviderConnectionException if any errors are encountered.
+     * \throws QgsProviderConnectionException
+     */
+    virtual QString tableUri( const QString &schema, const QString &name ) const SIP_THROW( QgsProviderConnectionException );
+
+    /**
      * Creates an empty table with \a name in the given \a schema (schema is ignored  if not supported by the backend).
      * Raises a QgsProviderConnectionException if any errors are encountered.
      * \throws QgsProviderConnectionException

--- a/src/core/qgsabstractdatabaseproviderconnection.h
+++ b/src/core/qgsabstractdatabaseproviderconnection.h
@@ -321,6 +321,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * Returns the URI string for the given \a table and \a schema.
      * Raises a QgsProviderConnectionException if any errors are encountered.
      * \throws QgsProviderConnectionException
+     * \since QGIS 3.12
      */
     virtual QString tableUri( const QString &schema, const QString &name ) const SIP_THROW( QgsProviderConnectionException );
 
@@ -423,6 +424,7 @@ class CORE_EXPORT QgsAbstractDatabaseProviderConnection : public QgsAbstractProv
      * Raises a QgsProviderConnectionException if any errors are encountered or if the table does not exist.
      * \throws QgsProviderConnectionException
      * \note Not available in Python bindings
+     * \since QGIS 3.12
      */
     virtual QgsAbstractDatabaseProviderConnection::TableProperty table( const QString &schema, const QString &table ) const;
 

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -110,6 +110,18 @@ void QgsPostgresProviderConnection::createVectorTable( const QString &schema,
   }
 }
 
+QString QgsPostgresProviderConnection::tableUri( const QString &schema, const QString &name ) const
+{
+  if ( ! tableExists( schema, name ) )
+  {
+    throw QgsProviderConnectionException( QObject::tr( "Table '%1' does not exists in schema '%2'" ).arg( name, schema ) );
+  }
+  QgsDataSourceUri dsUri( uri() );
+  dsUri.setTable( name );
+  dsUri.setSchema( schema );
+  return dsUri.uri( false );
+}
+
 void QgsPostgresProviderConnection::dropVectorTable( const QString &schema, const QString &name ) const
 {
   checkCapability( Capability::DropVectorTable );

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -36,12 +36,10 @@ QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &nam
 }
 
 QgsPostgresProviderConnection::QgsPostgresProviderConnection( const QString &uri, const QVariantMap &configuration ):
-  QgsAbstractDatabaseProviderConnection( uri, configuration )
+  QgsAbstractDatabaseProviderConnection( QgsDataSourceUri( uri ).connectionInfo( false ), configuration )
 {
   setDefaultCapabilities();
 }
-
-
 
 void QgsPostgresProviderConnection::setDefaultCapabilities()
 {

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -36,6 +36,7 @@ class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnecti
                             const QgsCoordinateReferenceSystem &srs, bool overwrite,
                             const QMap<QString, QVariant> *options ) const override;
 
+    QString tableUri( const QString &schema, const QString &name ) const override;
     void dropVectorTable( const QString &schema, const QString &name ) const override;
     void dropRasterTable( const QString &schema, const QString &name ) const override;
     void renameVectorTable( const QString &schema, const QString &name, const QString &newName ) const override;

--- a/src/providers/postgres/qgspostgresproviderconnection.h
+++ b/src/providers/postgres/qgspostgresproviderconnection.h
@@ -19,6 +19,7 @@
 
 
 class QgsPostgresProviderConnection : public QgsAbstractDatabaseProviderConnection
+
 {
   public:
 

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -45,7 +45,7 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         gpkg_original_path = '{}/qgis_server/test_project_wms_grouped_layers.gpkg'.format(TEST_DATA_DIR)
         cls.gpkg_path = '{}/qgis_server/test_project_wms_grouped_layers_test.gpkg'.format(TEST_DATA_DIR)
         shutil.copy(gpkg_original_path, cls.gpkg_path)
-        vl = QgsVectorLayer('{}|cdb_lines'.format(cls.gpkg_path), 'test', 'ogr')
+        vl = QgsVectorLayer('{}|layername=cdb_lines'.format(cls.gpkg_path), 'test', 'ogr')
         assert vl.isValid()
         cls.uri = cls.gpkg_path
 
@@ -58,9 +58,18 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         """Create a connection from a layer uri and retrieve it"""
 
         md = QgsProviderRegistry.instance().providerMetadata('ogr')
-        vl = QgsVectorLayer('{}|cdb_lines'.format(self.gpkg_path), 'test', 'ogr')
+        vl = QgsVectorLayer('{}|layername=cdb_lines'.format(self.gpkg_path), 'test', 'ogr')
         conn = md.createConnection(vl.dataProvider().uri().uri(), {})
         self.assertEqual(conn.uri(), self.gpkg_path)
+
+    def test_gpkg_table_uri(self):
+        """Create a connection from a layer uri and create a table URI"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('ogr')
+        conn = md.createConnection(self.uri, {})
+        self.assertEqual(conn.tableUri('', 'cdb_lines'), '{}|layername=cdb_lines'.format(self.gpkg_path))
+        vl = QgsVectorLayer(conn.tableUri('', 'cdb_lines'), 'lines', 'ogr')
+        self.assertTrue(vl.isValid())
 
     def test_gpkg_connections(self):
         """Create some connections and retrieve them"""

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -54,6 +54,14 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         """Run after all tests"""
         os.unlink(cls.gpkg_path)
 
+    def test_gpkg_connections_from_uri(self):
+        """Create a connection from a layer uri and retrieve it"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('ogr')
+        vl = QgsVectorLayer('{}|cdb_lines'.format(self.gpkg_path), 'test', 'ogr')
+        conn = md.createConnection(vl.dataProvider().uri().uri(), {})
+        self.assertEqual(conn.uri(), self.gpkg_path)
+
     def test_gpkg_connections(self):
         """Create some connections and retrieve them"""
 

--- a/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
+++ b/tests/src/python/test_qgsproviderconnection_ogr_gpkg.py
@@ -21,6 +21,7 @@ from qgis.core import (
     QgsAbstractDatabaseProviderConnection,
     QgsProviderConnectionException,
     QgsVectorLayer,
+    QgsRasterLayer,
     QgsProviderRegistry,
     QgsFields,
     QgsCoordinateReferenceSystem,
@@ -70,6 +71,14 @@ class TestPyQgsProviderConnectionGpkg(unittest.TestCase, TestPyQgsProviderConnec
         self.assertEqual(conn.tableUri('', 'cdb_lines'), '{}|layername=cdb_lines'.format(self.gpkg_path))
         vl = QgsVectorLayer(conn.tableUri('', 'cdb_lines'), 'lines', 'ogr')
         self.assertTrue(vl.isValid())
+
+        # Test table(), throws if not found
+        table_info = conn.table('', 'osm')
+        table_info = conn.table('', 'cdb_lines')
+
+        self.assertEqual(conn.tableUri('', 'osm'), "GPKG:%s:osm" % self.uri)
+        rl = QgsRasterLayer(conn.tableUri('', 'osm'), 'r', 'gdal')
+        self.assertTrue(rl.isValid())
 
     def test_gpkg_connections(self):
         """Create some connections and retrieve them"""

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -45,7 +45,15 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
         # Create test layers
         vl = QgsVectorLayer(cls.postgres_conn + ' sslmode=disable key=\'"key1","key2"\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=', 'test', 'postgres')
         assert vl.isValid()
-        cls.uri = cls.postgres_conn + ' port=5432 sslmode=disable '
+        cls.uri = cls.postgres_conn + ' sslmode=disable'
+
+    def test_postgis_connections_from_uri(self):
+        """Create a connection from a layer uri and retrieve it"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('postgres')
+        vl = QgsVectorLayer(self.postgres_conn + ' sslmode=disable key=\'"key1","key2"\' srid=4326 type=POINT table="qgis_test"."someData" (geom) sql=', 'test', 'postgres')
+        conn = md.createConnection(vl.dataProvider().uri().uri(), {})
+        self.assertEqual(conn.uri(), self.uri)
 
     def test_postgis_connections(self):
         """Create some connections and retrieve them"""

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -61,9 +61,11 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
 
         # Test raster
         self.assertEqual(conn.tableUri('qgis_test', 'Raster1'),
-                         'PG: dbname=\'qgis_test\' sslmode=disable mode=2 schema=\'qgis_test\' table=\'Raster1\' column=\'Rast\'')
-        rl = QgsRasterLayer(conn.tableUri('qgis_test', 'Raster1'), 'r1', 'gdal')
-        self.assertTrue(rl.isValid())
+                         'PG: %s mode=2 schema=\'qgis_test\' table=\'Raster1\' column=\'Rast\'' % self.uri)
+
+        if (gdal.VersionInfo() >= '2040000'):
+            rl = QgsRasterLayer(conn.tableUri('qgis_test', 'Raster1'), 'r1', 'gdal')
+            self.assertTrue(rl.isValid())
 
     def test_postgis_table_uri(self):
         """Create a connection from a layer uri and create a table URI"""

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -55,6 +55,16 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
         conn = md.createConnection(vl.dataProvider().uri().uri(), {})
         self.assertEqual(conn.uri(), self.uri)
 
+        # Test table(), throws if not found
+        table_info = conn.table('qgis_test', 'someData')
+        table_info = conn.table('qgis_test', 'Raster1')
+
+        # Test raster
+        self.assertEqual(conn.tableUri('qgis_test', 'Raster1'),
+                         'PG: dbname=\'qgis_test\' sslmode=disable mode=2 schema=\'qgis_test\' table=\'Raster1\' column=\'Rast\'')
+        rl = QgsRasterLayer(conn.tableUri('qgis_test', 'Raster1'), 'r1', 'gdal')
+        self.assertTrue(rl.isValid())
+
     def test_postgis_table_uri(self):
         """Create a connection from a layer uri and create a table URI"""
 

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -55,6 +55,14 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
         conn = md.createConnection(vl.dataProvider().uri().uri(), {})
         self.assertEqual(conn.uri(), self.uri)
 
+    def test_postgis_table_uri(self):
+        """Create a connection from a layer uri and create a table URI"""
+
+        md = QgsProviderRegistry.instance().providerMetadata('postgres')
+        conn = md.createConnection(self.uri, {})
+        vl = QgsVectorLayer(conn.tableUri('qgis_test', 'geometries_table'), 'my', 'postgres')
+        self.assertTrue(vl.isValid())
+
     def test_postgis_connections(self):
         """Create some connections and retrieve them"""
 


### PR DESCRIPTION
Adds a few utility methods to the connections DB API:

- tableUri -> returns the uri string to create the vector or raster layer from the table schema and name
- table -> returns the information about an existing table in the given schema
