### PR TITLE
[Backport 3.10] [WFS provider] Do not expand authentication config to username/password when adding layers from source select or browser

### DIFF
--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -54,14 +54,14 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
   if ( !username.isEmpty() )
   {
     // check for a password, if none prompt to get it
-    mUri.setParam( QStringLiteral( "username" ), username );
-    mUri.setParam( QStringLiteral( "password" ), password );
+    mUri.setUsername( username );
+    mUri.setPassword( password );
   }
 
   QString authcfg = settings.value( credentialsKey + "/authcfg" ).toString();
   if ( !authcfg.isEmpty() )
   {
-    mUri.setParam( QStringLiteral( "authcfg" ), authcfg );
+    mUri.setAuthConfigId( authcfg );
   }
   mConnectionInfo.append( ",authcfg=" + authcfg );
 

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -191,7 +191,7 @@ QVector<QgsDataItem *> QgsWfsRootItem::createChildren()
   {
     QgsWfsConnection connection( connName );
     QString path = "wfs:/" + connName;
-    QgsDataItem *conn = new QgsWfsConnectionItem( this, connName, path, connection.uri().uri() );
+    QgsDataItem *conn = new QgsWfsConnectionItem( this, connName, path, connection.uri().uri( false ) );
     connections.append( conn );
   }
   return connections;
@@ -260,7 +260,7 @@ QgsDataItem *QgsWfsDataItemProvider::createDataItem( const QString &path, QgsDat
 
       QgsDebugMsgLevel( QStringLiteral( "WFS full uri: '%1'." ).arg( QString( sourceUri.uri() ) ), 4 );
 
-      return new QgsWfsConnectionItem( parentItem, QStringLiteral( "WFS" ), path, sourceUri.uri( false ) );
+      return new QgsWfsConnectionItem( parentItem, QStringLiteral( "WFS" ), path, sourceUri.uri() );
     }
   }
 
@@ -287,9 +287,9 @@ QVector<QgsDataItem *> QgsWfsDataItemProvider::createDataItems( const QString &p
         for ( const QString &encodedUri : encodedUris )
         {
           QgsWFSDataSourceURI uri( encodedUri );
-          QgsDebugMsgLevel( QStringLiteral( "WFS full uri: '%1'." ).arg( uri.uri( false ) ), 4 );
+          QgsDebugMsgLevel( QStringLiteral( "WFS full uri: '%1'." ).arg( uri.uri() ), 4 );
 
-          QgsDataItem *item = new QgsWfsConnectionItem( parentItem, QStringLiteral( "WFS" ), path, uri.uri( false ) );
+          QgsDataItem *item = new QgsWfsConnectionItem( parentItem, QStringLiteral( "WFS" ), path, uri.uri() );
           if ( item )
           {
             items.append( item );

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -144,7 +144,7 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
   }
 }
 
-const QString QgsWFSDataSourceURI::uri( bool expandAuthConfig ) const
+const QString QgsWFSDataSourceURI::uri() const
 {
   QgsDataSourceUri theURI( mURI );
   // Add authcfg param back into the uri (must be non-empty value)
@@ -164,8 +164,8 @@ const QString QgsWFSDataSourceURI::uri( bool expandAuthConfig ) const
       theURI.setPassword( mAuth.mPassword );
     }
   }
-  // NOTE: avoid expanding authcfg here; it is handled during network access
-  return theURI.uri( expandAuthConfig );
+  // NOTE: do not expand authcfg here; it is handled during network access
+  return theURI.uri( false );
 }
 
 

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -85,7 +85,7 @@ class QgsWFSDataSourceURI
     explicit QgsWFSDataSourceURI( const QString &uri );
 
     //! Returns the URI, avoiding expansion of authentication configuration, which is handled during network access
-    const QString uri( bool expandAuthConfig = false ) const;
+    const QString uri() const;
 
     //! Returns base URL (with SERVICE=WFS parameter if bIncludeServiceWFS=true)
     QUrl baseURL( bool bIncludeServiceWFS = true ) const;

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -404,7 +404,7 @@ void QgsWFSSourceSelect::addButtonClicked()
     }
     QgsDebugMsg( "Layer " + typeName + " SQL is " + sql );
 
-    mUri = QgsWFSDataSourceURI::build( connection.uri().uri(), typeName, pCrsString,
+    mUri = QgsWFSDataSourceURI::build( connection.uri().uri( false ), typeName, pCrsString,
                                        sql, cbxFeatureCurrentViewExtent->isChecked() );
 
     emit addVectorLayer( mUri, layerName );


### PR DESCRIPTION
Related suggested QGIS 4.0 API change : qgis/qgis4.0_api#100