### PR TITLE
Fix map renderer world file not taking into account complete base name

### DIFF
--- a/src/core/qgsmaprenderertask.cpp
+++ b/src/core/qgsmaprenderertask.cpp
@@ -402,7 +402,7 @@ bool QgsMapRendererTask::run()
 
         if ( !skipWorldFile )
         {
-          QString worldFileName = info.absolutePath() + '/' + info.baseName() + '.'
+          QString worldFileName = info.absolutePath() + '/' + info.completeBaseName() + '.'
                                   + outputSuffix.at( 0 ) + outputSuffix.at( info.suffix().size() - 1 ) + 'w';
           QFile worldFile( worldFileName );
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This fixes the following scenario: when exporting the map canvas as an image using the following filename: 'my_canvas-v.1.25.png', the world file name would wrongly be 'my_canvas-v.pgw'.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
