### PR TITLE
add QGIS version in model exported as Python

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -19,6 +19,7 @@
 #include "qgsprocessingregistry.h"
 #include "qgsprocessingfeedback.h"
 #include "qgsprocessingutils.h"
+#include "qgis.h"
 #include "qgsxmlutils.h"
 #include "qgsexception.h"
 #include "qgsvectorlayer.h"
@@ -362,6 +363,15 @@ void QgsProcessingModelAlgorithm::setSourceFilePath( const QString &sourceFile )
 
 QStringList QgsProcessingModelAlgorithm::asPythonCode( const QgsProcessing::PythonOutputType outputType, const int indentSize ) const
 {
+  QStringList fileDocString;
+  fileDocString << QStringLiteral( "\"\"\"" );
+  fileDocString << QStringLiteral( "Model exported as python." );
+  fileDocString << QStringLiteral( "Name : %1" ).arg( displayName() );
+  fileDocString << QStringLiteral( "Group : %1" ).arg( group() );
+  fileDocString << QStringLiteral( "With QGIS : %1" ).arg( Qgis::QGIS_VERSION_INT );
+  fileDocString << QStringLiteral( "\"\"\"" );
+  fileDocString << QString();
+
   QStringList lines;
   QString indent = QString( ' ' ).repeated( indentSize );
   QString currentIndent;
@@ -680,7 +690,7 @@ QStringList QgsProcessingModelAlgorithm::asPythonCode( const QgsProcessing::Pyth
         }
       }
 
-      lines = importLines + lines;
+      lines = fileDocString + importLines + lines;
       break;
   }
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -7755,7 +7755,13 @@ void TestQgsProcessing::modelExecution()
   model2.childAlgorithm( "cx1" ).setDescription( "first step in my model" );
   QStringList actualParts = model2.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, 2 );
   QgsDebugMsg( actualParts.join( '\n' ) );
-  QStringList expectedParts = QStringLiteral( "from qgis.core import QgsProcessing\n"
+  QStringList expectedParts = QStringLiteral( "\"\"\"\n"
+                              "Model exported as python.\n"
+                              "Name : 2my model\n"
+                              "Group : \n"
+                              "With QGIS : %1\n"
+                              "\"\"\"\n\n"
+                              "from qgis.core import QgsProcessing\n"
                               "from qgis.core import QgsProcessingAlgorithm\n"
                               "from qgis.core import QgsProcessingMultiStepFeedback\n"
                               "from qgis.core import QgsProcessingParameterFeatureSource\n"
@@ -7833,7 +7839,7 @@ void TestQgsProcessing::modelExecution()
                               "    return ''\n"
                               "\n"
                               "  def createInstance(self):\n"
-                              "    return MyModel()\n" ).split( '\n' );
+                              "    return MyModel()\n" ).arg( Qgis::QGIS_VERSION_INT ).split( '\n' );
   QCOMPARE( actualParts, expectedParts );
 }
 


### PR DESCRIPTION
## Description

A model created in QGIS 3.8, might not be compatible with an older version of QGIS:
* The API might be improved
* Algorithm not available, etc

I just tried a model from QGIS 3.8 in QGIS 3.6 and I got a Python exception.

This PR is adding the QGIS version which has been used to export the model as Python script, in the docstring metadata.
Ideally, we should add the QGIS version which as been used to create the model too. (It needs to be added in the `.model3` file)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
