### PR TITLE
Fix waitforfinished

### DIFF
--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -57,8 +57,8 @@ qint64 QgsTask::elapsedTime() const
 
 void QgsTask::start()
 {
-  mNotStartedMutex.unlock();
   mNotFinishedMutex.lock();
+  mNotStartedMutex.unlock();
   mStartCount++;
   Q_ASSERT( mStartCount == 1 );
 

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -310,6 +310,7 @@ class CORE_EXPORT QgsTask : public QObject
      * it's used as a trigger for waitForFinished.
      */
     QMutex mNotFinishedMutex;
+    QMutex mNotStartedMutex;
 
     //! Progress of this (parent) task alone
     double mProgress = 0.0;

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -396,10 +396,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
 
         counterTask = point_layer.countSymbolFeatures()
         counterTask.waitForFinished()
-        TM = QgsApplication.taskManager()
-        actask = TM.activeTasks()
-        print(TM.tasks(), actask)
-        count = actask[0]
         legend.model().refreshLayerLegend(legendlayer)
         legendnodes = legend.model().layerLegendNodes(legendlayer)
         legendnodes[0].setUserLabel('[% @symbol_id %]')
@@ -408,7 +404,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         label1 = legendnodes[0].evaluateLabel()
         label2 = legendnodes[1].evaluateLabel()
         label3 = legendnodes[2].evaluateLabel()
-        count.waitForFinished()
         self.assertEqual(label1, '0')
         #self.assertEqual(label2, '5')
         #self.assertEqual(label3, '12')
@@ -463,7 +458,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         group = legend.model().rootGroup().addGroup("Group [% 1 + 5 %] [% @layout_name %]")
         layer_tree_layer = group.addLayer(point_layer)
         counterTask = point_layer.countSymbolFeatures()
-        counterTask.waitForFinished() # does this even work?
+        counterTask.waitForFinished()
         layer_tree_layer.setCustomProperty("legend/title-label", 'bbbb [% 1+2 %] xx [% @layout_name %] [% @layer_name %]')
         QgsMapLayerLegendUtils.setLegendNodeUserLabel(layer_tree_layer, 0, 'xxxx')
         legend.model().refreshLayerLegend(layer_tree_layer)
@@ -475,11 +470,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         legend.setLinkedMap(map)
         legend.updateLegend()
         print(layer_tree_layer.labelExpression())
-        TM = QgsApplication.taskManager()
-        actask = TM.activeTasks()
-        print(TM.tasks(), actask)
-        count = actask[0]
-        count.waitForFinished()
         map.setExtent(QgsRectangle(-102.51, 41.16, -102.36, 41.30))
         checker = QgsLayoutChecker(
             'composer_legend_symbol_expression', layout)


### PR DESCRIPTION
## Description

This PR fixes Task::waitForFinished methods. The method doesn't wait the task to be finished if the task has not yet being started (because the task wait to start if there is no thread available for instance). 

It could lead to crashes (If you access some shared memory data believing the task has finished to run) so I will be in favor to backporting this to 3.4.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
