### PR TITLE
[processing] allow to select files without suffix in the Processing options dialog

### DIFF
--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -463,7 +463,7 @@ class FileDirectorySelector(QWidget):
                                                             QFileDialog.ShowDirsOnly)
         else:
             selectedPath, selected_filter = QFileDialog.getOpenFileName(None,
-                                                                        self.tr('Select file'), lastDir, self.tr('All files (*.*)')
+                                                                        self.tr('Select file'), lastDir, self.tr('All files (*)')
                                                                         )
 
         if not selectedPath:


### PR DESCRIPTION
## Description
Adjust filter string in the Processing settings file selector widged to allow selecting files without suffixes on platforms which does not use them.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
