### PR TITLE
set current view mode to attribute editor

### DIFF
--- a/src/gui/qgsfeatureselectiondlg.cpp
+++ b/src/gui/qgsfeatureselectiondlg.cpp
@@ -35,6 +35,7 @@ QgsFeatureSelectionDlg::QgsFeatureSelectionDlg( QgsVectorLayer *vl, QgsAttribute
 
   // TODO: Proper QgsDistanceArea, proper mapcanvas
   mDualView->init( mVectorLayer, nullptr, QgsFeatureRequest(), context );
+  mDualView->setView( QgsDualView::AttributeEditor );
 }
 
 const QgsFeatureIds &QgsFeatureSelectionDlg::selectedFeatures()


### PR DESCRIPTION
## Description

Since this commit a8d145a80a, the view mode is the attribute table by default but for the feature selection dialog it should be attribute editor. This PR force the view mode to attribute editor.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
