### PR TITLE
Add default values to QgsJsonUtils::stringToFeatureList

### DIFF
--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -267,15 +267,13 @@ Helper utilities for working with JSON and GeoJSON conversions.
 %End
   public:
 
-    static QgsFeatureList stringToFeatureList( const QString &string, const QgsFields &fields, QTextCodec *encoding );
+    static QgsFeatureList stringToFeatureList( const QString &string, const QgsFields &fields = QgsFields(), QTextCodec *encoding = 0 );
 %Docstring
-Attempts to parse a GeoJSON string to a collection of features.
+Attempts to parse a GeoJSON ``string`` to a collection of features.
+It is possible to specify ``fields`` to parse specific fields, if not provided, no fields will be included.
+An ``encoding`` can be specified which defaults to UTF-8 if it is `None`.
 
-:param string: GeoJSON string to parse
-:param fields: fields collection to use for parsed features
-:param encoding: text encoding
-
-:return: list of parsed features, or an empty list if no features could be parsed
+:return: a list of parsed features, or an empty list if no features could be parsed
 
 .. seealso:: :py:func:`stringToFields`
 
@@ -284,12 +282,10 @@ Attempts to parse a GeoJSON string to a collection of features.
    this function is a wrapper around :py:func:`QgsOgrUtils.stringToFeatureList()`
 %End
 
-    static QgsFields stringToFields( const QString &string, QTextCodec *encoding );
+    static QgsFields stringToFields( const QString &string, QTextCodec *encoding = 0 );
 %Docstring
-Attempts to retrieve the fields from a GeoJSON string representing a collection of features.
-
-:param string: GeoJSON string to parse
-:param encoding: text encoding
+Attempts to retrieve the fields from a GeoJSON  ``string`` representing a collection of features.
+An ``encoding`` can be specified which defaults to UTF-8 if it is `None`.
 
 :return: retrieved fields collection, or an empty list if no fields could be determined from the string
 

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -248,11 +248,17 @@ json QgsJsonExporter::exportFeaturesToJsonObject( const QgsFeatureList &features
 
 QgsFeatureList QgsJsonUtils::stringToFeatureList( const QString &string, const QgsFields &fields, QTextCodec *encoding )
 {
+  if ( !encoding )
+    encoding = QTextCodec::codecForName( "UTF-8" );
+
   return QgsOgrUtils::stringToFeatureList( string, fields, encoding );
 }
 
 QgsFields QgsJsonUtils::stringToFields( const QString &string, QTextCodec *encoding )
 {
+  if ( !encoding )
+    encoding = QTextCodec::codecForName( "UTF-8" );
+
   return QgsOgrUtils::stringToFields( string, encoding );
 }
 

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -284,25 +284,23 @@ class CORE_EXPORT QgsJsonUtils
   public:
 
     /**
-     * Attempts to parse a GeoJSON string to a collection of features.
-     * \param string GeoJSON string to parse
-     * \param fields fields collection to use for parsed features
-     * \param encoding text encoding
-     * \returns list of parsed features, or an empty list if no features could be parsed
+     * Attempts to parse a GeoJSON \a string to a collection of features.
+     * It is possible to specify \a fields to parse specific fields, if not provided, no fields will be included.
+     * An \a encoding can be specified which defaults to UTF-8 if it is `nullptr`.
+     * \returns a list of parsed features, or an empty list if no features could be parsed
      * \see stringToFields()
      * \note this function is a wrapper around QgsOgrUtils::stringToFeatureList()
      */
-    static QgsFeatureList stringToFeatureList( const QString &string, const QgsFields &fields, QTextCodec *encoding );
+    static QgsFeatureList stringToFeatureList( const QString &string, const QgsFields &fields = QgsFields(), QTextCodec *encoding = nullptr );
 
     /**
-     * Attempts to retrieve the fields from a GeoJSON string representing a collection of features.
-     * \param string GeoJSON string to parse
-     * \param encoding text encoding
+     * Attempts to retrieve the fields from a GeoJSON  \a string representing a collection of features.
+     * An \a encoding can be specified which defaults to UTF-8 if it is `nullptr`.
      * \returns retrieved fields collection, or an empty list if no fields could be determined from the string
      * \see stringToFeatureList()
      * \note this function is a wrapper around QgsOgrUtils::stringToFields()
      */
-    static QgsFields stringToFields( const QString &string, QTextCodec *encoding );
+    static QgsFields stringToFields( const QString &string, QTextCodec *encoding = nullptr );
 
     /**
      * Encodes a value to a JSON string representation, adding appropriate quotations and escaping


### PR DESCRIPTION
Because we can assume the user does not care for fields if he does not specify
them and that UTF-8 is the default except when it's not.