### PR TITLE
Selection widget in feature selection dialog

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -291,7 +291,8 @@ The following operations will be performed to convert the input features:
     static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );
 %Docstring
 
-:return: the ``layer`` ``feature`` display string
+:return: a descriptive string for a ``feature``, suitable for displaying to the user.
+         The definition is taken from the ``displayExpression`` property of ``layer``.
 
 .. versionadded:: 3.12
 %End

--- a/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
+++ b/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
@@ -53,13 +53,12 @@ Set the selected features
     virtual void keyPressEvent( QKeyEvent *evt );
 
 
-  protected:
-
     virtual void showEvent( QShowEvent *event );
 
 %Docstring
 Make sure the dialog does not grow too much
 %End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
+++ b/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
@@ -29,7 +29,7 @@ class QgsFeatureSelectionDlg : QDialog
 %End
   public:
 
-    explicit QgsFeatureSelectionDlg( QgsVectorLayer *vl, QgsAttributeEditorContext &context, QWidget *parent /TransferThis/ = 0 );
+    explicit QgsFeatureSelectionDlg( QgsVectorLayer *vl, const QgsAttributeEditorContext &context, QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsFeatureSelectionDlg
 %End
@@ -47,6 +47,11 @@ Set the selected features
 
 :param ids: The feature ids to select
 %End
+
+  protected:
+
+    virtual void keyPressEvent( QKeyEvent *evt );
+
 
   protected:
 

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -23,7 +23,6 @@
 #include "qgsattributetablefiltermodel.h"
 #include "qgsattributetableview.h"
 #include "qgsexpressioncontextutils.h"
-#include "qgsexpressionlineedit.h"
 
 #include "qgsapplication.h"
 #include "qgsvectorlayer.h"
@@ -31,7 +30,6 @@
 #include "qgsvectordataprovider.h"
 #include "qgsexpression.h"
 #include "qgsexpressionbuilderwidget.h"
-#include "qgisapp.h"
 #include "qgsaddattrdialog.h"
 #include "qgsdelattrdialog.h"
 #include "qgsdockwidget.h"
@@ -43,7 +41,6 @@
 #include "qgsfieldcalculator.h"
 #include "qgsfeatureaction.h"
 #include "qgsactionmanager.h"
-#include "qgsexpressionbuilderdialog.h"
 #include "qgsmessagebar.h"
 #include "qgsexpressionselectiondialog.h"
 #include "qgsfeaturelistmodel.h"
@@ -56,8 +53,7 @@
 #include "qgsfeaturestore.h"
 #include "qgsguiutils.h"
 #include "qgsproxyprogresstask.h"
-#include "qgsstoredexpressionmanager.h"
-#include "qgsdialog.h"
+#include "qgisapp.h"
 
 QgsExpressionContext QgsAttributeTableDialog::createExpressionContext() const
 {
@@ -184,27 +180,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   QgsAttributeTableConfig config = mLayer->attributeTableConfig();
   mMainView->setAttributeTableConfig( config );
 
-  // Initialize filter gui elements
-  mFilterActionMapper = new QSignalMapper( this );
-  mFilterColumnsMenu = new QMenu( this );
-  mActionFilterColumnsMenu->setMenu( mFilterColumnsMenu );
-  mStoredFilterExpressionMenu = new QMenu( this );
-  mActionStoredFilterExpressions->setMenu( mStoredFilterExpressionMenu );
-
-  // Set filter icon in a couple of places
-  QIcon filterIcon = QgsApplication::getThemeIcon( "/mActionFilter2.svg" );
-  mActionShowAllFilter->setIcon( filterIcon );
-  mActionAdvancedFilter->setIcon( filterIcon );
-  mActionSelectedFilter->setIcon( filterIcon );
-  mActionVisibleFilter->setIcon( filterIcon );
-  mActionEditedFilter->setIcon( filterIcon );
-
-  // Set button to store or delete stored filter expressions
-  mStoreFilterExpressionButton->setDefaultAction( mActionHandleStoreFilterExpression );
-  connect( mActionSaveAsStoredFilterExpression, &QAction::triggered, this, &QgsAttributeTableDialog::saveAsStoredFilterExpression );
-  connect( mActionEditStoredFilterExpression, &QAction::triggered, this, &QgsAttributeTableDialog::editStoredFilterExpression );
-  connect( mActionHandleStoreFilterExpression, &QAction::triggered, this, &QgsAttributeTableDialog::handleStoreFilterExpression );
-  mApplyFilterButton->setDefaultAction( mActionApplyFilter );
+  mFeatureFilterWidget->init( mLayer, mEditorContext, mMainView, QgisApp::instance()->messageBar(), QgisApp::instance()->messageTimeout() );
 
   mActionFeatureActions = new QToolButton();
   mActionFeatureActions->setAutoRaise( false );
@@ -215,21 +191,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
 
   mToolbar->addWidget( mActionFeatureActions );
 
-  // Connect filter signals
-  connect( mActionAdvancedFilter, &QAction::triggered, this, &QgsAttributeTableDialog::filterExpressionBuilder );
-  connect( mActionShowAllFilter, &QAction::triggered, this, &QgsAttributeTableDialog::filterShowAll );
-  connect( mActionSelectedFilter, &QAction::triggered, this, &QgsAttributeTableDialog::filterSelected );
-  connect( mActionVisibleFilter, &QAction::triggered, this, &QgsAttributeTableDialog::filterVisible );
-  connect( mActionEditedFilter, &QAction::triggered, this, &QgsAttributeTableDialog::filterEdited );
-  connect( mFilterActionMapper, SIGNAL( mapped( QObject * ) ), SLOT( filterColumnChanged( QObject * ) ) );
-  connect( mFilterQuery, &QLineEdit::returnPressed, this, &QgsAttributeTableDialog::filterQueryAccepted );
-  connect( mActionApplyFilter, &QAction::triggered, this, &QgsAttributeTableDialog::filterQueryAccepted );
-  connect( mFilterQuery, &QLineEdit::textChanged, this, &QgsAttributeTableDialog::onFilterQueryTextChanged );
   connect( mActionSetStyles, &QAction::triggered, this, &QgsAttributeTableDialog::openConditionalStyles );
-
-  //set delay on entering text
-  mFilterQueryTimer.setSingleShot( true );
-  connect( &mFilterQueryTimer, &QTimer::timeout, this, &QgsAttributeTableDialog::updateCurrentStoredFilterExpression );
 
   // info from layer to table
   connect( mLayer, &QgsVectorLayer::editingStarted, this, &QgsAttributeTableDialog::editingToggled );
@@ -239,8 +201,6 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mLayer, &QgsVectorLayer::featureAdded, this, &QgsAttributeTableDialog::updateTitle );
   connect( mLayer, &QgsVectorLayer::featuresDeleted, this, &QgsAttributeTableDialog::updateTitle );
   connect( mLayer, &QgsVectorLayer::editingStopped, this, &QgsAttributeTableDialog::updateTitle );
-  connect( mLayer, &QgsVectorLayer::attributeAdded, this, &QgsAttributeTableDialog::columnBoxInit );
-  connect( mLayer, &QgsVectorLayer::attributeDeleted, this, &QgsAttributeTableDialog::columnBoxInit );
   connect( mLayer, &QgsVectorLayer::readOnlyChanged, this, &QgsAttributeTableDialog::editingToggled );
 
   // connect table info to window
@@ -262,10 +222,6 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   mActionDockUndock->setChecked( dockTable );
   connect( mActionDockUndock, &QAction::toggled, this, &QgsAttributeTableDialog::toggleDockMode );
   installEventFilter( this );
-
-  columnBoxInit();
-  storedFilterExpressionBoxInit();
-  storeExpressionButtonInit();
 
   updateTitle();
 
@@ -324,16 +280,16 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   switch ( initialMode )
   {
     case QgsAttributeTableFilterModel::ShowVisible:
-      filterVisible();
+      mFeatureFilterWidget->filterVisible();
       break;
 
     case QgsAttributeTableFilterModel::ShowSelected:
-      filterSelected();
+      mFeatureFilterWidget->filterSelected();
       break;
 
     case QgsAttributeTableFilterModel::ShowAll:
     default:
-      filterShowAll();
+      mFeatureFilterWidget->filterShowAll();
       break;
   }
 
@@ -440,93 +396,6 @@ bool QgsAttributeTableDialog::eventFilter( QObject *object, QEvent *ev )
   }
 
   return QDialog::eventFilter( object, ev );
-}
-
-void QgsAttributeTableDialog::columnBoxInit()
-{
-  const auto constActions = mFilterColumnsMenu->actions();
-  for ( QAction *a : constActions )
-  {
-    mFilterColumnsMenu->removeAction( a );
-    mFilterActionMapper->removeMappings( a );
-    mFilterButton->removeAction( a );
-    delete a;
-  }
-
-  mFilterButton->addAction( mActionShowAllFilter );
-  mFilterButton->addAction( mActionSelectedFilter );
-  if ( mLayer->isSpatial() )
-  {
-    mFilterButton->addAction( mActionVisibleFilter );
-  }
-  mFilterButton->addAction( mActionEditedFilter );
-  mFilterButton->addAction( mActionFilterColumnsMenu );
-  mFilterButton->addAction( mActionAdvancedFilter );
-  mFilterButton->addAction( mActionStoredFilterExpressions );
-
-  const QList<QgsField> fields = mLayer->fields().toList();
-
-  const auto constFields = fields;
-  for ( const QgsField &field : constFields )
-  {
-    int idx = mLayer->fields().lookupField( field.name() );
-    if ( idx < 0 )
-      continue;
-
-    if ( QgsGui::editorWidgetRegistry()->findBest( mLayer, field.name() ).type() != QLatin1String( "Hidden" ) )
-    {
-      QIcon icon = mLayer->fields().iconForField( idx );
-      QString alias = mLayer->attributeDisplayName( idx );
-
-      // Generate action for the filter popup button
-      QAction *filterAction = new QAction( icon, alias, mFilterButton );
-      filterAction->setData( field.name() );
-      mFilterActionMapper->setMapping( filterAction, filterAction );
-      connect( filterAction, SIGNAL( triggered() ), mFilterActionMapper, SLOT( map() ) );
-      mFilterColumnsMenu->addAction( filterAction );
-    }
-  }
-}
-
-void QgsAttributeTableDialog::storedFilterExpressionBoxInit()
-{
-  const auto constActions = mStoredFilterExpressionMenu->actions();
-  for ( QAction *a : constActions )
-  {
-    mStoredFilterExpressionMenu->removeAction( a );
-    delete a;
-  }
-
-  const QList< QgsStoredExpression > storedExpressions = mLayer->storedExpressionManager()->storedExpressions();
-  for ( const QgsStoredExpression &storedExpression : storedExpressions )
-  {
-    QAction *storedExpressionAction = new QAction( storedExpression.name, mFilterButton );
-    connect( storedExpressionAction, &QAction::triggered, this, [ = ]()
-    {
-      setFilterExpression( storedExpression.expression, QgsAttributeForm::ReplaceFilter, true );
-    } );
-    mStoredFilterExpressionMenu->addAction( storedExpressionAction );
-  }
-}
-
-void QgsAttributeTableDialog::storeExpressionButtonInit()
-{
-  if ( mActionHandleStoreFilterExpression->isChecked() )
-  {
-    mActionHandleStoreFilterExpression->setToolTip( tr( "Delete stored expression" ) );
-    mActionHandleStoreFilterExpression->setText( tr( "Delete Stored Expression" ) );
-    mActionHandleStoreFilterExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionHandleStoreFilterExpressionChecked.svg" ) ) );
-    mStoreFilterExpressionButton->removeAction( mActionSaveAsStoredFilterExpression );
-    mStoreFilterExpressionButton->addAction( mActionEditStoredFilterExpression );
-  }
-  else
-  {
-    mActionHandleStoreFilterExpression->setToolTip( tr( "Save expression with the text as name" ) );
-    mActionHandleStoreFilterExpression->setText( tr( "Save Expression" ) );
-    mActionHandleStoreFilterExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionHandleStoreFilterExpressionUnchecked.svg" ) ) );
-    mStoreFilterExpressionButton->addAction( mActionSaveAsStoredFilterExpression );
-    mStoreFilterExpressionButton->removeAction( mActionEditStoredFilterExpression );
-  }
 }
 
 void QgsAttributeTableDialog::updateFieldFromExpression()
@@ -654,15 +523,6 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer *layer, const 
   }
 }
 
-void QgsAttributeTableDialog::replaceSearchWidget( QWidget *oldw, QWidget *neww )
-{
-  mFilterLayout->removeWidget( oldw );
-  oldw->setVisible( false );
-  mFilterLayout->addWidget( neww, 0, 0, nullptr );
-  neww->setVisible( true );
-  neww->setFocus();
-}
-
 void QgsAttributeTableDialog::layerActionTriggered()
 {
   QAction *qAction = qobject_cast<QAction *>( sender() );
@@ -677,110 +537,6 @@ void QgsAttributeTableDialog::layerActionTriggered()
   action.run( context );
 }
 
-void QgsAttributeTableDialog::filterColumnChanged( QObject *filterAction )
-{
-  mFilterButton->setDefaultAction( qobject_cast<QAction *>( filterAction ) );
-  mFilterButton->setPopupMode( QToolButton::InstantPopup );
-  // replace the search line edit with a search widget that is suited to the selected field
-  // delete previous widget
-  if ( mCurrentSearchWidgetWrapper )
-  {
-    mCurrentSearchWidgetWrapper->widget()->setVisible( false );
-    delete mCurrentSearchWidgetWrapper;
-  }
-  QString fieldName = mFilterButton->defaultAction()->data().toString();
-  // get the search widget
-  int fldIdx = mLayer->fields().lookupField( fieldName );
-  if ( fldIdx < 0 )
-    return;
-  const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( mLayer, fieldName );
-  mCurrentSearchWidgetWrapper = QgsGui::editorWidgetRegistry()->
-                                createSearchWidget( setup.type(), mLayer, fldIdx, setup.config(), mFilterContainer, mEditorContext );
-  if ( mCurrentSearchWidgetWrapper->applyDirectly() )
-  {
-    connect( mCurrentSearchWidgetWrapper, &QgsSearchWidgetWrapper::expressionChanged, this, &QgsAttributeTableDialog::filterQueryChanged );
-    mApplyFilterButton->setVisible( false );
-    mStoreFilterExpressionButton->setVisible( false );
-  }
-  else
-  {
-    connect( mCurrentSearchWidgetWrapper, &QgsSearchWidgetWrapper::expressionChanged, this, &QgsAttributeTableDialog::filterQueryAccepted );
-    mApplyFilterButton->setVisible( true );
-    mStoreFilterExpressionButton->setVisible( true );
-  }
-
-  replaceSearchWidget( mFilterQuery, mCurrentSearchWidgetWrapper->widget() );
-}
-
-void QgsAttributeTableDialog::filterExpressionBuilder()
-{
-  // Show expression builder
-  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
-
-  QgsExpressionBuilderDialog dlg( mLayer, mFilterQuery->text(), this, QStringLiteral( "generic" ), context );
-  dlg.setWindowTitle( tr( "Expression Based Filter" ) );
-
-  QgsDistanceArea myDa;
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
-  dlg.setGeomCalculator( myDa );
-
-  if ( dlg.exec() == QDialog::Accepted )
-  {
-    setFilterExpression( dlg.expressionText(), QgsAttributeForm::ReplaceFilter, true );
-  }
-}
-
-void QgsAttributeTableDialog::filterShowAll()
-{
-  mFilterButton->setDefaultAction( mActionShowAllFilter );
-  mFilterButton->setPopupMode( QToolButton::InstantPopup );
-  mFilterQuery->setVisible( false );
-  mFilterQuery->setText( QString() );
-  if ( mCurrentSearchWidgetWrapper )
-  {
-    mCurrentSearchWidgetWrapper->widget()->setVisible( false );
-  }
-  mApplyFilterButton->setVisible( false );
-  mStoreFilterExpressionButton->setVisible( false );
-  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowAll );
-}
-
-void QgsAttributeTableDialog::filterSelected()
-{
-  mFilterButton->setDefaultAction( mActionSelectedFilter );
-  mFilterButton->setPopupMode( QToolButton::InstantPopup );
-  mFilterQuery->setVisible( false );
-  mApplyFilterButton->setVisible( false );
-  mStoreFilterExpressionButton->setVisible( false );
-  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowSelected );
-}
-
-void QgsAttributeTableDialog::filterVisible()
-{
-  if ( !mLayer->isSpatial() )
-  {
-    filterShowAll();
-    return;
-  }
-
-  mFilterButton->setDefaultAction( mActionVisibleFilter );
-  mFilterButton->setPopupMode( QToolButton::InstantPopup );
-  mFilterQuery->setVisible( false );
-  mApplyFilterButton->setVisible( false );
-  mStoreFilterExpressionButton->setVisible( false );
-  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowVisible );
-}
-
-void QgsAttributeTableDialog::filterEdited()
-{
-  mFilterButton->setDefaultAction( mActionEditedFilter );
-  mFilterButton->setPopupMode( QToolButton::InstantPopup );
-  mFilterQuery->setVisible( false );
-  mApplyFilterButton->setVisible( false );
-  mStoreFilterExpressionButton->setVisible( false );
-  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowEdited );
-}
 
 void QgsAttributeTableDialog::mActionSelectedToTop_toggled( bool checked )
 {
@@ -1043,7 +799,6 @@ void QgsAttributeTableDialog::mActionAddAttribute_triggered()
 
     // update model - a field has been added or updated
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
-    columnBoxInit();
   }
 }
 
@@ -1077,244 +832,20 @@ void QgsAttributeTableDialog::mActionRemoveAttribute_triggered()
     }
     // update model - a field has been added or updated
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );
-    columnBoxInit();
   }
 }
 
-void QgsAttributeTableDialog::filterQueryChanged( const QString &query )
-{
-  QString str;
-  if ( mFilterButton->defaultAction() == mActionAdvancedFilter )
-  {
-    str = query;
-  }
-  else if ( mCurrentSearchWidgetWrapper )
-  {
-    str = mCurrentSearchWidgetWrapper->expression();
-  }
-
-  setFilterExpression( str );
-}
-
-void QgsAttributeTableDialog::filterQueryAccepted()
-{
-  if ( ( mFilterQuery->isVisible() && mFilterQuery->text().isEmpty() ) ||
-       ( mCurrentSearchWidgetWrapper && mCurrentSearchWidgetWrapper->widget()->isVisible()
-         && mCurrentSearchWidgetWrapper->expression().isEmpty() ) )
-  {
-    filterShowAll();
-    return;
-  }
-  filterQueryChanged( mFilterQuery->text() );
-}
 
 void QgsAttributeTableDialog::openConditionalStyles()
 {
   mMainView->openConditionalStyles();
 }
 
-void QgsAttributeTableDialog::handleStoreFilterExpression()
-{
-  if ( !mActionHandleStoreFilterExpression->isChecked() )
-  {
-    mLayer->storedExpressionManager()->removeStoredExpression( mActionHandleStoreFilterExpression->data().toString() );
-  }
-  else
-  {
-    mLayer->storedExpressionManager()->addStoredExpression( mFilterQuery->text(), mFilterQuery->text() );
-  }
-
-  updateCurrentStoredFilterExpression();
-  storedFilterExpressionBoxInit();
-}
-
-void QgsAttributeTableDialog::saveAsStoredFilterExpression()
-{
-  QgsDialog *dlg = new QgsDialog( this, nullptr, QDialogButtonBox::Save | QDialogButtonBox::Cancel );
-  dlg->setWindowTitle( tr( "Save Expression As" ) );
-  QVBoxLayout *layout = dlg->layout();
-  dlg->resize( std::max( 400, this->width() / 2 ), dlg->height() );
-
-  QLabel *nameLabel = new QLabel( tr( "Name" ), dlg );
-  QLineEdit *nameEdit = new QLineEdit( dlg );
-  layout->addWidget( nameLabel );
-  layout->addWidget( nameEdit );
-
-  if ( dlg->exec() == QDialog::Accepted )
-  {
-    mLayer->storedExpressionManager()->addStoredExpression( nameEdit->text(), mFilterQuery->text() );
-
-    updateCurrentStoredFilterExpression();
-    storedFilterExpressionBoxInit();
-  }
-}
-
-void QgsAttributeTableDialog::editStoredFilterExpression()
-{
-  QgsDialog *dlg = new QgsDialog( this, nullptr, QDialogButtonBox::Save | QDialogButtonBox::Cancel );
-  dlg->setWindowTitle( tr( "Edit expression" ) );
-  QVBoxLayout *layout = dlg->layout();
-  dlg->resize( std::max( 400, this->width() / 2 ), dlg->height() );
-
-  QLabel *nameLabel = new QLabel( tr( "Name" ), dlg );
-  QLineEdit *nameEdit = new QLineEdit( mLayer->storedExpressionManager()->storedExpression( mActionHandleStoreFilterExpression->data().toString() ).name, dlg );
-  QLabel *expressionLabel = new QLabel( tr( "Expression" ), dlg );
-  QgsExpressionLineEdit *expressionEdit = new QgsExpressionLineEdit( dlg );
-  expressionEdit->setExpression( mLayer->storedExpressionManager()->storedExpression( mActionHandleStoreFilterExpression->data().toString() ).expression );
-
-  layout->addWidget( nameLabel );
-  layout->addWidget( nameEdit );
-  layout->addWidget( expressionLabel );
-  layout->addWidget( expressionEdit );
-
-  if ( dlg->exec() == QDialog::Accepted )
-  {
-    //update stored expression
-    mLayer->storedExpressionManager()->updateStoredExpression( mActionHandleStoreFilterExpression->data().toString(), nameEdit->text(), expressionEdit->expression(), QgsStoredExpression::Category::FilterExpression );
-
-    //update text
-    mFilterQuery->setValue( expressionEdit->expression() );
-
-    storedFilterExpressionBoxInit();
-  }
-}
-
-void QgsAttributeTableDialog::updateCurrentStoredFilterExpression()
-{
-  QgsStoredExpression currentStoredExpression = mLayer->storedExpressionManager()->findStoredExpressionByExpression( mFilterQuery->value() );
-
-  //set checked when it's an existing stored expression
-  mActionHandleStoreFilterExpression->setChecked( !currentStoredExpression.id.isNull() );
-
-  mActionHandleStoreFilterExpression->setData( currentStoredExpression.id );
-  mActionEditStoredFilterExpression->setData( currentStoredExpression.id );
-
-  //update bookmark button
-  storeExpressionButtonInit();
-}
-
-void QgsAttributeTableDialog::onFilterQueryTextChanged( const QString &value )
-{
-  Q_UNUSED( value );
-  mFilterQueryTimer.start( 300 );
-}
-
 void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, QgsAttributeForm::FilterType type,
     bool alwaysShowFilter )
 {
-  QString filter;
-  if ( !mFilterQuery->text().isEmpty() && !filterString.isEmpty() )
-  {
-    switch ( type )
-    {
-      case QgsAttributeForm::ReplaceFilter:
-        filter = filterString;
-        break;
-
-      case QgsAttributeForm::FilterAnd:
-        filter = QStringLiteral( "(%1) AND (%2)" ).arg( mFilterQuery->text(), filterString );
-        break;
-
-      case QgsAttributeForm::FilterOr:
-        filter = QStringLiteral( "(%1) OR (%2)" ).arg( mFilterQuery->text(), filterString );
-        break;
-    }
-  }
-  else if ( !filterString.isEmpty() )
-  {
-    filter = filterString;
-  }
-  else
-  {
-    filterShowAll();
-    return;
-  }
-
-  mFilterQuery->setText( filter );
-
-  if ( alwaysShowFilter || !mCurrentSearchWidgetWrapper || !mCurrentSearchWidgetWrapper->applyDirectly() )
-  {
-
-    mFilterButton->setDefaultAction( mActionAdvancedFilter );
-    mFilterButton->setPopupMode( QToolButton::MenuButtonPopup );
-    mFilterQuery->setVisible( true );
-    mApplyFilterButton->setVisible( true );
-    mStoreFilterExpressionButton->setVisible( true );
-    if ( mCurrentSearchWidgetWrapper )
-    {
-      // replace search widget widget with the normal filter query line edit
-      replaceSearchWidget( mCurrentSearchWidgetWrapper->widget(), mFilterQuery );
-    }
-  }
-
-  QgsFeatureIds filteredFeatures;
-  QgsDistanceArea myDa;
-
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
-
-  // parse search string and build parsed tree
-  QgsExpression filterExpression( filter );
-  if ( filterExpression.hasParserError() )
-  {
-    QgisApp::instance()->messageBar()->pushMessage( tr( "Parsing error" ), filterExpression.parserErrorString(), Qgis::Warning, QgisApp::instance()->messageTimeout() );
-    return;
-  }
-
-  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
-
-  if ( !filterExpression.prepare( &context ) )
-  {
-    QgisApp::instance()->messageBar()->pushMessage( tr( "Evaluation error" ), filterExpression.evalErrorString(), Qgis::Warning, QgisApp::instance()->messageTimeout() );
-  }
-
-  bool fetchGeom = filterExpression.needsGeometry();
-
-  QApplication::setOverrideCursor( Qt::WaitCursor );
-
-  filterExpression.setGeomCalculator( &myDa );
-  filterExpression.setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  filterExpression.setAreaUnits( QgsProject::instance()->areaUnits() );
-  QgsFeatureRequest request( mMainView->masterModel()->request() );
-  request.setSubsetOfAttributes( filterExpression.referencedColumns(), mLayer->fields() );
-  if ( !fetchGeom )
-  {
-    request.setFlags( QgsFeatureRequest::NoGeometry );
-  }
-  else
-  {
-    // force geometry extraction if the filter requests it
-    request.setFlags( request.flags() & ~QgsFeatureRequest::NoGeometry );
-  }
-  QgsFeatureIterator featIt = mLayer->getFeatures( request );
-
-  QgsFeature f;
-
-  while ( featIt.nextFeature( f ) )
-  {
-    context.setFeature( f );
-    if ( filterExpression.evaluate( &context ).toInt() != 0 )
-      filteredFeatures << f.id();
-
-    // check if there were errors during evaluating
-    if ( filterExpression.hasEvalError() )
-      break;
-  }
-
-  featIt.close();
-
-  mMainView->setFilteredFeatures( filteredFeatures );
-
-  QApplication::restoreOverrideCursor();
-
-  if ( filterExpression.hasEvalError() )
-  {
-    QgisApp::instance()->messageBar()->pushMessage( tr( "Error filtering" ), filterExpression.evalErrorString(), Qgis::Warning, QgisApp::instance()->messageTimeout() );
-    return;
-  }
-  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowFilteredList );
+  mFeatureFilterWidget->setFilterExpression( filterString, type, alwaysShowFilter );
 }
-
 
 void QgsAttributeTableDialog::deleteFeature( const QgsFeatureId fid )
 {

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -169,42 +169,6 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     void mActionAddFeature_triggered();
 
     void mActionExpressionSelect_triggered();
-    void filterColumnChanged( QObject *filterAction );
-    void filterExpressionBuilder();
-    void filterShowAll();
-    void filterSelected();
-    void filterVisible();
-    void filterEdited();
-    void filterQueryChanged( const QString &query );
-    void filterQueryAccepted();
-
-    /**
-    * Handles the expression (save or delete) when the bookmark button for stored
-    * filter expressions is triggered.
-    */
-    void handleStoreFilterExpression();
-
-    /**
-    * Opens dialog and give the possibility to save the expression with a name.
-    */
-    void saveAsStoredFilterExpression();
-
-    /**
-    * Opens dialog and give the possibility to edit the name and the expression
-    * of the stored expression.
-    */
-    void editStoredFilterExpression();
-
-    /**
-     * Updates the bookmark button and it's actions regarding the stored filter
-     * expressions according to the values
-     */
-    void updateCurrentStoredFilterExpression( );
-
-    /**
-     * Starts timer with timeout 300 ms.
-     */
-    void onFilterQueryTextChanged( const QString &value );
 
     void openConditionalStyles();
 
@@ -214,9 +178,6 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     void updateTitle();
 
     void updateButtonStatus( const QString &fieldName, bool isValid );
-
-    /* replace the search widget with a new one */
-    void replaceSearchWidget( QWidget *oldw, QWidget *neww );
 
     void layerActionTriggered();
   signals:
@@ -239,14 +200,6 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
 
   private slots:
 
-    //! Initialize column box
-    void columnBoxInit();
-
-    //! Initialize storedexpression box e.g after adding/deleting/edditing stored expression
-    void storedFilterExpressionBoxInit();
-    //! Functionalities of store expression button changes regarding the status of it
-    void storeExpressionButtonInit();
-
     void runFieldCalculation( QgsVectorLayer *layer, const QString &fieldName, const QString &expression, const QgsFeatureIds &filteredIds = QgsFeatureIds() );
     void updateFieldFromExpression();
     void updateFieldFromExpressionSelected();
@@ -262,16 +215,9 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     QgsDockWidget *mDock = nullptr;
     QDialog *mDialog = nullptr;
 
-    QMenu *mFilterColumnsMenu = nullptr;
-    QSignalMapper *mFilterActionMapper = nullptr;
-    QMenu *mStoredFilterExpressionMenu = nullptr;
-
     QPointer< QgsVectorLayer > mLayer = nullptr;
-    QgsSearchWidgetWrapper *mCurrentSearchWidgetWrapper = nullptr;
     QStringList mVisibleFields;
     QgsAttributeEditorContext mEditorContext;
-
-    QTimer mFilterQueryTimer;
 
     void updateMultiEditButtonState();
     void deleteFeature( QgsFeatureId fid );

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -314,7 +314,8 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QHash<QString, QSet<QgsSymbolLayerId>> symbolLayerMasks( const QgsVectorLayer * ) SIP_SKIP;
 
     /**
-     * \return the \a layer \a feature display string
+     * \returns a descriptive string for a \a feature, suitable for displaying to the user.
+     *         The definition is taken from the ``displayExpression`` property of \a layer.
      * \since QGIS 3.12
      */
     static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(QGIS_GUI_SRCS
   attributetable/qgsgenericfeatureselectionmanager.cpp
   attributetable/qgsvectorlayerselectionmanager.cpp
   attributetable/qgsorganizetablecolumnsdialog.cpp
+  attributetable/qgsfeaturefilterwidget.cpp
 
   auth/qgsauthauthoritieseditor.cpp
   auth/qgsauthcertificateinfo.cpp
@@ -631,6 +632,7 @@ SET(QGIS_GUI_HDRS
   attributetable/qgsattributetablemodel.h
   attributetable/qgsattributetableview.h
   attributetable/qgsdualview.h
+  attributetable/qgsfeaturefilterwidget.h
   attributetable/qgsfeaturelistmodel.h
   attributetable/qgsfeaturelistview.h
   attributetable/qgsfeaturelistviewdelegate.h
@@ -919,6 +921,7 @@ SET(QGIS_GUI_UI_HDRS
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionbuilderdialogbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionbuilder.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsexpressionselectiondialogbase.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsfeaturefilterwidget.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsgenericprojectionselectorbase.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmessagelogviewer.h
   ${CMAKE_CURRENT_BINARY_DIR}/../ui/ui_qgsmessageviewer.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -632,7 +632,7 @@ SET(QGIS_GUI_HDRS
   attributetable/qgsattributetablemodel.h
   attributetable/qgsattributetableview.h
   attributetable/qgsdualview.h
-  attributetable/qgsfeaturefilterwidget.h
+  attributetable/qgsfeaturefilterwidget_p.h
   attributetable/qgsfeaturelistmodel.h
   attributetable/qgsfeaturelistview.h
   attributetable/qgsfeaturelistviewdelegate.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -632,7 +632,6 @@ SET(QGIS_GUI_HDRS
   attributetable/qgsattributetablemodel.h
   attributetable/qgsattributetableview.h
   attributetable/qgsdualview.h
-  attributetable/qgsfeaturefilterwidget_p.h
   attributetable/qgsfeaturelistmodel.h
   attributetable/qgsfeaturelistview.h
   attributetable/qgsfeaturelistviewdelegate.h
@@ -869,6 +868,7 @@ SET(QGIS_GUI_HDRS
 SET(QGIS_GUI_PRIVATE_HDRS
   qgsbrowserdockwidget_p.cpp
   qgswidgetstatehelper_p.h
+  attributetable/qgsfeaturefilterwidget_p.h
 )
 
 FIND_PACKAGE(Qt5Qml REQUIRED)

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -1,0 +1,522 @@
+/***************************************************************************
+    qgsfeaturefilterwidget.cpp
+     --------------------------------------
+    Date                 : 20.9.2019
+    Copyright            : (C) 2019 Julien Cabieces
+    Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsfeaturefilterwidget.h"
+
+#include "qgsapplication.h"
+#include "qgssearchwidgetwrapper.h"
+#include "qgsdualview.h"
+#include "qgsstoredexpressionmanager.h"
+#include "qgseditorwidgetregistry.h"
+#include "qgsexpressioncontextutils.h"
+#include "qgsexpressionbuilderdialog.h"
+#include "qgsgui.h"
+#include "qgsdialog.h"
+#include "qgsexpressionlineedit.h"
+#include "qgsmessagebar.h"
+
+#include <QMenu>
+
+QgsFeatureFilterWidget::QgsFeatureFilterWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+
+  // Initialize filter gui elements
+  mFilterActionMapper = new QSignalMapper( this );
+  mFilterColumnsMenu = new QMenu( this );
+  mActionFilterColumnsMenu->setMenu( mFilterColumnsMenu );
+  mStoredFilterExpressionMenu = new QMenu( this );
+  mActionStoredFilterExpressions->setMenu( mStoredFilterExpressionMenu );
+
+  // Set filter icon in a couple of places
+  QIcon filterIcon = QgsApplication::getThemeIcon( "/mActionFilter2.svg" );
+  mActionShowAllFilter->setIcon( filterIcon );
+  mActionAdvancedFilter->setIcon( filterIcon );
+  mActionSelectedFilter->setIcon( filterIcon );
+  mActionVisibleFilter->setIcon( filterIcon );
+  mActionEditedFilter->setIcon( filterIcon );
+
+
+  // Set button to store or delete stored filter expressions
+  mStoreFilterExpressionButton->setDefaultAction( mActionHandleStoreFilterExpression );
+  connect( mActionSaveAsStoredFilterExpression, &QAction::triggered, this, &QgsFeatureFilterWidget::saveAsStoredFilterExpression );
+  connect( mActionEditStoredFilterExpression, &QAction::triggered, this, &QgsFeatureFilterWidget::editStoredFilterExpression );
+  connect( mActionHandleStoreFilterExpression, &QAction::triggered, this, &QgsFeatureFilterWidget::handleStoreFilterExpression );
+  mApplyFilterButton->setDefaultAction( mActionApplyFilter );
+
+  // Connect filter signals
+  connect( mActionAdvancedFilter, &QAction::triggered, this, &QgsFeatureFilterWidget::filterExpressionBuilder );
+  connect( mActionShowAllFilter, &QAction::triggered, this, &QgsFeatureFilterWidget::filterShowAll );
+  connect( mActionSelectedFilter, &QAction::triggered, this, &QgsFeatureFilterWidget::filterSelected );
+  connect( mActionVisibleFilter, &QAction::triggered, this, &QgsFeatureFilterWidget::filterVisible );
+  connect( mActionEditedFilter, &QAction::triggered, this, &QgsFeatureFilterWidget::filterEdited );
+  connect( mFilterActionMapper, SIGNAL( mapped( QObject * ) ), SLOT( filterColumnChanged( QObject * ) ) );
+  connect( mFilterQuery, &QLineEdit::returnPressed, this, &QgsFeatureFilterWidget::filterQueryAccepted );
+  connect( mActionApplyFilter, &QAction::triggered, this, &QgsFeatureFilterWidget::filterQueryAccepted );
+  connect( mFilterQuery, &QLineEdit::textChanged, this, &QgsFeatureFilterWidget::onFilterQueryTextChanged );
+}
+
+void QgsFeatureFilterWidget::init( QgsVectorLayer *layer, const QgsAttributeEditorContext &context, QgsDualView *mainView,
+                                   QgsMessageBar *messageBar, int messageBarTimeout )
+{
+  mMainView = mainView;
+  mLayer = layer;
+  mEditorContext = context;
+  mMessageBar = messageBar;
+  mMessageBarTimeout = messageBarTimeout;
+
+  connect( mLayer, &QgsVectorLayer::attributeAdded, this, &QgsFeatureFilterWidget::columnBoxInit );
+  connect( mLayer, &QgsVectorLayer::attributeDeleted, this, &QgsFeatureFilterWidget::columnBoxInit );
+
+  //set delay on entering text
+  mFilterQueryTimer.setSingleShot( true );
+  connect( &mFilterQueryTimer, &QTimer::timeout, this, &QgsFeatureFilterWidget::updateCurrentStoredFilterExpression );
+
+  columnBoxInit();
+  storedFilterExpressionBoxInit();
+  storeExpressionButtonInit();
+}
+
+void QgsFeatureFilterWidget::filterShowAll()
+{
+  mFilterButton->setDefaultAction( mActionShowAllFilter );
+  mFilterButton->setPopupMode( QToolButton::InstantPopup );
+  mFilterQuery->setVisible( false );
+  mFilterQuery->setText( QString() );
+  if ( mCurrentSearchWidgetWrapper )
+  {
+    mCurrentSearchWidgetWrapper->widget()->setVisible( false );
+  }
+  mApplyFilterButton->setVisible( false );
+  mStoreFilterExpressionButton->setVisible( false );
+  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowAll );
+}
+
+void QgsFeatureFilterWidget::filterSelected()
+{
+  mFilterButton->setDefaultAction( mActionSelectedFilter );
+  mFilterButton->setPopupMode( QToolButton::InstantPopup );
+  mFilterQuery->setVisible( false );
+  mApplyFilterButton->setVisible( false );
+  mStoreFilterExpressionButton->setVisible( false );
+  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowSelected );
+}
+
+void QgsFeatureFilterWidget::filterVisible()
+{
+  if ( !mLayer->isSpatial() )
+  {
+    filterShowAll();
+    return;
+  }
+
+  mFilterButton->setDefaultAction( mActionVisibleFilter );
+  mFilterButton->setPopupMode( QToolButton::InstantPopup );
+  mFilterQuery->setVisible( false );
+  mApplyFilterButton->setVisible( false );
+  mStoreFilterExpressionButton->setVisible( false );
+  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowVisible );
+}
+
+void QgsFeatureFilterWidget::filterEdited()
+{
+  mFilterButton->setDefaultAction( mActionEditedFilter );
+  mFilterButton->setPopupMode( QToolButton::InstantPopup );
+  mFilterQuery->setVisible( false );
+  mApplyFilterButton->setVisible( false );
+  mStoreFilterExpressionButton->setVisible( false );
+  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowEdited );
+}
+
+
+void QgsFeatureFilterWidget::filterQueryAccepted()
+{
+  if ( ( mFilterQuery->isVisible() && mFilterQuery->text().isEmpty() ) ||
+       ( mCurrentSearchWidgetWrapper && mCurrentSearchWidgetWrapper->widget()->isVisible()
+         && mCurrentSearchWidgetWrapper->expression().isEmpty() ) )
+  {
+    filterShowAll();
+    return;
+  }
+  filterQueryChanged( mFilterQuery->text() );
+}
+
+void QgsFeatureFilterWidget::filterQueryChanged( const QString &query )
+{
+  QString str;
+  if ( mFilterButton->defaultAction() == mActionAdvancedFilter )
+  {
+    str = query;
+  }
+  else if ( mCurrentSearchWidgetWrapper )
+  {
+    str = mCurrentSearchWidgetWrapper->expression();
+  }
+
+  setFilterExpression( str );
+}
+
+void QgsFeatureFilterWidget::columnBoxInit()
+{
+  const auto constActions = mFilterColumnsMenu->actions();
+  for ( QAction *a : constActions )
+  {
+    mFilterColumnsMenu->removeAction( a );
+    mFilterActionMapper->removeMappings( a );
+    mFilterButton->removeAction( a );
+    delete a;
+  }
+
+  mFilterButton->addAction( mActionShowAllFilter );
+  mFilterButton->addAction( mActionSelectedFilter );
+  if ( mLayer->isSpatial() )
+  {
+    mFilterButton->addAction( mActionVisibleFilter );
+  }
+  mFilterButton->addAction( mActionEditedFilter );
+  mFilterButton->addAction( mActionFilterColumnsMenu );
+  mFilterButton->addAction( mActionAdvancedFilter );
+  mFilterButton->addAction( mActionStoredFilterExpressions );
+
+  const QList<QgsField> fields = mLayer->fields().toList();
+
+  const auto constFields = fields;
+  for ( const QgsField &field : constFields )
+  {
+    int idx = mLayer->fields().lookupField( field.name() );
+    if ( idx < 0 )
+      continue;
+
+    if ( QgsGui::editorWidgetRegistry()->findBest( mLayer, field.name() ).type() != QLatin1String( "Hidden" ) )
+    {
+      QIcon icon = mLayer->fields().iconForField( idx );
+      QString alias = mLayer->attributeDisplayName( idx );
+
+      // Generate action for the filter popup button
+      QAction *filterAction = new QAction( icon, alias, mFilterButton );
+      filterAction->setData( field.name() );
+      mFilterActionMapper->setMapping( filterAction, filterAction );
+      connect( filterAction, SIGNAL( triggered() ), mFilterActionMapper, SLOT( map() ) );
+      mFilterColumnsMenu->addAction( filterAction );
+    }
+  }
+}
+
+void QgsFeatureFilterWidget::handleStoreFilterExpression()
+{
+  if ( !mActionHandleStoreFilterExpression->isChecked() )
+  {
+    mLayer->storedExpressionManager()->removeStoredExpression( mActionHandleStoreFilterExpression->data().toString() );
+  }
+  else
+  {
+    mLayer->storedExpressionManager()->addStoredExpression( mFilterQuery->text(), mFilterQuery->text() );
+  }
+
+  updateCurrentStoredFilterExpression();
+  storedFilterExpressionBoxInit();
+}
+
+void QgsFeatureFilterWidget::storedFilterExpressionBoxInit()
+{
+  const auto constActions = mStoredFilterExpressionMenu->actions();
+  for ( QAction *a : constActions )
+  {
+    mStoredFilterExpressionMenu->removeAction( a );
+    delete a;
+  }
+
+  const QList< QgsStoredExpression > storedExpressions = mLayer->storedExpressionManager()->storedExpressions();
+  for ( const QgsStoredExpression &storedExpression : storedExpressions )
+  {
+    QAction *storedExpressionAction = new QAction( storedExpression.name, mFilterButton );
+    connect( storedExpressionAction, &QAction::triggered, this, [ = ]()
+    {
+      setFilterExpression( storedExpression.expression, QgsAttributeForm::ReplaceFilter, true );
+    } );
+    mStoredFilterExpressionMenu->addAction( storedExpressionAction );
+  }
+}
+
+void QgsFeatureFilterWidget::storeExpressionButtonInit()
+{
+  if ( mActionHandleStoreFilterExpression->isChecked() )
+  {
+    mActionHandleStoreFilterExpression->setToolTip( tr( "Delete stored expression" ) );
+    mActionHandleStoreFilterExpression->setText( tr( "Delete Stored Expression" ) );
+    mActionHandleStoreFilterExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionHandleStoreFilterExpressionChecked.svg" ) ) );
+    mStoreFilterExpressionButton->removeAction( mActionSaveAsStoredFilterExpression );
+    mStoreFilterExpressionButton->addAction( mActionEditStoredFilterExpression );
+  }
+  else
+  {
+    mActionHandleStoreFilterExpression->setToolTip( tr( "Save expression with the text as name" ) );
+    mActionHandleStoreFilterExpression->setText( tr( "Save Expression" ) );
+    mActionHandleStoreFilterExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionHandleStoreFilterExpressionUnchecked.svg" ) ) );
+    mStoreFilterExpressionButton->addAction( mActionSaveAsStoredFilterExpression );
+    mStoreFilterExpressionButton->removeAction( mActionEditStoredFilterExpression );
+  }
+}
+
+
+void QgsFeatureFilterWidget::filterColumnChanged( QObject *filterAction )
+{
+  mFilterButton->setDefaultAction( qobject_cast<QAction *>( filterAction ) );
+  mFilterButton->setPopupMode( QToolButton::InstantPopup );
+  // replace the search line edit with a search widget that is suited to the selected field
+  // delete previous widget
+  if ( mCurrentSearchWidgetWrapper )
+  {
+    mCurrentSearchWidgetWrapper->widget()->setVisible( false );
+    delete mCurrentSearchWidgetWrapper;
+  }
+  QString fieldName = mFilterButton->defaultAction()->data().toString();
+  // get the search widget
+  int fldIdx = mLayer->fields().lookupField( fieldName );
+  if ( fldIdx < 0 )
+    return;
+  const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( mLayer, fieldName );
+  mCurrentSearchWidgetWrapper = QgsGui::editorWidgetRegistry()->
+                                createSearchWidget( setup.type(), mLayer, fldIdx, setup.config(), mFilterContainer, mEditorContext );
+  if ( mCurrentSearchWidgetWrapper->applyDirectly() )
+  {
+    connect( mCurrentSearchWidgetWrapper, &QgsSearchWidgetWrapper::expressionChanged, this, &QgsFeatureFilterWidget::filterQueryChanged );
+    mApplyFilterButton->setVisible( false );
+    mStoreFilterExpressionButton->setVisible( false );
+  }
+  else
+  {
+    connect( mCurrentSearchWidgetWrapper, &QgsSearchWidgetWrapper::expressionChanged, this, &QgsFeatureFilterWidget::filterQueryAccepted );
+    mApplyFilterButton->setVisible( true );
+    mStoreFilterExpressionButton->setVisible( true );
+  }
+
+  replaceSearchWidget( mFilterQuery, mCurrentSearchWidgetWrapper->widget() );
+}
+
+void QgsFeatureFilterWidget::filterExpressionBuilder()
+{
+  // Show expression builder
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+
+  QgsExpressionBuilderDialog dlg( mLayer, mFilterQuery->text(), this, QStringLiteral( "generic" ), context );
+  dlg.setWindowTitle( tr( "Expression Based Filter" ) );
+
+  QgsDistanceArea myDa;
+  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
+  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  dlg.setGeomCalculator( myDa );
+
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    setFilterExpression( dlg.expressionText(), QgsAttributeForm::ReplaceFilter, true );
+  }
+}
+
+void QgsFeatureFilterWidget::saveAsStoredFilterExpression()
+{
+  QgsDialog *dlg = new QgsDialog( this, nullptr, QDialogButtonBox::Save | QDialogButtonBox::Cancel );
+  dlg->setWindowTitle( tr( "Save Expression As" ) );
+  QVBoxLayout *layout = dlg->layout();
+  dlg->resize( std::max( 400, this->width() / 2 ), dlg->height() );
+
+  QLabel *nameLabel = new QLabel( tr( "Name" ), dlg );
+  QLineEdit *nameEdit = new QLineEdit( dlg );
+  layout->addWidget( nameLabel );
+  layout->addWidget( nameEdit );
+
+  if ( dlg->exec() == QDialog::Accepted )
+  {
+    mLayer->storedExpressionManager()->addStoredExpression( nameEdit->text(), mFilterQuery->text() );
+
+    updateCurrentStoredFilterExpression();
+    storedFilterExpressionBoxInit();
+  }
+}
+
+void QgsFeatureFilterWidget::editStoredFilterExpression()
+{
+  QgsDialog *dlg = new QgsDialog( this, nullptr, QDialogButtonBox::Save | QDialogButtonBox::Cancel );
+  dlg->setWindowTitle( tr( "Edit expression" ) );
+  QVBoxLayout *layout = dlg->layout();
+  dlg->resize( std::max( 400, this->width() / 2 ), dlg->height() );
+
+  QLabel *nameLabel = new QLabel( tr( "Name" ), dlg );
+  QLineEdit *nameEdit = new QLineEdit( mLayer->storedExpressionManager()->storedExpression( mActionHandleStoreFilterExpression->data().toString() ).name, dlg );
+  QLabel *expressionLabel = new QLabel( tr( "Expression" ), dlg );
+  QgsExpressionLineEdit *expressionEdit = new QgsExpressionLineEdit( dlg );
+  expressionEdit->setExpression( mLayer->storedExpressionManager()->storedExpression( mActionHandleStoreFilterExpression->data().toString() ).expression );
+
+  layout->addWidget( nameLabel );
+  layout->addWidget( nameEdit );
+  layout->addWidget( expressionLabel );
+  layout->addWidget( expressionEdit );
+
+  if ( dlg->exec() == QDialog::Accepted )
+  {
+    //update stored expression
+    mLayer->storedExpressionManager()->updateStoredExpression( mActionHandleStoreFilterExpression->data().toString(), nameEdit->text(), expressionEdit->expression(), QgsStoredExpression::Category::FilterExpression );
+
+    //update text
+    mFilterQuery->setValue( expressionEdit->expression() );
+
+    storedFilterExpressionBoxInit();
+  }
+}
+
+void QgsFeatureFilterWidget::updateCurrentStoredFilterExpression()
+{
+  QgsStoredExpression currentStoredExpression = mLayer->storedExpressionManager()->findStoredExpressionByExpression( mFilterQuery->value() );
+
+  //set checked when it's an existing stored expression
+  mActionHandleStoreFilterExpression->setChecked( !currentStoredExpression.id.isNull() );
+
+  mActionHandleStoreFilterExpression->setData( currentStoredExpression.id );
+  mActionEditStoredFilterExpression->setData( currentStoredExpression.id );
+
+  //update bookmark button
+  storeExpressionButtonInit();
+}
+
+void QgsFeatureFilterWidget::setFilterExpression( const QString &filterString, QgsAttributeForm::FilterType type, bool alwaysShowFilter )
+{
+  QString filter;
+  if ( !mFilterQuery->text().isEmpty() && !filterString.isEmpty() )
+  {
+    switch ( type )
+    {
+      case QgsAttributeForm::ReplaceFilter:
+        filter = filterString;
+        break;
+
+      case QgsAttributeForm::FilterAnd:
+        filter = QStringLiteral( "(%1) AND (%2)" ).arg( mFilterQuery->text(), filterString );
+        break;
+
+      case QgsAttributeForm::FilterOr:
+        filter = QStringLiteral( "(%1) OR (%2)" ).arg( mFilterQuery->text(), filterString );
+        break;
+    }
+  }
+  else if ( !filterString.isEmpty() )
+  {
+    filter = filterString;
+  }
+  else
+  {
+    filterShowAll();
+    return;
+  }
+
+  mFilterQuery->setText( filter );
+
+  if ( alwaysShowFilter || !mCurrentSearchWidgetWrapper || !mCurrentSearchWidgetWrapper->applyDirectly() )
+  {
+
+    mFilterButton->setDefaultAction( mActionAdvancedFilter );
+    mFilterButton->setPopupMode( QToolButton::MenuButtonPopup );
+    mFilterQuery->setVisible( true );
+    mApplyFilterButton->setVisible( true );
+    mStoreFilterExpressionButton->setVisible( true );
+    if ( mCurrentSearchWidgetWrapper )
+    {
+      // replace search widget widget with the normal filter query line edit
+      replaceSearchWidget( mCurrentSearchWidgetWrapper->widget(), mFilterQuery );
+    }
+  }
+
+  QgsFeatureIds filteredFeatures;
+  QgsDistanceArea myDa;
+
+  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
+  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+
+  // parse search string and build parsed tree
+  QgsExpression filterExpression( filter );
+  if ( filterExpression.hasParserError() )
+  {
+    mMessageBar->pushMessage( tr( "Parsing error" ), filterExpression.parserErrorString(), Qgis::Warning, mMessageBarTimeout );
+    return;
+  }
+
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
+
+  if ( !filterExpression.prepare( &context ) )
+  {
+    mMessageBar->pushMessage( tr( "Evaluation error" ), filterExpression.evalErrorString(), Qgis::Warning, mMessageBarTimeout );
+  }
+
+  bool fetchGeom = filterExpression.needsGeometry();
+
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+
+  filterExpression.setGeomCalculator( &myDa );
+  filterExpression.setDistanceUnits( QgsProject::instance()->distanceUnits() );
+  filterExpression.setAreaUnits( QgsProject::instance()->areaUnits() );
+  QgsFeatureRequest request( mMainView->masterModel()->request() );
+  request.setSubsetOfAttributes( filterExpression.referencedColumns(), mLayer->fields() );
+  if ( !fetchGeom )
+  {
+    request.setFlags( QgsFeatureRequest::NoGeometry );
+  }
+  else
+  {
+    // force geometry extraction if the filter requests it
+    request.setFlags( request.flags() & ~QgsFeatureRequest::NoGeometry );
+  }
+  QgsFeatureIterator featIt = mLayer->getFeatures( request );
+
+  QgsFeature f;
+
+  while ( featIt.nextFeature( f ) )
+  {
+    context.setFeature( f );
+    if ( filterExpression.evaluate( &context ).toInt() != 0 )
+      filteredFeatures << f.id();
+
+    // check if there were errors during evaluating
+    if ( filterExpression.hasEvalError() )
+      break;
+  }
+
+  featIt.close();
+
+  mMainView->setFilteredFeatures( filteredFeatures );
+
+  QApplication::restoreOverrideCursor();
+
+  if ( filterExpression.hasEvalError() )
+  {
+    mMessageBar->pushMessage( tr( "Error filtering" ), filterExpression.evalErrorString(), Qgis::Warning, mMessageBarTimeout );
+    return;
+  }
+  mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowFilteredList );
+}
+
+void QgsFeatureFilterWidget::replaceSearchWidget( QWidget *oldw, QWidget *neww )
+{
+  mFilterLayout->removeWidget( oldw );
+  oldw->setVisible( false );
+  mFilterLayout->addWidget( neww, 0, 0, nullptr );
+  neww->setVisible( true );
+  neww->setFocus();
+}
+
+void QgsFeatureFilterWidget::onFilterQueryTextChanged( const QString &value )
+{
+  Q_UNUSED( value );
+  mFilterQueryTimer.start( 300 );
+}

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -13,7 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsfeaturefilterwidget.h"
+#include "qgsfeaturefilterwidget_p.h"
 
 #include "qgsapplication.h"
 #include "qgssearchwidgetwrapper.h"

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -13,6 +13,17 @@
  *                                                                         *
  ***************************************************************************/
 
+/// @cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
 #include "qgsfeaturefilterwidget_p.h"
 
 #include "qgsapplication.h"
@@ -520,3 +531,5 @@ void QgsFeatureFilterWidget::onFilterQueryTextChanged( const QString &value )
   Q_UNUSED( value );
   mFilterQueryTimer.start( 300 );
 }
+
+/// @endcond

--- a/src/gui/attributetable/qgsfeaturefilterwidget.h
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.h
@@ -16,20 +16,13 @@
 #ifndef QGSFEATUREFILTERWIDGET_H
 #define QGSFEATUREFILTERWIDGET_H
 
+#define SIP_NO_FILE
+
 #include "ui_qgsfeaturefilterwidget.h"
 
 #include "qgsattributeform.h"
 
-/* #include "qgis_sip.h" */
 #include "qgis_gui.h"
-
-/* #ifdef SIP_RUN */
-/* // This is required for the ConvertToSubClassCode to work properly */
-/* // so RTTI for casting is available in the whole module. */
-/* % ModuleCode */
-/* #include "qgsfeatureselectiondlg.h" */
-/* % End */
-/* #endif */
 
 class QgsVectorLayer;
 class QgsAttributeEditorContext;
@@ -43,16 +36,6 @@ class QgsMessageBar;
  */
 class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeatureFilterWidget
 {
-
-    /* #ifdef SIP_RUN */
-    /*     SIP_CONVERT_TO_SUBCLASS_CODE */
-    /*     if ( qobject_cast<QgsFeatureFilterWidget *>( sipCpp ) ) */
-    /*       sipType = sipType_QgsFeatureFilterWidget; */
-    /*     else */
-    /*       sipType = 0; */
-    /*     SIP_END */
-    /* #endif */
-
     Q_OBJECT
 
   public:

--- a/src/gui/attributetable/qgsfeaturefilterwidget.h
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.h
@@ -1,0 +1,142 @@
+/***************************************************************************
+    qgsfeaturefilterwidget.h
+     --------------------------------------
+    Date                 : 20.9.2019
+    Copyright            : (C) 2019 Julien Cabieces
+    Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSFEATUREFILTERWIDGET_H
+#define QGSFEATUREFILTERWIDGET_H
+
+#include "ui_qgsfeaturefilterwidget.h"
+
+#include "qgsattributeform.h"
+
+/* #include "qgis_sip.h" */
+#include "qgis_gui.h"
+
+/* #ifdef SIP_RUN */
+/* // This is required for the ConvertToSubClassCode to work properly */
+/* // so RTTI for casting is available in the whole module. */
+/* % ModuleCode */
+/* #include "qgsfeatureselectiondlg.h" */
+/* % End */
+/* #endif */
+
+class QgsVectorLayer;
+class QgsAttributeEditorContext;
+class QgsSearchWidgetWrapper;
+class QgsDualView;
+class QgsMessageBar;
+
+/**
+ * \ingroup gui
+ * \class QgsFeatureFilterWidget
+ */
+class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeatureFilterWidget
+{
+
+    /* #ifdef SIP_RUN */
+    /*     SIP_CONVERT_TO_SUBCLASS_CODE */
+    /*     if ( qobject_cast<QgsFeatureFilterWidget *>( sipCpp ) ) */
+    /*       sipType = sipType_QgsFeatureFilterWidget; */
+    /*     else */
+    /*       sipType = 0; */
+    /*     SIP_END */
+    /* #endif */
+
+    Q_OBJECT
+
+  public:
+
+    //! Constructor for QgsFeatureFilterWidget
+    explicit QgsFeatureFilterWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    void init( QgsVectorLayer *layer, const QgsAttributeEditorContext &context, QgsDualView *mainView,
+               QgsMessageBar *messageBar, int messagebarTimeout );
+
+    /**
+     * Sets the filter expression to filter visible features
+     * \param filterString filter query string. QgsExpression compatible.
+     */
+    void setFilterExpression( const QString &filterString,
+                              QgsAttributeForm::FilterType type = QgsAttributeForm::ReplaceFilter,
+                              bool alwaysShowFilter = false );
+
+  public slots:
+    void filterShowAll();
+    void filterSelected();
+    void filterVisible();
+
+
+  private slots:
+
+    //! Initialize column box
+    void columnBoxInit();
+
+    //! Initialize storedexpression box e.g after adding/deleting/edditing stored expression
+    void storedFilterExpressionBoxInit();
+    //! Functionalities of store expression button changes regarding the status of it
+    void storeExpressionButtonInit();
+
+    void filterExpressionBuilder();
+    void filterEdited();
+    void filterQueryChanged( const QString &query );
+    void filterQueryAccepted();
+
+    /**
+     * Starts timer with timeout 300 ms.
+     */
+    void onFilterQueryTextChanged( const QString &value );
+
+    /**
+    * Handles the expression (save or delete) when the bookmark button for stored
+    * filter expressions is triggered.
+    */
+    void handleStoreFilterExpression();
+
+    /**
+    * Opens dialog and give the possibility to save the expression with a name.
+    */
+    void saveAsStoredFilterExpression();
+
+    /**
+    * Opens dialog and give the possibility to edit the name and the expression
+    * of the stored expression.
+    */
+    void editStoredFilterExpression();
+
+    /**
+     * Updates the bookmark button and it's actions regarding the stored filter
+     * expressions according to the values
+     */
+    void updateCurrentStoredFilterExpression( );
+
+    void filterColumnChanged( QObject *filterAction );
+
+  private:
+
+    /* replace the search widget with a new one */
+    void replaceSearchWidget( QWidget *oldw, QWidget *neww );
+
+    QMenu *mFilterColumnsMenu = nullptr;
+    QSignalMapper *mFilterActionMapper = nullptr;
+    QMenu *mStoredFilterExpressionMenu = nullptr;
+    QTimer mFilterQueryTimer;
+    QgsSearchWidgetWrapper *mCurrentSearchWidgetWrapper = nullptr;
+    QgsDualView *mMainView = nullptr;
+    QgsVectorLayer *mLayer = nullptr;
+    QgsAttributeEditorContext mEditorContext;
+    QgsMessageBar *mMessageBar = nullptr;
+    int mMessageBarTimeout = 0;
+};
+
+#endif // QGSFEATUREFILTERWIDGET_H

--- a/src/gui/attributetable/qgsfeaturefilterwidget_p.h
+++ b/src/gui/attributetable/qgsfeaturefilterwidget_p.h
@@ -13,10 +13,21 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSFEATUREFILTERWIDGET_H
-#define QGSFEATUREFILTERWIDGET_H
+#ifndef QGSFEATUREFILTERWIDGET_P_H
+#define QGSFEATUREFILTERWIDGET_P_H
 
 #define SIP_NO_FILE
+
+/// @cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
 
 #include "ui_qgsfeaturefilterwidget.h"
 
@@ -122,4 +133,6 @@ class GUI_EXPORT QgsFeatureFilterWidget : public QWidget, private Ui::QgsFeature
     int mMessageBarTimeout = 0;
 };
 
-#endif // QGSFEATUREFILTERWIDGET_H
+#endif // QGSFEATUREFILTERWIDGET_P_H
+
+/// @endcond

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -44,6 +44,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturefiltermodel.h"
 #include "qgsidentifymenu.h"
+#include "qgsvectorlayerutils.h"
 
 
 bool qVariantListIsNull( const QVariantList &list )
@@ -999,15 +1000,7 @@ void QgsRelationReferenceWidget::addEntry()
   {
     QString title = tr( "Relation %1 for %2." ).arg( mRelation.name(), mReferencingLayer->name() );
 
-    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mReferencingLayer ) );
-    if ( mCanvas )
-      context.appendScope( QgsExpressionContextUtils::mapSettingsScope( mCanvas->mapSettings() ) );
-
-    QgsExpression exp( mReferencingLayer->displayExpression() );
-    context.setFeature( mFormFeature );
-    exp.prepare( &context );
-    QString displayString = exp.evaluate( &context ).toString();
-
+    QString displayString = QgsVectorLayerUtils::getFeatureDisplayString( mReferencingLayer, mFormFeature );
     QString msg = tr( "Link feature to %1 \"%2\" : Digitize the geometry for the new feature on layer %3. Press &lt;ESC&gt; to cancel." )
                   .arg( mReferencingLayer->name(), displayString, mReferencedLayer->name() );
     mMessageBarItem = QgsMessageBar::createMessage( title, msg, this );

--- a/src/gui/qgsfeatureselectiondlg.h
+++ b/src/gui/qgsfeatureselectiondlg.h
@@ -70,6 +70,9 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
 
     void keyPressEvent( QKeyEvent *evt ) override;
 
+    //! Make sure the dialog does not grow too much
+    void showEvent( QShowEvent *event ) override;
+
   private slots:
 
     /**
@@ -107,12 +110,6 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
     QgsVectorLayerSelectionManager *mFeatureSelection = nullptr;
     QgsVectorLayer *mVectorLayer = nullptr;
     QgsAttributeEditorContext mContext;
-
-    // QWidget interface
-  protected:
-
-    //! Make sure the dialog does not grow too much
-    void showEvent( QShowEvent *event ) override;
 };
 
 #endif // QGSFEATURESELECTIONDLG_H

--- a/src/gui/qgsfeatureselectiondlg.h
+++ b/src/gui/qgsfeatureselectiondlg.h
@@ -51,7 +51,7 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
   public:
 
     //! Constructor for QgsFeatureSelectionDlg
-    explicit QgsFeatureSelectionDlg( QgsVectorLayer *vl, QgsAttributeEditorContext &context, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsFeatureSelectionDlg( QgsVectorLayer *vl, const QgsAttributeEditorContext &context, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * Gets the selected features
@@ -66,9 +66,47 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
      */
     void setSelectedFeatures( const QgsFeatureIds &ids );
 
+  protected:
+
+    void keyPressEvent( QKeyEvent *evt ) override;
+
+  private slots:
+
+    /**
+     * Inverts selection
+     */
+    void mActionInvertSelection_triggered();
+
+    /**
+     * Clears selection
+     */
+    void mActionRemoveSelection_triggered();
+
+    /**
+     * Select all
+     */
+    void mActionSelectAll_triggered();
+
+    /**
+     * Zooms to selected features
+     */
+    void mActionZoomMapToSelectedRows_triggered();
+
+    /**
+     * Pans to selected features
+     */
+    void mActionPanMapToSelectedRows_triggered();
+
+    /**
+     * Select feature using an expression
+     */
+    void mActionExpressionSelect_triggered();
+
   private:
+
     QgsVectorLayerSelectionManager *mFeatureSelection = nullptr;
     QgsVectorLayer *mVectorLayer = nullptr;
+    QgsAttributeEditorContext mContext;
 
     // QWidget interface
   protected:

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -530,6 +530,10 @@ void QgsRelationEditorWidget::linkFeature()
     layer = mRelation.referencingLayer();
 
   QgsFeatureSelectionDlg *selectionDlg = new QgsFeatureSelectionDlg( layer, mEditorContext, this );
+
+  const QString displayString = QgsVectorLayerUtils::getFeatureDisplayString( mRelation.referencedLayer(), mFeature );
+  selectionDlg->setWindowTitle( tr( "Link existing child features for parent %1 \"%2\"" ).arg( mRelation.referencedLayer()->name(), displayString ) );
+
   connect( selectionDlg, &QDialog::accepted, this, &QgsRelationEditorWidget::onLinkFeatureDlgAccepted );
   selectionDlg->show();
 }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -530,6 +530,7 @@ void QgsRelationEditorWidget::linkFeature()
     layer = mRelation.referencingLayer();
 
   QgsFeatureSelectionDlg *selectionDlg = new QgsFeatureSelectionDlg( layer, mEditorContext, this );
+  selectionDlg->setAttribute( Qt::WA_DeleteOnClose );
 
   const QString displayString = QgsVectorLayerUtils::getFeatureDisplayString( mRelation.referencedLayer(), mFeature );
   selectionDlg->setWindowTitle( tr( "Link existing child features for parent %1 \"%2\"" ).arg( mRelation.referencedLayer()->name(), displayString ) );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -529,80 +529,83 @@ void QgsRelationEditorWidget::linkFeature()
   else
     layer = mRelation.referencingLayer();
 
-  QgsFeatureSelectionDlg selectionDlg( layer, mEditorContext, this );
+  QgsFeatureSelectionDlg *selectionDlg = new QgsFeatureSelectionDlg( layer, mEditorContext, this );
+  connect( selectionDlg, &QDialog::accepted, this, &QgsRelationEditorWidget::onLinkFeatureDlgAccepted );
+  selectionDlg->show();
+}
 
-  if ( selectionDlg.exec() )
+void QgsRelationEditorWidget::onLinkFeatureDlgAccepted()
+{
+  QgsFeatureSelectionDlg *selectionDlg = qobject_cast<QgsFeatureSelectionDlg *>( sender() );
+  if ( mNmRelation.isValid() )
   {
-    if ( mNmRelation.isValid() )
+    QgsFeatureIterator it = mNmRelation.referencedLayer()->getFeatures(
+                              QgsFeatureRequest()
+                              .setFilterFids( selectionDlg->selectedFeatures() )
+                              .setSubsetOfAttributes( mNmRelation.referencedFields() ) );
+
+    QgsFeature relatedFeature;
+
+    QgsFeatureList newFeatures;
+
+    // Fields of the linking table
+    const QgsFields fields = mRelation.referencingLayer()->fields();
+
+    // Expression context for the linking table
+    QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
+
+    QgsAttributeMap linkAttributes;
+    const auto constFieldPairs = mRelation.fieldPairs();
+    for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
     {
-      QgsFeatureIterator it = mNmRelation.referencedLayer()->getFeatures(
-                                QgsFeatureRequest()
-                                .setFilterFids( selectionDlg.selectedFeatures() )
-                                .setSubsetOfAttributes( mNmRelation.referencedFields() ) );
+      int index = fields.indexOf( fieldPair.first );
+      linkAttributes.insert( index,  mFeature.attribute( fieldPair.second ) );
+    }
 
-      QgsFeature relatedFeature;
-
-      QgsFeatureList newFeatures;
-
-      // Fields of the linking table
-      const QgsFields fields = mRelation.referencingLayer()->fields();
-
-      // Expression context for the linking table
-      QgsExpressionContext context = mRelation.referencingLayer()->createExpressionContext();
-
-      QgsAttributeMap linkAttributes;
-      const auto constFieldPairs = mRelation.fieldPairs();
+    while ( it.nextFeature( relatedFeature ) )
+    {
+      const auto constFieldPairs = mNmRelation.fieldPairs();
       for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
       {
         int index = fields.indexOf( fieldPair.first );
-        linkAttributes.insert( index,  mFeature.attribute( fieldPair.second ) );
+        linkAttributes.insert( index, relatedFeature.attribute( fieldPair.second ) );
       }
+      const QgsFeature linkFeature = QgsVectorLayerUtils::createFeature( mRelation.referencingLayer(), QgsGeometry(), linkAttributes, &context );
 
-      while ( it.nextFeature( relatedFeature ) )
-      {
-        const auto constFieldPairs = mNmRelation.fieldPairs();
-        for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
-        {
-          int index = fields.indexOf( fieldPair.first );
-          linkAttributes.insert( index, relatedFeature.attribute( fieldPair.second ) );
-        }
-        const QgsFeature linkFeature = QgsVectorLayerUtils::createFeature( mRelation.referencingLayer(), QgsGeometry(), linkAttributes, &context );
-
-        newFeatures << linkFeature;
-      }
-
-      mRelation.referencingLayer()->addFeatures( newFeatures );
-      QgsFeatureIds ids;
-      const auto constNewFeatures = newFeatures;
-      for ( const QgsFeature &f : constNewFeatures )
-        ids << f.id();
-      mRelation.referencingLayer()->selectByIds( ids );
-    }
-    else
-    {
-      QMap<int, QVariant> keys;
-      const auto constFieldPairs = mRelation.fieldPairs();
-      for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
-      {
-        int idx = mRelation.referencingLayer()->fields().lookupField( fieldPair.referencingField() );
-        QVariant val = mFeature.attribute( fieldPair.referencedField() );
-        keys.insert( idx, val );
-      }
-
-      const auto constSelectedFeatures = selectionDlg.selectedFeatures();
-      for ( QgsFeatureId fid : constSelectedFeatures )
-      {
-        QMapIterator<int, QVariant> it( keys );
-        while ( it.hasNext() )
-        {
-          it.next();
-          mRelation.referencingLayer()->changeAttributeValue( fid, it.key(), it.value() );
-        }
-      }
+      newFeatures << linkFeature;
     }
 
-    updateUi();
+    mRelation.referencingLayer()->addFeatures( newFeatures );
+    QgsFeatureIds ids;
+    const auto constNewFeatures = newFeatures;
+    for ( const QgsFeature &f : constNewFeatures )
+      ids << f.id();
+    mRelation.referencingLayer()->selectByIds( ids );
   }
+  else
+  {
+    QMap<int, QVariant> keys;
+    const auto constFieldPairs = mRelation.fieldPairs();
+    for ( const QgsRelation::FieldPair &fieldPair : constFieldPairs )
+    {
+      int idx = mRelation.referencingLayer()->fields().lookupField( fieldPair.referencingField() );
+      QVariant val = mFeature.attribute( fieldPair.referencedField() );
+      keys.insert( idx, val );
+    }
+
+    const auto constSelectedFeatures = selectionDlg->selectedFeatures();
+    for ( QgsFeatureId fid : constSelectedFeatures )
+    {
+      QMapIterator<int, QVariant> it( keys );
+      while ( it.hasNext() )
+      {
+        it.next();
+        mRelation.referencingLayer()->changeAttributeValue( fid, it.key(), it.value() );
+      }
+    }
+  }
+
+  updateUi();
 }
 
 void QgsRelationEditorWidget::duplicateFeature()

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -196,6 +196,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void mapToolDeactivated();
     void onKeyPressed( QKeyEvent *e );
     void onDigitizingCompleted( const QgsFeature &feature );
+    void onLinkFeatureDlgAccepted();
 
   private:
     void updateUi();

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -556,7 +556,7 @@
   <customwidget>
    <class>QgsFeatureFilterWidget</class>
    <extends>QWidget</extends>
-   <header>qgsfeaturefilterwidget.h</header>
+   <header>qgsfeaturefilterwidget_p.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -71,7 +71,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QgsFieldExpressionWidget" name="mUpdateExpressionText" native="true">
+       <widget class="QgsFieldExpressionWidget" name="mUpdateExpressionText">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -115,80 +115,13 @@
       <number>3</number>
      </property>
      <item>
-      <widget class="QToolButton" name="mFilterButton">
-       <property name="toolTip">
-        <string>The filter defines which features are currently shown in the list or on the table</string>
-       </property>
-       <property name="text">
-        <string>Filter</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::MenuButtonPopup</enum>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextBesideIcon</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QWidget" name="mFilterContainer" native="true">
-       <layout class="QGridLayout" name="mFilterLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item row="0" column="0">
-         <widget class="QgsFilterLineEdit" name="mFilterQuery"/>
-        </item>
-        <item row="0" column="1">
-         <widget class="QToolButton" name="mStoreFilterExpressionButton">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="checkable">
-           <bool>false</bool>
-          </property>
-          <property name="popupMode">
-           <enum>QToolButton::MenuButtonPopup</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mApplyFilterButton">
-       <property name="toolTip">
-        <string>Filters the visible features according to the current filter selection and filter string.</string>
-       </property>
-       <property name="text">
-        <string>Apply</string>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonTextOnly</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <property name="spacing">
         <number>0</number>
        </property>
+       <item>
+        <widget class="QgsFeatureFilterWidget" name="mFeatureFilterWidget" native="true"/>
+       </item>
        <item>
         <widget class="QToolButton" name="mAttributeViewButton">
          <property name="toolTip">
@@ -283,67 +216,6 @@
     </widget>
    </item>
   </layout>
-  <action name="mActionAdvancedFilter">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Advanced Filter (Expression)</string>
-   </property>
-   <property name="toolTip">
-    <string>Use the Expression Builder to define the filter</string>
-   </property>
-  </action>
-  <action name="mActionShowAllFilter">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Show All Features</string>
-   </property>
-  </action>
-  <action name="mActionSelectedFilter">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Show Selected Features</string>
-   </property>
-  </action>
-  <action name="mActionVisibleFilter">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Show Features Visible On Map</string>
-   </property>
-  </action>
-  <action name="mActionFilterColumnsMenu">
-   <property name="text">
-    <string>Field Filter</string>
-   </property>
-  </action>
-  <action name="mActionEditedFilter">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Show Edited and New Features</string>
-   </property>
-   <property name="toolTip">
-    <string>Filter all the features which have been edited but not yet saved</string>
-   </property>
-  </action>
-  <action name="mActionApplyFilter">
-   <property name="text">
-    <string>Apply</string>
-   </property>
-  </action>
   <action name="mActionSearchForm">
    <property name="checkable">
     <bool>true</bool>
@@ -662,69 +534,18 @@
     <string>Dock Attribute Table</string>
    </property>
   </action>
-  <action name="mActionStoredFilterExpressions">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Stored Filter Expressions</string>
-   </property>
-   <property name="toolTip">
-    <string>Stored expressions to filter features</string>
-   </property>
-  </action>
-  <action name="mActionHandleStoreFilterExpression">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</iconset>
-   </property>
-   <property name="text">
-    <string/>
-   </property>
-   <property name="toolTip">
-    <string>Handle expression (save or delete)</string>
-   </property>
-  </action>
-  <action name="mActionSaveAsStoredFilterExpression">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Save Expression as...</string>
-   </property>
-   <property name="toolTip">
-    <string>Save expression under defined name</string>
-   </property>
-  </action>
-  <action name="mActionEditStoredFilterExpression">
-   <property name="icon">
-    <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</iconset>
-   </property>
-   <property name="text">
-    <string>Edit Expression</string>
-   </property>
-   <property name="toolTip">
-    <string>Edit the stored expression (change name or content)</string>
-   </property>
-  </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldcombobox.h</header>
+  </customwidget>
   <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDualView</class>
@@ -733,9 +554,10 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFieldComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
+   <class>QgsFeatureFilterWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfeaturefilterwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>
@@ -743,9 +565,6 @@
   <tabstop>mUpdateExpressionText</tabstop>
   <tabstop>mRunFieldCalc</tabstop>
   <tabstop>mRunFieldCalcSelected</tabstop>
-  <tabstop>mFilterButton</tabstop>
-  <tabstop>mFilterQuery</tabstop>
-  <tabstop>mApplyFilterButton</tabstop>
   <tabstop>mAttributeViewButton</tabstop>
   <tabstop>mTableViewButton</tabstop>
  </tabstops>

--- a/src/ui/qgsfeaturefilterwidget.ui
+++ b/src/ui/qgsfeaturefilterwidget.ui
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsFeatureFilterWidget</class>
+ <widget class="QWidget" name="QgsFeatureFilterWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1127</width>
+    <height>43</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="mFilterButton">
+       <property name="toolTip">
+        <string>The filter defines which features are currently shown in the list or on the table</string>
+       </property>
+       <property name="text">
+        <string>Filter</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::MenuButtonPopup</enum>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextBesideIcon</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QWidget" name="mFilterContainer" native="true">
+       <layout class="QGridLayout" name="mFilterLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QgsFilterLineEdit" name="mFilterQuery"/>
+        </item>
+        <item row="0" column="1">
+         <widget class="QToolButton" name="mStoreFilterExpressionButton">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="checkable">
+           <bool>false</bool>
+          </property>
+          <property name="popupMode">
+           <enum>QToolButton::MenuButtonPopup</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mApplyFilterButton">
+       <property name="toolTip">
+        <string>Filters the visible features according to the current filter selection and filter string.</string>
+       </property>
+       <property name="text">
+        <string>Apply</string>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextOnly</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+  <action name="mActionApplyFilter">
+   <property name="text">
+    <string>Apply</string>
+   </property>
+  </action>
+  <action name="mActionFilterColumnsMenu">
+   <property name="text">
+    <string>Field Filter</string>
+   </property>
+  </action>
+  <action name="mActionEditStoredFilterExpression">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Edit Expression</string>
+   </property>
+   <property name="toolTip">
+    <string>Edit the stored expression (change name or content)</string>
+   </property>
+  </action>
+  <action name="mActionSaveAsStoredFilterExpression">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Save Expression as...</string>
+   </property>
+   <property name="toolTip">
+    <string>Save expression under defined name</string>
+   </property>
+  </action>
+  <action name="mActionHandleStoreFilterExpression">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</iconset>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="toolTip">
+    <string>Handle expression (save or delete)</string>
+   </property>
+  </action>
+  <action name="mActionStoredFilterExpressions">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</normaloff>:/images/themes/default/mActionHandleStoreFilterExpressionChecked.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Stored Filter Expressions</string>
+   </property>
+   <property name="toolTip">
+    <string>Stored expressions to filter features</string>
+   </property>
+  </action>
+  <action name="mActionShowAllFilter">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show All Features</string>
+   </property>
+  </action>
+  <action name="mActionAdvancedFilter">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Advanced Filter (Expression)</string>
+   </property>
+   <property name="toolTip">
+    <string>Use the Expression Builder to define the filter</string>
+   </property>
+  </action>
+  <action name="mActionSelectedFilter">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show Selected Features</string>
+   </property>
+  </action>
+  <action name="mActionVisibleFilter">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show Features Visible On Map</string>
+   </property>
+  </action>
+  <action name="mActionEditedFilter">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilter.svg</normaloff>:/images/themes/default/mActionFilter.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show Edited and New Features</string>
+   </property>
+   <property name="toolTip">
+    <string>Filter all the features which have been edited but not yet saved</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/ui/qgsfeatureselectiondlg.ui
+++ b/src/ui/qgsfeatureselectiondlg.ui
@@ -15,6 +15,30 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QToolBar" name="mToolbar">
+     <property name="iconSize">
+      <size>
+       <width>18</width>
+       <height>18</height>
+      </size>
+     </property>
+     <property name="floatable">
+      <bool>false</bool>
+     </property>
+     <addaction name="mActionExpressionSelect"/>
+     <addaction name="mActionSelectAll"/>
+     <addaction name="mActionInvertSelection"/>
+     <addaction name="mActionRemoveSelection"/>
+     <addaction name="mActionSearchForm"/>
+     <addaction name="mActionSelectedToTop"/>
+     <addaction name="mActionZoomMapToSelectedRows"/>
+     <addaction name="mActionPanMapToSelectedRows"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsMessageBar" name="mMessageBar" native="true"/>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
@@ -25,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>448</width>
-        <height>444</height>
+        <height>389</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -40,16 +64,149 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QgsFeatureFilterWidget" name="mFeatureFilterWidget" native="true"/>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="mButtonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
+  <action name="mActionSearchForm">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilter2.svg</normaloff>:/images/themes/default/mActionFilter2.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select/filter features using form</string>
+   </property>
+   <property name="toolTip">
+    <string>Select/filter features using form (Ctrl+F)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+F</string>
+   </property>
+  </action>
+  <action name="mActionExpressionSelect">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mIconExpressionSelect.svg</normaloff>:/images/themes/default/mIconExpressionSelect.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select features using an expression</string>
+   </property>
+   <property name="toolTip">
+    <string>Select features using an expression</string>
+   </property>
+  </action>
+  <action name="mActionSelectAll">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSelectAll.svg</normaloff>:/images/themes/default/mActionSelectAll.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select all</string>
+   </property>
+   <property name="toolTip">
+    <string>Select all (Ctrl+A)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
+   </property>
+  </action>
+  <action name="mActionInvertSelection">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionInvertSelection.svg</normaloff>:/images/themes/default/mActionInvertSelection.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Invert selection</string>
+   </property>
+   <property name="toolTip">
+    <string>Invert selection (Ctrl+R)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+R</string>
+   </property>
+  </action>
+  <action name="mActionRemoveSelection">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionDeselectAll.svg</normaloff>:/images/themes/default/mActionDeselectAll.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Deselect all</string>
+   </property>
+   <property name="toolTip">
+    <string>Deselect all (Ctrl+Shift+A)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+A</string>
+   </property>
+  </action>
+  <action name="mActionSelectedToTop">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSelectedToTop.svg</normaloff>:/images/themes/default/mActionSelectedToTop.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Move selection to top</string>
+   </property>
+   <property name="toolTip">
+    <string>Move selection to top</string>
+   </property>
+  </action>
+  <action name="mActionPanMapToSelectedRows">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionPanToSelected.svg</normaloff>:/images/themes/default/mActionPanToSelected.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Pan map to the selected rows</string>
+   </property>
+   <property name="toolTip">
+    <string>Pan map to the selected rows (Ctrl+P)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
+   </property>
+  </action>
+  <action name="mActionZoomMapToSelectedRows">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomToSelected.svg</normaloff>:/images/themes/default/mActionZoomToSelected.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom map to the selected rows</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom map to the selected rows (Ctrl+J)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+J</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -58,8 +215,22 @@
    <header>qgsdualview.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFeatureFilterWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfeaturefilterwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMessageBar</class>
+   <extends>QWidget</extends>
+   <header>qgsmessagebar.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>mButtonBox</sender>

--- a/src/ui/qgsfeatureselectiondlg.ui
+++ b/src/ui/qgsfeatureselectiondlg.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Link existing child features</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/ui/qgsfeatureselectiondlg.ui
+++ b/src/ui/qgsfeatureselectiondlg.ui
@@ -218,7 +218,7 @@
   <customwidget>
    <class>QgsFeatureFilterWidget</class>
    <extends>QWidget</extends>
-   <header>qgsfeaturefilterwidget.h</header>
+   <header>qgsfeaturefilterwidget_p.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -198,12 +198,12 @@ void TestQgsAttributeTable::testNoGeom()
   QVERIFY( !( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry ) );
 
   // try changing existing dialog to no geometry mode
-  dlg->filterShowAll();
+  dlg->mFeatureFilterWidget->filterShowAll();
   QVERIFY( !dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
   QVERIFY( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry );
 
   // and back to a geometry mode
-  dlg->filterVisible();
+  dlg->mFeatureFilterWidget->filterVisible();
   QVERIFY( dlg->mMainView->masterModel()->layerCache()->cacheGeometry() );
   QVERIFY( !( dlg->mMainView->masterModel()->request().flags() & QgsFeatureRequest::NoGeometry ) );
 

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -39,7 +39,7 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
     QDialogButtonBox,
     QTableView,
-    QApplication
+    QDialog
 )
 from qgis.testing import start_app, unittest
 
@@ -176,22 +176,14 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         f.setAttributes([self.vl_books.dataProvider().defaultValueClause(0), 'The Hitchhiker\'s Guide to the Galaxy', 'Sputnik Editions', 1961])
         self.vl_books.addFeature(f)
 
-        def choose_linked_feature():
-            dlg = QApplication.activeModalWidget()
-            dlg.setSelectedFeatures([f.id()])
-            dlg.accept()
-
         btn = self.widget.findChild(QToolButton, 'mLinkFeatureButton')
-
-        timer = QTimer()
-        timer.setSingleShot(True)
-        timer.setInterval(0)  # will run in the event loop as soon as it's processed when the dialog is opened
-        timer.timeout.connect(choose_linked_feature)
-        timer.start()
-
         btn.click()
-        # magically the above code selects the feature here...
 
+        dlg = self.widget.findChild(QDialog)
+        dlg.setSelectedFeatures([f.id()])
+        dlg.accept()
+
+        # magically the above code selects the feature here...
         link_feature = next(self.vl_link_books_authors.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0]))))
         self.assertIsNotNone(link_feature[0])
 


### PR DESCRIPTION
## Description

This PR is the following of #31951 

it adds the feature selection widget ![widget_sel1](https://user-images.githubusercontent.com/14358135/65410788-89c5b780-ddeb-11e9-921e-18d170f14b0f.png) and ![widget_sel2](https://user-images.githubusercontent.com/14358135/65410787-892d2100-ddeb-11e9-8fa3-f6fec9af0b9a.png) to the feature selection dialog and make it non modal.

![feature_selection_dialog](https://user-images.githubusercontent.com/14358135/67744684-804ef100-fa22-11e9-94d6-4717bbf3cd87.gif)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
