### PR TITLE
Add topological points on background layers for qgsmaptooladdfeature

### DIFF
--- a/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
+++ b/tests/src/app/testqgsmaptooladdfeaturepoint.cpp
@@ -46,12 +46,14 @@ class TestQgsMapToolAddFeaturePoint : public QObject
     void cleanupTestCase();// will be called after the last testfunction was executed.
 
     void testPointZ();
+    void testTopologicalEditingZ();
 
   private:
     QgisApp *mQgisApp = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
     QgsMapToolAddFeature *mCaptureTool = nullptr;
     QgsVectorLayer *mLayerPointZSnap = nullptr;
+    QgsVectorLayer *mLayerLineZSnap = nullptr;
     QgsVectorLayer *mLayerPointZ = nullptr;
 };
 
@@ -109,6 +111,18 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   mLayerPointZSnap->addFeature( pointF );
   QCOMPARE( mLayerPointZSnap->featureCount(), ( long )1 );
 
+  // make line layer for snapping
+  mLayerLineZSnap = new QgsVectorLayer( QStringLiteral( "LineStringZ?crs=EPSG:27700" ), QStringLiteral( "Snap line" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerLineZSnap->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerLineZSnap );
+
+  mLayerLineZSnap->startEditing();
+  QgsFeature lineF;
+  lineF.setGeometry( QgsGeometry::fromWkt( "LineStringZ( 1 1 1, 5 5 5)" ) );
+
+  mLayerLineZSnap->addFeature( lineF );
+  QCOMPARE( mLayerLineZSnap->featureCount(), ( long )1 );
+
   QgsSnappingConfig cfg = mCanvas->snappingUtils()->config();
   cfg.setMode( QgsSnappingConfig::AllLayers );
   cfg.setTolerance( 100 );
@@ -116,11 +130,12 @@ void TestQgsMapToolAddFeaturePoint::initTestCase()
   cfg.setEnabled( true );
   mCanvas->snappingUtils()->setConfig( cfg );
 
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerPointZ << mLayerPointZSnap );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerPointZ << mLayerPointZSnap << mLayerLineZSnap );
   mCanvas->setCurrentLayer( mLayerPointZ );
 
   mCanvas->snappingUtils()->locatorForLayer( mLayerPointZ )->init();
   mCanvas->snappingUtils()->locatorForLayer( mLayerPointZSnap )->init();
+  mCanvas->snappingUtils()->locatorForLayer( mLayerLineZSnap )->init();
 
   // create the tool
   mCaptureTool = new QgsMapToolAddFeature( mCanvas, /*mAdvancedDigitizingDockWidget, */ QgsMapToolCapture::CapturePoint );
@@ -167,5 +182,38 @@ void TestQgsMapToolAddFeaturePoint::testPointZ()
   mLayerPointZ->undoStack()->undo();
 }
 
+void TestQgsMapToolAddFeaturePoint::testTopologicalEditingZ()
+{
+  bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+  QgsProject::instance()->setTopologicalEditing( true );
+
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  // test with default Z value = 333
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/default_z_value" ), 333 );
+
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+
+  utils.mouseClick( 3, 3, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  QgsFeatureId newFid = utils.newFeatureId( oldFids );
+
+  QCOMPARE( mLayerPointZ->featureCount(), ( long )2 );
+
+  QString wkt = "PointZ (3 3 3)";
+  QCOMPARE( mLayerPointZ->getFeature( newFid ).geometry().asWkt(), wkt );
+
+
+  QCOMPARE( mLayerLineZSnap->featureCount(), ( long )1 );
+
+  wkt = "LineStringZ (1 1 1, 3 3 3, 5 5 5)";
+  QgsFeature f;
+  QgsFeatureIterator it = mLayerLineZSnap->getFeatures();
+  it.nextFeature( f );
+  QCOMPARE( f.geometry().asWkt(), wkt );
+  QgsProject::instance()->setTopologicalEditing( topologicalEditing );
+  mLayerPointZ->undoStack()->undo();
+  mLayerLineZSnap->undoStack()->undo();
+
+}
 QGSTEST_MAIN( TestQgsMapToolAddFeaturePoint )
 #include "testqgsmaptooladdfeaturepoint.moc"


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Unlike other map tools I fixed, this one doesn't add topological points on background layers / snapped layers. 

before:

![before webm](https://user-images.githubusercontent.com/7521540/67744807-d3c13f00-fa22-11e9-82fb-c3b6911a315a.gif)

after:

![topological_addfeature_background_layers webm](https://user-images.githubusercontent.com/7521540/67744808-d3c13f00-fa22-11e9-93e3-62e9d0022f1e.gif)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
