### PR TITLE
[feature] Value relation restore missing layers from DBs

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1538,9 +1538,13 @@ Emitted whenever the layer's data source has been changed.
 .. versionadded:: 3.5
 %End
 
-    void styleLoaded();
+    void styleLoaded( const QgsMapLayer::StyleCategories &categories );
 %Docstring
 Emitted when a style has been loaded
+
+:param categories: style categories
+
+.. versionadded:: 3.12
 %End
 
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1538,7 +1538,7 @@ Emitted whenever the layer's data source has been changed.
 .. versionadded:: 3.5
 %End
 
-    void styleLoaded( const QgsMapLayer::StyleCategories &categories );
+    void styleLoaded( QgsMapLayer::StyleCategories categories );
 %Docstring
 Emitted when a style has been loaded
 

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1538,6 +1538,11 @@ Emitted whenever the layer's data source has been changed.
 .. versionadded:: 3.5
 %End
 
+    void styleLoaded();
+%Docstring
+Emitted when a style has been loaded
+%End
+
 
   protected:
 

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -187,6 +187,7 @@ of attribute values failing enforced field constraints.
 .. versionadded:: 3.0
 %End
 
+
     QString constraintFailureReason() const;
 %Docstring
 Returns the reason why a constraint check has failed (or an empty string

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2070,7 +2070,7 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
         }
         else
         {
-          messageBar()->pushSuccess( tr( "Missing layer form dependency" ), tr( "Layer form dependency '%2' required by '%1' was automatically loaded." )
+          messageBar()->pushSuccess( tr( "Missing layer form dependency" ), tr( "Layer dependency '%2' required by '%1' was automatically loaded." )
                                      .arg( vl->name() )
                                      .arg( dependency.name ) );
         }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2031,7 +2031,7 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
             }
 
             // Helper to find layers in connections
-            auto layerFinder = [ &conn, &dependency, &providerName, this ]( const QString & tableSchema, const QString & tableName ) -> bool
+            auto layerFinder = [ &conn, &dependency, &providerName ]( const QString & tableSchema, const QString & tableName ) -> bool
             {
               // First try the current schema (or no schema if it's not supported from the provider)
               try

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1982,45 +1982,71 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
       // try to aggressively resolve the broken dependencies
       bool loaded = false;
       const QString providerName { vl->dataProvider()->name() };
-      QgsProviderMetadata *md { QgsProviderRegistry::instance()->providerMetadata( providerName ) };
-      if ( md )
+      QgsProviderMetadata *providerMetadata { QgsProviderRegistry::instance()->providerMetadata( providerName ) };
+      if ( providerMetadata )
       {
-        std::unique_ptr< QgsAbstractDatabaseProviderConnection > conn { static_cast<QgsAbstractDatabaseProviderConnection *>( md->createConnection( vl->dataProvider()->uri().uri(), {} ) ) };
+        // Retrieve the DB connection (if any)
+        std::unique_ptr< QgsAbstractDatabaseProviderConnection > conn { static_cast<QgsAbstractDatabaseProviderConnection *>( providerMetadata->createConnection( vl->dataProvider()->uri().uri(), {} ) ) };
         if ( conn )
         {
           QString tableSchema;
           QString tableName;
-          const QVariantMap sourceParts { md->decodeUri( dependency.source ) };
-          // HACK HACK HACK!
-          // This part should really be abstracted out to the connection classes or to the provider directly
-          // GPKG
-          if ( providerName == QStringLiteral( "ogr" ) )
-          {
-            tableName = sourceParts.value( QStringLiteral( "layerName" ) ).toString();
-          }
-          else // PG
+          const QVariantMap sourceParts { providerMetadata->decodeUri( dependency.source ) };
+
+          // This part should really be abstracted out to the connection classes or to the providers directly.
+          // Different providers decode the uri differently, fo example we don't get the table name out of OGR
+          // but the layerName/layerId instead, so let's try different approachs
+
+          // This works for GPKG
+          tableName = sourceParts.value( QStringLiteral( "layerName" ) ).toString();
+
+          // This works for PG and spatialite
+          if ( tableName.isEmpty() )
           {
             tableName = sourceParts.value( QStringLiteral( "table" ) ).toString();
             tableSchema = sourceParts.value( QStringLiteral( "schema" ) ).toString();
           }
-          try
+
+          // Helper to find layers in connections
+          auto layerFinder = [ &conn, &dependency, &providerName, this ]( const QString & tableSchema, const QString & tableName ) -> bool
           {
-            const QString layerUri { conn->tableUri( tableSchema, tableName )};
-            // Load it!
-            std::unique_ptr< QgsVectorLayer > newVl = qgis::make_unique< QgsVectorLayer >( layerUri, dependency.name, providerName );
-            if ( newVl->isValid() )
+            // First try the current schema (or no schema if it's not supported from the provider)
+            try
             {
-              connect( newVl.get(), &QgsVectorLayer::styleLoaded, this, &QgisApp::vectorLayerStyleLoaded );
-              QgsProject::instance()->addMapLayer( newVl.release() );
-              loaded = true;
+              const QString layerUri { conn->tableUri( tableSchema, tableName )};
+              // Load it!
+              std::unique_ptr< QgsVectorLayer > newVl = qgis::make_unique< QgsVectorLayer >( layerUri, dependency.name, providerName );
+              if ( newVl->isValid() )
+              {
+                connect( newVl.get(), &QgsVectorLayer::styleLoaded, this, &QgisApp::vectorLayerStyleLoaded );
+                QgsProject::instance()->addMapLayer( newVl.release() );
+                return true;
+              }
             }
-          }
-          catch ( QgsProviderConnectionException &ex )
+            catch ( QgsProviderConnectionException & )
+            {
+              // Do nothing!
+            }
+            return false;
+          };
+
+          loaded = layerFinder( tableSchema, tableName );
+
+          // Try different schemas
+          if ( ! loaded && conn->capabilities().testFlag( QgsAbstractDatabaseProviderConnection::Capability::Schemas ) && ! tableSchema.isEmpty() )
           {
-            QgsDebugMsg( QStringLiteral( "Error resolving dependency layer %1 - required by %2: %3" )
-                         .arg( dependency.name )
-                         .arg( vl->name() )
-                         .arg( ex.what() ) );
+            const QStringList schemas { conn->schemas() };
+            for ( const QString &schemaName : schemas )
+            {
+              if ( schemaName != tableSchema )
+              {
+                loaded = layerFinder( schemaName, tableName );
+              }
+              if ( loaded )
+              {
+                break;
+              }
+            }
           }
         }
       }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2012,7 +2012,7 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
 
           // This part should really be abstracted out to the connection classes or to the providers directly.
           // Different providers decode the uri differently, for example we don't get the table name out of OGR
-          // but the layerName/layerId instead, so let's try different approachs
+          // but the layerName/layerId instead, so let's try different approaches
 
           // This works for GPKG
           tableName = sourceParts.value( QStringLiteral( "layerName" ) ).toString();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -661,7 +661,7 @@ void QgisApp::onActiveLayerChanged( QgsMapLayer *layer )
   emit activeLayerChanged( layer );
 }
 
-void QgisApp::vectorLayerStyleLoaded( const QgsMapLayer::StyleCategories &categories )
+void QgisApp::vectorLayerStyleLoaded( QgsMapLayer::StyleCategories categories )
 {
   if ( categories.testFlag( QgsMapLayer::StyleCategory::Forms ) )
   {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1969,7 +1969,9 @@ QList<QgsVectorLayerRef> QgisApp::findBrokenWidgetDependencies( QgsVectorLayer *
       const auto constDependencies { ww->layerDependencies() };
       for ( const QgsVectorLayerRef &dependency : constDependencies )
       {
-        const QgsVectorLayer *depVl { QgsVectorLayerRef( dependency ).resolveWeakly( QgsProject::instance() ) };
+        const QgsVectorLayer *depVl { QgsVectorLayerRef( dependency ).resolveWeakly(
+                                        QgsProject::instance(),
+                                        QgsVectorLayerRef::MatchType::Name ) };
         if ( ! depVl || ! depVl->isValid() )
         {
           brokenDependencies.append( dependency );
@@ -1987,20 +1989,7 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
     const auto constDependencies { findBrokenWidgetDependencies( vl ) };
     for ( const QgsVectorLayerRef &dependency : constDependencies )
     {
-      const QgsVectorLayer *depVl = nullptr;
-      // The default resolution logic does not recognize a positive match if the datasource is
-      // not exactly the same, for this reason we try a loose match here where the layer name
-      // equality is sufficient for a positive match within the same provider.
-      const auto constVLayers { QgsProject::instance()->layers< QgsVectorLayer * >( ) };
-      for ( const QgsVectorLayer *vl : constVLayers )
-      {
-        if ( vl->name() == dependency.name && vl->providerType() == dependency.provider )
-        {
-          depVl = vl;
-          break;
-        }
-      }
-      if ( ! depVl || ! depVl->isValid() )
+      if ( ! vl || ! vl->isValid() )
       {
         // try to aggressively resolve the broken dependencies
         bool loaded = false;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -161,6 +161,7 @@ class QgsNetworkRequestParameters;
 #include "ogr/qgsvectorlayersaveasdialog.h"
 #include "ui_qgisapp.h"
 #include "qgis_app.h"
+#include "qgsvectorlayerref.h"
 
 #include <QGestureEvent>
 #include <QTapAndHoldGesture>
@@ -1700,6 +1701,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void onActiveLayerChanged( QgsMapLayer *layer );
 
+    /**
+     * Triggered when a vector layer style has changed, check for widget config layer dependencies
+     */
+    void vectorLayerStyleLoaded();
+
   signals:
 
     /**
@@ -2008,7 +2014,19 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Returns the message bar of the datasource manager dialog if it is visible, the canvas's message bar otherwise.
     QgsMessageBar *visibleMessageBar();
 
+    /**
+     * Searchs for layer widget dependencies
+     * \return a list of weak references to broken widget layer dependencies
+     */
+    QList< QgsVectorLayerRef > findBrokenWidgetDependencies( QgsVectorLayer *vectorLayer );
+
+    /**
+     * Scans the \a vectorLayer for broken dependencies and warns the user
+     */
+    void checkVectorLayerDependencies( QgsVectorLayer *vectorLayer );
+
     QgisAppStyleSheet *mStyleSheetBuilder = nullptr;
+
 
     // actions for menus and toolbars -----------------
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2017,7 +2017,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsMessageBar *visibleMessageBar();
 
     /**
-     * Searchs for layer widget dependencies
+     * Searches for layer widget dependencies
      * \return a list of weak references to broken widget layer dependencies
      */
     QList< QgsVectorLayerRef > findBrokenWidgetDependencies( QgsVectorLayer *vectorLayer );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1702,9 +1702,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void onActiveLayerChanged( QgsMapLayer *layer );
 
     /**
-     * Triggered when a vector layer style has changed, check for widget config layer dependencies
+     * Triggered when a vector layer style has changed, checks for widget config layer dependencies
+     * \param categories style categories
+     * \since QGIS 3.12
      */
-    void vectorLayerStyleLoaded();
+    void vectorLayerStyleLoaded( const QgsMapLayer::StyleCategories &categories );
 
   signals:
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1706,7 +1706,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \param categories style categories
      * \since QGIS 3.12
      */
-    void vectorLayerStyleLoaded( const QgsMapLayer::StyleCategories &categories );
+    void vectorLayerStyleLoaded( const QgsMapLayer::StyleCategories categories );
 
   signals:
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1372,8 +1372,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Emitted when a style has been loaded
+     * \param categories style categories
+     * \since QGIS 3.12
      */
-    void styleLoaded();
+    void styleLoaded( const QgsMapLayer::StyleCategories &categories );
 
 
   private slots:

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1375,7 +1375,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \param categories style categories
      * \since QGIS 3.12
      */
-    void styleLoaded( const QgsMapLayer::StyleCategories &categories );
+    void styleLoaded( QgsMapLayer::StyleCategories categories );
 
 
   private slots:

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1370,6 +1370,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void dataSourceChanged();
 
+    /**
+     * Emitted when a style has been loaded
+     */
+    void styleLoaded();
+
 
   private slots:
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4678,6 +4678,7 @@ QgsAuxiliaryLayer *QgsVectorLayer::auxiliaryLayer()
 QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &resultFlag, bool loadFromLocalDB, QgsMapLayer::StyleCategories categories )
 {
   QgsDataSourceUri dsUri( theURI );
+  QString returnMessage;
   if ( !loadFromLocalDB && mDataProvider && mDataProvider->isSaveAndLoadStyleToDatabaseSupported() )
   {
     QString qml, errorMsg;
@@ -4687,10 +4688,12 @@ QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &resultFlag,
       QDomDocument myDocument( QStringLiteral( "qgis" ) );
       myDocument.setContent( qml );
       resultFlag = importNamedStyle( myDocument, errorMsg );
-      return QObject::tr( "Loaded from Provider" );
+      returnMessage = QObject::tr( "Loaded from Provider" );
     }
   }
-  return QgsMapLayer::loadNamedStyle( theURI, resultFlag, categories );
+  returnMessage = QgsMapLayer::loadNamedStyle( theURI, resultFlag, categories );
+  emit styleLoaded();
+  return returnMessage;
 }
 
 QSet<QgsMapLayerDependency> QgsVectorLayer::dependencies() const

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4692,7 +4692,7 @@ QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &resultFlag,
     }
   }
   returnMessage = QgsMapLayer::loadNamedStyle( theURI, resultFlag, categories );
-  emit styleLoaded();
+  emit styleLoaded( categories );
   return returnMessage;
 }
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -80,7 +80,7 @@ QgsEditorWidgetSetup QgsEditorWidgetRegistry::findBest( const QgsVectorLayer *vl
 
   if ( index > -1 )
   {
-    QgsEditorWidgetSetup setup = vl->fields().at( index ).editorWidgetSetup();
+    QgsEditorWidgetSetup setup = fields.at( index ).editorWidgetSetup();
     if ( !setup.isNull() )
       return setup;
   }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -267,6 +267,11 @@ bool QgsEditorWidgetWrapper::isBlockingCommit() const
   return mIsBlockingCommit;
 }
 
+QList<QgsVectorLayerRef> QgsEditorWidgetWrapper::layerDependencies() const
+{
+  return QList<QgsVectorLayerRef>();
+}
+
 QString QgsEditorWidgetWrapper::constraintFailureReason() const
 {
   return mConstraintFailureReason;

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -27,6 +27,7 @@ class QgsField;
 #include "qgswidgetwrapper.h"
 #include "qgis_gui.h"
 #include "qgis_sip.h"
+#include "qgsvectorlayerref.h"
 
 /**
  * \ingroup gui
@@ -191,6 +192,19 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * \since QGIS 3.0
      */
     bool isBlockingCommit() const;
+
+    /**
+     * Returns a list of weak layer references to other layers required by this widget.
+     * The default implementation returns an empty list.
+     *
+     * This method should be reimplemented by widgets that handle relations with other layers,
+     * (e.g. ValueRelation) and can be used by client code to warn the user about
+     * missing required dependencies or to add some resolution logic in order
+     * to load the missing dependency.
+     * \note not available in Python bindings
+     * \since QGIS 3.12
+     */
+    virtual QList< QgsVectorLayerRef > layerDependencies() const SIP_SKIP;
 
     /**
      * Returns the reason why a constraint check has failed (or an empty string

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -457,3 +457,18 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
   else
     QgsEditorWidgetWrapper::setEnabled( enabled );
 }
+
+
+QList<QgsVectorLayerRef> QgsValueRelationWidgetWrapper::layerDependencies() const
+{
+  QList<QgsVectorLayerRef> result;
+  const QString layerId { config().value( QStringLiteral( "Layer" ) ).toString() };
+  const QString layerName { config().value( QStringLiteral( "LayerName" ) ).toString() };
+  const QString providerName { config().value( QStringLiteral( "LayerProviderName" ) ).toString() };
+  const QString layerSource { config().value( QStringLiteral( "LayerSource" ) ).toString() };
+  if ( ! layerId.isEmpty() && ! layerName.isEmpty() && ! providerName.isEmpty() && ! layerSource.isEmpty() )
+  {
+    result.append( QgsVectorLayerRef( layerId, layerName, layerSource, providerName ) );
+  }
+  return result;
+}

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -102,6 +102,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
      */
     void setFeature( const QgsFeature &feature ) override;
 
+    QList<QgsVectorLayerRef> layerDependencies() const override;
 
   private:
     void updateValues( const QVariant &value, const QVariantList & = QVariantList() ) override;
@@ -131,6 +132,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
     friend class QgsValueRelationWidgetFactory;
     friend class TestQgsValueRelationWidgetWrapper;
+
 };
 
 #endif // QGSVALUERELATIONWIDGETWRAPPER_H

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5237,3 +5237,29 @@ QGISEXTERN QgsProviderMetadata *providerMetadataFactory()
   return new QgsPostgresProviderMetadata();
 }
 #endif
+
+
+QVariantMap QgsPostgresProviderMetadata::decodeUri( const QString &uri )
+{
+  const QgsDataSourceUri dsUri { uri };
+  return
+  {
+    { QStringLiteral( "dbname" ), dsUri.database() },
+    { QStringLiteral( "host" ), dsUri.host() },
+    { QStringLiteral( "port" ), dsUri.port() },
+    { QStringLiteral( "service" ), dsUri.service() },
+    { QStringLiteral( "username" ), dsUri.username() },
+    { QStringLiteral( "password" ), dsUri.password() },
+    { QStringLiteral( "authcfg" ), dsUri.authConfigId() },
+    { QStringLiteral( "type" ), dsUri.wkbType() },
+    { QStringLiteral( "selectatid" ), dsUri.selectAtIdDisabled() },
+    { QStringLiteral( "table" ), dsUri.table() },
+    { QStringLiteral( "schema" ), dsUri.schema() },
+    { QStringLiteral( "key" ), dsUri.keyColumn() },
+    { QStringLiteral( "srid" ), dsUri.srid() },
+    { QStringLiteral( "estimatedmetadata" ), dsUri.useEstimatedMetadata() },
+    { QStringLiteral( "sslmode" ), dsUri.sslMode() },
+    { QStringLiteral( "sql" ), dsUri.sql() },
+    { QStringLiteral( "geometrycolumn" ), dsUri.geometryColumn() },
+  };
+}

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -573,7 +573,7 @@ class QgsPostgresProviderMetadata: public QgsProviderMetadata
     void saveConnection( const QgsAbstractProviderConnection *createConnection, const QString &name ) override;
     void initProvider() override;
     void cleanupProvider() override;
-
+    QVariantMap decodeUri( const QString &uri ) override;
 };
 
 // clazy:excludeall=qstring-allocations


### PR DESCRIPTION
Checks for missing layers in value relation widget and loads them automatically (if possible), also warns the user if the layer could not be found.

The API is generic enough to be used by other widgets too, if they happen to require one or more other layers to work correctly.

The use case we address here is when a layer stored in PG or GPKG or SpatiaLite is configured to use a value-relation widget but the required layer was not already loaded in the project (or it was loaded but it was moved to another schema), in that case the weak resolution won't find the layer and the widget will not work. With this implementation, the layer is first searched in the loaded layers (matching the provider name and the layer name) and if it is not found it will be searched in the same connection as the parent layer (first in the same schema, then in the other schemas) and loaded if found.

The implementation also works when applying a style that uses a value relation widget to an existing layer.

Funded by **ARPA Piemonte**
