### PR TITLE
Fix crash with invalid postgres provider

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4277,11 +4277,14 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
     else
     {
       QgsPostgresConn *conn = connectionRO();
-      QgsPostgresResult result( conn->PQexec( QStringLiteral( "SELECT proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
-      if ( result.PQresultStatus() == PGRES_TUPLES_OK )
+      if ( conn )
       {
-        srs = QgsCoordinateReferenceSystem::fromProj4( result.PQgetvalue( 0, 0 ) );
-        sCrsCache.insert( srid, srs );
+        QgsPostgresResult result( conn->PQexec( QStringLiteral( "SELECT proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) ) );
+        if ( result.PQresultStatus() == PGRES_TUPLES_OK )
+        {
+          srs = QgsCoordinateReferenceSystem::fromProj4( result.PQgetvalue( 0, 0 ) );
+          sCrsCache.insert( srid, srs );
+        }
       }
     }
   }


### PR DESCRIPTION
Crash is triggered by opening the postgres vector layer properties with a not-yet-known CRS.