### PR TITLE
[dxf export] Bail out if extent could not be determined

### DIFF
--- a/python/core/auto_additions/qgsdxfexport.py
+++ b/python/core/auto_additions/qgsdxfexport.py
@@ -4,5 +4,5 @@ QgsDxfExport.ExportResult.Success.__doc__ = "Successful export"
 QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ = "Invalid device error"
 QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ = "Device not writable error"
 QgsDxfExport.ExportResult.EmptyExtentError.__doc__ = "Empty extent, no extent given and no extent could be derived from layers"
-QgsDxfExport.ExportResult.__doc__ = 'The result of an export as dxf operaion\n\n.. versionadded:: 3.12\n\n' + '* ``Success``: ' + QgsDxfExport.ExportResult.Success.__doc__ + '\n' + '* ``InvalidDeviceError``: ' + QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ + '\n' + '* ``DeviceNotWritableError``: ' + QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ + '\n' + '* ``EmptyExtentError``: ' + QgsDxfExport.ExportResult.EmptyExtentError.__doc__
+QgsDxfExport.ExportResult.__doc__ = 'The result of an export as dxf operation\n\n.. versionadded:: 3.12\n\n' + '* ``Success``: ' + QgsDxfExport.ExportResult.Success.__doc__ + '\n' + '* ``InvalidDeviceError``: ' + QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ + '\n' + '* ``DeviceNotWritableError``: ' + QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ + '\n' + '* ``EmptyExtentError``: ' + QgsDxfExport.ExportResult.EmptyExtentError.__doc__
 # --

--- a/python/core/auto_additions/qgsdxfexport.py
+++ b/python/core/auto_additions/qgsdxfexport.py
@@ -4,5 +4,5 @@ QgsDxfExport.ExportResult.Success.__doc__ = "Successful export"
 QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ = "Invalid device error"
 QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ = "Device not writable error"
 QgsDxfExport.ExportResult.EmptyExtentError.__doc__ = "Empty extent, no extent given and no extent could be derived from layers"
-QgsDxfExport.ExportResult.__doc__ = 'The result of an export as dxf operation\n\n.. versionadded:: 3.12\n\n' + '* ``Success``: ' + QgsDxfExport.ExportResult.Success.__doc__ + '\n' + '* ``InvalidDeviceError``: ' + QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ + '\n' + '* ``DeviceNotWritableError``: ' + QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ + '\n' + '* ``EmptyExtentError``: ' + QgsDxfExport.ExportResult.EmptyExtentError.__doc__
+QgsDxfExport.ExportResult.__doc__ = 'The result of an export as dxf operation\n\n.. versionadded:: 3.10.1\n\n' + '* ``Success``: ' + QgsDxfExport.ExportResult.Success.__doc__ + '\n' + '* ``InvalidDeviceError``: ' + QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ + '\n' + '* ``DeviceNotWritableError``: ' + QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ + '\n' + '* ``EmptyExtentError``: ' + QgsDxfExport.ExportResult.EmptyExtentError.__doc__
 # --

--- a/python/core/auto_additions/qgsdxfexport.py
+++ b/python/core/auto_additions/qgsdxfexport.py
@@ -1,0 +1,8 @@
+# The following has been generated automatically from src/core/dxf/qgsdxfexport.h
+# monkey patching scoped based enum
+QgsDxfExport.ExportResult.Success.__doc__ = "Successful export"
+QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ = "Invalid device error"
+QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ = "Device not writable error"
+QgsDxfExport.ExportResult.EmptyExtentError.__doc__ = "Empty extent, no extent given and no extent could be derived from layers"
+QgsDxfExport.ExportResult.__doc__ = 'The result of an export as dxf operaion\n\n.. versionadded:: 3.12\n\n' + '* ``Success``: ' + QgsDxfExport.ExportResult.Success.__doc__ + '\n' + '* ``InvalidDeviceError``: ' + QgsDxfExport.ExportResult.InvalidDeviceError.__doc__ + '\n' + '* ``DeviceNotWritableError``: ' + QgsDxfExport.ExportResult.DeviceNotWritableError.__doc__ + '\n' + '* ``EmptyExtentError``: ' + QgsDxfExport.ExportResult.EmptyExtentError.__doc__
+# --

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -52,6 +52,14 @@ The attribute value is used for layer names.
     typedef QFlags<QgsDxfExport::Flag> Flags;
 
 
+    enum ExportResult
+    {
+      Success,
+      InvalidDeviceError,
+      DeviceNotWritableError,
+      EmptyExtentError
+    };
+
     QgsDxfExport();
 %Docstring
 Constructor for QgsDxfExport.
@@ -91,7 +99,7 @@ Add layers to export
 .. seealso:: :py:func:`setLayerTitleAsName`
 %End
 
-    int writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
+    ExportResult writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
 
     void setSymbologyScale( double scale );
 %Docstring

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -52,7 +52,7 @@ The attribute value is used for layer names.
     typedef QFlags<QgsDxfExport::Flag> Flags;
 
 
-    enum ExportResult
+    enum class ExportResult
     {
       Success,
       InvalidDeviceError,

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1510,9 +1510,24 @@ int main( int argc, char *argv[] )
       dxfFile.setFileName( dxfOutputFile );
     }
 
-    int res = dxfExport.writeToFile( &dxfFile, dxfEncoding );
-    if ( res )
-      std::cerr << "dxf output failed with error code " << res << std::endl;
+    QgsDxfExport::ExportResult res = dxfExport.writeToFile( &dxfFile, dxfEncoding );
+    switch ( res )
+    {
+      case QgsDxfExport::ExportResult::Success:
+        break;
+
+      case QgsDxfExport::ExportResult::DeviceNotWritableError:
+        std::cerr << "dxf output failed, the device is not wriable" << std::endl;
+        break;
+
+      case QgsDxfExport::ExportResult::InvalidDeviceError:
+        std::cerr << "dxf output failed, the device is invalid" << std::endl;
+        break;
+
+      case QgsDxfExport::ExportResult::EmptyExtentError:
+        std::cerr << "dxf output failed, the extent could not be determined" << std::endl;
+        break;
+    }
 
     delete qgis;
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1531,7 +1531,7 @@ int main( int argc, char *argv[] )
 
     delete qgis;
 
-    return res;
+    return static_cast<int>( res );
   }
 
   // make sure we don't have a dirty blank project after launch

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6534,13 +6534,23 @@ void QgisApp::dxfExport()
       fileName += QLatin1String( ".dxf" );
     QFile dxfFile( fileName );
     QApplication::setOverrideCursor( Qt::BusyCursor );
-    if ( dxfExport.writeToFile( &dxfFile, d.encoding() ) == 0 )
+    switch ( dxfExport.writeToFile( &dxfFile, d.encoding() ) )
     {
-      visibleMessageBar()->pushMessage( tr( "DXF export completed" ), Qgis::Info, 4 );
-    }
-    else
-    {
-      visibleMessageBar()->pushMessage( tr( "DXF export failed" ), Qgis::Critical, 4 );
+      case QgsDxfExport::ExportResult::Success:
+        visibleMessageBar()->pushMessage( tr( "DXF export completed" ), Qgis::Info, 4 );
+        break;
+
+      case QgsDxfExport::ExportResult::DeviceNotWritableError:
+        visibleMessageBar()->pushMessage( tr( "DXF export failed, device is not writable" ), Qgis::Critical, 4 );
+        break;
+
+      case QgsDxfExport::ExportResult::InvalidDeviceError:
+        visibleMessageBar()->pushMessage( tr( "DXF export failed, the device is invalid" ), Qgis::Critical, 4 );
+        break;
+
+      case QgsDxfExport::ExportResult::EmptyExtentError:
+        visibleMessageBar()->pushMessage( tr( "DXF export failed, the extent could not be determined" ), Qgis::Critical, 4 );
+        break;
     }
     QApplication::restoreOverrideCursor();
   }

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -505,12 +505,12 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
 {
   if ( !d )
   {
-    return InvalidDeviceError;
+    return ExportResult::InvalidDeviceError;
   }
 
   if ( !d->isOpen() && !d->open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
-    return DeviceNotWritableError;
+    return ExportResult::DeviceNotWritableError;
   }
 
   mTextStream.setDevice( d );
@@ -546,7 +546,7 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
   }
 
   if ( mExtent.isEmpty() )
-    return EmptyExtentError;
+    return ExportResult::EmptyExtentError;
 
   QgsUnitTypes::DistanceUnit mapUnits = mCrs.mapUnits();
   mMapSettings.setExtent( mExtent );
@@ -562,7 +562,7 @@ QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QStrin
   writeEntities();
   writeEndFile();
 
-  return Success;
+  return ExportResult::Success;
 }
 
 QgsUnitTypes::DistanceUnit QgsDxfExport::mapUnits() const

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -501,16 +501,16 @@ void QgsDxfExport::writeString( const QString &s )
   mTextStream << s << '\n';
 }
 
-int QgsDxfExport::writeToFile( QIODevice *d, const QString &encoding )
+QgsDxfExport::ExportResult QgsDxfExport::writeToFile( QIODevice *d, const QString &encoding )
 {
   if ( !d )
   {
-    return 1;
+    return InvalidDeviceError;
   }
 
   if ( !d->isOpen() && !d->open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
-    return 2;
+    return DeviceNotWritableError;
   }
 
   mTextStream.setDevice( d );
@@ -545,6 +545,9 @@ int QgsDxfExport::writeToFile( QIODevice *d, const QString &encoding )
     }
   }
 
+  if ( mExtent.isEmpty() )
+    return EmptyExtentError;
+
   QgsUnitTypes::DistanceUnit mapUnits = mCrs.mapUnits();
   mMapSettings.setExtent( mExtent );
 
@@ -559,7 +562,7 @@ int QgsDxfExport::writeToFile( QIODevice *d, const QString &encoding )
   writeEntities();
   writeEndFile();
 
-  return 0;
+  return Success;
 }
 
 QgsUnitTypes::DistanceUnit QgsDxfExport::mapUnits() const

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -96,6 +96,19 @@ class CORE_EXPORT QgsDxfExport
     Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
+     * The result of an export as dxf operaion
+     *
+     * \since QGIS 3.12
+     */
+    enum ExportResult
+    {
+      Success = 0, //!< Successful export
+      InvalidDeviceError, //!< Invalid device error
+      DeviceNotWritableError, //!< Device not writable error
+      EmptyExtentError //!< Empty extent, no extent given and no extent could be derived from layers
+    };
+
+    /**
      * Constructor for QgsDxfExport.
      */
     QgsDxfExport() = default;
@@ -133,9 +146,9 @@ class CORE_EXPORT QgsDxfExport
      * Export to a dxf file in the given encoding
      * \param d device
      * \param codec encoding
-     * \returns 0 on success, 1 on invalid device, 2 when devices is not writable
+     * \returns an ExportResult
      */
-    int writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
+    ExportResult writeToFile( QIODevice *d, const QString &codec );  //maybe add progress dialog? other parameters (e.g. scale, dpi)?
 
     /**
      * Set reference \a scale for output.

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -98,7 +98,7 @@ class CORE_EXPORT QgsDxfExport
     /**
      * The result of an export as dxf operation
      *
-     * \since QGIS 3.12
+     * \since QGIS 3.10.1
      */
     enum class ExportResult
     {

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -100,7 +100,7 @@ class CORE_EXPORT QgsDxfExport
      *
      * \since QGIS 3.12
      */
-    enum ExportResult
+    enum class ExportResult
     {
       Success = 0, //!< Successful export
       InvalidDeviceError, //!< Invalid device error

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsDxfExport
     Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
-     * The result of an export as dxf operaion
+     * The result of an export as dxf operation
      *
      * \since QGIS 3.12
      */

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -153,7 +153,7 @@ void TestQgsDxfExport::testPoints()
 
   QString file = getTempFileName( "point_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   // reload and compare
@@ -181,7 +181,7 @@ void TestQgsDxfExport::testLines()
 
   QString file = getTempFileName( "line_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   // reload and compare
@@ -209,7 +209,7 @@ void TestQgsDxfExport::testPolygons()
 
   QString file = getTempFileName( "polygon_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   // reload and compare
@@ -242,7 +242,7 @@ void TestQgsDxfExport::testMultiSurface()
 
   QString file = getTempFileName( "multisurface_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   // reload and compare
@@ -295,7 +295,7 @@ void TestQgsDxfExport::testMTextEscapeSpaces()
 
   QString file = getTempFileName( "mtext_escape_spaces" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
   QVERIFY( fileContainsText( file, "\\fQGIS Vera Sans|i0|b1;\\H3.81136;A\\~text\\~with\\~spaces" ) );
 }
@@ -331,7 +331,7 @@ void TestQgsDxfExport::testText()
 
   QString file = getTempFileName( "text_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
 
@@ -397,7 +397,7 @@ bool TestQgsDxfExport::testMtext( QgsVectorLayer *vlayer, const QString &tempFil
 
   QString file = getTempFileName( tempFileName );
   QFile dxfFile( file );
-  if ( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ) != 0 )
+  if ( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ) != QgsDxfExport::ExportResult::Success )
   {
     return false;
   }
@@ -451,7 +451,7 @@ void TestQgsDxfExport::testGeometryGeneratorExport()
 
   QString file = getTempFileName( "geometry_generator_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   QVERIFY( fileContainsText( file, "HATCH" ) );
@@ -484,7 +484,7 @@ void TestQgsDxfExport::testCurveExport()
 
   QString file = getTempFileName( wktType );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   QVERIFY( fileContainsText( file, dxfText ) );

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -153,7 +153,7 @@ void TestQgsDxfExport::testPoints()
 
   QString file = getTempFileName( "point_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
   // reload and compare
@@ -181,7 +181,7 @@ void TestQgsDxfExport::testLines()
 
   QString file = getTempFileName( "line_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
   // reload and compare
@@ -209,7 +209,7 @@ void TestQgsDxfExport::testPolygons()
 
   QString file = getTempFileName( "polygon_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
   // reload and compare
@@ -242,7 +242,7 @@ void TestQgsDxfExport::testMultiSurface()
 
   QString file = getTempFileName( "multisurface_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
   // reload and compare
@@ -295,7 +295,7 @@ void TestQgsDxfExport::testMTextEscapeSpaces()
 
   QString file = getTempFileName( "mtext_escape_spaces" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
   QVERIFY( fileContainsText( file, "\\fQGIS Vera Sans|i0|b1;\\H3.81136;A\\~text\\~with\\~spaces" ) );
 }
@@ -331,7 +331,7 @@ void TestQgsDxfExport::testText()
 
   QString file = getTempFileName( "text_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
 
@@ -451,7 +451,7 @@ void TestQgsDxfExport::testGeometryGeneratorExport()
 
   QString file = getTempFileName( "geometry_generator_dxf" );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
   QVERIFY( fileContainsText( file, "HATCH" ) );
@@ -484,7 +484,7 @@ void TestQgsDxfExport::testCurveExport()
 
   QString file = getTempFileName( wktType );
   QFile dxfFile( file );
-  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), 0 );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::Success );
   dxfFile.close();
 
   QVERIFY( fileContainsText( file, dxfText ) );


### PR DESCRIPTION
E.g. because no layers are given.

So far invalid dxf files (with viewport height = 0) have been exported, which would choke when opened in cad software.