### PR TITLE
Fix copy items from value map configuration

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -202,12 +202,13 @@ void QgsValueMapConfigDlg::populateComboBox( QComboBox *comboBox, const QVariant
 bool QgsValueMapConfigDlg::eventFilter( QObject *watched, QEvent *event )
 {
   Q_UNUSED( watched )
-  if ( event->type() == QEvent::KeyRelease )
+  if ( event->type() == QEvent::KeyPress )
   {
     QKeyEvent *keyEvent = static_cast<QKeyEvent *>( event );
     if ( keyEvent->matches( QKeySequence::Copy ) )
     {
       copySelectionToClipboard();
+      event->accept();
       return true;
     }
   }


### PR DESCRIPTION
QAbstractItemView internally uses the KeyPress signal, so in order to
make sure our code takes precedence we need to react to the same signal.
Apparently it's not enough to trust Qt that the KeyReleased is always
triggered after a KeyPress.

Fix #32256
