### PR TITLE
Create child feature with geometry from the relation editor

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -287,6 +287,14 @@ The following operations will be performed to convert the input features:
 %End
 
 
+
+    static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );
+%Docstring
+
+:return: the ``layer`` ``feature`` display string
+
+.. versionadded:: 3.12
+%End
 };
 
 

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -258,6 +258,20 @@ Returns given ``attributeFormMode`` as string
 .. versionadded:: 3.4
 %End
 
+    void setMainInfoBar( QgsMessageBar *messageBar );
+%Docstring
+Set current ``messageBar`` as the main information bar
+
+.. versionadded:: 3.12
+%End
+
+    QgsMessageBar *mainInfoBar();
+%Docstring
+Returns the main information bar
+
+.. versionadded:: 3.12
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -258,16 +258,16 @@ Returns given ``attributeFormMode`` as string
 .. versionadded:: 3.4
 %End
 
-    void setMainInfoBar( QgsMessageBar *messageBar );
+    void setMainMessageBar( QgsMessageBar *messageBar );
 %Docstring
-Set current ``messageBar`` as the main information bar
+Set current ``messageBar`` as the main message bar
 
 .. versionadded:: 3.12
 %End
 
-    QgsMessageBar *mainInfoBar();
+    QgsMessageBar *mainMessageBar();
 %Docstring
-Returns the main information bar
+Returns the main message bar
 
 .. versionadded:: 3.12
 %End

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -158,7 +158,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
 
   mEditorContext.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
   mEditorContext.setMapCanvas( QgisApp::instance()->mapCanvas() );
-  mEditorContext.setMainInfoBar( QgisApp::instance()->messageBar() );
+  mEditorContext.setMainMessageBar( QgisApp::instance()->messageBar() );
   mEditorContext.setCadDockWidget( QgisApp::instance()->cadDockWidget() );
 
   QgsFeatureRequest r;

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -158,6 +158,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
 
   mEditorContext.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
   mEditorContext.setMapCanvas( QgisApp::instance()->mapCanvas() );
+  mEditorContext.setMainInfoBar( QgisApp::instance()->messageBar() );
   mEditorContext.setCadDockWidget( QgisApp::instance()->cadDockWidget() );
 
   QgsFeatureRequest r;

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -1029,3 +1029,15 @@ QHash<QString, QSet<QgsSymbolLayerId>> QgsVectorLayerUtils::symbolLayerMasks( co
   layer->renderer()->accept( &visitor );
   return visitor.masks;
 }
+
+QString QgsVectorLayerUtils::getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature )
+{
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+
+  QgsExpression exp( layer->displayExpression() );
+  context.setFeature( feature );
+  exp.prepare( &context );
+  QString displayString = exp.evaluate( &context ).toString();
+
+  return displayString;
+}

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -312,6 +312,12 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \since QGIS 3.12
      */
     static QHash<QString, QSet<QgsSymbolLayerId>> symbolLayerMasks( const QgsVectorLayer * ) SIP_SKIP;
+
+    /**
+     * \return the \a layer \a feature display string
+     * \since QGIS 3.12
+     */
+    static QString getFeatureDisplayString( const QgsVectorLayer *layer, const QgsFeature &feature );
 };
 
 

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -28,6 +28,7 @@
 
 class QgsMapCanvas;
 class QgsAdvancedDigitizingDockWidget;
+class QgsMessageBar;
 
 /**
  * \ingroup gui
@@ -79,6 +80,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       : mParentContext( &parentContext )
       , mVectorLayerTools( parentContext.mVectorLayerTools )
       , mMapCanvas( parentContext.mMapCanvas )
+      , mMainInfoBar( parentContext.mMainInfoBar )
       , mCadDockWidget( parentContext.mCadDockWidget )
       , mDistanceArea( parentContext.mDistanceArea )
       , mFormFeature( parentContext.mFormFeature )
@@ -91,6 +93,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       : mParentContext( &parentContext )
       , mVectorLayerTools( parentContext.mVectorLayerTools )
       , mMapCanvas( parentContext.mMapCanvas )
+      , mMainInfoBar( parentContext.mMainInfoBar )
       , mCadDockWidget( parentContext.mCadDockWidget )
       , mDistanceArea( parentContext.mDistanceArea )
       , mRelation( relation )
@@ -261,11 +264,24 @@ class GUI_EXPORT QgsAttributeEditorContext
       return metaEnum.valueToKey( static_cast<int>( mAttributeFormMode ) );
     }
 
+    /**
+     * Set current \a messageBar as the main information bar
+     * \since QGIS 3.12
+     */
+    void setMainInfoBar( QgsMessageBar *messageBar ) { mMainInfoBar = messageBar; }
+
+    /**
+     * Returns the main information bar
+     * \since QGIS 3.12
+     */
+    QgsMessageBar *mainInfoBar() { return mMainInfoBar; }
+
   private:
     const QgsAttributeEditorContext *mParentContext = nullptr;
     QgsVectorLayer *mLayer = nullptr;
     QgsVectorLayerTools *mVectorLayerTools = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
+    QgsMessageBar *mMainInfoBar = nullptr;
     QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
     QgsDistanceArea mDistanceArea;
     QgsRelation mRelation;

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       : mParentContext( &parentContext )
       , mVectorLayerTools( parentContext.mVectorLayerTools )
       , mMapCanvas( parentContext.mMapCanvas )
-      , mMainInfoBar( parentContext.mMainInfoBar )
+      , mMainMessageBar( parentContext.mMainMessageBar )
       , mCadDockWidget( parentContext.mCadDockWidget )
       , mDistanceArea( parentContext.mDistanceArea )
       , mFormFeature( parentContext.mFormFeature )
@@ -93,7 +93,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       : mParentContext( &parentContext )
       , mVectorLayerTools( parentContext.mVectorLayerTools )
       , mMapCanvas( parentContext.mMapCanvas )
-      , mMainInfoBar( parentContext.mMainInfoBar )
+      , mMainMessageBar( parentContext.mMainMessageBar )
       , mCadDockWidget( parentContext.mCadDockWidget )
       , mDistanceArea( parentContext.mDistanceArea )
       , mRelation( relation )
@@ -265,23 +265,23 @@ class GUI_EXPORT QgsAttributeEditorContext
     }
 
     /**
-     * Set current \a messageBar as the main information bar
+     * Set current \a messageBar as the main message bar
      * \since QGIS 3.12
      */
-    void setMainInfoBar( QgsMessageBar *messageBar ) { mMainInfoBar = messageBar; }
+    void setMainMessageBar( QgsMessageBar *messageBar ) { mMainMessageBar = messageBar; }
 
     /**
-     * Returns the main information bar
+     * Returns the main message bar
      * \since QGIS 3.12
      */
-    QgsMessageBar *mainInfoBar() { return mMainInfoBar; }
+    QgsMessageBar *mainMessageBar() { return mMainMessageBar; }
 
   private:
     const QgsAttributeEditorContext *mParentContext = nullptr;
     QgsVectorLayer *mLayer = nullptr;
     QgsVectorLayerTools *mVectorLayerTools = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
-    QgsMessageBar *mMainInfoBar = nullptr;
+    QgsMessageBar *mMainMessageBar = nullptr;
     QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
     QgsDistanceArea mDistanceArea;
     QgsRelation mRelation;

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -447,12 +447,7 @@ void QgsRelationEditorWidget::addFeatureGeometry()
 
   if ( mEditorContext.mainInfoBar() )
   {
-    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
-
-    QgsExpression exp( layer->displayExpression() );
-    context.setFeature( mFeature );
-    exp.prepare( &context );
-    QString displayString = exp.evaluate( &context ).toString();
+    QString displayString = QgsVectorLayerUtils::getFeatureDisplayString( layer, mFeature );
 
     QString title = tr( "Create child feature for parent %1 \"%2\"" ).arg( mRelation.referencedLayer()->name(), displayString );
     QString msg = tr( "Digitize the geometry for the new feature on layer %1. Press &lt;ESC&gt; to cancel." )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -446,7 +446,7 @@ void QgsRelationEditorWidget::addFeatureGeometry()
   connect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::onDigitizingCompleted );
   connect( mEditorContext.mapCanvas(), &QgsMapCanvas::keyPressed, this, &QgsRelationEditorWidget::onKeyPressed );
 
-  if ( mEditorContext.mainInfoBar() )
+  if ( mEditorContext.mainMessageBar() )
   {
     QString displayString = QgsVectorLayerUtils::getFeatureDisplayString( layer, mFeature );
 
@@ -454,7 +454,7 @@ void QgsRelationEditorWidget::addFeatureGeometry()
     QString msg = tr( "Digitize the geometry for the new feature on layer %1. Press &lt;ESC&gt; to cancel." )
                   .arg( layer->name() );
     mMessageBarItem = QgsMessageBar::createMessage( title, msg, this );
-    mEditorContext.mainInfoBar()->pushItem( mMessageBarItem );
+    mEditorContext.mainMessageBar()->pushItem( mMessageBarItem );
   }
 
 }
@@ -952,9 +952,9 @@ void QgsRelationEditorWidget::mapToolDeactivated()
   window()->raise();
   window()->activateWindow();
 
-  if ( mEditorContext.mainInfoBar() && mMessageBarItem )
+  if ( mEditorContext.mainMessageBar() && mMessageBarItem )
   {
-    mEditorContext.mainInfoBar()->popWidget( mMessageBarItem );
+    mEditorContext.mainMessageBar()->popWidget( mMessageBarItem );
   }
   mMessageBarItem = nullptr;
 }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -520,6 +520,8 @@ void QgsRelationEditorWidget::addFeature( const QgsGeometry &geometry )
 void QgsRelationEditorWidget::onDigitizingCompleted( const QgsFeature &feature )
 {
   addFeature( feature.geometry() );
+
+  unsetMapTool();
 }
 
 void QgsRelationEditorWidget::linkFeature()
@@ -934,14 +936,11 @@ void QgsRelationEditorWidget::unsetMapTool()
 {
   QgsMapCanvas *mapCanvas = mEditorContext.mapCanvas();
 
-  if ( mapCanvas->mapTool() != mMapToolDigitize )
-    return;
-
   // this will call mapToolDeactivated
   mapCanvas->unsetMapTool( mMapToolDigitize );
 
   disconnect( mapCanvas, &QgsMapCanvas::keyPressed, this, &QgsRelationEditorWidget::onKeyPressed );
-  disconnect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::addFeatureGeometry );
+  disconnect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::onDigitizingCompleted );
 }
 
 void QgsRelationEditorWidget::onKeyPressed( QKeyEvent *e )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -34,6 +34,7 @@
 #include "qgsmaptooldigitizefeature.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsmessagebar.h"
+#include "qgsmessagebaritem.h"
 
 #include <QHBoxLayout>
 #include <QLabel>

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -20,7 +20,9 @@
 #include <QToolButton>
 #include <QButtonGroup>
 #include <QGridLayout>
+#include "qobjectuniqueptr.h"
 
+#include "qobjectuniqueptr.h"
 #include "qgsattributeeditorcontext.h"
 #include "qgscollapsiblegroupbox.h"
 #include "qgsdualview.h"
@@ -31,6 +33,8 @@
 class QgsFeature;
 class QgsVectorLayer;
 class QgsVectorLayerTools;
+class QgsMapTool;
+class QgsMapToolDigitizeFeature;
 
 #ifdef SIP_RUN
 % ModuleHeaderCode
@@ -176,7 +180,8 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void setViewMode( int mode ) {setViewMode( static_cast<QgsDualView::ViewMode>( mode ) );}
     void updateButtons();
 
-    void addFeature();
+    void addFeature( const QgsGeometry &geometry = QgsGeometry() );
+    void addFeatureGeometry();
     void duplicateFeature();
     void linkFeature();
     void deleteFeature( QgsFeatureId featureid = QgsFeatureId() );
@@ -188,12 +193,18 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void toggleEditing( bool state );
     void onCollapsedStateChanged( bool collapsed );
     void showContextMenu( QgsActionMenu *menu, QgsFeatureId fid );
+    void mapToolDeactivated();
+    void onKeyPressed( QKeyEvent *e );
+    void onDigitizingCompleted( const QgsFeature &feature );
 
   private:
     void updateUi();
     void initDualView( QgsVectorLayer *layer, const QgsFeatureRequest &request );
+    void setMapTool( QgsMapTool *mapTool );
+    void unsetMapTool();
 
     QgsDualView *mDualView = nullptr;
+    QgsMessageBarItem *mMessageBarItem = nullptr;
     QgsDualView::ViewMode mViewMode = QgsDualView::AttributeEditor;
     QgsVectorLayerSelectionManager *mFeatureSelectionMgr = nullptr;
     QgsAttributeEditorContext mEditorContext;
@@ -211,7 +222,9 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QToolButton *mZoomToFeatureButton = nullptr;
     QToolButton *mFormViewButton = nullptr;
     QToolButton *mTableViewButton = nullptr;
+    QToolButton *mAddFeatureGeometryButton = nullptr;
     QGridLayout *mRelationLayout = nullptr;
+    QObjectUniquePtr<QgsMapToolDigitizeFeature> mMapToolDigitize;
     QButtonGroup *mViewModeButtonGroup = nullptr;
 
     bool mShowLabel = true;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -204,7 +204,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void unsetMapTool();
 
     QgsDualView *mDualView = nullptr;
-    QgsMessageBarItem *mMessageBarItem = nullptr;
+    QPointer<QgsMessageBarItem> mMessageBarItem;
     QgsDualView::ViewMode mViewMode = QgsDualView::AttributeEditor;
     QgsVectorLayerSelectionManager *mFeatureSelectionMgr = nullptr;
     QgsAttributeEditorContext mEditorContext;

--- a/tests/testdata/provider/testdata_pg_reltests.sql
+++ b/tests/testdata/provider/testdata_pg_reltests.sql
@@ -3,7 +3,8 @@ DROP TABLE IF EXISTS qgis_test.books_authors;
 DROP TABLE IF EXISTS qgis_test.books;
 DROP TABLE IF EXISTS qgis_test.authors;
 DROP TABLE IF EXISTS qgis_test.editors;
-
+DROP TABLE IF EXISTS qgis_test.pipes;
+DROP TABLE IF EXISTS qgis_test.leaks;
 
 -- Table: qgis_test.authors
 
@@ -83,3 +84,35 @@ INSERT INTO qgis_test.books_authors(fk_book, fk_author)
               (1, 2),
               (1, 3),
               (1, 4);
+
+-- Table: qgis_test.pipes
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE qgis_test.pipes
+(
+  id serial PRIMARY KEY,
+  name text,
+  geom geometry('LINESTRING',4326),
+  CONSTRAINT pipes_name_key UNIQUE (name)
+);
+
+INSERT INTO qgis_test.pipes(name, geom)
+VALUES ('pipe 1', ST_GeometryFromText('LINESTRING(0 0,0 1)',4326)),
+       ('pipe 2', ST_GeometryFromText('LINESTRING(0 0,1 0)',4326));
+
+-- Table: qgis_test.leaks
+
+CREATE TABLE qgis_test.leaks
+(
+  id serial PRIMARY KEY,
+  name text,
+  pipe integer references qgis_test.pipes(id),
+  geom geometry('POINT',4326),
+  CONSTRAINT leaks_name_key UNIQUE (name)
+);
+
+INSERT INTO qgis_test.leaks(name, pipe, geom)
+VALUES ('leak 1', 1, ST_GeometryFromText('POINT(0 0.5)',4326)),
+       ('leak 2', 2, ST_GeometryFromText('POINT(0.25 0)',4326)),
+       ('leak 3', 2, ST_GeometryFromText('POINT(0.75 0)',4326));


### PR DESCRIPTION
## Description

This PR allows to create a child feature by digitizing its geometry in the canvas directly from the relation editor widget. 

![createchild](https://user-images.githubusercontent.com/14358135/67881832-87205580-fb41-11e9-9d50-fbe348a2daf4.gif)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
