### PR TITLE
Deprecate old QgsRasterResampler interface, add a new more efficient interface

### DIFF
--- a/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -10,7 +10,8 @@
 
 
 
-class QgsBilinearRasterResampler: QgsRasterResampler
+
+class QgsBilinearRasterResampler: QgsRasterResamplerV2
 {
 %Docstring
 Bilinear Raster Resampler
@@ -25,10 +26,13 @@ Bilinear Raster Resampler
 %Docstring
 Constructor for QgsBilinearRasterResampler.
 %End
-
     virtual void resample( const QImage &srcImage, QImage &dstImage );
 
+
+    virtual QImage resampleV2( const QImage &source, const QSize &size );
+
     virtual QString type() const;
+
     virtual QgsBilinearRasterResampler *clone() const /Factory/;
 
 };

--- a/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsbilinearrasterresampler.sip.in
@@ -26,7 +26,7 @@ Bilinear Raster Resampler
 %Docstring
 Constructor for QgsBilinearRasterResampler.
 %End
-    virtual void resample( const QImage &srcImage, QImage &dstImage );
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
 
     virtual QImage resampleV2( const QImage &source, const QSize &size );

--- a/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsCubicRasterResampler: QgsRasterResampler
+class QgsCubicRasterResampler: QgsRasterResamplerV2
 {
 %Docstring
 Cubic Raster Resampler
@@ -27,9 +27,15 @@ Constructor for QgsCubicRasterResampler.
 %End
     virtual QgsCubicRasterResampler *clone() const /Factory/;
 
+
+    virtual QImage resampleV2( const QImage &source, const QSize &size );
+
+
     virtual void resample( const QImage &srcImage, QImage &dstImage );
 
+
     virtual QString type() const;
+
 
 };
 

--- a/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgscubicrasterresampler.sip.in
@@ -31,7 +31,7 @@ Constructor for QgsCubicRasterResampler.
     virtual QImage resampleV2( const QImage &source, const QSize &size );
 
 
-    virtual void resample( const QImage &srcImage, QImage &dstImage );
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) /Deprecated/;
 
 
     virtual QString type() const;

--- a/python/core/auto_generated/raster/qgsrasterresampler.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterresampler.sip.in
@@ -31,7 +31,17 @@ Interface for resampling rasters (e.g. to have a smoother appearance)
 %End
   public:
     virtual ~QgsRasterResampler();
-    virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0;
+
+ virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0 /Deprecated/;
+%Docstring
+Resamples a source image to a destination image.
+
+The size of the passed destination image should be respected during the resampling
+process.
+
+.. deprecated:: QGIS 3.10.1
+  use the more efficient QgsRasterResamplerV2 interface instead.
+%End
 
     virtual QString type() const = 0;
 %Docstring
@@ -45,6 +55,30 @@ Gets a deep copy of this object.
 Needs to be reimplemented by subclasses.
 Ownership is transferred to the caller.
 %End
+};
+
+
+class QgsRasterResamplerV2 : QgsRasterResampler
+{
+%Docstring
+Interface for resampling rasters (V2) (e.g. to have a smoother appearance),
+which provides a more efficient interface vs QgsRasterResampler.
+
+.. versionadded:: 3.10.1
+%End
+
+%TypeHeaderCode
+#include "qgsrasterresampler.h"
+%End
+  public:
+
+    virtual QImage resampleV2( const QImage &source, const QSize &size ) = 0;
+%Docstring
+Resamples a ``source`` image to the specified ``size``.
+
+Returns the resampled image, or a null QImage if the resampling fails.
+%End
+
 };
 
 /************************************************************************

--- a/src/core/raster/qgsbilinearrasterresampler.cpp
+++ b/src/core/raster/qgsbilinearrasterresampler.cpp
@@ -24,7 +24,19 @@ QgsBilinearRasterResampler *QgsBilinearRasterResampler::clone() const
   return new QgsBilinearRasterResampler();
 }
 
+Q_NOWARN_DEPRECATED_PUSH
 void QgsBilinearRasterResampler::resample( const QImage &srcImage, QImage &dstImage )
 {
   dstImage = srcImage.scaled( dstImage.width(), dstImage.height(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation );
+}
+Q_NOWARN_DEPRECATED_POP
+
+QImage QgsBilinearRasterResampler::resampleV2( const QImage &source, const QSize &size )
+{
+  return source.scaled( size.width(), size.height(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation );
+}
+
+QString QgsBilinearRasterResampler::type() const
+{
+  return QStringLiteral( "bilinear" );
 }

--- a/src/core/raster/qgsbilinearrasterresampler.h
+++ b/src/core/raster/qgsbilinearrasterresampler.h
@@ -38,7 +38,7 @@ class CORE_EXPORT QgsBilinearRasterResampler: public QgsRasterResamplerV2
      * Constructor for QgsBilinearRasterResampler.
      */
     QgsBilinearRasterResampler() = default;
-    void resample( const QImage &srcImage, QImage &dstImage ) override;
+    Q_DECL_DEPRECATED void resample( const QImage &srcImage, QImage &dstImage ) override SIP_DEPRECATED;
 
     QImage resampleV2( const QImage &source, const QSize &size ) override;
     QString type() const override;

--- a/src/core/raster/qgsbilinearrasterresampler.h
+++ b/src/core/raster/qgsbilinearrasterresampler.h
@@ -20,6 +20,8 @@
 
 #include "qgsrasterresampler.h"
 #include "qgis_sip.h"
+#include "qgis.h"
+
 #include <QColor>
 
 #include "qgis_core.h"
@@ -28,7 +30,7 @@
  * \ingroup core
     Bilinear Raster Resampler
 */
-class CORE_EXPORT QgsBilinearRasterResampler: public QgsRasterResampler
+class CORE_EXPORT QgsBilinearRasterResampler: public QgsRasterResamplerV2
 {
   public:
 
@@ -36,9 +38,10 @@ class CORE_EXPORT QgsBilinearRasterResampler: public QgsRasterResampler
      * Constructor for QgsBilinearRasterResampler.
      */
     QgsBilinearRasterResampler() = default;
-
     void resample( const QImage &srcImage, QImage &dstImage ) override;
-    QString type() const override { return QStringLiteral( "bilinear" ); }
+
+    QImage resampleV2( const QImage &source, const QSize &size ) override;
+    QString type() const override;
     QgsBilinearRasterResampler *clone() const override SIP_FACTORY;
 };
 

--- a/src/core/raster/qgscubicrasterresampler.cpp
+++ b/src/core/raster/qgscubicrasterresampler.cpp
@@ -24,6 +24,19 @@ QgsCubicRasterResampler *QgsCubicRasterResampler::clone() const
   return new QgsCubicRasterResampler();
 }
 
+QImage QgsCubicRasterResampler::resampleV2( const QImage &source, const QSize &size )
+{
+  QImage dest = QImage( size.width(), size.height(), QImage::Format_ARGB32 );
+
+  // note, when removing deprecated members, just make the existing overridden resample method private!
+  Q_NOWARN_DEPRECATED_PUSH
+  resample( source, dest );
+  Q_NOWARN_DEPRECATED_POP
+
+  return dest;
+}
+
+Q_NOWARN_DEPRECATED_PUSH
 void QgsCubicRasterResampler::resample( const QImage &srcImage, QImage &dstImage )
 {
   int nCols = srcImage.width();
@@ -273,6 +286,12 @@ void QgsCubicRasterResampler::resample( const QImage &srcImage, QImage &dstImage
   delete[] yDerivativeMatrixGreen;
   delete[] yDerivativeMatrixBlue;
   delete[] yDerivativeMatrixAlpha;
+}
+Q_NOWARN_DEPRECATED_POP
+
+QString QgsCubicRasterResampler::type() const
+{
+  return QStringLiteral( "cubic" );
 }
 
 void QgsCubicRasterResampler::xDerivativeMatrix( int nCols, int nRows, double *matrix, const int *colorMatrix )

--- a/src/core/raster/qgscubicrasterresampler.h
+++ b/src/core/raster/qgscubicrasterresampler.h
@@ -20,6 +20,7 @@
 
 #include "qgsrasterresampler.h"
 #include "qgis_sip.h"
+#include "qgis.h"
 #include <QColor>
 
 #include "qgis_core.h"
@@ -28,7 +29,7 @@
  * \ingroup core
     Cubic Raster Resampler
 */
-class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResampler
+class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResamplerV2
 {
   public:
 
@@ -37,8 +38,12 @@ class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResampler
      */
     QgsCubicRasterResampler() = default;
     QgsCubicRasterResampler *clone() const override SIP_FACTORY;
+
+    QImage resampleV2( const QImage &source, const QSize &size ) override;
+
     void resample( const QImage &srcImage, QImage &dstImage ) override;
-    QString type() const override { return QStringLiteral( "cubic" ); }
+
+    QString type() const override;
 
   private:
     static void xDerivativeMatrix( int nCols, int nRows, double *matrix, const int *colorMatrix );

--- a/src/core/raster/qgscubicrasterresampler.h
+++ b/src/core/raster/qgscubicrasterresampler.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResamplerV2
 
     QImage resampleV2( const QImage &source, const QSize &size ) override;
 
-    void resample( const QImage &srcImage, QImage &dstImage ) override;
+    Q_DECL_DEPRECATED void resample( const QImage &srcImage, QImage &dstImage ) override SIP_DEPRECATED;
 
     QString type() const override;
 

--- a/src/core/raster/qgsrasterresamplefilter.cpp
+++ b/src/core/raster/qgsrasterresamplefilter.cpp
@@ -184,18 +184,41 @@ QgsRasterBlock *QgsRasterResampleFilter::block( int bandNo, QgsRectangle  const 
 
   //resample image
   QImage img = inputBlock->image();
-
-  QImage dstImg = QImage( width, height, QImage::Format_ARGB32_Premultiplied );
+  QImage dstImg;
 
   if ( mZoomedInResampler && ( oversamplingX < 1.0 || qgsDoubleNear( oversampling, 1.0 ) ) )
   {
     QgsDebugMsgLevel( QStringLiteral( "zoomed in resampling" ), 4 );
-    mZoomedInResampler->resample( img, dstImg );
+
+    if ( QgsRasterResamplerV2 *resamplerV2 = dynamic_cast< QgsRasterResamplerV2 * >( mZoomedInResampler.get( ) ) )
+    {
+      dstImg = resamplerV2->resampleV2( img, QSize( width, height ) );
+    }
+    else
+    {
+      // old inefficient interface
+      Q_NOWARN_DEPRECATED_PUSH
+      QImage dstImg = QImage( width, height, QImage::Format_ARGB32_Premultiplied );
+      mZoomedInResampler->resample( img, dstImg );
+      Q_NOWARN_DEPRECATED_POP
+    }
   }
   else if ( mZoomedOutResampler && oversamplingX > 1.0 )
   {
     QgsDebugMsgLevel( QStringLiteral( "zoomed out resampling" ), 4 );
-    mZoomedOutResampler->resample( img, dstImg );
+
+    if ( QgsRasterResamplerV2 *resamplerV2 = dynamic_cast< QgsRasterResamplerV2 * >( mZoomedOutResampler.get( ) ) )
+    {
+      dstImg = resamplerV2->resampleV2( img, QSize( width, height ) );
+    }
+    else
+    {
+      // old inefficient interface
+      Q_NOWARN_DEPRECATED_PUSH
+      QImage dstImg = QImage( width, height, QImage::Format_ARGB32_Premultiplied );
+      mZoomedOutResampler->resample( img, dstImg );
+      Q_NOWARN_DEPRECATED_POP
+    }
   }
   else
   {

--- a/src/core/raster/qgsrasterresampler.h
+++ b/src/core/raster/qgsrasterresampler.h
@@ -24,6 +24,7 @@
 
 class QString;
 class QImage;
+class QSize;
 
 /**
  * \ingroup core
@@ -50,7 +51,16 @@ class CORE_EXPORT QgsRasterResampler
 
   public:
     virtual ~QgsRasterResampler() = default;
-    virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0;
+
+    /**
+     * Resamples a source image to a destination image.
+     *
+     * The size of the passed destination image should be respected during the resampling
+     * process.
+     *
+     * \deprecated since QGIS 3.10.1, use the more efficient QgsRasterResamplerV2 interface instead.
+     */
+    Q_DECL_DEPRECATED virtual void resample( const QImage &srcImage, QImage &dstImage ) = 0 SIP_DEPRECATED;
 
     /**
      * Gets a descriptive type identifier for this raster resampler.
@@ -64,6 +74,27 @@ class CORE_EXPORT QgsRasterResampler
      * Ownership is transferred to the caller.
      */
     virtual QgsRasterResampler *clone() const = 0 SIP_FACTORY;
+};
+
+
+/**
+ * \ingroup core
+  * Interface for resampling rasters (V2) (e.g. to have a smoother appearance),
+  * which provides a more efficient interface vs QgsRasterResampler.
+  *
+  * \since QGIS 3.10.1
+  */
+class CORE_EXPORT QgsRasterResamplerV2 : public QgsRasterResampler
+{
+  public:
+
+    /**
+     * Resamples a \a source image to the specified \a size.
+     *
+     * Returns the resampled image, or a null QImage if the resampling fails.
+     */
+    virtual QImage resampleV2( const QImage &source, const QSize &size ) = 0;
+
 };
 
 #endif // QGSRASTERRESAMPLER_H


### PR DESCRIPTION
...which doesn't require pre-allocation of a temporary QImage

The existing interface is very inefficient for the bilinear resampler,
because it requires allocation of a temporary QImage just to pass
the desired height and width to the resampler...
