### PR TITLE
[RPM] Update sip references in spec file

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -103,7 +103,7 @@ BuildRequires:  python3-qscintilla-devel
 BuildRequires:  python3-qscintilla-qt5
 BuildRequires:  python3-qscintilla-qt5-devel
 BuildRequires:  python3-qt5-devel
-BuildRequires:  sip-devel
+BuildRequires:  python3-sip-devel
 
 # Qca stuff
 BuildRequires:  qca-qt5-devel
@@ -200,7 +200,7 @@ Requires:       python3-PyYAML
 Requires:       python3-qscintilla
 Requires:       python3-qscintilla-qt5
 Requires:       python3-qt5
-%{?_sip_api:Requires: sip-api(%{_sip_api_major}) >= %{_sip_api}}
+%{?_sip_api:Requires: python3-pyqt5-sip-api(%{_sip_api_major}) >= %{_sip_api}}
 
 %description -n python3-qgis
 Python integration and plug-ins for QGIS.


### PR DESCRIPTION
## Description
This PR updates references about `sip` in the spec file. It addresses the

```
Error: 
 Problem: conflicting requests
  - nothing provides sip-api(12) >= 12.7 needed by python3-qgis-3.10.0-1.fc31.x86_64
```

error on F31 (which has been released yesterday).

The change is backward compatible with all Fedora releases in their life cycle (29-31).
_Needs backport to 3.10 and 3.4_

/cc @m-kuhn 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
