### PR TITLE
[feature] Ignored credentials temporary cache

### DIFF
--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -60,9 +60,9 @@ QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WindowFlags fl )
   // Setup ignore button
   mIgnoreButton->setToolTip( tr( "All requests for this connection will be automatically rejected" ) );
   QMenu *menu = new QMenu( mIgnoreButton );
-  QAction *ignoreTemporarily = new QAction( tr( "Ignore for 10 seconds" ), menu );
+  QAction *ignoreTemporarily = new QAction( tr( "Ignore for 10 Seconds" ), menu );
   ignoreTemporarily->setToolTip( tr( "All requests for this connection will be automatically rejected for 10 seconds" ) );
-  QAction *ignoreForSession = new QAction( tr( "Ignore for session" ), menu );
+  QAction *ignoreForSession = new QAction( tr( "Ignore for Session" ), menu );
   ignoreForSession->setToolTip( tr( "All requests for this connection will be automatically rejected for the duration of the current session" ) );
   menu->addAction( ignoreTemporarily );
   menu->addAction( ignoreForSession );

--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -52,9 +52,9 @@ QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WindowFlags fl )
            Qt::BlockingQueuedConnection );
   mOkButton = buttonBox->button( QDialogButtonBox::Ok );
   QPushButton *ignoreButton { buttonBox->button( QDialogButtonBox::StandardButton::Ignore ) };
-  ignoreButton->setToolTip( tr( "All requests for this connection will be automatically rejected for the next 5 seconds." ) );
+  ignoreButton->setToolTip( tr( "All requests for this connection will be automatically rejected for the next 60 seconds." ) );
 
-  // Keep a cache of ignored connections, and ignore them for 5 seconds.
+  // Keep a cache of ignored connections, and ignore them for 60 seconds.
   connect( ignoreButton, &QPushButton::clicked, [ = ]( bool )
   {
     const QString realm { labelRealm->text() };
@@ -63,7 +63,7 @@ QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WindowFlags fl )
       // Insert the realm in the cache of ignored connections
       sIgnoredConnectionsCache.insert( realm );
     }
-    QTimer::singleShot( 5000, [ = ]()
+    QTimer::singleShot( 60000, [ = ]()
     {
       QgsDebugMsgLevel( QStringLiteral( "Removing ignored connection from cache: %1" ).arg( realm ), 4 );
       QMutexLocker locker( &sIgnoredConnectionsCacheMutex );

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -64,6 +64,10 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
 
   private:
     QPushButton *mOkButton = nullptr;
+    //! Temporary cache for ignored connections, to avoid GUI freezing by multiple credentials requests to the same connection
+    static QSet<QString> sIgnoredConnectionsCache;
+    static QMutex sIgnoredConnectionsCacheMutex;
+
 };
 
 #endif

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -63,10 +63,20 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
     bool requestMasterPassword( QString &password SIP_INOUT, bool stored = false ) override;
 
   private:
-    QPushButton *mOkButton = nullptr;
-    //! Temporary cache for ignored connections, to avoid GUI freezing by multiple credentials requests to the same connection
-    static QSet<QString> sIgnoredConnectionsCache;
+
+    /**
+     * The ConnectionsIgnoreMode enum represent the modes a connection can be ignored
+     */
+    enum ConnectionsIgnoreMode
+    {
+      IgnoreTemporarily, //!< Ignore for a certain amount of time
+      IgnoreForSession,  //!< Ignore for the whole QGIS session
+    };
+
+    //! mutex for the static ignored connections cache
     static QMutex sIgnoredConnectionsCacheMutex;
+
+    ConnectionsIgnoreMode mIgnoreMode = ConnectionsIgnoreMode::IgnoreTemporarily;
 
 };
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -435,6 +435,10 @@ class QgsPostgresConn : public QObject
     static QMap<QString, QgsPostgresConn *> sConnectionsRW;
     static QMap<QString, QgsPostgresConn *> sConnectionsRO;
 
+    //! Temporary cache for broken connections, to avoid GUI freezing by multiple credentials requests
+    static QSet<QString> sBrokenConnectionsCache;
+    static QMutex sBrokenConnectionsCacheMutex;
+
     //! Count number of spatial columns in a given relation
     void addColumnInfo( QgsPostgresLayerProperty &layerProperty, const QString &schemaName, const QString &viewName, bool fetchPkCandidates );
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -435,10 +435,6 @@ class QgsPostgresConn : public QObject
     static QMap<QString, QgsPostgresConn *> sConnectionsRW;
     static QMap<QString, QgsPostgresConn *> sConnectionsRO;
 
-    //! Temporary cache for broken connections, to avoid GUI freezing by multiple credentials requests
-    static QSet<QString> sBrokenConnectionsCache;
-    static QMutex sBrokenConnectionsCacheMutex;
-
     //! Count number of spatial columns in a given relation
     void addColumnInfo( QgsPostgresLayerProperty &layerProperty, const QString &schemaName, const QString &viewName, bool fetchPkCandidates );
 

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>396</width>
-    <height>289</height>
+    <height>293</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>396</width>
+    <width>358</width>
     <height>293</height>
    </rect>
   </property>
@@ -14,20 +14,7 @@
    <string>Enter Credentials</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::ExpandingFieldsGrow</enum>
-   </property>
-   <item row="3" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ignore|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item row="0" column="0">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
       <number>1</number>
@@ -212,6 +199,62 @@ font-style: italic;
      </widget>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mOkButton">
+       <property name="text">
+        <string>Ok</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mIgnoreButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>All requests for this connection will be automatically rejected for the next 60 seconds</string>
+       </property>
+       <property name="text">
+        <string>Ignore</string>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::MenuButtonPopup</enum>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonTextOnly</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="mCancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -229,38 +272,5 @@ font-style: italic;
   <tabstop>chkbxEraseAuthDb</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>QgsCredentialDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsCredentialDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
## Description

The problem we want to solve here is when a project contains multiple layers that require access to the same connection and that connection is not available.

What happens now is that the credentials dialog will open for each (broken) layer and there is no way to tell QGIS to ignore all future requests to the same connection.

## Proposed solution

A new "Ignore" button is added to the dialog, with a tooltip explaining what it does.

![Screenshot_20191031_140513](https://user-images.githubusercontent.com/142164/67949543-2dbf3180-fbe8-11e9-9a94-70acca5f8154.png)


When the "Ignore" button is clicked, the connection is added to a temporary cache of ignored connections and all future credentials requests to the same connection will be automatically rejected without the user intervention.

The connection is automatically removed from the cache after ~~5~~ 60 seconds to allow future retries to the same connection.

Funded by **ARPA Piemonte**


