### PR TITLE
field displayNameWithAlias

### DIFF
--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -90,9 +90,9 @@ field alias if set, otherwise the field name.
 
     QString displayNameWithAlias() const;
 %Docstring
-Returns a friendly name string to use when displaying this field (adding the field alias in parenthesis if it is defined).
+Returns the name to use when displaying this field and adds the alias in parenthesis if it is defined.
 
-This should be used when working close to the data structure (i.e. building expressions and queries),
+This will be used when working close to the data structure (i.e. building expressions and queries),
 when the real field name must be shown but the alias is also useful to understand what the field
 represents.
 

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -88,6 +88,21 @@ field alias if set, otherwise the field name.
 .. versionadded:: 3.0
 %End
 
+    QString displayNameWithAlias() const;
+%Docstring
+Returns the name to use when displaying this field and adds the alias in parenthesis if it is defined.
+
+This will be used when working close to the data structure (i.e. building expressions and queries),
+when the real field name must be shown but the alias is also useful to understand what the field
+represents.
+
+.. seealso:: :py:func:`name`
+
+.. seealso:: :py:func:`alias`
+
+.. versionadded:: 3.12
+%End
+
     QVariant::Type type() const;
 %Docstring
 Gets variant type of the field as it will be retrieved from data source

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -92,7 +92,7 @@ field alias if set, otherwise the field name.
 %Docstring
 Returns the name to use when displaying this field and adds the alias in parenthesis if it is defined.
 
-This will be used when working close to the data structure (i.e. building expressions and queries),
+This should be used when working close to the data structure (i.e. building expressions and queries),
 when the real field name must be shown but the alias is also useful to understand what the field
 represents.
 

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -90,7 +90,7 @@ field alias if set, otherwise the field name.
 
     QString displayNameWithAlias() const;
 %Docstring
-Returns the name to use when displaying this field and adds the alias in parenthesis if it is defined.
+Returns a friendly name string to use when displaying this field (adding the field alias in parenthesis if it is defined).
 
 This should be used when working close to the data structure (i.e. building expressions and queries),
 when the real field name must be shown but the alias is also useful to understand what the field

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -92,6 +92,15 @@ QString QgsField::displayName() const
     return d->name;
 }
 
+QString QgsField::displayNameWithAlias() const
+{
+  if ( alias().isEmpty() )
+  {
+    return name();
+  }
+  return QStringLiteral( "%1 (%2)" ).arg( name() ).arg( alias() );
+}
+
 QVariant::Type QgsField::type() const
 {
   return d->type;

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -116,6 +116,19 @@ class CORE_EXPORT QgsField
      */
     QString displayName() const;
 
+    /**
+     * Returns the name to use when displaying this field and adds the alias in parenthesis if it is defined.
+     *
+     * This will be used when working close to the data structure (i.e. building expressions and queries),
+     * when the real field name must be shown but the alias is also useful to understand what the field
+     * represents.
+     *
+     * \see name()
+     * \see alias()
+     * \since QGIS 3.12
+     */
+    QString displayNameWithAlias() const;
+
     //! Gets variant type of the field as it will be retrieved from data source
     QVariant::Type type() const;
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -411,17 +411,13 @@ void QgsExpressionBuilderWidget::loadFieldNames( const QgsFields &fields )
 
   txtExpressionString->setFields( fields );
 
-  QStringList fieldNames;
-  fieldNames.reserve( fields.count() );
   for ( int i = 0; i < fields.count(); ++i )
   {
-    QgsField field = fields.at( i );
-    QString fieldName = field.name();
-    fieldNames << fieldName;
+    const QgsField field = fields.at( i );
     QIcon icon = fields.iconForField( i );
-    registerItem( QStringLiteral( "Fields and Values" ), fieldName, " \"" + fieldName + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
+    registerItem( QStringLiteral( "Fields and Values" ), field.displayNameWithAlias(),
+                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
   }
-  //  highlighter->addFields( fieldNames );
 }
 
 void QgsExpressionBuilderWidget::loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues )

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -98,7 +98,7 @@ void QgsQueryBuilder::populateFields()
       // only consider native fields
       continue;
     }
-    QStandardItem *myItem = new QStandardItem( fields.at( idx ).name() );
+    QStandardItem *myItem = new QStandardItem( fields.at( idx ).displayNameWithAlias() );
     myItem->setData( idx );
     myItem->setEditable( false );
     mModelFields->insertRow( mModelFields->rowCount(), myItem );

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -47,6 +47,7 @@ class TestQgsField: public QObject
     void convertCompatible();
     void dataStream();
     void displayName();
+    void displayNameWithAlias();
     void editorWidgetSetup();
     void collection();
 
@@ -713,6 +714,19 @@ void TestQgsField::displayName()
   field.setAlias( QString() );
   QCOMPARE( field.displayName(), QString( "name" ) );
 }
+
+
+void TestQgsField::displayNameWithAlias()
+{
+  QgsField field;
+  field.setName( QStringLiteral( "name" ) );
+  QCOMPARE( field.displayNameWithAlias(), QString( "name" ) );
+  field.setAlias( QStringLiteral( "alias" ) );
+  QCOMPARE( field.displayNameWithAlias(), QString( "name (alias)" ) );
+  field.setAlias( QString() );
+  QCOMPARE( field.displayNameWithAlias(), QString( "name" ) );
+}
+
 
 void TestQgsField::editorWidgetSetup()
 {


### PR DESCRIPTION
This adds another method to display field names with alias, this is to be used when 
working close to the data structure (sql builder, expressions etc.) when the information
in the alias is sometimes fundamental to indentify what the field contains.

displayNameWithAlias is now used (insted of field name) in:
- expressions dialog
- query builder

The format is:

```
alias (field_name)
# and, in case there is no alias:
field_name
```

Funded by **ARPA Piemonte**