### PR TITLE
Fixes #32545 Revert qgstaskmanager waitforfinished fix

### DIFF
--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -29,7 +29,6 @@ QgsTask::QgsTask( const QString &name, Flags flags )
   : mFlags( flags )
   , mDescription( name )
 {
-  mNotStartedMutex.lock();
 }
 
 QgsTask::~QgsTask()
@@ -42,7 +41,6 @@ QgsTask::~QgsTask()
     delete subTask.task;
   }
   mNotFinishedMutex.unlock();
-  mNotStartedMutex.unlock();
 }
 
 void QgsTask::setDescription( const QString &description )
@@ -58,7 +56,6 @@ qint64 QgsTask::elapsedTime() const
 void QgsTask::start()
 {
   mNotFinishedMutex.lock();
-  mNotStartedMutex.unlock();
   mStartCount++;
   Q_ASSERT( mStartCount == 1 );
 
@@ -155,9 +152,6 @@ QList<QgsMapLayer *> QgsTask::dependentLayers() const
 
 bool QgsTask::waitForFinished( int timeout )
 {
-  // We wait the task to be started
-  mNotStartedMutex.lock();
-
   bool rv = true;
   if ( mOverallStatus == Complete || mOverallStatus == Terminated )
   {

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -310,7 +310,6 @@ class CORE_EXPORT QgsTask : public QObject
      * it's used as a trigger for waitForFinished.
      */
     QMutex mNotFinishedMutex;
-    QMutex mNotStartedMutex;
 
     //! Progress of this (parent) task alone
     double mProgress = 0.0;

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -437,43 +437,6 @@ class TestQgsPointLocator : public QObject
       mVL->rollBack();
     }
 
-    void testWaitForIndexingFinished()
-    {
-      QgsPointLocator loc( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr );
-      QgsPointXY pt( 2, 2 );
-
-      // locator is not ready yet
-      QgsPointLocator::Match m = loc.nearestVertex( pt, 999, nullptr, true );
-      QVERIFY( !m.isValid() );
-      QVERIFY( loc.mIsIndexing );
-
-      // non relaxed call, this will block until the first indexing is finished
-      // so the match point has to be valid
-      m = loc.nearestVertex( pt, 999, nullptr );
-      QVERIFY( m.isValid() );
-      QVERIFY( !loc.mIsIndexing );
-
-      // now locator is ready
-      m = loc.nearestVertex( pt, 999 );
-      QVERIFY( m.isValid() );
-      QVERIFY( m.hasVertex() );
-      QCOMPARE( m.layer(), mVL );
-      QCOMPARE( m.featureId(), ( QgsFeatureId )1 );
-      QCOMPARE( m.point(), QgsPointXY( 1, 1 ) );
-      QCOMPARE( m.distance(), std::sqrt( 2.0 ) );
-      QCOMPARE( m.vertexIndex(), 2 );
-    }
-
-    void testDeleteLocator()
-    {
-      QgsPointLocator *loc = new QgsPointLocator( mVL, QgsCoordinateReferenceSystem(), QgsCoordinateTransformContext(), nullptr );
-      QgsPointXY pt( 2, 2 );
-
-      // delete locator while we are indexing (could happen when closing project for instance)
-      loc->nearestVertex( pt, 999, nullptr, true );
-      delete loc;
-    }
-
 };
 
 QGSTEST_MAIN( TestQgsPointLocator )

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -396,6 +396,10 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
 
         counterTask = point_layer.countSymbolFeatures()
         counterTask.waitForFinished()
+        TM = QgsApplication.taskManager()
+        actask = TM.activeTasks()
+        print(TM.tasks(), actask)
+        count = actask[0]
         legend.model().refreshLayerLegend(legendlayer)
         legendnodes = legend.model().layerLegendNodes(legendlayer)
         legendnodes[0].setUserLabel('[% @symbol_id %]')
@@ -404,6 +408,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         label1 = legendnodes[0].evaluateLabel()
         label2 = legendnodes[1].evaluateLabel()
         label3 = legendnodes[2].evaluateLabel()
+        count.waitForFinished()
         self.assertEqual(label1, '0')
         #self.assertEqual(label2, '5')
         #self.assertEqual(label3, '12')
@@ -458,7 +463,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         group = legend.model().rootGroup().addGroup("Group [% 1 + 5 %] [% @layout_name %]")
         layer_tree_layer = group.addLayer(point_layer)
         counterTask = point_layer.countSymbolFeatures()
-        counterTask.waitForFinished()
+        counterTask.waitForFinished() # does this even work?
         layer_tree_layer.setCustomProperty("legend/title-label", 'bbbb [% 1+2 %] xx [% @layout_name %] [% @layer_name %]')
         QgsMapLayerLegendUtils.setLegendNodeUserLabel(layer_tree_layer, 0, 'xxxx')
         legend.model().refreshLayerLegend(layer_tree_layer)
@@ -470,6 +475,11 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         legend.setLinkedMap(map)
         legend.updateLegend()
         print(layer_tree_layer.labelExpression())
+        TM = QgsApplication.taskManager()
+        actask = TM.activeTasks()
+        print(TM.tasks(), actask)
+        count = actask[0]
+        count.waitForFinished()
         map.setExtent(QgsRectangle(-102.51, 41.16, -102.36, 41.30))
         checker = QgsLayoutChecker(
             'composer_legend_symbol_expression', layout)


### PR DESCRIPTION
## Description

This reverts https://github.com/qgis/QGIS/pull/32453

The fix doesn't works on Windows and Mac.  A possible fix could be https://github.com/qgis/QGIS/commit/c98f07e9c6349abcf90545c711596d39c59fcbb6 but it may be better to revert this for now while I check this work on Windows.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
