### PR TITLE
fix Processing/GRASS v_net_centrality

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.net.centrality.txt
+++ b/python/plugins/processing/algs/grass7/description/v.net.centrality.txt
@@ -1,5 +1,5 @@
 v.net.centrality
-Computes degree, centrality, betweeness, closeness and eigenvector centrality measures in the network.
+Computes degree, centrality, betweenness, closeness and eigenvector centrality measures in the network.
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input vector line layer (network)|1|None|False
 QgsProcessingParameterString|degree|Name of output degree centrality column|degree|False|True

--- a/python/plugins/processing/algs/grass7/description/v.net.centrality.txt
+++ b/python/plugins/processing/algs/grass7/description/v.net.centrality.txt
@@ -1,20 +1,15 @@
 v.net.centrality
-Computes degree, centrality, betweenness, closeness and eigenvector centrality measures in the network.
+Computes degree, centrality, betweeness, closeness and eigenvector centrality measures in the network.
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input vector line layer (network)|1|None|False
-QgsProcessingParameterFeatureSource|points|Centers point layer (nodes)|0|None|False
-QgsProcessingParameterNumber|threshold|Threshold for connecting centers to the network (in map unit)|QgsProcessingParameterNumber.Double|50.0|False|0.0|None
 QgsProcessingParameterString|degree|Name of output degree centrality column|degree|False|True
 QgsProcessingParameterString|closeness|Name of output closeness centrality column|closeness|False|True
-QgsProcessingParameterString|betweenness|Name of output betweenness centrality column|None|False|True
-QgsProcessingParameterString|eigenvector|Name of output eigenvector centrality column|None|False|True
+QgsProcessingParameterString|betweenness|Name of output betweenness centrality column|betweenness|False|True
+QgsProcessingParameterString|eigenvector|Name of output eigenvector centrality column|eigenvector|False|True
 *QgsProcessingParameterNumber|iterations|Maximum number of iterations to compute eigenvector centrality|QgsProcessingParameterNumber.Integer|1000|True|1|None
 *QgsProcessingParameterNumber|error|Cumulative error tolerance for eigenvector centrality|QgsProcessingParameterNumber.Double|0.1|True|0.0|None
-*QgsProcessingParameterString|cats|Category values|None|False|True
-*QgsProcessingParameterString|where|WHERE conditions of SQL statement without 'where' keyword|None|True|True
 *QgsProcessingParameterField|arc_column|Arc forward/both direction(s) cost column (number)|None|input|0|False|True
 *QgsProcessingParameterField|arc_backward_column|Arc backward direction cost column (number)|None|input|0|False|True
-*QgsProcessingParameterField|node_column|Node cost column (number)|None|points|0|False|True
-*QgsProcessingParameterBoolean|-a|Add points on nodes|True|True
+Hardcoded|-a
 *QgsProcessingParameterBoolean|-g|Use geodesic calculation for longitude-latitude locations|False|True
 QgsProcessingParameterVectorDestination|output|Network Centrality


### PR DESCRIPTION
Trying to fix this GRASS module after

https://lists.osgeo.org/pipermail/qgis-developer/2019-October/059084.html

I removed a couple of parameters that were completely wrong (never existed even in old GRASS releases)

The module description now looks more like as it was in 2.18. And there was a reason why it was like that. Basically the Processing implementation only works if extracting nodes from the line network, and not by using an existing node layer (which makes the tool return always an empty layer). For this reason the "Add points on nodes" parameter was hardcoded and the parameters that have to do with an existing node layer were removed.

I have a gut feeling that there are possibly many other GRASS tools with similar issues.