### PR TITLE
Geopackage primary key available from PyQGIS

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -1044,6 +1044,7 @@ void QgsOgrProvider::loadFields()
   //the attribute fields need to be read again when the encoding changes
   mAttributeFields.clear();
   mDefaultValues.clear();
+  mPrimaryKeyAttrs.clear();
   if ( !mOgrLayer )
     return;
 
@@ -1084,6 +1085,7 @@ void QgsOgrProvider::loadFields()
     );
     mDefaultValues.insert( 0, tr( "Autogenerate" ) );
     createdFields++;
+    mPrimaryKeyAttrs << 0;
   }
 
   for ( int i = 0; i < fdef.GetFieldCount(); ++i )

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -131,6 +131,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     bool createSpatialIndex() override;
     bool createAttributeIndex( int field ) override;
     QgsVectorDataProvider::Capabilities capabilities() const override;
+    QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     void setEncoding( const QString &e ) override;
     bool enterUpdateMode() override { return _enterUpdateMode(); }
     bool leaveUpdateMode() override;
@@ -230,6 +231,8 @@ class QgsOgrProvider : public QgsVectorDataProvider
     bool mFirstFieldIsFid = false;
     mutable std::unique_ptr< OGREnvelope > mExtent;
     bool mForceRecomputeExtent = false;
+
+    QList<int> mPrimaryKeyAttrs;
 
     /**
      * This member variable receives the same value as extent_

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -737,6 +737,24 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         features = [f for f in vl1.getFeatures(request)]
         self.assertEqual(len(features), 1)
 
+    def testPkAttributeIndexes(self):
+      ''' Test the primary key index '''
+      # lyr = ds.CreateLayer('layer', geom_type=ogr.wkbPoint, options=['COLUMN_TYPES=foo=int8,bar=string','GEOMETRY_NAME=the_geom','FID=customfid'])
+      # lyr = ds.CreateLayer('layer', geom_type=ogr.wkbPoint, options=['GEOMETRY_NAME=the_geom','FID=customfid'])
+      # lyr = ds.CreateLayer('layer', geom_type=ogr.wkbPoint, options=['GEOMETRY_NAME=the_geom'])
+      tmpfile = os.path.join(self.basetestpath, 'testPkAttributeIndexes.gpkg')
+      ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
+      ds.CreateLayer('test', geom_type=ogr.wkbPoint, options=['COLUMN_TYPES=foo=int8,bar=string','GEOMETRY_NAME=the_geom','FID=customfid'])
+      ds = None
+      vl = QgsVectorLayer('{}|layerid=0'.format(tmpfile), 'test', 'ogr')
+      pks = vl.primaryKeyAttributes()
+      fields = vl.fields()
+      pkfield = fields.at(pks[0])
+      self.assertEqual(len(pks), 1)
+      self.assertEqual(pks[0], 0)
+      self.assertEqual(pkfield.name(), 'customfid')
+      self.assertTrue(pkfield.constraints().constraints() & QgsFieldConstraints.ConstraintUnique)
+
     def testSublayerWithComplexLayerName(self):
         ''' Test reading a gpkg with a sublayer name containing : '''
         tmpfile = os.path.join(self.basetestpath, 'testGeopackageComplexLayerName.gpkg')

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -738,22 +738,19 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertEqual(len(features), 1)
 
     def testPkAttributeIndexes(self):
-      ''' Test the primary key index '''
-      # lyr = ds.CreateLayer('layer', geom_type=ogr.wkbPoint, options=['COLUMN_TYPES=foo=int8,bar=string','GEOMETRY_NAME=the_geom','FID=customfid'])
-      # lyr = ds.CreateLayer('layer', geom_type=ogr.wkbPoint, options=['GEOMETRY_NAME=the_geom','FID=customfid'])
-      # lyr = ds.CreateLayer('layer', geom_type=ogr.wkbPoint, options=['GEOMETRY_NAME=the_geom'])
-      tmpfile = os.path.join(self.basetestpath, 'testPkAttributeIndexes.gpkg')
-      ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
-      ds.CreateLayer('test', geom_type=ogr.wkbPoint, options=['COLUMN_TYPES=foo=int8,bar=string','GEOMETRY_NAME=the_geom','FID=customfid'])
-      ds = None
-      vl = QgsVectorLayer('{}|layerid=0'.format(tmpfile), 'test', 'ogr')
-      pks = vl.primaryKeyAttributes()
-      fields = vl.fields()
-      pkfield = fields.at(pks[0])
-      self.assertEqual(len(pks), 1)
-      self.assertEqual(pks[0], 0)
-      self.assertEqual(pkfield.name(), 'customfid')
-      self.assertTrue(pkfield.constraints().constraints() & QgsFieldConstraints.ConstraintUnique)
+        ''' Test the primary key index '''
+        tmpfile = os.path.join(self.basetestpath, 'testPkAttributeIndexes.gpkg')
+        ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
+        ds.CreateLayer('test', geom_type=ogr.wkbPoint, options=['COLUMN_TYPES=foo=int8,bar=string', 'GEOMETRY_NAME=the_geom', 'FID=customfid'])
+        ds = None
+        vl = QgsVectorLayer('{}|layerid=0'.format(tmpfile), 'test', 'ogr')
+        pks = vl.primaryKeyAttributes()
+        fields = vl.fields()
+        pkfield = fields.at(pks[0])
+        self.assertEqual(len(pks), 1)
+        self.assertEqual(pks[0], 0)
+        self.assertEqual(pkfield.name(), 'customfid')
+        self.assertTrue(pkfield.constraints().constraints() & QgsFieldConstraints.ConstraintUnique)
 
     def testSublayerWithComplexLayerName(self):
         ''' Test reading a gpkg with a sublayer name containing : '''


### PR DESCRIPTION
## Description

`QgsVectorLayer::primaryKeyAttributes()` call the provider implementation of `pkAttributeIndexes()`. This method was not implemented in the `ogr` provider so far.

People were not able to get the primary key for a GeoPackage with:
```python
layer_gpkg = QgsProject.instance().mapLayersByName("freguesias")[0]
provider = layer_gpkg.dataProvider()
provider.storageType()
'GPKG'
layer_gpkg.primaryKeyAttributes()
[]
```
The result was always an empty list, as [reported](http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-PyQGIS-how-to-handle-primary-keys-in-geopackage-td5359689.html), for example, by @SrNetoChan.

## What this PR does

This PR provides an implementation for `QgsOgrProvider::pkAttributeIndexes()`.

Running again the previous PyQGIS example, it now provides the primary key index, as expected:
```python
layer_gpkg = QgsProject.instance().mapLayersByName("freguesias")[0]
provider = layer_gpkg.dataProvider()
provider.storageType()
'GPKG'
layer_gpkg.primaryKeyAttributes()
[0]
```

Other parts of the software will take advantage of this override. For example, the browser will display the Geopackage key properly. Until now, it was always empty.

![geopackage primary key correctly reported in the browser](https://user-images.githubusercontent.com/163681/68045882-76ebb000-fcd2-11e9-9232-2db96f34e854.png)

### Alternative implementation

I'm detecting the primary key within the existent `QgsOgrProvider::loadFields()`. 

As an alternative approach, we can execute the `PRAGMA table_info(table)`, which reports the primary columns, as well, but I think is not necessary to run it.

![gpkg pragma table_info](https://user-images.githubusercontent.com/163681/68069664-37b57180-fd5b-11e9-93a4-4d8e35e4f5b1.png)

## Unchecklist

I've made this just thinking about Geopackage support. (Probably) this will not work with other `ogr` drivers, but it does not hurt.

```python
layer_shp = QgsProject.instance().mapLayersByName("Cont_AAD_CAOP2018")[0]
provider = layer_shp.dataProvider()
provider.storageType()
'ESRI Shapefile'
layer_shp.primaryKeyAttributes()
[]
```

## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
