### PR TITLE
Make sure Python console text size can't be accidentally changed 

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -428,6 +428,10 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             sys.stdout.fire_keyboard_interrupt = True
             return
 
+        #prevent accidental change in text size
+        if e.modifiers() & (Qt.ControlModifier) and e.key() in (Qt.Key_Plus, Qt.Key_Minus):
+            return
+
         line, index = self.getCursorPosition()
         cmd = self.text(line)
 


### PR DESCRIPTION
Fixes #26116

Previously when pressing Control -> - in the Scintilla Python console the text would get smaller and there was no way of making it bigger