### PR TITLE
[processing] handle advanced flag when exporting model to Python (fix #32579)

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -427,12 +427,20 @@ QStringList QgsProcessingModelAlgorithm::asPythonCode( const QgsProcessing::Pyth
       importLines << QStringLiteral( "from qgis.core import QgsProcessing" );
       importLines << QStringLiteral( "from qgis.core import QgsProcessingAlgorithm" );
       importLines << QStringLiteral( "from qgis.core import QgsProcessingMultiStepFeedback" );
+
+      bool hasAdvancedParams = false;
       for ( const QgsProcessingParameterDefinition *def : params )
       {
+        if ( def->flags() & QgsProcessingParameterDefinition::FlagAdvanced )
+          hasAdvancedParams = true;
+
         const QString importString = QgsApplication::processingRegistry()->parameterType( def->type() )->pythonImportString();
         if ( !importString.isEmpty() && !importLines.contains( importString ) )
           importLines << importString;
       }
+
+      if ( hasAdvancedParams )
+        importLines << QStringLiteral( "from qgis.core import QgsProcessingParameterDefinition" );
 
       lines << QStringLiteral( "import processing" );
       lines << QString() << QString();
@@ -460,7 +468,16 @@ QStringList QgsProcessingModelAlgorithm::asPythonCode( const QgsProcessing::Pyth
             defClone->setName( friendlyName );
           }
 
-          lines << indent + indent + QStringLiteral( "self.addParameter(%1)" ).arg( defClone->asPythonString() );
+          if ( defClone->flags() & QgsProcessingParameterDefinition::FlagAdvanced )
+          {
+            lines << indent + indent + QStringLiteral( "param = %1" ).arg( defClone->asPythonString() );
+            lines << indent + indent + QStringLiteral( "param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)" );
+            lines << indent + indent + QStringLiteral( "self.addParameter(param)" );
+          }
+          else
+          {
+            lines << indent + indent + QStringLiteral( "self.addParameter(%1)" ).arg( defClone->asPythonString() );
+          }
         }
       }
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -7561,7 +7561,9 @@ void TestQgsProcessing::modelExecution()
   QgsProcessingModelAlgorithm model2;
   model2.addModelParameter( new QgsProcessingParameterFeatureSource( "SOURCE_LAYER" ), QgsProcessingModelParameter( "SOURCE_LAYER" ) );
   model2.addModelParameter( new QgsProcessingParameterNumber( "DIST", QString(), QgsProcessingParameterNumber::Double ), QgsProcessingModelParameter( "DIST" ) );
-  model2.addModelParameter( new QgsProcessingParameterCrs( "CRS", QString(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28355" ) ) ), QgsProcessingModelParameter( "CRS" ) );
+  QgsProcessingParameterCrs *p = new QgsProcessingParameterCrs( "CRS", QString(), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28355" ) ) );
+  p->setFlags( p->flags() | QgsProcessingParameterDefinition::FlagAdvanced );
+  model2.addModelParameter( p, QgsProcessingModelParameter( "CRS" ) );
   QgsProcessingModelChildAlgorithm alg2c1;
   QgsExpressionContext expContext;
   QgsExpressionContextScope *scope = new QgsExpressionContextScope();
@@ -7768,6 +7770,7 @@ void TestQgsProcessing::modelExecution()
                               "from qgis.core import QgsProcessingParameterNumber\n"
                               "from qgis.core import QgsProcessingParameterCrs\n"
                               "from qgis.core import QgsProcessingParameterFeatureSink\n"
+                              "from qgis.core import QgsProcessingParameterDefinition\n"
                               "from qgis.core import QgsCoordinateReferenceSystem\n"
                               "from qgis.core import QgsExpression\n"
                               "import processing\n"
@@ -7778,7 +7781,9 @@ void TestQgsProcessing::modelExecution()
                               "  def initAlgorithm(self, config=None):\n"
                               "    self.addParameter(QgsProcessingParameterFeatureSource('SOURCE_LAYER', '', defaultValue=None))\n"
                               "    self.addParameter(QgsProcessingParameterNumber('DIST', '', type=QgsProcessingParameterNumber.Double, defaultValue=None))\n"
-                              "    self.addParameter(QgsProcessingParameterCrs('CRS', '', defaultValue=QgsCoordinateReferenceSystem('EPSG:28355')))\n"
+                              "    param = QgsProcessingParameterCrs('CRS', '', defaultValue=QgsCoordinateReferenceSystem('EPSG:28355'))\n"
+                              "    param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)\n"
+                              "    self.addParameter(param)\n"
                               "    self.addParameter(QgsProcessingParameterFeatureSink('MyModelOutput', 'my model output', type=QgsProcessing.TypeVectorPolygon, createByDefault=True, defaultValue=None))\n"
                               "    self.addParameter(QgsProcessingParameterFeatureSink('cx3:MY_OUT', '', type=QgsProcessing.TypeVectorAnyGeometry, createByDefault=True, defaultValue=None))\n"
                               "\n"


### PR DESCRIPTION
## Description
Add necessary import and logic to mark parameters as advanced when exporting model to Python algorithm. Fixes #32579.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
