### PR TITLE
WIP: QGIS Server GetServerSettings request

### DIFF
--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -47,6 +47,11 @@ Load setting for a specific environment variable name.
 Log a summary of settings currently loaded.
 %End
 
+    QJsonObject logSummaryJson() const;
+%Docstring
+Log a summary of settings currently loaded in JSON format
+%End
+
     QString iniFile() const;
 %Docstring
 Returns the ini file loaded by QSetting.
@@ -59,6 +64,13 @@ Returns the ini file loaded by QSetting.
 Returns parallel rendering setting.
 
 :return: ``True`` if parallel rendering is activated, ``False`` otherwise.
+%End
+
+    bool revealServerSettings() const;
+%Docstring
+Returns reveal server settings setting.
+
+:return: ``True`` if reveal server settings is enabled, ``False`` otherwise.
 %End
 
     int maxThreads() const;

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -66,7 +66,8 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_WMS_MAX_HEIGHT, //! Maximum height for a WMS request. The most conservative between this and the project one is used (since QGIS 3.8)
       QGIS_SERVER_WMS_MAX_WIDTH, //! Maximum width for a WMS request. The most conservative between this and the project one is used (since QGIS 3.8)
       QGIS_SERVER_API_RESOURCES_DIRECTORY, //! Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for (since QGIS 3.10).
-      QGIS_SERVER_API_WFS3_MAX_LIMIT //! Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
+      QGIS_SERVER_API_WFS3_MAX_LIMIT, //! Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
+      QGIS_REVEAL_SERVER_SETTINGS //! Enables QGIS Server legacy request GetServerSettings
     };
     Q_ENUM( EnvVar )
 };
@@ -114,6 +115,11 @@ class SERVER_EXPORT QgsServerSettings
     void logSummary() const;
 
     /**
+     * Log a summary of settings currently loaded in JSON format
+     */
+    QJsonObject logSummaryJson() const;
+
+    /**
      * Returns the ini file loaded by QSetting.
      * \returns the path of the ini file or an empty string if none is loaded.
      */
@@ -124,6 +130,12 @@ class SERVER_EXPORT QgsServerSettings
      * \returns TRUE if parallel rendering is activated, FALSE otherwise.
      */
     bool parallelRendering() const;
+
+    /**
+     * Returns reveal server settings setting.
+     * \returns TRUE if reveal server settings is enabled, FALSE otherwise.
+     */
+    bool revealServerSettings() const;
 
     /**
      * Returns the maximum number of threads to use.

--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -21,6 +21,7 @@ SET (wms_SRCS
   qgswmsparameters.cpp
   qgslayerrestorer.cpp
   qgswmsrendercontext.cpp
+  qgswmsgetserversettings.cpp
 )
 
 SET (wms_MOC_HDRS

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -32,6 +32,7 @@
 #include "qgswmsdescribelayer.h"
 #include "qgswmsgetlegendgraphics.h"
 #include "qgswmsparameters.h"
+#include "qgswmsgetserversettings.h"
 
 #define QSTR_COMPARE( str, lit )\
   (str.compare( QLatin1String( lit ), Qt::CaseInsensitive ) == 0)
@@ -149,6 +150,10 @@ namespace QgsWms
         else if ( QSTR_COMPARE( req, "GetPrint" ) )
         {
           writeGetPrint( mServerIface, project, version, request, response );
+        }
+        else if ( QSTR_COMPARE( req, "GetServerSettings" ) && mServerIface->serverSettings()->revealServerSettings() )
+        {
+          writeServerSettings( mServerIface, response );
         }
         else
         {

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -39,7 +39,6 @@
 #include "qgsrasterdataprovider.h"
 
 #include "qgsvectorlayerserverproperties.h"
-#include <QFontDatabase>
 
 namespace QgsWms
 {
@@ -48,8 +47,6 @@ namespace QgsWms
   {
 
     void appendLayerProjectSettings( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer );
-
-    void appendAvailableFonts( QDomDocument &doc, QDomElement &parentElem );
 
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface,
                              const QgsProject *project );
@@ -251,7 +248,6 @@ namespace QgsWms
     if ( projectSettings )
     {
       appendDrawingOrder( doc, capabilityElement, serverIface, project );
-      appendAvailableFonts( doc, capabilityElement );
     }
 
     return doc;
@@ -1757,33 +1753,6 @@ namespace QgsWms
       }
       appendLayerBoundingBoxes( doc, groupElem, combinedBBox, groupCRS, combinedCRSSet.toList(), outputCrsList, project );
 
-    }
-
-    void appendAvailableFonts( QDomDocument &doc, QDomElement &parentElem )
-    {
-      QDomElement fontsElem = doc.createElement( QStringLiteral( "Fonts" ) );
-      QFontDatabase database;
-      const QStringList fontFamilies = database.families();
-      for ( const QString &family : fontFamilies )
-      {
-        QDomElement familyElem = doc.createElement( QStringLiteral( "Family" ) );
-        familyElem.setAttribute( QStringLiteral( "name" ), family );
-        const QStringList fontStyles = database.styles( family );
-        for ( const QString &style : fontStyles )
-        {
-          QDomElement fontElem = doc.createElement( QStringLiteral( "Font" ) );
-          fontElem.setAttribute( QStringLiteral( "style" ), style );
-          QString sizes;
-          const QList<int> smoothSizes = database.smoothSizes( family, style );
-          for ( int points : smoothSizes )
-            sizes += QString::number( points ) + ' ';
-          QDomText styleText = doc.createTextNode( sizes.trimmed() );
-          fontElem.appendChild( styleText );
-          familyElem.appendChild( fontElem );
-        }
-        fontsElem.appendChild( familyElem );
-      }
-      parentElem.appendChild( fontsElem );
     }
 
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface,

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -39,7 +39,7 @@
 #include "qgsrasterdataprovider.h"
 
 #include "qgsvectorlayerserverproperties.h"
-
+#include <QFontDatabase>
 
 namespace QgsWms
 {
@@ -48,6 +48,8 @@ namespace QgsWms
   {
 
     void appendLayerProjectSettings( QDomDocument &doc, QDomElement &layerElem, QgsMapLayer *currentLayer );
+
+    void appendAvailableFonts( QDomDocument &doc, QDomElement &parentElem );
 
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface,
                              const QgsProject *project );
@@ -249,6 +251,7 @@ namespace QgsWms
     if ( projectSettings )
     {
       appendDrawingOrder( doc, capabilityElement, serverIface, project );
+      appendAvailableFonts( doc, capabilityElement );
     }
 
     return doc;
@@ -1754,6 +1757,33 @@ namespace QgsWms
       }
       appendLayerBoundingBoxes( doc, groupElem, combinedBBox, groupCRS, combinedCRSSet.toList(), outputCrsList, project );
 
+    }
+
+    void appendAvailableFonts( QDomDocument &doc, QDomElement &parentElem )
+    {
+      QDomElement fontsElem = doc.createElement( QStringLiteral( "Fonts" ) );
+      QFontDatabase database;
+      const QStringList fontFamilies = database.families();
+      for ( const QString &family : fontFamilies )
+      {
+        QDomElement familyElem = doc.createElement( QStringLiteral( "Family" ) );
+        familyElem.setAttribute( QStringLiteral( "name" ), family );
+        const QStringList fontStyles = database.styles( family );
+        for ( const QString &style : fontStyles )
+        {
+          QDomElement fontElem = doc.createElement( QStringLiteral( "Font" ) );
+          fontElem.setAttribute( QStringLiteral( "style" ), style );
+          QString sizes;
+          const QList<int> smoothSizes = database.smoothSizes( family, style );
+          for ( int points : smoothSizes )
+            sizes += QString::number( points ) + ' ';
+          QDomText styleText = doc.createTextNode( sizes.trimmed() );
+          fontElem.appendChild( styleText );
+          familyElem.appendChild( fontElem );
+        }
+        fontsElem.appendChild( familyElem );
+      }
+      parentElem.appendChild( fontsElem );
     }
 
     void appendDrawingOrder( QDomDocument &doc, QDomElement &parentElem, QgsServerInterface *serverIface,

--- a/src/server/services/wms/qgswmsgetserversettings.cpp
+++ b/src/server/services/wms/qgswmsgetserversettings.cpp
@@ -19,18 +19,18 @@
 #include "qgswmsrenderer.h"
 #include "qgswmsserviceexception.h"
 #include "qgsserverplugins.h"
-#include "ogr_core.h"
-#include "sqlite3.h"
-#include "geos_c.h"
-#include "pg_config.h"
-#include "spatialite.h"
-#include "qwt/qwt_global.h"
+#include <ogr_core.h>
+#include <sqlite3.h>
+#include <geos_c.h>
+#include <pg_config.h>
+#include <spatialite.h>
+#include <qwt/qwt_global.h>
 #if PROJ_VERSION_MAJOR>=6
 #include <proj.h>
 #else
 #include <proj_api.h>
 #endif
-#include "qgis.h"
+#include <qgis.h>
 #include <QThread>
 #include <QFontDatabase>
 #ifdef Q_OS_LINUX

--- a/src/server/services/wms/qgswmsgetserversettings.cpp
+++ b/src/server/services/wms/qgswmsgetserversettings.cpp
@@ -25,7 +25,7 @@
 #include "pg_config.h"
 #include "spatialite.h"
 #include "qwt/qwt_global.h"
-#include "proj.h"
+#include <proj.h>
 #include "qgis.h"
 #include <QThread>
 #include <QFontDatabase>

--- a/src/server/services/wms/qgswmsgetserversettings.cpp
+++ b/src/server/services/wms/qgswmsgetserversettings.cpp
@@ -25,7 +25,11 @@
 #include "pg_config.h"
 #include "spatialite.h"
 #include "qwt/qwt_global.h"
+#if PROJ_VERSION_MAJOR>=6
 #include <proj.h>
+#else
+#include <proj_api.h>
+#endif
 #include "qgis.h"
 #include <QThread>
 #include <QFontDatabase>

--- a/src/server/services/wms/qgswmsgetserversettings.cpp
+++ b/src/server/services/wms/qgswmsgetserversettings.cpp
@@ -135,6 +135,7 @@ namespace QgsWms
     QJsonObject serverSettings;
     serverSettings["about"] = about();
     serverSettings["settings"] = serverIface->serverSettings()->logSummaryJson();
+    serverSettings["fonts"] = availableFonts();
 
     QJsonObject serverPlugins;
     QJsonArray availablePlugins = {};
@@ -144,8 +145,6 @@ namespace QgsWms
     serverPlugins["enabled"] = availablePlugins;
     serverSettings["plugins"] = serverPlugins;
 
-    serverSettings["settings"] = serverIface->serverSettings()->logSummaryJson();
-    serverSettings["fonts"] = availableFonts();
     QJsonDocument document( serverSettings );
 
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "application/json" ) );

--- a/src/server/services/wms/qgswmsgetserversettings.cpp
+++ b/src/server/services/wms/qgswmsgetserversettings.cpp
@@ -30,7 +30,7 @@
 #else
 #include <proj_api.h>
 #endif
-#include <qgis.h>
+#include "qgis.h"
 #include <QThread>
 #include <QFontDatabase>
 #ifdef Q_OS_LINUX

--- a/src/server/services/wms/qgswmsgetserversettings.cpp
+++ b/src/server/services/wms/qgswmsgetserversettings.cpp
@@ -1,0 +1,154 @@
+/***************************************************************************
+                              qgswmsgetserversettings.cpp
+                              ---------------------------
+  begin                : Nov 7, 2019
+  copyright            : (C) 2019 by Jorge Gustavo Rocha
+  email                : jgr at geomaster dot pt
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgswmsutils.h"
+#include "qgswmsgetprint.h"
+#include "qgswmsrenderer.h"
+#include "qgswmsserviceexception.h"
+#include "qgsserverplugins.h"
+#include "ogr_core.h"
+#include "sqlite3.h"
+#include "geos_c.h"
+#include "pg_config.h"
+#include "spatialite.h"
+#include "qwt/qwt_global.h"
+#include "proj.h"
+#include "qgis.h"
+#include <QThread>
+#include <QFontDatabase>
+#ifdef Q_OS_LINUX
+#include <unistd.h>
+#endif
+
+namespace QgsWms
+{
+
+  QJsonArray availableFonts()
+  {
+    QJsonArray availableFamilies = {};
+    QFontDatabase database;
+    const QStringList fontFamilies = database.families();
+    for ( const QString &family : fontFamilies )
+    {
+      QJsonObject thisFamily = {};
+      thisFamily["family"] = family;
+      QJsonArray familyStyles = {};
+      const QStringList fontStyles = database.styles( family );
+      for ( const QString &style : fontStyles )
+      {
+        QJsonObject thisStyle = {};
+        thisStyle["style"] = style;
+        // uncomment to provide all font sizes available
+        // QJsonArray styleSizes = {};
+        // QString sizes;
+        // const QList<int> smoothSizes = database.smoothSizes( family, style );
+        // for ( int points : smoothSizes )
+        // {
+        //   styleSizes.append( points );
+        // }
+        // thisStyle["sizes"] = styleSizes;
+        familyStyles.append( thisStyle );
+      }
+      thisFamily["styles"] = familyStyles;
+      availableFamilies.append( thisFamily );
+    }
+    return availableFamilies;
+  }
+
+  QJsonObject about()
+  {
+    QJsonObject aboutServer = {};
+    QString caption = QStringLiteral( "QGIS Server - %1 ('%2')" ).arg( Qgis::QGIS_VERSION, Qgis::QGIS_RELEASE_NAME );
+    aboutServer["Version"] = caption;
+    if ( QString( Qgis::QGIS_DEV_VERSION ) == QLatin1String( "exported" ) )
+    {
+      caption = QStringLiteral( "https://github.com/qgis/QGIS/tree/release-%1_%2" )
+                .arg( Qgis::QGIS_VERSION_INT / 10000 ).arg( Qgis::QGIS_VERSION_INT / 100 % 100 );
+      aboutServer["QGIS code branch"] = caption;
+    }
+    else
+    {
+      caption = QStringLiteral( "https://github.com/qgis/QGIS/commit/%2" ).arg( Qgis::QGIS_DEV_VERSION );
+      aboutServer["QGIS code revision"] = caption;
+    }
+    aboutServer["Compiled against Qt"] = QT_VERSION_STR;
+    aboutServer["Running against Qt"] = qVersion();
+
+    aboutServer["Compiled against GDAL/OGR"] = GDAL_RELEASE_NAME;
+    aboutServer["Running against GDAL/OGR"] = GDALVersionInfo( "RELEASE_NAME" );
+
+    aboutServer["Compiled against GEOS"] = GEOS_CAPI_VERSION;
+    aboutServer["Running against GEOS"] = GEOSversion();
+
+    aboutServer["Compiled against GEOS"] = SQLITE_VERSION;
+    aboutServer["Running against GEOS"] = sqlite3_libversion();
+
+#ifdef HAVE_POSTGRESQL
+    aboutServer["PostgreSQL Client Version"] = QStringLiteral( PG_VERSION );
+#else
+    aboutServer["PostgreSQL Client Version"] = QStringLiteral( "No support" );
+#endif
+
+    aboutServer["SpatiaLite Version"] = spatialite_version();
+    aboutServer["QWT Version"] = QWT_VERSION_STR;
+    aboutServer["QScintilla2 Version"] = QSCINTILLA_VERSION_STR;
+
+#if PROJ_VERSION_MAJOR > 4
+    PJ_INFO info = proj_info();
+    aboutServer["Compiled against PROJ"] = QStringLiteral( "%1.%2.%3" ).arg( PROJ_VERSION_MAJOR ).arg( PROJ_VERSION_MINOR ).arg( PROJ_VERSION_PATCH );
+    aboutServer["Running against PROJ"] = info.release;
+#else
+    aboutServer["PROJ.4 Version"] = QString::number( PJ_VERSION );
+#endif
+
+    aboutServer["OS Version"] = QSysInfo::prettyProductName();
+    aboutServer["Kernel version"] = QSysInfo::kernelVersion();
+    aboutServer["Hostname"] = QSysInfo::machineHostName();
+    aboutServer["CPU Cores"] = QThread::idealThreadCount();
+
+#ifdef Q_OS_LINUX
+    long pages = sysconf( _SC_PHYS_PAGES );
+    long pagesAvailable = sysconf( _SC_AVPHYS_PAGES );
+    long page_size = sysconf( _SC_PAGE_SIZE );
+    aboutServer["System Memory (Mb)"] = QStringLiteral( "%1" ).arg( pages * page_size / 1024 / 1024 );
+    aboutServer["Available memory (Mb)"] = QStringLiteral( "%1" ).arg( pagesAvailable * page_size / 1024 / 1024 );
+#endif
+
+    return aboutServer;
+  }
+
+  void writeServerSettings( QgsServerInterface *serverIface, QgsServerResponse &response )
+  {
+    QJsonObject serverSettings;
+    serverSettings["about"] = about();
+    serverSettings["settings"] = serverIface->serverSettings()->logSummaryJson();
+
+    QJsonObject serverPlugins;
+    QJsonArray availablePlugins = {};
+    QStringList plugins = QgsServerPlugins::serverPlugins();
+    for ( int i = 0; i < plugins.size(); ++i )
+      availablePlugins.append( plugins.at( i ) );
+    serverPlugins["enabled"] = availablePlugins;
+    serverSettings["plugins"] = serverPlugins;
+
+    serverSettings["settings"] = serverIface->serverSettings()->logSummaryJson();
+    serverSettings["fonts"] = availableFonts();
+    QJsonDocument document( serverSettings );
+
+    response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "application/json" ) );
+    response.write( document.toJson() );
+  }
+} // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetserversettings.h
+++ b/src/server/services/wms/qgswmsgetserversettings.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+                              qgswmsgetserversettings.h
+                              -------------------------
+  begin                : Nov 7, 2019
+  copyright            : (C) 2019 by Jorge Gustavo Rocha
+  email                : jgr at geomaster dot pt
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+namespace QgsWms
+{
+
+  /**
+   * Creates Json object with the available fonts
+   */
+  QJsonArray availableFonts();
+
+  /**
+   * Creates Json version of the about
+   */
+  QJsonObject about();
+
+  /**
+   * Output GetPrint response
+   */
+  void writeServerSettings( QgsServerInterface *serverIface, QgsServerResponse &response );
+
+} // namespace QgsWms
+
+
+
+

--- a/tests/src/python/test_qgsserver_settings.py
+++ b/tests/src/python/test_qgsserver_settings.py
@@ -206,6 +206,21 @@ class TestQgsServerSettings(unittest.TestCase):
         # clear environment
         os.environ.pop(env)
 
+    def test_getserversettings_enabling(self):
+        env = "QGIS_REVEAL_SERVER_SETTINGS"
+        os.environ[env] = "true"
+        self.settings.load()
+        self.assertTrue(self.settings.revealServerSettings())
+        os.environ.pop(env)
+
+    def test_getserversettings_disabling(self):
+        env = "QGIS_REVEAL_SERVER_SETTINGS"
+        os.environ[env] = "false"
+        self.settings.load()
+        self.assertFalse(self.settings.revealServerSettings())
+        os.environ.pop(env)
+        self.assertFalse(self.settings.revealServerSettings())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -38,6 +38,8 @@ from qgis.core import QgsProject
 RE_STRIP_UNCHECKABLE = b'MAP=[^"]+|Content-Length: \\d+'
 RE_STRIP_EXTENTS = b'<(north|east|south|west)Bound(Lat|Long)itude>.*</(north|east|south|west)Bound(Lat|Long)itude>|<BoundingBox .*/>'
 RE_ATTRIBUTES = b'[^>\\s]+=[^>\\s]+'
+RE_STRIP_FONTS = b'<Fonts>.*</Fonts>\n'
+RE_COUNT_FONT_FAMILIES = b'<Family name='
 
 
 class TestQgsServerWMSTestBase(QgsServerTestBase):
@@ -87,6 +89,39 @@ class TestQgsServerWMSTestBase(QgsServerTestBase):
         msg = "request %s failed.\nQuery: %s\nExpected file: %s\nResponse:\n%s" % (query_string, request, reference_path, response.decode('utf-8'))
         self.assertXMLEqual(response, expected, msg=msg)
 
+    def wms_getprojectsettings_request_compare(self, request, extra=None, reference_file=None, project='test_project.qgs', version='1.3.0', ignoreExtent=False):
+        response_header, response_body, query_string = self.wms_request(request, extra, project, version)
+        allfamilies = re.findall(RE_COUNT_FONT_FAMILIES, response_body)
+        self.assertTrue(len(allfamilies) > 1)
+
+        response = response_header + re.sub(RE_STRIP_FONTS, b'', response_body, flags=re.MULTILINE | re.DOTALL)
+        reference_path = os.path.join(self.testdata_path, (request.lower() if not reference_file else reference_file) + '.txt')
+        self.store_reference(reference_path, response)
+        f = open(reference_path, 'rb')
+        expected = f.read()
+
+        def _n(r):
+            lines = r.split(b'\n')
+            b = lines[2:]
+            h = lines[:2]
+            try:
+                return b'\n'.join(h) + json.dumps(json.loads(b'\n'.join(b))).encode('utf8')
+            except:
+                return r
+
+        response = _n(response)
+        expected = _n(expected)
+
+        f.close()
+        response = re.sub(RE_STRIP_UNCHECKABLE, b'*****', response)
+        expected = re.sub(RE_STRIP_UNCHECKABLE, b'*****', expected)
+        if ignoreExtent:
+            response = re.sub(RE_STRIP_EXTENTS, b'*****', response)
+            expected = re.sub(RE_STRIP_EXTENTS, b'*****', expected)
+
+        msg = "request %s failed.\nQuery: %s\nExpected file: %s\nResponse:\n%s" % (query_string, request, reference_path, response.decode('utf-8'))
+        self.assertXMLEqual(response, expected, msg=msg)
+
 
 class TestQgsServerWMS(TestQgsServerWMSTestBase):
 
@@ -100,7 +135,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         self.wms_request_compare('GETCAPABILITIES')
 
     def test_getprojectsettings(self):
-        self.wms_request_compare('GetProjectSettings')
+        self.wms_getprojectsettings_request_compare('GetProjectSettings')
 
     def test_getcontext(self):
         self.wms_request_compare('GetContext')


### PR DESCRIPTION
## Description (update)

This PR implements a new request `GetServerSettings` to provide valuable feedback to tune QGIS Server deployment.

This request is not enabled by default. Only works if `QGIS_REVEAL_SERVER_SETTINGS` is defined with true or 1. This can be done, for example, in the Apache configuration with:
```
FcgidInitialEnv QGIS_REVEAL_SERVER_SETTINGS 1
```
## Output (JSON encoded)

The output is divided in four sections:
```json
{
    "about": {
    },
    "fonts": [
    ],
    "plugins": {
    },
    "settings": {
   }
}
```
### About contents
The `about` section contains more or less the same contents as the regular QGIS about dialogue: QGIS version, QT version and so on.
```json
    "about": {
        "Available memory": "1191 Mb",
        "Compiled against GDAL/OGR": "3.0.1",
        "Compiled against GEOS": "3.24.0",
        "Compiled against PROJ": "6.1.0",
        "Compiled against Qt": "5.11.1",
        "Cores": 8,
        "Hostname": "zoe",
        "Kernel version": "4.18.0-25-generic",
        "OS Version": "Ubuntu 18.10",
        "PostgreSQL Client Version": "11.4 (Ubuntu 11.4-1.pgdg18.10+1)",
        "QGIS code revision": "https://github.com/qgis/QGIS/commit/b28aa902c4",
        "QScintilla2 Version": "2.10.4",
        "QWT Version": "6.1.3",
        "Running against GDAL/OGR": "3.0.1",
        "Running against GEOS": "3.24.0",
        "Running against PROJ": "Rel. 6.1.0, May 15th, 2019",
        "Running against Qt": "5.11.1",
        "SpatiaLite Version": "4.3.0a",
        "System Memory": "15464 Mb",
        "Version": "QGIS Server - 3.11.0-Master ('Master')"
    }
```
There are a few additional entries that might help DevOps/SysOps: the number of available cores and memory. The available memory is only displayed on Linux servers (code is protected by `#ifdef Q_OS_LINUX`).
```json
    "about": {

        "Cores": 8,
        "Available memory": "1191 Mb",
        "System Memory": "15464 Mb",

    }
```
### Font contents
The prevent a large response, only the font families and the available styles are included. The sizes of each style is omitted (still in the code, but commented).

```json
"fonts": [
        {
            "family": "Libertinus Sans",
            "styles": [
                { "style": "Italic" },
                { "style": "Regular" },
                { "style": "Bold" }
            ]
        },
```
### Plugins contents
If plugins are loaded, they will be listed here.
```json
    "plugins": {
        "enabled": [
            "ServerSimpleBrowser"
        ]
    },
```
### Settings contents
This section contains all the settings defined on the server instance.
```json
"settings": {
        "ini": "/.local/share/QGIS/QGIS3/profiles/default/QGIS/QGIS3.ini",
        "summary": [
            {
                "description": "Override the default path for user configuration",
                "key": "",
                "setting": "QGIS_OPTIONS_PATH",
                "source": "DEFAULT_VALUE",
                "value": ""
            },
            {
                "description": "Activate/Deactivate parallel rendering for WMS getMap request",
                "key": "/qgis/parallel_rendering",
                "setting": "QGIS_SERVER_PARALLEL_RENDERING",
                "source": "DEFAULT_VALUE",
                "value": "false"
            },
            {
                "description": "Number of threads to use when parallel rendering is activated",
                "key": "/qgis/max_threads",
                "setting": "QGIS_SERVER_MAX_THREADS",
                "source": "DEFAULT_VALUE",
                "value": "-1"
            },
            {
                "description": "Log level",
                "key": "",
                "setting": "QGIS_SERVER_LOG_LEVEL",
                "source": "ENVIRONMENT_VARIABLE",
                "value": "0"
            },
            {
                "description": "Log file",
                "key": "",
                "setting": "QGIS_SERVER_LOG_FILE",
                "source": "ENVIRONMENT_VARIABLE",
                "value": "/var/log/qgis/qgisserver.log"
            },
            {
                "description": "Activate/Deactivate logging to stderr",
                "key": "",
                "setting": "QGIS_SERVER_LOG_STDERR",
                "source": "DEFAULT_VALUE",
                "value": "false"
            },
            {
                "description": "QGIS project file",
                "key": "",
                "setting": "QGIS_PROJECT_FILE",
                "source": "DEFAULT_VALUE",
                "value": ""
            },
            {
                "description": "Specify the maximum number of cached layers",
                "key": "",
                "setting": "MAX_CACHE_LAYERS",
                "source": "DEFAULT_VALUE",
                "value": "100"
            },
            {
                "description": "Specify the cache directory",
                "key": "/cache/directory",
                "setting": "QGIS_SERVER_CACHE_DIRECTORY",
                "source": "DEFAULT_VALUE",
                "value": "//.local/share/QGIS/QGIS3/profiles/default/cache"
            },
            {
                "description": "Specify the cache size",
                "key": "/cache/size",
                "setting": "QGIS_SERVER_CACHE_SIZE",
                "source": "DEFAULT_VALUE",
                "value": "52428800"
            },
            {
                "description": "Show group (thousands) separator",
                "key": "/locale/showGroupSeparator",
                "setting": "QGIS_SERVER_SHOW_GROUP_SEPARATOR",
                "source": "DEFAULT_VALUE",
                "value": "false"
            },
            {
                "description": "Override system locale",
                "key": "/locale/userLocale",
                "setting": "QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE",
                "source": "DEFAULT_VALUE",
                "value": ""
            },
            {
                "description": "Maximum height for a WMS request. The lower one of this and the project configuration is used.",
                "key": "/qgis/max_wms_height",
                "setting": "QGIS_SERVER_WMS_MAX_HEIGHT",
                "source": "DEFAULT_VALUE",
                "value": "-1"
            },
            {
                "description": "Maximum width for a WMS request. The most conservative between this and the project one is used",
                "key": "/qgis/max_wms_width",
                "setting": "QGIS_SERVER_WMS_MAX_WIDTH",
                "source": "DEFAULT_VALUE",
                "value": "-1"
            },
            {
                "description": "Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for",
                "key": "/qgis/server_api_resources_directory",
                "setting": "QGIS_SERVER_API_RESOURCES_DIRECTORY",
                "source": "DEFAULT_VALUE",
                "value": "/home/jgr/dev/cpp/build-QGIS/output/data/resources/server/api"
            },
            {
                "description": "Maximum value for \"limit\" in a features request, defaults to 10000",
                "key": "/qgis/server_api_wfs3_max_limit",
                "setting": "QGIS_SERVER_API_WFS3_MAX_LIMIT",
                "source": "DEFAULT_VALUE",
                "value": "10000"
            },
            {
                "description": "Enable/disable the GetServerSettings QGIS Server request",
                "key": "/qgis/reveal_server_settings",
                "setting": "QGIS_REVEAL_SERVER_SETTINGS",
                "source": "ENVIRONMENT_VARIABLE",
                "value": "1"
            }
        ]
```
## Discussion
I didn't changed the logic to route this request to the WMS service. This requires that a project is passed as a parameter. To issue a GetServerSettings request, a project must be present (or a default project defined).

**Valid request:**

http://localhost/cgi-bin/qgis_mapserv.fcgi?MAP=/home/qgis/projects/world.qgz&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetServerSettings

**Invalid request** (without the `MAP` parameter and no default project defined on the configuration):

http://localhost/cgi-bin/qgis_mapserv.fcgi?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetServerSettings

The server will complain with:
```xml
<ServerException>Project file error</ServerException>
```
## Full example
On my development setup, the full GetServerSettings response is this 
[qgis_mapserv.fcgi.json.zip](https://github.com/qgis/QGIS/files/3827489/qgis_mapserv.fcgi.json.zip).

## Description (old)

When preparing projects for QGIS Server, we need to know which fonts are available on the server side.

There are also people complaining (like #30270, #32404, #29244, #27788) about the differences between fonts on client side and server side. With this PR, those issues are easier to debug and solve. 

This PR enables to user to know the fonts on the server side. Users will know which fonts they have to use to render properly on the server.

For sysadmins, this helps them to know which fonts they have to install on the server, if required by the users.

Geoserver, for example, also provides the available fonts on the web administration interface.

## Implementation

This PR adds the server supported fonts to the `GetProjectSettings` output. The fonts are provided by [QT QFontDatabase](https://doc.qt.io/qt-5/qfontdatabase.html) class.

![GetProjectSettingsWithFonts](https://user-images.githubusercontent.com/163681/68076247-1a5bc400-fdaa-11e9-9780-53e500208eb6.png)

### Fonts for QGIS Server requests

Besides the fonts used in the project (for labels, layouts, and so on), this list is also useful to know the exact names of the fonts to use in request like `GetLegendGraphic`, in parameters like `ITEMFONTFAMILY=Century Schoolbook L`, as shown in the following screen capture.

![ExactFontName](https://user-images.githubusercontent.com/163681/68076321-f5b41c00-fdaa-11e9-8612-d7d1ac2c5e42.png)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
