### PR TITLE
Automatic numbering in GitHub bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,9 +26,9 @@ If the issue concerns a **third party plugin**, then it **cannot** be fixed by t
 <!-- Steps, sample datasets and qgis project file to reproduce the behavior. Screencasts or screenshots welcome
 
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error -->
+1. Click on '....'
+1. Scroll down to '....'
+1. See error -->
 
 **QGIS and OS versions**
 


### PR DESCRIPTION
Markdown will automatically increment lists like 1., 1., 1., ... to 1., 2., 3., and so on. Changing the template to this makes it more convenient for users.