### PR TITLE
[processing] restore rasterize over existing raster tools

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -67,6 +67,7 @@ from .tpi import tpi
 from .tri import tri
 from .warp import warp
 from .pansharp import pansharp
+from .rasterize_over_fixed_value import rasterize_over_fixed_value
 
 from .extractprojection import ExtractProjection
 from .rasterize_over import rasterize_over
@@ -175,6 +176,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             # rasterize(),
             ExtractProjection(),
             rasterize_over(),
+            rasterize_over_fixed_value(),
             # ----- OGR tools -----
             Buffer(),
             ClipVectorByExtent(),

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -69,7 +69,7 @@ from .warp import warp
 from .pansharp import pansharp
 
 from .extractprojection import ExtractProjection
-# from .rasterize_over import rasterize_over
+from .rasterize_over import rasterize_over
 
 from .Buffer import Buffer
 from .ClipVectorByExtent import ClipVectorByExtent
@@ -174,7 +174,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             pansharp(),
             # rasterize(),
             ExtractProjection(),
-            # rasterize_over(),
+            rasterize_over(),
             # ----- OGR tools -----
             Buffer(),
             ClipVectorByExtent(),

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -46,6 +46,7 @@ class rasterize_over(GdalAlgorithm):
     INPUT_RASTER = 'INPUT_RASTER'
     ADD = 'ADD'
     EXTRA = 'EXTRA'
+    BURN = 'BURN'
 
     def __init__(self):
         super().__init__()
@@ -64,7 +65,13 @@ class rasterize_over(GdalAlgorithm):
                                                       None,
                                                       self.INPUT,
                                                       QgsProcessingParameterField.Numeric,
-                                                      optional=False))
+                                                      optional=True))
+
+        self.addParameter(QgsProcessingParameterNumber(self.BURN,
+                                                       self.tr('A fixed value to burn'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       defaultValue=0.0,
+                                                       optional=True))
 
         add_param = QgsProcessingParameterBoolean(self.ADD,
                                                      self.tr('Add burn in values to existing raster values'),
@@ -108,6 +115,9 @@ class rasterize_over(GdalAlgorithm):
         if fieldName:
             arguments.append('-a')
             arguments.append(fieldName)
+        else:
+            arguments.append('-burn')
+            arguments.append(self.parameterAsDouble(parameters, self.BURN, context))
 
         if self.parameterAsBool(parameters, self.ADD, context):
             arguments.append('-add')

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -83,7 +83,7 @@ class rasterize_over(GdalAlgorithm):
         return 'rasterize_over'
 
     def displayName(self):
-        return self.tr('Rasterize (write attribute value over existing raster)')
+        return self.tr('Rasterize (overwrite with attribute)')
 
     def group(self):
         return self.tr('Vector conversion')

--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -26,6 +26,7 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsRasterFileWriter,
+                       QgsProcessingException,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
@@ -100,6 +101,9 @@ class rasterize_over(GdalAlgorithm):
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         ogrLayer, layerName = self.getOgrCompatibleSource(self.INPUT, parameters, context, feedback, executing)
         inLayer = self.parameterAsRasterLayer(parameters, self.INPUT_RASTER, context)
+        if inLayer is None:
+            raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_RASTER))
+
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
         self.setOutputValue(self.OUTPUT, inLayer.source())
 

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -39,13 +39,13 @@ from processing.algs.gdal.GdalUtils import GdalUtils
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
 
 
-class rasterize_over(GdalAlgorithm):
+class rasterize_over_fixed_value(GdalAlgorithm):
 
     INPUT = 'INPUT'
-    FIELD = 'FIELD'
     INPUT_RASTER = 'INPUT_RASTER'
     ADD = 'ADD'
     EXTRA = 'EXTRA'
+    BURN = 'BURN'
 
     def __init__(self):
         super().__init__()
@@ -59,12 +59,11 @@ class rasterize_over(GdalAlgorithm):
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT_RASTER, self.tr('Input raster layer')))
 
-        self.addParameter(QgsProcessingParameterField(self.FIELD,
-                                                      self.tr('Field to use for burn in value'),
-                                                      None,
-                                                      self.INPUT,
-                                                      QgsProcessingParameterField.Numeric,
-                                                      optional=False))
+        self.addParameter(QgsProcessingParameterNumber(self.BURN,
+                                                       self.tr('A fixed value to burn'),
+                                                       type=QgsProcessingParameterNumber.Double,
+                                                       defaultValue=0.0,
+                                                       optional=False))
 
         add_param = QgsProcessingParameterBoolean(self.ADD,
                                                      self.tr('Add burn in values to existing raster values'),
@@ -80,10 +79,10 @@ class rasterize_over(GdalAlgorithm):
         self.addParameter(extra_param)
 
     def name(self):
-        return 'rasterize_over'
+        return 'rasterize_over_fixed_value'
 
     def displayName(self):
-        return self.tr('Rasterize (write attribute value over existing raster)')
+        return self.tr('Rasterize (write fixed value over existing raster)')
 
     def group(self):
         return self.tr('Vector conversion')
@@ -106,8 +105,8 @@ class rasterize_over(GdalAlgorithm):
 
         fieldName = self.parameterAsString(parameters, self.FIELD, context)
 
-        arguments.append('-a')
-        arguments.append(fieldName)
+        arguments.append('-burn')
+        arguments.append(self.parameterAsDouble(parameters, self.BURN, context))
 
         if self.parameterAsBool(parameters, self.ADD, context):
             arguments.append('-add')

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -82,7 +82,7 @@ class rasterize_over_fixed_value(GdalAlgorithm):
         return 'rasterize_over_fixed_value'
 
     def displayName(self):
-        return self.tr('Rasterize (write fixed value over existing raster)')
+        return self.tr('Rasterize (overwrite with fixed value)')
 
     def group(self):
         return self.tr('Vector conversion')

--- a/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over_fixed_value.py
@@ -26,6 +26,7 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsRasterFileWriter,
+                       QgsProcessingException,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
@@ -98,6 +99,9 @@ class rasterize_over_fixed_value(GdalAlgorithm):
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         ogrLayer, layerName = self.getOgrCompatibleSource(self.INPUT, parameters, context, feedback, executing)
         inLayer = self.parameterAsRasterLayer(parameters, self.INPUT_RASTER, context)
+        if inLayer is None:
+            raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_RASTER))
+
         self.setOutputValue(self.OUTPUT, inLayer.source())
 
         arguments = ['-l']

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -67,6 +67,7 @@ from processing.algs.gdal.pansharp import pansharp
 from processing.algs.gdal.merge import merge
 from processing.algs.gdal.nearblack import nearblack
 from processing.algs.gdal.slope import slope
+from processing.algs.gdal.rasterize_over import rasterize_over
 
 testDataPath = os.path.join(os.path.dirname(__file__), 'testdata')
 
@@ -1502,6 +1503,41 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  '-l polys2 -a id -ts 0.0 0.0 -a_nodata 0.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
+
+    def testRasterizeOver(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        raster = os.path.join(testDataPath, 'dem.tif')
+        vector = os.path.join(testDataPath, 'polys.gml')
+        alg = rasterize_over()
+        alg.initAlgorithm()
+
+        with tempfile.TemporaryDirectory() as outdir:
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': vector,
+                                        'FIELD': 'id',
+                                        'INPUT_RASTER': raster}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -a id ' +
+                 vector + ' ' + raster])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': vector,
+                                        'FIELD': 'id',
+                                        'ADD': True,
+                                        'INPUT_RASTER': raster}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -a id -add ' +
+                 vector + ' ' + raster])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': vector,
+                                        'FIELD': 'id',
+                                        'EXTRA': '-i',
+                                        'INPUT_RASTER': raster}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -a id -i ' +
+                 vector + ' ' + raster])
 
     def testRetile(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -68,6 +68,7 @@ from processing.algs.gdal.merge import merge
 from processing.algs.gdal.nearblack import nearblack
 from processing.algs.gdal.slope import slope
 from processing.algs.gdal.rasterize_over import rasterize_over
+from processing.algs.gdal.rasterize_over_fixed_value import rasterize_over_fixed_value
 
 testDataPath = os.path.join(os.path.dirname(__file__), 'testdata')
 
@@ -1537,6 +1538,41 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'INPUT_RASTER': raster}, context, feedback),
                 ['gdal_rasterize',
                  '-l polys2 -a id -i ' +
+                 vector + ' ' + raster])
+
+    def testRasterizeOverFixed(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        raster = os.path.join(testDataPath, 'dem.tif')
+        vector = os.path.join(testDataPath, 'polys.gml')
+        alg = rasterize_over_fixed_value()
+        alg.initAlgorithm()
+
+        with tempfile.TemporaryDirectory() as outdir:
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': vector,
+                                        'BURN': 100,
+                                        'INPUT_RASTER': raster}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -burn 100.0 ' +
+                 vector + ' ' + raster])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': vector,
+                                        'BURN': 100,
+                                        'ADD': True,
+                                        'INPUT_RASTER': raster}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -burn 100.0 -add ' +
+                 vector + ' ' + raster])
+
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': vector,
+                                        'BURN': 100,
+                                        'EXTRA': '-i',
+                                        'INPUT_RASTER': raster}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -burn 100.0 -i ' +
                  vector + ' ' + raster])
 
     def testRetile(self):


### PR DESCRIPTION
## Description
Adds rasterize over exiting raster functionality to the Processing GDAL provider.
Supersedes #32081.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
