### PR TITLE
Allow enum input values to be used in expressions for model inputs

### DIFF
--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -721,6 +721,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
       << QgsProcessingParameterDistance::typeName()
       << QgsProcessingParameterScale::typeName()
       << QgsProcessingParameterBoolean::typeName()
+      << QgsProcessingParameterEnum::typeName()
       << QgsProcessingParameterExpression::typeName()
       << QgsProcessingParameterField::typeName()
       << QgsProcessingParameterString::typeName()


### PR DESCRIPTION
Fixes #32452

(cherry picked from commit c8255a99ea49cce7c3d497e430934e8bf981f221)
