### PR TITLE
[feature] Add save multiple styles action to style menu

### DIFF
--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -131,8 +131,20 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   QMenu *menuStyle = new QMenu( this );
   mActionLoadStyle = menuStyle->addAction( tr( "Load Style…" ) );
   connect( mActionLoadStyle, &QAction::triggered, this, &QgsVectorLayerProperties::loadStyle );
-  mActionSaveStyle = menuStyle->addAction( tr( "Save Style…" ) );
+
+  // If we have multiple styles, offer an option to save them at once
+  if ( lyr->styleManager()->styles().count() > 1 )
+  {
+    mActionSaveStyle = menuStyle->addAction( tr( "Save Current Style…" ) );
+    mActionSaveMultipleStyles = menuStyle->addAction( tr( "Save All Styles…" ) );
+    connect( mActionSaveMultipleStyles, &QAction::triggered, this, &QgsVectorLayerProperties::saveMultipleStylesAs );
+  }
+  else
+  {
+    mActionSaveStyle = menuStyle->addAction( tr( "Save Style…" ) );
+  }
   connect( mActionSaveStyle, &QAction::triggered, this, &QgsVectorLayerProperties::saveStyleAs );
+
   menuStyle->addSeparator();
   menuStyle->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultStyle_clicked );
   menuStyle->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultStyle_clicked );
@@ -1248,6 +1260,125 @@ void QgsVectorLayerProperties::saveStyleAs()
       }
     }
   }
+}
+
+void QgsVectorLayerProperties::saveMultipleStylesAs()
+{
+  QgsVectorLayerSaveStyleDialog dlg( mLayer );
+  dlg.setSaveOnlyCurrentStyle( false );
+  QgsSettings settings;
+
+  if ( dlg.exec() )
+  {
+    apply();
+
+    // Store the original style, that we can restore at the end
+    const QString originalStyle { mLayer->styleManager()->currentStyle() };
+    const auto stylesWidget { dlg.stylesWidget() };
+
+    // Collect selected (checked) styles for export/save
+    QStringList stylesSelected;
+    for ( int i = 0; i < stylesWidget->count(); i++ )
+    {
+      if ( stylesWidget->item( i )->checkState() == Qt::CheckState::Checked )
+      {
+        stylesSelected.push_back( stylesWidget->item( i )->text() );
+      }
+    }
+
+    if ( ! stylesSelected.isEmpty() )
+    {
+      int styleIndex = 0;
+      for ( const QString &styleName : qgis::as_const( stylesSelected ) )
+      {
+        bool defaultLoadedFlag = false;
+
+        StyleType type = dlg.currentStyleType();
+        mLayer->styleManager()->setCurrentStyle( styleName );
+        switch ( type )
+        {
+          case QML:
+          case SLD:
+          {
+            QString message;
+            const QString filePath { dlg.outputFilePath() };
+            QString safePath { filePath };
+            if ( styleIndex > 0 && stylesSelected.count( ) > 1 )
+            {
+              int i = 1;
+              while ( QFile::exists( safePath ) )
+              {
+                const QFileInfo fi { filePath };
+                safePath = QString( filePath ).replace( '.' + fi.completeSuffix(), QStringLiteral( "_%1.%2" )
+                                                        .arg( QString::number( i ) )
+                                                        .arg( fi.completeSuffix() ) );
+                i++;
+              }
+            }
+            if ( type == QML )
+              message = mLayer->saveNamedStyle( safePath, defaultLoadedFlag, dlg.styleCategories() );
+            else
+              message = mLayer->saveSldStyle( safePath, defaultLoadedFlag );
+
+            //reset if the default style was loaded OK only
+            if ( defaultLoadedFlag )
+            {
+              syncToLayer();
+            }
+            else
+            {
+              //let the user know what went wrong
+              QMessageBox::information( this, tr( "Save Style" ), message );
+            }
+
+            break;
+          }
+          case DB:
+          {
+            QString infoWindowTitle = QObject::tr( "Save style '%1' to DB (%2)" )
+                                      .arg( styleName )
+                                      .arg( mLayer->providerType() );
+            QString msgError;
+
+            QgsVectorLayerSaveStyleDialog::SaveToDbSettings dbSettings = dlg.saveToDbSettings();
+
+            // If a name is defined, we add _1 etc. else we use the style name
+            QString name { dbSettings.name };
+            if ( name.isEmpty() )
+            {
+              name = styleName;
+            }
+            else
+            {
+              QStringList ids, names, descriptions;
+              mLayer->listStylesInDatabase( ids, names, descriptions, msgError );
+              int i = 1;
+              while ( names.contains( name ) )
+              {
+                name = QStringLiteral( "%1 %2" ).arg( name ).arg( QString::number( i ) );
+                i++;
+              }
+            }
+            mLayer->saveStyleToDatabase( name, dbSettings.description, dbSettings.isDefault, dbSettings.uiFileContent, msgError );
+
+            if ( !msgError.isNull() )
+            {
+              QgisApp::instance()->messageBar()->pushMessage( infoWindowTitle, msgError, Qgis::Warning, QgisApp::instance()->messageTimeout() );
+            }
+            else
+            {
+              QgisApp::instance()->messageBar()->pushMessage( infoWindowTitle, tr( "Style '%1' saved" ).arg( styleName ),
+                  Qgis::Info, QgisApp::instance()->messageTimeout() );
+            }
+            break;
+          }
+        }
+        styleIndex ++;
+      }
+      // Restore original style
+      mLayer->styleManager()->setCurrentStyle( originalStyle );
+    }
+  } // Nothing selected!
 }
 
 void QgsVectorLayerProperties::aboutToShowStyleMenu()

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -381,12 +381,12 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mLayersDependenciesTreeGroup->setItemVisibilityChecked( false );
 
   QSet<QString> dependencySources;
-  const auto constDependencies = mLayer->dependencies();
+  const QSet<QgsMapLayerDependency> constDependencies = mLayer->dependencies();
   for ( const QgsMapLayerDependency &dep : constDependencies )
   {
     dependencySources << dep.layerId();
   }
-  const auto constFindLayers = mLayersDependenciesTreeGroup->findLayers();
+  const QList<QgsLayerTreeLayer *> constFindLayers = mLayersDependenciesTreeGroup->findLayers();
   for ( QgsLayerTreeLayer *layer : constFindLayers )
   {
     layer->setItemVisibilityChecked( dependencySources.contains( layer->layerId() ) );
@@ -1274,7 +1274,7 @@ void QgsVectorLayerProperties::saveMultipleStylesAs()
 
     // Store the original style, that we can restore at the end
     const QString originalStyle { mLayer->styleManager()->currentStyle() };
-    const auto stylesWidget { dlg.stylesWidget() };
+    const QListWidget *stylesWidget { dlg.stylesWidget() };
 
     // Collect selected (checked) styles for export/save
     QStringList stylesSelected;

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -149,6 +149,9 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     //! Save the style
     void saveStyleAs();
 
+    //! Save multiple styles
+    void saveMultipleStylesAs();
+
     //! Load the style
     void loadStyle();
 
@@ -198,6 +201,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     QAction *mActionLoadStyle = nullptr;
     QAction *mActionSaveStyle = nullptr;
+    QAction *mActionSaveMultipleStyles = nullptr;
 
     //! Renderer dialog which is shown
     QgsRendererPropertiesDialog *mRendererDialog = nullptr;

--- a/src/app/qgsvectorlayersavestyledialog.cpp
+++ b/src/app/qgsvectorlayersavestyledialog.cpp
@@ -181,13 +181,20 @@ void QgsVectorLayerSaveStyleDialog::setupMultipleStyles()
   // Show/hide part of the UI according to multiple style support
   if ( ! mSaveOnlyCurrentStyle )
   {
-    const auto mgr { mLayer->styleManager() };
-    const auto constStyles = mgr->styles();
+    const QgsMapLayerStyleManager *styleManager { mLayer->styleManager() };
+    const QStringList constStyles = styleManager->styles();
     for ( const QString &name : constStyles )
     {
-      // TODO: highlight the current style: bool active = name == mgr->currentStyle();
       QListWidgetItem *item = new QListWidgetItem( name, mStylesWidget );
       item->setCheckState( Qt::CheckState::Checked );
+      // Highlight the current style
+      if ( name == styleManager->currentStyle() )
+      {
+        item->setToolTip( tr( "Current style" ) );
+        QFont font { item->font() };
+        font.setItalic( true );
+        item->setFont( font );
+      }
       mStylesWidget->addItem( item );
     }
     mDbStyleNameEdit->setToolTip( tr( "Leave blank to use style names or set the base name (an incremental number will be automatically appended)" ) );

--- a/src/app/qgsvectorlayersavestyledialog.h
+++ b/src/app/qgsvectorlayersavestyledialog.h
@@ -24,6 +24,11 @@ class QgsVectorLayer;
 class QgsMapLayerStyleCategoriesModel;
 
 
+/**
+ * The QgsVectorLayerSaveStyleDialog class provides the UI to save the current style
+ * or multiple styles into different storage containers (QML, SLD and DB).
+ * The user can select what categories must be saved.
+ */
 class QgsVectorLayerSaveStyleDialog : public QDialog, private Ui::QgsVectorLayerSaveStyleDialog
 {
     Q_OBJECT
@@ -47,6 +52,11 @@ class QgsVectorLayerSaveStyleDialog : public QDialog, private Ui::QgsVectorLayer
 
     QgsVectorLayerProperties::StyleType currentStyleType() const;
 
+    bool saveOnlyCurrentStyle() const;
+    void setSaveOnlyCurrentStyle( bool saveCurrentStyle );
+
+    const QListWidget *stylesWidget( );
+
   public slots:
     void accept() override;
 
@@ -56,9 +66,11 @@ class QgsVectorLayerSaveStyleDialog : public QDialog, private Ui::QgsVectorLayer
     void readUiFileContent( const QString &filePath );
 
   private:
+    void setupMultipleStyles();
     QgsVectorLayer *mLayer = nullptr;
     QgsMapLayerStyleCategoriesModel *mModel;
     QString mUiFileContent;
+    bool mSaveOnlyCurrentStyle = true;
 };
 
 #endif // QGSVECTORLAYERSAVESTYLE_H

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -20,7 +20,7 @@
    <string>Layer Properties</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../images/images.qrc">
+   <iconset>
     <normaloff>:/images/icons/qgis-icon-16x16.png</normaloff>:/images/icons/qgis-icon-16x16.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -107,7 +107,7 @@
            <string>General information</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
           </property>
          </item>
@@ -119,7 +119,7 @@
            <string>Source</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/system.svg</normaloff>:/images/themes/default/propertyicons/system.svg</iconset>
           </property>
          </item>
@@ -131,7 +131,7 @@
            <string>Control feature symbology</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/symbology.svg</normaloff>:/images/themes/default/propertyicons/symbology.svg</iconset>
           </property>
          </item>
@@ -143,7 +143,7 @@
            <string>Control feature labeling</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/labels.svg</normaloff>:/images/themes/default/propertyicons/labels.svg</iconset>
           </property>
          </item>
@@ -155,7 +155,7 @@
            <string>Diagrams</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/diagram.svg</normaloff>:/images/themes/default/propertyicons/diagram.svg</iconset>
           </property>
          </item>
@@ -167,7 +167,7 @@
            <string>3D View</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/3d.svg</normaloff>:/images/themes/default/3d.svg</iconset>
           </property>
          </item>
@@ -179,7 +179,7 @@
            <string>Manage fields</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mSourceFields.svg</normaloff>:/images/themes/default/mSourceFields.svg</iconset>
           </property>
          </item>
@@ -191,7 +191,7 @@
            <string>Manage custom forms and field editor configuration</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mActionFormView.svg</normaloff>:/images/themes/default/mActionFormView.svg</iconset>
           </property>
          </item>
@@ -203,7 +203,7 @@
            <string>Manage joins to other layers</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/join.svg</normaloff>:/images/themes/default/propertyicons/join.svg</iconset>
           </property>
          </item>
@@ -215,7 +215,7 @@
            <string>Manage additional per-project fields associated with the layer</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mIconAuxiliaryStorage.svg</normaloff>:/images/themes/default/mIconAuxiliaryStorage.svg</iconset>
           </property>
          </item>
@@ -227,7 +227,7 @@
            <string>Manage automated actions</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/action.svg</normaloff>:/images/themes/default/propertyicons/action.svg</iconset>
           </property>
          </item>
@@ -239,7 +239,7 @@
            <string>Display</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/display.svg</normaloff>:/images/themes/default/propertyicons/display.svg</iconset>
           </property>
          </item>
@@ -251,7 +251,7 @@
            <string>Rendering</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/rendering.svg</normaloff>:/images/themes/default/propertyicons/rendering.svg</iconset>
           </property>
          </item>
@@ -263,7 +263,7 @@
            <string>Variables</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
           </property>
          </item>
@@ -275,7 +275,7 @@
            <string>Layer metadata</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/editmetadata.svg</normaloff>:/images/themes/default/propertyicons/editmetadata.svg</iconset>
           </property>
          </item>
@@ -287,7 +287,7 @@
            <string>Set dependent layers for automatic update</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/dependencies.svg</normaloff>:/images/themes/default/dependencies.svg</iconset>
           </property>
          </item>
@@ -299,7 +299,7 @@
            <string>Manage the layer's legend</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/legend.svg</normaloff>:/images/themes/default/legend.svg</iconset>
           </property>
          </item>
@@ -311,7 +311,7 @@
            <string>Edit QGIS Server settings</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/overlay.svg</normaloff>:/images/themes/default/propertyicons/overlay.svg</iconset>
           </property>
          </item>
@@ -323,7 +323,7 @@
            <string>Control geometry and topology constraints for digitizing operations.</string>
           </property>
           <property name="icon">
-           <iconset resource="../../images/images.qrc">
+           <iconset>
             <normaloff>:/images/themes/default/propertyicons/digitizing.svg</normaloff>:/images/themes/default/propertyicons/digitizing.svg</iconset>
           </property>
          </item>
@@ -366,7 +366,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>17</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -443,7 +443,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>807</height>
+                <height>806</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -569,7 +569,7 @@ border-radius: 2px;</string>
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -584,7 +584,7 @@ border-radius: 2px;</string>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+                   <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -731,7 +731,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>807</height>
+                <height>806</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -917,7 +917,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>807</height>
+                <height>806</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -967,7 +967,7 @@ border-radius: 2px;</string>
                     <string/>
                    </property>
                    <property name="icon">
-                    <iconset resource="../../images/images.qrc">
+                    <iconset>
                      <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                    </property>
                   </widget>
@@ -981,7 +981,7 @@ border-radius: 2px;</string>
                     <string/>
                    </property>
                    <property name="icon">
-                    <iconset resource="../../images/images.qrc">
+                    <iconset>
                      <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                    </property>
                   </widget>
@@ -995,7 +995,7 @@ border-radius: 2px;</string>
                     <string/>
                    </property>
                    <property name="icon">
-                    <iconset resource="../../images/images.qrc">
+                    <iconset>
                      <normaloff>:/images/themes/default/mActionToggleEditing.svg</normaloff>:/images/themes/default/mActionToggleEditing.svg</iconset>
                    </property>
                   </widget>
@@ -1061,7 +1061,7 @@ border-radius: 2px;</string>
                 <property name="checkable">
                  <bool>false</bool>
                 </property>
-                <property name="syncGroup">
+                <property name="syncGroup" stdset="0">
                  <string notr="true">vectormeta</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_11">
@@ -1203,7 +1203,7 @@ border-radius: 2px;</string>
                       <string/>
                      </property>
                      <property name="icon">
-                      <iconset resource="../../images/images.qrc">
+                      <iconset>
                        <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                      </property>
                     </widget>
@@ -1217,7 +1217,7 @@ border-radius: 2px;</string>
                       <string/>
                      </property>
                      <property name="icon">
-                      <iconset resource="../../images/images.qrc">
+                      <iconset>
                        <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                      </property>
                     </widget>
@@ -1311,8 +1311,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>653</width>
+                <height>806</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1395,7 +1395,7 @@ border-radius: 2px;</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_50">
                  <item row="0" column="0">
-                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget">
+                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget" native="true">
                    <property name="focusPolicy">
                     <enum>Qt::StrongFocus</enum>
                    </property>
@@ -1459,7 +1459,7 @@ border-radius: 2px;</string>
                   </widget>
                  </item>
                  <item row="1" column="0" colspan="2">
-                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget">
+                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget" native="true">
                    <property name="focusPolicy">
                     <enum>Qt::StrongFocus</enum>
                    </property>
@@ -1513,8 +1513,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>695</width>
-                <height>424</height>
+                <width>653</width>
+                <height>806</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1540,7 +1540,7 @@ border-radius: 2px;</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
                   <item row="0" column="0">
-                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
+                   <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -1971,7 +1971,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>653</width>
-                <height>807</height>
+                <height>806</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1992,7 +1992,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Description</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_5">
@@ -2134,7 +2134,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Attribution</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
@@ -2180,7 +2180,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>MetadataUrl</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_9">
@@ -2361,7 +2361,7 @@ border-radius: 2px;</string>
                        <string/>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
                       </property>
                      </widget>
@@ -2372,7 +2372,7 @@ border-radius: 2px;</string>
                        <string/>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/symbologyEdit.svg</normaloff>:/images/themes/default/symbologyEdit.svg</iconset>
                       </property>
                      </widget>
@@ -2383,7 +2383,7 @@ border-radius: 2px;</string>
                        <string/>
                       </property>
                       <property name="icon">
-                       <iconset resource="../../images/images.qrc">
+                       <iconset>
                         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
                       </property>
                      </widget>
@@ -2450,7 +2450,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>651</width>
-                <height>805</height>
+                <height>804</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -2717,9 +2717,7 @@ border-radius: 2px;</string>
   <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
   <tabstop>mRemoveDuplicateNodesCheckbox</tabstop>
  </tabstops>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>mOptionsListWidget</sender>

--- a/src/ui/qgsvectorlayersavestyledialog.ui
+++ b/src/ui/qgsvectorlayersavestyledialog.ui
@@ -14,16 +14,6 @@
    <string>Save Layer Style</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
-    <widget class="QComboBox" name="mStyleTypeComboBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="mModeLabel">
      <property name="text">
@@ -32,67 +22,6 @@
     </widget>
    </item>
    <item row="3" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QWidget" name="mSaveToFileWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>File</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Categories</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QListView" name="mStyleCategoriesListView">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
     <widget class="QWidget" name="mSaveToDbWidget" native="true">
      <layout class="QGridLayout" name="gridLayout_3">
       <property name="leftMargin">
@@ -155,6 +84,87 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="mStyleTypeComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QWidget" name="mSaveToFileWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Categories</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>File</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QListView" name="mStyleCategoriesListView">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QListWidget" name="mStylesWidget"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mStylesWidgetLabel">
+     <property name="text">
+      <string>Styles</string>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION

Adds the possibility to save/export multiple styles
at once in QML/SLD and in the DB, in case of file system
export an incremental number is appended to the base
file name i.e. `export.qml`, `export_1.qml` etc.
in case of DBs the user can specify a new name
for the exported syles, and in that case an incremental
number is appended to the base style name i.e. name,
`name 1`, `name 2` etc., if the new name is left blank,
the style name is used and in case of conflicts the
incremental number is appended as well.

![ezgif com-optimize](https://user-images.githubusercontent.com/142164/68129308-9c1e2f80-ff19-11e9-92d0-95d5dadb5eee.gif)


Funded by **ARPA Piemonte**