### PR TITLE
[FEATURE] add maptip and expression display in expressions

### DIFF
--- a/resources/function_help/json/display
+++ b/resources/function_help/json/display
@@ -1,0 +1,29 @@
+{
+	"name": "display",
+	"type": "function",
+	"description": "Returns the display expression for a given feature in a layer. The expression is evaluated by default.",
+	"arguments": [{
+			"arg": "layer",
+			"description": "a vector layer"
+		},
+		{
+			"arg": "feature",
+			"description": "a feature"
+		},
+		{
+			"arg": "evaluate",
+			"description": "if the expression must be evaluated. If False, you should call 'eval'",
+			"optional": true,
+			"default": "true"
+		}
+	],
+	"examples": [{
+			"expression": "display('a_layer_id', $currentFeature)",
+			"returns": "the display expression of the current feature"
+		},
+		{
+			"expression": "display('a_layer_id', $currentFeature, 'False')",
+			"returns": "the display expression of the current feature not evaluated."
+		}
+	]
+}

--- a/resources/function_help/json/display
+++ b/resources/function_help/json/display
@@ -18,11 +18,11 @@
 		}
 	],
 	"examples": [{
-			"expression": "display('a_layer_id', $currentFeature)",
+			"expression": "display('a_layer_id', $currentfeature)",
 			"returns": "the display expression of the current feature"
 		},
 		{
-			"expression": "display('a_layer_id', $currentFeature, 'False')",
+			"expression": "display('a_layer_id', $currentfeature, 'False')",
 			"returns": "the display expression of the current feature not evaluated."
 		}
 	]

--- a/resources/function_help/json/eval_template
+++ b/resources/function_help/json/eval_template
@@ -1,10 +1,10 @@
 {
 	"name": "eval_template",
 	"type": "function",
-	"description": "Evaluates an template which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields.",
+	"description": "Evaluates a template which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields.",
 	"arguments": [{
 		"arg": "template",
-		"description": "an template string"
+		"description": "a template string"
 	}],
 	"examples": [{
 		"expression": "eval_template(QGIS [% 'rocks' || '!' %])",

--- a/resources/function_help/json/eval_template
+++ b/resources/function_help/json/eval_template
@@ -1,0 +1,13 @@
+{
+	"name": "eval_template",
+	"type": "function",
+	"description": "Evaluates an template which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields.",
+	"arguments": [{
+		"arg": "template",
+		"description": "an template string"
+	}],
+	"examples": [{
+		"expression": "eval_template(QGIS [% 'rocks' || '!' %])",
+		"returns": "'QGIS rocks!'"
+	}]
+}

--- a/resources/function_help/json/maptip
+++ b/resources/function_help/json/maptip
@@ -1,0 +1,29 @@
+{
+	"name": "maptip",
+	"type": "function",
+	"description": "Returns the maptip for a given feature in a layer. The maptip is evaluated by default.",
+	"arguments": [{
+			"arg": "layer",
+			"description": "a vector layer"
+		},
+		{
+			"arg": "feature",
+			"description": "a feature"
+		},
+		{
+			"arg": "evaluate",
+			"description": "if the maptip must be evaluated. If False, you should call 'eval_template'",
+			"optional": true,
+			"default": "true"
+		}
+	],
+	"examples": [{
+			"expression": "maptip('a_layer_id', $currentFeature)",
+			"returns": "the maptip of the current feature"
+		},
+		{
+			"expression": "maptip('a_layer_id', $currentFeature, 'False')",
+			"returns": "the maptip of the current feature not evaluated."
+		}
+	]
+}


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Expose the display expression and the maptip in expressions.

This is useful if we don't want to copy/paste the maptip in the composer when we generate an atlas.

By default, these are evaluated. But we can choose to not evaluate the expression, so it can be modified on runtime (search and replace, remove first line...).
In this case, we need to use the `eval` function. For the maptip, as it's a template with `[%...%]`, I needed to add `eval_template`. I just thought I can merge in `eval` with a flag `isTemplate=False` by default? Any idea?

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
