### PR TITLE
Update readme with guide to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ repository, and then [create a pull request](https://help.github.com/articles/cr
 If you commit a new feature, add [FEATURE] to your commit message AND give a clear description of the new feature. A webhook will automatically create an issue on the QGIS-Documentation repo to tell people to write documentation about it.
 
 If you are not a developer, there are many other possibilities which do not require programming skills to help QGIS to evolve. Check our [project homepage for more information](http://qgis.org/en/site/getinvolved/index.html).
+
+### Building from source
+
+The [building guide](http://htmlpreview.github.io/?https://raw.github.com/qgis/QGIS/master/doc/INSTALL.html) can be used to get started with building QGIS from source.


### PR DESCRIPTION
Updates the main README with a link to the HTML preview to help get starting building from source.    I know this is in the INSTALL file but only if you know to look there and it's not friendly to not just have it on the main README landing page.