### PR TITLE
Fix unreported wfs3 Url without offset and limit regex

### DIFF
--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1195,7 +1195,7 @@ void QgsWfs3CollectionsItemsHandler::handleRequest( const QgsServerApiContext &c
     const QUrl url { context.request()->url() };
 
     // Url without offset and limit
-    QString cleanedUrl { url.toString().replace( QRegularExpression( R"raw(&?(offset|limit)(=\d+)*)raw" ), QString() ) };
+    QString cleanedUrl { url.toString().replace( QRegularExpression( R"raw(&(offset|limit)(=\d+)*)raw" ), QString() ) };
 
     if ( ! url.hasQuery() )
     {


### PR DESCRIPTION
@elpaso 

The regex was too greedy and it also stripped any layer named limit* or offset*

Before, starting from an url like
*  ``..wfs3/collections/limits/items.html?`` would have gone to 
* ``..wfs3/collections/s/items.html?&offset=10&limit=10``
Notice ``limits`` has been cut the ``limit`` part.