### PR TITLE
fix build with proj >= 6

### DIFF
--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -349,7 +349,7 @@ QgsEllipsoidUtils::EllipsoidParameters QgsEllipsoidUtils::ellipsoidParameters( c
 #else
   params.valid = false;
 
-  QgsReadWriteLocker l( *sEllipsoidCacheLock() QgsReadWriteLocker::Write );
+  QgsReadWriteLocker l( *sEllipsoidCacheLock(), QgsReadWriteLocker::Write );
   if ( !sDisableCache )
   {
     sEllipsoidCache()->insert( ellipsoid, params );
@@ -371,7 +371,7 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
   QList<QgsEllipsoidUtils::EllipsoidDefinition> defs;
 
 #if PROJ_VERSION_MAJOR>=6
-  QgsReadWriteLocker locker( *sEllipsoidCacheLock() QgsReadWriteLocker::Write );
+  QgsReadWriteLocker locker( *sEllipsoidCacheLock(), QgsReadWriteLocker::Write );
 
   PJ_CONTEXT *context = QgsProjContext::get();
   if ( PROJ_STRING_LIST authorities = proj_get_authorities_from_database( context ) )


### PR DESCRIPTION
## Description

The error:

cc @m-kuhn 
```
/home/lbartoletti/QGIS/src/core/qgsellipsoidutils.cpp:374:53: error: expected ')'
  QgsReadWriteLocker locker( *sEllipsoidCacheLock() QgsReadWriteLocker::Write );
                                                    ^
/home/lbartoletti/QGIS/src/core/qgsellipsoidutils.cpp:374:28: note: to match this '('
  QgsReadWriteLocker locker( *sEllipsoidCacheLock() QgsReadWriteLocker::Write );
                           ^
/home/lbartoletti/QGIS/src/core/qgsellipsoidutils.cpp:374:22: error: no matching constructor for initialization of 'QgsReadWriteLocker'
  QgsReadWriteLocker locker( *sEllipsoidCacheLock() QgsReadWriteLocker::Write );
                     ^       ~~~~~~~~~~~~~~~~~~~~~~
/home/lbartoletti/QGIS/src/core/qgsreadwritelocker.h:40:19: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'QGlobalStatic<QReadWriteLock, &(anonymous namespace)::Q_QGS_sEllipsoidCacheLock::
innerFunction, &(anonymous namespace)::Q_QGS_sEllipsoidCacheLock::guard>::Type' (aka 'QReadWriteLock') to 'const QgsReadWriteLocker' for 1st argument
class CORE_EXPORT QgsReadWriteLocker
                  ^
/home/lbartoletti/QGIS/src/core/qgsreadwritelocker.h:57:5: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
    QgsReadWriteLocker( QReadWriteLock &lock, Mode mode );
    ^
2 errors generated.
```

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ x I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
