### PR TITLE
[feature] Server OAPIF properties

### DIFF
--- a/resources/server/api/ogc/templates/wfs3/getApiDescription.html
+++ b/resources/server/api/ogc/templates/wfs3/getApiDescription.html
@@ -68,14 +68,14 @@
                                      {% if existsIn(param, "name") %}
                                      <tr>
                                        <td>{{ param.name }}</td>
-                                       <td class="small">{{ param.description }}</td>
+                                       <td class="small">{{ nl2br( param.description ) }}</td>
                                        <td>{{ param.schema.type }}</td>
                                     </tr>
                                     {% else %}
                                     {% for comp_param in component_parameter( param ) %}
                                     <tr>
                                       <td>{{ comp_param.name }}</td>
-                                      <td class="small">{{ comp_param.description }}</td>
+                                      <td class="small">{{ nl2br( comp_param.description ) }}</td>
                                       <td>{{ comp_param.schema.type }}</td>
                                     </tr>
                                     {% endfor %}

--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -359,6 +359,13 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
       return QgsServerOgcApi::contentTypeToStdString( ct );
     } );
 
+    // Replace newlines with <br>
+    env.add_callback( "nl2br", 1, [ = ]( Arguments & args )
+    {
+      QString text { QString::fromStdString( args.at( 0 )->get<std::string>( ) ) };
+      return text.replace( '\n', QLatin1String( "<br>" ) ).toStdString();
+    } );
+
 
     // Returns a list of parameter component data from components -> parameters by ref name
     // parameter( <ref object> )

--- a/src/server/qgsserverogcapihandler.h
+++ b/src/server/qgsserverogcapihandler.h
@@ -181,6 +181,7 @@ class SERVER_EXPORT QgsServerOgcApiHandler
      *   static( "/style/black.css" ) will return something like "/wfs3/static/style/black.css".
      * - links_filter( links, key, value ): Returns filtered links from a link list
      * - content_type_name( content_type ): Returns a short name from a content type for example "text/html" will return "HTML"
+     * - nl2br( text ): Returns the input text with all newlines replaced by "<br>" tags
      *
      * \note not available in Python bindings
      */

--- a/src/server/qgsserverquerystringparameter.cpp
+++ b/src/server/qgsserverquerystringparameter.cpp
@@ -126,7 +126,7 @@ json QgsServerQueryStringParameter::data() const
   return
   {
     { "name", nameString },
-    { "description", "Filter the collection by '" + nameString + "'" },
+    { "description", description().toStdString() },
     { "required", mRequired },
     { "in", "query"},
     { "style", "form"},

--- a/src/server/services/wfs3/qgswfs3handlers.h
+++ b/src/server/services/wfs3/qgswfs3handlers.h
@@ -47,9 +47,10 @@ class QgsWfs3AbstractItemsHandler: public QgsServerOgcApiHandler
      * Creates a filtered QgsFeatureRequest containing only fields published for WMS and plugin filters applied.
      * \param layer the vector layer
      * \param context the server api context
+     * \param subsetAttributes optional list of field names requested by the client, if empty all published attributes will be added to the request
      * \return QgsFeatureRequest with filters applied
      */
-    QgsFeatureRequest filteredRequest( const QgsVectorLayer *layer, const QgsServerApiContext &context ) const;
+    QgsFeatureRequest filteredRequest( const QgsVectorLayer *layer, const QgsServerApiContext &context, const QStringList &subsetAttributes = QStringList() ) const;
 
     /**
      * Returns a filtered list of fields containing only fields published for WMS and plugin filters applied.

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -703,10 +703,13 @@ Content-Type: application/openapi+json;version=3.0
             "$ref": "#/components/parameters/bbox-crs"
           },
           {
+            "$ref": "#/components/parameters/crs"
+          },
+          {
             "$ref": "#/components/parameters/datetime"
           },
           {
-            "description": "Filter the collection by 'id'",
+            "description": "Retrieve features filtered by: id (Integer)",
             "explode": false,
             "in": "query",
             "name": "id",
@@ -717,10 +720,21 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'utf8nameè'",
+            "description": "Retrieve features filtered by: utf8nameè (String)",
             "explode": false,
             "in": "query",
             "name": "utf8nameè",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Comma separated list of feature property names to be added to the result. Valid values: 'id', 'utf8nameè'",
+            "explode": false,
+            "in": "query",
+            "name": "properties",
             "required": false,
             "schema": {
               "type": "string"
@@ -876,10 +890,13 @@ Content-Type: application/openapi+json;version=3.0
             "$ref": "#/components/parameters/bbox-crs"
           },
           {
+            "$ref": "#/components/parameters/crs"
+          },
+          {
             "$ref": "#/components/parameters/datetime"
           },
           {
-            "description": "Filter the collection by 'alias_id'",
+            "description": "Retrieve features filtered by: alias_id (Integer)",
             "explode": false,
             "in": "query",
             "name": "alias_id",
@@ -890,7 +907,7 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'alias_name'",
+            "description": "Retrieve features filtered by: alias_name (String)",
             "explode": false,
             "in": "query",
             "name": "alias_name",
@@ -901,10 +918,21 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'utf8nameè'",
+            "description": "Retrieve features filtered by: utf8nameè (String)",
             "explode": false,
             "in": "query",
             "name": "utf8nameè",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Comma separated list of feature property names to be added to the result. Valid values: 'id', 'name', 'utf8nameè'",
+            "explode": false,
+            "in": "query",
+            "name": "properties",
             "required": false,
             "schema": {
               "type": "string"
@@ -1060,10 +1088,13 @@ Content-Type: application/openapi+json;version=3.0
             "$ref": "#/components/parameters/bbox-crs"
           },
           {
+            "$ref": "#/components/parameters/crs"
+          },
+          {
             "$ref": "#/components/parameters/datetime"
           },
           {
-            "description": "Filter the collection by 'id'",
+            "description": "Retrieve features filtered by: id (Integer)",
             "explode": false,
             "in": "query",
             "name": "id",
@@ -1074,7 +1105,7 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'name'",
+            "description": "Retrieve features filtered by: name (String)",
             "explode": false,
             "in": "query",
             "name": "name",
@@ -1085,10 +1116,21 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'utf8nameè'",
+            "description": "Retrieve features filtered by: utf8nameè (String)",
             "explode": false,
             "in": "query",
             "name": "utf8nameè",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Comma separated list of feature property names to be added to the result. Valid values: 'id', 'name', 'utf8nameè'",
+            "explode": false,
+            "in": "query",
+            "name": "properties",
             "required": false,
             "schema": {
               "type": "string"
@@ -1244,10 +1286,13 @@ Content-Type: application/openapi+json;version=3.0
             "$ref": "#/components/parameters/bbox-crs"
           },
           {
+            "$ref": "#/components/parameters/crs"
+          },
+          {
             "$ref": "#/components/parameters/datetime"
           },
           {
-            "description": "Filter the collection by 'id'",
+            "description": "Retrieve features filtered by: id (Integer)",
             "explode": false,
             "in": "query",
             "name": "id",
@@ -1258,7 +1303,7 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'name'",
+            "description": "Retrieve features filtered by: name (String)",
             "explode": false,
             "in": "query",
             "name": "name",
@@ -1269,10 +1314,21 @@ Content-Type: application/openapi+json;version=3.0
             "style": "form"
           },
           {
-            "description": "Filter the collection by 'utf8nameè'",
+            "description": "Retrieve features filtered by: utf8nameè (String)",
             "explode": false,
             "in": "query",
             "name": "utf8nameè",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Comma separated list of feature property names to be added to the result. Valid values: 'id', 'name', 'utf8nameè'",
+            "explode": false,
+            "in": "query",
+            "name": "properties",
             "required": false,
             "schema": {
               "type": "string"
@@ -1422,6 +1478,5 @@ Content-Type: application/openapi+json;version=3.0
       "description": "Access to data (features).",
       "name": "Features"
     }
-  ],
-  "timeStamp": "2019-07-05T12:27:07Z"
+  ]
 }


### PR DESCRIPTION
Makes it possible to specify a comma separate list
of attributes to be returned by items call.

This is apparently not in core specifications
but most of sample implementations supports it
and well, it's just useful.

Also adds `nl2br` utility function for templates.
