### PR TITLE
Fix compilation issues related to automoc'ification

### DIFF
--- a/src/plugins/coordinate_capture/CMakeLists.txt
+++ b/src/plugins/coordinate_capture/CMakeLists.txt
@@ -7,13 +7,6 @@ SET (coordinatecapture_SRCS
      coordinatecapturegui.cpp
      coordinatecapturemaptool.cpp
 )
-
-SET (coordinatecapture_MOC_HDRS
-     coordinatecapture.h
-     coordinatecapturegui.h
-     coordinatecapturemaptool.h
-)
-
 SET (coordinatecapture_RCCS  coordinatecapture.qrc)
 
 ########################################################
@@ -21,11 +14,9 @@ SET (coordinatecapture_RCCS  coordinatecapture.qrc)
 
 QT5_WRAP_UI (coordinatecapture_UIS_H  ${coordinatecapture_UIS})
 
-QT5_WRAP_CPP (coordinatecapture_MOC_SRCS  ${coordinatecapture_MOC_HDRS})
-
 QT5_ADD_RESOURCES(coordinatecapture_RCC_SRCS ${coordinatecapture_RCCS})
 
-ADD_LIBRARY (coordinatecaptureplugin MODULE ${coordinatecapture_SRCS} ${coordinatecapture_MOC_SRCS} ${coordinatecapture_RCC_SRCS})
+ADD_LIBRARY (coordinatecaptureplugin MODULE ${coordinatecapture_SRCS} ${coordinatecapture_RCC_SRCS})
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core

--- a/src/plugins/evis/CMakeLists.txt
+++ b/src/plugins/evis/CMakeLists.txt
@@ -23,18 +23,6 @@ SET (evis_UIS
      ui/evisgenericeventbrowserguibase.ui
 )
 
-SET (evis_MOC_HDRS
-     evis.h
-
-     databaseconnection/evisdatabaseconnectiongui.h
-     databaseconnection/evisdatabaselayerfieldselectiongui.h
-
-     eventbrowser/evisgenericeventbrowsergui.h
-     eventbrowser/evisimagedisplaywidget.h
-
-     idtool/eviseventidtool.h
-)
-
 SET (evis_RCCS resources/evis.qrc)
 
 ########################################################
@@ -42,11 +30,9 @@ SET (evis_RCCS resources/evis.qrc)
 
 QT5_WRAP_UI (evis_UIS_H  ${evis_UIS})
 
-QT5_WRAP_CPP (evis_MOC_SRCS  ${evis_MOC_HDRS})
-
 QT5_ADD_RESOURCES(evis_RCC_SRCS ${evis_RCCS})
 
-ADD_LIBRARY (evis MODULE ${evis_SRCS} ${evis_MOC_SRCS} ${evis_RCC_SRCS} ${evis_UIS_H})
+ADD_LIBRARY (evis MODULE ${evis_SRCS} ${evis_RCC_SRCS} ${evis_UIS_H})
 
 INCLUDE_DIRECTORIES(SYSTEM
   ${GDAL_INCLUDE_DIR}

--- a/src/plugins/geometry_checker/CMakeLists.txt
+++ b/src/plugins/geometry_checker/CMakeLists.txt
@@ -17,15 +17,6 @@ SET (geometrychecker_HDRS
     qgsgeometrycheckfactory.h
 )
 
-SET (geometrychecker_MOC_HDRS
-    qgsgeometrycheckerplugin.h
-    qgsgeometrycheckerdialog.h
-    qgsgeometrycheckersetuptab.h
-    qgsgeometrycheckerresulttab.h
-    qgsgeometrycheckfixdialog.h
-    qgsgeometrycheckerfixsummarydialog.h
-)
-
 SET (geometrychecker_UIS
     qgsgeometrycheckersetuptab.ui
     qgsgeometrycheckerresulttab.ui
@@ -41,11 +32,9 @@ SET (geometrychecker_RCCS
 
 QT5_WRAP_UI (geometrychecker_UIS_H  ${geometrychecker_UIS})
 
-QT5_WRAP_CPP (geometrychecker_MOC_SRCS  ${geometrychecker_MOC_HDRS})
-
 QT5_ADD_RESOURCES(geometrychecker_RCC_SRCS ${geometrychecker_RCCS})
 
-ADD_LIBRARY (geometrycheckerplugin   MODULE ${geometrychecker_HDRS} ${geometrychecker_MOC_HDRS} ${geometrychecker_SRCS} ${geometrychecker_MOC_SRCS} ${geometrychecker_RCC_SRCS} ${geometrychecker_UIS_H})
+ADD_LIBRARY (geometrycheckerplugin   MODULE ${geometrychecker_HDRS} ${geometrychecker_SRCS}  ${geometrychecker_RCC_SRCS} ${geometrychecker_UIS_H})
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core

--- a/src/plugins/georeferencer/CMakeLists.txt
+++ b/src/plugins/georeferencer/CMakeLists.txt
@@ -29,6 +29,10 @@ SET (GEOREF_SRCS
      qgsrasterchangecoords.cpp
 )
 
+SET (GEOREF_HDRS
+     qgsvalidateddoublespinbox.h
+)
+
 SET (GEOREF_UIS
      qgsgeorefconfigdialogbase.ui
      qgsgeorefdescriptiondialogbase.ui
@@ -39,25 +43,6 @@ SET (GEOREF_UIS
      ../../ui/qgsrasterlayerpropertiesbase.ui
 )
 
-SET (GEOREF_MOC_HDRS
-     qgsgeorefconfigdialog.h
-     qgsgeorefdatapoint.h
-     qgsgeorefdelegates.h
-     qgsgeorefdescriptiondialog.h
-     qgsgeorefplugin.h
-     qgsgeorefplugingui.h
-     qgsgeoreftooladdpoint.h
-     qgsgeoreftooldeletepoint.h
-     qgsgeoreftoolmovepoint.h
-     qgsgeorefvalidators.h
-     qgsmapcoordsdialog.h
-     qgsresidualplotitem.h
-     qgstransformsettingsdialog.h
-     qgsvalidateddoublespinbox.h
-     
-     qgsgcplistmodel.h
-     qgsgcplistwidget.h
-)
 SET (GEOREF_RCCS  georeferencer.qrc)
 
 
@@ -66,11 +51,9 @@ SET (GEOREF_RCCS  georeferencer.qrc)
 
 QT5_WRAP_UI (GEOREF_UIS_H  ${GEOREF_UIS})
 
-QT5_WRAP_CPP (GEOREF_MOC_SRCS  ${GEOREF_MOC_HDRS})
-
 QT5_ADD_RESOURCES(GEOREF_RCC_SRCS ${GEOREF_RCCS})
 
-ADD_LIBRARY (georefplugin MODULE ${GEOREF_SRCS} ${GEOREF_MOC_SRCS} ${GEOREF_RCC_SRCS} ${GEOREF_UIS_H})
+ADD_LIBRARY (georefplugin MODULE ${GEOREF_SRCS} ${GEOREF_HDRS} ${GEOREF_RCC_SRCS} ${GEOREF_UIS_H})
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/plugins/gps_importer/CMakeLists.txt
+++ b/src/plugins/gps_importer/CMakeLists.txt
@@ -14,12 +14,6 @@ SET (GPS_UIS
      qgsgpsdevicedialogbase.ui
 )
 
-SET (GPS_MOC_HDRS
-     qgsgpsplugin.h
-     qgsgpsplugingui.h
-     qgsgpsdevicedialog.h
-)
-
 SET (GPS_RCCS  qgsgps_plugin.qrc)
 
 
@@ -28,11 +22,9 @@ SET (GPS_RCCS  qgsgps_plugin.qrc)
 
 QT5_WRAP_UI (GPS_UIS_H  ${GPS_UIS})
 
-QT5_WRAP_CPP (GPS_MOC_SRCS  ${GPS_MOC_HDRS})
-
 QT5_ADD_RESOURCES(GPS_RCC_SRCS ${GPS_RCCS})
 
-ADD_LIBRARY (gpsimporterplugin MODULE ${GPS_SRCS} ${GPS_MOC_SRCS} ${GPS_RCC_SRCS} ${GPS_UIS_H})
+ADD_LIBRARY (gpsimporterplugin MODULE ${GPS_SRCS} ${GPS_RCC_SRCS} ${GPS_UIS_H})
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core

--- a/src/plugins/offline_editing/CMakeLists.txt
+++ b/src/plugins/offline_editing/CMakeLists.txt
@@ -13,12 +13,6 @@ SET (offline_editing_plugin_UIS
   offline_editing_progress_dialog_base.ui
 )
 
-SET (offline_editing_plugin_MOC_HDRS
-  offline_editing_plugin.h
-  offline_editing_plugin_gui.h
-  offline_editing_progress_dialog.h
-)
-
 SET (offline_editing_plugin_RCCS  offline_editing_plugin.qrc)
 
 ########################################################
@@ -26,13 +20,10 @@ SET (offline_editing_plugin_RCCS  offline_editing_plugin.qrc)
 
 QT5_WRAP_UI(offline_editing_plugin_UIS_H ${offline_editing_plugin_UIS})
 
-QT5_WRAP_CPP(offline_editing_plugin_MOC_SRCS ${offline_editing_plugin_MOC_HDRS})
-
 QT5_ADD_RESOURCES(offline_editing_plugin_RCC_SRCS ${offline_editing_plugin_RCCS})
 
 ADD_LIBRARY (offlineeditingplugin MODULE
   ${offline_editing_plugin_SRCS}
-  ${offline_editing_plugin_MOC_SRCS}
   ${offline_editing_plugin_RCC_SRCS}
   ${offline_editing_plugin_UIS_H}
 )

--- a/src/plugins/topology/CMakeLists.txt
+++ b/src/plugins/topology/CMakeLists.txt
@@ -16,14 +16,6 @@ SET (topol_UIS
   checkDock.ui
 )
 
-SET (topol_MOC_HDRS
-  topol.h
-  rulesDialog.h
-  checkDock.h
-  topolTest.h
-  dockModel.h
-)
-
 SET (topol_RCCS  topol.qrc)
 
 ########################################################
@@ -31,11 +23,9 @@ SET (topol_RCCS  topol.qrc)
 
 QT5_WRAP_UI (topol_UIS_H  ${topol_UIS})
 
-QT5_WRAP_CPP (topol_MOC_SRCS  ${topol_MOC_HDRS})
-
 QT5_ADD_RESOURCES(topol_RCC_SRCS ${topol_RCCS})
 
-ADD_LIBRARY (topolplugin MODULE ${topol_SRCS} ${topol_MOC_SRCS} ${topol_RCC_SRCS} ${topol_UIS_H})
+ADD_LIBRARY (topolplugin MODULE ${topol_SRCS} ${topol_RCC_SRCS} ${topol_UIS_H})
 
 INCLUDE_DIRECTORIES(SYSTEM
   ${GEOS_INCLUDE_DIR}

--- a/tests/bench/CMakeLists.txt
+++ b/tests/bench/CMakeLists.txt
@@ -6,16 +6,10 @@ SET (BENCH_SRCS
      qgsbench.cpp
 )
 
-SET (BENCH_MOC_HDRS
-     qgsbench.h
-)
-
 ########################################################
 # Build
 
-QT5_WRAP_CPP (BENCH_MOC_SRCS  ${BENCH_MOC_HDRS})
-
-ADD_EXECUTABLE (qgis_bench MACOSX_BUNDLE WIN32 ${BENCH_SRCS} ${BENCH_MOC_SRCS} )
+ADD_EXECUTABLE (qgis_bench MACOSX_BUNDLE WIN32 ${BENCH_SRCS} )
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/external

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -111,14 +111,8 @@ IF(UNIX AND NOT ANDROID AND CMAKE_BUILD_TYPE MATCHES Debug)
         ../../../src/providers/wcs/qgswcscapabilities.cpp
         testqgswcspublicservers.cpp
   )
-  SET ( WCSTEST_MOC_HDRS
-        ../../../src/providers/wcs/qgswcscapabilities.h
-        testqgswcspublicservers.h
-  )
 
-  QT5_WRAP_CPP ( WCSTEST_MOC_SRCS  ${WCSTEST_MOC_HDRS})
-
-  ADD_EXECUTABLE ( qgis_wcstest ${WCSTEST_SRCS} ${WCSTEST_MOC_SRCS} )
+  ADD_EXECUTABLE ( qgis_wcstest ${WCSTEST_SRCS} )
 
   INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/core


### PR DESCRIPTION
Not sure why they trigger on my end and not on CI... Perhaps
because I didn't make clean. The symptoms are the linker complaining
about double definition of symbols.
