### PR TITLE
Fix issues relating to features not matching graduated ranges

### DIFF
--- a/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgsgraduatedsymbolrenderer.sip.in
@@ -499,6 +499,14 @@ Updates the labels of the ranges
 .. versionadded:: 3.10
 %End
 
+    const QgsRendererRange *rangeForValue( double value ) const;
+%Docstring
+Returns the renderer range matching the provided ``value``, or ``None`` if no
+range matches the value.
+
+.. versionadded:: 3.10.1
+%End
+
   protected:
 
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3821,7 +3821,14 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
   {
     return QVariant();
   }
-  const QgsField fld = mAttributeFields.at( index );
+  const QgsField originalField = mAttributeFields.at( index );
+  QgsField fld = originalField;
+
+  // can't use native date/datetime types -- OGR converts these to string in the MAX return value
+  if ( fld.type() == QVariant::DateTime || fld.type() == QVariant::Date )
+  {
+    fld.setType( QVariant::String );
+  }
 
   // Don't quote column name (see https://trac.osgeo.org/gdal/ticket/5799#comment:9)
   QByteArray sql = "SELECT MIN(" + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) );
@@ -3846,9 +3853,13 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
   }
 
   bool ok = false;
-  const QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
+  QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
   if ( !ok )
     return QVariant();
+
+  if ( res.type() != originalField.type() )
+    res = convertValue( originalField.type(), res.toString() );
+
   return res;
 }
 
@@ -3858,7 +3869,14 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
   {
     return QVariant();
   }
-  const QgsField fld = mAttributeFields.at( index );
+  const QgsField originalField = mAttributeFields.at( index );
+  QgsField fld = originalField;
+
+  // can't use native date/datetime types -- OGR converts these to string in the MAX return value
+  if ( fld.type() == QVariant::DateTime || fld.type() == QVariant::Date )
+  {
+    fld.setType( QVariant::String );
+  }
 
   // Don't quote column name (see https://trac.osgeo.org/gdal/ticket/5799#comment:9)
   QByteArray sql = "SELECT MAX(" + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) );
@@ -3883,9 +3901,13 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
   }
 
   bool ok = false;
-  const QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
+  QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
   if ( !ok )
     return QVariant();
+
+  if ( res.type() != originalField.type() )
+    res = convertValue( originalField.type(), res.toString() );
+
   return res;
 }
 

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3718,7 +3718,7 @@ QSet<QVariant> QgsOgrProvider::uniqueValues( int index, int limit ) const
   if ( !mValid || index < 0 || index >= mAttributeFields.count() )
     return uniqueValues;
 
-  QgsField fld = mAttributeFields.at( index );
+  const QgsField fld = mAttributeFields.at( index );
   if ( fld.name().isNull() )
   {
     return uniqueValues; //not a provider field
@@ -3755,9 +3755,13 @@ QSet<QVariant> QgsOgrProvider::uniqueValues( int index, int limit ) const
   }
 
   gdal::ogr_feature_unique_ptr f;
+  bool ok = false;
   while ( f.reset( l->GetNextFeature() ), f )
   {
-    uniqueValues << ( OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) ) ) : QVariant( fld.type() ) );
+    const QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
+    if ( ok )
+      uniqueValues << res;
+
     if ( limit >= 0 && uniqueValues.size() >= limit )
       break;
   }
@@ -3817,7 +3821,7 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
   {
     return QVariant();
   }
-  QgsField fld = mAttributeFields.at( index );
+  const QgsField fld = mAttributeFields.at( index );
 
   // Don't quote column name (see https://trac.osgeo.org/gdal/ticket/5799#comment:9)
   QByteArray sql = "SELECT MIN(" + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) );
@@ -3841,8 +3845,11 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
     return QVariant();
   }
 
-  QVariant value = OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) ) ) : QVariant( fld.type() );
-  return value;
+  bool ok = false;
+  const QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
+  if ( !ok )
+    return QVariant();
+  return res;
 }
 
 QVariant QgsOgrProvider::maximumValue( int index ) const
@@ -3851,7 +3858,7 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
   {
     return QVariant();
   }
-  QgsField fld = mAttributeFields.at( index );
+  const QgsField fld = mAttributeFields.at( index );
 
   // Don't quote column name (see https://trac.osgeo.org/gdal/ticket/5799#comment:9)
   QByteArray sql = "SELECT MAX(" + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) );
@@ -3875,8 +3882,11 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
     return QVariant();
   }
 
-  QVariant value = OGR_F_IsFieldSetAndNotNull( f.get(), 0 ) ? convertValue( fld.type(), textEncoding()->toUnicode( OGR_F_GetFieldAsString( f.get(), 0 ) ) ) : QVariant( fld.type() );
-  return value;
+  bool ok = false;
+  const QVariant res = QgsOgrUtils::getOgrFeatureAttribute( f.get(), fld, 0, textEncoding(), &ok );
+  if ( !ok )
+    return QVariant();
+  return res;
 }
 
 QByteArray QgsOgrProvider::quotedIdentifier( const QByteArray &field ) const

--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -169,9 +169,23 @@ QgsFields QgsOgrUtils::readOgrFields( OGRFeatureH ogrFet, QTextCodec *encoding )
   return fields;
 }
 
+
 QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsFields &fields, int attIndex, QTextCodec *encoding, bool *ok )
 {
-  if ( !ogrFet || attIndex < 0 || attIndex >= fields.count() )
+  if ( attIndex < 0 || attIndex >= fields.count() )
+  {
+    if ( ok )
+      *ok = false;
+    return QVariant();
+  }
+
+  const QgsField field = fields.at( attIndex );
+  return getOgrFeatureAttribute( ogrFet, field, attIndex, encoding, ok );
+}
+
+QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField &field, int attIndex, QTextCodec *encoding, bool *ok )
+{
+  if ( !ogrFet || attIndex < 0 )
   {
     if ( ok )
       *ok = false;
@@ -196,7 +210,7 @@ QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField
 
   if ( OGR_F_IsFieldSetAndNotNull( ogrFet, attIndex ) )
   {
-    switch ( fields.at( attIndex ).type() )
+    switch ( field.type() )
     {
       case QVariant::String:
       {
@@ -225,9 +239,9 @@ QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField
         int year, month, day, hour, minute, second, tzf;
 
         OGR_F_GetFieldAsDateTime( ogrFet, attIndex, &year, &month, &day, &hour, &minute, &second, &tzf );
-        if ( fields.at( attIndex ).type() == QVariant::Date )
+        if ( field.type() == QVariant::Date )
           value = QDate( year, month, day );
-        else if ( fields.at( attIndex ).type() == QVariant::Time )
+        else if ( field.type() == QVariant::Time )
           value = QTime( hour, minute, second );
         else
           value = QDateTime( QDate( year, month, day ), QTime( hour, minute, second ) );
@@ -250,7 +264,7 @@ QVariant QgsOgrUtils::getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField
 
       case QVariant::List:
       {
-        if ( fields.at( attIndex ).subType() == QVariant::String )
+        if ( field.subType() == QVariant::String )
         {
           QStringList list;
           char **lst = OGR_F_GetFieldAsStringList( ogrFet, attIndex );

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -192,6 +192,20 @@ class CORE_EXPORT QgsOgrUtils
     static QVariant getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsFields &fields, int attIndex, QTextCodec *encoding, bool *ok = nullptr );
 
     /**
+     * Retrieves an attribute value from an OGR feature, using a provided \a field definition.
+     * \param ogrFet OGR feature handle
+     * \param field definition of corresponding field
+     * \param attIndex index of attribute to retrieve from \a ogrFet
+     * \param encoding text encoding
+     * \param ok optional storage for success of retrieval
+     * \returns attribute converted to a QVariant object
+     * \see readOgrFeatureAttributes()
+     *
+     * \since QGIS 3.10.1
+     */
+    static QVariant getOgrFeatureAttribute( OGRFeatureH ogrFet, const QgsField &field, int attIndex, QTextCodec *encoding, bool *ok = nullptr );
+
+    /**
      * Reads all attributes from an OGR feature into a QgsFeature.
      * \param ogrFet OGR feature handle
      * \param fields fields collection corresponding to feature

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -17,6 +17,7 @@
 #include <QDomElement>
 
 #include <ctime>
+#include <cmath>
 
 #include "qgsgraduatedsymbolrenderer.h"
 
@@ -70,14 +71,15 @@ QgsGraduatedSymbolRenderer::~QgsGraduatedSymbolRenderer()
   mRanges.clear(); // should delete all the symbols
 }
 
-QgsSymbol *QgsGraduatedSymbolRenderer::symbolForValue( double value ) const
+
+const QgsRendererRange *QgsGraduatedSymbolRenderer::rangeForValue( double value ) const
 {
   for ( const QgsRendererRange &range : mRanges )
   {
     if ( range.lowerValue() <= value && range.upperValue() >= value )
     {
       if ( range.renderState() || mCounting )
-        return range.symbol();
+        return &range;
       else
         return nullptr;
     }
@@ -86,21 +88,25 @@ QgsSymbol *QgsGraduatedSymbolRenderer::symbolForValue( double value ) const
   return nullptr;
 }
 
+QgsSymbol *QgsGraduatedSymbolRenderer::symbolForValue( double value ) const
+{
+  if ( const QgsRendererRange *range = rangeForValue( value ) )
+    return range->symbol();
+  return nullptr;
+}
+
 QString QgsGraduatedSymbolRenderer::legendKeyForValue( double value ) const
 {
-  int i = 0;
-  for ( const QgsRendererRange &range : mRanges )
+  if ( const QgsRendererRange *matchingRange = rangeForValue( value ) )
   {
-    if ( range.lowerValue() <= value && range.upperValue() >= value )
+    int i = 0;
+    for ( const QgsRendererRange &range : mRanges )
     {
-      if ( range.renderState() || mCounting )
+      if ( matchingRange == &range )
         return QString::number( i );
-      else
-        return QString();
+      i++;
     }
-    i++;
   }
-  // the value is out of the range: return NULL
   return QString();
 }
 
@@ -1053,7 +1059,6 @@ void QgsGraduatedSymbolRenderer::updateRangeLabels()
     mRanges[i].setLabel( mClassificationMethod->labelForRange( mRanges[i], pos ) );
   }
 }
-
 
 void QgsGraduatedSymbolRenderer::calculateLabelPrecision( bool updateRanges )
 {

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -84,6 +84,20 @@ const QgsRendererRange *QgsGraduatedSymbolRenderer::rangeForValue( double value 
         return nullptr;
     }
   }
+
+  // second chance -- use a bit of double tolerance to avoid floating point equality fuzziness
+  // if a value falls just outside of a range, but within acceptable double precision tolerance
+  // then we accept it anyway
+  for ( const QgsRendererRange &range : mRanges )
+  {
+    if ( qgsDoubleNear( range.lowerValue(), value ) || qgsDoubleNear( range.upperValue(), value ) )
+    {
+      if ( range.renderState() || mCounting )
+        return &range;
+      else
+        return nullptr;
+    }
+  }
   // the value is out of the range: return NULL instead of symbol
   return nullptr;
 }

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -429,6 +429,14 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
      */
     void updateRangeLabels();
 
+    /**
+     * Returns the renderer range matching the provided \a value, or NULLPTR if no
+     * range matches the value.
+     *
+     * \since QGIS 3.10.1
+     */
+    const QgsRendererRange *rangeForValue( double value ) const;
+
   protected:
     QString mAttrName;
     QgsRangeList mRanges;
@@ -479,6 +487,9 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
     QgsGraduatedSymbolRenderer( const QgsGraduatedSymbolRenderer & );
     QgsGraduatedSymbolRenderer &operator=( const QgsGraduatedSymbolRenderer & );
 #endif
+
+    friend class TestQgsGraduatedSymbolRenderer;
+
 };
 
 #endif // QGSGRADUATEDSYMBOLRENDERER_H

--- a/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
+++ b/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
@@ -309,6 +309,10 @@ void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
   QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
   QCOMPARE( renderer.legendKeyForValue( 3.7 ), QStringLiteral( "3" ) );
   QVERIFY( renderer.legendKeyForValue( 3.5 ).isEmpty() );
+
+  // test values which fall just outside ranges, e.g. due to double precision (refs https://github.com/qgis/QGIS/issues/27420)
+  QCOMPARE( renderer.rangeForValue( 1.1 - std::numeric_limits<double>::epsilon() * 2 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.7 + std::numeric_limits<double>::epsilon() * 2 )->label(), QStringLiteral( "r4" ) );
 }
 
 QGSTEST_MAIN( TestQgsGraduatedSymbolRenderer )

--- a/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
+++ b/tests/src/core/testqgsgraduatedsymbolrenderer.cpp
@@ -21,6 +21,8 @@
 #include "qgsgraduatedsymbolrenderer.h"
 #include "qgsclassificationequalinterval.h"
 #include "qgssymbollayerutils.h"
+#include "qgsvectorlayer.h"
+#include "qgsclassificationquantile.h"
 
 /**
  * \ingroup UnitTests
@@ -39,7 +41,7 @@ class TestQgsGraduatedSymbolRenderer: public QObject
     void rangesOverlap();
     void rangesHaveGaps();
     void classifySymmetric();
-
+    void testMatchingRangeForValue();
 
   private:
 };
@@ -214,6 +216,99 @@ void TestQgsGraduatedSymbolRenderer::classifySymmetric()
       QVERIFY( !breaks.contains( symmetryPointForEqualInterval[valTest] ) );
     }
   }
+}
+
+void TestQgsGraduatedSymbolRenderer::testMatchingRangeForValue()
+{
+  QgsGraduatedSymbolRenderer renderer;
+  //test with no ranges
+  QVERIFY( !renderer.rangeForValue( 1 ) );
+  QVERIFY( !renderer.rangeForValue( 12 ) );
+  QVERIFY( !renderer.rangeForValue( -1 ) );
+  QVERIFY( !renderer.symbolForValue( 1 ) );
+  QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
+
+  QgsMarkerSymbol ms;
+  ms.setColor( QColor( 255, 0, 0 ) );
+  QgsRendererRange r1( 1.1, 3.2, ms.clone(), QStringLiteral( "r1" ) );
+  renderer.addClass( r1 );
+
+  QVERIFY( !renderer.rangeForValue( 1 ) );
+  QVERIFY( !renderer.rangeForValue( 12 ) );
+  QVERIFY( !renderer.rangeForValue( -1 ) );
+  QCOMPARE( renderer.rangeForValue( 1.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 2.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.2 )->label(), QStringLiteral( "r1" ) );
+  QVERIFY( !renderer.symbolForValue( 1 ) );
+  QCOMPARE( renderer.symbolForValue( 2.1 )->color().name(), QStringLiteral( "#ff0000" ) );
+  QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
+
+  ms.setColor( QColor( 255, 255, 0 ) );
+  QgsRendererRange r2( 3.2, 3.3, ms.clone(), QStringLiteral( "r2" ) );
+  renderer.addClass( r2 );
+
+  QVERIFY( !renderer.rangeForValue( 1 ) );
+  QVERIFY( !renderer.rangeForValue( 12 ) );
+  QVERIFY( !renderer.rangeForValue( -1 ) );
+  QCOMPARE( renderer.rangeForValue( 1.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 2.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.2 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.25 )->label(), QStringLiteral( "r2" ) );
+  QCOMPARE( renderer.rangeForValue( 3.3 )->label(), QStringLiteral( "r2" ) );
+  QVERIFY( !renderer.symbolForValue( 1 ) );
+  QCOMPARE( renderer.symbolForValue( 2.1 )->color().name(), QStringLiteral( "#ff0000" ) );
+  QCOMPARE( renderer.symbolForValue( 3.25 )->color().name(), QStringLiteral( "#ffff00" ) );
+  QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
+  QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
+
+  // disabled range
+  ms.setColor( QColor( 255, 0, 255 ) );
+  QgsRendererRange r3( 3.3, 3.6, ms.clone(), QStringLiteral( "r3" ), false );
+  renderer.addClass( r3 );
+  QVERIFY( !renderer.rangeForValue( 1 ) );
+  QVERIFY( !renderer.rangeForValue( 12 ) );
+  QVERIFY( !renderer.rangeForValue( -1 ) );
+  QCOMPARE( renderer.rangeForValue( 1.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 2.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.2 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.25 )->label(), QStringLiteral( "r2" ) );
+  QCOMPARE( renderer.rangeForValue( 3.3 )->label(), QStringLiteral( "r2" ) );
+  QVERIFY( !renderer.rangeForValue( 3.5 ) );
+  QVERIFY( !renderer.symbolForValue( 1 ) );
+  QCOMPARE( renderer.symbolForValue( 2.1 )->color().name(), QStringLiteral( "#ff0000" ) );
+  QCOMPARE( renderer.symbolForValue( 3.25 )->color().name(), QStringLiteral( "#ffff00" ) );
+  QVERIFY( !renderer.symbolForValue( 3.5 ) );
+  QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
+  QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
+  QVERIFY( renderer.legendKeyForValue( 3.5 ).isEmpty() );
+
+  // zero width range
+  ms.setColor( QColor( 0, 255, 255 ) );
+  QgsRendererRange r4( 3.7, 3.7, ms.clone(), QStringLiteral( "r4" ) );
+  renderer.addClass( r4 );
+  QVERIFY( !renderer.rangeForValue( 1 ) );
+  QVERIFY( !renderer.rangeForValue( 12 ) );
+  QVERIFY( !renderer.rangeForValue( -1 ) );
+  QCOMPARE( renderer.rangeForValue( 1.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 2.1 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.2 )->label(), QStringLiteral( "r1" ) );
+  QCOMPARE( renderer.rangeForValue( 3.25 )->label(), QStringLiteral( "r2" ) );
+  QCOMPARE( renderer.rangeForValue( 3.3 )->label(), QStringLiteral( "r2" ) );
+  QCOMPARE( renderer.rangeForValue( 3.7 )->label(), QStringLiteral( "r4" ) );
+  QVERIFY( !renderer.rangeForValue( 3.5 ) );
+  QVERIFY( !renderer.symbolForValue( 1 ) );
+  QCOMPARE( renderer.symbolForValue( 2.1 )->color().name(), QStringLiteral( "#ff0000" ) );
+  QCOMPARE( renderer.symbolForValue( 3.25 )->color().name(), QStringLiteral( "#ffff00" ) );
+  QCOMPARE( renderer.symbolForValue( 3.7 )->color().name(), QStringLiteral( "#00ffff" ) );
+  QVERIFY( !renderer.symbolForValue( 3.5 ) );
+  QVERIFY( renderer.legendKeyForValue( 1 ).isEmpty() );
+  QCOMPARE( renderer.legendKeyForValue( 2.1 ), QStringLiteral( "0" ) );
+  QCOMPARE( renderer.legendKeyForValue( 3.25 ), QStringLiteral( "1" ) );
+  QCOMPARE( renderer.legendKeyForValue( 3.7 ), QStringLiteral( "3" ) );
+  QVERIFY( renderer.legendKeyForValue( 3.5 ).isEmpty() );
 }
 
 QGSTEST_MAIN( TestQgsGraduatedSymbolRenderer )


### PR DESCRIPTION
Caused by exact matching double values, when we need to have a little bit of tolerance. Also implements a fix in the OGR provider where certain methods (minimum/maximum/unique values) was force converting values via a string, resulting in loss of precision)