### PR TITLE
Fix crash if a vector layer is removed while the property assistant is open

### DIFF
--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -714,6 +714,9 @@ void QgsPropertyOverrideButton::showAssistant()
       this->emit changed();
     } );
 
+    // if the source layer is removed, we need to dismiss the assistant immediately
+    connect( mVectorLayer, &QObject::destroyed, widget, &QgsPanelWidget::acceptPanel );
+
     connect( widget, &QgsPropertyAssistantWidget::panelAccepted, this, [ = ] { updateGui(); } );
 
     panel->openPanel( widget );


### PR DESCRIPTION
Identified in the dataplotly plugin (https://github.com/ghtmtt/DataPlotly/issues/163)