### PR TITLE
Move private headers where they belong

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -822,7 +822,6 @@ SET(QGIS_CORE_HDRS
   qgsprojectviewsettings.h
   qgsprojutils.h
   qgsproperty.h
-  qgsproperty_p.h
   qgspropertycollection.h
   qgspropertytransformer.h
   qgsprovidermetadata.h
@@ -1235,6 +1234,7 @@ SET(QGIS_CORE_PRIVATE_HDRS
   qgsfeature_p.h
   qgsfield_p.h
   qgsfields_p.h
+  qgsproperty_p.h
   qgsrelation_p.h
   qgsspatialindexkdbush_p.h
   qgstextrenderer_p.h


### PR DESCRIPTION
@jef-n qgsproperty_p.h should be fixed with https://github.com/qgis/QGIS/commit/c1f2d439cf28bef9776cdda73963cf1448a0d63f

What's wrong with qgsbrowserdockwidget_p.h, where's that required ?