### PR TITLE
Fix crash when deactivating vertex editor (fixes #32685)

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1413,12 +1413,13 @@ void QgsVertexTool::showVertexEditor()  //#spellok
 
 void QgsVertexTool::cleanupVertexEditor()
 {
-  mLockedFeature.reset();
-  // do not delete immediately because vertex editor
-  // can be still used in the qt event loop
-  mVertexEditor->deleteLater();
-
-  updateLockedFeatureVertices();
+  if ( mVertexEditor )
+  {
+    cleanupLockedFeature();
+    // do not delete immediately because vertex editor
+    // can be still used in the qt event loop
+    mVertexEditor->deleteLater();
+  }
 }
 
 void QgsVertexTool::cleanupLockedFeature()


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR insures that the vertex editor's model is cleared when the vertex tool is deactivated to avoid a crash under certain circumstances (demonstrated in a useful GIF attached to issue #32685 ).

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
