### PR TITLE
[quick] fix deprecated use of QApplication::desktopWidget()->screenGeometry()

### DIFF
--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -13,9 +13,10 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QApplication>
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QString>
+#include <QWindow>
 
 #include "qgis.h"
 #include "qgscoordinatereferencesystem.h"
@@ -334,11 +335,12 @@ void QgsQuickUtils::formatToUSCSDistance( double srcDistance,
 
 QString QgsQuickUtils::dumpScreenInfo() const
 {
-  QRect rec = QApplication::desktop()->screenGeometry();
-  int dpiX = QApplication::desktop()->physicalDpiX();
-  int dpiY = QApplication::desktop()->physicalDpiY();
-  int height = rec.height();
-  int width = rec.width();
+  // take the first top level window
+  QScreen *screen = QGuiApplication::topLevelWindows().at( 0 )->screen();
+  double dpiX = screen->physicalDotsPerInchX();
+  double dpiY = screen->physicalDotsPerInchY();
+  int height = screen->geometry().height();
+  int width = screen->geometry().width();
   double sizeX = static_cast<double>( width ) / dpiX * 25.4;
   double sizeY = static_cast<double>( height ) / dpiY * 25.4;
 
@@ -379,12 +381,13 @@ qreal QgsQuickUtils::screenDensity() const
 {
   return mScreenDensity;
 }
-
 qreal QgsQuickUtils::calculateScreenDensity()
 {
   // calculate screen density for calculation of real pixel sizes from density-independent pixels
-  int dpiX = QApplication::desktop()->physicalDpiX();
-  int dpiY = QApplication::desktop()->physicalDpiY();
-  int dpi = dpiX < dpiY ? dpiX : dpiY; // In case of asymmetrical DPI. Improbable
+  // take the first top level window
+  QScreen *screen = QGuiApplication::topLevelWindows().at( 0 )->screen();
+  double dpiX = screen->physicalDotsPerInchX();
+  double dpiY = screen->physicalDotsPerInchY();
+  double dpi = dpiX < dpiY ? dpiX : dpiY; // In case of asymmetrical DPI. Improbable
   return dpi / 160.;  // 160 DPI is baseline for density-independent pixels in Android
 }


### PR DESCRIPTION

This takes the first top level window and use it to get the screen.

The "perfect" approach would be to use a widget as argument in the method.

@PeterPetrik thoughts?

