### PR TITLE
[Bugfix] QgsVectorLayer: Read SLD Labeling

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -85,6 +85,7 @@
 #include "qgsdiagramrenderer.h"
 #include "qgsstyle.h"
 #include "qgspallabeling.h"
+#include "qgsrulebasedlabeling.h"
 #include "qgssimplifymethod.h"
 #include "qgsstoredexpressionmanager.h"
 #include "qgsexpressioncontext.h"
@@ -4081,31 +4082,207 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
     return;
   }
 
-  QDomElement featureTypeStyleElem = userStyleElem.firstChildElement( QStringLiteral( "FeatureTypeStyle" ) );
-  if ( featureTypeStyleElem.isNull() )
+  QDomElement featTypeStyleElem = userStyleElem.firstChildElement( QStringLiteral( "FeatureTypeStyle" ) );
+  if ( featTypeStyleElem.isNull() )
   {
     QgsDebugMsgLevel( QStringLiteral( "Info: FeatureTypeStyle element not found." ), 4 );
     return;
   }
 
-  // use last rule
-  QDomElement ruleElem = featureTypeStyleElem.lastChildElement( QStringLiteral( "Rule" ) );
-  if ( ruleElem.isNull() )
+  // create empty FeatureTypeStyle element to merge TextSymbolizer's Rule's from all FeatureTypeStyle's
+  QDomElement mergedFeatTypeStyle = featTypeStyleElem.cloneNode( false ).toElement();
+
+  // use the RuleRenderer when more rules are present or the rule
+  // has filters or min/max scale denominators set,
+  // otherwise use the Simple labeling
+  bool needRuleBasedLabeling = false;
+  int ruleCount = 0;
+
+  while ( !featTypeStyleElem.isNull() )
   {
-    QgsDebugMsgLevel( QStringLiteral( "Info: Rule element not found." ), 4 );
+    QDomElement ruleElem = featTypeStyleElem.firstChildElement( QStringLiteral( "Rule" ) );
+    while ( !ruleElem.isNull() )
+    {
+      // test rule children element to check if we need to create RuleRenderer
+      // and if the rule has a symbolizer
+      bool hasTextSymbolizer = false;
+      bool hasRuleBased = false;
+      QDomElement ruleChildElem = ruleElem.firstChildElement();
+      while ( !ruleChildElem.isNull() )
+      {
+        // rule has filter or min/max scale denominator, use the RuleRenderer
+        if ( ruleChildElem.localName() == QLatin1String( "Filter" ) ||
+             ruleChildElem.localName() == QLatin1String( "MinScaleDenominator" ) ||
+             ruleChildElem.localName() == QLatin1String( "MaxScaleDenominator" ) )
+        {
+          hasRuleBased = true;
+        }
+        // rule has a renderer symbolizer, not a text symbolizer
+        else if ( ruleChildElem.localName() == QLatin1String( "TextSymbolizer" ) )
+        {
+          QgsDebugMsg( QStringLiteral( "TextSymbolizer element found" ) );
+          hasTextSymbolizer = true;
+        }
+
+        ruleChildElem = ruleChildElem.nextSiblingElement();
+      }
+
+      if ( hasTextSymbolizer )
+      {
+        ruleCount++;
+
+        // append a clone of all Rules to the merged FeatureTypeStyle element
+        mergedFeatTypeStyle.appendChild( ruleElem.cloneNode().toElement() );
+
+        if ( hasRuleBased )
+        {
+          QgsDebugMsg( QStringLiteral( "Filter or Min/MaxScaleDenominator element found: need a RuleBasedLabeling" ) );
+          needRuleBasedLabeling = true;
+        }
+      }
+
+      // more rules present, use the RuleRenderer
+      if ( ruleCount > 1 )
+      {
+        QgsDebugMsg( QStringLiteral( "more Rule elements found: need a RuleBasedLabeling" ) );
+        needRuleBasedLabeling = true;
+      }
+
+      // not use the rule based labeling if no rules with textSymbolizer
+      if ( ruleCount == 0 )
+      {
+        needRuleBasedLabeling = false;
+      }
+
+      ruleElem = ruleElem.nextSiblingElement( QStringLiteral( "Rule" ) );
+    }
+    featTypeStyleElem = featTypeStyleElem.nextSiblingElement( QStringLiteral( "FeatureTypeStyle" ) );
+  }
+
+  if ( ruleCount == 0 )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "Info: No TextSymbolizer element." ), 4 );
     return;
   }
 
-  // use last text symbolizer
-  QDomElement textSymbolizerElem = ruleElem.lastChildElement( QStringLiteral( "TextSymbolizer" ) );
-  if ( textSymbolizerElem.isNull() )
+  QDomElement ruleElem = mergedFeatTypeStyle.firstChildElement( QStringLiteral( "Rule" ) );
+
+  if ( needRuleBasedLabeling )
   {
-    QgsDebugMsgLevel( QStringLiteral( "Info: TextSymbolizer element not found." ), 4 );
-    return;
+    QgsDebugMsg( QStringLiteral( "Info: rule based labeling" ) );
+    QgsRuleBasedLabeling::Rule *rootRule = new QgsRuleBasedLabeling::Rule( nullptr );
+    while ( !ruleElem.isNull() )
+    {
+
+      QString label, description, filterExp;
+      int scaleMinDenom = 0, scaleMaxDenom = 0;
+      QgsPalLayerSettings settings;
+
+      // retrieve the Rule element child nodes
+      QDomElement childElem = ruleElem.firstChildElement();
+      while ( !childElem.isNull() )
+      {
+        if ( childElem.localName() == QLatin1String( "Name" ) )
+        {
+          // <se:Name> tag contains the rule identifier,
+          // so prefer title tag for the label property value
+          if ( label.isEmpty() )
+            label = childElem.firstChild().nodeValue();
+        }
+        else if ( childElem.localName() == QLatin1String( "Description" ) )
+        {
+          // <se:Description> can contains a title and an abstract
+          QDomElement titleElem = childElem.firstChildElement( QStringLiteral( "Title" ) );
+          if ( !titleElem.isNull() )
+          {
+            label = titleElem.firstChild().nodeValue();
+          }
+
+          QDomElement abstractElem = childElem.firstChildElement( QStringLiteral( "Abstract" ) );
+          if ( !abstractElem.isNull() )
+          {
+            description = abstractElem.firstChild().nodeValue();
+          }
+        }
+        else if ( childElem.localName() == QLatin1String( "Abstract" ) )
+        {
+          // <sld:Abstract> (v1.0)
+          description = childElem.firstChild().nodeValue();
+        }
+        else if ( childElem.localName() == QLatin1String( "Title" ) )
+        {
+          // <sld:Title> (v1.0)
+          label = childElem.firstChild().nodeValue();
+        }
+        else if ( childElem.localName() == QLatin1String( "Filter" ) )
+        {
+          QgsExpression *filter = QgsOgcUtils::expressionFromOgcFilter( childElem );
+          if ( filter )
+          {
+            if ( filter->hasParserError() )
+            {
+              QgsDebugMsg( "parser error: " + filter->parserErrorString() );
+            }
+            else
+            {
+              filterExp = filter->expression();
+            }
+            delete filter;
+          }
+        }
+        else if ( childElem.localName() == QLatin1String( "MinScaleDenominator" ) )
+        {
+          bool ok;
+          int v = childElem.firstChild().nodeValue().toInt( &ok );
+          if ( ok )
+            scaleMinDenom = v;
+        }
+        else if ( childElem.localName() == QLatin1String( "MaxScaleDenominator" ) )
+        {
+          bool ok;
+          int v = childElem.firstChild().nodeValue().toInt( &ok );
+          if ( ok )
+            scaleMaxDenom = v;
+        }
+        else if ( childElem.localName() == QLatin1String( "TextSymbolizer" ) )
+        {
+          readSldTextSymbolizer( childElem, settings );
+        }
+
+        childElem = childElem.nextSiblingElement();
+      }
+
+      QgsRuleBasedLabeling::Rule *ruleLabeling = new QgsRuleBasedLabeling::Rule( &settings, scaleMinDenom, scaleMaxDenom, filterExp, label );
+      rootRule->appendChild( ruleLabeling );
+
+      ruleElem = ruleElem.nextSiblingElement();
+    }
+
+    setLabeling( new QgsRuleBasedLabeling( rootRule ) );
+    setLabelsEnabled( true );
   }
+  else
+  {
+    QgsDebugMsg( QStringLiteral( "Info: simple labeling" ) );
+    // retrieve the TextSymbolizer element child node
+    QDomElement textSymbolizerElem = ruleElem.firstChildElement( QStringLiteral( "TextSymbolizer" ) );
+    QgsPalLayerSettings s;
+    if ( readSldTextSymbolizer( textSymbolizerElem, s ) )
+    {
+      setLabeling( new QgsVectorLayerSimpleLabeling( s ) );
+      setLabelsEnabled( true );
+    }
+  }
+}
 
-  QgsPalLayerSettings settings;
-
+bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSettings &settings ) const
+{
+  if ( node.localName() != QLatin1String( "TextSymbolizer" ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Not a TextSymbolizer element: %1" ).arg( node.localName() ) );
+    return false;
+  }
+  QDomElement textSymbolizerElem = node.toElement();
   // Label
   QDomElement labelElem = textSymbolizerElem.firstChildElement( QStringLiteral( "Label" ) );
   if ( !labelElem.isNull() )
@@ -4132,19 +4309,22 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
         else
         {
           QgsDebugMsgLevel( QStringLiteral( "SLD label attribute error: %1" ).arg( exp.evalErrorString() ), 3 );
+          QgsDebugMsg( QStringLiteral( "SLD label attribute error: %1" ).arg( exp.evalErrorString() ) );
         }
       }
     }
     else
     {
       QgsDebugMsgLevel( QStringLiteral( "Info: PropertyName element not found." ), 4 );
-      return;
+      QgsDebugMsg( QStringLiteral( "Info: PropertyName element not found." ) );
+      return false;
     }
   }
   else
   {
     QgsDebugMsgLevel( QStringLiteral( "Info: Label element not found." ), 4 );
-    return;
+    QgsDebugMsg( QStringLiteral( "Info: Label element not found." ) );
+    return false;
   }
 
   QString fontFamily = QStringLiteral( "Sans-Serif" );
@@ -4157,44 +4337,35 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
   QDomElement fontElem = textSymbolizerElem.firstChildElement( QStringLiteral( "Font" ) );
   if ( !fontElem.isNull() )
   {
-    QString cssName;
-    QString elemText;
-    QDomElement cssElem = fontElem.firstChildElement( QStringLiteral( "CssParameter" ) );
-    while ( !cssElem.isNull() )
+    QgsStringMap fontSvgParams = QgsSymbolLayerUtils::getSvgParameterList( fontElem );
+    for ( QgsStringMap::iterator it = fontSvgParams.begin(); it != fontSvgParams.end(); ++it )
     {
-      cssName = cssElem.attribute( QStringLiteral( "name" ), QStringLiteral( "not_found" ) );
-      if ( cssName != QLatin1String( "not_found" ) )
-      {
-        elemText = cssElem.text();
-        if ( cssName == QLatin1String( "font-family" ) )
-        {
-          fontFamily = elemText;
-        }
-        else if ( cssName == QLatin1String( "font-style" ) )
-        {
-          fontItalic = ( elemText == QLatin1String( "italic" ) ) || ( elemText == QLatin1String( "Italic" ) );
-        }
-        else if ( cssName == QLatin1String( "font-size" ) )
-        {
-          bool ok;
-          int fontSize = elemText.toInt( &ok );
-          if ( ok )
-          {
-            fontPointSize = fontSize;
-          }
-        }
-        else if ( cssName == QLatin1String( "font-weight" ) )
-        {
-          if ( ( elemText == QLatin1String( "bold" ) ) || ( elemText == QLatin1String( "Bold" ) ) )
-            fontWeight = QFont::Bold;
-        }
-        else if ( cssName == QLatin1String( "font-underline" ) )
-        {
-          fontUnderline = ( elemText == QLatin1String( "underline" ) ) || ( elemText == QLatin1String( "Underline" ) );
-        }
-      }
+      QgsDebugMsg( QStringLiteral( "found fontSvgParams %1: %2" ).arg( it.key(), it.value() ) );
 
-      cssElem = cssElem.nextSiblingElement( QStringLiteral( "CssParameter" ) );
+      if ( it.key() == QLatin1String( "font-family" ) )
+      {
+        fontFamily = it.value();
+      }
+      else if ( it.key() == QLatin1String( "font-style" ) )
+      {
+        fontItalic = ( it.value() == QLatin1String( "italic" ) ) || ( it.value() == QLatin1String( "Italic" ) );
+      }
+      else if ( it.key() == QLatin1String( "font-size" ) )
+      {
+        bool ok;
+        int fontSize = it.value().toInt( &ok );
+        if ( ok )
+          fontPointSize = fontSize;
+      }
+      else if ( it.key() == QLatin1String( "font-weight" ) )
+      {
+        if ( ( it.value() == QLatin1String( "bold" ) ) || ( it.value() == QLatin1String( "Bold" ) ) )
+          fontWeight = QFont::Bold;
+      }
+      else if ( it.key() == QLatin1String( "font-underline" ) )
+      {
+        fontUnderline = ( it.value() == QLatin1String( "underline" ) ) || ( it.value() == QLatin1String( "Underline" ) );
+      }
     }
   }
 
@@ -4205,9 +4376,13 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
   format.setSize( fontPointSize );
 
   // Fill
-  QColor textColor = QgsOgcUtils::colorFromOgcFill( textSymbolizerElem.firstChildElement( QStringLiteral( "Fill" ) ) );
+  QDomElement fillElem = textSymbolizerElem.firstChildElement( QStringLiteral( "Fill" ) );
+  QColor textColor;
+  Qt::BrushStyle textBrush = Qt::SolidPattern;
+  QgsSymbolLayerUtils::fillFromSld( fillElem, textBrush, textColor );
   if ( textColor.isValid() )
   {
+    QgsDebugMsg( QStringLiteral( "Info: textColor %1." ).arg( QVariant( textColor ).toString() ) );
     format.setColor( textColor );
   }
 
@@ -4231,9 +4406,13 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
       }
     }
 
-    QColor bufferColor = QgsOgcUtils::colorFromOgcFill( haloElem.firstChildElement( QStringLiteral( "Fill" ) ) );
+    QDomElement haloFillElem = haloElem.firstChildElement( QStringLiteral( "Fill" ) );
+    QColor bufferColor;
+    Qt::BrushStyle bufferBrush = Qt::SolidPattern;
+    QgsSymbolLayerUtils::fillFromSld( haloFillElem, bufferBrush, bufferColor );
     if ( bufferColor.isValid() )
     {
+      QgsDebugMsg( QStringLiteral( "Info: bufferColor %1." ).arg( QVariant( bufferColor ).toString() ) );
       bufferSettings.setColor( bufferColor );
     }
   }
@@ -4272,6 +4451,30 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
           }
         }
       }
+      QDomElement anchorPointElem = pointPlacementElem.firstChildElement( QStringLiteral( "AnchorPoint" ) );
+      if ( !anchorPointElem.isNull() )
+      {
+        QDomElement anchorPointXElem = anchorPointElem.firstChildElement( QStringLiteral( "AnchorPointX" ) );
+        if ( !anchorPointXElem.isNull() )
+        {
+          bool ok;
+          double xOffset = anchorPointXElem.text().toDouble( &ok );
+          if ( ok )
+          {
+            settings.xOffset = xOffset;
+          }
+        }
+        QDomElement anchorPointYElem = anchorPointElem.firstChildElement( QStringLiteral( "AnchorPointY" ) );
+        if ( !anchorPointYElem.isNull() )
+        {
+          bool ok;
+          double yOffset = anchorPointYElem.text().toDouble( &ok );
+          if ( ok )
+          {
+            settings.yOffset = yOffset;
+          }
+        }
+      }
 
       QDomElement rotationElem = pointPlacementElem.firstChildElement( QStringLiteral( "Rotation" ) );
       if ( !rotationElem.isNull() )
@@ -4288,8 +4491,7 @@ void QgsVectorLayer::readSldLabeling( const QDomNode &node )
 
   format.setBuffer( bufferSettings );
   settings.setFormat( format );
-  setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );
-  setLabelsEnabled( true );
+  return true;
 }
 
 QgsEditFormConfig QgsVectorLayer::editFormConfig() const

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -71,6 +71,7 @@ class QgsVectorLayerEditBuffer;
 class QgsVectorLayerJoinBuffer;
 class QgsVectorLayerFeatureCounter;
 class QgsAbstractVectorLayerLabeling;
+class QgsPalLayerSettings;
 class QgsPoint;
 class QgsFeedback;
 class QgsAuxiliaryStorage;
@@ -2662,6 +2663,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     //! Read labeling from SLD
     void readSldLabeling( const QDomNode &node );
+
+    //! Read settings from SLD TextSymbolizer element
+    bool readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSettings &settings ) const;
 
     //! Read simple labeling from layer's custom properties (QGIS 2.x projects)
     QgsAbstractVectorLayerLabeling *readLabelingFromCustomProperties();

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -238,18 +238,10 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, QgsWkbTyp
     QDomElement ruleElem = featTypeStyleElem.firstChildElement( QStringLiteral( "Rule" ) );
     while ( !ruleElem.isNull() )
     {
-      ruleCount++;
-
-      // append a clone of all Rules to the merged FeatureTypeStyle element
-      mergedFeatTypeStyle.appendChild( ruleElem.cloneNode().toElement() );
-      // more rules present, use the RuleRenderer
-
-      if ( ruleCount > 1 )
-      {
-        QgsDebugMsgLevel( QStringLiteral( "more Rule elements found: need a RuleRenderer" ), 2 );
-        needRuleRenderer = true;
-      }
-
+      // test rule children element to check if we need to create RuleRenderer
+      // and if the rule has a symbolizer
+      bool hasRendererSymbolizer = false;
+      bool hasRuleRenderer = false;
       QDomElement ruleChildElem = ruleElem.firstChildElement();
       while ( !ruleChildElem.isNull() )
       {
@@ -258,12 +250,38 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, QgsWkbTyp
              ruleChildElem.localName() == QLatin1String( "MinScaleDenominator" ) ||
              ruleChildElem.localName() == QLatin1String( "MaxScaleDenominator" ) )
         {
-          QgsDebugMsgLevel( QStringLiteral( "Filter or Min/MaxScaleDenominator element found: need a RuleRenderer" ), 2 );
-          needRuleRenderer = true;
-          break;
+          hasRuleRenderer = true;
+        }
+        // rule has a renderer symbolizer, not a text symbolizer
+        else if ( ruleChildElem.localName().endsWith( QLatin1String( "Symbolizer" ) ) &&
+                  ruleChildElem.localName() != QLatin1String( "TextSymbolizer" ) )
+        {
+          QgsDebugMsgLevel( QStringLiteral( "Symbolizer element found and not a TextSymbolizer" ), 2 );
+          hasRendererSymbolizer = true;
         }
 
         ruleChildElem = ruleChildElem.nextSiblingElement();
+      }
+
+      if ( hasRendererSymbolizer )
+      {
+        ruleCount++;
+
+        // append a clone of all Rules to the merged FeatureTypeStyle element
+        mergedFeatTypeStyle.appendChild( ruleElem.cloneNode().toElement() );
+
+        if ( hasRuleRenderer )
+        {
+          QgsDebugMsgLevel( QStringLiteral( "Filter or Min/MaxScaleDenominator element found: need a RuleRenderer" ), 2 );
+          needRuleRenderer = true;
+        }
+      }
+
+      // more rules present, use the RuleRenderer
+      if ( ruleCount > 1 )
+      {
+        QgsDebugMsgLevel( QStringLiteral( "more Rule elements found: need a RuleRenderer" ), 2 );
+        needRuleRenderer = true;
       }
 
       ruleElem = ruleElem.nextSiblingElement( QStringLiteral( "Rule" ) );

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -401,6 +401,52 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         self.assertEqual(first_size, second_size)
         self.assertEqual(first_unit, second_unit)
 
+    def test_Literal_within_CSSParameter_and_Text(self):
+        layer = createLayerWithOneLine()
+        mFilePath = os.path.join(TEST_DATA_DIR, 'symbol_layer/external_sld/simple_line_with_text.sld')
+        layer.loadSldStyle(mFilePath)
+        props = layer.renderer().symbol().symbolLayers()[0].properties()
+
+        def testLineColor():
+            # stroke SvgParameter within ogc:Literal
+            # expected color is #003EBA, RGB 0,62,186
+            self.assertEqual(layer.renderer().symbol().symbolLayers()[0].color().name(), '#003eba')
+
+        def testLineWidth():
+            # stroke-width SvgParameter within ogc:Literal
+            self.assertEqual(props['line_width'], '2')
+
+        def testLineOpacity():
+            # stroke-opacity SvgParameter NOT within ogc:Literal
+            # stroke-opacity=0.1
+            self.assertEqual(props['line_color'], '0,62,186,24')
+
+        testLineColor()
+        testLineWidth()
+        testLineOpacity()
+
+        from qgis.core import QgsPalLayerSettings
+
+        self.assertTrue(layer.labelsEnabled())
+        self.assertEqual(layer.labeling().type(), 'simple')
+
+        settings = layer.labeling().settings()
+        self.assertEqual(settings.fieldName, 'name')
+
+        format = settings.format()
+        self.assertEqual(format.color().name(), '#ff0000')
+
+        font = format.font()
+        self.assertEqual(font.family(), 'QGIS Vera Sans')
+        self.assertTrue(font.bold())
+        self.assertFalse(font.italic())
+
+        self.assertEqual(format.size(), 18)
+
+        self.assertEqual(settings.placement, QgsPalLayerSettings.OverPoint)
+        self.assertEqual(settings.xOffset, 1)
+        self.assertEqual(settings.yOffset, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/symbol_layer/external_sld/simple_line_with_text.sld
+++ b/tests/testdata/symbol_layer/external_sld/simple_line_with_text.sld
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" version="1.1.0" xmlns:se="http://www.opengis.net/se">
+ <NamedLayer>
+  <se:Name>simple_line</se:Name>
+  <UserStyle>
+   <se:Name>simple_line</se:Name>
+   <se:FeatureTypeStyle>
+    <se:Rule>
+     <se:Name>Single symbol</se:Name>
+     <se:LineSymbolizer>
+      <se:Stroke>
+       <se:SvgParameter name="stroke">#003eba</se:SvgParameter>
+       <se:SvgParameter name="stroke-opacity">0.098</se:SvgParameter>
+       <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+       <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+       <se:SvgParameter name="stroke-linecap">square</se:SvgParameter>
+      </se:Stroke>
+     </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+     <se:TextSymbolizer>
+      <se:Label>
+       <ogc:PropertyName>name</ogc:PropertyName>
+      </se:Label>
+      <se:Font>
+        <se:SvgParameter name="font-family">QGIS Vera Sans</se:SvgParameter>
+        <se:SvgParameter name="font-size">18</se:SvgParameter>
+        <se:SvgParameter name="font-weight">bold</se:SvgParameter>
+      </se:Font>
+      <se:LabelPlacement>
+       <se:PointPlacement>
+        <se:AnchorPoint>
+          <se:AnchorPointX>1</se:AnchorPointX>
+          <se:AnchorPointY>0</se:AnchorPointY>
+        </se:AnchorPoint>
+       </se:PointPlacement>
+      </se:LabelPlacement>
+      <se:Fill>
+       <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+      </se:Fill>
+      <se:VendorOption name="maxDisplacement">1</se:VendorOption>
+     </se:TextSymbolizer>
+    </se:Rule>
+   </se:FeatureTypeStyle>
+  </UserStyle>
+ </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
## Description
The error was:
* QgsRenderer did not exclude SLD TextSymbolzer as a rendering configuration.
* QgsVectorLayer did not well detect SLD Text Symbolizer
* QgsVectorLayer did not well read SLD Labeling produced by QgsVectorLayer

The QgsOgcUtils and QgsSymbolLayerUtils classes have to be enhanced for a better homogenized capabilities.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
