### PR TITLE
Extend temporary layer warning to include layers stored inside temp paths

### DIFF
--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -513,6 +513,16 @@ Returns ``True`` if the layer is considered a spatial layer, ie it has some form
 .. versionadded:: 2.16
 %End
 
+    virtual bool isTemporary() const;
+%Docstring
+Returns ``True`` if the layer is considered a temporary layer.
+
+These include memory-only layers such as those created by the "memory" data provider, or layers
+stored inside a local temporary folder (such as the "/tmp" folder on Linux).
+
+.. versionadded:: 3.10.1
+%End
+
     enum ReadFlag
     {
       FlagDontResolveLayers,

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -298,7 +298,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( vlayer )
       {
-        if ( vlayer->providerType() == QLatin1String( "memory" ) )
+        if ( vlayer->isTemporary() )
         {
           QAction *actionMakePermanent = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
           connect( actionMakePermanent, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );

--- a/src/app/qgslayertreeviewmemoryindicator.cpp
+++ b/src/app/qgslayertreeviewmemoryindicator.cpp
@@ -42,10 +42,10 @@ void QgsLayerTreeViewMemoryIndicatorProvider::onIndicatorClicked( const QModelIn
 
 bool QgsLayerTreeViewMemoryIndicatorProvider::acceptLayer( QgsMapLayer *layer )
 {
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( !( vlayer && vlayer->isValid() ) )
+  if ( !layer )
     return false;
-  return  vlayer->providerType() == QLatin1String( "memory" );
+
+  return layer->isTemporary();
 }
 
 QString QgsLayerTreeViewMemoryIndicatorProvider::iconName( QgsMapLayer *layer )
@@ -56,7 +56,9 @@ QString QgsLayerTreeViewMemoryIndicatorProvider::iconName( QgsMapLayer *layer )
 
 QString QgsLayerTreeViewMemoryIndicatorProvider::tooltipText( QgsMapLayer *layer )
 {
-  Q_UNUSED( layer )
-  return tr( "<b>Temporary scratch layer only!</b><br>Contents will be discarded after closing this project" );
+  if ( layer->providerType() == QLatin1String( "memory" ) )
+    return tr( "<b>Temporary scratch layer only!</b><br>Contents will be discarded after closing this project" );
+
+  return tr( "<b>Temporary layer only!</b><br>Contents will be discarded after closing QGIS." );
 }
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1727,6 +1727,31 @@ bool QgsMapLayer::isSpatial() const
   return true;
 }
 
+bool QgsMapLayer::isTemporary() const
+{
+  // invalid layers are temporary? -- who knows?!
+  if ( !isValid() )
+    return false;
+
+  if ( mProviderKey == QLatin1String( "memory" ) )
+    return true;
+
+  const QVariantMap sourceParts = QgsProviderRegistry::instance()->decodeUri( mProviderKey, mDataSource );
+  const QString path = sourceParts.value( QStringLiteral( "path" ) ).toString();
+  if ( path.isEmpty() )
+    return false;
+
+  // check if layer path is inside one of the standard temporary file locations for this platform
+  const QStringList tempPaths = QStandardPaths::standardLocations( QStandardPaths::TempLocation );
+  for ( const QString &tempPath : tempPaths )
+  {
+    if ( path.startsWith( tempPath ) )
+      return true;
+  }
+
+  return false;
+}
+
 void QgsMapLayer::setValid( bool valid )
 {
   mValid = valid;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -523,6 +523,16 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual bool isSpatial() const;
 
     /**
+     * Returns TRUE if the layer is considered a temporary layer.
+     *
+     * These include memory-only layers such as those created by the "memory" data provider, or layers
+     * stored inside a local temporary folder (such as the "/tmp" folder on Linux).
+     *
+     * \since QGIS 3.10.1
+     */
+    virtual bool isTemporary() const;
+
+    /**
      * Flags which control project read behavior.
      * \since QGIS 3.10
      */


### PR DESCRIPTION
e.g. the "/tmp" folder on Linux

This can lead to irretrievable data loss.

Fixes #32582