### PR TITLE
Remove SIP convert to subclass code for QgsRubberBand and QgsVertexMarker

### DIFF
--- a/python/gui/auto_generated/qgsrubberband.sip.in
+++ b/python/gui/auto_generated/qgsrubberband.sip.in
@@ -10,11 +10,6 @@
 
 
 
-%ModuleHeaderCode
-// For ConvertToSubClassCode.
-#include <qgsrubberband.h>
-%End
-
 class QgsRubberBand : QObject, QgsMapCanvasItem
 {
 %Docstring
@@ -26,12 +21,6 @@ for tracking the mouse while drawing polylines or polygons.
 
 %TypeHeaderCode
 #include "qgsrubberband.h"
-%End
-%ConvertToSubClassCode
-    if ( dynamic_cast<QgsRubberBand *>( sipCpp ) )
-      sipType = sipType_QgsRubberBand;
-    else
-      sipType = nullptr;
 %End
   public:
 

--- a/python/gui/auto_generated/qgsvertexmarker.sip.in
+++ b/python/gui/auto_generated/qgsvertexmarker.sip.in
@@ -9,11 +9,6 @@
 
 
 
-%ModuleHeaderCode
-// For ConvertToSubClassCode.
-#include <qgsvertexmarker.h>
-%End
-
 class QgsVertexMarker : QgsMapCanvasItem
 {
 %Docstring
@@ -22,12 +17,6 @@ A class for marking vertices of features using e.g. circles or 'x'.
 
 %TypeHeaderCode
 #include "qgsvertexmarker.h"
-%End
-%ConvertToSubClassCode
-    if ( dynamic_cast<QgsVertexMarker *>( sipCpp ) )
-      sipType = sipType_QgsVertexMarker;
-    else
-      sipType = nullptr;
 %End
   public:
 

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -31,13 +31,6 @@
 class QgsVectorLayer;
 class QPaintEvent;
 
-#ifdef SIP_RUN
-% ModuleHeaderCode
-// For ConvertToSubClassCode.
-#include <qgsrubberband.h>
-% End
-#endif
-
 /**
  * \ingroup gui
  * A class for drawing transient features (e.g. digitizing lines) on the map.
@@ -49,14 +42,6 @@ class GUI_EXPORT QgsRubberBand : public QObject, public QgsMapCanvasItem
 {
     Q_OBJECT
 
-#ifdef SIP_RUN
-    SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( dynamic_cast<QgsRubberBand *>( sipCpp ) )
-      sipType = sipType_QgsRubberBand;
-    else
-      sipType = nullptr;
-    SIP_END
-#endif
   public:
 
     Q_PROPERTY( QColor fillColor READ fillColor WRITE setFillColor )

--- a/src/gui/qgsvertexmarker.h
+++ b/src/gui/qgsvertexmarker.h
@@ -22,13 +22,6 @@
 
 class QPainter;
 
-#ifdef SIP_RUN
-% ModuleHeaderCode
-// For ConvertToSubClassCode.
-#include <qgsvertexmarker.h>
-% End
-#endif
-
 /**
  * \ingroup gui
  * A class for marking vertices of features using e.g. circles or 'x'.
@@ -36,14 +29,6 @@ class QPainter;
 class GUI_EXPORT QgsVertexMarker : public QgsMapCanvasItem
 {
 
-#ifdef SIP_RUN
-    SIP_CONVERT_TO_SUBCLASS_CODE
-    if ( dynamic_cast<QgsVertexMarker *>( sipCpp ) )
-      sipType = sipType_QgsVertexMarker;
-    else
-      sipType = nullptr;
-    SIP_END
-#endif
   public:
 
     //! Icons


### PR DESCRIPTION
These conversions just crash sip (woo. sip. yay. good times.). I can't find
any alternative approach which avoids this crash, so just remove the cast
to avoid the crash.

Fixes #32700
