### PR TITLE
Processing - "Use filename as layer name" as default

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingcontext.sip.in
@@ -162,6 +162,13 @@ Ownership of ``processor`` is transferred.
 .. versionadded:: 3.2
 %End
 
+        void setOutputLayerName( QgsMapLayer *layer ) const;
+%Docstring
+Sets a ``layer`` name to match this output, respecting any local user settings which affect this name.
+
+.. versionadded:: 3.10.1
+%End
+
         QgsProject *project;
 
     };

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -49,7 +49,7 @@ class ProcessingConfig:
     VECTOR_LINE_STYLE = 'VECTOR_LINE_STYLE'
     VECTOR_POLYGON_STYLE = 'VECTOR_POLYGON_STYLE'
     FILTER_INVALID_GEOMETRIES = 'FILTER_INVALID_GEOMETRIES'
-    USE_FILENAME_AS_LAYER_NAME = 'USE_FILENAME_AS_LAYER_NAME'
+    PREFER_FILENAME_AS_LAYER_NAME = 'PREFER_FILENAME_AS_LAYER_NAME'
     KEEP_DIALOG_OPEN = 'KEEP_DIALOG_OPEN'
     PRE_EXECUTION_SCRIPT = 'PRE_EXECUTION_SCRIPT'
     POST_EXECUTION_SCRIPT = 'POST_EXECUTION_SCRIPT'
@@ -74,8 +74,8 @@ class ProcessingConfig:
             ProcessingConfig.tr('Keep dialog open after running an algorithm'), True))
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
-            ProcessingConfig.USE_FILENAME_AS_LAYER_NAME,
-            ProcessingConfig.tr('Use filename as layer name'), False))
+            ProcessingConfig.PREFER_FILENAME_AS_LAYER_NAME,
+            ProcessingConfig.tr('Prefer output filename for layer names'), True))
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
             ProcessingConfig.SHOW_PROVIDERS_TOOLTIP,

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -17,6 +17,8 @@
 
 #include "qgsprocessingcontext.h"
 #include "qgsprocessingutils.h"
+#include "qgsproviderregistry.h"
+#include "qgssettings.h"
 
 QgsProcessingContext::QgsProcessingContext()
   : mPreferredVectorFormat( QgsProcessingUtils::defaultVectorExtension() )
@@ -118,4 +120,40 @@ void QgsProcessingContext::LayerDetails::setPostProcessor( QgsProcessingLayerPos
     delete mPostProcessor;
 
   mPostProcessor = processor;
+}
+
+void QgsProcessingContext::LayerDetails::setOutputLayerName( QgsMapLayer *layer ) const
+{
+  if ( !layer )
+    return;
+
+  const bool preferFilenameAsLayerName = QgsSettings().value( QStringLiteral( "Processing/Configuration/PREFER_FILENAME_AS_LAYER_NAME" ), true ).toBool();
+
+  // note - for temporary layers, we don't use the filename, regardless of user setting (it will be meaningless!)
+  if ( ( preferFilenameAsLayerName && !layer->isTemporary() ) || name.isEmpty() )
+  {
+    const QVariantMap sourceParts = QgsProviderRegistry::instance()->decodeUri( layer->providerType(), layer->source() );
+    const QString layerName = sourceParts.value( QStringLiteral( "layerName" ) ).toString();
+    // if output layer name exists, use that!
+    if ( !layerName.isEmpty() )
+      layer->setName( layerName );
+    else
+    {
+      const QString path = sourceParts.value( QStringLiteral( "path" ) ).toString();
+      if ( !path.isEmpty() )
+      {
+        const QFileInfo fi( path );
+        layer->setName( fi.baseName() );
+      }
+      else if ( !name.isEmpty() )
+      {
+        // fallback to parameter's name -- shouldn't happen!
+        layer->setName( name );
+      }
+    }
+  }
+  else
+  {
+    layer->setName( name );
+  }
 }

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -172,10 +172,17 @@ class CORE_EXPORT QgsProcessingContext
         //! Default constructor
         LayerDetails() = default;
 
-        //! Friendly name for layer, to use when loading layer into project.
+        /**
+         * Friendly name for layer, possibly for use when loading layer into project.
+         *
+         * \warning Instead of directly using this value, prefer to call setOutputLayerName() to
+         * generate a layer name which respects the user's local Processing settings.
+         */
         QString name;
 
-        //! Associated output name from algorithm which generated the layer.
+        /**
+         * Associated output name from algorithm which generated the layer.
+         */
         QString outputName;
 
         /**
@@ -201,6 +208,13 @@ class CORE_EXPORT QgsProcessingContext
          * \since QGIS 3.2
          */
         void setPostProcessor( QgsProcessingLayerPostProcessorInterface *processor SIP_TRANSFER );
+
+        /**
+         * Sets a \a layer name to match this output, respecting any local user settings which affect this name.
+         *
+         * \since QGIS 3.10.1
+         */
+        void setOutputLayerName( QgsMapLayer *layer ) const;
 
         //! Destination project
         QgsProject *project = nullptr;


### PR DESCRIPTION
Seems this option is widely desirable and should be the new default. Here I've refined it's behavior, added unit tests, and changed the setting key so that everyone gets the new enabled-by-default state.

Fixes #32591