### PR TITLE
[Bugfix][Server] WFS: Add primary keys to request to build Server Feature Id

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -344,7 +344,7 @@ namespace QgsWfs
 #endif
 
       // Force pkAttributes in subset of attributes for primary fid building
-      QgsAttributeList pkAttributes = provider->pkAttributeIndexes();
+      const QgsAttributeList pkAttributes = provider->pkAttributeIndexes();
       if ( !pkAttributes.isEmpty() )
       {
         QgsAttributeList subsetOfAttrs = featureRequest.subsetOfAttributes();

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -323,6 +323,7 @@ namespace QgsWfs
         featureRequest.setFlags( featureRequest.flags() | QgsFeatureRequest::NoGeometry );
       else
         featureRequest.setFlags( featureRequest.flags() | ( withGeom ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry ) );
+
       // subset of attributes
       featureRequest.setSubsetOfAttributes( attrIndexes );
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
@@ -338,8 +339,28 @@ namespace QgsWfs
         featureRequest.setSubsetOfAttributes(
           accessControl->layerAttributes( vlayer, attributes ),
           vlayer->fields() );
+        attrIndexes = featureRequest.subsetOfAttributes();
       }
 #endif
+
+      // Force pkAttributes in subset of attributes for primary fid building
+      QgsAttributeList pkAttributes = provider->pkAttributeIndexes();
+      if ( !pkAttributes.isEmpty() )
+      {
+        QgsAttributeList subsetOfAttrs = featureRequest.subsetOfAttributes();
+        for ( int idx : pkAttributes )
+        {
+          if ( !subsetOfAttrs.contains( idx ) )
+          {
+            subsetOfAttrs.prepend( idx );
+          }
+        }
+        if ( subsetOfAttrs.size() != featureRequest.subsetOfAttributes().size() )
+        {
+          featureRequest.setSubsetOfAttributes( subsetOfAttrs );
+        }
+      }
+
       if ( onlyOneLayer )
       {
         requestPrecision = QgsServerProjectUtils::wfsLayerPrecision( *project, vlayer->id() );


### PR DESCRIPTION
## Description
To build Server Feature Id, it is necessary to add primary keys to the subset of attributes of the request used in WFS GetFeature Request.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
