### PR TITLE
[BUGFIX] Fix an hardcoded 'gpkg' extension in ProcessingConfig.py

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -152,7 +152,7 @@ class ProcessingConfig:
             ProcessingConfig.tr('General'),
             ProcessingConfig.DEFAULT_OUTPUT_VECTOR_LAYER_EXT,
             ProcessingConfig.tr('Default output vector layer extension'),
-            'gpkg',
+            QgsVectorFileWriter.supportedFormatExtensions()[0],
             valuetype=Setting.SELECTION,
             options=extensions))
 


### PR DESCRIPTION
## Description
GDAL must be compiled with sqlite to enable gpkg. Don't hardcode 'gpkg' but use `QgsVectorFileWriter.supportedFormatExtensions()[0]` instead that will return 'gpkg' if present else 'shp'.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
