### PR TITLE
Urlencode non ascii chars in User-Agent

### DIFF
--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -221,8 +221,8 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   QString userAgent = s.value( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), "Mozilla/5.0" ).toString();
   if ( !userAgent.isEmpty() )
     userAgent += ' ';
-  userAgent += QStringLiteral( "QGIS/%1" ).arg( Qgis::version() );
-  pReq->setRawHeader( "User-Agent", QUrlQuery( userAgent ).toString( QUrl::ComponentFormattingOption::EncodeUnicode ).toUtf8() );
+  userAgent += QStringLiteral( "QGIS/%1" ).arg( Qgis::versionInt() );
+  pReq->setRawHeader( "User-Agent", userAgent.toLatin1() );
 
 #ifndef QT_NO_SSL
   bool ishttps = pReq->url().scheme().compare( QLatin1String( "https" ), Qt::CaseInsensitive ) == 0;

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -222,7 +222,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   if ( !userAgent.isEmpty() )
     userAgent += ' ';
   userAgent += QStringLiteral( "QGIS/%1" ).arg( Qgis::version() );
-  pReq->setRawHeader( "User-Agent", userAgent.toUtf8() );
+  pReq->setRawHeader( "User-Agent", QUrlQuery( userAgent ).toString( QUrl::ComponentFormattingOption::EncodeUnicode ).toUtf8() );
 
 #ifndef QT_NO_SSL
   bool ishttps = pReq->url().scheme().compare( QLatin1String( "https" ), Qt::CaseInsensitive ) == 0;


### PR DESCRIPTION
Fixes #32740

This fixes the issue on my tests, the user agent looks like this:

```
'User-Agent', 'Mozilla/5.0 QGIS/Coru%C3%B1a'
```

I tried to encode following https://tools.ietf.org/html/rfc2047 but it didn't work, if anyone has a better idea about how to encode non-ascii chars in the headers please speak out.

Also, there is no transliterate options in `toAscii()` that is just an (misnamed) alias to `toLatin1()` that encodes in `ISO-8859-15` and does not solve this issue either.

