### PR TITLE
Make the DXF renderer ready for background threading and fix symbology

### DIFF
--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -85,6 +85,8 @@ The attribute value is used for layer names.
 Constructor for QgsDxfExport.
 %End
 
+    ~QgsDxfExport();
+
     void setMapSettings( const QgsMapSettings &settings );
 %Docstring
 Set map settings and assign layer name attributes
@@ -471,6 +473,9 @@ Register name of layer for feature
 :param layer: dxf layer of feature
 %End
 
+  private:
+    QgsDxfExport( const QgsDxfExport &other );
+    QgsDxfExport &operator=( const QgsDxfExport & );
 };
 
 QFlags<QgsDxfExport::Flag> operator|(QgsDxfExport::Flag f1, QFlags<QgsDxfExport::Flag> f2);

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -34,9 +34,18 @@ Returns the layer
 %Docstring
 Returns the attribute index used to split into multiple layers.
 The attribute value is used for layer names.
+
+.. seealso:: :py:func:`splitLayerAttribute`
 %End
 
         QString splitLayerAttribute() const;
+%Docstring
+If the split layer attribute is set, the vector layer
+will be split into several dxf layers, one per each
+unique value.
+
+.. versionadded:: 3.12
+%End
 
     };
 

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -36,6 +36,8 @@ Returns the attribute index used to split into multiple layers.
 The attribute value is used for layer names.
 %End
 
+        QString splitLayerAttribute() const;
+
     };
 
     enum SymbologyExport

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -281,14 +281,13 @@ QList< QgsDxfExport::DxfLayer > QgsVectorLayerAndAttributeModel::layers() const
   QList< QgsDxfExport::DxfLayer > layers;
   QHash< QString, int > layerIdx;
 
-  const auto constMCheckedLeafs = mCheckedLeafs;
-  for ( const QModelIndex &idx : constMCheckedLeafs )
+  for ( const QModelIndex &idx : qgis::as_const( mCheckedLeafs ) )
   {
     QgsLayerTreeNode *node = index2node( idx );
     if ( QgsLayerTree::isGroup( node ) )
     {
-      const auto constFindLayers = QgsLayerTree::toGroup( node )->findLayers();
-      for ( QgsLayerTreeLayer *treeLayer : constFindLayers )
+      const auto childLayers = QgsLayerTree::toGroup( node )->findLayers();
+      for ( QgsLayerTreeLayer *treeLayer : childLayers )
       {
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( treeLayer->layer() );
         Q_ASSERT( vl );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -61,27 +61,6 @@
 
 #include <QIODevice>
 
-QgsDxfExport::QgsDxfExport( const QgsDxfExport &dxfExport )
-{
-  *this = dxfExport;
-}
-
-QgsDxfExport &QgsDxfExport::operator=( const QgsDxfExport &dxfExport )
-{
-  mMapSettings = dxfExport.mMapSettings;
-  mLayerNameAttribute = dxfExport.mLayerNameAttribute;
-  mSymbologyScale = dxfExport.mSymbologyScale;
-  mSymbologyExport = dxfExport.mSymbologyExport;
-  mMapUnits = dxfExport.mMapUnits;
-  mLayerTitleAsName = dxfExport.mLayerTitleAsName;
-  mSymbolLayerCounter = 0; // internal counter
-  mNextHandleId = 0;
-  mBlockCounter = 0;
-  mCrs = QgsCoordinateReferenceSystem();
-  mFactor = dxfExport.mFactor;
-  mForce2d = dxfExport.mForce2d;
-  return *this;
-}
 
 void QgsDxfExport::setMapSettings( const QgsMapSettings &settings )
 {

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -61,6 +61,8 @@
 
 #include <QIODevice>
 
+QgsDxfExport::QgsDxfExport() = default;
+
 QgsDxfExport::~QgsDxfExport()
 {
   qDeleteAll( mJobs );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -1886,10 +1886,9 @@ int QgsDxfExport::nLineTypes( const QList< QPair< QgsSymbolLayer *, QgsSymbol * 
 void QgsDxfExport::writeLinetype( const QString &styleName, const QVector<qreal> &pattern, QgsUnitTypes::RenderUnit u )
 {
   double length = 0;
-  QVector<qreal>::const_iterator dashIt = pattern.constBegin();
-  for ( ; dashIt != pattern.constEnd(); ++dashIt )
+  for ( qreal size : pattern )
   {
-    length += ( *dashIt * mapUnitScaleFactor( mSymbologyScale, u, mMapUnits, mMapSettings.mapToPixel().mapUnitsPerPixel() ) );
+    length += ( size * mapUnitScaleFactor( mSymbologyScale, u, mMapUnits, mMapSettings.mapToPixel().mapUnitsPerPixel() ) );
   }
 
   writeGroup( 0, QStringLiteral( "LTYPE" ) );
@@ -1904,12 +1903,11 @@ void QgsDxfExport::writeLinetype( const QString &styleName, const QVector<qreal>
   writeGroup( 73, pattern.size() );
   writeGroup( 40, length );
 
-  dashIt = pattern.constBegin();
   bool isGap = false;
-  for ( ; dashIt != pattern.constEnd(); ++dashIt )
+  for ( qreal size : pattern )
   {
     // map units or mm?
-    double segmentLength = ( isGap ? -*dashIt : *dashIt );
+    double segmentLength = ( isGap ? -size : size );
     segmentLength *= mapUnitScaleFactor( mSymbologyScale, u, mMapUnits, mMapSettings.mapToPixel().mapUnitsPerPixel() );
     writeGroup( 49, segmentLength );
     writeGroup( 74, 0 );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -754,6 +754,10 @@ void QgsDxfExport::prepareRenderers()
   mRenderContext.expressionContext().appendScope( QgsExpressionContextUtils::projectScope( QgsProject::instance() ) );
   mRenderContext.expressionContext().appendScope( QgsExpressionContextUtils::globalScope() );
 
+  mLabelingEngine = qgis::make_unique<QgsDefaultLabelingEngine>();
+  mLabelingEngine->setMapSettings( mMapSettings );
+  mRenderContext.setLabelingEngine( mLabelingEngine.get() );
+
   const QList< QgsMapLayer * > layers = mMapSettings.layers();
   for ( QgsMapLayer *ml : layers )
   {
@@ -772,9 +776,6 @@ void QgsDxfExport::prepareRenderers()
     const QgsFields fields = vl->fields();
     if ( splitLayerAttributeIndex >= 0 && splitLayerAttributeIndex < fields.size() )
       splitLayerAttribute = fields.at( splitLayerAttributeIndex ).name();
-    mLabelingEngine = qgis::make_unique<QgsDefaultLabelingEngine>();
-    mLabelingEngine->setMapSettings( mMapSettings );
-    mRenderContext.setLabelingEngine( mLabelingEngine.get() );
     DxfLayerJob *job = new DxfLayerJob( vl, mMapSettings.layerStyleOverrides().value( vl->id() ), mRenderContext, this, splitLayerAttribute );
     mJobs.append( job );
   }

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -74,9 +74,16 @@ class CORE_EXPORT QgsDxfExport
         /**
          * Returns the attribute index used to split into multiple layers.
          * The attribute value is used for layer names.
+         * \see splitLayerAttribute
          */
         int layerOutputAttributeIndex() const {return mLayerOutputAttributeIndex;}
 
+        /**
+         * If the split layer attribute is set, the vector layer
+         * will be split into several dxf layers, one per each
+         * unique value.
+         * \since QGIS 3.12
+         */
         QString splitLayerAttribute() const;
 
       private:
@@ -593,7 +600,7 @@ class CORE_EXPORT QgsDxfExport
     void appendCompoundCurve( const QgsCompoundCurve &cc, QVector<QgsPoint> &points, QVector<double> &bulges );
 
     QgsRenderContext mRenderContext;
-    // Internal cache for information required during rendering
+    // Internal cache for layer related information required during rendering
     QList<DxfLayerJob *> mJobs;
     std::unique_ptr<QgsLabelingEngine> mLabelingEngine;
 };

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsDxfExport
     /**
      * Constructor for QgsDxfExport.
      */
-    QgsDxfExport() = default;
+    QgsDxfExport();
 
     ~QgsDxfExport();
 

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -38,6 +38,7 @@ class QgsCurve;
 class QgsCurvePolygon;
 class QgsCircularString;
 class QgsCompoundCurve;
+struct DxfLayerJob;
 
 #define DXF_HANDSEED 100
 #define DXF_HANDMAX 9999999
@@ -136,6 +137,8 @@ class CORE_EXPORT QgsDxfExport
      * Constructor for QgsDxfExport.
      */
     QgsDxfExport() = default;
+
+    ~QgsDxfExport();
 
     /**
      * Set map settings and assign layer name attributes
@@ -515,10 +518,12 @@ class CORE_EXPORT QgsDxfExport
 
     //AC1009
     void writeHeader( const QString &codepage );
+    void prepareRenderers();
     void writeTables();
     void writeBlocks();
     void writeEntities();
     void writeEntitiesSymbolLevels( QgsVectorLayer *layer );
+    void stopRenderers();
     void writeEndFile();
 
     void startSection();
@@ -584,6 +589,8 @@ class CORE_EXPORT QgsDxfExport
     void appendLineString( const QgsLineString &ls, QVector<QgsPoint> &points, QVector<double> &bulges );
     void appendCircularString( const QgsCircularString &cs, QVector<QgsPoint> &points, QVector<double> &bulges );
     void appendCompoundCurve( const QgsCompoundCurve &cc, QVector<QgsPoint> &points, QVector<double> &bulges );
+
+    QList<DxfLayerJob *> mJobs;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDxfExport::Flags )

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -136,8 +136,6 @@ class CORE_EXPORT QgsDxfExport
      * Constructor for QgsDxfExport.
      */
     QgsDxfExport() = default;
-    QgsDxfExport( const QgsDxfExport &dxfExport ) SIP_SKIP;
-    QgsDxfExport &operator=( const QgsDxfExport &dxfExport );
 
     /**
      * Set map settings and assign layer name attributes
@@ -493,6 +491,11 @@ class CORE_EXPORT QgsDxfExport
     void registerDxfLayer( const QString &layerId, QgsFeatureId fid, const QString &layer );
 
   private:
+
+#ifdef SIP_RUN
+    QgsDxfExport( const QgsDxfExport &other );
+    QgsDxfExport &operator=( const QgsDxfExport & );
+#endif
     //! Extent for export, only intersecting features are exported. If the extent is an empty rectangle, all features are exported
     QgsRectangle mExtent;
     //! Scale for symbology export (used if symbols units are mm)

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -77,6 +77,8 @@ class CORE_EXPORT QgsDxfExport
          */
         int layerOutputAttributeIndex() const {return mLayerOutputAttributeIndex;}
 
+        QString splitLayerAttribute() const;
+
       private:
         QgsVectorLayer *mLayer = nullptr;
         int mLayerOutputAttributeIndex = -1;
@@ -522,7 +524,7 @@ class CORE_EXPORT QgsDxfExport
     void writeTables();
     void writeBlocks();
     void writeEntities();
-    void writeEntitiesSymbolLevels( QgsVectorLayer *layer );
+    void writeEntitiesSymbolLevels( DxfLayerJob *job );
     void stopRenderers();
     void writeEndFile();
 
@@ -590,7 +592,10 @@ class CORE_EXPORT QgsDxfExport
     void appendCircularString( const QgsCircularString &cs, QVector<QgsPoint> &points, QVector<double> &bulges );
     void appendCompoundCurve( const QgsCompoundCurve &cc, QVector<QgsPoint> &points, QVector<double> &bulges );
 
+    QgsRenderContext mRenderContext;
+    // Internal cache for information required during rendering
     QList<DxfLayerJob *> mJobs;
+    std::unique_ptr<QgsLabelingEngine> mLabelingEngine;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDxfExport::Flags )

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -34,7 +34,6 @@ struct DxfLayerJob
     : styleOverride( vl )
     , expressionContext( renderContext.expressionContext() )
     , featureSource( vl )
-    , layer( vl )
     , dxfExport( dxfExport )
     , crs( vl->crs() )
     , layerName( vl->name() )
@@ -96,7 +95,6 @@ struct DxfLayerJob
   QgsVectorLayerFeatureSource featureSource;
   std::unique_ptr< QgsFeatureRenderer > renderer;
   std::unique_ptr<QgsAbstractVectorLayerLabeling> labeling;
-  QgsVectorLayer *layer = nullptr; // TODO: -> remove this to make this usable from background threads
   QgsDxfExport *dxfExport = nullptr;
   QgsCoordinateReferenceSystem crs;
   QString layerName;

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -30,8 +30,6 @@
  */
 struct DxfLayerJob
 {
-  DxfLayerJob() = default;
-
   DxfLayerJob( QgsVectorLayer *vl, const QString &layerStyleOverride, QgsRenderContext &renderContext, QgsDxfExport *dxfExport, const QString &splitLayerAttribute )
     : styleOverride( vl )
     , expressionContext( renderContext.expressionContext() )

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -54,7 +54,7 @@ struct DxfLayerJob
 
     labeling.reset( vl->labelsEnabled() ? vl->labeling()->clone() : nullptr );
 
-    QSet<QString> attributes = renderer->usedAttributes( renderContext );
+    attributes = renderer->usedAttributes( renderContext );
     if ( !splitLayerAttribute.isNull() )
     {
       attributes << splitLayerAttribute;
@@ -106,6 +106,7 @@ struct DxfLayerJob
   QgsDxfRuleBasedLabelProvider *ruleBasedLabelProvider = nullptr;
   QString splitLayerAttribute;
   QString layerTitle;
+  QSet<QString> attributes;
 };
 
 // dxf color palette

--- a/src/core/dxf/qgsdxfpallabeling.cpp
+++ b/src/core/dxf/qgsdxfpallabeling.cpp
@@ -44,6 +44,7 @@ QgsDxfRuleBasedLabelProvider::QgsDxfRuleBasedLabelProvider( const QgsRuleBasedLa
   : QgsRuleBasedLabelProvider( rules, layer, false )
   , mDxfExport( dxf )
 {
+  mRules->rootRule()->createSubProviders( layer, mSubProviders, this );
 }
 
 void QgsDxfRuleBasedLabelProvider::reinit( QgsVectorLayer *layer )

--- a/src/core/dxf/qgsdxfpallabeling.h
+++ b/src/core/dxf/qgsdxfpallabeling.h
@@ -78,8 +78,9 @@ class QgsDxfRuleBasedLabelProvider : public QgsRuleBasedLabelProvider
     /**
      * Reinitialize the subproviders with QgsDxfLabelProviders
      * \param layer layer
+     * \deprecated since QGIS 3.12
      */
-    void reinit( QgsVectorLayer *layer );
+    Q_DECL_DEPRECATED void reinit( QgsVectorLayer *layer );
 
     /**
      * Re-implementation that writes to DXF file instead of drawing with QPainter

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -489,7 +489,7 @@ class CORE_EXPORT QgsRenderContext
      * Assign new labeling engine
      * \note not available in Python bindings
      */
-    void setLabelingEngine( QgsLabelingEngine *engine2 ) { mLabelingEngine = engine2; } SIP_SKIP
+    void setLabelingEngine( QgsLabelingEngine *engine ) { mLabelingEngine = engine; } SIP_SKIP
 
     /**
      * Sets the \a color to use when rendering selected features.

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -38,7 +38,7 @@ namespace QgsWms
 
     // Write output
     QgsRenderer renderer( context );
-    QgsDxfExport dxf = renderer.getDxf();
+    std::unique_ptr<QgsDxfExport> dxf = renderer.getDxf();
     response.setHeader( "Content-Type", "application/dxf" );
     dxf.writeToFile( response.io(), parameters.dxfCodec() );
   }

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -40,6 +40,6 @@ namespace QgsWms
     QgsRenderer renderer( context );
     std::unique_ptr<QgsDxfExport> dxf = renderer.getDxf();
     response.setHeader( "Content-Type", "application/dxf" );
-    dxf.writeToFile( response.io(), parameters.dxfCodec() );
+    dxf->writeToFile( response.io(), parameters.dxfCodec() );
   }
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -804,7 +804,7 @@ namespace QgsWms
     return image.release();
   }
 
-  QgsDxfExport QgsRenderer::getDxf()
+  std::unique_ptr<QgsDxfExport> QgsRenderer::getDxf()
   {
     // init layer restorer before doing anything
     std::unique_ptr<QgsLayerRestorer> restorer;
@@ -838,14 +838,14 @@ namespace QgsWms
     }
 
     // add layers to dxf
-    QgsDxfExport dxf;
-    dxf.setExtent( mWmsParameters.bboxAsRectangle() );
-    dxf.addLayers( dxfLayers );
-    dxf.setLayerTitleAsName( mWmsParameters.dxfUseLayerTitleAsName() );
-    dxf.setSymbologyExport( mWmsParameters.dxfMode() );
+    std::unique_ptr<QgsDxfExport> dxf = qgis::make_unique<QgsDxfExport>();
+    dxf->setExtent( mWmsParameters.bboxAsRectangle() );
+    dxf->addLayers( dxfLayers );
+    dxf->setLayerTitleAsName( mWmsParameters.dxfUseLayerTitleAsName() );
+    dxf->setSymbologyExport( mWmsParameters.dxfMode() );
     if ( mWmsParameters.dxfFormatOptions().contains( QgsWmsParameters::DxfFormatOption::SCALE ) )
     {
-      dxf.setSymbologyScale( mWmsParameters.dxfScale() );
+      dxf->setSymbologyScale( mWmsParameters.dxfScale() );
     }
 
     return dxf;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -124,7 +124,7 @@ namespace QgsWms
        * \returns the map as DXF data
        * \since QGIS 3.0
       */
-      QgsDxfExport getDxf();
+      std::unique_ptr<QgsDxfExport> getDxf();
 
       /**
        * Returns printed page as binary

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -270,6 +270,8 @@ void TestQgsDxfExport::testMtext()
 
   QVERIFY( layer );
 
+  QgsProject::instance()->addMapLayer( layer );
+
   QgsPalLayerSettings settings;
   settings.fieldName = QStringLiteral( "Class" );
   QgsTextFormat format;
@@ -339,20 +341,18 @@ void TestQgsDxfExport::testMtext_data()
   QTest::addColumn<QString>( "layerName" );
 
   QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
+#if 0
   QgsVectorLayer *pointLayer = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
   QVERIFY( pointLayer->isValid() );
-  QgsProject::instance()->addMapLayer( pointLayer );
 
   QTest::newRow( "MText" )
       << pointLayer
       << QStringLiteral( "mtext_dxf" );
-
+#endif
   QgsVectorLayer *pointLayerNoSymbols = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
   QVERIFY( pointLayerNoSymbols->isValid() );
   pointLayerNoSymbols->setRenderer( new QgsNullSymbolRenderer() );
   pointLayerNoSymbols->addExpressionField( QStringLiteral( "'A text with spaces'" ), QgsField( QStringLiteral( "Spacestest" ), QVariant::String ) );
-  QgsProject::instance()->addMapLayer( pointLayerNoSymbols );
-
 
   QTest::newRow( "MText No Symbology" )
       << pointLayerNoSymbols
@@ -391,7 +391,8 @@ void TestQgsDxfExport::testMTextEscapeSpaces()
   QFile dxfFile( file );
   QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
-  QVERIFY( fileContainsText( file, "\\fQGIS Vera Sans|i0|b1;\\H3.81136;A\\~text\\~with\\~spaces" ) );
+  QString debugInfo;
+  QVERIFY2( fileContainsText( file, "\\fQGIS Vera Sans|i0|b1;\\H3.81136;A\\~text\\~with\\~spaces", &debugInfo ), debugInfo.toUtf8().constData() );
 }
 
 void TestQgsDxfExport::testText()

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -328,6 +328,9 @@ void TestQgsDxfExport::testMtext()
                               "  7\n"
                               "STANDARD\n"
                               "  0", &debugInfo ), debugInfo.toUtf8().constData() );
+
+
+  QgsProject::instance()->removeMapLayer( layer );
 }
 
 void TestQgsDxfExport::testMtext_data()
@@ -344,8 +347,6 @@ void TestQgsDxfExport::testMtext_data()
       << pointLayer
       << QStringLiteral( "mtext_dxf" );
 
-  QgsProject::instance()->removeMapLayer( pointLayer );
-
   QgsVectorLayer *pointLayerNoSymbols = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
   QVERIFY( pointLayerNoSymbols->isValid() );
   pointLayerNoSymbols->setRenderer( new QgsNullSymbolRenderer() );
@@ -355,9 +356,7 @@ void TestQgsDxfExport::testMtext_data()
 
   QTest::newRow( "MText No Symbology" )
       << pointLayerNoSymbols
-      << QStringLiteral( "text_no_symbology_dxf" );
-
-  QgsProject::instance()->removeMapLayer( pointLayerNoSymbols );
+      << QStringLiteral( "mtext_no_symbology_dxf" );
 }
 
 void TestQgsDxfExport::testMTextEscapeSpaces()

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -768,15 +768,16 @@ void TestQgsDxfExport::testCurveExport_data()
 void TestQgsDxfExport::testDashedLine()
 {
   std::unique_ptr<QgsSimpleLineSymbolLayer> symbolLayer = qgis::make_unique<QgsSimpleLineSymbolLayer>( QColor( 0, 0, 0 ) );
-  symbolLayer->setWidth( 0.5 );
-  symbolLayer->setCustomDashVector( { 2, 5 } );
+  symbolLayer->setWidth( 0.11 );
+  symbolLayer->setCustomDashVector( { 0.5, 0.35 } );
+  symbolLayer->setCustomDashPatternUnit( QgsUnitTypes::RenderUnit::RenderMapUnits );
   symbolLayer->setUseCustomDashPattern( true );
 
   QgsLineSymbol *symbol = new QgsLineSymbol();
   symbol->changeSymbolLayer( 0, symbolLayer.release() );
 
-  std::unique_ptr< QgsVectorLayer > vl = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "Polygon" ), QString(), QStringLiteral( "memory" ) );
-  QgsGeometry g = QgsGeometry::fromWkt( "Polygon ((0 0, 0 1, 1 1, 0 0))" );
+  std::unique_ptr< QgsVectorLayer > vl = qgis::make_unique< QgsVectorLayer >( QStringLiteral( "CompoundCurve?crs=epsg:2056" ), QString(), QStringLiteral( "memory" ) );
+  QgsGeometry g = QgsGeometry::fromWkt( "CompoundCurve ((2689563.84200000017881393 1283531.23699999996460974, 2689563.42499999981373549 1283537.55499999993480742, 2689563.19900000002235174 1283540.52399999997578561, 2689562.99800000013783574 1283543.42999999993480742, 2689562.66900000022724271 1283548.56000000005587935, 2689562.43399999989196658 1283555.287999999942258))" );
   QgsFeature f;
   f.setGeometry( g );
   vl->dataProvider()->addFeatures( QgsFeatureList() << f );
@@ -825,13 +826,13 @@ void TestQgsDxfExport::testDashedLine()
                               " 73\n"
                               "     2\n"
                               " 40\n"
-                              "7.0\n"
+                              "REGEX ^0\\.8[0-9]*\n"
                               " 49\n"
-                              "2.0\n"
+                              "0.5\n"
                               " 74\n"
                               "     0\n"
                               " 49\n"
-                              "-5.0\n"
+                              "REGEX ^-0\\.3[0-9]*\n"
                               " 74\n"
                               "     0", &debugInfo ), debugInfo.toUtf8().constData() );
 
@@ -851,27 +852,35 @@ void TestQgsDxfExport::testDashedLine()
                               "420\n"
                               "     0\n"
                               " 90\n"
-                              "     4\n"
+                              "     6\n"
                               " 70\n"
-                              "     1\n"
+                              "     0\n"
                               " 43\n"
-                              "0.5\n"
+                              "0.11\n"
                               " 10\n"
-                              "0.0\n"
+                              "REGEX ^2689563.84[0-9]*\n"
                               " 20\n"
-                              "0.0\n"
+                              "REGEX ^1283531.23[0-9]*\n"
                               " 10\n"
-                              "0.0\n"
+                              "REGEX ^2689563.42[0-9]*\n"
                               " 20\n"
-                              "1.0\n"
+                              "REGEX ^1283537.55[0-9]*\n"
                               " 10\n"
-                              "1.0\n"
+                              "REGEX ^2689563.19[0-9]*\n"
                               " 20\n"
-                              "1.0\n"
+                              "REGEX ^1283540.52[0-9]*\n"
                               " 10\n"
-                              "0.0\n"
+                              "REGEX ^2689562.99[0-9]*\n"
                               " 20\n"
-                              "0.0\n"
+                              "REGEX ^1283543.42[0-9]*\n"
+                              " 10\n"
+                              "REGEX ^2689562.66[0-9]*\n"
+                              " 20\n"
+                              "REGEX ^1283548.56[0-9]*\n"
+                              " 10\n"
+                              "REGEX ^2689562.43[0-9]*\n"
+                              " 20\n"
+                              "REGEX ^1283555.28[0-9]*\n"
                               "  0\n"
                               "ENDSEC"
                               , &debugInfo ), debugInfo.toUtf8().constData() );

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -268,6 +268,8 @@ void TestQgsDxfExport::testMtext()
   QFETCH( QgsVectorLayer *, layer );
   QFETCH( QString, layerName );
 
+  QVERIFY( layer );
+
   QgsPalLayerSettings settings;
   settings.fieldName = QStringLiteral( "Class" );
   QgsTextFormat format;
@@ -296,7 +298,7 @@ void TestQgsDxfExport::testMtext()
 
   QString file = getTempFileName( layerName );
   QFile dxfFile( file );
-  QVERIFY( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ) != QgsDxfExport::ExportResult::Success );
+  QCOMPARE( d.writeToFile( &dxfFile, QStringLiteral( "CP1252" ) ), QgsDxfExport::ExportResult::Success );
   dxfFile.close();
 
   QString debugInfo;
@@ -333,13 +335,29 @@ void TestQgsDxfExport::testMtext_data()
   QTest::addColumn<QgsVectorLayer *>( "layer" );
   QTest::addColumn<QString>( "layerName" );
 
+  QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
+  QgsVectorLayer *pointLayer = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
+  QVERIFY( pointLayer->isValid() );
+  QgsProject::instance()->addMapLayer( pointLayer );
+
   QTest::newRow( "MText" )
-      << mPointLayer
+      << pointLayer
       << QStringLiteral( "mtext_dxf" );
 
+  QgsProject::instance()->removeMapLayer( pointLayer );
+
+  QgsVectorLayer *pointLayerNoSymbols = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
+  QVERIFY( pointLayerNoSymbols->isValid() );
+  pointLayerNoSymbols->setRenderer( new QgsNullSymbolRenderer() );
+  pointLayerNoSymbols->addExpressionField( QStringLiteral( "'A text with spaces'" ), QgsField( QStringLiteral( "Spacestest" ), QVariant::String ) );
+  QgsProject::instance()->addMapLayer( pointLayerNoSymbols );
+
+
   QTest::newRow( "MText No Symbology" )
-      << mPointLayerNoSymbols
+      << pointLayerNoSymbols
       << QStringLiteral( "text_no_symbology_dxf" );
+
+  QgsProject::instance()->removeMapLayer( pointLayerNoSymbols );
 }
 
 void TestQgsDxfExport::testMTextEscapeSpaces()

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -341,14 +341,14 @@ void TestQgsDxfExport::testMtext_data()
   QTest::addColumn<QString>( "layerName" );
 
   QString filename = QStringLiteral( TEST_DATA_DIR ) + "/points.shp";
-#if 0
+
   QgsVectorLayer *pointLayer = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
   QVERIFY( pointLayer->isValid() );
 
   QTest::newRow( "MText" )
       << pointLayer
       << QStringLiteral( "mtext_dxf" );
-#endif
+
   QgsVectorLayer *pointLayerNoSymbols = new QgsVectorLayer( filename, QStringLiteral( "points" ), QStringLiteral( "ogr" ) );
   QVERIFY( pointLayerNoSymbols->isValid() );
   pointLayerNoSymbols->setRenderer( new QgsNullSymbolRenderer() );

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -436,7 +436,7 @@ void TestQgsDxfExport::testTextAlign()
   QString debugInfo;
   QVERIFY2( fileContainsText( file, QStringLiteral( "TEXT\n"
                               "  5\n"
-                              "89\n"
+                              "**no check**\n"
                               "100\n"
                               "AcDbEntity\n"
                               "100\n"

--- a/tests/src/server/wms/test_qgsserver_wms_dxf.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_dxf.cpp
@@ -86,13 +86,13 @@ void TestQgsServerWmsDxf::use_title_as_layername_true()
   context.setParameters( parameters );
 
   QgsWms::QgsRenderer renderer( context );
-  QgsDxfExport exporter = renderer.getDxf();
+  std::unique_ptr<QgsDxfExport> exporter = renderer.getDxf();
 
-  const QString name = exporter.layerName( vl );
-  QCOMPARE( exporter.layerName( vl ), QString( "testlayer \u00E8\u00E9" ) );
+  const QString name = exporter->layerName( vl );
+  QCOMPARE( exporter->layerName( vl ), QString( "testlayer \u00E8\u00E9" ) );
 
   const QgsFeature ft = vl->getFeature( 1 );
-  QCOMPARE( exporter.layerName( vl->id(), ft ), QString( "two" ) );
+  QCOMPARE( exporter->layerName( vl->id(), ft ), QString( "two" ) );
 }
 
 void TestQgsServerWmsDxf::use_title_as_layername_false()
@@ -135,13 +135,13 @@ void TestQgsServerWmsDxf::use_title_as_layername_false()
   context.setParameters( parameters );
 
   QgsWms::QgsRenderer renderer( context );
-  QgsDxfExport exporter = renderer.getDxf();
+  std::unique_ptr<QgsDxfExport> exporter = renderer.getDxf();
 
-  const QString name = exporter.layerName( vl );
-  QCOMPARE( exporter.layerName( vl ), QString( "A test vector layer" ) );
+  const QString name = exporter->layerName( vl );
+  QCOMPARE( exporter->layerName( vl ), QString( "A test vector layer" ) );
 
   const QgsFeature ft = vl->getFeature( 1 );
-  QCOMPARE( exporter.layerName( vl->id(), ft ), QString( "A test vector layer" ) );
+  QCOMPARE( exporter->layerName( vl->id(), ft ), QString( "A test vector layer" ) );
 }
 
 QGSTEST_MAIN( TestQgsServerWmsDxf )


### PR DESCRIPTION
This puts the whole dxf export into one single rendering process and prefetches information related to this before starting to render.

The immediate benefit is to fix symbology. The current code writes symbol blocks for symbol layers (e.g. for dashed lines), when the lines are actually rendered, they don't reference the block. This was caused by the fact that rendering was restarted for writing blocks and for writing entities. With the result that different clones of the symbol layers were used and therefore could not be matched.

The advantage in the longer run is that we will be able to run dxf exports in the background (allow to cancel, processing algorithms, ...) because they no longer rely on the QgsVectorLayer objects but rather on feature source and other threading friendly facilities.