### PR TITLE
Topology is unavailable when user cannot read topology.topology

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -353,10 +353,9 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
     {
       QgsMessageLog::logMessage( tr( "Your PostGIS installation has no GEOS support. Feature selection and identification will not work properly. Please install PostGIS with GEOS support (http://geos.refractions.net)" ), tr( "PostGIS" ) );
     }
-
-    if ( hasTopology() )
+    else
     {
-      QgsDebugMsg( QStringLiteral( "Topology support available!" ) );
+      QgsDebugMsg( QStringLiteral( "GEOS support available!" ) );
     }
   }
 
@@ -1095,6 +1094,15 @@ QString QgsPostgresConn::postgisVersion()
     {
       mTopologyAvailable = true;
     }
+  }
+
+  if ( mTopologyAvailable )
+  {
+    QgsDebugMsg( QStringLiteral( "Topology support available!" ) );
+  }
+  else
+  {
+    QgsDebugMsg( QStringLiteral( "Topology support not available :(" ) );
   }
 
   mGotPostgisVersion = true;

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -543,7 +543,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
                    " AND a.attnum>0"
                    " AND n.oid=c.relnamespace"
                    " AND has_schema_privilege(n.nspname,'usage')"
-                   " AND has_table_privilege('\"'||n.nspname||'\".\"'||c.relname||'\"','select')" // user has select privilege
+                   " AND has_table_privilege(c.oid,'select')" // user has select privilege
                  )
           .arg( tableName, schemaName, columnName, typeName, sridName, dimName, gtableName )
           .arg( 1 )
@@ -662,7 +662,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
   //search for geometry columns in tables that are not in the geometry_columns metatable
   if ( !searchGeometryColumnsOnly )
   {
-    // Now have a look for geometry columns that aren't in the geometry_columns table.
+    // Now have a look for spatial columns that aren't in the geometry_columns table.
     QString sql = "SELECT"
                   " c.relname"
                   ",n.nspname"
@@ -677,7 +677,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
                   " LEFT JOIN pg_type b ON b.oid=t.typbasetype"
                   " WHERE c.relkind IN ('v','r','m','p')"
                   " AND has_schema_privilege( n.nspname, 'usage' )"
-                  " AND has_table_privilege( QUOTE_IDENT(n.nspname) || '.' || QUOTE_IDENT(c.relname), 'select' )"
+                  " AND has_table_privilege( c.oid, 'select' )"
                   " AND (t.typname IN ('geometry','geography','topogeometry') OR b.typname IN ('geometry','geography','topogeometry','pcpatch','raster'))";
 
     // user has select privilege
@@ -806,7 +806,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
                   ",pg_attribute a"
                   " WHERE pg_namespace.oid=pg_class.relnamespace"
                   " AND has_schema_privilege(pg_namespace.nspname,'usage')"
-                  " AND has_table_privilege('\"' || pg_namespace.nspname || '\".\"' || pg_class.relname || '\"','select')"
+                  " AND has_table_privilege(pg_class.oid,'select')"
                   " AND pg_class.relkind IN ('v','r','m','p')"
                   " AND pg_class.oid = a.attrelid"
                   " AND NOT a.attisdropped"

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -408,8 +408,11 @@ QStringList QgsPostgresConn::supportedSpatialTypes() const
   supportedSpatialTypes << quotedValue( "geometry" )
                         << quotedValue( "geography" )
                         << quotedValue( "pcpatch" );
-  if ( hasRaster() ) supportedSpatialTypes << quotedValue( "raster" );
-  if ( hasTopology() ) supportedSpatialTypes << quotedValue( "topogeometry" );
+  if ( hasRaster() )
+    supportedSpatialTypes << quotedValue( "raster" );
+
+  if ( hasTopology() )
+    supportedSpatialTypes << quotedValue( "topogeometry" );
 
   return supportedSpatialTypes;
 }
@@ -1081,7 +1084,7 @@ QString QgsPostgresConn::postgisVersion() const
 
   if ( mTopologyAvailable )
   {
-    QgsDebugMsg( QStringLiteral( "Topology support available!" ) );
+    QgsDebugMsg( QStringLiteral( "Topology support available :)" ) );
   }
   else
   {

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -202,37 +202,31 @@ class QgsPostgresConn : public QObject
     void unref();
 
     //! Gets postgis version string
-    QString postgisVersion();
+    QString postgisVersion() const;
 
     //! Gets status of GEOS capability
-    bool hasGEOS();
+    bool hasGEOS() const;
 
     //! Gets status of topology capability
-    bool hasTopology();
+    bool hasTopology() const;
 
     //! Gets status of Pointcloud capability
-    bool hasPointcloud();
+    bool hasPointcloud() const;
 
     //! Gets status of Raster capability
-    bool hasRaster();
-
-    //! Gets status of GIST capability
-    bool hasGIST();
-
-    //! Gets status of PROJ4 capability
-    bool hasPROJ();
+    bool hasRaster() const;
 
     //! encode wkb in hex
-    bool useWkbHex() { return mUseWkbHex; }
+    bool useWkbHex() const { return mUseWkbHex; }
 
     //! major PostGIS version
-    int majorVersion() { return mPostgisVersionMajor; }
+    int majorVersion() const { return mPostgisVersionMajor; }
 
     //! minor PostGIS version
-    int minorVersion() { return mPostgisVersionMinor; }
+    int minorVersion() const { return mPostgisVersionMinor; }
 
     //! PostgreSQL version
-    int pgVersion() { return mPostgresqlVersion; }
+    int pgVersion() const { return mPostgresqlVersion; }
 
     //! run a query and free result buffer
     bool PQexecNR( const QString &query );
@@ -395,44 +389,38 @@ class QgsPostgresConn : public QObject
     QString mConnInfo;
 
     //! GEOS capability
-    bool mGeosAvailable;
+    mutable bool mGeosAvailable;
 
     //! Topology capability
-    bool mTopologyAvailable;
+    mutable bool mTopologyAvailable;
 
     //! PostGIS version string
-    QString mPostgisVersionInfo;
+    mutable QString mPostgisVersionInfo;
 
-    //! Are mPostgisVersionMajor, mPostgisVersionMinor, mGeosAvailable, mGistAvailable, mProjAvailable, mTopologyAvailable valid?
-    bool mGotPostgisVersion;
+    //! Are mPostgisVersionMajor, mPostgisVersionMinor, mGeosAvailable, mTopologyAvailable valid?
+    mutable bool mGotPostgisVersion;
 
     //! PostgreSQL version
-    int mPostgresqlVersion;
+    mutable int mPostgresqlVersion;
 
     //! PostGIS major version
-    int mPostgisVersionMajor;
+    mutable int mPostgisVersionMajor;
 
     //! PostGIS minor version
-    int mPostgisVersionMinor;
-
-    //! GIST capability
-    bool mGistAvailable;
-
-    //! PROJ4 capability
-    bool mProjAvailable;
+    mutable int mPostgisVersionMinor;
 
     //! pointcloud support available
-    bool mPointcloudAvailable;
+    mutable bool mPointcloudAvailable;
 
     //! raster support available
-    bool mRasterAvailable;
+    mutable bool mRasterAvailable;
 
     //! encode wkb in hex
-    bool mUseWkbHex;
+    mutable bool mUseWkbHex;
 
     bool mReadOnly;
 
-    QStringList supportedSpatialTypes();
+    QStringList supportedSpatialTypes() const;
 
     static QMap<QString, QgsPostgresConn *> sConnectionsRW;
     static QMap<QString, QgsPostgresConn *> sConnectionsRO;

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -432,6 +432,8 @@ class QgsPostgresConn : public QObject
 
     bool mReadOnly;
 
+    QStringList supportedSpatialTypes();
+
     static QMap<QString, QgsPostgresConn *> sConnectionsRW;
     static QMap<QString, QgsPostgresConn *> sConnectionsRO;
 

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -126,6 +126,34 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
         self.assertEqual(srids_and_types,
                          [[0, 1], [0, 2], [0, 3], [0, 7], [3857, 1], [4326, 1]])
 
+        # Check TopoGeometry layers are found in vector table names
+
+        tables = conn.tables('qgis_test', QgsAbstractDatabaseProviderConnection.Vector)
+        table_names = self._table_names(tables)
+        self.assertTrue('TopoLayer1' in table_names)
+        self.assertTrue('geometries_table' in table_names)
+
+        # Revoke select permissions on topology.topology from qgis_test_user
+        conn.executeSql('REVOKE SELECT ON topology.topology FROM qgis_test_user')
+
+        # Re-connect as the qgis_test_role role
+        newuri = self.uri + ' user=qgis_test_user password=qgis_test_user_password'
+        conn = md.createConnection(newuri, {})
+
+        tables = conn.tables('qgis_test', QgsAbstractDatabaseProviderConnection.Vector)
+        table_names = self._table_names(tables)
+        self.assertFalse('TopoLayer1' in table_names)
+        self.assertTrue('geometries_table' in table_names)
+
+        # TODO: only revoke select permission on topology.layer, grant
+        #       on topology.topology
+
+        # TODO: only revoke usage permission on topology, grant
+        #       all on topology.layer and  topology.topology
+
+        # TODO: only revoke select permission the actual topology
+        #       schema associated with TopoLayer1
+
     # error: ERROR: relation "qgis_test.raster1" does not exist
     @unittest.skipIf(gdal.VersionInfo() < '2040000', 'This test requires GDAL >= 2.4.0')
     def test_postgis_raster_rename(self):

--- a/tests/testdata/provider/testdata_pg.sh
+++ b/tests/testdata/provider/testdata_pg.sh
@@ -5,10 +5,12 @@ DB=${DB:-qgis_test}
 SCRIPTS="
   tests/testdata/provider/testdata_pg.sql
   tests/testdata/provider/testdata_pg_reltests.sql
+  tests/testdata/provider/testdata_pg_role.sql
   tests/testdata/provider/testdata_pg_vectorjoin.sql
   tests/testdata/provider/testdata_pg_hstore.sql
   tests/testdata/provider/testdata_pg_array.sql
   tests/testdata/provider/testdata_pg_raster.sql
+  tests/testdata/provider/testdata_pg_topology.sql
   tests/testdata/provider/testdata_pg_domain.sql
   tests/testdata/provider/testdata_pg_json.sql
 "

--- a/tests/testdata/provider/testdata_pg_raster.sql
+++ b/tests/testdata/provider/testdata_pg_raster.sql
@@ -1,5 +1,3 @@
--- Table: qgis_test.raster1
-
 DO $$
 BEGIN
   IF EXISTS ( SELECT * FROM pg_catalog.pg_available_extensions
@@ -10,6 +8,8 @@ BEGIN
   END IF;
 END;
 $$;
+
+-- Table: qgis_test.Raster1
 
 CREATE TABLE qgis_test."Raster1"
 (

--- a/tests/testdata/provider/testdata_pg_role.sql
+++ b/tests/testdata/provider/testdata_pg_role.sql
@@ -1,0 +1,3 @@
+DROP USER IF EXISTS qgis_test_user;
+CREATE USER qgis_test_user PASSWORD 'qgis_test_user_password' LOGIN;
+

--- a/tests/testdata/provider/testdata_pg_topology.sql
+++ b/tests/testdata/provider/testdata_pg_topology.sql
@@ -1,0 +1,38 @@
+DO $$
+DECLARE
+  layerid INTEGER;
+
+BEGIN
+  IF EXISTS ( SELECT * FROM pg_catalog.pg_available_extensions
+              WHERE name = 'postgis_topology' )
+  THEN
+    RAISE NOTICE 'Loading postgis_topology';
+    CREATE EXTENSION IF NOT EXISTS postgis_topology;
+
+  -- Topology: qgis_test_Topo1
+
+  IF EXISTS ( SELECT * FROM pg_catalog.pg_namespace WHERE
+    nspname = 'qgis_test_Topo1' )
+  THEN
+    PERFORM topology.DropTopology('qgis_test_Topo1');
+  END IF;
+
+  PERFORM topology.CreateTopology('qgis_test_Topo1');
+
+  -- TopoLayer: qgis_test.TopoLayer1
+
+  DROP TABLE IF EXISTS qgis_test."TopoLayer1";
+  CREATE TABLE qgis_test."TopoLayer1" (id serial primary key);
+  layerid := topology.AddTopoGeometryColumn('qgis_test_Topo1',
+                                        'qgis_test',
+                                        'TopoLayer1',
+                                        'topogeom',
+                                        'POLYGON');
+  INSERT INTO qgis_test."TopoLayer1" (topogeom) SELECT
+    topology.toTopoGeom('POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))',
+        'qgis_test_Topo1', layerid);
+
+  END IF;
+END;
+$$;
+


### PR DESCRIPTION
Fixes determination of tables from metadata when user has no
privileges on topology. The bug was introduced by
commit bbdbca418c0eeb5a349fc257ad033adad7b4fc47

References #32002

Closes #32726