### PR TITLE
Update CreateConstantRaster.py

### DIFF
--- a/python/plugins/processing/algs/qgis/CreateConstantRaster.py
+++ b/python/plugins/processing/algs/qgis/CreateConstantRaster.py
@@ -84,8 +84,8 @@ class CreateConstantRaster(QgisAlgorithm):
         outputFile = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         outputFormat = QgsRasterFileWriter.driverForExtension(os.path.splitext(outputFile)[1])
 
-        rows = max([math.ceil(extent.height() / pixelSize), 1.0])
-        cols = max([math.ceil(extent.width() / pixelSize), 1.0])
+        rows = int(max([math.ceil(extent.height() / pixelSize), 1.0]))
+        cols = int(max([math.ceil(extent.width() / pixelSize), 1.0]))
 
         writer = QgsRasterFileWriter(outputFile)
         writer.setOutputProviderKey('gdal')


### PR DESCRIPTION
Cast cols (and rows) to int to fix the error.
This is fix that works for me with master on Ubuntu 18.04.
Fixes: #32827

Backporting to 3.4 should be straight forward.

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
