### PR TITLE
The "Convert map to raster" algorithm does not handle extent CRS corr…

### DIFF
--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -33,7 +33,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterBoolean,
     QgsProcessingParameterMapLayer,
-    QgsProcessingParameterRasterDestination,
+    QgsProcessinAgParameterRasterDestination,
     QgsRasterFileWriter
 )
 
@@ -171,7 +171,8 @@ class RasterizeAlgorithm(QgisAlgorithm):
         extent = self.parameterAsExtent(
             parameters,
             self.EXTENT,
-            context)
+            context,
+            context.project().crs())
 
         tile_size = self.parameterAsInt(
             parameters,

--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -33,7 +33,7 @@ from qgis.core import (
     QgsProcessingParameterNumber,
     QgsProcessingParameterBoolean,
     QgsProcessingParameterMapLayer,
-    QgsProcessinAgParameterRasterDestination,
+    QgsProcessingParameterRasterDestination,
     QgsRasterFileWriter
 )
 


### PR DESCRIPTION
The "Convert map to raster" algorithm does not handle extent CRS correctly.
This is a fix that works for me with master on Ubuntu 18.04.

Fixes #32829

Backporting to 3.4 should be straight forward.

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
