### PR TITLE
Followup 64949d : fix failure to load provider-provided style

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4677,20 +4677,26 @@ QString QgsVectorLayer::loadNamedStyle( const QString &theURI, bool &resultFlag,
 {
   QgsDataSourceUri dsUri( theURI );
   QString returnMessage;
+  QString qml, errorMsg;
   if ( !loadFromLocalDB && mDataProvider && mDataProvider->isSaveAndLoadStyleToDatabaseSupported() )
   {
-    QString qml, errorMsg;
     qml = QgsProviderRegistry::instance()->loadStyle( mProviderKey, mDataSource, errorMsg );
-    if ( !qml.isEmpty() )
-    {
-      QDomDocument myDocument( QStringLiteral( "qgis" ) );
-      myDocument.setContent( qml );
-      resultFlag = importNamedStyle( myDocument, errorMsg );
-      returnMessage = QObject::tr( "Loaded from Provider" );
-    }
   }
-  returnMessage = QgsMapLayer::loadNamedStyle( theURI, resultFlag, categories );
-  emit styleLoaded( categories );
+  if ( !qml.isEmpty() )
+  {
+    QDomDocument myDocument( QStringLiteral( "qgis" ) );
+    myDocument.setContent( qml );
+    resultFlag = importNamedStyle( myDocument, errorMsg );
+    returnMessage = QObject::tr( "Loaded from Provider" );
+  }
+  else
+  {
+    returnMessage = QgsMapLayer::loadNamedStyle( theURI, resultFlag, categories );
+  }
+
+  if ( resultFlag )
+    emit styleLoaded( categories );
+
   return returnMessage;
 }
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR is a follow up to this commit (https://github.com/qgis/QGIS/commit/64949dc227848cec94d3993e46f985664017587d) to fix loading of style from the provider. The regression lead to issues such as #32853 ).

@elpaso , ping.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
