### PR TITLE
Fix default defaultValue in algfactory (processing scripts)

### DIFF
--- a/python/processing/algfactory.py
+++ b/python/processing/algfactory.py
@@ -185,7 +185,7 @@ class AlgWrapper(QgsProcessingAlgorithm):
                 raise ProcessingAlgFactoryException("Can't find parent named {}".format(parentname))
 
         kwargs['description'] = kwargs.pop("label", "")
-        kwargs['defaultValue'] = kwargs.pop("default", "")
+        kwargs['defaultValue'] = kwargs.pop("default", None)
         advanced = kwargs.pop("advanced", False)
         try:
             if output:


### PR DESCRIPTION
## Description
   
According to doc: https://qgis.org/pyqgis/3.10/core/QgsProcessingParameterDefinition.html?highlight=qgsprocessingparameterdefinition#module-QgsProcessingParameterDefinition defaultValue should be `None` if not specified - In C++ the default is a null QVariant which map to `None` in Python.

But it is set to empty string in scripts  (python/processing/algfactory.py) which may be interpreted as acceptable value in some cases.

This PR set the defaultValue to 'None' if not specified as described in documentation and with respect to C++ and PyQgis implémentations.