### PR TITLE
[TilesXYZ] Render layers with scale-dependant styles correctly

### DIFF
--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -199,7 +199,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
         extent = QgsRectangle(*metatile.extent())
         threadSpecificSettings.setExtent(self.wgs_to_dest.transformBoundingBox(extent))
         threadSpecificSettings.setOutputSize(size)
-        
+
         #Append MapSettings scope in order to update map variables (e.g @map_scale) with new extent data
         exp_context = threadSpecificSettings.expressionContext()
         exp_context.appendScope(QgsExpressionContextUtils.mapSettingsScope(threadSpecificSettings))
@@ -270,7 +270,7 @@ class TilesXYZAlgorithmBase(QgisAlgorithm):
             labeling_engine_settings = self.settingsDictionary[thread].labelingEngineSettings()
             labeling_engine_settings.setFlag(QgsLabelingEngineSettings.UsePartialCandidates, False)
             self.settingsDictionary[thread].setLabelingEngineSettings(labeling_engine_settings)
-            
+
             # Transfer context scopes to MapSettings
             self.settingsDictionary[thread].setExpressionContext(context.expressionContext())
 


### PR DESCRIPTION
Now tiles are rendered correctly if there are layers with scale-dependant styles.

Fixes #30524

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
