### PR TITLE
Warn when we know for certain that no spatial index exists

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -412,6 +412,8 @@ iterator, eg by restricting the returned attributes or geometry.
 
     virtual QgsFeatureIds allFeatureIds() const;
 
+    virtual SpatialIndexPresence hasSpatialIndex() const;
+
 
     QgsExpressionContextScope *createExpressionContextScope() const /Factory/;
 %Docstring

--- a/python/core/auto_generated/qgsfeaturesource.sip.in
+++ b/python/core/auto_generated/qgsfeaturesource.sip.in
@@ -159,6 +159,24 @@ for its ownership.
 
 .. versionadded:: 3.0
 %End
+
+    enum SpatialIndexPresence
+    {
+      SpatialIndexUnknown,
+      SpatialIndexNotPresent,
+      SpatialIndexPresent,
+    };
+
+    virtual SpatialIndexPresence hasSpatialIndex() const;
+%Docstring
+Returns an enum value representing the presence of a valid spatial index on the source,
+if it can be determined.
+
+If QgsFeatureSource.SpatialIndexUnknown is returned then the presence of an index cannot
+be determined.
+
+.. versionadded:: 3.10.1
+%End
 };
 
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2558,6 +2558,9 @@ Sets the coordinate transform context to ``transformContext``
 .. versionadded:: 3.8
 %End
 
+    virtual SpatialIndexPresence hasSpatialIndex() const;
+
+
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
 
 

--- a/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
@@ -195,6 +195,7 @@ the QgsVectorLayerSelectedFeatureSource will not be reflected.
 
     virtual QgsExpressionContextScope *createExpressionContextScope() const;
 
+    virtual SpatialIndexPresence hasSpatialIndex() const;
 
 
 };

--- a/python/plugins/processing/algs/qgis/SpatialJoin.py
+++ b/python/plugins/processing/algs/qgis/SpatialJoin.py
@@ -38,7 +38,8 @@ from qgis.core import (QgsFields,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterString,
-                       QgsProcessingOutputNumber)
+                       QgsProcessingOutputNumber,
+                       QgsFeatureSource)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
@@ -205,6 +206,9 @@ class SpatialJoin(QgisAlgorithm):
         request = QgsFeatureRequest().setSubsetOfAttributes(join_field_indexes).setDestinationCrs(source.sourceCrs(), context.transformContext())
         features = join_source.getFeatures(request)
         total = 100.0 / join_source.featureCount() if join_source.featureCount() else 0
+
+        if source.hasSpatialIndex() == QgsFeatureSource.SpatialIndexNotPresent:
+            feedback.reportError(self.tr('No spatial index exists for input layer, performance will be severely degraded'))
 
         joined_count = 0
         unjoined_count = 0

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -259,12 +259,18 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   syncToLayer();
 
-  if ( mLayer->dataProvider() )//enable spatial index button group if supported by provider
+  if ( mLayer->dataProvider() )
   {
+    //enable spatial index button group if supported by provider, or if one already exists
     QgsVectorDataProvider::Capabilities capabilities = mLayer->dataProvider()->capabilities();
     if ( !( capabilities & QgsVectorDataProvider::CreateSpatialIndex ) )
     {
       pbnIndex->setEnabled( false );
+    }
+    if ( mLayer->dataProvider()->hasSpatialIndex() == QgsFeatureSource::SpatialIndexPresent )
+    {
+      pbnIndex->setEnabled( false );
+      pbnIndex->setText( tr( "Spatial Index Exists" ) );
     }
 
     if ( capabilities & QgsVectorDataProvider::SelectEncoding )
@@ -990,12 +996,13 @@ void QgsVectorLayerProperties::pbnIndex_clicked()
     setCursor( Qt::ArrowCursor );
     if ( errval )
     {
+      pbnIndex->setEnabled( false );
+      pbnIndex->setText( tr( "Spatial Index Exists" ) );
       QMessageBox::information( this, tr( "Spatial Index" ), tr( "Creation of spatial index successful" ) );
     }
     else
     {
-      // TODO: Remind the user to use OGR >= 1.2.6 and Shapefile
-      QMessageBox::information( this, tr( "Spatial Index" ), tr( "Creation of spatial index failed" ) );
+      QMessageBox::warning( this, tr( "Spatial Index" ), tr( "Creation of spatial index failed" ) );
     }
   }
 }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -1039,6 +1039,11 @@ QgsFeatureIds QgsProcessingFeatureSource::allFeatureIds() const
   return mSource->allFeatureIds();
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsProcessingFeatureSource::hasSpatialIndex() const
+{
+  return mSource->hasSpatialIndex();
+}
+
 QgsExpressionContextScope *QgsProcessingFeatureSource::createExpressionContextScope() const
 {
   QgsExpressionContextScope *expressionContextScope = nullptr;

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -466,6 +466,7 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
     QVariant maximumValue( int fieldIndex ) const override;
     QgsRectangle sourceExtent() const override;
     QgsFeatureIds allFeatureIds() const override;
+    SpatialIndexPresence hasSpatialIndex() const override;
 
     /**
      * Returns an expression context scope suitable for this source.

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -630,6 +630,11 @@ bool QgsMemoryProvider::createSpatialIndex()
   return true;
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsMemoryProvider::hasSpatialIndex() const
+{
+  return mSpatialIndex ? SpatialIndexPresent : SpatialIndexNotPresent;
+}
+
 QgsVectorDataProvider::Capabilities QgsMemoryProvider::capabilities() const
 {
   return AddFeatures | DeleteFeatures | ChangeGeometries |

--- a/src/core/providers/memory/qgsmemoryprovider.h
+++ b/src/core/providers/memory/qgsmemoryprovider.h
@@ -67,6 +67,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     bool setSubsetString( const QString &theSQL, bool updateFeatureCount = true ) override;
     bool supportsSubsetString() const override { return true; }
     bool createSpatialIndex() override;
+    QgsFeatureSource::SpatialIndexPresence hasSpatialIndex() const override;
     QgsVectorDataProvider::Capabilities capabilities() const override;
     bool truncate() override;
 

--- a/src/core/qgsfeaturesource.cpp
+++ b/src/core/qgsfeaturesource.cpp
@@ -187,3 +187,8 @@ QgsVectorLayer *QgsFeatureSource::materialize( const QgsFeatureRequest &request,
   return layer.release();
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsFeatureSource::hasSpatialIndex() const
+{
+  return SpatialIndexUnknown;
+}
+

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -179,6 +179,28 @@ class CORE_EXPORT QgsFeatureSource
      */
     QgsVectorLayer *materialize( const QgsFeatureRequest &request,
                                  QgsFeedback *feedback = nullptr ) SIP_FACTORY;
+
+    /**
+     * Enumeration of spatial index presence states.
+     * \since QGIS 3.10.1
+     */
+    enum SpatialIndexPresence
+    {
+      SpatialIndexUnknown = 0, //!< Spatial index presence cannot be determined, index may or may not exist
+      SpatialIndexNotPresent = 1, //!< No spatial index exists for the source
+      SpatialIndexPresent = 2, //!< A valid spatial index exists for the source
+    };
+
+    /**
+     * Returns an enum value representing the presence of a valid spatial index on the source,
+     * if it can be determined.
+     *
+     * If QgsFeatureSource::SpatialIndexUnknown is returned then the presence of an index cannot
+     * be determined.
+     *
+     * \since QGIS 3.10.1
+     */
+    virtual SpatialIndexPresence hasSpatialIndex() const;
 };
 
 Q_DECLARE_METATYPE( QgsFeatureSource * )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1437,6 +1437,11 @@ void QgsVectorLayer::setTransformContext( const QgsCoordinateTransformContext &t
     mDataProvider->setTransformContext( transformContext );
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsVectorLayer::hasSpatialIndex() const
+{
+  return mDataProvider ? mDataProvider->hasSpatialIndex() : QgsFeatureSource::SpatialIndexUnknown;
+}
+
 bool QgsVectorLayer::accept( QgsStyleEntityVisitorInterface *visitor ) const
 {
   if ( mRenderer )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2374,6 +2374,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     virtual void setTransformContext( const QgsCoordinateTransformContext &transformContext ) override;
 
+    SpatialIndexPresence hasSpatialIndex() const override;
+
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
   signals:

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -1249,6 +1249,14 @@ QgsExpressionContextScope *QgsVectorLayerSelectedFeatureSource::createExpression
     return nullptr;
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsVectorLayerSelectedFeatureSource::hasSpatialIndex() const
+{
+  if ( mLayer )
+    return mLayer->hasSpatialIndex();
+  else
+    return QgsFeatureSource::SpatialIndexUnknown;
+}
+
 //
 // QgsVectorLayerSelectedFeatureIterator
 //

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -315,7 +315,7 @@ class CORE_EXPORT QgsVectorLayerSelectedFeatureSource : public QgsFeatureSource,
     long featureCount() const override;
     QString sourceName() const override;
     QgsExpressionContextScope *createExpressionContextScope() const override;
-
+    SpatialIndexPresence hasSpatialIndex() const override;
 
   private:
 

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -282,6 +282,11 @@ bool QgsDelimitedTextProvider::createSpatialIndex()
   return true;
 }
 
+QgsFeatureSource::SpatialIndexPresence QgsDelimitedTextProvider::hasSpatialIndex() const
+{
+  return mSpatialIndex ? QgsFeatureSource::SpatialIndexPresent : QgsFeatureSource::SpatialIndexNotPresent;
+}
+
 // Really want to merge scanFile and rescan into single code.  Currently the reason
 // this is not done is that scanFile is done initially to create field names and, rescan
 // file includes building subset expression and assumes field names/types are already

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -86,78 +86,21 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
     /* Implementation of functions from QgsVectorDataProvider */
 
     QgsAbstractFeatureSource *featureSource() const override;
-
-    /**
-     * Returns the permanent storage type for this layer as a friendly name.
-     */
     QString storageType() const override;
-
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) const override;
-
     QgsWkbTypes::Type wkbType() const override;
-
     long featureCount() const override;
-
     QgsFields fields() const override;
-
-    /**
-     * Returns a bitmask containing the supported capabilities
-     * Note, some capabilities may change depending on whether
-     * a spatial filter is active on this provider, so it may
-     * be prudent to check this value per intended operation.
-     */
     QgsVectorDataProvider::Capabilities capabilities() const override;
-
-    /**
-     * Creates a spatial index on the data
-     * \returns indexCreated  Returns true if a spatial index is created
-     */
     bool createSpatialIndex() override;
-
-    /* Implementation of functions from QgsDataProvider */
-
-    /**
-     * Returns a provider name
-     *
-     *  Essentially just returns the provider key.  Should be used to build file
-     *  dialogs so that providers can be shown with their supported types. Thus
-     *  if more than one provider supports a given format, the user is able to
-     *  select a specific provider to open that file.
-     *
-     *  \note
-     *
-     *  Instead of being pure virtual, might be better to generalize this
-     *  behavior and presume that none of the sub-classes are going to do
-     *  anything strange with regards to their name or description?
-     */
+    QgsFeatureSource::SpatialIndexPresence hasSpatialIndex() const override;
     QString name() const override;
-
-    /**
-     * Returns description
-     *
-     *  Return a terse string describing what the provider is.
-     *
-     *  \note
-     *
-     *  Instead of being pure virtual, might be better to generalize this
-     *  behavior and presume that none of the sub-classes are going to do
-     *  anything strange with regards to their name or description?
-     */
     QString description() const override;
-
     QgsRectangle extent() const override;
     bool isValid() const override;
-
     QgsCoordinateReferenceSystem crs() const override;
-
-    /**
-     * Set the subset string used to create a subset of features in
-     * the layer.
-     */
     bool setSubsetString( const QString &subset, bool updateFeatureCount = true ) override;
-
     bool supportsSubsetString() const override { return true; }
-
     QString subsetString() const override
     {
       return mSubsetString;

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -26,7 +26,8 @@ from qgis.core import (
     QgsMemoryProviderUtils,
     QgsCoordinateReferenceSystem,
     QgsRectangle,
-    QgsTestUtils
+    QgsTestUtils,
+    QgsFeatureSource
 )
 
 from qgis.testing import (
@@ -642,6 +643,14 @@ class TestPyQgsMemoryProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(dp.addFeature(f))
 
         self.assertEqual([f.attributes() for f in dp.getFeatures()], [[1, True, NULL], [2, False, NULL], [3, NULL, NULL], [2, NULL, True]])
+
+    def testSpatialIndex(self):
+        vl = QgsVectorLayer(
+            'Point?crs=epsg:4326&field=f1:integer&field=f2:bool',
+            'test', 'memory')
+        self.assertEqual(vl.hasSpatialIndex(), QgsFeatureSource.SpatialIndexNotPresent)
+        vl.dataProvider().createSpatialIndex()
+        self.assertEqual(vl.hasSpatialIndex(), QgsFeatureSource.SpatialIndexPresent)
 
 
 class TestPyQgsMemoryProviderIndexed(unittest.TestCase, ProviderTestCase):

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -42,7 +42,8 @@ from qgis.core import (
     QgsRectangle,
     QgsApplication,
     QgsFeature,
-    QgsWkbTypes)
+    QgsWkbTypes,
+    QgsFeatureSource)
 
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath, compareWkt
@@ -887,6 +888,24 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         assert vl.isValid(), "{} is invalid".format(basetestfile)
         assert vl.wkbType() == QgsWkbTypes.PointM, "wrong wkb type, should be PointM"
         assert vl.getFeature(2).geometry().asWkt() == "PointM (-71.12300000000000466 78.23000000000000398 2)", "wrong PointM geometry"
+
+    def testSpatialIndex(self):
+        srcpath = os.path.join(TEST_DATA_DIR, 'provider')
+        basetestfile = os.path.join(srcpath, 'delimited_xyzm.csv')
+
+        url = MyUrl.fromLocalFile(basetestfile)
+        url.addQueryItem("crs", "epsg:4326")
+        url.addQueryItem("type", "csv")
+        url.addQueryItem("xField", "X")
+        url.addQueryItem("yField", "Y")
+        url.addQueryItem("spatialIndex", "no")
+
+        vl = QgsVectorLayer(url.toString(), 'test', 'delimitedtext')
+        self.assertTrue(vl.isValid())
+
+        self.assertEqual(vl.hasSpatialIndex(), QgsFeatureSource.SpatialIndexNotPresent)
+        vl.dataProvider().createSpatialIndex()
+        self.assertEqual(vl.hasSpatialIndex(), QgsFeatureSource.SpatialIndexPresent)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
...on a source used for the Join by Location algorithm

Advise users that performance will be severely degraded as a result. Results from a question asked at FOSS4G Oceania about why a join by location execution was taking 4-5 hours to run. (Correct answer: with a spatial index present, it takes only 3-4 minutes :laughing: )

Also improve UI around creating spatial indexes in the vector layer properties. 

Note that only the memory provider and delimited provider support determining spatial index presence -- GDAL has no api to test for this presence unfortunately.