### PR TITLE
Fix crash when resetting a project-less snapping config

### DIFF
--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -147,14 +147,17 @@ void QgsSnappingConfig::reset()
   mIntersectionSnapping = false;
 
   // set advanced config
-  mIndividualLayerSettings = QHash<QgsVectorLayer *, IndividualLayerSettings>();
-  const auto constMapLayers = mProject->mapLayers();
-  for ( QgsMapLayer *ml : constMapLayers )
+  if ( mProject )
   {
-    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
-    if ( vl )
+    mIndividualLayerSettings = QHash<QgsVectorLayer *, IndividualLayerSettings>();
+    const auto constMapLayers = mProject->mapLayers();
+    for ( QgsMapLayer *ml : constMapLayers )
     {
-      mIndividualLayerSettings.insert( vl, IndividualLayerSettings( enabled, type, tolerance, units ) );
+      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
+      if ( vl )
+      {
+        mIndividualLayerSettings.insert( vl, IndividualLayerSettings( enabled, type, tolerance, units ) );
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR patches a crash when resetting a project-less snapping config object, as highlighted in #32867 .


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
