### PR TITLE
Weight field should be numeric in count points in polygon

### DIFF
--- a/python/plugins/processing/algs/qgis/PointsInPolygon.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygon.py
@@ -75,6 +75,7 @@ class PointsInPolygon(QgisAlgorithm):
                                                               self.tr('Points'), [QgsProcessing.TypeVectorPoint]))
         self.addParameter(QgsProcessingParameterField(self.WEIGHT,
                                                       self.tr('Weight field'), parentLayerParameterName=self.POINTS,
+                                                      type=QgsProcessingParameterField.Numeric,
                                                       optional=True))
         self.addParameter(QgsProcessingParameterField(self.CLASSFIELD,
                                                       self.tr('Class field'), parentLayerParameterName=self.POINTS,


### PR DESCRIPTION
alg if we want to sum them up
Using a string field the returned count is 0 while no field or numeric field returned count.