### PR TITLE
Only load plotly library on demand

### DIFF
--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -21,9 +21,8 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
 
+import warnings
 
 from qgis.core import (QgsFeatureRequest,
                        QgsProcessingParameterFeatureSource,
@@ -69,6 +68,16 @@ class BarPlot(QgisAlgorithm):
         return self.tr('Bar plot')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -21,8 +21,7 @@ __author__ = 'Matteo Ghetta'
 __date__ = 'March 2017'
 __copyright__ = '(C) 2017, Matteo Ghetta'
 
-import plotly as plt
-import plotly.graph_objs as go
+import warnings
 
 from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterFeatureSource,
@@ -80,6 +79,16 @@ class BoxPlot(QgisAlgorithm):
         return self.tr('Box plot')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/algs/qgis/HypsometricCurves.py
+++ b/python/plugins/processing/algs/qgis/HypsometricCurves.py
@@ -22,7 +22,6 @@ __date__ = 'November 2014'
 __copyright__ = '(C) 2014, Alexander Bruy'
 
 import os
-import numpy
 import csv
 
 from osgeo import gdal, ogr, osr
@@ -79,6 +78,11 @@ class HypsometricCurves(QgisAlgorithm):
         return self.tr('Hypsometric curves')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            import numpy
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “numpy” library. Please install this library and try again.'))
+
         raster_layer = self.parameterAsRasterLayer(parameters, self.INPUT_DEM, context)
         target_crs = raster_layer.crs()
         rasterPath = raster_layer.source()

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -21,8 +21,7 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
+import warnings
 
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
@@ -68,6 +67,16 @@ class MeanAndStdDevPlot(QgisAlgorithm):
         return self.tr('Mean and standard deviation plot')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -74,7 +74,10 @@ class PolarPlot(QgisAlgorithm):
         except ImportError:
             raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
 
-        import numpy as np
+        try:
+            import numpy as np
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “numpy” library. Please install this library and try again.'))
 
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -21,9 +21,7 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
-import numpy as np
+import warnings
 
 from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterFeatureSource,
@@ -66,6 +64,18 @@ class PolarPlot(QgisAlgorithm):
         return self.tr('Polar plot')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
+        import numpy as np
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
@@ -22,17 +22,6 @@ __date__ = 'December 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
 import os
-import warnings
-
-try:
-    # importing plotly throws Python warnings from within the library - filter these out
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=ResourceWarning)
-        warnings.filterwarnings("ignore", category=ImportWarning)
-        import plotly  # NOQA
-        hasPlotly = True
-except:
-    hasPlotly = False
 
 from qgis.core import (QgsApplication,
                        QgsProcessingProvider)
@@ -46,7 +35,9 @@ from .QgisAlgorithm import QgisAlgorithm
 from .AddTableField import AddTableField
 from .Aggregate import Aggregate
 from .Aspect import Aspect
+from .BarPlot import BarPlot
 from .BasicStatistics import BasicStatisticsForField
+from .BoxPlot import BoxPlot
 from .CheckValidity import CheckValidity
 from .Climb import Climb
 from .ConcaveHull import ConcaveHull
@@ -79,6 +70,7 @@ from .ImportIntoSpatialite import ImportIntoSpatialite
 from .KeepNBiggestParts import KeepNBiggestParts
 from .KNearestConcaveHull import KNearestConcaveHull
 from .LinesToPolygons import LinesToPolygons
+from .MeanAndStdDevPlot import MeanAndStdDevPlot
 from .MinimumBoundingGeometry import MinimumBoundingGeometry
 from .NearestNeighbourAnalysis import NearestNeighbourAnalysis
 from .Orthogonalize import Orthogonalize
@@ -89,6 +81,7 @@ from .PointsFromPolygons import PointsFromPolygons
 from .PointsInPolygon import PointsInPolygon
 from .PointsLayerFromTable import PointsLayerFromTable
 from .PointsToPaths import PointsToPaths
+from .PolarPlot import PolarPlot
 from .PoleOfInaccessibility import PoleOfInaccessibility
 from .Polygonize import Polygonize
 from .PostGISExecuteSQL import PostGISExecuteSQL
@@ -103,6 +96,7 @@ from .RandomSelection import RandomSelection
 from .RandomSelectionWithinSubsets import RandomSelectionWithinSubsets
 from .Rasterize import RasterizeAlgorithm
 from .RasterCalculator import RasterCalculator
+from .RasterLayerHistogram import RasterLayerHistogram
 from .RasterLayerStatistics import RasterLayerStatistics
 from .RasterSampling import RasterSampling
 from .RectanglesOvalsDiamondsFixed import RectanglesOvalsDiamondsFixed
@@ -132,6 +126,9 @@ from .TopoColors import TopoColor
 from .TruncateTable import TruncateTable
 from .UniqueValues import UniqueValues
 from .VariableDistanceBuffer import VariableDistanceBuffer
+from .VectorLayerHistogram import VectorLayerHistogram
+from .VectorLayerScatterplot import VectorLayerScatterplot
+from .VectorLayerScatterplot3D import VectorLayerScatterplot3D
 from .VectorSplit import VectorSplit
 from .VoronoiPolygons import VoronoiPolygons
 from .ZonalStatistics import ZonalStatistics
@@ -153,7 +150,9 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
         algs = [AddTableField(),
                 Aggregate(),
                 Aspect(),
+                BarPlot(),
                 BasicStatisticsForField(),
+                BoxPlot(),
                 CheckValidity(),
                 Climb(),
                 ConcaveHull(),
@@ -186,6 +185,7 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
                 KeepNBiggestParts(),
                 KNearestConcaveHull(),
                 LinesToPolygons(),
+                MeanAndStdDevPlot(),
                 MinimumBoundingGeometry(),
                 NearestNeighbourAnalysis(),
                 Orthogonalize(),
@@ -196,6 +196,7 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
                 PointsInPolygon(),
                 PointsLayerFromTable(),
                 PointsToPaths(),
+                PolarPlot(),
                 PoleOfInaccessibility(),
                 Polygonize(),
                 PostGISExecuteSQL(),
@@ -210,6 +211,7 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
                 RandomSelectionWithinSubsets(),
                 RasterCalculator(),
                 RasterizeAlgorithm(),
+                RasterLayerHistogram(),
                 RasterLayerStatistics(),
                 RasterSampling(),
                 RectanglesOvalsDiamondsFixed(),
@@ -240,29 +242,13 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
                 TruncateTable(),
                 UniqueValues(),
                 VariableDistanceBuffer(),
+                VectorLayerHistogram(),
+                VectorLayerScatterplot(),
+                VectorLayerScatterplot3D(),
                 VectorSplit(),
                 VoronoiPolygons(),
                 ZonalStatistics()
                 ]
-
-        if hasPlotly:
-            from .BarPlot import BarPlot
-            from .BoxPlot import BoxPlot
-            from .MeanAndStdDevPlot import MeanAndStdDevPlot
-            from .PolarPlot import PolarPlot
-            from .RasterLayerHistogram import RasterLayerHistogram
-            from .VectorLayerHistogram import VectorLayerHistogram
-            from .VectorLayerScatterplot import VectorLayerScatterplot
-            from .VectorLayerScatterplot3D import VectorLayerScatterplot3D
-
-            algs.extend([BarPlot(),
-                         BoxPlot(),
-                         MeanAndStdDevPlot(),
-                         PolarPlot(),
-                         RasterLayerHistogram(),
-                         VectorLayerHistogram(),
-                         VectorLayerScatterplot(),
-                         VectorLayerScatterplot3D()])
 
         # to store algs added by 3rd party plugins as scripts
         #folder = os.path.join(os.path.dirname(__file__), 'scripts')

--- a/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
@@ -28,10 +28,6 @@ from qgis.core import (QgsApplication,
 
 from PyQt5.QtCore import QCoreApplication
 
-from processing.script import ScriptUtils
-
-from .QgisAlgorithm import QgisAlgorithm
-
 from .AddTableField import AddTableField
 from .Aggregate import Aggregate
 from .Aspect import Aspect
@@ -132,10 +128,6 @@ from .VectorLayerScatterplot3D import VectorLayerScatterplot3D
 from .VectorSplit import VectorSplit
 from .VoronoiPolygons import VoronoiPolygons
 from .ZonalStatistics import ZonalStatistics
-
-
-pluginPath = os.path.normpath(os.path.join(
-    os.path.split(os.path.dirname(__file__))[0], os.pardir))
 
 
 class QgisAlgorithmProvider(QgsProcessingProvider):
@@ -249,13 +241,6 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
                 VoronoiPolygons(),
                 ZonalStatistics()
                 ]
-
-        # to store algs added by 3rd party plugins as scripts
-        #folder = os.path.join(os.path.dirname(__file__), 'scripts')
-        #scripts = ScriptUtils.loadFromFolder(folder)
-        #for script in scripts:
-        #    script.allowEdit = False
-        #algs.extend(scripts)
 
         return algs
 

--- a/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
@@ -21,13 +21,13 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
+import warnings
 
 from qgis.core import (QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterBand,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFileDestination)
+                       QgsProcessingParameterFileDestination,
+                       QgsProcessingException)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import raster
 
@@ -67,6 +67,16 @@ class RasterLayerHistogram(QgisAlgorithm):
         return self.tr('Raster layer histogram')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         layer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
         band = self.parameterAsInt(parameters, self.BAND, context)
         nbins = self.parameterAsInt(parameters, self.BINS, context)

--- a/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
@@ -21,8 +21,7 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
+import warnings
 
 from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterFeatureSource,
@@ -67,6 +66,16 @@ class VectorLayerHistogram(QgisAlgorithm):
         return self.tr('Vector layer histogram')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -21,9 +21,7 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
-
+import warnings
 from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
@@ -70,6 +68,16 @@ class VectorLayerScatterplot(QgisAlgorithm):
         return self.tr('Vector layer scatterplot')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -21,9 +21,7 @@ __author__ = 'Victor Olaya'
 __date__ = 'January 2013'
 __copyright__ = '(C) 2013, Victor Olaya'
 
-import plotly as plt
-import plotly.graph_objs as go
-
+import warnings
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFileDestination,
@@ -76,6 +74,16 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
         return self.tr('Vector layer scatterplot 3D')
 
     def processAlgorithm(self, parameters, context, feedback):
+        try:
+            # importing plotly throws Python warnings from within the library - filter these out
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=ResourceWarning)
+                warnings.filterwarnings("ignore", category=ImportWarning)
+                import plotly as plt
+                import plotly.graph_objs as go
+        except ImportError:
+            raise QgsProcessingException(self.tr('This algorithm requires the Python “plotly” library. Please install this library and try again.'))
+
         source = self.parameterAsSource(parameters, self.INPUT, context)
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))

--- a/python/plugins/processing/tools/raster.py
+++ b/python/plugins/processing/tools/raster.py
@@ -21,10 +21,8 @@ __author__ = 'Victor Olaya  and Alexander Bruy'
 __date__ = 'February 2013'
 __copyright__ = '(C) 2013, Victor Olaya  and Alexander Bruy'
 
-import os
 import struct
 
-import numpy
 from osgeo import gdal
 
 from qgis.core import QgsProcessingException


### PR DESCRIPTION
(i.e. at time of algorithm execution)

Because:
1. It's nicer to show all algorithms on all installs, and give a descriptive
error message to users when they try to run algorithms which depend on Plotly
if the library is missing. Otherwise on some installs these algorithms are
just missing for no apparent reason.

2. The plotly library takes a long time to load on windows (3-4 seconds),
so by moving this load to an on-demand load at time of algorithm execution
we can shave a few seconds off the QGIS startup time for ALL users.

(As discovered by @NathanW2 )