### PR TITLE
Resolve cpu spikes when options dialog is shown

### DIFF
--- a/src/app/qgssettingstree.h
+++ b/src/app/qgssettingstree.h
@@ -99,7 +99,7 @@ class QgsSettingsTree : public QTreeWidget
 
     QgsSettings *mSettings = nullptr;
     QTimer mRefreshTimer;
-    bool mAutoRefresh = true;
+    bool mAutoRefresh = false;
     QIcon mGroupIcon;
     QIcon mKeyIcon;
 


### PR DESCRIPTION
Disable auto-update of the advanced settings tree widget. This is causing
CPU spikes every 2 seconds while the dialog is open. It's useless for QGIS,
because this dialog is modal and blocking, and changes to settings aren't
saved until the dialog is dismissed. So basically nothing should be updating
these settings while the dialog is opened anyway...

Fixes #32892
