### PR TITLE
Add FlatGeobuf as an exportable format

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -3187,10 +3187,6 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
         return true; // Make https://twitter.com/shapefiIe a sad little fellow
       else if ( b.driverName == QLatin1String( "GPKG" ) )
         return false;
-      else if ( a.driverName == QLatin1String( "FlatGeobuf" ) )
-        return true;
-      else if ( b.driverName == QLatin1String( "FlatGeobuf" ) )
-        return false;
       else if ( a.driverName == QLatin1String( "ESRI Shapefile" ) )
         return true;
       else if ( b.driverName == QLatin1String( "ESRI Shapefile" ) )
@@ -3232,10 +3228,6 @@ QStringList QgsVectorFileWriter::supportedFormatExtensions( const VectorFormatOp
       if ( a == QLatin1String( "gpkg" ) )
         return true; // Make https://twitter.com/shapefiIe a sad little fellow
       else if ( b == QLatin1String( "gpkg" ) )
-        return false;
-      else if ( a == QLatin1String( "fgb" ) )
-        return true;
-      else if ( b == QLatin1String( "fgb" ) )
         return false;
       else if ( a == QLatin1String( "shp" ) )
         return true;
@@ -3331,10 +3323,6 @@ QList< QgsVectorFileWriter::DriverDetails > QgsVectorFileWriter::ogrDriverList( 
       if ( a.driverName == QLatin1String( "GPKG" ) )
         return true; // Make https://twitter.com/shapefiIe a sad little fellow
       else if ( b.driverName == QLatin1String( "GPKG" ) )
-        return false;
-      else if ( a.driverName == QLatin1String( "FlatGeobuf" ) )
-        return true;
-      else if ( b.driverName == QLatin1String( "FlatGeobuf" ) )
         return false;
       else if ( a.driverName == QLatin1String( "ESRI Shapefile" ) )
         return true;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -962,6 +962,7 @@ class QgsVectorFileWriterMetadataContainer
                              )
                            );
 
+#if defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3,1,0)
       // FlatGeobuf
       datasetOptions.clear();
       layerOptions.clear();
@@ -976,6 +977,7 @@ class QgsVectorFileWriterMetadataContainer
                                layerOptions
                              )
                            );
+#endif
 
       // ESRI Shapefile
       datasetOptions.clear();

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -962,6 +962,21 @@ class QgsVectorFileWriterMetadataContainer
                              )
                            );
 
+      // FlatGeobuf
+      datasetOptions.clear();
+      layerOptions.clear();
+
+      driverMetadata.insert( QStringLiteral( "FlatGeobuf" ),
+                             QgsVectorFileWriter::MetaData(
+                               QStringLiteral( "FlatGeobuf" ),
+                               QObject::tr( "FlatGeobuf" ),
+                               QStringLiteral( "*.fgb" ),
+                               QStringLiteral( "fgb" ),
+                               datasetOptions,
+                               layerOptions
+                             )
+                           );
+
       // ESRI Shapefile
       datasetOptions.clear();
       layerOptions.clear();
@@ -3172,6 +3187,10 @@ QList< QgsVectorFileWriter::FilterFormatDetails > QgsVectorFileWriter::supported
         return true; // Make https://twitter.com/shapefiIe a sad little fellow
       else if ( b.driverName == QLatin1String( "GPKG" ) )
         return false;
+      else if ( a.driverName == QLatin1String( "FlatGeobuf" ) )
+        return true;
+      else if ( b.driverName == QLatin1String( "FlatGeobuf" ) )
+        return false;
       else if ( a.driverName == QLatin1String( "ESRI Shapefile" ) )
         return true;
       else if ( b.driverName == QLatin1String( "ESRI Shapefile" ) )
@@ -3213,6 +3232,10 @@ QStringList QgsVectorFileWriter::supportedFormatExtensions( const VectorFormatOp
       if ( a == QLatin1String( "gpkg" ) )
         return true; // Make https://twitter.com/shapefiIe a sad little fellow
       else if ( b == QLatin1String( "gpkg" ) )
+        return false;
+      else if ( a == QLatin1String( "fgb" ) )
+        return true;
+      else if ( b == QLatin1String( "fgb" ) )
         return false;
       else if ( a == QLatin1String( "shp" ) )
         return true;
@@ -3308,6 +3331,10 @@ QList< QgsVectorFileWriter::DriverDetails > QgsVectorFileWriter::ogrDriverList( 
       if ( a.driverName == QLatin1String( "GPKG" ) )
         return true; // Make https://twitter.com/shapefiIe a sad little fellow
       else if ( b.driverName == QLatin1String( "GPKG" ) )
+        return false;
+      else if ( a.driverName == QLatin1String( "FlatGeobuf" ) )
+        return true;
+      else if ( b.driverName == QLatin1String( "FlatGeobuf" ) )
         return false;
       else if ( a.driverName == QLatin1String( "ESRI Shapefile" ) )
         return true;


### PR DESCRIPTION
Initial attempt to add FlatGeobuf as an exportable vector format. FlatGeobuf is already readable in QGIS when compiled against GDAL master.

Short story on FlatGeobuf is that it tries to fill a potential void between Shapefile and GPKG by being simple as a Shapefile, better performing and suitable for streaming. Long story can be found at https://github.com/bjornharrtell/flatgeobuf. FlatGeobuf is in GDAL master and expected to be in GDAL 3.1 as per https://gdal.org/drivers/vector/flatgeobuf.html.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards]
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
