### PR TITLE
Fix broken QMap<QVariantList,...> finding

### DIFF
--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -258,6 +258,8 @@ QVariant data types (such as strings, numeric values, dates and times)
 .. seealso:: :py:func:`qgsVariantLessThan`
 %End
 
+
+
 QString qgsVsiPrefix( const QString &path );
 
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -294,3 +294,11 @@ QString Qgis::devVersion()
 {
   return QString::fromUtf8( QGIS_DEV_VERSION );
 }
+
+template<>
+bool qMapLessThanKey<QVariantList>( const QVariantList &key1, const QVariantList &key2 )
+{
+  // qt's built in qMapLessThanKey for QVariantList is broken and does a case-insensitive operation.
+  // this breaks QMap< QVariantList, ... >, where key matching incorrectly becomes case-insensitive..!!?!
+  return qgsVariantGreaterThan( key1, key2 ) && key1 != key2;
+}

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -571,6 +571,12 @@ CORE_EXPORT bool qgsVariantEqual( const QVariant &lhs, const QVariant &rhs );
  */
 CORE_EXPORT bool qgsVariantGreaterThan( const QVariant &lhs, const QVariant &rhs );
 
+/**
+ * Compares two QVariantList values and returns whether the first is less than the second.
+ */
+template<> CORE_EXPORT bool qMapLessThanKey<QVariantList>( const QVariantList &key1, const QVariantList &key2 ) SIP_SKIP;
+
+
 CORE_EXPORT QString qgsVsiPrefix( const QString &path );
 
 /**

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -49,6 +49,7 @@ class TestQgis : public QObject
     void testQgsVariantEqual();
     void testQgsEnumValueToKey();
     void testQgsEnumKeyToValue();
+    void testQMapQVariantList();
 
   private:
     QString mReport;
@@ -410,6 +411,24 @@ void TestQgis::testQgsEnumKeyToValue()
   QCOMPARE( qgsEnumKeyToValue<QgsMapLayerModel::ItemDataRole>( QStringLiteral( "UnknownKey" ), QgsMapLayerModel::LayerIdRole ), QgsMapLayerModel::LayerIdRole );
 }
 
+void TestQgis::testQMapQVariantList()
+{
+  QMap<QVariantList, long> ids;
+  ids.insert( QVariantList() << "B" << "c", 5 );
+  ids.insert( QVariantList() << "b" << "C", 7 );
+
+  QVariantList v = QVariantList() << "b" << "C";
+  QMap<QVariantList, long>::const_iterator it = ids.constFind( v );
+
+  QVERIFY( it != ids.constEnd() );
+  QCOMPARE( it.value(), 7L );
+
+  v = QVariantList() << "B" << "c";
+  it = ids.constFind( v );
+
+  QVERIFY( it != ids.constEnd() );
+  QCOMPARE( it.value(), 5L );
+}
 
 
 QGSTEST_MAIN( TestQgis )


### PR DESCRIPTION
...which causes case-insensitive comparisons to be made when resolving primary keys in the Oracle and Postgres providers

qt's built in qMapLessThanKey for QVariantList is broken and does a case-insensitive operation, so we replace it with a working version instead! Ouch!
