### PR TITLE
Disable flaky svg cache test

### DIFF
--- a/tests/src/python/test_qgssvgcache.py
+++ b/tests/src/python/test_qgssvgcache.py
@@ -69,6 +69,7 @@ class TestQgsSvgCache(unittest.TestCase):
         while not self.fetched:
             QCoreApplication.processEvents()
 
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Failing on Travis')
     def testRemoteSVG(self):
         """Test fetching remote svg."""
         url = 'http://localhost:{}/qgis_local_server/sample_svg.svg'.format(str(TestQgsSvgCache.port))
@@ -83,6 +84,7 @@ class TestQgsSvgCache(unittest.TestCase):
                                                                strokeWidth=0.1, widthScaleFactor=1)
         self.assertTrue(self.imageCheck('Remote SVG', 'remote_svg', image))
 
+    @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true', 'Failing on Travis')
     def testRemoteSvgAsText(self):
         """Test fetching remote svg with text mime format - e.g. github raw svgs"""
         url = 'http://localhost:{}/qgis_local_server/svg_as_text.txt'.format(str(TestQgsSvgCache.port))


### PR DESCRIPTION
This test is randomly failing.
See e.g. https://github.com/qgis/QGIS/pull/31930#issuecomment-548837574

CC @rldhont 