### PR TITLE
Revert 5c1cc4a40d84 in order to allow dashes in plugin directory names

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -397,11 +397,7 @@ class Repositories(QObject):
                     fileName = pluginNodes.item(i).firstChildElement("file_name").text().strip()
                     if not fileName:
                         fileName = QFileInfo(pluginNodes.item(i).firstChildElement("download_url").text().strip().split("?")[0]).fileName()
-                    match = re.match('(.*?)[.-]', fileName)
-                    if match:
-                        name = match.groups()[0]
-                    else:
-                        name = fileName
+                    name = fileName.partition(".")[0]
                     experimental = False
                     if pluginNodes.item(i).firstChildElement("experimental").text().strip().upper() in ["TRUE", "YES"]:
                         experimental = True


### PR DESCRIPTION
A few weeks ago I pushed the 5c1cc4a40d84 commit, so QGIS started interpreting dashes in zip file names as a version suffix delimiter (e.g. MyPlugin-0.0.1.zip should contain "MyPlugin" directory). The purpose was to end a frequent confusion: plugin authors was naming zip files like that and they were reporting those zips are not installable.

However, now it turned out (see #32968) that dashes are also used in the directory names for some time (40 plugins for QGIS 3.x vs zero for 2.x), they are even officially allowed: https://docs.qgis.org/3.4/en/docs/pyqgis_developer_cookbook/plugins/releasing.html#validation . And yes, QGIS is able to import packages with dashes in names.

In this situation I guess we have to revert that commit (although personally I'm obviously against playing with fire and allowing dashes in Python packages).

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
