### PR TITLE
Fix data defined symbology in dxf export

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -650,7 +650,7 @@ void QgsDxfExport::writeEntities()
 
     QgsCoordinateTransform ct( mMapSettings.destinationCrs(), job->crs, mMapSettings.transformContext() );
 
-    QgsFeatureRequest request = QgsFeatureRequest().setSubsetOfAttributes( job->attributes, job->fields ).setExpressionContext( job->expressionContext );
+    QgsFeatureRequest request = QgsFeatureRequest().setSubsetOfAttributes( job->attributes, job->fields ).setExpressionContext( job->renderContext.expressionContext() );
     request.setFilterRect( ct.transform( mExtent ) );
 
     QgsFeatureIterator featureIt = job->featureSource.getFeatures( request );
@@ -786,7 +786,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( DxfLayerJob *job )
   QHash< QgsSymbol *, QList<QgsFeature> > features;
 
   QgsRenderContext ctx = renderContext();
-  const QList<QgsExpressionContextScope *> scopes = job->expressionContext.scopes();
+  const QList<QgsExpressionContextScope *> scopes = job->renderContext.expressionContext().scopes();
   for ( QgsExpressionContextScope *scope : scopes )
     ctx.expressionContext().appendScope( new QgsExpressionContextScope( *scope ) );
   QgsSymbolRenderContext sctx( ctx, QgsUnitTypes::RenderMillimeters, 1.0, false, nullptr, nullptr );

--- a/src/core/dxf/qgsdxfexport_p.h
+++ b/src/core/dxf/qgsdxfexport_p.h
@@ -31,8 +31,8 @@
 struct DxfLayerJob
 {
   DxfLayerJob( QgsVectorLayer *vl, const QString &layerStyleOverride, QgsRenderContext &renderContext, QgsDxfExport *dxfExport, const QString &splitLayerAttribute )
-    : styleOverride( vl )
-    , expressionContext( renderContext.expressionContext() )
+    : renderContext( renderContext )
+    , styleOverride( vl )
     , featureSource( vl )
     , dxfExport( dxfExport )
     , crs( vl->crs() )
@@ -42,7 +42,7 @@ struct DxfLayerJob
   {
     fields = vl->fields();
     renderer.reset( vl->renderer()->clone() );
-    expressionContext.appendScope( vl->createExpressionContextScope() );
+    renderContext.expressionContext().appendScope( QgsExpressionContextUtils::layerScope( vl ) );
 
     if ( !layerStyleOverride.isNull() )
     {
@@ -89,9 +89,9 @@ struct DxfLayerJob
     renderer->startRender( renderContext, fields );
   };
 
+  QgsRenderContext renderContext;
   QgsFields fields;
   QgsMapLayerStyleOverride styleOverride;
-  QgsExpressionContext expressionContext;
   QgsVectorLayerFeatureSource featureSource;
   std::unique_ptr< QgsFeatureRenderer > renderer;
   std::unique_ptr<QgsAbstractVectorLayerLabeling> labeling;


### PR DESCRIPTION
This was (partially) broken since #32770
The layer scope was missing in the rendering context.