### PR TITLE
[canvas] Fix zoom to selection for single point selection when layer is reprojected

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1029,8 +1029,9 @@ void QgsMapCanvas::zoomToSelected( QgsVectorLayer *layer )
   if ( layer->geometryType() == QgsWkbTypes::PointGeometry && rect.isEmpty() )
   {
     int scaleFactor = 5;
-    QgsPointXY center = mSettings.mapToLayerCoordinates( layer, rect.center() );
-    QgsRectangle extentRect = mSettings.mapToLayerCoordinates( layer, extent() ).scaled( 1.0 / scaleFactor, &center );
+    QgsPointXY centerMapCoordinates = rect.center();
+    QgsPointXY centerLayerCoordinates = mSettings.mapToLayerCoordinates( layer, centerMapCoordinates );
+    QgsRectangle extentRect = mSettings.mapToLayerCoordinates( layer, extent() ).scaled( 1.0 / scaleFactor, &centerLayerCoordinates );
     QgsFeatureRequest req = QgsFeatureRequest().setFilterRect( extentRect ).setLimit( 1000 ).setNoAttributes();
     QgsFeatureIterator fit = layer->getFeatures( req );
     QgsFeature f;
@@ -1040,7 +1041,7 @@ void QgsMapCanvas::zoomToSelected( QgsVectorLayer *layer )
     while ( fit.nextFeature( f ) )
     {
       QgsPointXY point = f.geometry().asPoint();
-      double sqrDist = point.sqrDist( center );
+      double sqrDist = point.sqrDist( centerLayerCoordinates );
       if ( sqrDist > closestSquaredDistance || sqrDist < 4 * std::numeric_limits<double>::epsilon() )
         continue;
       pointFound = true;
@@ -1051,7 +1052,7 @@ void QgsMapCanvas::zoomToSelected( QgsVectorLayer *layer )
     {
       // combine selected point with closest point and scale this rect
       rect.combineExtentWith( mSettings.layerToMapCoordinates( layer, closestPoint ) );
-      rect.scale( scaleFactor, &center );
+      rect.scale( scaleFactor, &centerMapCoordinates );
     }
   }
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

There was a (long-standing) bug with the canvas zooming to selection code that resulted in a failure to zoom to selection when a single point was selected from a reprojected layer. This PR fixes the situation.

Discovered while fooling around with the latest DataPlotty.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
