### PR TITLE
[API] Alt aggregate call using symbol ID

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2277,6 +2277,28 @@ been changed inside the edit buffer then the previous saved value may be returne
 .. seealso:: :py:func:`uniqueValues`
 %End
 
+    QVariant aggregate( QgsAggregateCalculator::Aggregate calculation,
+                        const QString &fieldOrExpression,
+                        const QgsAggregateCalculator::AggregateParameters &parameters,
+                        QgsExpressionContext *context,
+                        bool *ok,
+                        QString &symbolId ) const;
+%Docstring
+Calculates an aggregated value from the layer's features.
+Currently any filtering expression provided will override filters in the FeatureRequest.
+
+:param calculation: aggregate to calculate
+:param fieldOrExpression: source field or expression to use as basis for aggregated values.
+:param parameters: parameters controlling aggregate calculation
+:param context: expression context for expressions and filters
+:param ok: if specified, will be set to ``True`` if aggregate calculation was successful
+:param symbolId: Id of the symbol to use, otherwise uses all features
+
+:return: calculated aggregate value
+
+.. versionadded:: 3.12
+%End
+
     QVariant aggregate( QgsAggregateCalculator::Aggregate aggregate,
                         const QString &fieldOrExpression,
                         const QgsAggregateCalculator::AggregateParameters &parameters = QgsAggregateCalculator::AggregateParameters(),
@@ -2562,6 +2584,7 @@ Sets the coordinate transform context to ``transformContext``
 
 
     virtual bool accept( QgsStyleEntityVisitorInterface *visitor ) const;
+
 
 
   signals:

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -782,7 +782,6 @@ void QgsLayoutItemLegend::updateFilterByMap( bool redraw )
   // the actual update will take place before the redraw.
   // This is to avoid multiple calls to the filter
   mFilterAskedForUpdate = true;
-
   if ( redraw )
     update();
 }
@@ -898,7 +897,6 @@ QgsLegendModel::QgsLegendModel( QgsLayerTree *rootNode,  QgsLayoutItemLegend *la
 QVariant QgsLegendModel::data( const QModelIndex &index, int role ) const
 {
   // handle custom layer node labels
-
   QgsLayerTreeNode *node = index2node( index );
   QgsLayerTreeLayer *nodeLayer = QgsLayerTree::isLayer( node ) ? QgsLayerTree::toLayer( node ) : nullptr;
   if ( nodeLayer && ( role == Qt::DisplayRole || role == Qt::EditRole ) )
@@ -914,15 +912,16 @@ QVariant QgsLegendModel::data( const QModelIndex &index, int role ) const
       name = node->customProperty( QStringLiteral( "legend/title-label" ) ).toString();
     if ( name.isEmpty() )
       name = node->name();
-    if ( nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt() )
+    if ( nodeLayer->customProperty( QStringLiteral( "showFeatureCount" ), 0 ).toInt() && vlayer )
     {
-      if ( vlayer && vlayer->featureCount() >= 0 )
+      connect( vlayer, &QgsVectorLayer::symbolFeatureCountMapChanged, this, &QgsLegendModel::forceRefresh, Qt::UniqueConnection );
+      vlayer->countSymbolFeatures();
+      if ( vlayer->featureCount() >= 0 )
       {
         name += QStringLiteral( " [%1]" ).arg( vlayer->featureCount() );
         return name;
       }
     }
-
     bool evaluate = vlayer ? !nodeLayer->labelExpression().isEmpty() : false;
 
     if ( evaluate || name.contains( "[%" ) )
@@ -932,7 +931,7 @@ QVariant QgsLegendModel::data( const QModelIndex &index, int role ) const
       {
         connect( vlayer, &QgsVectorLayer::symbolFeatureCountMapChanged, this, &QgsLegendModel::forceRefresh, Qt::UniqueConnection );
         // counting is done here to ensure that a valid vector layer needs to be evaluated, count is used to validate previous count or update the count if invalidated
-        vlayer->countSymbolFeatures();
+        vlayer->countSymbolFeatures( true );
       }
 
       if ( mLayoutLegend )
@@ -950,7 +949,9 @@ QVariant QgsLegendModel::data( const QModelIndex &index, int role ) const
         }
       }
       else if ( QgsSymbolLegendNode *symnode = qobject_cast<QgsSymbolLegendNode *>( legendnodes.first() ) )
+      {
         name = symnode->evaluateLabel( expressionContext );
+      }
     }
     return name;
   }
@@ -982,5 +983,4 @@ void QgsLegendModel::forceRefresh()
 {
   emit refreshLegend();
 }
-
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3389,7 +3389,6 @@ void QgsVectorLayer::setRenderer( QgsFeatureRenderer *r )
     mSymbolFeatureCounted = false;
     mSymbolFeatureCountMap.clear();
     mSymbolFeatureIdMap.clear();
-
     emit rendererChanged();
     emit styleChanged();
   }
@@ -3993,6 +3992,18 @@ QVariant QgsVectorLayer::minimumOrMaximumValue( int index, bool minimum ) const
   return QVariant();
 }
 
+QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate calculation, const QString &fieldOrExpression,
+                                    const QgsAggregateCalculator::AggregateParameters &parameters, QgsExpressionContext *context,
+                                    bool *ok, QString &symbolId ) const
+{
+  if ( ! symbolId.isEmpty() && mFeatureCounter )
+  {
+    QgsFeatureIds ids = symbolFeatureIds( symbolId );
+    return aggregate( calculation, fieldOrExpression, parameters, context, ok, &ids );
+  }
+  return aggregate( calculation, fieldOrExpression, parameters, context, ok );
+}
+
 QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate, const QString &fieldOrExpression,
                                     const QgsAggregateCalculator::AggregateParameters &parameters, QgsExpressionContext *context,
                                     bool *ok, QgsFeatureIds *fids ) const
@@ -4004,7 +4015,11 @@ QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate,
   {
     return QVariant();
   }
-
+  bool hasFids = false;
+  if ( fids )
+  {
+    hasFids = true;
+  }
   // test if we are calculating based on a field
   int attrIndex = mFields.lookupField( fieldOrExpression );
   if ( attrIndex >= 0 )
@@ -4028,8 +4043,10 @@ QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate,
 
   // fallback to using aggregate calculator to determine aggregate
   QgsAggregateCalculator c( this );
-  if ( fids )
+  if ( hasFids )
+  {
     c.setFidsFilter( *fids );
+  }
   c.setParameters( parameters );
   return c.calculate( aggregate, fieldOrExpression, context, ok );
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2086,6 +2086,25 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Calculates an aggregated value from the layer's features.
      * Currently any filtering expression provided will override filters in the FeatureRequest.
+     * \param calculation aggregate to calculate
+     * \param fieldOrExpression source field or expression to use as basis for aggregated values.
+     * \param parameters parameters controlling aggregate calculation
+     * \param context expression context for expressions and filters
+     * \param ok if specified, will be set to TRUE if aggregate calculation was successful
+     * \param symbolId Id of the symbol to use, otherwise uses all features
+     * \returns calculated aggregate value
+     * \since QGIS 3.12
+     */
+    QVariant aggregate( QgsAggregateCalculator::Aggregate calculation,
+                        const QString &fieldOrExpression,
+                        const QgsAggregateCalculator::AggregateParameters &parameters,
+                        QgsExpressionContext *context,
+                        bool *ok,
+                        QString &symbolId ) const;
+
+    /**
+     * Calculates an aggregated value from the layer's features.
+     * Currently any filtering expression provided will override filters in the FeatureRequest.
      * \param aggregate aggregate to calculate
      * \param fieldOrExpression source field or expression to use as basis for aggregated values.
      * \param parameters parameters controlling aggregate calculation
@@ -2378,6 +2397,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     bool accept( QgsStyleEntityVisitorInterface *visitor ) const override;
 
+    //! cache the results of the feature counter
+    void onSymbolsCounted() SIP_SKIP;
+
   signals:
 
     /**
@@ -2641,7 +2663,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void onJoinedFieldsChanged();
     void onFeatureDeleted( QgsFeatureId fid );
     void onRelationsLoaded();
-    void onSymbolsCounted();
     void onDirtyTransaction( const QString &sql, const QString &name );
     void emitDataChanged();
 


### PR DESCRIPTION
## Description
This is a section of #30727 , this branch was suggested a long time ago by @nyalldawson  and in the hope to start the review I have decided to give a second try to splitting the PR, (though the main PR will be unchanged)

This change has minor tweaks and add an alternative way to call the aggregate function by providing the symbol id instead of the full set of filtered fids.

I don't think tests are necessary for this, a better test is provided in the aforementioned PR.

## Checklist


- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
