### PR TITLE
Fix QGIS crashing when loading a recent project after saving dirty project

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6800,12 +6800,13 @@ void QgisApp::openProject( QAction *action )
 {
   // possibly save any pending work before opening a different project
   Q_ASSERT( action );
+  const QString project = action->data().toString().replace( "&&", "&" );
 
   if ( checkTasksDependOnProject() )
     return;
 
   if ( checkUnsavedLayerEdits() && checkMemoryLayers() && saveDirty() )
-    addProject( action->data().toString().replace( "&&", "&" ) );
+    addProject( project );
 }
 
 void QgisApp::runScript( const QString &filePath )


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Steps to reproduce crasher:
1. Launch QGIS, load a project
2. Make a modification to that project (e.g. hide a layer)
3. Open the project menu, and in the recent projects sub menu click on a project
4. You'll see a "project changed, save?" dialog, click on [ save ]
5. *boom* QGIS crashes

Somehow, saveDirty() has some impact on the action object, which is passed on as a pointer in the openProject(...) function. This PR fixes the crasher by moving our use of the action data _prior to_ calling saveDirty().

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
