### PR TITLE
QgsCoordinateTransform::transformCoords(): with PROJ 6, do no raise o…

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -662,7 +662,18 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
                       y, sizeof( double ), numPoints,
                       z, sizeof( double ), numPoints,
                       nullptr, sizeof( double ), 0 );
-  projResult = proj_errno( projData );
+  // Try to - approximatively - emulate the behavior of pj_transform()...
+  // In the case of a single point transform, and a transformation error occurs,
+  // pj_transform() would return the errno. In cases of multiple point transform,
+  // it would continue (for non-transient errors, that is pipeline definition
+  // errors) and just set the resulting x,y to infinity. This is in fact a
+  // bit more subtle than that, and I'm not completely sure the logic in
+  // pj_transform() was really sane & fully bullet proof
+  // So here just check proj_errno() for single point transform
+  if ( numPoints == 1 )
+  {
+    projResult = proj_errno( projData );
+  }
 #else
   bool sourceIsLatLong = false;
   bool destIsLatLong = false;


### PR DESCRIPTION
…n partial failure of multiple point transformation

Fixes #32973 or at least improve it significantly

Currently with PROJ 6 transformCoords() will raise an exception as soon
as a single point fails to transform. With PROJ < 6, this (generally)
did not occur. Exceptions were raised only (mostly) on failures on
single point.
Imitate that

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
