### PR TITLE
Fix WMTS Capabilities document and related tests

### DIFF
--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -378,11 +378,11 @@ namespace QgsWmts
         // WGS84 bounding box
         int wgs84precision = 6;
         QDomElement wgs84BBoxElement = doc.createElement( QStringLiteral( "ows:WGS84BoundingBox" ) );
-        QDomElement wgs84LowerCornerElement = doc.createElement( QStringLiteral( "LowerCorner" ) );
+        QDomElement wgs84LowerCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
         QDomText wgs84LowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( wmtsLayer.wgs84BoundingRect.xMinimum(), wgs84precision ), wgs84precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( wmtsLayer.wgs84BoundingRect.yMinimum(), wgs84precision ), wgs84precision ) );
         wgs84LowerCornerElement.appendChild( wgs84LowerCornerText );
         wgs84BBoxElement.appendChild( wgs84LowerCornerElement );
-        QDomElement wgs84UpperCornerElement = doc.createElement( QStringLiteral( "UpperCorner" ) );
+        QDomElement wgs84UpperCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
         QDomText wgs84UpperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( wmtsLayer.wgs84BoundingRect.xMaximum(), wgs84precision ), wgs84precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( wmtsLayer.wgs84BoundingRect.yMaximum(), wgs84precision ), wgs84precision ) );
         wgs84UpperCornerElement.appendChild( wgs84UpperCornerText );
         wgs84BBoxElement.appendChild( wgs84UpperCornerElement );
@@ -414,11 +414,11 @@ namespace QgsWmts
 
           QDomElement bboxElement = doc.createElement( QStringLiteral( "ows:BoundingBox" ) );
           bboxElement.setAttribute( QStringLiteral( "crs" ), tms.ref );
-          QDomElement lowerCornerElement = doc.createElement( QStringLiteral( "LowerCorner" ) );
+          QDomElement lowerCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
           QDomText lowerCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.xMinimum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::floorWithPrecision( rect.yMinimum(), precision ), precision ) );
           lowerCornerElement.appendChild( lowerCornerText );
           bboxElement.appendChild( lowerCornerElement );
-          QDomElement upperCornerElement = doc.createElement( QStringLiteral( "UpperCorner" ) );
+          QDomElement upperCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
           QDomText upperCornerText = doc.createTextNode( qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.xMaximum(), precision ), precision ) + ' ' + qgsDoubleToString( QgsServerProjectUtils::ceilWithPrecision( rect.yMaximum(), precision ), precision ) );
           upperCornerElement.appendChild( upperCornerText );
           bboxElement.appendChild( upperCornerElement );

--- a/tests/testdata/qgis_server/wmts_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities.txt
@@ -63,12 +63,12 @@ Content-Type: text/xml; charset=utf-8
    <ows:Title>QGIS Server Hello World</ows:Title>
    <ows:Abstract>QGIS Server Hello World</ows:Abstract>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-174.766573 -69.957839</LowerCorner>
-    <UpperCorner>177.930819 84.307877</UpperCorner>
+    <ows:LowerCorner>-174.766573 -69.957839</ows:LowerCorner>
+    <ows:UpperCorner>177.930819 84.307877</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-19454925.899 -11055006.823</LowerCorner>
-    <UpperCorner>19807168.137 19143772.794</UpperCorner>
+    <ows:LowerCorner>-19454925.899 -11055006.823</ows:LowerCorner>
+    <ows:UpperCorner>19807168.137 19143772.794</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>
@@ -377,12 +377,12 @@ Content-Type: text/xml; charset=utf-8
    <ows:Identifier>CountryGroup</ows:Identifier>
    <ows:Title>CountryGroup</ows:Title>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-176.248495 -67.592996</LowerCorner>
-    <UpperCorner>179.412741 83.621086</UpperCorner>
+    <ows:LowerCorner>-176.248495 -67.592996</ows:LowerCorner>
+    <ows:UpperCorner>179.412741 83.621086</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-19619892.681 -10327100.343</LowerCorner>
-    <UpperCorner>19972134.919 18415866.313</UpperCorner>
+    <ows:LowerCorner>-19619892.681 -10327100.343</ows:LowerCorner>
+    <ows:UpperCorner>19972134.919 18415866.313</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>
@@ -695,12 +695,12 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <ows:Identifier>Hello</ows:Identifier>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-132.467819 -1.006739</LowerCorner>
-    <UpperCorner>101.888717 69.520496</UpperCorner>
+    <ows:LowerCorner>-132.467819 -1.006739</ows:LowerCorner>
+    <ows:UpperCorner>101.888717 69.520496</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-14746250.076 -112075.429</LowerCorner>
-    <UpperCorner>11342200.078 10914413.715</UpperCorner>
+    <ows:LowerCorner>-14746250.076 -112075.429</ows:LowerCorner>
+    <ows:UpperCorner>11342200.078 10914413.715</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
@@ -63,12 +63,12 @@ Content-Type: text/xml; charset=utf-8
    <ows:Title>QGIS Server Hello World</ows:Title>
    <ows:Abstract>QGIS Server Hello World</ows:Abstract>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-174.766573 -69.957839</LowerCorner>
-    <UpperCorner>177.930819 84.307877</UpperCorner>
+    <ows:LowerCorner>-174.766573 -69.957839</ows:LowerCorner>
+    <ows:UpperCorner>177.930819 84.307877</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-19454925.899 -11055006.823</LowerCorner>
-    <UpperCorner>19807168.137 19143772.794</UpperCorner>
+    <ows:LowerCorner>-19454925.899 -11055006.823</ows:LowerCorner>
+    <ows:UpperCorner>19807168.137 19143772.794</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>
@@ -377,12 +377,12 @@ Content-Type: text/xml; charset=utf-8
    <ows:Identifier>CountryGroup</ows:Identifier>
    <ows:Title>CountryGroup</ows:Title>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-176.248495 -67.592996</LowerCorner>
-    <UpperCorner>179.412741 83.621086</UpperCorner>
+    <ows:LowerCorner>-176.248495 -67.592996</ows:LowerCorner>
+    <ows:UpperCorner>179.412741 83.621086</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-19619892.681 -10327100.343</LowerCorner>
-    <UpperCorner>19972134.919 18415866.313</UpperCorner>
+    <ows:LowerCorner>-19619892.681 -10327100.343</ows:LowerCorner>
+    <ows:UpperCorner>19972134.919 18415866.313</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>
@@ -695,12 +695,12 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <ows:Identifier>Hello</ows:Identifier>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-132.467819 -1.006739</LowerCorner>
-    <UpperCorner>101.888717 69.520496</UpperCorner>
+    <ows:LowerCorner>-132.467819 -1.006739</ows:LowerCorner>
+    <ows:UpperCorner>101.888717 69.520496</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-14746250.076 -112075.429</LowerCorner>
-    <UpperCorner>11342200.078 10914413.715</UpperCorner>
+    <ows:LowerCorner>-14746250.076 -112075.429</ows:LowerCorner>
+    <ows:UpperCorner>11342200.078 10914413.715</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
@@ -63,12 +63,12 @@ Content-Type: text/xml; charset=utf-8
    <ows:Title>QGIS Server Hello World</ows:Title>
    <ows:Abstract>QGIS Server Hello World</ows:Abstract>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-174.766573 -69.957839</LowerCorner>
-    <UpperCorner>177.930819 84.307877</UpperCorner>
+    <ows:LowerCorner>-174.766573 -69.957839</ows:LowerCorner>
+    <ows:UpperCorner>177.930819 84.307877</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-19454925.899 -11055006.823</LowerCorner>
-    <UpperCorner>19807168.137 19143772.794</UpperCorner>
+    <ows:LowerCorner>-19454925.899 -11055006.823</ows:LowerCorner>
+    <ows:UpperCorner>19807168.137 19143772.794</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>
@@ -232,12 +232,12 @@ Content-Type: text/xml; charset=utf-8
    <ows:Identifier>CountryGroup</ows:Identifier>
    <ows:Title>CountryGroup</ows:Title>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-176.248495 -67.592996</LowerCorner>
-    <UpperCorner>179.412741 83.621086</UpperCorner>
+    <ows:LowerCorner>-176.248495 -67.592996</ows:LowerCorner>
+    <ows:UpperCorner>179.412741 83.621086</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-19619892.681 -10327100.343</LowerCorner>
-    <UpperCorner>19972134.919 18415866.313</UpperCorner>
+    <ows:LowerCorner>-19619892.681 -10327100.343</ows:LowerCorner>
+    <ows:UpperCorner>19972134.919 18415866.313</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>
@@ -405,12 +405,12 @@ Content-Type: text/xml; charset=utf-8
   <Layer>
    <ows:Identifier>Hello</ows:Identifier>
    <ows:WGS84BoundingBox>
-    <LowerCorner>-132.467819 -1.006739</LowerCorner>
-    <UpperCorner>101.888717 69.520496</UpperCorner>
+    <ows:LowerCorner>-132.467819 -1.006739</ows:LowerCorner>
+    <ows:UpperCorner>101.888717 69.520496</ows:UpperCorner>
    </ows:WGS84BoundingBox>
    <ows:BoundingBox crs="EPSG:3857">
-    <LowerCorner>-14746250.076 -112075.429</LowerCorner>
-    <UpperCorner>11342200.078 10914413.715</UpperCorner>
+    <ows:LowerCorner>-14746250.076 -112075.429</ows:LowerCorner>
+    <ows:UpperCorner>11342200.078 10914413.715</ows:UpperCorner>
    </ows:BoundingBox>
    <Style isDefault="true">
     <ows:Identifier>default</ows:Identifier>


### PR DESCRIPTION
## Description

This PR does a minor modification to the WMTS Capabilities document. The output was not valid.
OWSLib, for example, was not able to read it.

With this fix, the document is well parsed by OWSLib:

```python
>>> from owslib.wmts import WebMapTileService
>>> wmts = WebMapTileService("http://localhost/cgi-bin/qgis_mapserv.fcgi?MAP=/home/qgis/projects/costanova.qgz&SERVICE=WMTS&REQUEST=GetCapabilities")
>>> print(wmts.contents)
{'concelho': <owslib.wmts.ContentMetadata object at 0x7f9dcbe889e8>}
```

Basically, this changes:
```xml
<LowerCorner>-9.575005 36.948018</LowerCorner>
<UpperCorner>-6.172036 42.15432</UpperCorner>
```
to
```
<ows:LowerCorner>-9.575005 36.948018</ows:LowerCorner>
<ows:UpperCorner>-6.172036 42.15432</ows:UpperCorner>
```
Test data was also fixed.

Fix #33008 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] Unit tests have been update
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
