### PR TITLE
MetaSearch plugin: CSW catalogue url update

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -13,6 +13,6 @@
     <csw name="Sweden: National CSW" url="http://www.geodata.se/InspireCswProxy/csw"/>
     <csw name="UK Location Catalogue Publishing Service" url="http://csw.data.gov.uk/geonetwork/srv/en/csw"/>
     <csw name="UNEP GRID-Geneva Metadata Catalog" url="http://geonetwork.grid.unep.ch:8080/geonetwork/srv/eng/csw"/>
-    <csw name="Portugal: Sistema Nacional de Informação Geográfica (SNIG)" url="http://snig.dgterritorio.pt/geoportal/csw/discovery"/>
+    <csw name="Portugal: Sistema Nacional de Informação Geográfica (SNIG)" url="https://snig.dgterritorio.gov.pt/rndg/srv/eng/csw"/>
     <csw name="Spain: Centro Nacional de Información Geográfica (CNIG)" url="http://www.ign.es/csw-inspire/srv/spa/csw"/>
 </qgsCSWConnections>


### PR DESCRIPTION
## Description

URL update of the CSW catalogue of the portuguese mapping agency. The previous one was deprecated and no longer works.

The catalogue administrator was notified by email.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
