### PR TITLE
QgsDebugMsgLevel optimisations

### DIFF
--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -299,9 +299,7 @@ Converts the provided variant to a compatible format
         Py_BEGIN_ALLOW_THREADS
         try
         {
-          QgsDebugMsg( a0->toString() );
           sipRes = sipCpp->convertCompatible( *a0 );
-          QgsDebugMsg( a0->toString() );
         }
         catch ( ... )
         {

--- a/src/app/layout/qgslayoutlegendwidget.cpp
+++ b/src/app/layout/qgslayoutlegendwidget.cpp
@@ -954,7 +954,7 @@ void QgsLayoutLegendWidget::resetLayerNodeToDefaults()
 
 void QgsLayoutLegendWidget::mCountToolButton_clicked( bool checked )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   if ( !mLegend )
   {
     return;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2002,8 +2002,8 @@ QList<QgsVectorLayerRef> QgisApp::findBrokenWidgetDependencies( QgsVectorLayer *
       for ( const QgsVectorLayerRef &dependency : constDependencies )
       {
         const QgsVectorLayer *depVl { QgsVectorLayerRef( dependency ).resolveWeakly(
-                                        QgsProject::instance(),
-                                        QgsVectorLayerRef::MatchType::Name ) };
+            QgsProject::instance(),
+            QgsVectorLayerRef::MatchType::Name ) };
         if ( ! depVl || ! depVl->isValid() )
         {
           brokenDependencies.append( dependency );
@@ -2094,8 +2094,8 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
       if ( ! loaded )
       {
         const QString msg { tr( "layer '%1' requires layer '%2' to be loaded but '%2' could not be found, please load it manually if possible." )
-                            .arg( vl->name() )
-                            .arg( dependency.name ) };
+          .arg( vl->name() )
+          .arg( dependency.name ) };
         messageBar()->pushWarning( tr( "Missing layer form dependency" ), msg );
       }
       else
@@ -6458,7 +6458,7 @@ bool QgisApp::addProject( const QString &projectFile )
     }
 
     mMapCanvas->updateScale();
-    QgsDebugMsg( QStringLiteral( "Scale restored..." ) );
+    QgsDebugMsgLevel( QStringLiteral( "Scale restored..." ), 3 );
 
     mActionFilterLegend->setChecked( QgsProject::instance()->readBoolEntry( QStringLiteral( "Legend" ), QStringLiteral( "filterByMap" ) ) );
 

--- a/src/core/classification/qgsclassificationjenks.cpp
+++ b/src/core/classification/qgsclassificationjenks.cpp
@@ -83,8 +83,8 @@ QList<double> QgsClassificationJenks::calculateBreaks( double minimum, double ma
 
     sample.resize( std::max( mMaximumSize, values.size() / 10 ) );
 
-    QgsDebugMsg( QStringLiteral( "natural breaks (jenks) sample size: %1" ).arg( sample.size() ) );
-    QgsDebugMsg( QStringLiteral( "values:%1" ).arg( values.size() ) );
+    QgsDebugMsgLevel( QStringLiteral( "natural breaks (jenks) sample size: %1" ).arg( sample.size() ), 2 );
+    QgsDebugMsgLevel( QStringLiteral( "values:%1" ).arg( values.size() ), 2 );
 
     sample[ 0 ] = minimum;
     sample[ 1 ] = maximum;

--- a/src/core/dxf/qgsdxfpallabeling.cpp
+++ b/src/core/dxf/qgsdxfpallabeling.cpp
@@ -49,20 +49,20 @@ QgsDxfRuleBasedLabelProvider::QgsDxfRuleBasedLabelProvider( const QgsRuleBasedLa
 
 void QgsDxfRuleBasedLabelProvider::reinit( QgsVectorLayer *layer )
 {
-  QgsDebugMsg( QStringLiteral( "Entering." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entering." ), 4 );
   mRules->rootRule()->createSubProviders( layer, mSubProviders, this );
 }
 
 QgsVectorLayerLabelProvider *QgsDxfRuleBasedLabelProvider::createProvider( QgsVectorLayer *layer, const QString &providerId, bool withFeatureLoop, const QgsPalLayerSettings *settings )
 {
-  QgsDebugMsg( QStringLiteral( "Entering." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entering." ), 4 );
   Q_UNUSED( withFeatureLoop )
   return new QgsDxfLabelProvider( layer, providerId, mDxfExport, settings );
 }
 
 void QgsDxfRuleBasedLabelProvider::drawLabel( QgsRenderContext &context, pal::LabelPosition *label ) const
 {
-  QgsDebugMsg( QStringLiteral( "Entering." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entering." ), 4 );
   Q_ASSERT( mDxfExport );
   mDxfExport->drawLabel( layerId(), context, label, mSettings );
 }

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -433,7 +433,7 @@ QString QgsExpression::replaceExpressionText( const QString &action, const QgsEx
     const int start = index;
     index = pos + match.capturedLength( 0 );
     const QString toReplace = match.captured( 1 ).trimmed();
-    QgsDebugMsg( "Found expression: " + toReplace );
+    QgsDebugMsgLevel( "Found expression: " + toReplace, 3 );
 
     QgsExpression exp( toReplace );
     if ( exp.hasParserError() )
@@ -458,7 +458,7 @@ QString QgsExpression::replaceExpressionText( const QString &action, const QgsEx
       continue;
     }
 
-    QgsDebugMsg( "Expression result is: " + result.toString() );
+    QgsDebugMsgLevel( "Expression result is: " + result.toString(), 3 );
     expr_action += action.mid( start, pos - start ) + result.toString();
   }
 

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -164,12 +164,12 @@ void QgsGeoNodeRequest::setProtocol( const QString &protocol )
 
 void QgsGeoNodeRequest::replyFinished()
 {
-  QgsDebugMsg( QStringLiteral( "Reply finished" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Reply finished" ), 2 );
   if ( !mIsAborted && mGeoNodeReply )
   {
     if ( mGeoNodeReply->error() == QNetworkReply::NoError )
     {
-      QgsDebugMsg( QStringLiteral( "reply OK" ) );
+      QgsDebugMsgLevel( QStringLiteral( "reply OK" ), 2 );
       QVariant redirect = mGeoNodeReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
       if ( !redirect.isNull() )
       {
@@ -218,7 +218,7 @@ void QgsGeoNodeRequest::replyFinished()
           }
           cmd.setRawHeaders( hl );
 
-          QgsDebugMsg( QStringLiteral( "expirationDate:%1" ).arg( cmd.expirationDate().toString() ) );
+          QgsDebugMsgLevel( QStringLiteral( "expirationDate:%1" ).arg( cmd.expirationDate().toString() ), 2 );
           if ( cmd.expirationDate().isNull() )
           {
             QgsSettings settings;
@@ -517,7 +517,7 @@ void QgsGeoNodeRequest::request( const QString &endPoint )
   mIsAborted = false;
   // Handle case where the endpoint is full url
   QString url = endPoint.startsWith( mBaseUrl ) ? endPoint : mBaseUrl + endPoint;
-  QgsDebugMsg( "Requesting to " + url );
+  QgsDebugMsgLevel( "Requesting to " + url, 2 );
   setProtocol( url.split( QStringLiteral( "://" ) ).at( 0 ) );
   QUrl layerUrl( url );
   layerUrl.setScheme( protocol() );

--- a/src/core/geometry/qgsgeometrymakevalid.cpp
+++ b/src/core/geometry/qgsgeometrymakevalid.cpp
@@ -348,7 +348,7 @@ static bool lwcollection_make_geos_friendly( QgsGeometryCollection *g );
 // Ensure the geometry is "structurally" valid (enough for GEOS to accept it)
 static bool lwgeom_make_geos_friendly( QgsAbstractGeometry *geom )
 {
-  QgsDebugMsg( QStringLiteral( "lwgeom_make_geos_friendly enter (type %1)" ).arg( geom->wkbType() ) );
+  QgsDebugMsgLevel( QStringLiteral( "lwgeom_make_geos_friendly enter (type %1)" ).arg( geom->wkbType() ), 3 );
   switch ( QgsWkbTypes::flatType( geom->wkbType() ) )
   {
     case QgsWkbTypes::Point:
@@ -911,7 +911,7 @@ std::unique_ptr< QgsAbstractGeometry > _qgis_lwgeom_make_valid( const QgsAbstrac
   geos::unique_ptr geosgeom = QgsGeos::asGeos( lwgeom_in );
   if ( !geosgeom )
   {
-    QgsDebugMsg( QStringLiteral( "Original geom can't be converted to GEOS - will try cleaning that up first" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Original geom can't be converted to GEOS - will try cleaning that up first" ), 3 );
 
     std::unique_ptr<QgsAbstractGeometry> lwgeom_in_clone( lwgeom_in->clone() );
     if ( !lwgeom_make_geos_friendly( lwgeom_in_clone.get() ) )

--- a/src/core/gps/qgsgpsdconnection.cpp
+++ b/src/core/gps/qgsgpsdconnection.cpp
@@ -33,7 +33,7 @@ QgsGpsdConnection::QgsGpsdConnection( const QString &host, qint16 port, const QS
 
 void QgsGpsdConnection::connected()
 {
-  QgsDebugMsg( QStringLiteral( "connected!" ) );
+  QgsDebugMsgLevel( QStringLiteral( "connected!" ), 2 );
   QTcpSocket *socket = qobject_cast< QTcpSocket * >( mSource );
   socket->write( QStringLiteral( "?WATCH={\"enable\":true,\"nmea\":true,\"raw\":true%1};" ).arg( mDevice.isEmpty() ? mDevice : QStringLiteral( ",\"device\":%1" ).arg( mDevice ) ).toUtf8() );
 }

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -56,7 +56,7 @@ void QgsNmeaConnection::parseData()
     numBytes = mSource->bytesAvailable();
   }
 
-  QgsDebugMsg( "numBytes:" + QString::number( numBytes ) );
+  QgsDebugMsgLevel( "numBytes:" + QString::number( numBytes ), 2 );
 
   if ( numBytes >= 6 )
   {
@@ -96,17 +96,17 @@ void QgsNmeaConnection::processStringBuffer()
         QByteArray ba = substring.toLocal8Bit();
         if ( substring.startsWith( QLatin1String( "$GPGGA" ) ) )
         {
-          QgsDebugMsg( substring );
+          QgsDebugMsgLevel( substring, 2 );
           processGgaSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
-          QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
         else if ( substring.startsWith( QLatin1String( "$GPRMC" ) ) || substring.startsWith( QLatin1String( "$GNRMC" ) ) )
         {
-          QgsDebugMsg( substring );
+          QgsDebugMsgLevel( substring, 2 );
           processRmcSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
-          QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
         else if ( substring.startsWith( QLatin1String( "$GPGSV" ) ) )
         {
@@ -117,24 +117,24 @@ void QgsNmeaConnection::processStringBuffer()
         }
         else if ( substring.startsWith( QLatin1String( "$GPVTG" ) ) )
         {
-          QgsDebugMsg( substring );
+          QgsDebugMsgLevel( substring, 2 );
           processVtgSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
-          QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
         else if ( substring.startsWith( QLatin1String( "$GPGSA" ) ) )
         {
-          QgsDebugMsg( substring );
+          QgsDebugMsgLevel( substring, 2 );
           processGsaSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
-          QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
         else if ( substring.startsWith( QLatin1String( "$GPGST" ) ) )
         {
-          QgsDebugMsg( substring );
+          QgsDebugMsgLevel( substring, 2 );
           processGstSentence( ba.data(), ba.length() );
           mStatus = GPSDataReceived;
-          QgsDebugMsg( QStringLiteral( "*******************GPS data received****************" ) );
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
         emit nmeaSentenceReceived( substring );  // added to be able to save raw data
       }
@@ -214,10 +214,10 @@ void QgsNmeaConnection::processRmcSentence( const char *data, int len )
       mLastGPSInformation.utcDateTime.setTimeSpec( Qt::UTC );
       mLastGPSInformation.utcDateTime.setDate( date );
       mLastGPSInformation.utcDateTime.setTime( time );
-      QgsDebugMsg( QStringLiteral( "utc time:" ) );
-      QgsDebugMsg( mLastGPSInformation.utcDateTime.toString() );
-      QgsDebugMsg( QStringLiteral( "local time:" ) );
-      QgsDebugMsg( mLastGPSInformation.utcDateTime.toLocalTime().toString() );
+      QgsDebugMsgLevel( QStringLiteral( "utc time:" ), 2 );
+      QgsDebugMsgLevel( mLastGPSInformation.utcDateTime.toString(), 2 );
+      QgsDebugMsgLevel( QStringLiteral( "local time:" ), 2 );
+      QgsDebugMsgLevel( mLastGPSInformation.utcDateTime.toLocalTime().toString(), 2 );
     }
   }
 }

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -356,7 +356,7 @@ void QgsLayoutItemPicture::refreshPicture( const QgsExpressionContext *context )
     else if ( source.type() != QVariant::ByteArray )
     {
       source = source.toString().trimmed();
-      QgsDebugMsg( QStringLiteral( "exprVal PictureSource:%1" ).arg( source.toString() ) );
+      QgsDebugMsgLevel( QStringLiteral( "exprVal PictureSource:%1" ).arg( source.toString() ), 2 );
     }
   }
 

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -156,7 +156,7 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, const ProviderOptions &opt
   mGeoTransform[4] = 0;
   mGeoTransform[5] = -1;
 
-  QgsDebugMsg( "constructing with uri '" + uri + "'." );
+  QgsDebugMsgLevel( "constructing with uri '" + uri + "'.", 1 );
 
   QgsGdalProviderBase::registerGdalDrivers();
 
@@ -305,7 +305,7 @@ bool QgsGdalProvider::crsFromWkt( const char *wkt )
       QString authid = QStringLiteral( "%1:%2" )
                        .arg( OSRGetAuthorityName( hCRS, nullptr ),
                              OSRGetAuthorityCode( hCRS, nullptr ) );
-      QgsDebugMsg( "authid recognized as " + authid );
+      QgsDebugMsgLevel( "authid recognized as " + authid, 1 );
       mCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( authid );
     }
     else
@@ -313,7 +313,7 @@ bool QgsGdalProvider::crsFromWkt( const char *wkt )
       // get the proj4 text
       char *pszProj4 = nullptr;
       OSRExportToProj4( hCRS, &pszProj4 );
-      QgsDebugMsg( pszProj4 );
+      QgsDebugMsgLevel( pszProj4, 1 );
       CPLFree( pszProj4 );
 
       char *pszWkt = nullptr;
@@ -743,7 +743,7 @@ bool QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &extent, int pi
   QgsRectangle rasterExtent = extent.intersect( mExtent );
   if ( rasterExtent.isEmpty() )
   {
-    QgsDebugMsg( QStringLiteral( "draw request outside view extent." ) );
+    QgsDebugMsgLevel( QStringLiteral( "draw request outside view extent." ), 2 );
     return false;
   }
   QgsDebugMsgLevel( "extent: " + mExtent.toString(), 5 );
@@ -1350,7 +1350,7 @@ int QgsGdalProvider::colorInterpretation( int bandNo ) const
 
 bool QgsGdalProvider::isValid() const
 {
-  QgsDebugMsg( QStringLiteral( "valid = %1" ).arg( mValid ) );
+  QgsDebugMsgLevel( QStringLiteral( "valid = %1" ).arg( mValid ), 4 );
   return mValid;
 }
 
@@ -1412,7 +1412,7 @@ QStringList QgsGdalProvider::subLayers( GDALDatasetH dataset )
 
   if ( !subLayers.isEmpty() )
   {
-    QgsDebugMsg( "sublayers:\n  " + subLayers.join( "\n  " ) );
+    QgsDebugMsgLevel( "sublayers:\n  " + subLayers.join( "\n  " ), 3 );
   }
 
   return subLayers;
@@ -1429,7 +1429,7 @@ bool QgsGdalProvider::hasHistogram( int bandNo,
   if ( !initIfNeeded() )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "theBandNo = %1 binCount = %2 minimum = %3 maximum = %4 sampleSize = %5" ).arg( bandNo ).arg( binCount ).arg( minimum ).arg( maximum ).arg( sampleSize ) );
+  QgsDebugMsgLevel( QStringLiteral( "theBandNo = %1 binCount = %2 minimum = %3 maximum = %4 sampleSize = %5" ).arg( bandNo ).arg( binCount ).arg( minimum ).arg( maximum ).arg( sampleSize ), 3 );
 
   // First check if cached in mHistograms
   if ( QgsRasterDataProvider::hasHistogram( bandNo, binCount, minimum, maximum, boundingBox, sampleSize, includeOutOfRange ) )
@@ -1450,11 +1450,11 @@ bool QgsGdalProvider::hasHistogram( int bandNo,
   if ( ( sourceHasNoDataValue( bandNo ) && !useSourceNoDataValue( bandNo ) ) ||
        !userNoDataValues( bandNo ).isEmpty() )
   {
-    QgsDebugMsg( QStringLiteral( "Custom no data values -> GDAL histogram not sufficient." ) );
+    QgsDebugMsgLevel( QStringLiteral( "Custom no data values -> GDAL histogram not sufficient." ), 3 );
     return false;
   }
 
-  QgsDebugMsg( QStringLiteral( "Looking for GDAL histogram" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Looking for GDAL histogram" ), 4 );
 
   GDALRasterBandH myGdalBand = getBand( bandNo );
   if ( ! myGdalBand )
@@ -1462,7 +1462,7 @@ bool QgsGdalProvider::hasHistogram( int bandNo,
     return false;
   }
 
-  // get default histogram with force=false to see if there is a cached histo
+// get default histogram with force=false to see if there is a cached histo
   double myMinVal, myMaxVal;
   int myBinCount;
 

--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -291,7 +291,7 @@ static QgsOgrLayerItem *dataItemForLayer( QgsDataItem *parentItem, QString name,
   {
     // we are in a collection
     name = QString::fromUtf8( OGR_FD_GetName( hDef ) );
-    QgsDebugMsg( "OGR layer name : " + name );
+    QgsDebugMsgLevel( "OGR layer name : " + name, 2 );
     if ( !uniqueNames )
     {
       layerUri += "|layerid=" + QString::number( layerId );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -196,7 +196,7 @@ void QgsOgrProvider::repack()
 
   // run REPACK on shape files
   QByteArray sql = QByteArray( "REPACK " ) + mOgrOrigLayer->name();   // don't quote the layer name as it works with spaces in the name and won't work if the name is quoted
-  QgsDebugMsg( QStringLiteral( "SQL: %1" ).arg( QString::fromUtf8( sql ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "SQL: %1" ).arg( QString::fromUtf8( sql ) ), 2 );
   CPLErrorReset();
   mOgrOrigLayer->ExecuteSQLNoReturn( sql );
   if ( CPLGetLastErrorType() != CE_None )
@@ -270,7 +270,7 @@ static QString AnalyzeURI( QString const &uri,
   subsetString = QString();
   ogrGeometryTypeFilter = wkbUnknown;
 
-  QgsDebugMsg( "Data source uri is [" + uri + ']' );
+  QgsDebugMsgLevel( "Data source uri is [" + uri + ']', 2 );
 
   // try to open for update, but disable error messages to avoid a
   // message if the file is read only, because we cope with that
@@ -472,7 +472,7 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
 
   // make connection to the data source
 
-  QgsDebugMsg( "Data source uri is [" + uri + ']' );
+  QgsDebugMsgLevel( "Data source uri is [" + uri + ']', 2 );
 
   mFilePath = AnalyzeURI( uri,
                           mIsSubLayer,
@@ -639,7 +639,7 @@ QgsTransaction *QgsOgrProvider::transaction() const
 
 void QgsOgrProvider::setTransaction( QgsTransaction *transaction )
 {
-  QgsDebugMsg( QStringLiteral( "set transaction %1" ).arg( transaction != nullptr ) );
+  QgsDebugMsgLevel( QStringLiteral( "set transaction %1" ).arg( transaction != nullptr ), 1 );
   // static_cast since layers cannot be added to a transaction of a non-matching provider
   mTransaction = static_cast<QgsOgrTransaction *>( transaction );
 }
@@ -819,7 +819,7 @@ void QgsOgrProvider::addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer
     longDescription = layer->GetMetadataItem( "TITLE" );
   }
 
-  QgsDebugMsg( QStringLiteral( "id = %1 name = %2 layerGeomType = %3 longDescription = %4" ).arg( i ).arg( layerName ).arg( layerGeomType ). arg( longDescription ) );
+  QgsDebugMsgLevel( QStringLiteral( "id = %1 name = %2 layerGeomType = %3 longDescription = %4" ).arg( i ).arg( layerName ).arg( layerGeomType ). arg( longDescription ), 2 );
 
   if ( slowGeomTypeRetrieval || wkbFlatten( layerGeomType ) != wkbUnknown )
   {
@@ -909,7 +909,7 @@ void QgsOgrProvider::addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer
                           << longDescription;
 
       QString sl = parts.join( sublayerSeparator() );
-      QgsDebugMsg( "sub layer: " + sl );
+      QgsDebugMsgLevel( "sub layer: " + sl, 1 );
       mSubLayerList << sl;
     }
   }
@@ -1309,14 +1309,14 @@ QgsRectangle QgsOgrProvider::extent() const
     mExtent.reset( new OGREnvelope() );
 
     // get the extent_ (envelope) of the layer
-    QgsDebugMsg( QStringLiteral( "Starting get extent" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Starting get extent" ), 3 );
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,1,2)
     if ( mForceRecomputeExtent && mValid && mGDALDriverName == QLatin1String( "GPKG" ) && mOgrOrigLayer )
     {
       // works with unquoted layerName
       QByteArray sql = QByteArray( "RECOMPUTE EXTENT ON " ) + mOgrOrigLayer->name();
-      QgsDebugMsg( QStringLiteral( "SQL: %1" ).arg( QString::fromUtf8( sql ) ) );
+      QgsDebugMsgLevel( QStringLiteral( "SQL: %1" ).arg( QString::fromUtf8( sql ) ), 2 );
       mOgrOrigLayer->ExecuteSQLNoReturn( sql );
     }
 #endif
@@ -1366,7 +1366,7 @@ QgsRectangle QgsOgrProvider::extent() const
       mOgrLayer->ResetReading();
     }
 
-    QgsDebugMsg( QStringLiteral( "Finished get extent" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Finished get extent" ), 4 );
   }
 
   mExtentRect.set( mExtent->MinX, mExtent->MinY, mExtent->MaxX, mExtent->MaxY );
@@ -2429,7 +2429,7 @@ bool QgsOgrProvider::createSpatialIndex()
   if ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) )
   {
     QByteArray sql = QByteArray( "CREATE SPATIAL INDEX ON " ) + quotedIdentifier( layerName );  // quote the layer name so spaces are handled
-    QgsDebugMsg( QStringLiteral( "SQL: %1" ).arg( QString::fromUtf8( sql ) ) );
+    QgsDebugMsgLevel( QStringLiteral( "SQL: %1" ).arg( QString::fromUtf8( sql ) ), 2 );
     mOgrOrigLayer->ExecuteSQLNoReturn( sql );
 
     if ( !mFilePath.endsWith( QLatin1String( ".shp" ), Qt::CaseInsensitive ) )
@@ -2563,7 +2563,7 @@ bool QgsOgrProvider::doInitialActionsForEdition()
   // If mUpdateModeStackDepth > 0, it means that an updateMode is already active and that we have write access
   if ( mUpdateModeStackDepth == 0 )
   {
-    QgsDebugMsg( QStringLiteral( "Enter update mode implicitly" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Enter update mode implicitly" ), 1 );
     if ( !_enterUpdateMode( true ) )
       return false;
   }
@@ -2860,7 +2860,7 @@ QString createFilters( const QString &type )
     // theoreticaly we can open those files because there exists a
     // driver for them, the user will have to use the "All Files" to
     // open datasets with no explicitly defined file name extension.
-    QgsDebugMsg( QStringLiteral( "Driver count: %1" ).arg( OGRGetDriverCount() ) );
+    QgsDebugMsgLevel( QStringLiteral( "Driver count: %1" ).arg( OGRGetDriverCount() ), 3 );
 
     bool kmlFound = false;
     bool dwgFound = false;
@@ -3438,7 +3438,7 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
     const QgsCoordinateReferenceSystem &srs,
     QString &errorMessage )
 {
-  QgsDebugMsg( QStringLiteral( "Creating empty vector layer with format: %1" ).arg( format ) );
+  QgsDebugMsgLevel( QStringLiteral( "Creating empty vector layer with format: %1" ).arg( format ), 2 );
   errorMessage.clear();
 
   QgsApplication::registerOgrDrivers();
@@ -3653,7 +3653,7 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
     }
   }
 
-  QgsDebugMsg( QStringLiteral( "GDAL Version number %1" ).arg( GDAL_VERSION_NUM ) );
+  QgsDebugMsgLevel( QStringLiteral( "GDAL Version number %1" ).arg( GDAL_VERSION_NUM ), 2 );
   if ( reference )
   {
     OSRRelease( reference );
@@ -3756,7 +3756,7 @@ QSet<QVariant> QgsOgrProvider::uniqueValues( int index, int limit ) const
 
   sql += " ORDER BY " + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) ) + " ASC";
 
-  QgsDebugMsg( QStringLiteral( "SQL: %1" ).arg( textEncoding()->toUnicode( sql ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "SQL: %1" ).arg( textEncoding()->toUnicode( sql ) ), 2 );
   QgsOgrLayerUniquePtr l = mOgrLayer->ExecuteSQL( sql );
   if ( !l )
   {
@@ -3804,7 +3804,7 @@ QStringList QgsOgrProvider::uniqueStringsMatching( int index, const QString &sub
 
   sql += " ORDER BY " + quotedIdentifier( textEncoding()->fromUnicode( fld.name() ) ) + " ASC";
 
-  QgsDebugMsg( QStringLiteral( "SQL: %1" ).arg( textEncoding()->toUnicode( sql ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "SQL: %1" ).arg( textEncoding()->toUnicode( sql ) ), 2 );
   QgsOgrLayerUniquePtr l = mOgrLayer->ExecuteSQL( sql );
   if ( !l )
   {
@@ -4062,7 +4062,7 @@ static bool IsLocalFile( const QString &path )
   const QString fileSystem( info.fileSystemType() );
   bool isLocal = path != QLatin1String( "nfs" ) && path != QLatin1String( "smbfs" );
   if ( !isLocal )
-    QgsDebugMsg( QStringLiteral( "Filesystem for %1 is %2" ).arg( path, fileSystem ) );
+    QgsDebugMsgLevel( QStringLiteral( "Filesystem for %1 is %2" ).arg( path, fileSystem ), 2 );
   return isLocal;
 #endif
 }
@@ -4105,7 +4105,7 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
         }
 
         CPLPushErrorHandler( CPLQuietErrorHandler );
-        QgsDebugMsg( QStringLiteral( "GPKG: Trying to return to delete mode" ) );
+        QgsDebugMsgLevel( QStringLiteral( "GPKG: Trying to return to delete mode" ), 2 );
         OGRLayerH hSqlLyr = GDALDatasetExecuteSQL( hDS,
                             "PRAGMA journal_mode = delete",
                             nullptr, nullptr );
@@ -4116,7 +4116,7 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
           {
             const char *pszRet = OGR_F_GetFieldAsString( hFeat.get(), 0 );
             bSuccess = EQUAL( pszRet, "delete" );
-            QgsDebugMsg( QStringLiteral( "Return: %1" ).arg( pszRet ) );
+            QgsDebugMsgLevel( QStringLiteral( "Return: %1" ).arg( pszRet ), 2 );
           }
         }
         else if ( CPLGetLastErrorType() != CE_None )
@@ -4134,11 +4134,11 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
       {
         if ( openedAsUpdate )
         {
-          QgsDebugMsg( QStringLiteral( "GPKG: Trying again" ) );
+          QgsDebugMsgLevel( QStringLiteral( "GPKG: Trying again" ), 1 );
         }
         else
         {
-          QgsDebugMsg( QStringLiteral( "GPKG: Trying to return to delete mode" ) );
+          QgsDebugMsgLevel( QStringLiteral( "GPKG: Trying to return to delete mode" ), 1 );
         }
         CPLSetThreadLocalConfigOption( "OGR_SQLITE_JOURNAL", "DELETE" );
         hDS = GDALOpenEx( datasetName.toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr );
@@ -4157,7 +4157,7 @@ void QgsOgrProviderUtils::GDALCloseWrapper( GDALDatasetH hDS )
             if ( hFeat != nullptr )
             {
               const char *pszRet = OGR_F_GetFieldAsString( hFeat.get(), 0 );
-              QgsDebugMsg( QStringLiteral( "Return: %1" ).arg( pszRet ) );
+              QgsDebugMsgLevel( QStringLiteral( "Return: %1" ).arg( pszRet ), 1 );
             }
             GDALDatasetReleaseResultSet( hDS, hSqlLyr );
           }
@@ -4375,7 +4375,7 @@ OGRLayerH QgsOgrProviderUtils::setSubsetString( OGRLayerH layer, GDALDatasetH ds
   {
     QByteArray sql = encoding->fromUnicode( subsetString );
 
-    QgsDebugMsg( QStringLiteral( "SQL: %1" ).arg( encoding->toUnicode( sql ) ) );
+    QgsDebugMsgLevel( QStringLiteral( "SQL: %1" ).arg( encoding->toUnicode( sql ) ), 1 );
     subsetLayer = GDALDatasetExecuteSQL( ds, sql.constData(), nullptr, nullptr );
   }
   else
@@ -4406,7 +4406,7 @@ void QgsOgrProvider::open( OpenMode mode )
       mFilePath = vsiPrefix + mFilePath;
       setDataSourceUri( mFilePath );
     }
-    QgsDebugMsg( QStringLiteral( "Trying %1 syntax, mFilePath= %2" ).arg( vsiPrefix, mFilePath ) );
+    QgsDebugMsgLevel( QStringLiteral( "Trying %1 syntax, mFilePath= %2" ).arg( vsiPrefix, mFilePath ), 1 );
   }
 
   QgsDebugMsgLevel( "mFilePath: " + mFilePath, 3 );
@@ -4493,7 +4493,7 @@ void QgsOgrProvider::open( OpenMode mode )
     mGDALDriverName = mOgrOrigLayer->driverName();
     mShareSameDatasetAmongLayers = QgsOgrProviderUtils::canDriverShareSameDatasetAmongLayers( mGDALDriverName );
 
-    QgsDebugMsg( "OGR opened using Driver " + mGDALDriverName );
+    QgsDebugMsgLevel( "OGR opened using Driver " + mGDALDriverName, 2 );
 
     mOgrLayer = mOgrOrigLayer.get();
 
@@ -4519,7 +4519,7 @@ void QgsOgrProvider::open( OpenMode mode )
       {
         computeCapabilities();
       }
-      QgsDebugMsg( QStringLiteral( "Data source is valid" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Data source is valid" ), 2 );
     }
     else
     {
@@ -4630,7 +4630,7 @@ bool QgsOgrProvider::_enterUpdateMode( bool implicit )
   if ( mUpdateModeStackDepth == 0 )
   {
     Q_ASSERT( mDynamicWriteAccess );
-    QgsDebugMsg( QStringLiteral( "Reopening %1 in update mode" ).arg( dataSourceUri() ) );
+    QgsDebugMsgLevel( QStringLiteral( "Reopening %1 in update mode" ).arg( dataSourceUri() ), 1 );
     close();
     open( implicit ? OpenModeForceUpdate : OpenModeForceUpdateRepackOff );
     if ( !mOgrLayer || !mWriteAccess )
@@ -4700,7 +4700,7 @@ bool QgsOgrProvider::leaveUpdateMode()
   }
   if ( mUpdateModeStackDepth == 0 )
   {
-    QgsDebugMsg( QStringLiteral( "Reopening %1 in read-only mode" ).arg( dataSourceUri() ) );
+    QgsDebugMsgLevel( QStringLiteral( "Reopening %1 in read-only mode" ).arg( dataSourceUri() ), 1 );
     close();
     open( OpenModeForceReadOnly );
     if ( !mOgrLayer )
@@ -5008,7 +5008,7 @@ void QgsOgrProviderUtils::invalidateCachedLastModifiedDate( const QString &dsNam
   auto iter = sMapDSNameToLastModifiedDate()->find( dsName );
   if ( iter != sMapDSNameToLastModifiedDate()->end() )
   {
-    QgsDebugMsg( QStringLiteral( "invalidating last modified date for %1" ).arg( dsName ) );
+    QgsDebugMsgLevel( QStringLiteral( "invalidating last modified date for %1" ).arg( dsName ), 1 );
     iter.value() = iter.value().addSecs( -10 );
   }
 }

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1679,8 +1679,8 @@ void QgsApplication::applyGdalSkippedDrivers()
       realDisabledDriverList << driverName;
   }
   QString myDriverList = realDisabledDriverList.join( ' ' );
-  QgsDebugMsg( QStringLiteral( "Gdal Skipped driver list set to:" ) );
-  QgsDebugMsg( myDriverList );
+  QgsDebugMsgLevel( QStringLiteral( "Gdal Skipped driver list set to:" ), 1 );
+  QgsDebugMsgLevel( myDriverList, 1 );
   CPLSetConfigOption( "GDAL_SKIP", myDriverList.toUtf8() );
   GDALAllRegister(); //to update driver list and skip missing ones
 }
@@ -1948,7 +1948,7 @@ bool QgsApplication::createDatabase( QString *errorMessage )
 
 void QgsApplication::setMaxThreads( int maxThreads )
 {
-  QgsDebugMsg( QStringLiteral( "maxThreads: %1" ).arg( maxThreads ) );
+  QgsDebugMsgLevel( QStringLiteral( "maxThreads: %1" ).arg( maxThreads ), 1 );
 
   // make sure value is between 1 and #cores, if not set to -1 (use #cores)
   // 0 could be used to disable any parallel processing
@@ -1964,7 +1964,7 @@ void QgsApplication::setMaxThreads( int maxThreads )
 
   // set max thread count in QThreadPool
   QThreadPool::globalInstance()->setMaxThreadCount( maxThreads );
-  QgsDebugMsg( QStringLiteral( "set QThreadPool max thread count to %1" ).arg( QThreadPool::globalInstance()->maxThreadCount() ) );
+  QgsDebugMsgLevel( QStringLiteral( "set QThreadPool max thread count to %1" ).arg( QThreadPool::globalInstance()->maxThreadCount() ), 1 );
 }
 
 QgsTaskManager *QgsApplication::taskManager()

--- a/src/core/qgscredentials.cpp
+++ b/src/core/qgscredentials.cpp
@@ -47,7 +47,7 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
       QPair<QString, QString> credentials = mCredentialCache.take( realm );
       username = credentials.first;
       password = credentials.second;
-      QgsDebugMsg( QStringLiteral( "retrieved realm:%1 username:%2" ).arg( realm, username ) );
+      QgsDebugMsgLevel( QStringLiteral( "retrieved realm:%1 username:%2" ).arg( realm, username ), 2 );
 
       if ( !password.isNull() )
         return true;
@@ -56,7 +56,7 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
 
   if ( request( realm, username, password, message ) )
   {
-    QgsDebugMsg( QStringLiteral( "requested realm:%1 username:%2" ).arg( realm, username ) );
+    QgsDebugMsgLevel( QStringLiteral( "requested realm:%1 username:%2" ).arg( realm, username ), 2 );
     return true;
   }
   else
@@ -69,7 +69,7 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
 void QgsCredentials::put( const QString &realm, const QString &username, const QString &password )
 {
   QMutexLocker locker( &mCacheMutex );
-  QgsDebugMsg( QStringLiteral( "inserting realm:%1 username:%2" ).arg( realm, username ) );
+  QgsDebugMsgLevel( QStringLiteral( "inserting realm:%1 username:%2" ).arg( realm, username ), 2 );
   mCredentialCache.insert( realm, QPair<QString, QString>( username, password ) );
 }
 
@@ -77,7 +77,7 @@ bool QgsCredentials::getMasterPassword( QString &password, bool stored )
 {
   if ( requestMasterPassword( password, stored ) )
   {
-    QgsDebugMsg( QStringLiteral( "requested master password" ) );
+    QgsDebugMsgLevel( QStringLiteral( "requested master password" ), 2 );
     return true;
   }
   return false;

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -344,7 +344,7 @@ QgsAbstractFeatureSource::~QgsAbstractFeatureSource()
   while ( !mActiveIterators.empty() )
   {
     QgsAbstractFeatureIterator *it = *mActiveIterators.begin();
-    QgsDebugMsg( QStringLiteral( "closing active iterator" ) );
+    QgsDebugMsgLevel( QStringLiteral( "closing active iterator" ), 2 );
     it->close();
   }
 }

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -298,9 +298,7 @@ class CORE_EXPORT QgsField
         Py_BEGIN_ALLOW_THREADS
         try
         {
-          QgsDebugMsg( a0->toString() );
           sipRes = sipCpp->convertCompatible( *a0 );
-          QgsDebugMsg( a0->toString() );
         }
         catch ( ... )
         {

--- a/src/core/qgsimagecache.cpp
+++ b/src/core/qgsimagecache.cpp
@@ -72,7 +72,7 @@ int QgsImageCacheEntry::dataSize() const
 
 void QgsImageCacheEntry::dump() const
 {
-  QgsDebugMsg( QStringLiteral( "path: %1, size %2x%3" ).arg( path ).arg( size.width() ).arg( size.height() ) );
+  QgsDebugMsgLevel( QStringLiteral( "path: %1, size %2x%3" ).arg( path ).arg( size.width() ).arg( size.height() ), 3 );
 }
 
 ///@endcond

--- a/src/core/qgslogger.h
+++ b/src/core/qgslogger.h
@@ -136,11 +136,11 @@ class CORE_EXPORT QgsScopeLogger // clazy:exclude=rule-of-three
       , _func( func )
       , _line( line )
     {
-      QgsLogger::debug( QStringLiteral( "Entering." ), 1, _file, _func, _line );
+      QgsLogger::debug( QStringLiteral( "Entering." ), 2, _file, _func, _line );
     }
     ~QgsScopeLogger()
     {
-      QgsLogger::debug( QStringLiteral( "Leaving." ), 1, _file, _func, _line );
+      QgsLogger::debug( QStringLiteral( "Leaving." ), 2, _file, _func, _line );
     }
   private:
     const char *_file = nullptr;

--- a/src/core/qgslogger.h
+++ b/src/core/qgslogger.h
@@ -31,7 +31,7 @@ class QFile;
 
 #ifdef QGISDEBUG
 #define QgsDebugMsg(str) QgsLogger::debug(QString(str), 1, __FILE__, __FUNCTION__, __LINE__)
-#define QgsDebugMsgLevel(str, level) QgsLogger::debug(QString(str), (level), __FILE__, __FUNCTION__, __LINE__)
+#define QgsDebugMsgLevel(str, level) if ( level <= QgsLogger::debugLevel() ) { QgsLogger::debug(QString(str), (level), __FILE__, __FUNCTION__, __LINE__); }(void)(0)
 #define QgsDebugCall QgsScopeLogger _qgsScopeLogger(__FILE__, __FUNCTION__, __LINE__)
 #else
 #define QgsDebugCall
@@ -102,7 +102,12 @@ class CORE_EXPORT QgsLogger
     /**
      * Reads the environment variable QGIS_DEBUG and converts it to int. If QGIS_DEBUG is not set,
      the function returns 1 if QGISDEBUG is defined and 0 if not*/
-    static int debugLevel() { init(); return sDebugLevel; }
+    static int debugLevel()
+    {
+      if ( sDebugLevel == -999 )
+        init();
+      return sDebugLevel;
+    }
 
     //! Logs the message passed in to the logfile defined in QGIS_LOG_FILE if any. *
     static void logMessageToFile( const QString &message );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -61,7 +61,7 @@ void QgsMapSettings::setMagnificationFactor( double factor )
   mExtent = ext;
   mDpi = mDpi / ratio;
 
-  QgsDebugMsg( QStringLiteral( "Magnification factor: %1  dpi: %2  ratio: %3" ).arg( factor ).arg( mDpi ).arg( ratio ) );
+  QgsDebugMsgLevel( QStringLiteral( "Magnification factor: %1  dpi: %2  ratio: %3" ).arg( factor ).arg( mDpi ).arg( ratio ), 3 );
 
   updateDerived();
 }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -800,7 +800,7 @@ void QgsProject::clear()
 // basically a debugging tool to dump property list values
 void dump_( const QgsProjectPropertyKey &topQgsPropertyKey )
 {
-  QgsDebugMsg( QStringLiteral( "current properties:" ) );
+  QgsDebugMsgLevel( QStringLiteral( "current properties:" ), 3 );
   topQgsPropertyKey.dump();
 }
 
@@ -1189,7 +1189,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
 
   projectFile.close();
 
-  QgsDebugMsg( "Opened document " + projectFile.fileName() );
+  QgsDebugMsgLevel( "Opened document " + projectFile.fileName(), 2 );
 
   // get project version string, if any
   QgsProjectVersion fileVersion = getVersion( *doc );
@@ -1222,7 +1222,7 @@ bool QgsProject::readProjectFile( const QString &filename, QgsProject::ReadFlags
   // now get any properties
   _getProperties( *doc, mProperties );
 
-  QgsDebugMsg( QString::number( mProperties.count() ) + " properties read" );
+  QgsDebugMsgLevel( QString::number( mProperties.count() ) + " properties read", 2 );
 
 #if 0
   dump_( mProperties );
@@ -2070,7 +2070,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
   dump_( mProperties );
 #endif
 
-  QgsDebugMsg( QStringLiteral( "there are %1 property scopes" ).arg( static_cast<int>( mProperties.count() ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "there are %1 property scopes" ).arg( static_cast<int>( mProperties.count() ) ), 1 );
 
   if ( !mProperties.isEmpty() ) // only worry about properties if we
     // actually have any properties

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -41,12 +41,12 @@ void QgsProjectPropertyValue::dump( int tabs ) const
 
     for ( const auto &string : sl )
     {
-      QgsDebugMsg( QStringLiteral( "%1[%2] " ).arg( tabString, string ) );
+      QgsDebugMsgLevel( QStringLiteral( "%1[%2] " ).arg( tabString, string ), 4 );
     }
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "%1%2" ).arg( tabString, mValue.toString() ) );
+    QgsDebugMsgLevel( QStringLiteral( "%1%2" ).arg( tabString, mValue.toString() ), 4 );
   }
 #endif
 }
@@ -299,7 +299,7 @@ void QgsProjectPropertyKey::dump( int tabs ) const
 
   tabString.fill( '\t', tabs );
 
-  QgsDebugMsg( QStringLiteral( "%1name: %2" ).arg( tabString, name() ) );
+  QgsDebugMsgLevel( QStringLiteral( "%1name: %2" ).arg( tabString, name() ), 4 );
 
   tabs++;
   tabString.fill( '\t', tabs );
@@ -315,20 +315,20 @@ void QgsProjectPropertyKey::dump( int tabs ) const
 
         if ( QVariant::StringList == propertyValue->value().type() )
         {
-          QgsDebugMsg( QStringLiteral( "%1key: <%2>  value:" ).arg( tabString, i.key() ) );
+          QgsDebugMsgLevel( QStringLiteral( "%1key: <%2>  value:" ).arg( tabString, i.key() ), 4 );
           propertyValue->dump( tabs + 1 );
         }
         else
         {
-          QgsDebugMsg( QStringLiteral( "%1key: <%2>  value: %3" ).arg( tabString, i.key(), propertyValue->value().toString() ) );
+          QgsDebugMsgLevel( QStringLiteral( "%1key: <%2>  value: %3" ).arg( tabString, i.key(), propertyValue->value().toString() ), 4 );
         }
       }
       else
       {
-        QgsDebugMsg( QStringLiteral( "%1key: <%2>  subkey: <%3>" )
-                     .arg( tabString,
-                           i.key(),
-                           static_cast<QgsProjectPropertyKey *>( i.value() )->name() ) );
+        QgsDebugMsgLevel( QStringLiteral( "%1key: <%2>  subkey: <%3>" )
+                          .arg( tabString,
+                                i.key(),
+                                static_cast<QgsProjectPropertyKey *>( i.value() )->name() ), 4 );
         i.value()->dump( tabs + 1 );
       }
 

--- a/src/core/qgspythonrunner.cpp
+++ b/src/core/qgspythonrunner.cpp
@@ -29,7 +29,7 @@ bool QgsPythonRunner::run( const QString &command, const QString &messageOnError
 {
   if ( sInstance )
   {
-    QgsDebugMsg( "Running " + command );
+    QgsDebugMsgLevel( "Running " + command, 3 );
     return sInstance->runCommand( command, messageOnError );
   }
   else

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -388,7 +388,7 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
       }
     }
 
-    QgsDebugMsg( QStringLiteral( "native type matches" ) );
+    QgsDebugMsgLevel( QStringLiteral( "native type matches" ), 3 );
     return true;
   }
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1841,7 +1841,7 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     // TODO: very bad, we have to load twice!!! Make QgsDataProvider::timestamp() static?
     if ( stamp < mDataProvider->dataTimestamp() )
     {
-      QgsDebugMsg( QStringLiteral( "data changed, reload provider" ) );
+      QgsDebugMsgLevel( QStringLiteral( "data changed, reload provider" ), 3 );
       closeDataProvider();
       init();
       setDataProvider( mProviderKey );
@@ -2133,7 +2133,7 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
     if ( !src.contains( QLatin1String( "type=" ) ) &&
          !src.contains( QLatin1String( "crs=" ) ) && !src.contains( QLatin1String( "format=" ) ) )
     {
-      QgsDebugMsg( QStringLiteral( "Old WMS URI format detected -> converting to new format" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Old WMS URI format detected -> converting to new format" ), 2 );
       QgsDataSourceUri uri;
       if ( !src.startsWith( QLatin1String( "http:" ) ) )
       {

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -47,7 +47,7 @@ void QgsRasterLayerRendererFeedback::onNewData()
 
   // TODO: update only the area that got new data
 
-  QgsDebugMsg( QStringLiteral( "new raster preview! %1" ).arg( mLastPreview.msecsTo( QTime::currentTime() ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "new raster preview! %1" ).arg( mLastPreview.msecsTo( QTime::currentTime() ) ), 3 );
   QTime t;
   t.start();
   QgsRasterBlockFeedback feedback;
@@ -56,7 +56,7 @@ void QgsRasterLayerRendererFeedback::onNewData()
   QgsRasterIterator iterator( mR->mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
   drawer.draw( mR->renderContext()->painter(), mR->mRasterViewPort, &mR->renderContext()->mapToPixel(), &feedback );
-  QgsDebugMsg( QStringLiteral( "total raster preview time: %1 ms" ).arg( t.elapsed() ) );
+  QgsDebugMsgLevel( QStringLiteral( "total raster preview time: %1 ms" ).arg( t.elapsed() ), 3 );
   mLastPreview = QTime::currentTime();
 }
 
@@ -132,7 +132,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   QgsRectangle myRasterExtent = layer->ignoreExtents() ? myProjectedViewExtent : myProjectedViewExtent.intersect( myProjectedLayerExtent );
   if ( myRasterExtent.isEmpty() )
   {
-    QgsDebugMsg( QStringLiteral( "draw request outside view extent." ) );
+    QgsDebugMsgLevel( QStringLiteral( "draw request outside view extent." ), 2 );
     // nothing to do
     return;
   }

--- a/src/core/symbology/qgsellipsesymbollayer.cpp
+++ b/src/core/symbology/qgsellipsesymbollayer.cpp
@@ -416,7 +416,7 @@ void QgsEllipseSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &elem
 
 QgsSymbolLayer *QgsEllipseSymbolLayer::createFromSld( QDomElement &element )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement graphicElem = element.firstChildElement( QStringLiteral( "Graphic" ) );
   if ( graphicElem.isNull() )

--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -461,7 +461,7 @@ QString QgsSimpleLineSymbolLayer::ogrFeatureStyle( double mmScaleFactor, double 
 
 QgsSymbolLayer *QgsSimpleLineSymbolLayer::createFromSld( QDomElement &element )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement strokeElem = element.firstChildElement( QStringLiteral( "Stroke" ) );
   if ( strokeElem.isNull() )
@@ -1876,7 +1876,7 @@ void QgsMarkerLineSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, c
 
 QgsSymbolLayer *QgsMarkerLineSymbolLayer::createFromSld( QDomElement &element )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement strokeElem = element.firstChildElement( QStringLiteral( "Stroke" ) );
   if ( strokeElem.isNull() )

--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -1166,7 +1166,7 @@ QString QgsSimpleMarkerSymbolLayer::ogrFeatureStyle( double mmScaleFactor, doubl
 
 QgsSymbolLayer *QgsSimpleMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement graphicElem = element.firstChildElement( QStringLiteral( "Graphic" ) );
   if ( graphicElem.isNull() )
@@ -2317,7 +2317,7 @@ void QgsSvgMarkerSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &el
 
 QgsSymbolLayer *QgsSvgMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement graphicElem = element.firstChildElement( QStringLiteral( "Graphic" ) );
   if ( graphicElem.isNull() )
@@ -3349,7 +3349,7 @@ QRectF QgsFontMarkerSymbolLayer::bounds( QPointF point, QgsSymbolRenderContext &
 
 QgsSymbolLayer *QgsFontMarkerSymbolLayer::createFromSld( QDomElement &element )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement graphicElem = element.firstChildElement( QStringLiteral( "Graphic" ) );
   if ( graphicElem.isNull() )

--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -373,14 +373,14 @@ void QgsPointDistanceRenderer::printGroupInfo() const
 {
 #ifdef QGISDEBUG
   int nGroups = mClusteredGroups.size();
-  QgsDebugMsg( "number of displacement groups:" + QString::number( nGroups ) );
+  QgsDebugMsgLevel( "number of displacement groups:" + QString::number( nGroups ), 3 );
   for ( int i = 0; i < nGroups; ++i )
   {
-    QgsDebugMsg( "***************displacement group " + QString::number( i ) );
+    QgsDebugMsgLevel( "***************displacement group " + QString::number( i ), 3 );
     const auto constAt = mClusteredGroups.at( i );
     for ( const GroupedFeature &feature : constAt )
     {
-      QgsDebugMsg( FID_TO_STRING( feature.feature.id() ) );
+      QgsDebugMsgLevel( FID_TO_STRING( feature.feature.id() ), 3 );
     }
   }
 #endif

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -246,7 +246,7 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, QgsWkbTyp
 
       if ( ruleCount > 1 )
       {
-        QgsDebugMsg( QStringLiteral( "more Rule elements found: need a RuleRenderer" ) );
+        QgsDebugMsgLevel( QStringLiteral( "more Rule elements found: need a RuleRenderer" ), 2 );
         needRuleRenderer = true;
       }
 
@@ -258,7 +258,7 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, QgsWkbTyp
              ruleChildElem.localName() == QLatin1String( "MinScaleDenominator" ) ||
              ruleChildElem.localName() == QLatin1String( "MaxScaleDenominator" ) )
         {
-          QgsDebugMsg( QStringLiteral( "Filter or Min/MaxScaleDenominator element found: need a RuleRenderer" ) );
+          QgsDebugMsgLevel( QStringLiteral( "Filter or Min/MaxScaleDenominator element found: need a RuleRenderer" ), 2 );
           needRuleRenderer = true;
           break;
         }
@@ -280,7 +280,7 @@ QgsFeatureRenderer *QgsFeatureRenderer::loadSld( const QDomNode &node, QgsWkbTyp
   {
     rendererType = QStringLiteral( "singleSymbol" );
   }
-  QgsDebugMsg( QStringLiteral( "Instantiating a '%1' renderer..." ).arg( rendererType ) );
+  QgsDebugMsgLevel( QStringLiteral( "Instantiating a '%1' renderer..." ).arg( rendererType ), 2 );
 
   // create the renderer and return it
   QgsRendererAbstractMetadata *m = QgsApplication::rendererRegistry()->rendererMetadata( rendererType );

--- a/src/core/symbology/qgssvgcache.cpp
+++ b/src/core/symbology/qgssvgcache.cpp
@@ -87,7 +87,7 @@ int QgsSvgCacheEntry::dataSize() const
 
 void QgsSvgCacheEntry::dump() const
 {
-  QgsDebugMsg( QStringLiteral( "path: %1, size %2, width scale factor %3" ).arg( path ).arg( size ).arg( widthScaleFactor ) );
+  QgsDebugMsgLevel( QStringLiteral( "path: %1, size %2, width scale factor %3" ).arg( path ).arg( size ).arg( widthScaleFactor ), 4 );
 }
 ///@endcond
 

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -1230,7 +1230,7 @@ bool QgsSymbolLayerUtils::createSymbolLayerListFromSld( QDomElement &element,
     QgsWkbTypes::GeometryType geomType,
     QgsSymbolLayerList &layers )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   if ( element.isNull() )
     return false;
@@ -1630,7 +1630,7 @@ bool QgsSymbolLayerUtils::needSvgFill( QDomElement &element )
 
 bool QgsSymbolLayerUtils::convertPolygonSymbolizerToPointMarker( QDomElement &element, QgsSymbolLayerList &layerList )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   /* SE 1.1 says about PolygonSymbolizer:
   if a point geometry is referenced instead of a polygon,
@@ -1937,7 +1937,7 @@ void QgsSymbolLayerUtils::fillToSld( QDomDocument &doc, QDomElement &element, Qt
 
 bool QgsSymbolLayerUtils::fillFromSld( QDomElement &element, Qt::BrushStyle &brushStyle, QColor &color )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   brushStyle = Qt::SolidPattern;
   color = QColor( 128, 128, 128 );
@@ -2078,7 +2078,7 @@ bool QgsSymbolLayerUtils::lineFromSld( QDomElement &element,
                                        Qt::PenJoinStyle *penJoinStyle, Qt::PenCapStyle *penCapStyle,
                                        QVector<qreal> *customDashPattern, double *dashOffset )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   penStyle = Qt::SolidLine;
   color = QColor( 0, 0, 0 );
@@ -2291,7 +2291,7 @@ bool QgsSymbolLayerUtils::externalGraphicFromSld( QDomElement &element,
     QString &path, QString &mime,
     QColor &color, double &size )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   Q_UNUSED( color )
 
   QDomElement externalGraphicElem = element.firstChildElement( QStringLiteral( "ExternalGraphic" ) );
@@ -2346,7 +2346,7 @@ bool QgsSymbolLayerUtils::externalMarkerFromSld( QDomElement &element,
     QString &path, QString &format, int &markIndex,
     QColor &color, double &size )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   color = QColor();
   markIndex = -1;
@@ -2426,7 +2426,7 @@ bool QgsSymbolLayerUtils::wellKnownMarkerFromSld( QDomElement &element,
     QString &name, QColor &color, QColor &strokeColor, Qt::PenStyle &strokeStyle,
     double &strokeWidth, double &size )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   name = QStringLiteral( "square" );
   color = QColor();
@@ -2813,7 +2813,7 @@ void QgsSymbolLayerUtils::createOnlineResourceElement( QDomDocument &doc, QDomEl
 
 bool QgsSymbolLayerUtils::onlineResourceFromSldElement( QDomElement &element, QString &path, QString &format )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 
   QDomElement onlineResourceElem = element.firstChildElement( QStringLiteral( "OnlineResource" ) );
   if ( onlineResourceElem.isNull() )

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -67,10 +67,10 @@ void QgsMapCanvasMap::paint( QPainter *painter )
   bool scale = false;
   if ( mImage.size() != QSize( w, h ) * mImage.devicePixelRatioF() )
   {
-    QgsDebugMsg( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" )
-                 .arg( mImage.width() / mImage.devicePixelRatioF() )
-                 .arg( mImage.height() / mImage.devicePixelRatioF() )
-                 .arg( w ).arg( h ) );
+    QgsDebugMsgLevel( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" )
+                      .arg( mImage.width() / mImage.devicePixelRatioF() )
+                      .arg( mImage.height() / mImage.devicePixelRatioF() )
+                      .arg( w ).arg( h ), 2 );
     // This happens on zoom events when ::paint is called before
     // the renderer has completed
     scale = true;

--- a/src/gui/raster/qgsrasterminmaxwidget.cpp
+++ b/src/gui/raster/qgsrasterminmaxwidget.cpp
@@ -35,7 +35,7 @@ QgsRasterMinMaxWidget::QgsRasterMinMaxWidget( QgsRasterLayer *layer, QWidget *pa
   , mLastRectangleValid( false )
   , mBandsChanged( false )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   setupUi( this );
   connect( mUserDefinedRadioButton, &QRadioButton::toggled, this, &QgsRasterMinMaxWidget::mUserDefinedRadioButton_toggled );
   connect( mMinMaxRadioButton, &QRadioButton::toggled, this, &QgsRasterMinMaxWidget::mMinMaxRadioButton_toggled );
@@ -180,7 +180,7 @@ QgsRasterMinMaxOrigin QgsRasterMinMaxWidget::minMaxOrigin()
 
 void QgsRasterMinMaxWidget::doComputations()
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   if ( !mLayer->dataProvider() )
     return;
 

--- a/src/gui/symbology/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.cpp
@@ -56,7 +56,7 @@ static bool _initRenderer( const QString &name, QgsRendererWidgetFunc f, const Q
     m->setIcon( QgsApplication::getThemeIcon( iconName ) );
   }
 
-  QgsDebugMsg( "Set for " + name );
+  QgsDebugMsgLevel( "Set for " + name, 2 );
   return true;
 }
 

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -463,7 +463,7 @@ QString QgsWcsCapabilities::stripNS( const QString &name )
 
 bool QgsWcsCapabilities::parseCapabilitiesDom( QByteArray const &xml, QgsWcsCapabilitiesProperty &capabilities )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
 #ifdef QGISDEBUG
   QFile file( QDir::tempPath() + "/qgis-wcs-capabilities.xml" );
   if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
@@ -767,7 +767,7 @@ void QgsWcsCapabilities::parseCoverageOfferingBrief( QDomElement const &e, QgsWc
 
 bool QgsWcsCapabilities::convertToDom( QByteArray const &xml )
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   // Convert completed document into a Dom
   QString errorMsg;
   int errorLine;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3127,7 +3127,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
 void QgsWmsProvider::identifyReplyFinished()
 {
-  QgsDebugMsg( QStringLiteral( "Entered." ) );
+  QgsDebugMsgLevel( QStringLiteral( "Entered." ), 4 );
   mIdentifyResultHeaders.clear();
   mIdentifyResultBodies.clear();
 


### PR DESCRIPTION
Rework QgsDebugMsgLevel to avoid construction of strings which won't be logged at the current debug level

Instead of always constructing debug strings, and then potentially ignoring them if they fall outside the current debug level, we instead rework the QgsDebugMsgLevel macro so that strings are only ever constructed when they WILL be logged.

This avoids the (often very expensive) string construction for debug messages whenever the results won't be used. It allows low level (i.e. level 3 or 4) debug messages to be safely used without
incurring huge slowdowns in debug builds.

TODO: ensure we only ever use QgsDebugMsg() for ERROR reporting, and move all other debugging calls to QgsDebugMsgLevel instead.

Credit for original idea goes to @wonder-sk!