### PR TITLE
Hide coordinate operations which utilise a LAS/LOS grid shift file

### DIFF
--- a/src/core/qgsdatumtransform.cpp
+++ b/src/core/qgsdatumtransform.cpp
@@ -61,7 +61,10 @@ QList<QgsDatumTransform::TransformDetails> QgsDatumTransform::operations( const 
       if ( !op )
         continue;
 
-      res.push_back( transformDetailsFromPj( op.get() ) );
+      QgsDatumTransform::TransformDetails details = transformDetailsFromPj( op.get() );
+      if ( !details.proj.isEmpty() )
+        res.push_back( details );
+
     }
     proj_list_destroy( ops );
   }
@@ -326,6 +329,10 @@ QgsDatumTransform::TransformDetails QgsDatumTransform::transformDetailsFromPj( P
 
   if ( details.proj.isEmpty() )
     details.proj = QString( proj_as_proj_string( pjContext, op, PJ_PROJ_5, nullptr ) );
+
+  if ( details.proj.isEmpty() )
+    return details;
+
   details.name = QString( proj_get_name( op ) );
   details.accuracy = proj_coordoperation_get_accuracy( pjContext, op );
   details.isAvailable = proj_coordoperation_is_instantiable( pjContext, op );

--- a/tests/src/python/test_qgsdatumtransforms.py
+++ b/tests/src/python/test_qgsdatumtransforms.py
@@ -152,6 +152,21 @@ class TestPyQgsDatumTransform(unittest.TestCase):
         self.assertTrue(ops[op3_index].grids[0].directDownload)
         self.assertTrue(ops[op3_index].grids[0].openLicense)
 
+    @unittest.skipIf(QgsProjUtils.projVersionMajor() < 6, 'Not a proj6 build')
+    def testNoLasLos(self):
+        """
+        Test that operations which rely on an las/los grid shift file (which are unsupported by Proj6) are not returned
+        """
+        ops = QgsDatumTransform.operations(QgsCoordinateReferenceSystem('EPSG:3035'),
+                                           QgsCoordinateReferenceSystem('EPSG:5514'))
+        self.assertEqual(len(ops), 3)
+        self.assertTrue(ops[0].name)
+        self.assertTrue(ops[0].proj)
+        self.assertTrue(ops[1].name)
+        self.assertTrue(ops[1].proj)
+        self.assertTrue(ops[2].name)
+        self.assertTrue(ops[2].proj)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
which are unsupported by proj 6

E.g. some candidate operations between EPSG:3035 and EPSG:5514

Since these can NEVER (as of now) be instantiated by proj, even if
the grid shift files are present, it's misleading to present them
as options to users.

Refs #30569
