### PR TITLE
Keep order of value map items when importing CSV

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -148,6 +148,18 @@ void QgsValueMapConfigDlg::removeSelectedButtonPushed()
 
 void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool insertNull )
 {
+  QList<QPair<QString, QVariant>> orderedMap;
+  auto end = map.constEnd();
+  for ( auto it = map.constBegin(); it != end; ++it )
+  {
+    orderedMap.append( qMakePair( it.key(), it.value() ) );
+  }
+
+  updateMap( orderedMap, insertNull );
+}
+
+void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant> > &map, bool insertNull )
+{
   tableWidget->clearContents();
   for ( int i = tableWidget->rowCount() - 1; i > 0; i-- )
   {
@@ -161,12 +173,12 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
     ++row;
   }
 
-  for ( QMap<QString, QVariant>::const_iterator mit = map.begin(); mit != map.end(); ++mit, ++row )
+  for ( const auto &pair : map )
   {
-    if ( mit.value().isNull() )
-      setRow( row, mit.key(), QString() );
+    if ( pair.second.isNull() )
+      setRow( row, pair.first, QString() );
     else
-      setRow( row, mit.key(), mit.value().toString() );
+      setRow( row, pair.first, pair.second.toString() );
   }
 }
 
@@ -305,7 +317,8 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
   re0.setMinimal( true );
   QRegExp re1( "^([^,]*),(.*)$" );
   re1.setMinimal( true );
-  QMap<QString, QVariant> map;
+
+  QList<QPair<QString, QVariant>> map;
 
   s.readLine();
 
@@ -313,7 +326,9 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
   {
     QString l = s.readLine().trimmed();
 
-    QString key, val;
+    QString key;
+    QString val;
+
     if ( re0.indexIn( l ) >= 0 && re0.captureCount() == 2 )
     {
       key = re0.cap( 1 ).trimmed();
@@ -342,7 +357,7 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
     if ( key == QgsApplication::nullRepresentation() )
       key = QgsValueMapFieldFormatter::NULL_VALUE;
 
-    map[ key ] = val;
+    map.append( qMakePair( key, val ) );
   }
 
   updateMap( map, false );

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -158,7 +158,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
   updateMap( orderedMap, insertNull );
 }
 
-void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant> > &map, bool insertNull )
+void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant>> &list, bool insertNull )
 {
   tableWidget->clearContents();
   for ( int i = tableWidget->rowCount() - 1; i > 0; i-- )
@@ -173,7 +173,7 @@ void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant> > &ma
     ++row;
   }
 
-  for ( const auto &pair : map )
+  for ( const auto &pair : list )
   {
     if ( pair.second.isNull() )
       setRow( row, pair.first, QString() );

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -41,6 +41,7 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
     void setConfig( const QVariantMap &config ) override;
 
     void updateMap( const QMap<QString, QVariant> &map, bool insertNull );
+    void updateMap( const QList<QPair<QString, QVariant>> &map, bool insertNull );
 
     /**
      * Populates a \a comboBox with the appropriate entries based on a value map \a configuration.

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -40,8 +40,23 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
     QVariantMap config() override;
     void setConfig( const QVariantMap &config ) override;
 
+    /**
+     * Updates the displayed table with the values from \a map.
+     * If \a insertNull is set to TRUE, it will also insert a NULL value.
+     *
+     * \note In most cases the overload that accepts a list is preferred as it
+     * keeps the order of the values.
+     */
     void updateMap( const QMap<QString, QVariant> &map, bool insertNull );
-    void updateMap( const QList<QPair<QString, QVariant>> &map, bool insertNull );
+
+    /**
+     * Updates the displayed table with the values from \a list, the order of the values
+     * is preserved.
+     * If \a insertNull is set to TRUE, it will also insert a NULL value.
+     *
+     * \since QGIS 3.12
+     */
+    void updateMap( const QList<QPair<QString, QVariant>> &list, bool insertNull );
 
     /**
      * Populates a \a comboBox with the appropriate entries based on a value map \a configuration.


### PR DESCRIPTION
I think this can be treated as a bug fix and backported.