### PR TITLE
Fix crash in raster calculator on Windows builds

### DIFF
--- a/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -63,6 +63,7 @@ Performs raster layer calculations.
       ParserError,
       MemoryError,
       BandError,
+      CalculationError,
     };
 
 

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -186,6 +186,8 @@ class RasterCalculator(QgisAlgorithm):
         res = calc.processCalculation(feedback)
         if res == QgsRasterCalculator.ParserError:
             raise QgsProcessingException(self.tr("Error parsing formula"))
+        elif res == QgsRasterCalculator.CalculationError:
+            raise QgsProcessingException(self.tr("An error occurred while performing the calculation"))
 
         return {self.OUTPUT: output}
 

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -60,6 +60,7 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock * > &rasterData,
     QMap<QString, QgsRasterBlock *>::iterator it = rasterData.find( mRasterName );
     if ( it == rasterData.end() )
     {
+      QgsDebugMsg( QStringLiteral( "Error: could not find raster data for \"%1\"" ).arg( mRasterName ) );
       return false;
     }
 
@@ -190,9 +191,10 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock * > &rasterData,
   else if ( mType == tNumber )
   {
     size_t nEntries = static_cast<size_t>( result.nColumns() * result.nRows() );
-    std::vector<double> *data = new  std::vector<double>( nEntries );
-    std::fill( std::begin( *data ), std::end( *data ), mNumber );
-    result.setData( result.nColumns(), 1, data->data(), result.nodataValue() );
+    double *data = new double[ nEntries ];
+    std::fill( data, data + nEntries, mNumber );
+    result.setData( result.nColumns(), 1, data, result.nodataValue() );
+
     return true;
   }
   else if ( mType == tMatrix )

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -206,7 +206,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
       for ( auto &layerRef : inputBlocks )
       {
         QgsRasterCalculatorEntry ref = uniqueRasterEntries[layerRef.first];
-        if ( uniqueRasterEntries[layerRef.first].raster->crs() != mOutputCrs )
+        if ( ref.raster->crs() != mOutputCrs )
         {
           QgsRasterProjector proj;
           proj.setCrs( ref.raster->crs(), mOutputCrs, mTransformContext );
@@ -216,7 +216,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
         }
         else
         {
-          inputBlocks[layerRef.first].reset( ref.raster->dataProvider()->block( ref.bandNumber, rect, mNumOutputColumns, 1 ) );
+          layerRef.second.reset( ref.raster->dataProvider()->block( ref.bandNumber, rect, mNumOutputColumns, 1 ) );
         }
       }
 
@@ -226,7 +226,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
       _rasterData.clear();
       for ( const auto &layerRef : inputBlocks )
       {
-        _rasterData.insert( layerRef.first, inputBlocks[layerRef.first].get() );
+        _rasterData.insert( layerRef.first, layerRef.second.get() );
       }
 
       if ( calcNode->calculate( _rasterData, resultMatrix, 0 ) )

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -238,6 +238,12 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
           QgsDebugMsg( QStringLiteral( "RasterIO error!" ) );
         }
       }
+      else
+      {
+        //delete the dataset without closing (because it is faster)
+        gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
+        return CalculationError;
+      }
     }
 
     if ( feedback )
@@ -316,6 +322,13 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
         }
 
         delete[] calcData;
+      }
+      else
+      {
+        qDeleteAll( inputBlocks );
+        inputBlocks.clear();
+        gdal::fast_delete_and_close( outputDataset, outputDriver, mOutputFile );
+        return CalculationError;
       }
 
     }

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -163,13 +163,14 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
     // Map of raster names -> blocks
     std::map<QString, std::unique_ptr<QgsRasterBlock>> inputBlocks;
     std::map<QString, QgsRasterCalculatorEntry> uniqueRasterEntries;
-    for ( const auto &r : calcNode->findNodes( QgsRasterCalcNode::Type::tRasterRef ) )
+    const QList<const QgsRasterCalcNode *> rasterRefNodes = calcNode->findNodes( QgsRasterCalcNode::Type::tRasterRef );
+    for ( const QgsRasterCalcNode *r : rasterRefNodes )
     {
       QString layerRef( r->toString().remove( 0, 1 ) );
       layerRef.chop( 1 );
       if ( ! inputBlocks.count( layerRef ) )
       {
-        for ( const auto &ref : mRasterEntries )
+        for ( const QgsRasterCalculatorEntry &ref : qgis::as_const( mRasterEntries ) )
         {
           if ( ref.ref == layerRef )
           {

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -87,6 +87,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
       ParserError = 4, //!< Error parsing formula
       MemoryError = 5, //!< Error allocating memory for result
       BandError = 6, //!< Invalid band number for input
+      CalculationError = 7, //!< Error occurred while performing calculation
     };
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2002,8 +2002,8 @@ QList<QgsVectorLayerRef> QgisApp::findBrokenWidgetDependencies( QgsVectorLayer *
       for ( const QgsVectorLayerRef &dependency : constDependencies )
       {
         const QgsVectorLayer *depVl { QgsVectorLayerRef( dependency ).resolveWeakly(
-            QgsProject::instance(),
-            QgsVectorLayerRef::MatchType::Name ) };
+                                        QgsProject::instance(),
+                                        QgsVectorLayerRef::MatchType::Name ) };
         if ( ! depVl || ! depVl->isValid() )
         {
           brokenDependencies.append( dependency );
@@ -2094,8 +2094,8 @@ void QgisApp::checkVectorLayerDependencies( QgsVectorLayer *vl )
       if ( ! loaded )
       {
         const QString msg { tr( "layer '%1' requires layer '%2' to be loaded but '%2' could not be found, please load it manually if possible." )
-          .arg( vl->name() )
-          .arg( dependency.name ) };
+                            .arg( vl->name() )
+                            .arg( dependency.name ) };
         messageBar()->pushWarning( tr( "Missing layer form dependency" ), msg );
       }
       else
@@ -6245,6 +6245,12 @@ void QgisApp::showRasterCalculator()
       case QgsRasterCalculator::BandError:
         visibleMessageBar()->pushMessage( tr( "Raster calculator" ),
                                           tr( "Invalid band number for input layer." ),
+                                          Qgis::Critical );
+        break;
+
+      case QgsRasterCalculator::CalculationError:
+        visibleMessageBar()->pushMessage( tr( "Raster calculator" ),
+                                          tr( "An error occurred while performing the calculation." ),
                                           Qgis::Critical );
         break;
     }


### PR DESCRIPTION
It's not safe to take the data from a vector like this, it will be
deleted as soon as the vector itself is

Fixes #32855