### PR TITLE
[layouts] Legend widget UI/UX improvements

### DIFF
--- a/src/app/layout/qgslayoutlegendwidget.cpp
+++ b/src/app/layout/qgslayoutlegendwidget.cpp
@@ -107,7 +107,7 @@ QgsLayoutLegendWidget::QgsLayoutLegendWidget( QgsLayoutItemLegend *legend )
   connect( mCountToolButton, &QToolButton::clicked, this, &QgsLayoutLegendWidget::mCountToolButton_clicked );
   connect( mExpressionFilterButton, &QgsLegendFilterButton::toggled, this, &QgsLayoutLegendWidget::mExpressionFilterButton_toggled );
   connect( mLayerExpressionButton, &QToolButton::clicked, this, &QgsLayoutLegendWidget::mLayerExpressionButton_clicked );
-  connect( mFilterByMapToolButton, &QToolButton::toggled, this, &QgsLayoutLegendWidget::mFilterByMapToolButton_toggled );
+  connect( mFilterByMapCheckBox, &QCheckBox::toggled, this, &QgsLayoutLegendWidget::mFilterByMapCheckBox_toggled );
   connect( mUpdateAllPushButton, &QToolButton::clicked, this, &QgsLayoutLegendWidget::mUpdateAllPushButton_clicked );
   connect( mAddGroupToolButton, &QToolButton::clicked, this, &QgsLayoutLegendWidget::mAddGroupToolButton_clicked );
   connect( mFilterLegendByAtlasCheckBox, &QCheckBox::toggled, this, &QgsLayoutLegendWidget::mFilterLegendByAtlasCheckBox_toggled );
@@ -148,7 +148,6 @@ QgsLayoutLegendWidget::QgsLayoutLegendWidget( QgsLayoutItemLegend *legend )
   mRemoveToolButton->setIconSize( QgisApp::instance()->iconSize( true ) );
   mEditPushButton->setIconSize( QgisApp::instance()->iconSize( true ) );
   mCountToolButton->setIconSize( QgisApp::instance()->iconSize( true ) );
-  mFilterByMapToolButton->setIconSize( QgisApp::instance()->iconSize( true ) );
   mExpressionFilterButton->setIconSize( QgisApp::instance()->iconSize( true ) );
   mLayerExpressionButton->setIconSize( QgisApp::instance()->iconSize( true ) );
 
@@ -214,7 +213,7 @@ void QgsLayoutLegendWidget::setGuiElements()
   whileBlocking( mSubgroupAlignCombo )->setCurrentAlignment( mLegend->style( QgsLegendStyle::Subgroup ).alignment() );
   whileBlocking( mItemAlignCombo )->setCurrentAlignment( mLegend->style( QgsLegendStyle::SymbolLabel ).alignment() );
   whileBlocking( mArrangementCombo )->setCurrentAlignment( mLegend->symbolAlignment() );
-  mFilterByMapToolButton->setChecked( mLegend->legendFilterByMapEnabled() );
+  mFilterByMapCheckBox->setChecked( mLegend->legendFilterByMapEnabled() );
   mColumnCountSpinBox->setValue( mLegend->columnCount() );
   mSplitLayerCheckBox->setChecked( mLegend->splitLayer() );
   mEqualColumnWidthCheckBox->setChecked( mLegend->equalColumnWidth() );
@@ -978,7 +977,7 @@ void QgsLayoutLegendWidget::mCountToolButton_clicked( bool checked )
   mLegend->endCommand();
 }
 
-void QgsLayoutLegendWidget::mFilterByMapToolButton_toggled( bool checked )
+void QgsLayoutLegendWidget::mFilterByMapCheckBox_toggled( bool checked )
 {
   mLegend->beginCommand( tr( "Update Legend" ) );
   mLegend->setLegendFilterByMapEnabled( checked );
@@ -1160,7 +1159,7 @@ void QgsLayoutLegendWidget::blockAllSignals( bool b )
   mItemTreeView->blockSignals( b );
   mCheckBoxAutoUpdate->blockSignals( b );
   mMapComboBox->blockSignals( b );
-  mFilterByMapToolButton->blockSignals( b );
+  mFilterByMapCheckBox->blockSignals( b );
   mColumnCountSpinBox->blockSignals( b );
   mSplitLayerCheckBox->blockSignals( b );
   mEqualColumnWidthCheckBox->blockSignals( b );

--- a/src/app/layout/qgslayoutlegendwidget.cpp
+++ b/src/app/layout/qgslayoutlegendwidget.cpp
@@ -139,7 +139,7 @@ QgsLayoutLegendWidget::QgsLayoutLegendWidget( QgsLayoutItemLegend *legend )
   mMoveUpToolButton->setIcon( QIcon( QgsApplication::iconPath( "mActionArrowUp.svg" ) ) );
   mMoveDownToolButton->setIcon( QIcon( QgsApplication::iconPath( "mActionArrowDown.svg" ) ) );
   mCountToolButton->setIcon( QIcon( QgsApplication::iconPath( "mActionSum.svg" ) ) );
-  mLayerExpressionButton->setIcon( QIcon( QgsApplication::iconPath( "mActionAddExpression.svg" ) ) );
+  mLayerExpressionButton->setIcon( QIcon( QgsApplication::iconPath( "mIconExpression.svg" ) ) );
 
   mMoveDownToolButton->setIconSize( QgisApp::instance()->iconSize( true ) );
   mMoveUpToolButton->setIconSize( QgisApp::instance()->iconSize( true ) );

--- a/src/app/layout/qgslayoutlegendwidget.h
+++ b/src/app/layout/qgslayoutlegendwidget.h
@@ -82,7 +82,7 @@ class QgsLayoutLegendWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLayo
     void mEditPushButton_clicked();
     void mCountToolButton_clicked( bool checked );
     void mExpressionFilterButton_toggled( bool checked );
-    void mFilterByMapToolButton_toggled( bool checked );
+    void mFilterByMapCheckBox_toggled( bool checked );
     void resetLayerNodeToDefaults();
     void mUpdateAllPushButton_clicked();
     void mAddGroupToolButton_clicked();

--- a/src/ui/layout/qgslayoutlegendwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendwidgetbase.ui
@@ -339,6 +339,23 @@
              </widget>
             </item>
             <item>
+             <widget class="QToolButton" name="mLayerExpressionButton">
+              <property name="toolTip">
+               <string> Add an expression to the vector layer and each child symbol's label</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../../images/images.qrc">
+                <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QToolButton" name="mCountToolButton">
               <property name="enabled">
                <bool>false</bool>
@@ -365,6 +382,19 @@
              </widget>
             </item>
             <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QgsLegendFilterButton" name="mExpressionFilterButton">
               <property name="text">
                <string/>
@@ -380,36 +410,6 @@
                </size>
               </property>
              </widget>
-            </item>
-            <item>
-             <widget class="QToolButton" name="mLayerExpressionButton">
-              <property name="toolTip">
-               <string> Add an expression to the vector layer and each child symbol's label</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionAddExpression.svg</normaloff>:/images/themes/default/mActionAddExpression.svg</iconset>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </item>

--- a/src/ui/layout/qgslayoutlegendwidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendwidgetbase.ui
@@ -365,26 +365,6 @@
              </widget>
             </item>
             <item>
-             <widget class="QToolButton" name="mFilterByMapToolButton">
-              <property name="toolTip">
-               <string>Filter Legend by Map Content</string>
-              </property>
-              <property name="icon">
-               <iconset resource="../../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionFilter2.svg</normaloff>:/images/themes/default/mActionFilter2.svg</iconset>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="checkable">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
              <widget class="QgsLegendFilterButton" name="mExpressionFilterButton">
               <property name="text">
                <string/>
@@ -432,6 +412,16 @@
              </spacer>
             </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="mFilterByMapCheckBox">
+            <property name="toolTip">
+             <string>Filter out legend elements that lie outside the linked map item.</string>
+            </property>
+            <property name="text">
+             <string>Only show items inside linked map</string>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="mFilterLegendByAtlasCheckBox">
@@ -1283,8 +1273,8 @@
   <tabstop>mRemoveToolButton</tabstop>
   <tabstop>mEditPushButton</tabstop>
   <tabstop>mCountToolButton</tabstop>
-  <tabstop>mFilterByMapToolButton</tabstop>
   <tabstop>mExpressionFilterButton</tabstop>
+  <tabstop>mFilterByMapCheckBox</tabstop>
   <tabstop>mFilterLegendByAtlasCheckBox</tabstop>
   <tabstop>mFontsColGroupBox</tabstop>
   <tabstop>mTitleFontButton</tabstop>


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->
Screenshot of PR:
![image](https://user-images.githubusercontent.com/1728657/69599045-2865d300-103e-11ea-9961-d31a6c03e7be.png)

I'm trying to improve the messy situation with regards to tool buttons (i.e. eEE) usage for the legend item widget.

Changes done to improve UI/UX:
- make the filter content by map extent switch a check box, away from being an icon-only tool button. This harmonize the legend widget with the attribute table item widget, which also shows this option as a checkbox, and reduces the current visual clusterf***
- move the filter by expression icon away from the "show count" and "add/edit expression" tool buttons, as those three buttons are otherwise visually very similar in nature and can get confusing at first glance
- change the "add/edit expression" tool button icon to remove the green plus sign, it's confusing in this context, and add visual complexity to an already busy area

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
