### PR TITLE
[pal] Don't sort final label placements in pal

### DIFF
--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -816,11 +816,6 @@ void Problem::chain_search()
   delete[] ok;
 }
 
-bool Problem::compareLabelArea( pal::LabelPosition *l1, pal::LabelPosition *l2 )
-{
-  return l1->getWidth() * l1->getHeight() > l2->getWidth() * l2->getHeight();
-}
-
 QList<LabelPosition *> Problem::getSolution( bool returnInactive, QList<LabelPosition *> *unlabeled )
 {
   int i;
@@ -847,12 +842,6 @@ QList<LabelPosition *> Problem::getSolution( bool returnInactive, QList<LabelPos
   // unlabeled features also include those with no candidates
   if ( unlabeled )
     unlabeled->append( mPositionsWithNoCandidates );
-
-  // if features collide, order by size, so smaller ones appear on top
-  if ( returnInactive )
-  {
-    std::sort( solList.begin(), solList.end(), compareLabelArea );
-  }
 
   return solList;
 }

--- a/src/core/pal/problem.h
+++ b/src/core/pal/problem.h
@@ -136,8 +136,6 @@ namespace pal
       void init_sol_empty();
       void init_sol_falp();
 
-      static bool compareLabelArea( pal::LabelPosition *l1, pal::LabelPosition *l2 );
-
       /**
        * Returns a reference to the list of label positions which correspond to
        * features with no candidates.


### PR DESCRIPTION
We have a (better) sorting method in QGIS which accounts for other things like the label z orders, so this sorting in the pal library is completely redundant and is immediately overwritten by QGIS label sorting routines.
