### PR TITLE
Expose a project labeling option for "labeling engine version"

### DIFF
--- a/python/core/auto_generated/qgslabelingenginesettings.sip.in
+++ b/python/core/auto_generated/qgslabelingenginesettings.sip.in
@@ -43,6 +43,12 @@ Stores global configuration for labeling engine
       Falp
     };
 
+    enum PlacementEngineVersion
+    {
+      PlacementEngineVersion1,
+      PlacementEngineVersion2,
+    };
+
     QgsLabelingEngineSettings();
 
     void clear();
@@ -136,6 +142,24 @@ Sets the ``color`` to use when rendering unplaced labels.
 .. seealso:: :py:func:`unplacedLabelColor`
 
 .. versionadded:: 3.10
+%End
+
+    PlacementEngineVersion placementVersion() const;
+%Docstring
+Returns the placement engine version, which dictates how the label placement problem is solved.
+
+.. seealso:: :py:func:`setPlacementVersion`
+
+.. versionadded:: 3.10.2
+%End
+
+    void setPlacementVersion( PlacementEngineVersion version );
+%Docstring
+Sets the placement engine ``version``, which dictates how the label placement problem is solved.
+
+.. seealso:: :py:func:`placementVersion`
+
+.. versionadded:: 3.10.2
 %End
 
 };

--- a/src/app/qgslabelengineconfigdialog.cpp
+++ b/src/app/qgslabelengineconfigdialog.cpp
@@ -43,7 +43,7 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget *parent )
   mTextRenderFormatComboBox->addItem( tr( "Always Render Labels as Text" ), QgsRenderContext::TextFormatAlwaysText );
 
   mPlacementVersionComboBox->addItem( tr( "Version 1" ), QgsLabelingEngineSettings::PlacementEngineVersion1 );
-  mPlacementVersionComboBox->addItem( tr( "Version 2 (Recommended)" ), QgsLabelingEngineSettings::PlacementEngineVersion2 );
+  mPlacementVersionComboBox->addItem( tr( "Version 2 (Experimental)" ), QgsLabelingEngineSettings::PlacementEngineVersion2 );
 
   mPreviousEngineVersion = engineSettings.placementVersion();
   mPlacementVersionComboBox->setCurrentIndex( mPlacementVersionComboBox->findData( mPreviousEngineVersion ) );

--- a/src/app/qgslabelengineconfigdialog.h
+++ b/src/app/qgslabelengineconfigdialog.h
@@ -19,7 +19,9 @@
 
 #include "ui_qgslabelengineconfigdialog.h"
 #include "qgis_app.h"
+#include "qgslabelingenginesettings.h"
 
+class QgsMessageBar;
 
 class APP_EXPORT QgsLabelEngineConfigDialog : public QDialog, private Ui::QgsLabelEngineConfigDialog
 {
@@ -35,7 +37,10 @@ class APP_EXPORT QgsLabelEngineConfigDialog : public QDialog, private Ui::QgsLab
   private slots:
     void showHelp();
 
-  protected:
+  private:
+    QgsMessageBar *mMessageBar = nullptr;
+
+    QgsLabelingEngineSettings::PlacementEngineVersion mPreviousEngineVersion = QgsLabelingEngineSettings::PlacementEngineVersion2;
 };
 
 #endif // QGSLABELENGINECONFIGDIALOG_H

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -514,7 +514,7 @@ int Pal::getPolyP()
   return poly_p;
 }
 
-QgsLabelingEngineSettings::PlacementEngineVersion Pal::getPlacementVersion() const
+QgsLabelingEngineSettings::PlacementEngineVersion Pal::placementVersion() const
 {
   return mPlacementVersion;
 }

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -514,6 +514,16 @@ int Pal::getPolyP()
   return poly_p;
 }
 
+QgsLabelingEngineSettings::PlacementEngineVersion Pal::getPlacementVersion() const
+{
+  return mPlacementVersion;
+}
+
+void Pal::setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion placementVersion )
+{
+  mPlacementVersion = placementVersion;
+}
+
 int Pal::getMinIt()
 {
   return tabuMaxIt;

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -214,7 +214,7 @@ namespace pal
        *
        * \see setPlacementVersion()
        */
-      QgsLabelingEngineSettings::PlacementEngineVersion getPlacementVersion() const;
+      QgsLabelingEngineSettings::PlacementEngineVersion placementVersion() const;
 
       /**
        * Sets the placement engine \a version, which dictates how the label placement problem is solved.

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -37,6 +37,7 @@
 #include "qgsgeometry.h"
 #include "qgsgeos.h"
 #include "qgspallabeling.h"
+#include "qgslabelingenginesettings.h"
 #include <QList>
 #include <iostream>
 #include <ctime>
@@ -208,6 +209,20 @@ namespace pal
        */
       int getPolyP();
 
+      /**
+       * Returns the placement engine version, which dictates how the label placement problem is solved.
+       *
+       * \see setPlacementVersion()
+       */
+      QgsLabelingEngineSettings::PlacementEngineVersion getPlacementVersion() const;
+
+      /**
+       * Sets the placement engine \a version, which dictates how the label placement problem is solved.
+       *
+       * \see placementVersion()
+       */
+      void setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion placementVersion );
+
     private:
 
       QHash< QgsAbstractLabelProvider *, Layer * > mLayers;
@@ -245,6 +260,8 @@ namespace pal
        * \brief show partial labels (cut-off by the map canvas) or not
        */
       bool showPartial = true;
+
+      QgsLabelingEngineSettings::PlacementEngineVersion mPlacementVersion = QgsLabelingEngineSettings::PlacementEngineVersion2;
 
       //! Callback that may be called from PAL to check whether the job has not been canceled in meanwhile
       FnIsCanceled fnIsCanceled = nullptr;

--- a/src/core/qgslabelingenginesettings.cpp
+++ b/src/core/qgslabelingenginesettings.cpp
@@ -53,6 +53,8 @@ void QgsLabelingEngineSettings::readSettingsFromProject( QgsProject *prj )
     mDefaultTextRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( projectTextFormat );
 
   mUnplacedLabelColor = QgsSymbolLayerUtils::decodeColor( prj->readEntry( QStringLiteral( "PAL" ), QStringLiteral( "/UnplacedColor" ), QStringLiteral( "#ff0000" ) ) );
+
+  mPlacementVersion = static_cast< PlacementEngineVersion >( prj->readNumEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ), static_cast< int >( PlacementEngineVersion1 ) ) );
 }
 
 void QgsLabelingEngineSettings::writeSettingsToProject( QgsProject *project )
@@ -71,6 +73,8 @@ void QgsLabelingEngineSettings::writeSettingsToProject( QgsProject *project )
   project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/TextFormat" ), static_cast< int >( mDefaultTextRenderFormat ) );
 
   project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/UnplacedColor" ), QgsSymbolLayerUtils::encodeColor( mUnplacedLabelColor ) );
+
+  project->writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ), mPlacementVersion );
 }
 
 QColor QgsLabelingEngineSettings::unplacedLabelColor() const
@@ -81,6 +85,16 @@ QColor QgsLabelingEngineSettings::unplacedLabelColor() const
 void QgsLabelingEngineSettings::setUnplacedLabelColor( const QColor &unplacedLabelColor )
 {
   mUnplacedLabelColor = unplacedLabelColor;
+}
+
+QgsLabelingEngineSettings::PlacementEngineVersion QgsLabelingEngineSettings::placementVersion() const
+{
+  return mPlacementVersion;
+}
+
+void QgsLabelingEngineSettings::setPlacementVersion( PlacementEngineVersion placementVersion )
+{
+  mPlacementVersion = placementVersion;
 }
 
 

--- a/src/core/qgslabelingenginesettings.h
+++ b/src/core/qgslabelingenginesettings.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsLabelingEngineSettings
     enum PlacementEngineVersion
     {
       PlacementEngineVersion1, //!< Version 1, matches placement from QGIS <= 3.10.1
-      PlacementEngineVersion2, //!< Version 2, default for new projects created since 3.10.2
+      PlacementEngineVersion2, //!< Version 2 (currently experimental)
     };
 
     QgsLabelingEngineSettings();
@@ -173,7 +173,7 @@ class CORE_EXPORT QgsLabelingEngineSettings
 
     QColor mUnplacedLabelColor = QColor( 255, 0, 0 );
 
-    PlacementEngineVersion mPlacementVersion = PlacementEngineVersion2;
+    PlacementEngineVersion mPlacementVersion = PlacementEngineVersion1;
 
     QgsRenderContext::TextRenderFormat mDefaultTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 

--- a/src/core/qgslabelingenginesettings.h
+++ b/src/core/qgslabelingenginesettings.h
@@ -58,6 +58,17 @@ class CORE_EXPORT QgsLabelingEngineSettings
       Falp
     };
 
+    /**
+     * Placement engine version.
+     *
+     * \since QGIS 3.10.2
+     */
+    enum PlacementEngineVersion
+    {
+      PlacementEngineVersion1, //!< Version 1, matches placement from QGIS <= 3.10.1
+      PlacementEngineVersion2, //!< Version 2, default for new projects created since 3.10.2
+    };
+
     QgsLabelingEngineSettings();
 
     //! Returns the configuration to the defaults
@@ -136,6 +147,22 @@ class CORE_EXPORT QgsLabelingEngineSettings
      */
     void setUnplacedLabelColor( const QColor &color );
 
+    /**
+     * Returns the placement engine version, which dictates how the label placement problem is solved.
+     *
+     * \see setPlacementVersion()
+     * \since QGIS 3.10.2
+     */
+    PlacementEngineVersion placementVersion() const;
+
+    /**
+     * Sets the placement engine \a version, which dictates how the label placement problem is solved.
+     *
+     * \see placementVersion()
+     * \since QGIS 3.10.2
+     */
+    void setPlacementVersion( PlacementEngineVersion version );
+
   private:
     //! Flags
     Flags mFlags;
@@ -145,6 +172,8 @@ class CORE_EXPORT QgsLabelingEngineSettings
     int mCandPoint = 16, mCandLine = 50, mCandPolygon = 30;
 
     QColor mUnplacedLabelColor = QColor( 255, 0, 0 );
+
+    PlacementEngineVersion mPlacementVersion = PlacementEngineVersion2;
 
     QgsRenderContext::TextRenderFormat mDefaultTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 

--- a/src/test/qgstest.h
+++ b/src/test/qgstest.h
@@ -44,7 +44,7 @@
       qDebug( "Expecting %f got %f (diff %f > %f)", static_cast< double >( expected ), static_cast< double >( value ), std::fabs( static_cast< double >( expected ) - value ), static_cast< double >( epsilon ) ); \
     } \
     QVERIFY( qgsDoubleNear( value, expected, epsilon ) ); \
-  }
+  }(void)(0)
 
 #define QGSCOMPARENOTNEAR(value,not_expected,epsilon) { \
     bool _xxxresult = qgsDoubleNear( value, not_expected, epsilon ); \
@@ -53,7 +53,7 @@
       qDebug( "Expecting %f to be differerent from %f (diff %f > %f)", static_cast< double >( value ), static_cast< double >( not_expected ), std::fabs( static_cast< double >( not_expected ) - value ), static_cast< double >( epsilon ) ); \
     } \
     QVERIFY( !qgsDoubleNear( value, not_expected, epsilon ) ); \
-  }
+  }(void)(0)
 
 #define QGSCOMPARENEARPOINT(point1,point2,epsilon) { \
     QGSCOMPARENEAR( point1.x(), point2.x(), epsilon ); \

--- a/src/ui/qgslabelengineconfigdialog.ui
+++ b/src/ui/qgslabelengineconfigdialog.ui
@@ -160,19 +160,13 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
-     <item row="2" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowAllLabels">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="inputMethodHints">
-        <set>Qt::ImhNone</set>
-       </property>
+     <item row="0" column="1" colspan="2">
+      <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+     </item>
+     <item row="5" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowCandidates">
        <property name="text">
-        <string>Show all labels for all layers (i.e. including colliding objects)</string>
+        <string>Show candidates (for debugging)</string>
        </property>
       </widget>
      </item>
@@ -215,20 +209,19 @@
        </item>
       </layout>
      </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
-     </item>
-     <item row="5" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowCandidates">
-       <property name="text">
-        <string>Show candidates (for debugging)</string>
+     <item row="2" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowAllLabels">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowPartialsLabels">
+       <property name="inputMethodHints">
+        <set>Qt::ImhNone</set>
+       </property>
        <property name="text">
-        <string>Allow truncated labels on edges of map</string>
+        <string>Show all labels for all layers (i.e. including colliding objects)</string>
        </property>
       </widget>
      </item>
@@ -245,6 +238,23 @@
         <string>Show unplaced labels</string>
        </property>
       </widget>
+     </item>
+     <item row="1" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowPartialsLabels">
+       <property name="text">
+        <string>Allow truncated labels on edges of map</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Project labeling version</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1" colspan="2">
+      <widget class="QComboBox" name="mPlacementVersionComboBox"/>
      </item>
     </layout>
    </item>

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -134,16 +134,16 @@ void TestQgsLabelingEngine::testEngineSettings()
   // getters/setters
   QgsLabelingEngineSettings settings;
 
-  // default for new projects should be placement engine v2
-  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion2 );
+  // default for new projects should be placement engine v1 (for now!)
+  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
 
   settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
   QCOMPARE( settings.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
   settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
   QCOMPARE( settings.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
 
-  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion1 );
-  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
+  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion2 );
+  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion2 );
 
   settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
   QVERIFY( settings.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -133,10 +133,17 @@ void TestQgsLabelingEngine::testEngineSettings()
 
   // getters/setters
   QgsLabelingEngineSettings settings;
+
+  // default for new projects should be placement engine v2
+  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion2 );
+
   settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
   QCOMPARE( settings.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
   settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
   QCOMPARE( settings.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+
+  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion1 );
+  QCOMPARE( settings.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
 
   settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
   QVERIFY( settings.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
@@ -151,6 +158,7 @@ void TestQgsLabelingEngine::testEngineSettings()
   settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
   settings.setFlag( QgsLabelingEngineSettings::DrawUnplacedLabels, true );
   settings.setUnplacedLabelColor( QColor( 0, 255, 0 ) );
+  settings.setPlacementVersion( QgsLabelingEngineSettings::PlacementEngineVersion2 );
   settings.writeSettingsToProject( &p );
   QgsLabelingEngineSettings settings2;
   settings2.readSettingsFromProject( &p );
@@ -164,6 +172,7 @@ void TestQgsLabelingEngine::testEngineSettings()
   settings2.readSettingsFromProject( &p );
   QCOMPARE( settings2.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
   QVERIFY( !settings2.testFlag( QgsLabelingEngineSettings::DrawUnplacedLabels ) );
+  QCOMPARE( settings2.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion2 );
 
   // test that older setting is still respected as a fallback
   QgsProject p2;
@@ -175,6 +184,11 @@ void TestQgsLabelingEngine::testEngineSettings()
   p2.writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), true );
   settings3.readSettingsFromProject( &p2 );
   QCOMPARE( settings3.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+
+  // when opening an older project, labeling engine version should be 1
+  p2.removeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/PlacementEngineVersion" ) );
+  settings3.readSettingsFromProject( &p2 );
+  QCOMPARE( settings3.placementVersion(), QgsLabelingEngineSettings::PlacementEngineVersion1 );
 }
 
 void TestQgsLabelingEngine::setDefaultLabelParams( QgsPalLayerSettings &settings )


### PR DESCRIPTION
Adds the underlying API (currently unused) for specifying a labeling engine placement version to use for a project, and the corresponding setting in the project labeling setting dialog.

This allows users to upgrade existing projects to newer labeling engine versions. A warning will show advising users that change the version will alter the placement of labels within the project.

While currently unused, this is the framework which allows us the flexibility to tweak the labeling engine costs and obstacle avoidance strategies without altering the label placement in existing projects.