### PR TITLE
When exporting CRS information from GDAL >= 3.0, use WKT2 format

### DIFF
--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -239,8 +239,10 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     // update mode
     bool mUpdate;
 
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3,0,0)
     // initialize CRS from wkt
     bool crsFromWkt( const char *wkt );
+#endif
 
     //! Do some initialization on the dataset (e.g. handling of south-up datasets)
     void initBaseDataset();

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3698,20 +3698,9 @@ QgsCoordinateReferenceSystem QgsOgrProvider::crs() const
   // add towgs84 parameter
   QgsCoordinateReferenceSystem::setupESRIWktFix();
 
-  OGRSpatialReferenceH mySpatialRefSys = mOgrLayer->GetSpatialRef();
-  if ( mySpatialRefSys )
+  if ( OGRSpatialReferenceH spatialRefSys = mOgrLayer->GetSpatialRef() )
   {
-    // get the proj4 text
-    char *pszProj4 = nullptr;
-    OSRExportToProj4( mySpatialRefSys, &pszProj4 );
-    QgsDebugMsgLevel( pszProj4, 4 );
-    CPLFree( pszProj4 );
-
-    char *pszWkt = nullptr;
-    OSRExportToWkt( mySpatialRefSys, &pszWkt );
-
-    srs = QgsCoordinateReferenceSystem::fromWkt( pszWkt );
-    CPLFree( pszWkt );
+    srs = QgsOgrUtils::OGRSpatialReferenceToCrs( spatialRefSys );
   }
   else
   {

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -38,6 +38,7 @@
 #include "qgis.h" //const vals declared here
 #include "qgslocalec.h"
 #include "qgssettings.h"
+#include "qgsogrutils.h"
 
 #include <sqlite3.h>
 #if PROJ_VERSION_MAJOR>=6
@@ -335,7 +336,6 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
 bool QgsCoordinateReferenceSystem::createFromUserInput( const QString &definition )
 {
   QString userWkt;
-  char *wkt = nullptr;
   OGRSpatialReferenceH crs = OSRNewSpatialReference( nullptr );
 
   // make sure towgs84 parameter is loaded if using an ESRI definition and gdal >= 1.9
@@ -346,11 +346,7 @@ bool QgsCoordinateReferenceSystem::createFromUserInput( const QString &definitio
 
   if ( OSRSetFromUserInput( crs, definition.toLocal8Bit().constData() ) == OGRERR_NONE )
   {
-    if ( OSRExportToWkt( crs, &wkt ) == OGRERR_NONE )
-    {
-      userWkt = wkt;
-      CPLFree( wkt );
-    }
+    userWkt = QgsOgrUtils::OGRSpatialReferenceToWkt( crs );
     OSRDestroySpatialReference( crs );
   }
   //QgsDebugMsg( "definition: " + definition + " wkt = " + wkt );

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -268,6 +268,23 @@ class CORE_EXPORT QgsOgrUtils
      * \since QGIS 3.4.9
      */
     static QgsWkbTypes::Type ogrGeometryTypeToQgsWkbType( OGRwkbGeometryType ogrGeomType );
+
+    /**
+     * Returns a WKT string corresponding to the specified OGR \a srs object.
+     *
+     * The WKT string format will be selected using the most appropriate format (usually WKT2 if GDAL 3 is available).
+     *
+     * \since QGIS 3.10.1
+     */
+    static QString OGRSpatialReferenceToWkt( OGRSpatialReferenceH srs );
+
+    /**
+     * Returns a QgsCoordinateReferenceSystem corresponding to the specified OGR \a srs object, or an invalid
+     * QgsCoordinateReferenceSystem if \a srs could not be converted.
+     *
+     * \since QGIS 3.10.1
+     */
+    static QgsCoordinateReferenceSystem OGRSpatialReferenceToCrs( OGRSpatialReferenceH srs );
 };
 
 #endif // QGSOGRUTILS_H


### PR DESCRIPTION
...to avoid loss of CRS information
