### PR TITLE
Visible status for embedded layers in embedded group

### DIFF
--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -110,11 +110,6 @@ and thus whether expandedGroupNodes() and expandedLegendItems + expandedLayerNod
 .. versionadded:: 3.2
 %End
 
-        bool hasCheckedStateInfo() const;
-%Docstring
-Returns whether information about checked/unchecked state of groups has been recorded
-and thus whether checkedGroupNodes() is valid.
-%End
 
         void setHasExpandedStateInfo( bool hasInfo );
 %Docstring
@@ -123,10 +118,6 @@ Sets whether the map theme contains valid expanded/collapsed state of nodes
 .. versionadded:: 3.2
 %End
 
-        void setHasCheckedStateInfo( bool hasInfo );
-%Docstring
-Sets whether the map theme contains valid checked/unchecked state of group nodes
-%End
 
         QSet<QString> expandedGroupNodes() const;
 %Docstring
@@ -144,6 +135,8 @@ Returns a set of group identifiers for group nodes that should have checked stat
 The returned value is valid only when hasCheckedStateInfo() returns ``True``.
 Group identifiers are built using group names, a sub-group name is prepended by parent group's identifier
 and a forward slash, e.g. "level1/level2"
+
+.. versionadded:: 3.10.1
 %End
 
         void setExpandedGroupNodes( const QSet<QString> &expandedGroupNodes );
@@ -156,6 +149,8 @@ Sets a set of group identifiers for group nodes that should have expanded state.
         void setCheckedGroupNodes( const QSet<QString> &checkedGroupNodes );
 %Docstring
 Sets a set of group identifiers for group nodes that should have checked state. See checkedGroupNodes().
+
+.. versionadded:: 3.10.1
 %End
 
     };

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -110,11 +110,22 @@ and thus whether expandedGroupNodes() and expandedLegendItems + expandedLayerNod
 .. versionadded:: 3.2
 %End
 
+        bool hasCheckedStateInfo() const;
+%Docstring
+Returns whether information about checked/unchecked state of groups has been recorded
+and thus whether checkedGroupNodes() is valid.
+%End
+
         void setHasExpandedStateInfo( bool hasInfo );
 %Docstring
 Sets whether the map theme contains valid expanded/collapsed state of nodes
 
 .. versionadded:: 3.2
+%End
+
+        void setHasCheckedStateInfo( bool hasInfo );
+%Docstring
+Sets whether the map theme contains valid checked/unchecked state of group nodes
 %End
 
         QSet<QString> expandedGroupNodes() const;
@@ -127,11 +138,24 @@ and a forward slash, e.g. "level1/level2"
 .. versionadded:: 3.2
 %End
 
+        QSet<QString> checkedGroupNodes() const;
+%Docstring
+Returns a set of group identifiers for group nodes that should have checked state (other group nodes should be unchecked).
+The returned value is valid only when hasCheckedStateInfo() returns ``True``.
+Group identifiers are built using group names, a sub-group name is prepended by parent group's identifier
+and a forward slash, e.g. "level1/level2"
+%End
+
         void setExpandedGroupNodes( const QSet<QString> &expandedGroupNodes );
 %Docstring
 Sets a set of group identifiers for group nodes that should have expanded state. See expandedGroupNodes().
 
 .. versionadded:: 3.2
+%End
+
+        void setCheckedGroupNodes( const QSet<QString> &checkedGroupNodes );
+%Docstring
+Sets a set of group identifiers for group nodes that should have checked state. See checkedGroupNodes().
 %End
 
     };

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -110,14 +110,12 @@ and thus whether expandedGroupNodes() and expandedLegendItems + expandedLayerNod
 .. versionadded:: 3.2
 %End
 
-
         void setHasExpandedStateInfo( bool hasInfo );
 %Docstring
 Sets whether the map theme contains valid expanded/collapsed state of nodes
 
 .. versionadded:: 3.2
 %End
-
 
         QSet<QString> expandedGroupNodes() const;
 %Docstring

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -369,7 +369,10 @@ QStringList QgsLayerTreeUtils::invisibleLayerList( QgsLayerTreeNode *node )
     const auto constChildren = QgsLayerTree::toGroup( node )->children();
     for ( QgsLayerTreeNode *child : constChildren )
     {
-      list << invisibleLayerList( child );
+      if ( child->itemVisibilityChecked() == Qt::Unchecked )
+      {
+        list << invisibleLayerList( child );
+      }
     }
   }
   else if ( QgsLayerTree::isLayer( node ) )

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -155,7 +155,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
          * Returns whether information about checked/unchecked state of groups has been recorded
          * and thus whether checkedGroupNodes() is valid.
          */
-        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; }
+        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; } const SIP_SKIP;
 
         /**
          * Sets whether the map theme contains valid expanded/collapsed state of nodes
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         /**
          * Sets whether the map theme contains valid checked/unchecked state of group nodes
          */
-        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; }
+        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; } const SIP_SKIP;
 
         /**
          * Returns a set of group identifiers for group nodes that should have expanded state (other group nodes should be collapsed).
@@ -182,6 +182,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
          * The returned value is valid only when hasCheckedStateInfo() returns TRUE.
          * Group identifiers are built using group names, a sub-group name is prepended by parent group's identifier
          * and a forward slash, e.g. "level1/level2"
+         * \since QGIS 3.10.1
          */
         QSet<QString> checkedGroupNodes() const { return mCheckedGroupNodes; }
 
@@ -193,6 +194,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
         /**
          * Sets a set of group identifiers for group nodes that should have checked state. See checkedGroupNodes().
+         * \since QGIS 3.10.1
          */
         void setCheckedGroupNodes( const QSet<QString> &checkedGroupNodes ) { mCheckedGroupNodes = checkedGroupNodes; }
 

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -140,7 +140,6 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
         /**
          * Returns set with only records for valid layers
-         * \note not available in Python bindings
          */
         QHash<QgsMapLayer *, QgsMapThemeCollection::MapThemeLayerRecord> validLayerRecords() const SIP_SKIP;
 
@@ -154,8 +153,10 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         /**
          * Returns whether information about checked/unchecked state of groups has been recorded
          * and thus whether checkedGroupNodes() is valid.
+         * \note Not available in Python bindings
+         * \since QGIS 3.10.1
          */
-        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; } const SIP_SKIP;
+        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; } SIP_SKIP;
 
         /**
          * Sets whether the map theme contains valid expanded/collapsed state of nodes
@@ -165,8 +166,10 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
         /**
          * Sets whether the map theme contains valid checked/unchecked state of group nodes
+         * \note Not available in Python bindings
+         * \since QGIS 3.10.1
          */
-        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; } const SIP_SKIP;
+        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; } SIP_SKIP;
 
         /**
          * Returns a set of group identifiers for group nodes that should have expanded state (other group nodes should be collapsed).

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -118,7 +118,8 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         bool operator==( const QgsMapThemeCollection::MapThemeRecord &other ) const
         {
           return validLayerRecords() == other.validLayerRecords() &&
-                 mHasExpandedStateInfo == other.mHasExpandedStateInfo && mExpandedGroupNodes == other.mExpandedGroupNodes;
+                 mHasExpandedStateInfo == other.mHasExpandedStateInfo &&
+                 mExpandedGroupNodes == other.mExpandedGroupNodes && mCheckedGroupNodes == other.mCheckedGroupNodes;
         }
         bool operator!=( const QgsMapThemeCollection::MapThemeRecord &other ) const
         {
@@ -151,10 +152,21 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         bool hasExpandedStateInfo() const { return mHasExpandedStateInfo; }
 
         /**
+         * Returns whether information about checked/unchecked state of groups has been recorded
+         * and thus whether checkedGroupNodes() is valid.
+         */
+        bool hasCheckedStateInfo() const { return mHasCheckedStateInfo; }
+
+        /**
          * Sets whether the map theme contains valid expanded/collapsed state of nodes
          * \since QGIS 3.2
          */
         void setHasExpandedStateInfo( bool hasInfo ) { mHasExpandedStateInfo = hasInfo; }
+
+        /**
+         * Sets whether the map theme contains valid checked/unchecked state of group nodes
+         */
+        void setHasCheckedStateInfo( bool hasInfo ) { mHasCheckedStateInfo = hasInfo; }
 
         /**
          * Returns a set of group identifiers for group nodes that should have expanded state (other group nodes should be collapsed).
@@ -166,10 +178,23 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
         QSet<QString> expandedGroupNodes() const { return mExpandedGroupNodes; }
 
         /**
+         * Returns a set of group identifiers for group nodes that should have checked state (other group nodes should be unchecked).
+         * The returned value is valid only when hasCheckedStateInfo() returns TRUE.
+         * Group identifiers are built using group names, a sub-group name is prepended by parent group's identifier
+         * and a forward slash, e.g. "level1/level2"
+         */
+        QSet<QString> checkedGroupNodes() const { return mCheckedGroupNodes; }
+
+        /**
          * Sets a set of group identifiers for group nodes that should have expanded state. See expandedGroupNodes().
          * \since QGIS 3.2
          */
         void setExpandedGroupNodes( const QSet<QString> &expandedGroupNodes ) { mExpandedGroupNodes = expandedGroupNodes; }
+
+        /**
+         * Sets a set of group identifiers for group nodes that should have checked state. See checkedGroupNodes().
+         */
+        void setCheckedGroupNodes( const QSet<QString> &checkedGroupNodes ) { mCheckedGroupNodes = checkedGroupNodes; }
 
       private:
         //! Layer-specific records for the theme. Only visible layers are listed.
@@ -177,12 +202,20 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
         //! Whether the information about expanded/collapsed state of groups, layers and legend items has been stored
         bool mHasExpandedStateInfo = false;
+        //! Whether the information about checked/unchecked state of groups, layers and legend items has been stored
+        bool mHasCheckedStateInfo = false;
 
         /**
          * Which groups should be expanded. Each group is identified by its name (sub-groups IDs are prepended with parent
          * group and forward slash - e.g. "level1/level2/level3").
          */
         QSet<QString> mExpandedGroupNodes;
+
+        /**
+         * Which groups should be checked. Each group is identified by its name (sub-groups IDs are prepended with parent
+         * group and forward slash - e.g. "level1/level2/level3").
+         */
+        QSet<QString> mCheckedGroupNodes;
 
         friend class QgsMapThemeCollection;
     };

--- a/tests/src/core/testqgsmapthemecollection.cpp
+++ b/tests/src/core/testqgsmapthemecollection.cpp
@@ -34,6 +34,7 @@ class TestQgsMapThemeCollection : public QObject
     void cleanupTestCase();// will be called after the last testfunction was executed.
 
     void expandedState();
+    void checkedState();
 
   private:
     QgsVectorLayer *mPointsLayer = nullptr;
@@ -204,6 +205,85 @@ void TestQgsMapThemeCollection::expandedState()
   QgsMapThemeCollection::MapThemeLayerRecord recExpandedPoints2 = _recordForLayer( mPointsLayer, recExpanded2 );
   QCOMPARE( recExpandedPoints2.expandedLayerNode, true );
   QCOMPARE( recExpandedPoints2.expandedLegendItems.count(), 4 );
+}
+
+void TestQgsMapThemeCollection::checkedState()
+{
+  QgsMapThemeCollection themes( mProject );
+
+  QStringList pointLayerRootLegendNodes;
+  const QList<QgsLayerTreeModelLegendNode *> legendNodes = mLayerTreeModel->layerLegendNodes( mNodeLayerPoints, true );
+  for ( QgsLayerTreeModelLegendNode *legendNode : legendNodes )
+  {
+    QString key = legendNode->data( QgsLayerTreeModelLegendNode::RuleKeyRole ).toString();
+    pointLayerRootLegendNodes << key;
+  }
+  QCOMPARE( pointLayerRootLegendNodes.count(), 4 );
+
+  // make two themes: 1. all checked, 2. all collapsed
+  // keep a layer checked inside group3 to check behavior
+
+  mNodeGroup1->setItemVisibilityChecked( false );
+  mNodeGroup2->setItemVisibilityChecked( false );
+  mNodeGroup3->setItemVisibilityChecked( false );
+  mNodeLayerLines->setItemVisibilityChecked( false );
+  mNodeLayerPolys->setItemVisibilityChecked( true );
+
+  themes.insert( "all-unchecked", QgsMapThemeCollection::createThemeFromCurrentState( mLayerTree, mLayerTreeModel ) );
+
+  mNodeGroup1->setItemVisibilityChecked( true );
+  mNodeGroup2->setItemVisibilityChecked( true );
+  mNodeGroup3->setItemVisibilityChecked( true );
+  // keep a layer checked inside a group to check behavior
+  mNodeLayerPolys->setItemVisibilityChecked( true );
+
+  themes.insert( "all-checked", QgsMapThemeCollection::createThemeFromCurrentState( mLayerTree, mLayerTreeModel ) );
+
+  // check theme data
+
+  QgsMapThemeCollection::MapThemeRecord recUnchecked = themes.mapThemeState( "all-unchecked" );
+  QVERIFY( recUnchecked.hasCheckedStateInfo() );
+  QCOMPARE( recUnchecked.checkedGroupNodes().count(), 0 );
+  QCOMPARE( mNodeLayerLines->itemVisibilityChecked(), false );
+  QCOMPARE( mNodeLayerPolys->itemVisibilityChecked(), true );
+
+  QgsMapThemeCollection::MapThemeRecord recChecked = themes.mapThemeState( "all-checked" );
+  QVERIFY( recChecked.hasCheckedStateInfo() );
+  QCOMPARE( recChecked.checkedGroupNodes().count(), 3 );
+  QCOMPARE( mNodeLayerLines->itemVisibilityChecked(), false );
+  QCOMPARE( mNodeLayerPolys->itemVisibilityChecked(), true );
+
+  // switch themes
+
+  themes.applyTheme( "all-unchecked", mLayerTree, mLayerTreeModel );
+  QCOMPARE( mNodeGroup1->itemVisibilityChecked(), false );
+  QCOMPARE( mNodeGroup3->itemVisibilityChecked(), false );
+  QCOMPARE( mNodeLayerLines->itemVisibilityChecked(), false );
+  QCOMPARE( mNodeLayerPolys->itemVisibilityChecked(), true );
+
+  themes.applyTheme( "all-checked", mLayerTree, mLayerTreeModel );
+  QCOMPARE( mNodeGroup1->itemVisibilityChecked(), true );
+  QCOMPARE( mNodeGroup3->itemVisibilityChecked(), true );
+  QCOMPARE( mNodeLayerLines->itemVisibilityChecked(), false );
+  QCOMPARE( mNodeLayerPolys->itemVisibilityChecked(), true );
+
+  // test read+write
+
+  QDomDocument doc;
+  QDomElement elemRoot = doc.createElement( "qgis" );
+  doc.appendChild( elemRoot );
+  themes.writeXml( doc );
+
+  QgsMapThemeCollection themes2( mProject );
+  themes2.readXml( doc );
+
+  QgsMapThemeCollection::MapThemeRecord recUnchecked2 = themes2.mapThemeState( "all-unchecked" );
+  QVERIFY( recUnchecked2.hasCheckedStateInfo() );
+  QCOMPARE( recUnchecked2.checkedGroupNodes().count(), 0 );
+
+  QgsMapThemeCollection::MapThemeRecord recChecked2 = themes2.mapThemeState( "all-checked" );
+  QVERIFY( recChecked2.hasCheckedStateInfo() );
+  QCOMPARE( recChecked2.checkedGroupNodes().count(), 3 );
 }
 
 QGSTEST_MAIN( TestQgsMapThemeCollection )


### PR DESCRIPTION
- For project : check visible state for embedded layers inside an unchecked group, instead of putting all layers in embedded-invisible-layers
- For theme : Add an 'checked-group-node' to save group visible state independently to layers in it.
Fixes #33097

Hi,
My name is Sébastien Peillet and I'm a new member of Oslandia since September. It's been a few years that I began to write python plugin for Qgis and now that I am part of Oslandia, I hope I could contribute to the Qgis project in a more broadly way. All tips are welcome !

## Description
Issue explained in #33097 

To fix theses issues, some changes has been made : 

For project issue, all embbeded layers in a embedded group were listed as `embedded-invisible-layers` if the group visible state was unchecked. It has been changed with a if statement on layers visible state : 

```
      if ( child->itemVisibilityChecked() == Qt::Unchecked )
      {
        list << invisibleLayerList( child );
      }
```

For theme issue, layers are saved in the `visibility-preset` element. In the same way as before, if the group is unchecked, all layers checked within are not saved in the `visibility-preset` element, because the test is : 
```
     if ( nodeLayer->isVisible() )
```
I replaced it with:
```
     if ( node->itemVisibilityChecked() != Qt::Unchecked )
```
Like this, checked layers are saved, even if group are unchecked

And futhermore, groups have no visibility state. So I add a `has-checked-group-info` tag (similar to the `has-expanded-info` tag) in the `visibility-preset` element. It allows to list the checked group and apply the theme correctly (before there was no change applied on the group)

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
