### PR TITLE
Allow drag and drop of pictures onto layouts

### DIFF
--- a/python/gui/auto_generated/layout/qgslayoutcustomdrophandler.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutcustomdrophandler.sip.in
@@ -27,15 +27,33 @@ Abstract base class that may be implemented to handle new types of data to be dr
 Constructor for QgsLayoutCustomDropHandler.
 %End
 
-    virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file );
+ virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) /Deprecated/;
 %Docstring
 Called when the specified ``file`` has been dropped onto a QGIS layout. If ``True``
 is returned, then the handler has accepted this file and it should not
 be further processed (e.g. by other QgsLayoutCustomDropHandler).
 
 The base class implementation does nothing.
+
+.. deprecated::
+   use the version which specifies a drop location instead.
+%End
+
+    virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, QPointF dropPoint, const QString &file );
+%Docstring
+Called when the specified ``file`` has been dropped onto a QGIS layout. If ``True``
+is returned, then the handler has accepted this file and it should not
+be further processed (e.g. by other QgsLayoutCustomDropHandler).
+
+The ``dropPoint`` point specifies the location (in layout coordinates) at which
+the drop occurred.
+
+The base class implementation does nothing.
+
+.. versionadded:: 3.12
 %End
 };
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -202,6 +202,7 @@ SET(QGIS_APP_SRCS
   layout/qgslayoutdesignerdialog.cpp
   layout/qgslayoutguidewidget.cpp
   layout/qgslayouthtmlwidget.cpp
+  layout/qgslayoutimagedrophandler.cpp
   layout/qgslayoutimageexportoptionsdialog.cpp
   layout/qgslayoutitemslistview.cpp
   layout/qgslayoutappmenuprovider.cpp

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -1467,17 +1467,25 @@ void QgsLayoutDesignerDialog::dropEvent( QDropEvent *event )
     }
   }
 
-  connect( timer, &QTimer::timeout, this, [this, timer, files]
+  QPointF layoutPoint = mView->mapToScene( mView->mapFromGlobal( mapToGlobal( event->pos() ) ) );
+
+  connect( timer, &QTimer::timeout, this, [this, timer, files, layoutPoint]
   {
     for ( const QString &file : qgis::as_const( files ) )
     {
       const QVector<QPointer<QgsLayoutCustomDropHandler >> handlers = QgisApp::instance()->customLayoutDropHandlers();
       for ( QgsLayoutCustomDropHandler *handler : handlers )
       {
+        if ( handler && handler->handleFileDrop( iface(), layoutPoint, file ) )
+        {
+          break;
+        }
+        Q_NOWARN_DEPRECATED_PUSH
         if ( handler && handler->handleFileDrop( iface(), file ) )
         {
           break;
         }
+        Q_NOWARN_DEPRECATED_POP
       }
     }
 

--- a/src/app/layout/qgslayoutimagedrophandler.cpp
+++ b/src/app/layout/qgslayoutimagedrophandler.cpp
@@ -16,11 +16,8 @@
 #include "qgslayoutimagedrophandler.h"
 #include "qgslayoutdesignerinterface.h"
 #include "qgslayout.h"
-#include "qgsreadwritecontext.h"
-#include "qgsproject.h"
 #include "qgslayoutview.h"
 #include "qgslayoutitempicture.h"
-#include <QMessageBox>
 #include <QImageReader>
 
 QgsLayoutImageDropHandler::QgsLayoutImageDropHandler( QObject *parent )

--- a/src/app/layout/qgslayoutimagedrophandler.cpp
+++ b/src/app/layout/qgslayoutimagedrophandler.cpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+    qgslayoutimagedrophandler.cpp
+    ------------------------------
+    begin                : November 2019
+    copyright            : (C) 2019 by nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayoutimagedrophandler.h"
+#include "qgslayoutdesignerinterface.h"
+#include "qgslayout.h"
+#include "qgsreadwritecontext.h"
+#include "qgsproject.h"
+#include "qgslayoutview.h"
+#include "qgslayoutitempicture.h"
+#include <QMessageBox>
+#include <QImageReader>
+
+QgsLayoutImageDropHandler::QgsLayoutImageDropHandler( QObject *parent )
+  : QgsLayoutCustomDropHandler( parent )
+{
+
+}
+
+bool QgsLayoutImageDropHandler::handleFileDrop( QgsLayoutDesignerInterface *iface, QPointF point, const QString &file )
+{
+  QFileInfo fi( file );
+
+  bool matched = false;
+  const QList<QByteArray> formats = QImageReader::supportedImageFormats();
+  for ( const QByteArray &format : formats )
+  {
+    if ( fi.suffix().compare( format, Qt::CaseInsensitive ) == 0 )
+    {
+      matched = true;
+      break;
+    }
+  }
+  if ( !matched )
+
+    return false;
+
+  if ( !iface->layout() )
+    return false;
+
+  std::unique_ptr< QgsLayoutItemPicture > item = qgis::make_unique< QgsLayoutItemPicture >( iface->layout() );
+
+  QgsLayoutPoint layoutPoint = iface->layout()->convertFromLayoutUnits( point, iface->layout()->units() );
+  item->attemptMove( layoutPoint );
+
+  item->setPicturePath( file );
+
+  // force a resize to the image's actual size
+  item->setResizeMode( QgsLayoutItemPicture::FrameToImageSize );
+  // and then move back to standard freeform image sizing
+  item->setResizeMode( QgsLayoutItemPicture::Zoom );
+
+  // and auto select new item for convenience
+  QList< QgsLayoutItem * > newSelection;
+  newSelection << item.get();
+  iface->layout()->addLayoutItem( item.release() );
+  iface->layout()->deselectAll();
+  iface->selectItems( newSelection );
+
+  return true;
+}

--- a/src/app/layout/qgslayoutimagedrophandler.h
+++ b/src/app/layout/qgslayoutimagedrophandler.h
@@ -1,8 +1,8 @@
 /***************************************************************************
-    qgslayoutcustomdrophandler.cpp
-    ------------------------------
-    begin                : December 2017
-    copyright            : (C) 2017 by nyall Dawson
+    qgslayoutimagedrophandler.h
+    -------------------------
+    begin                : November 2019
+    copyright            : (C) 2019 by nyall Dawson
     email                : nyall dot dawson at gmail dot com
  ***************************************************************************
  *                                                                         *
@@ -13,21 +13,20 @@
  *                                                                         *
  ***************************************************************************/
 
+#ifndef QGSLAYOUTIMAGEDROPHANDLER_H
+#define QGSLAYOUTIMAGEDROPHANDLER_H
+
 #include "qgslayoutcustomdrophandler.h"
-#include <QPointF>
 
-QgsLayoutCustomDropHandler::QgsLayoutCustomDropHandler( QObject *parent )
-  : QObject( parent )
+class QgsLayoutImageDropHandler : public QgsLayoutCustomDropHandler
 {
+    Q_OBJECT
 
-}
+  public:
 
-bool QgsLayoutCustomDropHandler::handleFileDrop( QgsLayoutDesignerInterface *, const QString & )
-{
-  return false;
-}
+    QgsLayoutImageDropHandler( QObject *parent = nullptr );
 
-bool QgsLayoutCustomDropHandler::handleFileDrop( QgsLayoutDesignerInterface *, QPointF, const QString & )
-{
-  return false;
-}
+    bool handleFileDrop( QgsLayoutDesignerInterface *iface, QPointF point, const QString &file ) override;
+};
+
+#endif // QGSLAYOUTIMAGEDROPHANDLER_H

--- a/src/app/layout/qgslayoutqptdrophandler.cpp
+++ b/src/app/layout/qgslayoutqptdrophandler.cpp
@@ -27,7 +27,7 @@ QgsLayoutQptDropHandler::QgsLayoutQptDropHandler( QObject *parent )
 
 }
 
-bool QgsLayoutQptDropHandler::handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file )
+bool QgsLayoutQptDropHandler::handleFileDrop( QgsLayoutDesignerInterface *iface, QPointF, const QString &file )
 {
   QFileInfo fi( file );
   if ( fi.suffix().compare( QLatin1String( "qpt" ), Qt::CaseInsensitive ) != 0 )

--- a/src/app/layout/qgslayoutqptdrophandler.h
+++ b/src/app/layout/qgslayoutqptdrophandler.h
@@ -26,7 +26,7 @@ class QgsLayoutQptDropHandler : public QgsLayoutCustomDropHandler
 
     QgsLayoutQptDropHandler( QObject *parent = nullptr );
 
-    bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) override;
+    bool handleFileDrop( QgsLayoutDesignerInterface *iface, QPointF point, const QString &file ) override;
 };
 
 #endif // QGSLAYOUTQPTDROPHANDLER_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -233,6 +233,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayoutdesignerdialog.h"
 #include "qgslayoutmanager.h"
 #include "qgslayoutqptdrophandler.h"
+#include "qgslayoutimagedrophandler.h"
 #include "qgslayoutapputils.h"
 #include "qgslocatorwidget.h"
 #include "qgslocator.h"
@@ -1696,6 +1697,7 @@ QgisApp::~QgisApp()
   QgsApplication::setFileOpenEventReceiver( nullptr );
 
   unregisterCustomLayoutDropHandler( mLayoutQptDropHandler );
+  unregisterCustomLayoutDropHandler( mLayoutImageDropHandler );
 
 #ifdef WITH_BINDINGS
   delete mPythonUtils;
@@ -11731,6 +11733,8 @@ void QgisApp::initLayouts()
 
   mLayoutQptDropHandler = new QgsLayoutQptDropHandler( this );
   registerCustomLayoutDropHandler( mLayoutQptDropHandler );
+  mLayoutImageDropHandler = new QgsLayoutImageDropHandler( this );
+  registerCustomLayoutDropHandler( mLayoutImageDropHandler );
 }
 
 void QgisApp::new3DMapCanvas()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -134,7 +134,7 @@ class QgsDataSourceManagerDialog;
 class QgsBrowserGuiModel;
 class QgsBrowserModel;
 class QgsGeoCmsProviderRegistry;
-class QgsLayoutQptDropHandler;
+class QgsLayoutCustomDropHandler;
 class QgsProxyProgressTask;
 class QgsNetworkRequestParameters;
 
@@ -2323,7 +2323,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QVector<QPointer<QgsCustomDropHandler>> mCustomDropHandlers;
     QVector<QPointer<QgsLayoutCustomDropHandler>> mCustomLayoutDropHandlers;
 
-    QgsLayoutQptDropHandler *mLayoutQptDropHandler = nullptr;
+    QgsLayoutCustomDropHandler *mLayoutQptDropHandler = nullptr;
+    QgsLayoutCustomDropHandler *mLayoutImageDropHandler = nullptr;
 
     QDateTime mProjectLastModified;
 

--- a/src/gui/layout/qgslayoutcustomdrophandler.h
+++ b/src/gui/layout/qgslayoutcustomdrophandler.h
@@ -45,8 +45,25 @@ class GUI_EXPORT QgsLayoutCustomDropHandler : public QObject
      * be further processed (e.g. by other QgsLayoutCustomDropHandler).
      *
      * The base class implementation does nothing.
+     *
+     * \deprecated use the version which specifies a drop location instead.
      */
-    virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file );
+    Q_DECL_DEPRECATED virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, const QString &file ) SIP_DEPRECATED;
+
+    /**
+     * Called when the specified \a file has been dropped onto a QGIS layout. If TRUE
+     * is returned, then the handler has accepted this file and it should not
+     * be further processed (e.g. by other QgsLayoutCustomDropHandler).
+     *
+     * The \a dropPoint point specifies the location (in layout coordinates) at which
+     * the drop occurred.
+     *
+     * The base class implementation does nothing.
+     *
+     * \since QGIS 3.12
+     */
+    virtual bool handleFileDrop( QgsLayoutDesignerInterface *iface, QPointF dropPoint, const QString &file );
 };
+
 
 #endif // QGSLAYOUTCUSTOMDROPHANDLER_H


### PR DESCRIPTION
E.g. drag an svg from a file explorer onto the layout to create a
new picture item containing that svg image.

Convenience++!

![Peek 2019-11-28 14-15](https://user-images.githubusercontent.com/1829991/69777105-7b7c8900-11ea-11ea-9f89-6fc09d98c986.gif)
