### PR TITLE
Fix crash in PAL labeling engine

### DIFF
--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -292,7 +292,7 @@ void Problem::init_sol_falp()
     LabelPosition *retainedLabel = nullptr;
     int p;
 
-    for ( i = 0; i < static_cast< int >( mFeatureCount ); i++ ) // forearch hidden feature
+    for ( std::size_t i = 0; i < mFeatureCount; i++ ) // forearch hidden feature
     {
       if ( mSol.activeLabelIds[i] == -1 )
       {
@@ -783,10 +783,9 @@ void Problem::chain_search()
 
 QList<LabelPosition *> Problem::getSolution( bool returnInactive, QList<LabelPosition *> *unlabeled )
 {
-  int i;
   QList<LabelPosition *> solList;
 
-  for ( i = 0; i < static_cast< int >( mFeatureCount ); i++ )
+  for ( std::size_t i = 0; i < mFeatureCount; i++ )
   {
     if ( mSol.activeLabelIds[i] != -1 )
     {
@@ -817,8 +816,6 @@ void Problem::solution_cost()
 
   int nbOv;
 
-  int i;
-
   LabelPosition::CountContext context;
   context.inactiveCost = mInactiveCost;
   context.nbOv = &nbOv;
@@ -829,7 +826,7 @@ void Problem::solution_cost()
 
   int nbHidden = 0;
 
-  for ( i = 0; i < static_cast< int >( mFeatureCount ); i++ )
+  for ( std::size_t i = 0; i < mFeatureCount; i++ )
   {
     if ( mSol.activeLabelIds[i] == -1 )
     {

--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -218,7 +218,7 @@ void Problem::init_sol_falp()
   int label;
   PriorityQueue *list = nullptr;
 
-  mSol.init( mTotalCandidates );
+  mSol.init( mFeatureCount );
 
   list = new PriorityQueue( mTotalCandidates, mAllNblp, true );
 

--- a/src/core/pal/problem.h
+++ b/src/core/pal/problem.h
@@ -197,7 +197,7 @@ namespace pal
 
           double totalCost = 0;
 
-          void init( int featureCount )
+          void init( std::size_t featureCount )
           {
             activeLabelIds.resize( featureCount, -1 );
             totalCost = 0;


### PR DESCRIPTION
due to incorrect size initialization of vector

If the number of candidates is < the number of features (i.e. some features have
no candidates), we'll get a crash. And if the number of candidates >> number of features
(the usual case), we're just creating a much larger vector than we'll ever use...

(I think. It's pal. No-one know for sure.)