### PR TITLE
[Tests][Server] Add WMS GetFeatureInfo GML tests

### DIFF
--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -441,6 +441,26 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'wms_getfeatureinfo_polygon_tolerance_20_text_xml',
                                  'test_project_values.qgz')
 
+    def testGetFeatureInfoGML(self):
+        # Test getfeatureinfo response gml
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=application%2Fvnd.ogc.gml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
+                                 'wms_getfeatureinfo-text-gml')
+
+        # Test getfeatureinfo response gml with gml
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
+                                 'info_format=application%2Fvnd.ogc.gml&transparent=true&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&bbox=913190.6389747962%2C' +
+                                 '5606005.488876367%2C913235.426296057%2C5606035.347090538&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320&' +
+                                 'with_geometry=true',
+                                 'wms_getfeatureinfo-text-gml-geometry')
+
     def testGetFeatureInfoJSON(self):
         # simple test without geometry and info_format=application/json
         self.wms_request_compare('GetFeatureInfo',

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-gml-geometry.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-gml-geometry.txt
@@ -1,0 +1,22 @@
+*****
+Content-Type: application/vnd.ogc.gml; charset=utf-8
+
+<wfs:FeatureCollection xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows" xmlns:qgs="http://qgis.org/gml" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://qgis.org/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <gml:featureMember>
+  <qgs:testlayerèé fid="testlayer èé.2">
+   <gml:boundedBy>
+    <gml:Box srsName="EPSG:3857">
+     <gml:coordinates cs="," ts=" ">913204.9128,5606011.4565 913204.9128,5606011.4565</gml:coordinates>
+    </gml:Box>
+   </gml:boundedBy>
+   <qgs:geometry>
+    <gml:Point srsName="EPSG:3857">
+     <gml:coordinates cs="," ts=" ">913204.9128,5606011.4565</gml:coordinates>
+    </gml:Point>
+   </qgs:geometry>
+   <qgs:id>3</qgs:id>
+   <qgs:name>three</qgs:name>
+   <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+  </qgs:testlayerèé>
+ </gml:featureMember>
+</wfs:FeatureCollection>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-gml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-gml.txt
@@ -1,0 +1,17 @@
+*****
+Content-Type: application/vnd.ogc.gml; charset=utf-8
+
+<wfs:FeatureCollection xmlns:gml="http://www.opengis.net/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows" xmlns:qgs="http://qgis.org/gml" xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://qgis.org/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <gml:featureMember>
+  <qgs:testlayerèé fid="testlayer èé.2">
+   <gml:boundedBy>
+    <gml:Box srsName="EPSG:3857">
+     <gml:coordinates cs="," ts=" ">913204.9128,5606011.4565 913204.9128,5606011.4565</gml:coordinates>
+    </gml:Box>
+   </gml:boundedBy>
+   <qgs:id>3</qgs:id>
+   <qgs:name>three</qgs:name>
+   <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+  </qgs:testlayerèé>
+ </gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
## Description
No tests were provided for WMS GetFeatureInfo Request with GML format.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
