### PR TITLE
pal.cpp: fix compilation error with gcc 5.5

### DIFF
--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -88,7 +88,7 @@ Layer *Pal::addLayer( QgsAbstractLabelProvider *provider, const QString &layerNa
 
   std::unique_ptr< Layer > layer = qgis::make_unique< Layer >( provider, layerName, arrangement, defaultPriority, active, toLabel, this, displayAll );
   Layer *res = layer.get();
-  mLayers.insert( { provider, std::move( layer ) } );
+  mLayers.insert( std::pair<QgsAbstractLabelProvider *, std::unique_ptr< Layer >>( provider, std::move( layer ) ) );
   mMutex.unlock();
 
   return res;


### PR DESCRIPTION
Unfortunately the compiler cannot figure out that the type of
the { } is a std::pair, so we have to be explicit about that
