### PR TITLE
[pal] Provide more exit points for early cancelation

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -649,13 +649,13 @@ QList< LegendLayerAction > QgsAppLayerTreeViewMenuProvider::legendLayerActions( 
 #ifdef QGISDEBUG
   if ( mLegendLayerActionMap.contains( type ) )
   {
-    QgsDebugMsg( QStringLiteral( "legendLayerActions for layers of type %1:" ).arg( static_cast<int>( type ) ) );
+    QgsDebugMsgLevel( QStringLiteral( "legendLayerActions for layers of type %1:" ).arg( static_cast<int>( type ) ), 2 );
 
     const auto legendLayerActions { mLegendLayerActionMap.value( type ) };
     for ( const LegendLayerAction &lyrAction : legendLayerActions )
     {
       Q_UNUSED( lyrAction )
-      QgsDebugMsg( QStringLiteral( "%1/%2 - %3 layers" ).arg( lyrAction.menu, lyrAction.action->text() ).arg( lyrAction.layers.count() ) );
+      QgsDebugMsgLevel( QStringLiteral( "%1/%2 - %3 layers" ).arg( lyrAction.menu, lyrAction.action->text() ).arg( lyrAction.layers.count() ), 2 );
     }
   }
 #endif

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -688,8 +688,8 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
   }
 
   // calculate lengths of segments, and work out longest straight-ish segment
-  double *segmentLengths = new double[ numberNodes - 1 ]; // segments lengths distance bw pt[i] && pt[i+1]
-  double *distanceToSegment = new double[ numberNodes ]; // absolute distance bw pt[0] and pt[i] along the line
+  std::vector< double > segmentLengths( numberNodes - 1 ); // segments lengths distance bw pt[i] && pt[i+1]
+  std::vector< double > distanceToSegment( numberNodes ); // absolute distance bw pt[0] and pt[i] along the line
   double totalLineLength = 0.0;
   QVector< double > straightSegmentLengths;
   QVector< double > straightSegmentAngles;
@@ -730,8 +730,6 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
 
   if ( totalLineLength < labelWidth )
   {
-    delete[] segmentLengths;
-    delete[] distanceToSegment;
     return 0; //createCandidatesAlongLineNearMidpoint will be more appropriate
   }
 
@@ -768,8 +766,8 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
     while ( currentDistanceAlongLine + labelWidth < distanceToEndOfSegment )
     {
       // calculate positions along linestring corresponding to start and end of current label candidate
-      line->getPointByDistance( segmentLengths, distanceToSegment, currentDistanceAlongLine, &candidateStartX, &candidateStartY );
-      line->getPointByDistance( segmentLengths, distanceToSegment, currentDistanceAlongLine + labelWidth, &candidateEndX, &candidateEndY );
+      line->getPointByDistance( segmentLengths.data(), distanceToSegment.data(), currentDistanceAlongLine, &candidateStartX, &candidateStartY );
+      line->getPointByDistance( segmentLengths.data(), distanceToSegment.data(), currentDistanceAlongLine + labelWidth, &candidateEndX, &candidateEndY );
 
       candidateLength = std::sqrt( ( candidateEndX - candidateStartX ) * ( candidateEndX - candidateStartX ) + ( candidateEndY - candidateStartY ) * ( candidateEndY - candidateStartY ) );
 
@@ -861,8 +859,6 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
     }
   }
 
-  delete[] segmentLengths;
-  delete[] distanceToSegment;
   return lPos.size();
 }
 
@@ -885,8 +881,8 @@ std::size_t FeaturePart::createCandidatesAlongLineNearMidpoint( std::vector< std
   std::vector< double > &x = line->x;
   std::vector< double > &y = line->y;
 
-  double *segmentLengths = new double[nbPoints - 1]; // segments lengths distance bw pt[i] && pt[i+1]
-  double *distanceToSegment = new double[nbPoints]; // absolute distance bw pt[0] and pt[i] along the line
+  std::vector< double > segmentLengths( nbPoints - 1 ); // segments lengths distance bw pt[i] && pt[i+1]
+  std::vector< double >distanceToSegment( nbPoints ); // absolute distance bw pt[0] and pt[i] along the line
 
   double totalLineLength = 0.0; // line length
   for ( int i = 0; i < line->nbPoints - 1; i++ )
@@ -927,8 +923,8 @@ std::size_t FeaturePart::createCandidatesAlongLineNearMidpoint( std::vector< std
   while ( currentDistanceAlongLine < totalLineLength - labelWidth )
   {
     // calculate positions along linestring corresponding to start and end of current label candidate
-    line->getPointByDistance( segmentLengths, distanceToSegment, currentDistanceAlongLine, &candidateStartX, &candidateStartY );
-    line->getPointByDistance( segmentLengths, distanceToSegment, currentDistanceAlongLine + labelWidth, &candidateEndX, &candidateEndY );
+    line->getPointByDistance( segmentLengths.data(), distanceToSegment.data(), currentDistanceAlongLine, &candidateStartX, &candidateStartY );
+    line->getPointByDistance( segmentLengths.data(), distanceToSegment.data(), currentDistanceAlongLine + labelWidth, &candidateEndX, &candidateEndY );
 
     if ( currentDistanceAlongLine < 0 )
     {
@@ -1016,11 +1012,6 @@ std::size_t FeaturePart::createCandidatesAlongLineNearMidpoint( std::vector< std
     if ( lineStepDistance < 0 )
       break;
   }
-
-  //delete line;
-
-  delete[] segmentLengths;
-  delete[] distanceToSegment;
 
   return lPos.size();
 }

--- a/src/core/pal/feature.h
+++ b/src/core/pal/feature.h
@@ -130,7 +130,7 @@ namespace pal
       /**
        * Generates a list of candidate positions for labels for this feature.
        */
-      std::vector<std::unique_ptr<LabelPosition> > createCandidates();
+      std::vector<std::unique_ptr<LabelPosition> > createCandidates( Pal *pal );
 
       /**
        * Generate candidates for point feature, located around a specified point.
@@ -175,18 +175,20 @@ namespace pal
        * \param lPos pointer to an array of candidates, will be filled by generated candidates
        * \param mapShape a pointer to the line
        * \param allowOverrun set to TRUE to allow labels to overrun features
+       * \param pal point to pal settings object, for cancellation support
        * \returns the number of generated candidates
        */
-      std::size_t createCandidatesAlongLine( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, bool allowOverrun = false );
+      std::size_t createCandidatesAlongLine( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, bool allowOverrun, Pal *pal );
 
       /**
        * Generate candidates for line feature, by trying to place candidates towards the middle of the longest
        * straightish segments of the line. Segments closer to horizontal are preferred over vertical segments.
        * \param lPos pointer to an array of candidates, will be filled by generated candidates
        * \param mapShape a pointer to the line
+       * \param pal point to pal settings object, for cancellation support
        * \returns the number of generated candidates
        */
-      std::size_t createCandidatesAlongLineNearStraightSegments( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape );
+      std::size_t createCandidatesAlongLineNearStraightSegments( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, Pal *pal );
 
       /**
        * Generate candidates for line feature, by trying to place candidates as close as possible to the line's midpoint.
@@ -197,7 +199,7 @@ namespace pal
        * by a preset amount.
        * \returns the number of generated candidates
        */
-      std::size_t createCandidatesAlongLineNearMidpoint( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, double initialCost = 0.0 );
+      std::size_t createCandidatesAlongLineNearMidpoint( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, double initialCost = 0.0, Pal *pal = nullptr );
 
       /**
        * Returns the label position for a curved label at a specific offset along a path.
@@ -217,17 +219,19 @@ namespace pal
        * \param lPos pointer to an array of candidates, will be filled by generated candidates
        * \param mapShape a pointer to the line
        * \param allowOverrun set to TRUE to allow labels to overrun features
+       * \param pal point to pal settings object, for cancellation support
        * \returns the number of generated candidates
        */
-      std::size_t createCurvedCandidatesAlongLine( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, bool allowOverrun = false );
+      std::size_t createCurvedCandidatesAlongLine( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, bool allowOverrun, Pal *pal );
 
       /**
        * Generate candidates for polygon features.
        * \param lPos pointer to an array of candidates, will be filled by generated candidates
        * \param mapShape a pointer to the polygon
+       * \param pal point to pal settings object, for cancellation support
        * \returns the number of generated candidates
        */
-      std::size_t createCandidatesForPolygon( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape );
+      std::size_t createCandidatesForPolygon( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, Pal *pal );
 
       /**
        * Tests whether this feature part belongs to the same QgsLabelFeature as another

--- a/src/core/pal/feature.h
+++ b/src/core/pal/feature.h
@@ -197,6 +197,7 @@ namespace pal
        * \param mapShape a pointer to the line
        * \param initialCost initial cost for candidates generated using this method. If set, cost can be increased
        * by a preset amount.
+       * \param pal point to pal settings object, for cancellation support
        * \returns the number of generated candidates
        */
       std::size_t createCandidatesAlongLineNearMidpoint( std::vector<std::unique_ptr<LabelPosition> > &lPos, PointSet *mapShape, double initialCost = 0.0, Pal *pal = nullptr );

--- a/src/core/pal/pointset.h
+++ b/src/core/pal/pointset.h
@@ -80,7 +80,10 @@ namespace pal
       PointSet( int nbPoints, double *x, double *y );
       virtual ~PointSet();
 
-      PointSet *extractShape( int nbPtSh, int imin, int imax, int fps, int fpe, double fptx, double fpty );
+      /**
+       * Does... something completely inscrutable.
+       */
+      std::unique_ptr< PointSet > extractShape( int nbPtSh, int imin, int imax, int fps, int fpe, double fptx, double fpty );
 
       /**
        * Returns a copy of the point set.
@@ -106,13 +109,17 @@ namespace pal
        */
       bool containsLabelCandidate( double x, double y, double width, double height, double alpha = 0 ) const;
 
-      CHullBox *compute_chull_bbox();
+      /**
+       * Computes a con???? hull. Maybe convex, maybe concave. The person who wrote this
+       * had no care for anyone else ever reading their code.
+       */
+      CHullBox compute_chull_bbox();
 
       /**
        * Split a concave shape into several convex shapes.
        */
-      static void splitPolygons( QLinkedList<PointSet *> &shapes_toProcess,
-                                 QLinkedList<PointSet *> &shapes_final,
+      static void splitPolygons( QLinkedList<PointSet *> &inputShapes,
+                                 QLinkedList<PointSet *> &outputShapes,
                                  double xrm, double yrm );
 
       /**

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -309,7 +309,7 @@ void QgsVectorLayerRenderer::drawRenderer( QgsFeatureIterator &fit )
     {
       if ( context.renderingStopped() )
       {
-        QgsDebugMsg( QStringLiteral( "Drawing of vector layer %1 canceled." ).arg( layerId() ) );
+        QgsDebugMsgLevel( QStringLiteral( "Drawing of vector layer %1 canceled." ).arg( layerId() ), 2 );
         break;
       }
 


### PR DESCRIPTION
When a rendering operation was canceled, PAL had very few early
exit points. This often resulted in many canceled rendering operations
burning away in background threads as labeling candidates and solutions
were being generated for jobs which were no longer needed.

Add more exit points and cancel checks throughout various expensive
pal operations, allowing labeling jobs to terminate quickly.

Also more memory modernization.

Fixes #32489