### PR TITLE
Show "Open Document..." action when right clicking certain

### DIFF
--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -388,7 +388,7 @@ void QgsLayerItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *men
         if ( fi.suffix().compare( ext, Qt::CaseInsensitive ) == 0 )
         {
           // pdf file
-          QAction *viewAction = new QAction( tr( "Open %1…" ).arg( name ), menu );
+          QAction *viewAction = new QAction( tr( "Open %1 Externally…" ).arg( name ), menu );
           connect( viewAction, &QAction::triggered, this, [ = ]
           {
             QDesktopServices::openUrl( QUrl::fromLocalFile( filename ) );


### PR DESCRIPTION
files in the browser, allowing them to be opened with the default
application for that file type

E.g. PDFs will open with the default PDF viewer.

Works with PDF, ODS, XLS(X), CSV, TXT, PNG, JPEG, TIFF, SVG
(other types will likely need more work, since they aren't
currently shown in the browser)

![Peek 2019-11-29 12-55](https://user-images.githubusercontent.com/1829991/69840503-8a754100-12a7-11ea-9b5d-6aecdcab7829.gif)

