### PR TITLE
[cleanup] pal.cpp: remove useless constructor and destructor

### DIFF
--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -46,11 +46,9 @@
 
 using namespace pal;
 
-Pal::Pal()
-{
-  // do not init and exit GEOS - we do it inside QGIS
-  //initGEOS( geosNotice, geosError );
-}
+Pal::Pal() = default;
+
+Pal::~Pal() = default;
 
 void Pal::removeLayer( Layer *layer )
 {
@@ -68,16 +66,6 @@ void Pal::removeLayer( Layer *layer )
     }
   }
   mMutex.unlock();
-}
-
-Pal::~Pal()
-{
-  mMutex.lock();
-  mLayers.clear();
-  mMutex.unlock();
-
-  // do not init and exit GEOS - we do it inside QGIS
-  //finishGEOS();
 }
 
 Layer *Pal::addLayer( QgsAbstractLabelProvider *provider, const QString &layerName, QgsPalLayerSettings::Placement arrangement, double defaultPriority, bool active, bool toLabel, bool displayAll )


### PR DESCRIPTION
It is obvious that the constructor was a no-op.

Regarding the destructor, taking a mutex around an object doesn't
make sense because both the mutex and the object are member variables,
so if the pal object is used correctly, the destructor should only
be called after any other use of the object. And explicit clearing of
a unordered_map is unnecessary.
