### PR TITLE
Respect placement quadrant in DXF export

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -1259,6 +1259,63 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
   VAlign vali = VAlign::Undefined;
 
   const QgsPropertyCollection &props = layerSettings.dataDefinedProperties();
+
+  if ( props.isActive( QgsPalLayerSettings::OffsetQuad ) )
+  {
+    const QVariant exprVal = props.value( QgsPalLayerSettings::OffsetQuad, expressionContext );
+    if ( exprVal.isValid() )
+    {
+      int offsetQuad = exprVal.toInt();
+
+      lblX -= label->dX();
+      lblY -= label->dY();
+
+      switch ( offsetQuad )
+      {
+        case 0: // Above Left
+          hali = HAlign::HRight;
+          vali = VAlign::VBottom;
+          break;
+        case 1: // Above
+          hali = HAlign::HCenter;
+          vali = VAlign::VBottom;
+          break;
+        case 2: // Above Right
+          hali = HAlign::HLeft;
+          vali = VAlign::VBottom;
+          break;
+        case 3: // Left
+          hali = HAlign::HRight;
+          vali = VAlign::VMiddle;
+          break;
+        case 4: // Over
+          hali = HAlign::HCenter;
+          vali = VAlign::VMiddle;
+          break;
+        case 5: // Right
+          hali = HAlign::HLeft;
+          vali = VAlign::VMiddle;
+          break;
+        case 6: // Below Left
+          hali = HAlign::HRight;
+          vali = VAlign::VTop;
+          break;
+        case 7: // Below
+          hali = HAlign::HCenter;
+          vali = VAlign::VTop;
+          break;
+        case 8: // Below Right
+          hali = HAlign::HLeft;
+          vali = VAlign::VTop;
+          break;
+        default: // OverHali
+          hali = HAlign::HCenter;
+          vali = VAlign::VTop;
+          break;
+      }
+    }
+  }
+
   if ( props.isActive( QgsPalLayerSettings::Hali ) )
   {
     hali = HAlign::HLeft;
@@ -1393,7 +1450,7 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, const Q
     writeGroup( 1, pt ); // Second alignment point
   writeGroup( 40, size );
   writeGroup( 1, text );
-  writeGroup( 50, angle );
+  writeGroup( 50, fmod( angle, 360 ) );
   if ( hali != HAlign::Undefined )
     writeGroup( 72, static_cast<int>( hali ) );
   writeGroup( 7, QStringLiteral( "STANDARD" ) ); // so far only support for standard font

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -310,7 +310,7 @@ std::size_t FeaturePart::createCandidatesOverPoint( double x, double y, std::vec
     }
   }
 
-  lPos.emplace_back( qgis::make_unique< LabelPosition >( id, lx, ly, labelW, labelH, angle, cost, this, false, quadrantFromOffset() ) );
+  lPos.emplace_back( qgis::make_unique< LabelPosition >( id, lx, ly, labelW, labelH, angle, cost, this, false, quadrantFromOffset(), xdiff, ydiff ) );
   return nbp;
 }
 

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -40,7 +40,7 @@
 
 using namespace pal;
 
-LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, double alpha, double cost, FeaturePart *feature, bool isReversed, Quadrant quadrant )
+LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, double alpha, double cost, FeaturePart *feature, bool isReversed, Quadrant quadrant, double dX, double dY )
   : id( id )
   , feature( feature )
   , probFeat( 0 )
@@ -55,6 +55,8 @@ LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, 
   , mCost( cost )
   , mHasObstacleConflict( false )
   , mUpsideDownCharCount( 0 )
+  , mDx( dX )
+  , mDy( dY )
 {
   type = GEOS_POLYGON;
   nbPoints = 4;
@@ -160,6 +162,8 @@ LabelPosition::LabelPosition( const LabelPosition &other )
   quadrant = other.quadrant;
   mHasObstacleConflict = other.mHasObstacleConflict;
   mUpsideDownCharCount = other.mUpsideDownCharCount;
+  mDx = other.mDx;
+  mDy = other.mDy;
 }
 
 bool LabelPosition::isIn( double *bbox )
@@ -317,6 +321,16 @@ bool LabelPosition::isInConflictMultiPart( LabelPosition *lp )
     tmp1 = tmp1->nextPart;
   }
   return false; // no conflict found
+}
+
+double LabelPosition::dY() const
+{
+  return mDy;
+}
+
+double LabelPosition::dX() const
+{
+  return mDx;
 }
 
 int LabelPosition::partCount() const

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -88,14 +88,14 @@ namespace pal
        * \param feature labelpos owners
        * \param isReversed label is reversed
        * \param quadrant relative position of label to feature
-       * \param dx the correction of the anchor point in x direction
-       * \param dy the correction of the anchor point in y direction
+       * \param dX the correction of the anchor point in x direction
+       * \param dY the correction of the anchor point in y direction
        */
       LabelPosition( int id, double x1, double y1,
                      double w, double h,
                      double alpha, double cost,
                      FeaturePart *feature, bool isReversed = false, Quadrant quadrant = QuadrantOver,
-                     double dX = 0.0, double dy = 0.0 );
+                     double dX = 0.0, double dY = 0.0 );
 
       //! Copy constructor
       LabelPosition( const LabelPosition &other );

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -88,11 +88,14 @@ namespace pal
        * \param feature labelpos owners
        * \param isReversed label is reversed
        * \param quadrant relative position of label to feature
+       * \param dx the correction of the anchor point in x direction
+       * \param dy the correction of the anchor point in y direction
        */
       LabelPosition( int id, double x1, double y1,
                      double w, double h,
                      double alpha, double cost,
-                     FeaturePart *feature, bool isReversed = false, Quadrant quadrant = QuadrantOver );
+                     FeaturePart *feature, bool isReversed = false, Quadrant quadrant = QuadrantOver,
+                     double dX = 0.0, double dy = 0.0 );
 
       //! Copy constructor
       LabelPosition( const LabelPosition &other );
@@ -297,6 +300,20 @@ namespace pal
       // for polygon cost calculation
       static bool polygonObstacleCallback( pal::FeaturePart *obstacle, void *ctx );
 
+      /**
+       * The offset of the anchor point in x direction.
+       *
+       * \since QGIS 3.12
+       */
+      double dX() const;
+
+      /**
+       * The offset of the anchor point in y direction.
+       *
+       * \since QGIS 3.12
+       */
+      double dY() const;
+
     protected:
 
       int id;
@@ -331,6 +348,8 @@ namespace pal
       double mCost;
       bool mHasObstacleConflict;
       int mUpsideDownCharCount;
+      double mDx = 0.0;
+      double mDy = 0.0;
 
       /**
        * Calculates the total number of parts for this label position


### PR DESCRIPTION
If quadrant based placement is activated for labeling, this was up to now ignored on dxf export, leading to misplaced labels.
With this PR, the dxf alignment is set based on the quadrant.

PAL changes the anchor point for quadrant placed labels during candidate creation. In order to "undo" this change, the delta is now preserved in the PAL label.