### PR TITLE
Add DXF server export params NO_MTEXT and FORCE_2D

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1480,6 +1480,32 @@ namespace QgsWms
     return filters;
   }
 
+  bool QgsWmsParameters::force2D() const
+  {
+    bool force2D = false;
+    const QMap<DxfFormatOption, QString> options = dxfFormatOptions();
+
+    if ( options.contains( DxfFormatOption::FORCE_2D ) )
+    {
+      force2D = QVariant( options[ DxfFormatOption::FORCE_2D ] ).toBool();
+    }
+
+    return force2D;
+  }
+
+  bool QgsWmsParameters::noMText() const
+  {
+    bool noMText = false;
+    const QMap<DxfFormatOption, QString> options = dxfFormatOptions();
+
+    if ( options.contains( DxfFormatOption::NO_MTEXT ) )
+    {
+      noMText = QVariant( options[ DxfFormatOption::NO_MTEXT ] ).toBool();
+    }
+
+    return noMText;
+  }
+
   QList<QgsWmsParametersLayer> QgsWmsParameters::layersParameters() const
   {
     const QStringList layers = allLayersNickname();

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1480,7 +1480,7 @@ namespace QgsWms
     return filters;
   }
 
-  bool QgsWmsParameters::force2D() const
+  bool QgsWmsParameters::isForce2D() const
   {
     bool force2D = false;
     const QMap<DxfFormatOption, QString> options = dxfFormatOptions();

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -349,7 +349,9 @@ namespace QgsWms
         MODE,
         LAYERATTRIBUTES,
         USE_TITLE_AS_LAYERNAME,
-        CODEC
+        CODEC,
+        NO_MTEXT,
+        FORCE_2D
       };
       Q_ENUM( DxfFormatOption )
 
@@ -1309,6 +1311,22 @@ namespace QgsWms
        */
       QMap<QString, QString> dimensionValues() const;
 
+      /**
+       * \returns true if the FORCE_MTEXT parameter is set and the DXF should
+       * be produced with MTEXT instead of TEXT.
+       *
+       * \since QGIS 3.12
+       */
+      bool noMText() const;
+
+      /**
+       * \returns true if the FORCE_2D parameter is set and the DXF should
+       * be produced in 2D.
+       *
+       * \since QGIS 3.12
+       */
+      bool force2D() const;
+
     private:
       static bool isExternalLayer( const QString &name );
 
@@ -1324,6 +1342,7 @@ namespace QgsWms
       QgsWmsParametersExternalLayer externalLayerParameter( const QString &name ) const;
 
       QMultiMap<QString, QgsWmsParametersFilter> layerFilters( const QStringList &layers ) const;
+
 
       QMap<QgsWmsParameter::Name, QgsWmsParameter> mWmsParameters;
       QMap<QString, QMap<QString, QString> > mExternalWMSParameters;

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -1325,7 +1325,7 @@ namespace QgsWms
        *
        * \since QGIS 3.12
        */
-      bool force2D() const;
+      bool isForce2D() const;
 
     private:
       static bool isExternalLayer( const QString &name );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -848,6 +848,13 @@ namespace QgsWms
       dxf->setSymbologyScale( mWmsParameters.dxfScale() );
     }
 
+    dxf->setForce2d( mWmsParameters.force2D() );
+    QgsDxfExport::Flags flags;
+    if ( mWmsParameters.noMText() )
+      flags.setFlag( QgsDxfExport::Flag::FlagNoMText );
+
+    dxf->setFlags( flags );
+
     return dxf;
   }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -848,7 +848,7 @@ namespace QgsWms
       dxf->setSymbologyScale( mWmsParameters.dxfScale() );
     }
 
-    dxf->setForce2d( mWmsParameters.force2D() );
+    dxf->setForce2d( mWmsParameters.isForce2D() );
     QgsDxfExport::Flags flags;
     if ( mWmsParameters.noMText() )
       flags.setFlag( QgsDxfExport::Flag::FlagNoMText );


### PR DESCRIPTION
# Changelog

QGIS server now supports the new parameters `NO_MTEXT` and `FORCE_2D` to control text and line symbology for generated DXF files.

---------

# PR description

Adds missing parameters to GetDxf request