### PR TITLE
Add QgsEmfRenderer class for rendering EMF files to QPainter devices

### DIFF
--- a/.github/workflows/mxe.yml
+++ b/.github/workflows/mxe.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Upload build
       uses: actions/upload-artifact@v1
       with:
-        name: Store artifact
+        name: QGIS for Windows 64bit
         path: qgis-mxe-release.zip
       

--- a/external/libqemf/CHANGES.txt
+++ b/external/libqemf/CHANGES.txt
@@ -1,0 +1,28 @@
+libqemf
+------------------------
+2017-06-06 - Release 0.6: 
+- Fixed rendering of the cap and join style for pens.
+- Fixed rendering of pens with incorrect input width (larger than INT_MAX).
+- Improved EmfViewer demo application: added support for zooming in/out using Ctrl-key + mouse wheel.
+------------------------
+2016-09-05 - Release 0.5:
+Improved EmfViewer demo application: 
+- Added drag and drop support
+- Added support for converting metafiles to EPS, PDF and SVG vector formats and to QPictures (*.pic)
+- Added a context menu
+------------------------
+2016-06-02 - Release 0.4:
+- Fixed rendering of pen width.
+- Highly improved viewer demo application.
+------------------------
+2016-05-22 - Release 0.3:
+- Added support for EMR_ALPHABLEND records.
+------------------------
+2015-11-14 - Release 0.2:
+- On Windows systems the viewer test application also opens WMF files.
+- Fixed bug in text rendering.
+- Improved support for Unicode texts.
+- Fixed drawing of images having a transparency mask.
+- Fixed building process on Windows.
+------------------------
+2015-09-18 - Release 0.1: Initial release.

--- a/external/libqemf/COPYING.txt
+++ b/external/libqemf/COPYING.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/external/libqemf/README.txt
+++ b/external/libqemf/README.txt
@@ -1,0 +1,26 @@
+libqemf GNU GPL v. 3.0
+------------------------
+AUTHOR: Ion Vasilief
+------------------------
+FEATURES:  libqemf enables Qt based applications to draw the contents of EMF files onto paint devices.
+           The Enhanced MetaFile format (EMF) is the native vector graphics file format on Windows.
+————————————————————————————————————————————————————————————————————————————————————————————————————
+DEPENDENCIES: You need Qt (http://www.qt.io) installed on your system in order to build libqemf.
+————————————————————————————————————————————————————————————————————————————————————————————————————
+LICENSE: GNU GPL v. 3.0
+————————————————————————————————————————————————————————————————————————————————————————————————————
+CREDITS: libqemf is based on the libemf library from Calligra Suite (https://www.calligra.org/).
+	The original source code can be found in the Calligra project repository:
+	https://projects.kde.org/projects/calligra/repository/revisions/master/show/libs/vectorimage/libemf
+————————————————————————————————————————————————————————————————————————————————————————————————————
+COMPILING: libqemf uses qmake for the building process. 
+	qmake is part of a Qt distribution: 
+	qmake reads project files, that contain the options and rules how to build a certain project. 
+	A project file ends with the suffix "*.pro". Please read the qmake documentation for more details.
+
+After installing Qt on your system, type the following command lines: 
+	$ qmake
+	$ make
+————————————————————————————————————————————————————————————————————————————————————————————————————
+USE: a short demo application is provided in the “viewer” folder of the source archive.
+————————————————————————————————————————————————————————————————————————————————————————————————————

--- a/external/libqemf/config.pri
+++ b/external/libqemf/config.pri
@@ -1,0 +1,13 @@
+CONFIG      += qt warn_on thread
+CONFIG      += release
+
+contains (QT_VERSION, ^5.*){
+	QT += widgets
+}
+
+# Comment the lines bellow if you want to build libqemf statically
+#CONFIG      += QEmfDll
+
+	    
+	    
+

--- a/external/libqemf/libqemf.pro
+++ b/external/libqemf/libqemf.pro
@@ -1,0 +1,7 @@
+include( config.pri )
+
+TEMPLATE = subdirs
+
+SUBDIRS =  \
+	src \
+    EmfViewer

--- a/external/libqemf/src/Bitmap.cpp
+++ b/external/libqemf/src/Bitmap.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "Bitmap.h"
+
+#include <QDataStream>
+#include <QDebug>
+#include <QPixmap>
+
+#include "EmfEnums.h"
+
+
+namespace QEmf
+{
+
+static void soakBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	}
+}
+
+
+Bitmap::Bitmap( QDataStream &stream,
+				quint32 recordSize,  // total size of the EMF record
+				quint32 usedBytes,   // used bytes of the EMF record before the bitmap part
+				quint32 offBmiSrc, // offset to start of bitmapheader
+				quint32 cbBmiSrc,  // size of bitmap header
+				quint32 offBitsSrc,// offset to source bitmap
+				quint32 cbBitsSrc) // size of source bitmap
+	: m_hasImage(false)
+	, m_header(0)
+	, m_mask(QBitmap())
+	, m_imageIsValid(false)
+{
+	int size = (recordSize - usedBytes);
+	qint64 startPos = stream.device()->pos();
+
+	// If necessary read away garbage before the bitmap header.
+	if (offBmiSrc > usedBytes){
+		//qDebug() << "soaking " << offBmiSrc - usedBytes << "bytes before the header";
+		soakBytes(stream, offBmiSrc - usedBytes);
+		usedBytes = offBmiSrc;
+	}
+
+	qint64 posBeforeHeader = stream.device()->pos();
+	// Create the header
+	m_header = new BitmapHeader(stream, cbBmiSrc);
+	usedBytes += cbBmiSrc;
+
+	qint64 bitCount = m_header->bitCount();
+	if ((bitCount == BI_BITCOUNT_1) || (bitCount == BI_BITCOUNT_2) || (bitCount == BI_BITCOUNT_3)){
+		stream.device()->seek(posBeforeHeader);
+
+		typedef struct _BMPFILEHEADER {
+				quint16 bmType;
+				quint32 bmSize;
+				quint16 bmReserved1;
+				quint16 bmReserved2;
+				quint32 bmOffBits;
+		} BMPFILEHEADER;
+
+		int sizeBmp = size + 14;
+
+		QByteArray pattern;           // BMP header and DIB data
+		pattern.resize(sizeBmp);
+		pattern.fill(0);
+		stream.readRawData(pattern.data() + 14, size);
+
+		// add BMP header
+		BMPFILEHEADER* bmpHeader;
+		bmpHeader = (BMPFILEHEADER*)(pattern.data());
+		bmpHeader->bmType = 0x4D42;
+		bmpHeader->bmSize = sizeBmp;
+
+		if (bitCount == BI_BITCOUNT_1)
+			m_mask.loadFromData(pattern, "BMP");
+
+		if (m_image.loadFromData(pattern, "BMP")){
+			m_hasImage = true;
+			m_imageIsValid = true;
+		}
+
+		stream.device()->seek(startPos + size);
+		return;
+	}
+
+	// If necessary read away garbage between the bitmap header and the picture.
+	if (offBitsSrc > usedBytes) {
+		//qDebug() << "soaking " << offBmiSrc - usedBytes << "bytes between the header and the image";
+		soakBytes(stream, offBitsSrc - usedBytes);
+		usedBytes = offBitsSrc;
+	}
+
+	// Read the image data
+	if (cbBitsSrc > 0){
+		//qDebug() << "reading bitmap (" << cbBitsSrc << "bytes)";
+		m_imageData.resize(cbBitsSrc);
+		stream.readRawData(m_imageData.data(), cbBitsSrc);
+		m_hasImage = true;
+
+		usedBytes += cbBitsSrc;
+	}
+
+	// If necessary, read away garbage after the image.
+	if (recordSize > usedBytes) {
+		//qDebug() << "soaking " << recordSize - usedBytes << "bytes after the image";
+		soakBytes(stream, recordSize - usedBytes);
+		usedBytes = recordSize;
+	}
+}
+
+Bitmap::~Bitmap()
+{
+	delete m_header;
+	//delete m_image;
+}
+
+QImage Bitmap::image(QImage::Format format)
+{
+	if (!m_hasImage)
+		return QImage();
+
+	return QImage((const uchar*)m_imageData.constData(), m_header->width(), abs(m_header->height()), format);
+}
+
+#if 1
+QImage Bitmap::image()
+{
+	if (!m_hasImage)
+		return QImage();
+
+	if (m_imageIsValid)
+		return m_image;
+
+	QImage::Format format = QImage::Format_Invalid;
+
+	//qDebug() << "Image bitCount: " << m_header->bitCount() << "compression: " << m_header->compression();
+
+	// Start by determining which QImage format we are going to use.
+	if (m_header->bitCount() == BI_BITCOUNT_1){
+		format = QImage::Format_Mono;
+		return QImage();
+	} else if (m_header->bitCount() == BI_BITCOUNT_4){
+		if ( m_header->compression() == BI_RGB ) {
+			format = QImage::Format_RGB555;
+		} else {
+			qDebug() << "Unexpected compression format for BI_BITCOUNT_4:" << m_header->compression();
+			//Q_ASSERT( 0 );
+			return QImage();
+		}
+	} else if ( m_header->bitCount() == BI_BITCOUNT_5 ) {
+		format = QImage::Format_RGB888;
+	} else if ( m_header->bitCount() == BI_BITCOUNT_6 ) {
+		if (m_header->compression() == BI_RGB) {
+			format = QImage::Format_RGB32;
+			//format = QImage::Format_RGB888;
+		} else if (m_header->compression() == BI_BITFIELDS) {
+			// FIXME: The number of bits is correct, but we need to
+			//        handle the actual bits per colors specifically.
+			//
+			// The spec says (MS_WMF section 2.1.1.3):
+			//   If the Compression field of the BitmapInfoHeader
+			//   Object is set to BI_BITFIELDS, the Colors field
+			//   contains three DWORD color masks that specify the
+			//   red, green, and blue components, respectively, of
+			//   each pixel. Each DWORD in the bitmap array represents
+			//   a single pixel.
+			format = QImage::Format_RGB32;
+		}
+		else
+			return QImage();
+	} else {
+		qDebug() << "Unexpected format:" << m_header->bitCount();
+		//Q_ASSERT(0);
+		return QImage();
+	}
+
+	// According to MS-WMF 2.2.2.3, the sign of the height decides if
+	// this is a compressed bitmap or not.
+	if (m_header->height() > 0) {
+		// This bitmap is a top-down bitmap without compression.
+		m_image = QImage((const uchar*)m_imageData.constData(), m_header->width(), m_header->height(), format);
+
+		// This is a workaround around a strange bug.  Without this
+		// code it shows nothing.  Note that if we use Format_ARGB32
+		// to begin with, nothing is shown anyway.
+		//
+		// FIXME: Perhaps it could be tested again with a later
+		//        version of Qt (I have 4.6.3) /iw
+		if (m_header->bitCount() == BI_BITCOUNT_6 && m_header->compression() == BI_RGB)
+			m_image = m_image.convertToFormat(QImage::Format_ARGB32);
+
+		// The WMF images are in the BGR color order.
+		if (format == QImage::Format_RGB888)
+			m_image = m_image.rgbSwapped();
+
+		// We have to mirror this bitmap in the X axis since WMF images are stored bottom-up.
+		m_image = m_image.mirrored(false, true);
+	} else {
+		// This bitmap is a bottom-up bitmap which uses compression.
+		switch (m_header->compression()) {
+		case BI_RGB:
+			m_image = QImage((const uchar*)m_imageData.constData(), m_header->width(), -m_header->height(), format);
+			// The WMF images are in the BGR color order.
+			//m_image = m_image.rgbSwapped();
+			break;
+
+		// These compressions are not yet supported, so return an empty image.
+		case BI_RLE8:
+		case BI_RLE4:
+		case BI_BITFIELDS:
+		case BI_JPEG:
+		case BI_PNG:
+		case BI_CMYK:
+		case BI_CMYKRLE8:
+		case BI_CMYKRLE4:
+		default:
+			m_image = QImage(m_header->width(), m_header->height(), format);
+			break;
+		}
+	}
+
+	m_imageIsValid = true;
+	return m_image;
+}
+#else
+QImage *Bitmap::image()
+{
+	if (!m_hasImage) {
+		return 0;
+	}
+
+	if (m_image) {
+		return m_image;
+	}
+
+	QImage::Format format = QImage::Format_Invalid;
+	if ( m_header->bitCount() == BI_BITCOUNT_4 ) {
+		if ( m_header->compression() == 0x00 ) {
+			format = QImage::Format_RGB555;
+		} else {
+			//qDebug() << "Unexpected compression format for BI_BITCOUNT_4:"
+			//              << m_header->compression();
+			//Q_ASSERT( 0 );
+			return 0;
+		}
+	} else if ( m_header->bitCount() == BI_BITCOUNT_5 ) {
+		format = QImage::Format_RGB888;
+	} else {
+		qDebug() << "Unexpected format:" << m_header->bitCount();
+		//Q_ASSERT( 0 );
+		return 0;
+	}
+	m_image = new QImage( (const uchar*)m_imageData.constData(),
+						  m_header->width(), m_header->height(), format );
+
+	return m_image;
+}
+#endif
+
+
+} // namespace QEmf

--- a/external/libqemf/src/Bitmap.h
+++ b/external/libqemf/src/Bitmap.h
@@ -1,0 +1,108 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFBITMAP_H
+#define EMFBITMAP_H
+
+
+#include <Qt>                   // For qint, etc.
+#include <QByteArray>
+#include <QImage>
+#include <QBitmap>
+
+#include "BitmapHeader.h"
+
+class QDataStream;
+
+/**
+ * @file
+ *
+ * definitions for Device Independent Bitmaps, as used in both WMF and EMF files.
+*/
+
+/// Namespace for Enhanced Metafile (EMF) classes
+
+namespace QEmf
+{
+
+/**
+ * @class Bitmap
+ *
+ * Representation of a bitmap from an EMF file
+ */
+class Bitmap
+{
+public:
+	/**
+	 * Constructor
+	 *
+	 * The Bitmap structure is built from the specified stream.
+	 *
+	 * \param stream the data stream to read from.
+	 * \param recordSize the size of the EMF record that this bitmap is part of.
+	 * \param usedBytes  number of already used bytes of the EMF record before the bitmap part
+	 * \param offBmiSrc  offset to start of bitmapheader
+	 * \param cbBmiSrc   size of bitmap header
+	 * \param offBitsSrc offset to source bitmap
+	 * \param cbBitsSrc  size of source bitmap
+	 */
+	Bitmap( QDataStream &stream,
+			quint32 recordSize,  // total size of the EMF record
+			quint32 usedBytes,   // used bytes of the EMF record before the bitmap part
+			quint32 offBmiSrc,   // offset to start of bitmapheader
+			quint32 cbBmiSrc,    // size of bitmap header
+			quint32 offBitsSrc,  // offset to source bitmap
+			quint32 cbBitsSrc);  // size of source bitmap
+	~Bitmap();
+
+	/**
+	   The bitmap header
+	*/
+	BitmapHeader *header() const {return m_header;}
+
+	/**
+	   Return true if there is an image in this record.
+	 */
+	bool hasImage() const {return m_hasImage;}
+
+	/**
+	   The image.
+
+	   QImage shares its memory already.
+	*/
+	QImage image();
+
+	/**
+	   The image.
+	   QImage shares its memory already.
+	 *
+	 * \param format the format of the image requested by the caller
+	*/
+	QImage image(QImage::Format format);
+
+	QBitmap mask(){return m_mask;}
+
+private:
+	// No copying for now, because we will get into trouble with the pointers.
+	// The remedy is to write a real operator=() and Bitmap(Bitmap&).
+	explicit Bitmap(Bitmap&);
+	Bitmap &operator=(Bitmap&);
+
+private:
+	bool          m_hasImage;
+	BitmapHeader *m_header;
+
+	QBitmap       m_mask;
+	QByteArray    m_imageData;
+	QImage        m_image;
+	bool          m_imageIsValid;
+};
+
+
+
+} // namespace QEmf
+
+#endif

--- a/external/libqemf/src/BitmapHeader.cpp
+++ b/external/libqemf/src/BitmapHeader.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "BitmapHeader.h"
+
+#include <QDataStream>
+#include <QDebug>
+
+namespace QEmf
+{
+
+static void soakBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	}
+}
+
+
+BitmapHeader::BitmapHeader( QDataStream &stream, int size )
+{
+	m_headerType = BitmapInfoHeader;  // The default
+
+	int  read = 40;             // Keep track of how many bytes we have read;
+
+	//qDebug() << "BitmapHeader pos:" << stream.device()->pos();
+
+	// Read the data that is present in a BitmapInfoHeader (size 40)
+	stream >> m_headerSize;
+	stream >> m_width;
+	stream >> m_height;
+	stream >> m_planes;         // 16 bits
+	stream >> m_bitCount;       // 16 bits
+	stream >> m_compression;
+	stream >> m_imageSize;
+
+	stream >> m_xPelsPerMeter;
+	stream >> m_yPelsPerMeter;
+	stream >> m_colorUsed;
+	stream >> m_colorImportant;
+
+	if (m_bitCount == 1){
+		typedef struct tagRGBQUAD {
+				quint8 rgbBlue;
+				quint8 rgbGreen;
+				quint8 rgbRed;
+				quint8 rgbReserved;
+		} RGBQUAD;
+
+		unsigned int colors = abs(int(size - m_headerSize))/sizeof(RGBQUAD);
+		//printf("BitmapHeader size: %d m_headerSize: %d bmiColors: %d\n", size, m_headerSize, colors);
+		for (unsigned int i = 0; i < colors; i++){
+			quint8 rgbBlue, rgbGreen, rgbRed, rgbReserved;
+			stream >> rgbBlue;
+			stream >> rgbGreen;
+			stream >> rgbRed;
+			stream >> rgbReserved;
+			m_colorTable.append(qRgb(rgbRed, rgbGreen, rgbBlue));
+			//printf("i: %d r: %d g: %d b:%d a: %d\n", i, rgbRed, rgbGreen, rgbBlue, rgbReserved);
+		}
+	}
+
+#ifdef DEBUG_EMFPARSER
+	qDebug() << "HeaderSize:" << m_headerSize;
+	qDebug() << "Width:" << m_width;
+	qDebug() << "Height:" << m_height;
+	qDebug() << "planes:" << m_planes;
+	qDebug() << "BitCount:" << m_bitCount;
+	qDebug() << "Compression:" << m_compression;
+	qDebug() << "ImageSize:" << m_imageSize;
+	qDebug() << "Colors used:" << m_colorUsed;
+	qDebug() << "Colors Important:" << m_colorImportant;
+#endif
+	// BitmapV4Header (size 40+68 = 108)
+	if (size >= 108) {
+		m_headerType = BitmapV4Header;
+		read = 108;
+
+		stream >> m_redMask;
+		stream >> m_greenMask;
+		stream >> m_blueMask;
+		stream >> m_alphaMask;
+		stream >> m_colorSpaceType;
+
+		// FIXME sometime: Implement the real CIEXYZTriple
+		for (int i = 0; i < 9; ++i)
+			stream >> m_endpoints[i];
+
+		stream >> m_gammaRed;
+		stream >> m_gammaGreen;
+		stream >> m_gammaBlue;
+	}
+
+	// BitmapV5Header (size 108+16 = 124)
+	if (size >= 124) {
+		m_headerType = BitmapV5Header;
+		read = 124;
+
+		stream >> m_intent;
+		stream >> m_profileData;
+		stream >> m_profileSize;
+		stream >> m_reserved;
+	}
+
+#ifdef DEBUG_EMFPARSER
+	qDebug() << "header type:" << m_headerType;
+	qDebug() << "header size:" << size;
+	qDebug() << "read bytes: " << read;
+#endif
+	// Read away the overshot from the size parameter;
+	if (size > read)
+		soakBytes(stream, size - read);
+}
+
+BitmapHeader::~BitmapHeader()
+{
+}
+
+} // namespace QEmf

--- a/external/libqemf/src/BitmapHeader.h
+++ b/external/libqemf/src/BitmapHeader.h
@@ -1,0 +1,128 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFBITMAPHEADER_H
+#define EMFBITMAPHEADER_H
+
+#include <QColor>
+#include <QVector>
+#include <Qt>                   // For qint, etc.
+
+class QDataStream;
+
+/**
+ * @file
+ *
+ * definitions for Device Independent Bitmaps, as used in both WMF and EMF files.
+*/
+
+
+
+/// Namespace for Enhanced Metafile (EMF) classes
+
+namespace QEmf
+{
+
+/**
+ * @class BitmapHeader
+ *
+ * Representation of a bitmap header, including the following formats:
+ *  - BitmapInfoHeader [MS-WMF].pdf 2.2.2.3
+ *  - BitmapV4Header   [MS-WMF].pdf 2.2.2.4
+ *  - BitmapV5Header   [MS-WMF].pdf 2.2.2.5
+ */
+class BitmapHeader
+{
+public:
+	typedef enum {
+		//BitmapCoreHeader,   Not yet supported
+		BitmapInfoHeader,
+		BitmapV4Header,
+		BitmapV5Header
+	} Type;
+
+	/**
+	 * Constructor
+	 *
+	 * The header structure is built from the specified stream.
+	 *
+	 * \param stream the data stream to read from.
+	 * \param size the size of the header. This decides what type it is.
+	 */
+	BitmapHeader( QDataStream &stream, int size );
+	~BitmapHeader();
+
+	/**
+	   The width of the bitmap, in pixels
+	*/
+	qint32 width() const { return m_width; };
+
+	/**
+	   The height of the bitmap, in pixels
+	*/
+	qint32 height() const { return m_height; };
+
+	/**
+	   The number of bits that make up a pixel
+
+	   This is an enumerated type - see the BitCount enum
+	*/
+	quint16 bitCount() const { return m_bitCount; };
+
+	/**
+	   The type of compression used in the image
+
+	   This is an enumerated type
+	*/
+	quint32 compression() const { return m_compression; };
+
+	/**
+	   The number of colors in the color table
+	*/
+	quint32 colorCount() const {return m_colorUsed;}
+	QVector<QRgb> colorTable() const {return m_colorTable;}
+
+//private:
+	Type  m_headerType;         /// Which header type that is represented.
+
+	// Data to be found in a BitmapInfoHeader
+	quint32 m_headerSize;
+	qint32  m_width;
+	qint32  m_height;
+	quint16 m_planes;
+	quint16 m_bitCount;
+	quint32 m_compression;
+	quint32 m_imageSize;
+	qint32  m_xPelsPerMeter;
+	qint32  m_yPelsPerMeter;
+	quint32 m_colorUsed;
+	quint32 m_colorImportant;
+
+	// Additional data to be found in a BitmapV4Header
+	quint32 m_redMask;
+	quint32 m_greenMask;
+	quint32 m_blueMask;
+	quint32 m_alphaMask;
+	quint32 m_colorSpaceType;
+	quint32 m_endpoints[9];     // Actually a CIEXYZTriple
+	qint32  m_gammaRed;
+	qint32  m_gammaGreen;
+	qint32  m_gammaBlue;
+
+	// Additional data to be found in a BitmapV5Header
+	quint32 m_intent;
+	quint32 m_profileData;
+	quint32 m_profileSize;
+	quint32 m_reserved;
+
+	QVector<QRgb> m_colorTable;
+};
+
+
+
+} // namespace QEmf
+
+#endif

--- a/external/libqemf/src/EmfEnums.h
+++ b/external/libqemf/src/EmfEnums.h
@@ -1,0 +1,295 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2009-2011 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFENUMS_H
+#define EMFENUMS_H
+
+/**
+   \file
+
+   Enumerations used in various parts of EMF files
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+	/**
+	   Background fill mode
+	See [MS-EMF] Section 2.1.4
+	*/
+	enum BackgroundMode {
+		TRANSPARENT = 0x01, ///< Equivalent to Qt::TransparentMode
+		OPAQUE      = 0x02  ///< Equivalent to Qt::OpaqueMode
+	};
+
+	/**
+	   Parameters for text output.
+
+	   See [MS-EMF] Section 2.1.11
+	*/
+	enum TextOutOptions {
+		//ETO_OPAQUE            = 0x000002,    // Already defined in WmfEnums.h
+		//ETO_CLIPPED           = 0x000004,
+		//ETO_GLYPH_INDEX       = 0x000010,
+		//ETO_RTLREADING        = 0x000080,
+		ETO_NO_RECT           = 0x000100,
+		ETO_SMALL_CHARS       = 0x000200,
+		//ETO_NUMERICSLOCAL     = 0x000400,
+		//ETO_NUMERICSLATIN     = 0x000800,
+		ETO_IGNORELANGUAGE    = 0x001000,
+		//ETO_PDY               = 0x002000,
+		ETO_REVERSE_INDEX_MAP = 0x010000
+	};
+
+	/**
+	   Graphics mode, used to interpret shape data such as rectangles
+
+	   See [MS-EMF] Section 2.1.16
+	*/
+	enum GraphicsMode {
+		GM_COMPATIBLE = 0x01,
+		GM_ADVANCED   = 0x02
+	};
+
+	/**
+	   MapModes
+
+	   See [MS-EMF] Section 2.1.21
+	*/
+	typedef enum {
+		MM_TEXT        = 0x01,
+		MM_LOMETRIC    = 0x02,
+		MM_HIMETRIC    = 0x03,
+		MM_LOENGLISH   = 0x04,
+		MM_HIENGLISH   = 0x05,
+		MM_TWIPS       = 0x06,
+		MM_ISOTROPIC   = 0x07,
+		MM_ANISOTROPIC = 0x08
+	} MapMode;
+
+	/**
+	   World Transform modification modes
+
+	   See [MS-EMF] Section 2.1.24
+	*/
+	enum ModifyWorldTransformMode {
+		MWT_IDENTITY            = 0x01,
+		MWT_LEFTMULTIPLY        = 0x02,
+		MWT_RIGHTMULTIPLY       = 0x03,
+		MWT_SET                 = 0x04
+	};
+
+	/**
+	   Pen Styles
+
+	   See [MS-EMF] Section 2.1.25
+	*/
+	enum PenStyle {
+	PS_COSMETIC      = 0x00000000,
+	PS_ENDCAP_ROUND  = 0x00000000,
+	PS_JOIN_ROUND    = 0x00000000,
+	PS_SOLID         = 0x00000000,
+	PS_DASH          = 0x00000001,
+	PS_DOT           = 0x00000002,
+	PS_DASHDOT       = 0x00000003,
+	PS_DASHDOTDOT    = 0x00000004,
+	PS_NULL          = 0x00000005,
+	PS_INSIDEFRAME   = 0x00000006,
+	PS_USERSTYLE     = 0x00000007,
+	PS_ALTERNATE     = 0x00000008,
+	PS_STYLE_MASK    = 0x0000000f,
+	PS_ENDCAP_SQUARE = 0x00000100,
+	PS_ENDCAP_FLAT   = 0x00000200,
+	PS_ENDCAP_MASK   = 0x00000f00,
+	PS_JOIN_BEVEL    = 0x00001000,
+	PS_JOIN_MITER    = 0x00002000,
+	PS_JOIN_MASK     = 0x0000f000,
+	PS_GEOMETRIC     = 0x00010000,
+	PS_TYPE_MASK     = 0x000f0000
+	};
+
+	/**
+	   Stock Objects
+
+	   See [MS-EMF] Section 2.1.31
+	*/
+	enum StockObject {
+	WHITE_BRUSH	= 0x80000000,
+	LTGRAY_BRUSH	= 0x80000001,
+	GRAY_BRUSH	= 0x80000002,
+	DKGRAY_BRUSH	= 0x80000003,
+	BLACK_BRUSH	= 0x80000004,
+	NULL_BRUSH	= 0x80000005,
+	WHITE_PEN	= 0x80000006,
+	BLACK_PEN	= 0x80000007,
+	NULL_PEN	= 0x80000008,
+	OEM_FIXED_FONT	= 0x8000000A,
+	ANSI_FIXED_FONT	= 0x8000000B,
+	ANSI_VAR_FONT	= 0x8000000C,
+	SYSTEM_FONT	= 0x8000000D,
+	DEVICE_DEFAULT_FONT = 0x8000000E,
+	DEFAULT_PALETTE = 0x8000000F,
+	SYSTEM_FIXED_FONT = 0x80000010,
+	DEFAULT_GUI_FONT = 0x80000011,
+	DC_BRUSH	= 0x80000012,
+	DC_PEN		= 0x80000013
+	};
+
+	/**
+	   Fill mode
+
+	   See [MS-EMF] Section 2.1.27
+	*/
+	enum PolygonFillMode {
+		ALTERNATE = 0x01, ///< Equivalent to Qt::OddEvenFill
+		WINDING   = 0x02  ///< Equivalent to Qt::WindingFill
+	};
+
+	/**
+	  Clipping region mode
+
+	  See [MS-EMF] Section 2.1.29
+	*/
+	enum RegionMode {
+		RGN_AND = 0x01,   ///< Equivalent to Qt::IntersectClip
+		RGN_OR = 0x02,    ///< Equivalent to Qt::UniteClip
+		RGN_XOR = 0x03,
+		RGN_DIFF = 0x04,
+		RGN_COPY = 0x05   ///< Equivalent to Qt::ReplaceClip
+	};
+
+	/**
+	   Comment type as defined for the EMR_COMMENT record.
+
+	   See [MS-EMF] section 2.3.3
+	 */
+	enum CommentType {
+		EMR_COMMENT_EMFSPOOL = 0x00000000,
+		EMR_COMMENT_EMFPLUS  = 0x2B464D45, // The string "EMF+"
+		EMR_COMMENT_PUBLIC   = 0x43494447,
+
+		// The following value is not defined in [MS-EMF].pdf, but
+		// according to google it means that the file was created by
+		// Microsoft Graph.  It is present in one test file
+		// (Presentation_tips.ppt).
+		EMR_COMMENT_MSGR     = 0x5247534d // The string MSGR
+	};
+
+	/**
+	   WMF 2.1.1.3 BitCount Enumeration
+
+	   The BitCount Enumeration specifies the number of bits that define
+	   each pixel and the maximum number of colors in a device-independent
+	   bitmap (DIB).
+	*/
+	enum WmfBitCount {
+		BI_BITCOUNT_0 = 0x0000,
+		BI_BITCOUNT_1 = 0x0001,
+		BI_BITCOUNT_2 = 0x0004,
+		BI_BITCOUNT_3 = 0x0008,
+		BI_BITCOUNT_4 = 0x0010,
+		BI_BITCOUNT_5 = 0x0018,
+		BI_BITCOUNT_6 = 0x0020
+	};
+
+	/**
+	   MS-WMF 2.1.1.7 Compression Enumeration
+
+	   The Compression Enumeration specifies the type of compression for a
+	   bitmap image.
+	*/
+	enum WmfCompression {
+		BI_RGB       = 0x0000,
+		BI_RLE8      = 0x0001,
+		BI_RLE4      = 0x0002,
+		BI_BITFIELDS = 0x0003,
+		BI_JPEG      = 0x0004,
+		BI_PNG       = 0x0005,
+		BI_CMYK      = 0x000B,
+		BI_CMYKRLE8  = 0x000C,
+		BI_CMYKRLE4  = 0x000D
+	};
+
+	/**
+	   MS-WMF 2.1.1.4 BrushStyle Enumeration
+
+	   The BrushStyle Enumeration specifies the different possible brush
+	   types that can be used in graphics operations. For more
+	   information, see the specification of the Brush Object (section 2.2.1.1).
+	*/
+	enum WmfBrushStyle {
+		BS_SOLID         = 0x0000,
+		BS_NULL          = 0x0001,
+		BS_HATCHED       = 0x0002,
+		BS_PATTERN       = 0x0003,
+		BS_INDEXED       = 0x0004,
+		BS_DIBPATTERN    = 0x0005,
+		BS_DIBPATTERNPT  = 0x0006,
+		BS_PATTERN8X8    = 0x0007,
+		BS_DIBPATTERN8X8 = 0x0008,
+		BS_MONOPATTERN   = 0x0009
+	};
+
+	/**
+	   MS-WMF 2.1.1.12 HatchStyle Enumeration
+
+	   The HatchStyle Enumeration specifies the hatch pattern.
+	*/
+	enum WmfHatchStyle {
+		HS_HORIZONTAL = 0x0000,
+		HS_VERTICAL   = 0x0001,
+		HS_FDIAGONAL  = 0x0002,
+		HS_BDIAGONAL  = 0x0003,
+		HS_CROSS      = 0x0004,
+		HS_DIAGCROSS  = 0x0005
+	};
+
+	/**
+	   MS-WMF 2.1.1.13 Layout Enumeration
+
+	   The Layout Enumeration defines options for controlling the
+	   direction in which text and graphics are drawn.
+	*/
+	enum WmfLayout {
+		LAYOUT_LTR = 0x0000,
+		LAYOUT_RTL = 0x0001,
+		LAYOUT_BTT = 0x0002,
+		LAYOUT_VBH = 0x0004,
+		LAYOUT_BITMAPORIENTATIONPRESERVED = 0x0008
+	};
+
+	/**
+	   MS-WMF 2.1.2.3 TextAlignmentMode Flags
+
+	   TextAlignmentMode Flags specify the relationship between a
+	   reference point and a bounding rectangle, for text alignment. These
+	   flags can be combined to specify multiple options, with the
+	   restriction that only one flag can be chosen that alters the
+	   drawing position in the playback device context.
+
+	   Horizontal text alignment is performed when the font has a
+	   horizontal default baseline.
+	*/
+
+	#define TA_NOUPDATECP 0x0000  /// Do not update Current Point (default)
+	#define TA_LEFT       0x0000  /// The reference point is on the left edge of the bounding rectangle
+	#define TA_TOP        0x0000  /// The reference point is on the top edge of the bounding rectangle
+	#define TA_UPDATECP   0x0001  /// Use Current Point. The Current Point must be updated
+	#define TA_RIGHT      0x0002  /// The reference point is on the right edge of the bounding rectangle
+	#define TA_CENTER     0x0006  /// The reference point is at the center of the bounding rectangle
+	#define TA_BOTTOM     0x0008  /// The reference point is on the bottom edge of the bounding rectangle
+	#define TA_BASELINE   0x0018  /// The reference point is on the baseline
+
+	// Some useful masks, not part of the specification:
+	#define TA_HORZMASK 0x0006
+	#define TA_VERTMASK 0x0018
+}
+
+
+#endif

--- a/external/libqemf/src/EmfHeader.cpp
+++ b/external/libqemf/src/EmfHeader.cpp
@@ -1,0 +1,84 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "EmfHeader.h"
+
+#include <QDebug>
+
+namespace QEmf
+{
+
+/*****************************************************************************/
+const quint32 ENHMETA_SIGNATURE = 0x464D4520;
+
+Header::Header( QDataStream &stream )
+{
+	stream >> mType;
+	stream >> mSize;
+	stream >> mBounds;
+	stream >> mFrame;
+	stream >> mSignature;
+	stream >> mVersion;
+	stream >> mBytes;
+	stream >> mRecords;
+	stream >> mHandles;
+	stream >> mReserved;
+	stream >> m_nDescription;
+	stream >> m_offDescription;
+	stream >> m_nPalEntries;
+	stream >> mDevice;
+	stream >> mMillimeters;
+	if ( ( ENHMETA_SIGNATURE == mSignature ) && ( m_nDescription != 0 ) ){
+		// we have optional EmfDescription, but don't know how to read that yet.
+	}
+
+	// FIXME: We could need to read EmfMetafileHeaderExtension1 and
+	//        ..2 here but we have no example of that.
+	soakBytes( stream, mSize - 88 );
+}
+
+Header::~Header()
+{
+}
+
+bool Header::isValid() const
+{
+	return ( ( 0x00000001 == mType ) && ( ENHMETA_SIGNATURE == mSignature ) );
+}
+
+QRect Header::bounds() const
+{
+	return mBounds;
+}
+
+QRect Header::frame() const
+{
+	return mFrame;
+}
+
+QSize Header::device() const
+{
+	return mDevice;
+}
+
+QSize Header::millimeters() const
+{
+	return mMillimeters;
+}
+
+quint32 Header::recordCount() const
+{
+	return mRecords;
+}
+
+void Header::soakBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	}
+}
+
+}

--- a/external/libqemf/src/EmfHeader.h
+++ b/external/libqemf/src/EmfHeader.h
@@ -1,0 +1,88 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFHEADER_H
+#define EMFHEADER_H
+
+#include <QDataStream>
+#include <QRect> // also provides QSize
+#include <QString>
+
+/**
+   \file
+
+   Primary definitions for EMF Header record
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+/**
+	Simple representation of an EMF File header
+
+	See MS-EMF Section 2.3.4.2 for details
+*/
+class Header
+{
+public:
+	/**
+	   Constructor for header
+
+	   \param stream the stream to read the header structure from
+	*/
+	explicit Header(QDataStream &stream);
+	~Header();
+
+	/**
+	   Check whether this is a valid EMF Header
+	 */
+	bool isValid() const;
+
+	/**
+	   The number of records in the metafile
+	 */
+	quint32 recordCount() const;
+
+	/**
+	   The bounding box of the file content, in device units
+	*/
+	QRect bounds() const;
+
+	/**
+	   The frame of the file content, in 0.01 mm units
+	*/
+	QRect frame() const;
+
+	QSize device() const;
+	QSize millimeters() const;
+
+private:
+	// Temporary hack to read some bytes.
+	void soakBytes( QDataStream &stream, int numBytes );
+
+	quint32 mType;
+	quint32 mSize;
+	QRect mBounds;
+	QRect mFrame;
+	quint32 mSignature;
+	quint32 mVersion;
+	quint32 mBytes;
+	quint32 mRecords;
+	quint16 mHandles;
+	quint16 mReserved;
+	quint32 m_nDescription;
+	quint32 m_offDescription;
+	quint32 m_nPalEntries;
+	QSize mDevice;      // this might need to be converted to something better
+	QSize mMillimeters; // this might need to be converted to something better
+};
+
+}
+
+#endif

--- a/external/libqemf/src/EmfLogger.cpp
+++ b/external/libqemf/src/EmfLogger.cpp
@@ -1,0 +1,399 @@
+/*
+  Copyright 2008      Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009-2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "EmfLogger.h"
+#include "EmfObjects.h"
+
+#include <QFile>
+#include <QDebug>
+
+namespace QEmf
+{
+
+
+EmfLogger::EmfLogger(const QString& fileName):
+m_debug(0),
+m_file(0)
+{
+	if (!fileName.isEmpty()){
+		m_file = new QFile(fileName);
+		if (m_file->open(QFile::WriteOnly))
+			m_debug = new QDebug(m_file);
+	}
+}
+
+EmfLogger::~EmfLogger()
+{
+	if (m_file){
+		m_file->close();
+		delete m_file;
+		delete m_debug;
+	}
+}
+
+void EmfLogger::init( const Header *header )
+{
+	*m_debug << "Initialising EmfLogger";
+	*m_debug << "image size:" << header->bounds().size() << "\n";
+}
+
+void EmfLogger::cleanup( const Header *header )
+{
+	*m_debug << "Cleanup EmfLogger";
+	*m_debug << "image size:" << header->bounds().size() << "\n";
+}
+
+void EmfLogger::eof()
+{
+	*m_debug << "EMR_EOF" << "\n";
+}
+
+void EmfLogger::setPixelV( QPoint &point, quint8 red, quint8 green, quint8 blue, quint8 reserved )
+{
+	Q_UNUSED( reserved );
+	*m_debug << "EMR_SETPIXELV:" << point << QColor( red, green, blue ) << "\n";
+}
+
+void EmfLogger::beginPath()
+{
+	*m_debug << "EMR_BEGINPATH" << "\n";
+}
+
+void EmfLogger::closeFigure()
+{
+	*m_debug << "EMR_CLOSEFIGURE" << "\n";
+}
+
+void EmfLogger::endPath()
+{
+	*m_debug << "EMR_ENDPATH" << "\n";
+}
+
+void EmfLogger::saveDC()
+{
+	*m_debug << "EMR_SAVEDC" << "\n";
+}
+
+void EmfLogger::restoreDC( qint32 savedDC )
+{
+	*m_debug << "EMR_RESTOREDC" << savedDC << "\n";
+}
+
+void EmfLogger::setMetaRgn()
+{
+	*m_debug << "EMR_SETMETARGN" << "\n";
+}
+
+void EmfLogger::setWindowOrgEx( const QPoint &origin )
+{
+	*m_debug << "EMR_SETWINDOWORGEX" << origin << "\n";
+}
+
+void EmfLogger::setWindowExtEx( const QSize &size )
+{
+	*m_debug << "EMR_SETWINDOWEXTEX" << size << "\n";
+}
+
+void EmfLogger::setViewportOrgEx( const QPoint &origin )
+{
+	*m_debug << "EMR_SETVIEWPORTORGEX" << origin << "\n";
+}
+
+void EmfLogger::setViewportExtEx( const QSize &size )
+{
+	*m_debug << "EMR_SETVIEWPORTEXTEX" << size << "\n";
+}
+
+void EmfLogger::deleteObject( const quint32 ihObject )
+{
+	*m_debug << "EMR_DELETEOBJECT:" << ihObject << "\n";
+}
+
+void EmfLogger::arc( const QRect &box, const QPoint &start, const QPoint &end )
+{
+	*m_debug << "EMR_ARC" << box << start << end << "\n";
+}
+
+void EmfLogger::chord( const QRect &box, const QPoint &start, const QPoint &end )
+{
+	*m_debug << "EMR_CHORD" << box << start << end << "\n";
+}
+
+void EmfLogger::pie( const QRect &box, const QPoint &start, const QPoint &end )
+{
+	*m_debug << "EMR_PIE" << box << start << end << "\n";
+}
+
+void EmfLogger::ellipse( const QRect &box )
+{
+	*m_debug << "EMR_ELLIPSE:" << box << "\n";
+}
+
+void EmfLogger::rectangle( const QRect &box )
+{
+	*m_debug << "EMR_RECTANGLE:" << box << "\n";
+}
+
+void EmfLogger::modifyWorldTransform( quint32 mode, float M11, float M12,
+					float M21, float M22, float Dx, float Dy )
+{
+	*m_debug << "EMR_MODIFYWORLDTRANSFORM:" << mode << QTransform ( M11, M12, M21, M22, Dx, Dy ) << "\n";
+}
+
+void EmfLogger::setWorldTransform( float M11, float M12, float M21,
+					 float M22, float Dx, float Dy )
+{
+	*m_debug << "EMR_SETWORLDTRANSFORM:" << QTransform ( M11, M12, M21, M22, Dx, Dy ) << "\n";
+}
+
+void EmfLogger::setMapMode( quint32 mapMode )
+{
+	QString modeAsText;
+	switch ( mapMode ) {
+	case MM_TEXT:
+	modeAsText = QString( "map mode - text" );
+	break;
+	case MM_LOMETRIC:
+	modeAsText = QString( "map mode - lometric" );
+	break;
+	case MM_HIMETRIC:
+	modeAsText = QString( "map mode - himetric" );
+	break;
+	case MM_LOENGLISH:
+	modeAsText = QString( "map mode - loenglish" );
+	break;
+	case MM_HIENGLISH:
+	modeAsText = QString( "map mode - hienglish" );
+	break;
+	case MM_TWIPS:
+	modeAsText = QString( "map mode - twips" );
+	break;
+	case MM_ISOTROPIC:
+	modeAsText = QString( "map mode - isotropic" );
+	break;
+	case MM_ANISOTROPIC:
+	modeAsText = QString( "map mode - anisotropic" );
+	break;
+	default:
+	modeAsText = QString( "unexpected map mode: %1").arg( mapMode );
+	}
+	*m_debug << "EMR_SETMAPMODE:" << modeAsText << "\n";
+
+}
+
+void EmfLogger::setBkMode( const quint32 backgroundMode )
+{
+	if ( backgroundMode == TRANSPARENT ) {
+		*m_debug << "EMR_SETBKMODE: Transparent" << "\n";
+	} else if ( backgroundMode == OPAQUE ) {
+		*m_debug << "EMR_SETBKMODE: Opaque" << "\n";
+	} else {
+		*m_debug << "EMR_SETBKMODE: Unexpected value -" << backgroundMode << "\n";
+		Q_ASSERT( 0 );
+	}
+}
+
+void EmfLogger::setPolyFillMode( const quint32 polyFillMode )
+{
+	if ( polyFillMode == ALTERNATE ) {
+	*m_debug << "EMR_SETPOLYFILLMODE: OddEvenFill" << "\n";
+	} else if ( polyFillMode == WINDING ) {
+	*m_debug << "EMR_SETPOLYFILLMODE: WindingFill" << "\n";
+	} else {
+	*m_debug << "EMR_SETPOLYFILLMODE: Unexpected value -" << polyFillMode << "\n";
+	Q_ASSERT( 0 );
+	}
+}
+
+void EmfLogger::setLayout( const quint32 layoutMode )
+{
+	*m_debug << "EMR_SETLAYOUT:" << layoutMode << "\n";
+}
+
+void EmfLogger::extCreateFontIndirectW( const ExtCreateFontIndirectWRecord &extCreateFontIndirectW )
+{
+	*m_debug << "EMR_CREATEFONTINDIRECTW:" << extCreateFontIndirectW.fontFace() << "\n";
+}
+
+void EmfLogger::setTextAlign( const quint32 textAlignMode )
+{
+	*m_debug << "EMR_SETTEXTALIGN:" << textAlignMode << "\n";
+}
+
+void EmfLogger::setTextColor( const quint8 red, const quint8 green, const quint8 blue,
+				const quint8 reserved )
+{
+	Q_UNUSED( reserved );
+	*m_debug << "EMR_SETTEXTCOLOR" << QColor( red, green, blue ) << "\n";
+}
+
+void EmfLogger::setBkColor( const quint8 red, const quint8 green, const quint8 blue,
+							  const quint8 reserved )
+{
+	Q_UNUSED( reserved );
+	*m_debug << "EMR_SETBKCOLOR" << QColor( red, green, blue ) << "\n";
+}
+
+void EmfLogger::createPen(quint32 ihPen, quint32 penStyle, quint32 x, quint32 y,
+				   quint8 red, quint8 green, quint8 blue, quint32 brushStyle, quint8 reserved )
+{
+	Q_UNUSED( y );
+	Q_UNUSED( reserved );
+
+	*m_debug << "EMR_CREATEPEN" << "ihPen:" << ihPen << ", penStyle:" << penStyle
+				  << "width:" << x << "color:" << QColor( red, green, blue ) << ", brushStyle:" << brushStyle<< "\n";
+}
+
+void EmfLogger::createBrushIndirect( quint32 ihBrush, quint32 BrushStyle, quint8 red,
+					   quint8 green, quint8 blue, quint8 reserved,
+					   quint32 BrushHatch )
+{
+	Q_UNUSED( reserved );
+
+	*m_debug << "EMR_CREATEBRUSHINDIRECT:" << ihBrush << "style:" << BrushStyle
+			 << "Colour:" << QColor( red, green, blue ) << ", Hatch:" << BrushHatch << "\n";
+}
+
+void EmfLogger::createMonoBrush( quint32 ihBrush, Bitmap *bitmap )
+{
+	*m_debug << "EMR_CREATEMONOBRUSH:" << ihBrush << "bitmap:" << bitmap << "\n";
+}
+
+void EmfLogger::createDibPatternBrushPT( quint32 ihBrush, Bitmap *bitmap )
+{
+	*m_debug << "EMR_CREATEDIBPATTERNBRUSHPT:" << ihBrush << "bitmap:" << bitmap << "\n";
+}
+
+void EmfLogger::selectObject( const quint32 ihObject )
+{
+	*m_debug << "EMR_SELECTOBJECT" << ihObject << "\n";
+}
+
+void EmfLogger::extTextOut( const QRect &bounds, const EmrTextObject &textObject )
+{
+	*m_debug << "EMR_EXTTEXTOUTW:" << bounds
+				  << textObject.referencePoint()
+				  << textObject.textString() << "\n";
+}
+
+void EmfLogger::moveToEx( const qint32 x, const qint32 y )
+{
+	*m_debug << "EMR_MOVETOEX" << QPoint( x, y ) << "\n";
+}
+
+void EmfLogger::lineTo( const QPoint &finishPoint )
+{
+	*m_debug << "EMR_LINETO" << finishPoint << "\n";
+}
+
+void EmfLogger::arcTo( const QRect &box, const QPoint &start, const QPoint &end )
+{
+	*m_debug << "EMR_ARCTO" << box << start << end << "\n";
+}
+
+void EmfLogger::polygon16( const QRect &bounds, const QList<QPoint> points )
+{
+	*m_debug << "EMR_POLYGON16" << bounds << points << "\n";
+}
+
+void EmfLogger::polyLine( const QRect &bounds, const QList<QPoint> points )
+{
+	*m_debug << "EMR_POLYLINE" << bounds << points << "\n";
+}
+
+void EmfLogger::polyLine16( const QRect &bounds, const QList<QPoint> points )
+{
+	*m_debug << "EMR_POLYLINE16" << bounds << points << "\n";
+}
+
+void EmfLogger::polyPolyLine16( const QRect &bounds, const QList< QVector< QPoint > > &points )
+{
+	*m_debug << "EMR_POLYPOLYLINE16" << bounds << points << "\n";
+}
+
+void EmfLogger::polyPolygon16( const QRect &bounds, const QList< QVector< QPoint > > &points )
+{
+	*m_debug << "EMR_POLYPOLYGON16" << bounds << points << "\n";
+}
+
+void EmfLogger::polyLineTo16( const QRect &bounds, const QList<QPoint> points )
+{
+	*m_debug << "EMR_POLYLINETO16" << bounds << points << "\n";
+}
+
+void EmfLogger::polyBezier16( const QRect &bounds, const QList<QPoint> points )
+{
+	*m_debug << "EMR_POLYBEZIER16" << bounds << points << "\n";
+}
+
+void EmfLogger::polyBezierTo16( const QRect &bounds, const QList<QPoint> points )
+{
+	*m_debug << "EMR_POLYBEZIERTO16" << bounds << points << "\n";
+}
+
+void EmfLogger::fillPath( const QRect &bounds )
+{
+	*m_debug << "EMR_FILLPATH" << bounds << "\n";
+}
+
+void EmfLogger::strokeAndFillPath( const QRect &bounds )
+{
+	*m_debug << "EMR_STROKEANDFILLPATH" << bounds << "\n";
+}
+
+void EmfLogger::strokePath( const QRect &bounds )
+{
+	*m_debug << "EMR_STROKEPATH" << bounds << "\n";
+}
+
+void EmfLogger::setMitterLimit( const quint32 limit )
+{
+	*m_debug  << "EMR_SETMITERLIMIT" << limit  << "\n";
+}
+
+void EmfLogger::setClipPath( quint32 regionMode )
+{
+	*m_debug << "EMR_SETCLIPPATH:" << regionMode << "\n";
+}
+
+void EmfLogger::bitBlt( BitBltRecord &bitBltRecord )
+{
+	*m_debug << "EMR_BITBLT:" << bitBltRecord.destinationRectangle() << "\n";
+}
+
+void EmfLogger::setStretchBltMode( const quint32 stretchMode )
+{
+	switch ( stretchMode ) {
+	case 0x01:
+		*m_debug << "EMR_STRETCHBLTMODE: STRETCH_ANDSCANS" << "\n";
+		break;
+	case 0x02:
+		*m_debug << "EMR_STRETCHBLTMODE: STRETCH_ORSCANS" << "\n";
+		break;
+	case 0x03:
+		*m_debug << "EMR_STRETCHBLTMODE: STRETCH_DELETESCANS" << "\n";
+		break;
+	case 0x04:
+		*m_debug << "EMR_STRETCHBLTMODE: STRETCH_HALFTONE" << "\n";
+		break;
+	default:
+		*m_debug << "EMR_STRETCHBLTMODE - unknown stretch mode:" << stretchMode << "\n";
+	}
+}
+
+void EmfLogger::stretchDiBits( StretchDiBitsRecord &stretchDiBitsRecord )
+{
+	*m_debug << "EMR_STRETCHDIBITS:" << stretchDiBitsRecord.sourceRectangle()
+				  << "," << stretchDiBitsRecord.destinationRectangle() << "\n";
+}
+
+void EmfLogger::alphaBlend(AlphaBlendRecord& record)
+{
+	*m_debug << "EMR_ALPHABLEND:" << record.sourceRectangle()
+				  << "," << record.destinationRectangle() << "\n";
+}
+
+} // xnamespace...

--- a/external/libqemf/src/EmfLogger.h
+++ b/external/libqemf/src/EmfLogger.h
@@ -1,0 +1,119 @@
+/*
+  Copyright 2008 Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFLOGGER_H
+#define EMFLOGGER_H
+
+#include <QList>
+#include <QPainter>
+#include <QRect> // also provides QSize, QPoint
+#include <QString>
+#include <QVariant>
+#include <QDebug>
+
+#include "EmfEnums.h"
+#include "EmfHeader.h"
+#include "EmfRecords.h"
+#include "EmfOutput.h"
+
+class QFile;
+
+/**
+   \file
+
+   Contains definitions for an EMF debug output strategy
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+
+/**
+	Debug (text dump) output strategy for EMF Parser
+*/
+class EmfLogger : public AbstractOutput
+{
+public:
+	EmfLogger(const QString& = "");
+	~EmfLogger();
+
+	void init( const Header *header );
+	void cleanup( const Header *header );
+	void eof();
+
+	void createPen( quint32 ihPen, quint32 penStyle, quint32 x, quint32 y,
+			quint8 red, quint8 green, quint8 blue, quint32 brushStyle, quint8 reserved );
+	void createBrushIndirect( quint32 ihBrush, quint32 BrushStyle, quint8 red,
+				  quint8 green, quint8 blue, quint8 reserved,
+				  quint32 BrushHatch );
+	void createMonoBrush( quint32 ihBrush, Bitmap *bitmap );
+	void createDibPatternBrushPT( quint32 ihBrush, Bitmap *bitmap );
+	void selectObject( const quint32 ihObject );
+	void deleteObject( const quint32 ihObject );
+	void arc( const QRect &box, const QPoint &start, const QPoint &end );
+	void chord( const QRect &box, const QPoint &start, const QPoint &end );
+	void pie( const QRect &box, const QPoint &start, const QPoint &end );
+	void ellipse( const QRect &box );
+	void rectangle( const QRect &box );
+	void setMapMode( const quint32 mapMode );
+	void setMetaRgn();
+	void setWindowOrgEx( const QPoint &origin );
+	void setWindowExtEx( const QSize &size );
+	void setViewportOrgEx( const QPoint &origin );
+	void setViewportExtEx( const QSize &size );
+	void beginPath();
+	void closeFigure();
+	void endPath();
+	void setBkMode( const quint32 backgroundMode );
+	void setPolyFillMode( const quint32 polyFillMode );
+	void setLayout( const quint32 layoutMode );
+	void extCreateFontIndirectW( const ExtCreateFontIndirectWRecord &extCreateFontIndirectW );
+	void setTextAlign( const quint32 textAlignMode );
+	void setTextColor( const quint8 red, const quint8 green, const quint8 blue,
+			   const quint8 reserved );
+	void setBkColor( const quint8 red, const quint8 green, const quint8 blue,
+					 const quint8 reserved );
+	void setPixelV( QPoint &point, quint8 red, quint8 green, quint8 blue, quint8 reserved );
+	void modifyWorldTransform( quint32 mode, float M11, float M12,
+				   float M21, float M22, float Dx, float Dy );
+	void setWorldTransform( float M11, float M12, float M21,
+				float M22, float Dx, float Dy );
+	void extTextOut( const QRect &bounds, const EmrTextObject &textObject );
+	void moveToEx( const qint32 x, const qint32 y );
+	void saveDC();
+	void restoreDC( const qint32 savedDC );
+	void lineTo( const QPoint &finishPoint );
+	void arcTo( const QRect &box, const QPoint &start, const QPoint &end );
+	void polygon16( const QRect &bounds, const QList<QPoint> points );
+	void polyLine( const QRect &bounds, const QList<QPoint> points );
+	void polyLine16( const QRect &bounds, const QList<QPoint> points );
+	void polyPolygon16( const QRect &bounds, const QList< QVector< QPoint > > &points );
+	void polyPolyLine16( const QRect &bounds, const QList< QVector< QPoint > > &points );
+	void polyLineTo16( const QRect &bounds, const QList<QPoint> points );
+	void polyBezier16( const QRect &bounds, const QList<QPoint> points );
+	void polyBezierTo16( const QRect &bounds, const QList<QPoint> points );
+	void fillPath( const QRect &bounds );
+	void strokeAndFillPath( const QRect &bounds );
+	void strokePath( const QRect &bounds );
+	void setMitterLimit(const quint32 limit);
+	void setClipPath( const quint32 regionMode );
+	void bitBlt( BitBltRecord &bitBltRecord );
+	void setStretchBltMode( const quint32 stretchMode );
+	void stretchDiBits( StretchDiBitsRecord &stretchDiBitsRecord );
+	void alphaBlend(AlphaBlendRecord&);
+
+	private:
+		QDebug *m_debug;
+		QFile *m_file;
+};
+
+
+}
+
+#endif

--- a/external/libqemf/src/EmfObjects.cpp
+++ b/external/libqemf/src/EmfObjects.cpp
@@ -1,0 +1,137 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2009,2011 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "EmfObjects.h"
+
+namespace QEmf
+{
+
+
+// ================================================================
+//                         class EmrTextObject
+
+// See MS-EMF section 2.2.5.
+
+EmrTextObject::EmrTextObject( QDataStream &stream, quint32 size, TextType textType )
+{
+	stream >> m_referencePoint;
+	size -= 8;
+	//qDebug() << "Text ref. point:" << m_referencePoint;
+
+	stream >> m_charCount;
+	size -= 4;
+	//qDebug() << "Number of characters in string:" << m_charCount;
+
+	stream >> m_offString;
+	size -= 4;
+
+	// 36 bytes for the body of the parent structure (EMR_EXTTEXTOUTA or EMR_EXTTEXTOUTW)
+	// then parts of the EmrText structure
+	quint32 offString = m_offString - 36 - 8 - 4 - 4;
+
+	stream >> m_options;
+	size -= 4;
+	offString -= 4;
+
+	stream >> m_rectangle;
+	size -= 16;
+	offString -= 16;
+
+	stream >> m_offDx;
+	size -= 4;
+	offString -= 4;
+	// as for offString. 36 bytes for parent, then the earlier parts of EmrText
+	quint32 offDx = m_offDx - 36 - 8 - 4 - 4 - 4 - 16 - 4;
+
+	soakBytes( stream, offString ); // skips over UndefinedSpace1.
+	size -= offString;
+	offDx -= offString;
+
+	if ( textType ==  SixteenBitChars ) {
+		m_textString = recordWChars( stream, m_charCount );
+		size -= 2 * m_charCount;
+		offDx -= 2 * m_charCount;
+
+		// If the number of characters is uneven, then we need to soak 2
+		// bytes to make it a full word.
+		if (m_charCount & 0x01) {
+			soakBytes( stream, 2 );
+			size -= 2;
+			offDx -= 2;
+		}
+	} else {
+		m_textString = recordChars( stream, m_charCount );
+		size -= m_charCount;
+		offDx -= m_charCount;
+
+		// If the number of characters is not a multiple of 4, then we need to soak some
+		// bytes to make it a full word.
+		int rest = m_charCount % 4;
+		if (rest != 0) {
+			soakBytes( stream, 4 - rest );
+			size -= 4 - rest;
+			offDx -= 4 - rest;
+		}
+	}
+
+	// TODO: parse the spacing array
+	soakBytes( stream, size );
+}
+
+EmrTextObject::~EmrTextObject()
+{
+}
+
+QPoint EmrTextObject::referencePoint() const
+{
+	return m_referencePoint;
+}
+
+QString EmrTextObject::textString() const
+{
+	return m_textString;
+}
+
+quint32 EmrTextObject::options() const
+{
+	return m_options;
+}
+
+QRect EmrTextObject::rectangle() const
+{
+	return m_rectangle;
+}
+
+QString EmrTextObject::recordWChars( QDataStream &stream, int numChars )
+{
+	QString text;
+	QChar myChar;
+	for ( int i = 0; i < numChars; ++i ) {
+		stream >> myChar;
+		text.append( myChar );
+	}
+	return text;
+}
+
+QString EmrTextObject::recordChars(QDataStream &stream, int numChars)
+{
+	char *s = new char[numChars];
+	stream.readRawData(s, numChars);
+	QString text = QString::fromUtf8(s, numChars);
+	delete[] s;
+	return text;
+}
+
+void EmrTextObject::soakBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	}
+}
+
+
+}

--- a/external/libqemf/src/EmfObjects.h
+++ b/external/libqemf/src/EmfObjects.h
@@ -1,0 +1,93 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2009, 2011 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFOBJECTS_H
+#define EMFOBJECTS_H
+
+#include <QDataStream>
+#include <QRect> // also provides QSize
+#include <QString>
+
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+// There are a number of objects defined in the EMF
+// specification. These objects are common to several different EMF
+// records.  An example would be the EmfTextObject which is used in
+// among others the ExtTextOutA and ExtTextOutW records.
+//
+// All these objects are defined in sections 2.2.x in [MS-EMF].pdf
+//
+// Note: Not all objects in section 2.2 are implemented yet.
+
+
+// ================================================================
+//                         class EmrTextObject
+
+
+/**
+ * Simple representation of an EmrText object
+ *
+ *  See MS-EMF Section 2.2.5 for details
+ */
+class EmrTextObject
+{
+public:
+	/**
+	  The type of text to read
+	  */
+	enum TextType { EightBitChars, SixteenBitChars };
+
+	/**
+	   Constructor for EmrText object
+
+	   \param stream the stream to read the record structure from
+	   \param size the number of bytes in this record
+	   \param textType whether the text is normal (EightBitChars) or wide
+	   characters (SixteenBitChars)
+	*/
+	EmrTextObject( QDataStream &stream, quint32 size, TextType textType );
+	~EmrTextObject();
+
+	/// The reference point for the text output
+	QPoint referencePoint() const;
+
+	/// Options for rectangle
+	quint32 options() const;
+
+	// Clipping and/or opaquing rectangle
+	QRect rectangle() const;
+
+	/// The text to be output
+	QString textString() const;
+
+private:
+
+	QPoint  m_referencePoint;   // reference point used to position the string
+	quint32 m_charCount;        // number of characters (internal use only)
+	quint32 m_offString;        // offset to output string (internal use only)
+	quint32 m_options;          // specifies how to use the rectangle
+	QRect   m_rectangle;        // clipping and/or opaquing rectangle
+	quint32 m_offDx;            // offset to intercharacter spacing array (internal use only)
+	QString m_textString;       // the text string to output
+
+	// Convenience function to handle a 2-byte wide char stream
+	QString recordWChars( QDataStream &stream, int numChars );
+
+	// Convenience function to handle a 1-byte wide char stream
+	QString recordChars( QDataStream &stream, int numChars );
+
+	// Routine to throw away a specific number of bytes
+	void soakBytes( QDataStream &stream, int numBytes );
+};
+
+}
+
+#endif

--- a/external/libqemf/src/EmfOutput.cpp
+++ b/external/libqemf/src/EmfOutput.cpp
@@ -1,0 +1,27 @@
+/*
+  Copyright 2008 Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "EmfOutput.h"
+#include "EmfParser.h"
+
+namespace QEmf
+{
+
+bool AbstractOutput::load(const QByteArray &contents)
+{
+	EmfParser parser;
+	parser.setOutput(this);
+	return parser.load(contents);
+}
+
+bool AbstractOutput::load(const QString& fileName)
+{
+	EmfParser parser;
+	parser.setOutput(this);
+	return parser.load(QString(fileName));
+}
+
+} // xnamespace...

--- a/external/libqemf/src/EmfOutput.h
+++ b/external/libqemf/src/EmfOutput.h
@@ -1,0 +1,558 @@
+/*
+  Copyright 2008 Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFOUTPUT_H
+#define EMFOUTPUT_H
+
+#include <QList>
+#include <QPainter>
+#include <QRect> // also provides QSize, QPoint
+#include <QString>
+#include <QVariant>
+
+#include "EmfEnums.h"
+#include "EmfHeader.h"
+#include "EmfRecords.h"
+
+/**
+   \file
+
+   Primary definitions for EMF output strategies
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+/**
+	Abstract output strategy for EMF Parser
+*/
+class AbstractOutput
+{
+public:
+	AbstractOutput() {};
+	virtual ~AbstractOutput() {};
+
+	bool load(const QString&);
+	bool load(const QByteArray &);
+
+	/**
+	   Initialisation routine
+
+	   \param header the EMF Header record
+	*/
+	virtual void init( const Header *header ) = 0;
+
+	/**
+	   Cleanup routine
+
+	   This function is called when the painting is done.  Any
+	   initializations that are done in init() can be undone here if
+	   necessary.
+
+	   \param header the EMF Header record
+	*/
+	virtual void cleanup( const Header *header ) = 0;
+
+	/**
+	   Close-out routine
+	*/
+	virtual void eof() = 0;
+
+	/**
+	   Handler for the EMR_SETPIXELV record type
+
+	   This fills a specified pixel with a particular color
+
+	   \param point the point to fill
+	   \param red the red component of the color
+	   \param green the green component of the color
+	   \param blue the blue component of the color
+	   \param reserved reserved component of the color
+	*/
+	virtual void setPixelV( QPoint &point, quint8 red, quint8 green, quint8 blue, quint8 reserved ) = 0;
+
+	/**
+	   Handler for the EMR_CREATEPEN record type
+
+	   This creates a pen object (at position ihPen) using the specified parameters.
+
+	   \param ihPen the internal handle for the pen to be created
+	   \param penStyle the pen configuration (style, type) - see the PenStyle enumeration
+	   \param x the width of the pen
+	   \param y reserved value - ignore this
+	   \param red the red component of the pen color
+	   \param green the green component of the pen color
+	   \param blue the blue component of the pen color
+	   \param reserved reserved value - ignore this
+	*/
+	virtual void createPen( quint32 ihPen, quint32 penStyle, quint32 x, quint32 y,
+				quint8 red, quint8 green, quint8 blue, quint32 brushStyle, quint8 reserved ) = 0;
+
+	/**
+	   Handler for the EMR_CREATEBRUSHINDIRECT record type
+	*/
+	virtual void createBrushIndirect( quint32 ihBrush, quint32 BrushStyle, quint8 red,
+					  quint8 green, quint8 blue, quint8 reserved,
+					  quint32 BrushHatch ) = 0;
+
+	virtual void createMonoBrush( quint32 ihBrush, Bitmap *bitmap ) = 0;
+	virtual void createDibPatternBrushPT( quint32 ihBrush, Bitmap *bitmap ) = 0;
+
+	/**
+	   Handler for the EMR_SETMAPMODE record type.
+
+	   From [MS-EMF]:\n
+	   <em>The EMR_SETMAPMODE record specifies the mapping mode of the
+	   playback device context. The mapping mode specifies the unit of
+	   measure used to transform page-space units into device-space
+	   units, and also specifies the orientation of the device's x and
+	   y axes.</em>
+
+	   The valid mapping modes are:
+	   - 0x01 (MM_TEXT): Each logical unit is mapped to one device pixel.
+	   - 0x02 (MM_LOMETRIC): Each logical unit is mapped to 0.1 millimeter
+	   - 0x03 (MM_HIMETRIC): Each logical unit is mapped to 0.01 millimeter.
+	   - 0x04 (MM_LOENGLISH): Each logical unit is mapped to 0.01 inch.
+	   - 0x05 (MM_HIENGLISH): Each logical unit is mapped to 0.001 inch.
+	   - 0x06 (MM_TWIPS): Each logical unit is mapped to one twentieth of a printer's point (1/1440 inch).
+	   - 0x07 (MM_ISOTROPIC): Logical units are mapped to arbitrary units with equally-scaled axes; that is, one unit along the x-axis is equal to one unit along the y-axis.
+	   - 0x08 (MM_ANISOTROPIC): Logical units are mapped to arbitrary units with arbitrarily scaled axes.
+
+	   Note that increasing x is to the right, and increasing y is up,
+	   except for MM_TEXT, where it is down.
+
+	   You can expect to get several calls to this function
+	   (e.g. MM_ANISOTROPIC, followed by MM_HIMETRIC). If you maintain
+	   state based on this call, you probably need to maintain the
+	   dimensions / direction separate from the isotropic /
+	   anisotropic state.
+
+	   \param mapMode the mapping mode value
+	*/
+	virtual void setMapMode( const quint32 mapMode ) = 0;
+
+	/**
+	   Handler for the EMR_SETMETARGN record type
+	*/
+	virtual void setMetaRgn() = 0;
+
+	/**
+	   Handler for the EMR_SETWINDOWORGEX record type
+
+	   \param origin the origin of the window in logical coordinates
+	*/
+	virtual void setWindowOrgEx( const QPoint &origin ) = 0;
+
+	/**
+	   Handler for the EMR_SETWINDOWEXTEX record type
+
+	   \param size the size of the window in logical coordinates
+	*/
+	virtual void setWindowExtEx( const QSize &size ) = 0;
+
+	/**
+	   Handler for the EMR_SETVIEWPORTORGEX record type
+
+	   \param origin the origin of the viewport in logical coordinates
+	*/
+	virtual void setViewportOrgEx( const QPoint &origin ) = 0;
+
+	/**
+	   Handler for the EMR_SETVIEWPORTEXTEX record type
+
+	   \param size the size of the viewport in logical coordinates
+	*/
+	virtual void setViewportExtEx( const QSize &size ) = 0;
+
+	/**
+	   Handler for the EMR_SETBKMODE record type
+
+	   \param backgroundMode the background fill mode
+	*/
+	virtual void setBkMode( const quint32 backgroundMode ) = 0;
+
+	/**
+	   Handler for the EMR_SETPOLYFILLMODE record type
+
+	   \param polyFillMode the fill mode
+	*/
+	virtual void setPolyFillMode( const quint32 polyFillMode ) = 0;
+
+	/**
+	   Handler for the EMR_SETLAYOUT record type
+
+	   \param layoutMode the layout mode
+	*/
+	virtual void setLayout( const quint32 layoutMode ) = 0;
+
+	/**
+	   Handler for the EMR_MODIFYWORLDTRANSFORM record type
+
+	   There are a range of modes:
+	   - 0x01 (MWT_IDENTIFY): Reset current world transform to identity matrix
+	   - 0x02 (MWT_LEFTMULTIPLY): Left multiply this matrix with current matrix.
+	   - 0x03 (MWT_RIGHTMULTIPLY): Right multiply current matrix with this matrix.
+	   - 0x04 (MWT_SET): Set the world transform.
+
+	   \param mode the mode to use.
+	   \param M11
+	   \param M12
+	   \param M21
+	   \param M22
+	   \param Dx
+	   \param Dy
+	*/
+	virtual void modifyWorldTransform(quint32 mode, float M11, float M12,
+					  float M21, float M22, float Dx, float Dy ) = 0;
+
+	/**
+	   Handler for the EMR_SETWORLDTRANSFORM record type
+
+	   \param M11
+	   \param M12
+	   \param M21
+	   \param M22
+	   \param Dx
+	   \param Dy
+	*/
+	virtual void setWorldTransform( float M11, float M12, float M21,
+					float M22, float Dx, float Dy ) = 0;
+
+	/**
+	   Select a previously created (or stock) object
+
+	   \param ihObject the reference number for the object to select
+	*/
+	virtual void selectObject( const quint32 ihObject ) = 0;
+
+	/**
+	   Delete a previously created (or stock) object
+
+	   \param ihObject the reference number for the object to delete
+	*/
+	virtual void deleteObject( const quint32 ihObject ) = 0;
+
+	/**
+	   Handler for the EMR_ARC record type
+
+	   \param box the bounding box
+	   \param start the coordinates of the point that defines the first radial end point
+	   \param end the coordinates of the point that defines the second radial end point
+	*/
+	virtual void arc( const QRect &box, const QPoint &start, const QPoint &end ) = 0;
+
+	/**
+	   Handler for the EMR_CHORD record type
+
+	   \param box the bounding box
+	   \param start the coordinates of the point that defines the first radial end point
+	   \param end the coordinates of the point that defines the second radial end point
+	*/
+	virtual void chord( const QRect &box, const QPoint &start, const QPoint &end ) = 0;
+
+	/**
+	   Handler for the EMR_PIE record type
+
+	   \param box the bounding box
+	   \param start the coordinates of the point that defines the first radial end point
+	   \param end the coordinates of the point that defines the second radial end point
+	*/
+	virtual void pie( const QRect &box, const QPoint &start, const QPoint &end ) = 0;
+
+	/**
+	  Handler for the EMR_ELLIPSE record type
+
+	  \param box the bounding box for the ellipse
+	*/
+	virtual void ellipse( const QRect &box ) = 0;
+
+	/**
+	  Handler for the EMR_RECTANGLE record type
+
+	  \param box the bounding box for the rectangle
+	*/
+	virtual void rectangle( const QRect &box ) = 0;
+
+	/**
+	   Handler for the EMR_SETTEXTALIGN record type
+
+	  The textAlignMode is a bit mask, see [MS-WMF] Section 2.1.2.3 for
+	  values if the text has a horizontal baseline, [MS-WMF] Section
+	  2.1.2.4 if the text has a vertical baseline.
+
+	   \param textAlignMode the text alignment mode
+	*/
+	virtual void setTextAlign( const quint32 textAlignMode ) = 0;
+
+	/**
+	  Handler for the EMR_SETTEXTCOLOR record type
+
+	  \param red the red component of the text color
+	  \param green the blue component of the text color
+	  \param blue the blue component of the text color
+	  \param reserved an unused value - ignore this
+	*/
+	virtual void setTextColor( const quint8 red, const quint8 green, const quint8 blue,
+				   const quint8 reserved ) = 0;
+
+	/**
+	  Handler for the EMR_SETBKCOLOR record type
+
+	  \param red the red component of the background color
+	  \param green the blue component of the background color
+	  \param blue the blue component of the background color
+	  \param reserved an unused value - ignore this
+	*/
+	virtual void setBkColor( const quint8 red, const quint8 green, const quint8 blue,
+							 const quint8 reserved ) = 0;
+
+	/**
+	   Handler for the EMR_EXTCREATEFONTINDIRECTW record type
+
+	   \param extCreateFontIndirectWRecord the contents of the
+	   EMR_EXTCREATEFONTINDIRECTW record
+	*/
+	virtual void extCreateFontIndirectW( const ExtCreateFontIndirectWRecord &extCreateFontIndirectW ) = 0;
+
+	/**
+	   Handler for text rendering, as described in the
+	   EMR_EXTTEXTOUTW and EMR_EXTTEXTOUTA record types.
+
+	   \param bounds the bounds used for e.g. clipping
+	   \param texObject The object describing the text.
+	*/
+	virtual void extTextOut( const QRect &bounds, const EmrTextObject &textObject ) = 0;
+
+	/**
+	   Handler for the EMR_BEGINPATH record type
+	*/
+	virtual void beginPath() = 0;
+
+	/**
+	   Handler for the EMR_CLOSEFIGURE record type
+	*/
+	virtual void closeFigure() = 0;
+
+	/**
+	   Handler for the EMR_ENDPATH record type
+	*/
+	virtual void endPath() = 0;
+
+	/**
+	   Handler for the EMR_MOVETOEX record type
+
+	   \param x the X coordinate of the point to move to
+	   \param y the Y coordiante of the point to move to
+	*/
+	virtual void moveToEx( const qint32 x, const qint32 y ) = 0;
+
+	/**
+	   Handler for the EMR_SAVEDC record type
+	*/
+	virtual void saveDC() = 0;
+
+	/**
+	   Handler for the EMR_RESTOREDC record type
+
+	   \param savedDC the device context to restore to (always negative)
+	*/
+	virtual void restoreDC( const qint32 savedDC ) = 0;
+
+	/**
+	   Handler for the EMR_LINETO record type
+
+	   \param finishPoint the point to draw to
+	*/
+	virtual void lineTo( const QPoint &finishPoint ) = 0;
+
+	/**
+	   Handler for the EMR_ARCTO record type
+
+	   \param box the bounding box
+	   \param start the coordinates of the point that defines the first radial end point
+	   \param end the coordinates of the point that defines the second radial end point
+	*/
+	virtual void arcTo( const QRect &box, const QPoint &start, const QPoint &end ) = 0;
+
+	/**
+	   Handler for the EMR_POLYGON16 record type.
+
+	   This record type specifies how to output a multi-segment filled
+	   polygon.
+
+	   \param bounds the bounding rectangle for the line segment
+	   \param points the sequence of points that describe the polygon
+	*/
+	virtual void polygon16( const QRect &bounds, const QList<QPoint> points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYLINE record type.
+
+	   This record type specifies how to output a multi-segment line
+	   (unfilled polyline).
+
+	   \param bounds the bounding rectangle for the line segments
+	   \param points the sequence of points that describe the line
+
+	   \note the line is not meant to be closed (i.e. do not connect
+	   the last point to the first point) or filled.
+	*/
+	virtual void polyLine( const QRect &bounds, const QList<QPoint> points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYLINE16 record type.
+
+	   This record type specifies how to output a multi-segment line
+	   (unfilled polyline).
+
+	   \param bounds the bounding rectangle for the line segment
+	   \param points the sequence of points that describe the line
+
+	   \note the line is not meant to be closed (i.e. do not connect
+	   the last point to the first point) or filled.
+	*/
+	virtual void polyLine16( const QRect &bounds, const QList<QPoint> points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYPOLYLINE16 record type.
+
+	   This record type specifies how to output a set of multi-segment line
+	   (unfilled polylines). Each vector in the list is a separate polyline
+
+	   \param bounds the bounding rectangle for the line segments
+	   \param points the sequence of points that describe the line
+
+	   \note the lines are not meant to be closed (i.e. do not connect
+	   the last point to the first point) or filled.
+	*/
+	virtual void polyPolyLine16( const QRect &bounds, const QList< QVector< QPoint > > &points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYPOLYGON16 record type.
+
+	   This record type specifies how to output a set of multi-segment polygons.
+	   Each vector in the list is a separate filled polygon.
+
+	   \param bounds the bounding rectangle for the polygons
+	   \param points the sequence of points that describe the polygons
+	*/
+	virtual void polyPolygon16( const QRect &bounds, const QList< QVector< QPoint > > &points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYLINETO16 record type.
+
+	   This record type specifies how to output a multi-segment set of
+	   lines (unfilled).
+
+	   \param bounds the bounding rectangle for the bezier curves
+	   \param points the sequence of points that describe the curves
+
+	   \note the line is not meant to be closed (i.e. do not connect
+	   the last point to the first point) or filled.
+	*/
+	virtual void polyLineTo16( const QRect &bounds, const QList<QPoint> points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYBEZIERO16 record type.
+
+	   This record type specifies how to output a multi-segment set of
+	   bezier curves (unfilled).
+
+	   \param bounds the bounding rectangle for the bezier curves
+	   \param points the sequence of points that describe the curves
+
+	   \note the line is not meant to be closed (i.e. do not connect
+	   the last point to the first point) or filled.
+	*/
+	virtual void polyBezier16( const QRect &bounds, const QList<QPoint> points ) = 0;
+
+	/**
+	   Handler for the EMR_POLYLINETO16 record type.
+
+	   This record type specifies how to output a multi-segment set of
+	   bezier curves (unfilled), starting at the current point.
+
+	   \param bounds the bounding rectangle for the bezier curves
+	   \param points the sequence of points that describe the curves
+
+	   \note the line is not meant to be closed (i.e. do not connect
+	   the last point to the first point) or filled.
+	*/
+	virtual void polyBezierTo16( const QRect &bounds, const QList<QPoint> points ) = 0;
+
+	/**
+	   Handler for the EMR_FILLPATH record type.
+
+	   \param bounds the bounding rectangle for the region to be filled.
+	*/
+	virtual void fillPath( const QRect &bounds ) = 0;
+
+	/**
+	   Handler for the EMR_STROKEANDFILLPATH record type.
+
+	   \param bounds the bounding rectangle for the region to be stroked / filled
+	*/
+	virtual void strokeAndFillPath( const QRect &bounds ) = 0;
+
+	/**
+	   Handler for the EMR_STROKEPATH record type.
+
+	   \param bounds the bounding rectangle for the region to be stroked
+	*/
+	virtual void strokePath( const QRect &bounds ) = 0;
+
+	/**
+	   Handler for the EMR_SETCLIPPATH record type.
+
+	   See [MS-EMF] Section 2.1.29 for valid ways to set the path.
+
+	   \param regionMode how to set the clipping path.
+	*/
+	virtual void setClipPath( const quint32 regionMode ) = 0;
+
+	/**
+	   Handler for the EMR_BITBLT record type
+
+	   \param bitBltRecord contents of the record type
+	*/
+	virtual void bitBlt( BitBltRecord &bitBltRecord ) = 0;
+
+	/**
+	   Handler for the EMR_STRETCHBLTMODE record type
+
+	   \param stretchMode the stretch mode
+	*/
+	virtual void setStretchBltMode( const quint32 stretchMode ) = 0;
+
+	/**
+	   Handler for the EMR_STRETCHDIBITS record type
+
+	   \param stretchDiBitsRecord contents of the record type
+	*/
+	virtual void stretchDiBits( StretchDiBitsRecord &stretchDiBitsRecord ) = 0;
+
+	/**
+	   Handler for the EMR_ALPHABLEND record type
+
+	   \param alphaBlendRecord contents of the record type
+	*/
+	virtual void alphaBlend(AlphaBlendRecord &alphaBlendRecord ) = 0;
+
+	/**
+	   Handler for the EMR_SETMITERLIMIT record type
+
+	   \param limit mitter limit
+	*/
+	virtual void setMitterLimit(const quint32 limit) = 0;
+};
+
+
+}
+
+#endif

--- a/external/libqemf/src/EmfParser.cpp
+++ b/external/libqemf/src/EmfParser.cpp
@@ -1,0 +1,1125 @@
+/*
+  Copyright 2008        Brad Hards <bradh@frogmouth.net>
+  Copyright 2009 - 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+// Own
+#include "EmfParser.h"
+
+// Qt
+#include <QColor>
+#include <QFile>
+#include <QBuffer>
+#include <QDebug>
+
+// LibEmf
+#include "EmfRecords.h"
+#include "EmfObjects.h"
+
+// 0 - No debug
+// 1 - Print a lot of debug info
+// 2 - Just print all the records instead of parsing them
+#define DEBUG_EMFPARSER 0
+
+namespace QEmf
+{
+
+
+// ================================================================
+
+
+EmfParser::EmfParser()
+	: mOutput( 0 ), mHeaderOnly(false), mBounds(QRect())
+{
+}
+
+EmfParser::~EmfParser()
+{
+}
+
+
+bool EmfParser::load( const QString &fileName )
+{
+	QFile *file = new QFile( fileName );
+
+	if ( ! file->exists() ) {
+		qWarning( "Request to load file (%s) that does not exist", qPrintable(file->fileName()) );
+		delete file;
+		return false;
+	}
+
+	if ( ! file->open( QIODevice::ReadOnly ) ){
+		qWarning() << "Request to load file (" << file->fileName() << ") that cannot be opened";
+		delete file;
+		return false;
+	}
+
+	// Use version 11, which makes floats always be 32 bits without
+	// the need to call setFloatingPointPrecision().
+	QDataStream stream( file );
+	stream.setVersion(QDataStream::Qt_4_6);
+	stream.setFloatingPointPrecision(QDataStream::SinglePrecision);
+
+	bool result = loadFromStream( stream );
+
+	delete file;
+
+	return result;
+}
+
+bool EmfParser::load(const QByteArray &contents)
+{
+	// Create a QBuffer to read from...
+	QBuffer emfBuffer((QByteArray *)&contents, 0);
+	emfBuffer.open(QIODevice::ReadOnly);
+
+	// ...but what we really want is a stream.
+	QDataStream  emfStream;
+	emfStream.setDevice(&emfBuffer);
+	emfStream.setByteOrder(QDataStream::LittleEndian);
+
+	return loadFromStream(emfStream);
+}
+
+bool EmfParser::loadFromStream(QDataStream &stream)
+{
+	stream.setByteOrder( QDataStream::LittleEndian );
+
+	Header *header = new Header( stream );
+	if ( ! header->isValid() ) {
+		qWarning() << "Failed to parse header, perhaps not an EMF file";
+		delete header;
+		return false;
+	}
+
+	mBounds = header->bounds();//save the bounding box;
+
+	if (mHeaderOnly){
+		delete header;
+		return true;
+	}
+
+	mOutput->init( header );
+
+#if DEBUG_EMFPARSER
+	qDebug() << "========================================================== Starting EMF";
+#endif
+
+	int numRecords = header->recordCount();
+	for ( int i = 1; i < numRecords; ++i ) {
+		#if DEBUG_EMFPARSER
+			qDebug() << "Record" << i << "/" << numRecords << ":";
+		#endif
+		if (!readRecord(stream))
+			break;
+	}
+
+	mOutput->cleanup( header );
+
+	delete header;
+	return true;
+}
+
+void EmfParser::setOutput( AbstractOutput *output )
+{
+	mOutput = output;
+}
+
+void EmfParser::soakBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	}
+}
+
+void EmfParser::outputBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	//qDebug("byte(%i):%c", i, scratch);
+	}
+}
+
+/**
+   The supported EMF Record Types
+
+   Refer to [MS-EMF] Section 2.1.1 for more information.
+
+   NOTE: Not all records are part of this enum, only the implemented ones.
+*/
+enum RecordType {
+	EMR_POLYLINE               = 0x00000004,
+	EMR_POLYPOLYGON            = 0x00000008,
+	EMR_SETWINDOWEXTEX         = 0x00000009,
+	EMR_SETWINDOWORGEX         = 0x0000000A,
+	EMR_SETVIEWPORTEXTEX       = 0x0000000B,
+	EMR_SETVIEWPORTORGEX       = 0x0000000C,
+	EMR_SETBRUSHORGEX          = 0x0000000D,
+	EMR_EOF                    = 0x0000000E,
+	EMR_SETPIXELV              = 0x0000000F,
+	EMR_SETMAPMODE             = 0x00000011,
+	EMR_SETBKMODE              = 0x00000012,
+	EMR_SETPOLYFILLMODE        = 0x00000013,
+	EMR_SETROP2                = 0x00000014,
+	EMR_SETSTRETCHBLTMODE      = 0x00000015,
+	EMR_SETTEXTALIGN           = 0x00000016,
+	EMR_SETTEXTCOLOR           = 0x00000018,
+	EMR_SETBKCOLOR             = 0x00000019,
+	EMR_MOVETOEX               = 0x0000001B,
+	EMR_SETMETARGN             = 0x0000001C,
+	EMR_EXCLUDECLIPRECT        = 0x0000001D,
+	EMR_INTERSECTCLIPRECT      = 0x0000001E,
+	EMR_SAVEDC                 = 0x00000021,
+	EMR_RESTOREDC              = 0x00000022,
+	EMR_SETWORLDTRANSFORM      = 0x00000023,
+	EMR_MODIFYWORLDTRANSFORM   = 0x00000024,
+	EMR_SELECTOBJECT           = 0x00000025,
+	EMR_CREATEPEN              = 0x00000026,
+	EMR_CREATEBRUSHINDIRECT    = 0x00000027,
+	EMR_DELETEOBJECT           = 0x00000028,
+	EMR_ELLIPSE                = 0x0000002A,
+	EMR_RECTANGLE              = 0x0000002B,
+	EMR_ARC                    = 0x0000002D,
+	EMR_CHORD                  = 0x0000002E,
+	EMR_PIE                    = 0x0000002F,
+	EMR_SELECTPALLETTE         = 0x00000030,
+	EMR_LINETO                 = 0x00000036,
+	EMR_ARCTO                  = 0x00000037,
+	EMR_SETMITERLIMIT          = 0x0000003A,
+	EMR_BEGINPATH              = 0x0000003B,
+	EMR_ENDPATH                = 0x0000003C,
+	EMR_CLOSEFIGURE            = 0x0000003D,
+	EMR_FILLPATH               = 0x0000003E,
+	EMR_STROKEANDFILLPATH      = 0x0000003F,
+	EMR_STROKEPATH             = 0x00000040,
+	EMR_SELECTCLIPPATH         = 0x00000043,
+	EMR_COMMENT                = 0x00000046,
+	EMR_EXTSELECTCLIPRGN       = 0x0000004B,
+	EMR_BITBLT                 = 0x0000004C,
+	EMR_STRETCHDIBITS          = 0x00000051,
+	EMR_EXTCREATEFONTINDIRECTW = 0x00000052,
+	EMR_EXTTEXTOUTA            = 0x00000053,
+	EMR_EXTTEXTOUTW            = 0x00000054,
+	EMR_POLYBEZIER16           = 0x00000055,
+	EMR_POLYGON16              = 0x00000056,
+	EMR_POLYLINE16             = 0x00000057,
+	EMR_POLYBEZIERTO16         = 0x00000058,
+	EMR_POLYLINETO16           = 0x00000059,
+	EMR_POLYPOLYLINE16         = 0x0000005A,
+	EMR_POLYPOLYGON16          = 0x0000005B,
+	EMR_CREATEMONOBRUSH        = 0x0000005D,
+	EMR_CREATEDIBPATTERNBRUSHPT= 0x0000005E,
+	EMR_EXTCREATEPEN           = 0x0000005F,
+	EMR_SETICMMODE             = 0x00000062,
+	EMR_ALPHABLEND             = 0x00000072,
+	EMR_SETLAYOUT              = 0x00000073,
+
+	EMR_LASTRECORD             = 0x0000007A // Only a placeholder
+};
+
+static const struct {
+	int  recordType;
+	QString name;
+} EmfRecords[] = {
+	{ 0x00000000, "no type" },
+	{ 0x00000001, "EMR_HEADER" },
+	{ 0x00000002, "EMR_POLYBEZIER" },
+	{ 0x00000003, "EMR_POLYGON" },
+	{ 0x00000004, "EMR_POLYLINE" },
+	{ 0x00000005, "EMR_POLYBEZIERTO" },
+	{ 0x00000006, "EMR_POLYLINETO" },
+	{ 0x00000007, "EMR_POLYPOLYLINE" },
+	{ 0x00000008, "EMR_POLYPOLYGON" },
+	{ 0x00000009, "EMR_SETWINDOWEXTEX" },
+	{ 0x0000000A, "EMR_SETWINDOWORGEX" },
+	{ 0x0000000B, "EMR_SETVIEWPORTEXTEX" },
+	{ 0x0000000C, "EMR_SETVIEWPORTORGEX" },
+	{ 0x0000000D, "EMR_SETBRUSHORGEX" },
+	{ 0x0000000E, "EMR_EOF" },
+	{ 0x0000000F, "EMR_SETPIXELV" },
+	{ 0x00000010, "EMR_SETMAPPERFLAGS" },
+	{ 0x00000011, "EMR_SETMAPMODE" },
+	{ 0x00000012, "EMR_SETBKMODE" },
+	{ 0x00000013, "EMR_SETPOLYFILLMODE" },
+	{ 0x00000014, "EMR_SETROP2" },
+	{ 0x00000015, "EMR_SETSTRETCHBLTMODE" },
+	{ 0x00000016, "EMR_SETTEXTALIGN" },
+	{ 0x00000017, "EMR_SETCOLORADJUSTMENT" },
+	{ 0x00000018, "EMR_SETTEXTCOLOR" },
+	{ 0x00000019, "EMR_SETBKCOLOR" },
+	{ 0x0000001A, "EMR_OFFSETCLIPRGN" },
+	{ 0x0000001B, "EMR_MOVETOEX" },
+	{ 0x0000001C, "EMR_SETMETARGN" },
+	{ 0x0000001D, "EMR_EXCLUDECLIPRECT" },
+	{ 0x0000001E, "EMR_INTERSECTCLIPRECT" },
+	{ 0x0000001F, "EMR_SCALEVIEWPORTEXTEX" },
+	{ 0x00000020, "EMR_SCALEWINDOWEXTEX" },
+	{ 0x00000021, "EMR_SAVEDC" },
+	{ 0x00000022, "EMR_RESTOREDC" },
+	{ 0x00000023, "EMR_SETWORLDTRANSFORM" },
+	{ 0x00000024, "EMR_MODIFYWORLDTRANSFORM" },
+	{ 0x00000025, "EMR_SELECTOBJECT" },
+	{ 0x00000026, "EMR_CREATEPEN" },
+	{ 0x00000027, "EMR_CREATEBRUSHINDIRECT" },
+	{ 0x00000028, "EMR_DELETEOBJECT" },
+	{ 0x00000029, "EMR_ANGLEARC" },
+	{ 0x0000002A, "EMR_ELLIPSE" },
+	{ 0x0000002B, "EMR_RECTANGLE" },
+	{ 0x0000002C, "EMR_ROUNDRECT" },
+	{ 0x0000002D, "EMR_ARC" },
+	{ 0x0000002E, "EMR_CHORD" },
+	{ 0x0000002F, "EMR_PIE" },
+	{ 0x00000030, "EMR_SELECTPALETTE" },
+	{ 0x00000031, "EMR_CREATEPALETTE" },
+	{ 0x00000032, "EMR_SETPALETTEENTRIES" },
+	{ 0x00000033, "EMR_RESIZEPALETTE" },
+	{ 0x00000034, "EMR_REALIZEPALETTE" },
+	{ 0x00000035, "EMR_EXTFLOODFILL" },
+	{ 0x00000036, "EMR_LINETO" },
+	{ 0x00000037, "EMR_ARCTO" },
+	{ 0x00000038, "EMR_POLYDRAW" },
+	{ 0x00000039, "EMR_SETARCDIRECTION" },
+	{ 0x0000003A, "EMR_SETMITERLIMIT" },
+	{ 0x0000003B, "EMR_BEGINPATH" },
+	{ 0x0000003C, "EMR_ENDPATH" },
+	{ 0x0000003D, "EMR_CLOSEFIGURE" },
+	{ 0x0000003E, "EMR_FILLPATH" },
+	{ 0x0000003F, "EMR_STROKEANDFILLPATH" },
+	{ 0x00000040, "EMR_STROKEPATH" },
+	{ 0x00000041, "EMR_FLATTENPATH" },
+	{ 0x00000042, "EMR_WIDENPATH" },
+	{ 0x00000043, "EMR_SELECTCLIPPATH" },
+	{ 0x00000044, "EMR_ABORTPATH" },
+	{ 0x00000045, "no type" },
+	{ 0x00000046, "EMR_COMMENT" },
+	{ 0x00000047, "EMR_FILLRGN" },
+	{ 0x00000048, "EMR_FRAMERGN" },
+	{ 0x00000049, "EMR_INVERTRGN" },
+	{ 0x0000004A, "EMR_PAINTRGN" },
+	{ 0x0000004B, "EMR_EXTSELECTCLIPRGN" },
+	{ 0x0000004C, "EMR_BITBLT" },
+	{ 0x0000004D, "EMR_STRETCHBLT" },
+	{ 0x0000004E, "EMR_MASKBLT" },
+	{ 0x0000004F, "EMR_PLGBLT" },
+	{ 0x00000050, "EMR_SETDIBITSTODEVICE" },
+	{ 0x00000051, "EMR_STRETCHDIBITS" },
+	{ 0x00000052, "EMR_EXTCREATEFONTINDIRECTW" },
+	{ 0x00000053, "EMR_EXTTEXTOUTA" },
+	{ 0x00000054, "EMR_EXTTEXTOUTW" },
+	{ 0x00000055, "EMR_POLYBEZIER16" },
+	{ 0x00000056, "EMR_POLYGON16" },
+	{ 0x00000057, "EMR_POLYLINE16" },
+	{ 0x00000058, "EMR_POLYBEZIERTO16" },
+	{ 0x00000059, "EMR_POLYLINETO16" },
+	{ 0x0000005A, "EMR_POLYPOLYLINE16" },
+	{ 0x0000005B, "EMR_POLYPOLYGON16" },
+	{ 0x0000005C, "EMR_POLYDRAW16" },
+	{ 0x0000005D, "EMR_CREATEMONOBRUSH" },
+	{ 0x0000005E, "EMR_CREATEDIBPATTERNBRUSHPT" },
+	{ 0x0000005F, "EMR_EXTCREATEPEN" },
+	{ 0x00000060, "EMR_POLYTEXTOUTA" },
+	{ 0x00000061, "EMR_POLYTEXTOUTW" },
+	{ 0x00000062, "EMR_SETICMMODE" },
+	{ 0x00000063, "EMR_CREATECOLORSPACE" },
+	{ 0x00000064, "EMR_SETCOLORSPACE" },
+	{ 0x00000065, "EMR_DELETECOLORSPACE" },
+	{ 0x00000066, "EMR_GLSRECORD" },
+	{ 0x00000067, "EMR_GLSBOUNDEDRECORD" },
+	{ 0x00000068, "EMR_PIXELFORMAT" },
+	{ 0x00000069, "EMR_DRAWESCAPE" },
+	{ 0x0000006A, "EMR_EXTESCAPE" },
+	{ 0x0000006B, "no type" },
+	{ 0x0000006C, "EMR_SMALLTEXTOUT" },
+	{ 0x0000006D, "EMR_FORCEUFIMAPPING" },
+	{ 0x0000006E, "EMR_NAMEDESCAPE" },
+	{ 0x0000006F, "EMR_COLORCORRECTPALETTE" },
+	{ 0x00000070, "EMR_SETICMPROFILEA" },
+	{ 0x00000071, "EMR_SETICMPROFILEW" },
+	{ 0x00000072, "EMR_ALPHABLEND" },
+	{ 0x00000073, "EMR_SETLAYOUT" },
+	{ 0x00000074, "EMR_TRANSPARENTBLT" },
+	{ 0x00000075, "no type" },
+	{ 0x00000076, "EMR_GRADIENTFILL" },
+	{ 0x00000077, "EMR_SETLINKEDUFIS" },
+	{ 0x00000078, "EMR_SETTEXTJUSTIFICATION" },
+	{ 0x00000079, "EMR_COLORMATCHTOTARGETW" },
+	{ 0x0000007A, "EMR_CREATECOLORSPACEW" }
+};
+
+bool EmfParser::readRecord( QDataStream &stream )
+{
+	if ( ! mOutput ) {
+		qWarning() << "Output device not set";
+		return false;
+	}
+	quint32 type;
+	quint32 size;
+
+	stream >> type;
+	stream >> size;
+
+	{
+		QString name;
+		if (0 < type && type <= EMR_LASTRECORD)
+			name = EmfRecords[type].name;
+		else
+			name = "(out of bounds)";
+#if DEBUG_EMFPARSER
+		qDebug() << "\tlength" << size << "type " << hex << type << "(" << dec << type << ")" << name;
+#endif
+	}
+
+#if DEBUG_EMFPARSER == 2
+	soakBytes(stream, size - 8);
+#else
+	switch ( type ) {
+		case EMR_POLYLINE:
+		{
+			QRect bounds;
+			stream >> bounds;
+			quint32 count;
+			stream >> count;
+			QList<QPoint> aPoints;
+			for (quint32 i = 0; i < count; ++i) {
+				QPoint point;
+				stream >> point;
+				aPoints.append( point );
+			}
+			mOutput->polyLine( bounds, aPoints );
+		}
+		break;
+		case EMR_SETWINDOWEXTEX:
+		{
+			QSize size;
+			//stream >> size;
+			qint32 width, height;
+			stream >> width >> height;
+			//qDebug() << "SETWINDOWEXTEX" << width << height;
+			size = QSize(width, height);
+			mOutput->setWindowExtEx( size );
+		}
+		break;
+		case EMR_SETWINDOWORGEX:
+		{
+			QPoint origin;
+			stream >> origin;
+			mOutput->setWindowOrgEx( origin );
+		}
+		break;
+		case EMR_SETVIEWPORTEXTEX:
+		{
+			QSize size;
+			stream >> size;
+			mOutput->setViewportExtEx( size );
+		}
+		break;
+		case EMR_SETVIEWPORTORGEX:
+		{
+			QPoint origin;
+			stream >> origin;
+			mOutput->setViewportOrgEx( origin );
+		}
+		break;
+		case EMR_SETBRUSHORGEX:
+		{
+			QPoint origin;
+			stream >> origin;
+#if DEBUG_EMFPARSER
+			qDebug() << "EMR_SETBRUSHORGEX" << origin;
+#endif
+		}
+		break;
+		case EMR_EOF:
+		{
+			mOutput->eof();
+			soakBytes( stream, size-8 ); // because we already took 8.
+			return false;
+		}
+		break;
+		case EMR_SETPIXELV:
+		{
+			QPoint point;
+			quint8 red, green, blue, reserved;
+			stream >> point;
+			stream >> red >> green >> blue >> reserved;
+			mOutput->setPixelV( point, red, green, blue, reserved );
+		}
+		break;
+	case EMR_SETMAPMODE:
+	{
+		quint32 mapMode;
+		stream >> mapMode;
+		mOutput->setMapMode( mapMode );
+	}
+		break;
+	case EMR_SETBKMODE:
+	{
+		quint32 backgroundMode;
+		stream >> backgroundMode;
+			mOutput->setBkMode( backgroundMode );
+	}
+		break;
+	case EMR_SETPOLYFILLMODE:
+	{
+		quint32 PolygonFillMode;
+		stream >> PolygonFillMode;
+		mOutput->setPolyFillMode( PolygonFillMode );
+	}
+	break;
+		case EMR_SETROP2:
+		{
+			quint32 ROP2Mode;
+			stream >> ROP2Mode;
+			//qDebug() << "EMR_SETROP2" << ROP2Mode;
+		}
+		break;
+		case EMR_SETSTRETCHBLTMODE:
+		{
+			quint32 stretchMode;
+			stream >> stretchMode;
+			mOutput->setStretchBltMode( stretchMode );
+
+		}
+		break;
+		case EMR_SETTEXTALIGN:
+		{
+			quint32 textAlignMode;
+			stream >> textAlignMode;
+			mOutput->setTextAlign( textAlignMode );
+		}
+		break;
+	case EMR_SETTEXTCOLOR:
+	{
+		quint8 red, green, blue, reserved;
+		stream >> red >> green >> blue >> reserved;
+		mOutput->setTextColor( red, green, blue, reserved );
+	}
+	break;
+	case EMR_SETBKCOLOR:
+	{
+		quint8 red, green, blue, reserved;
+		stream >> red >> green >> blue >> reserved;
+			mOutput->setBkColor( red, green, blue, reserved );
+	}
+		break;
+	case EMR_MOVETOEX:
+	{
+		qint32 x, y;
+		stream >> x >> y;
+		mOutput->moveToEx( x, y );
+			//qDebug() << "xx EMR_MOVETOEX" << x << y;
+	}
+	break;
+		case EMR_SETMETARGN:
+		{
+			// Takes no arguments
+			mOutput->setMetaRgn();
+		}
+		break;
+	case EMR_EXCLUDECLIPRECT:
+	{
+		QRect clip;
+		stream >> clip;
+		//qDebug() << "EMR_EXCLUDECLIPRECT" << clip;
+	}
+	break;
+	case EMR_INTERSECTCLIPRECT:
+	{
+		QRect clip;
+		stream >> clip;
+		//qDebug() << "EMR_INTERSECTCLIPRECT" << clip;
+	}
+	break;
+	case EMR_SAVEDC:
+	{
+		mOutput->saveDC();
+	}
+	break;
+	case EMR_RESTOREDC:
+	{
+		qint32 savedDC;
+		stream >> savedDC;
+		mOutput->restoreDC( savedDC );
+	}
+	break;
+	case EMR_SETWORLDTRANSFORM:
+	{
+			stream.setFloatingPointPrecision(QDataStream::SinglePrecision);
+		float M11, M12, M21, M22, Dx, Dy;
+		stream >> M11;
+		stream >> M12;
+		stream >> M21;
+		stream >> M22;
+		stream >> Dx;
+		stream >> Dy;
+			//qDebug() << "Set world transform" << M11 << M12 << M21 << M22 << Dx << Dy;
+		mOutput->setWorldTransform( M11, M12, M21, M22, Dx, Dy );
+	}
+	break;
+	case EMR_MODIFYWORLDTRANSFORM:
+	{
+			stream.setFloatingPointPrecision(QDataStream::SinglePrecision);
+		float M11, M12, M21, M22, Dx, Dy;
+		stream >> M11;
+		stream >> M12;
+		stream >> M21;
+		stream >> M22;
+		stream >> Dx;
+		stream >> Dy;
+			//qDebug() << "stream position after the matrix: " << stream.device()->pos();
+		quint32 ModifyWorldTransformMode;
+		stream >> ModifyWorldTransformMode;
+		mOutput->modifyWorldTransform( ModifyWorldTransformMode, M11, M12, M21, M22, Dx, Dy );
+	}
+	break;
+	case EMR_SELECTOBJECT:
+	quint32 ihObject;
+	stream >> ihObject;
+	mOutput->selectObject( ihObject );
+		break;
+	case EMR_CREATEPEN:
+	{
+		quint32 ihPen;
+		stream >> ihPen;
+
+		quint32 penStyle;
+		stream >> penStyle;
+
+		quint32 x;
+		stream >> x;
+
+		quint32 brushStyle;
+		stream >> brushStyle; // unused
+
+		quint8 red, green, blue, reserved;
+		stream >> red >> green >> blue;
+		stream >> reserved; // unused;
+
+		mOutput->createPen( ihPen, penStyle, x, x, red, green, blue, brushStyle, reserved );
+		break;
+	}
+	case EMR_CREATEBRUSHINDIRECT:
+	{
+		quint32 ihBrush;
+		stream >> ihBrush;
+
+		quint32 BrushStyle;
+		stream >> BrushStyle;
+
+		quint8 red, green, blue, reserved;
+		stream >> red >> green >> blue;
+		stream >> reserved; // unused;
+
+		quint32 BrushHatch;
+		stream >> BrushHatch;
+
+		mOutput->createBrushIndirect( ihBrush, BrushStyle, red, green, blue, reserved, BrushHatch );
+
+		break;
+	}
+	case EMR_DELETEOBJECT:
+	{
+		quint32 ihObject;
+		stream >> ihObject;
+		mOutput->deleteObject( ihObject );
+	}
+		break;
+	case EMR_ELLIPSE:
+		{
+			QRect box;
+			stream >> box;
+			mOutput->ellipse( box );
+		}
+		break;
+	case EMR_RECTANGLE:
+		{
+			QRect box;
+			stream >> box;
+			mOutput->rectangle( box );
+			//qDebug() << "xx EMR_RECTANGLE" << box;
+		}
+		break;
+	case EMR_ARC:
+		{
+			QRect box;
+			QPoint start, end;
+			stream >> box;
+			stream >> start >> end;
+			mOutput->arc( box, start, end );
+		}
+		break;
+	case EMR_CHORD:
+		{
+			QRect box;
+			QPoint start, end;
+			stream >> box;
+			stream >> start >> end;
+			mOutput->chord( box, start, end );
+		}
+		break;
+	 case EMR_PIE:
+		{
+			QRect box;
+			QPoint start, end;
+			stream >> box;
+			stream >> start >> end;
+			mOutput->pie( box, start, end );
+		}
+		break;
+	case EMR_SELECTPALLETTE:
+	{
+		quint32 ihPal;
+		stream >> ihPal;
+#if DEBUG_EMFPARSER
+		qDebug() << "EMR_SELECTPALLETTE" << ihPal;
+#endif
+	}
+	break;
+	case EMR_SETMITERLIMIT:
+		{
+			quint32 miterLimit;
+			stream >> miterLimit;
+			mOutput->setMitterLimit(miterLimit);
+		}
+	break;
+	case EMR_BEGINPATH:
+	mOutput->beginPath();
+	break;
+	case EMR_ENDPATH:
+	mOutput->endPath();
+	break;
+	case EMR_CLOSEFIGURE:
+	mOutput->closeFigure();
+	break;
+	case EMR_FILLPATH:
+	{
+		QRect bounds;
+			// NOTE: The spec says that there should always be a
+			// bound, i.e. the size should be 24.  But the file
+			// http://www.eventlink.org.uk/uploads/DOCS2/53-Cartledge_Energy_Efficient_IT_Sheffield_Sep10.ppt
+			// has an EMF with a FILLPATH record without this
+			// bound. So let's allow without it too.
+			if (size >= 24) {
+				stream >> bounds;
+			}
+			else if (size > 8)
+				soakBytes(stream, size - 8);
+
+		mOutput->fillPath( bounds );
+			//qDebug() << "xx EMR_FILLPATH" << bounds;
+	}
+	break;
+	case EMR_STROKEANDFILLPATH:
+		{
+			QRect bounds;
+			stream >> bounds;
+			mOutput->strokeAndFillPath( bounds );
+			//qDebug() << "xx EMR_STROKEANDFILLPATHPATH" << bounds;
+		}
+		break;
+	case EMR_STROKEPATH:
+	{
+		QRect bounds;
+		stream >> bounds;
+		mOutput->strokePath( bounds );
+			//qDebug() << "xx EMR_STROKEPATH" << bounds;
+	}
+	break;
+	case EMR_SELECTCLIPPATH:
+		{
+			quint32 regionMode;
+			stream >> regionMode;
+			mOutput->setClipPath(regionMode);
+		}
+		break;
+	case EMR_LINETO:
+	{
+		quint32 x, y;
+		stream >> x >> y;
+		QPoint finishPoint( x, y );
+		mOutput->lineTo( finishPoint );
+			//qDebug() << "xx EMR_LINETO" << x << y;
+	}
+	break;
+	case EMR_ARCTO:
+		{
+			QRect box;
+			stream >> box;
+			QPoint start;
+			stream >> start;
+			QPoint end;
+			stream >> end;
+			mOutput->arcTo( box, start, end );
+		}
+		break;
+		case EMR_COMMENT:
+		{
+			quint32 dataSize;
+			quint32 commentIdentifier;
+
+			stream >> dataSize;
+			stream >> commentIdentifier;
+
+			switch (commentIdentifier) {
+			case EMR_COMMENT_EMFSPOOL:
+			#if DEBUG_EMFPARSER
+				qDebug() << "EMR_COMMENT_EMFSPOOL";
+			#endif
+				soakBytes( stream, size-16 ); // because we already took 16.
+				break;
+			case EMR_COMMENT_EMFPLUS:
+			#if DEBUG_EMFPARSER
+				qDebug() << "EMR_COMMENT_EMFPLUS";
+			#endif
+				soakBytes( stream, size-16 ); // because we already took 16.
+				break;
+			case EMR_COMMENT_PUBLIC:
+				quint32 commentType;
+				stream >> commentType;
+			#if DEBUG_EMFPARSER
+				qDebug() << "EMR_COMMENT_PUBLIC type" << commentType;
+			#endif
+				soakBytes( stream, size-20 ); // because we already took 20.
+				break;
+			case EMR_COMMENT_MSGR:
+			#if DEBUG_EMFPARSER
+				qDebug() << "EMR_COMMENT_MSGR";
+			#endif
+				soakBytes( stream, size-16 ); // because we already took 16.
+				break;
+			default:
+			#if DEBUG_EMFPARSER
+				qDebug() << "EMR_COMMENT unknown type" << hex << commentIdentifier << dec
+							  << "datasize =" << dataSize;
+			#endif
+				soakBytes( stream, size-16 ); // because we already took 16.
+			}
+		}
+	break;
+	case EMR_EXTSELECTCLIPRGN:
+	#if DEBUG_EMFPARSER
+	qDebug() << "EMR_EXTSELECTCLIPRGN";
+	#endif
+	soakBytes( stream, size-8 ); // because we already took 8.
+	break;
+	case EMR_BITBLT:
+	{
+			//qDebug() << "Found BitBlt record";
+		BitBltRecord bitBltRecord( stream, size );
+		mOutput->bitBlt( bitBltRecord );
+	}
+	break;
+	case EMR_STRETCHDIBITS:
+	{
+		StretchDiBitsRecord stretchDiBitsRecord(stream, size);
+		mOutput->stretchDiBits(stretchDiBitsRecord);
+	}
+	break;
+	case EMR_ALPHABLEND:
+	{
+		AlphaBlendRecord alphaBlendRecord(stream, size);
+		mOutput->alphaBlend(alphaBlendRecord);
+	}
+	break;
+	case EMR_EXTCREATEFONTINDIRECTW:
+	{
+		ExtCreateFontIndirectWRecord extCreateFontIndirectWRecord( stream, size );
+		mOutput->extCreateFontIndirectW( extCreateFontIndirectWRecord );
+	}
+	break;
+	case EMR_EXTTEXTOUTA:
+	case EMR_EXTTEXTOUTW:
+	{
+		QRect bounds;
+		quint32 iGraphicsMode;
+		// FIXME: These should really be floats, but that crashes
+		// for a test file where eyScale contains NaN.
+		// Unfortunately this file contains secret data and
+		// can't be committed into the test suite.  Let's just
+		// work around the problem until we support scaling anyway.
+		quint32 exScale;
+		quint32 eyScale;
+
+		//qDebug() << "size:" << size;
+		size -= 8;
+
+		stream >> bounds;
+		//qDebug() << "bounds:" << bounds;
+		size -= 16;
+
+		stream >> iGraphicsMode;
+		//qDebug() << "graphics mode:" << iGraphicsMode;
+		size -= 4;
+
+		stream >> exScale;
+		stream >> eyScale;
+#if DEBUG_EMFPARSER
+			if (iGraphicsMode == GM_COMPATIBLE) {
+				qDebug() << "exScale:" << exScale;
+				qDebug() << "eyScale:" << eyScale;
+			}
+#endif
+		size -= 8;
+
+		// The only difference between ExtTextOutA and ...W is that A uses 8 bit chars and W uses 16 bit chars.
+		EmrTextObject emrText(stream, size, (type == EMR_EXTTEXTOUTA) ? EmrTextObject::EightBitChars : EmrTextObject::SixteenBitChars);
+		mOutput->extTextOut(bounds, emrText);
+	}
+	break;
+	case EMR_SETLAYOUT:
+	{
+		quint32 layoutMode;
+		stream >> layoutMode;
+		mOutput->setLayout( layoutMode );
+	}
+	break;
+	case EMR_POLYBEZIER16:
+	{
+		QRect bounds;
+		stream >> bounds;
+		quint32 count;
+		stream >> count;
+		QList<QPoint> aPoints;
+		for (quint32 i = 0; i < count; ++i) {
+		qint16 x, y;
+		stream >> x;
+		stream >> y;
+		aPoints.append( QPoint( x, y ) );
+		}
+		mOutput->polyBezier16( bounds, aPoints );
+	}
+		break;
+	case EMR_POLYGON16:
+	{
+		QRect bounds;
+		stream >> bounds;
+		quint32 count;
+		stream >> count;
+		QList<QPoint> aPoints;
+		for (quint32 i = 0; i < count; ++i) {
+		qint16 x, y;
+		stream >> x;
+		stream >> y;
+		aPoints.append( QPoint( x, y ) );
+		}
+		mOutput->polygon16( bounds, aPoints );
+	}
+	break;
+	case EMR_POLYLINE16:
+	{
+		QRect bounds;
+		stream >> bounds;
+		quint32 count;
+		stream >> count;
+		QList<QPoint> aPoints;
+		for (quint32 i = 0; i < count; ++i) {
+		qint16 x, y;
+		stream >> x;
+		stream >> y;
+		aPoints.append( QPoint( x, y ) );
+		}
+		mOutput->polyLine16( bounds, aPoints );
+	}
+		break;
+	case EMR_POLYBEZIERTO16:
+	{
+		QRect bounds;
+		stream >> bounds;
+		quint32 count;
+		stream >> count;
+		QList<QPoint> aPoints;
+		for (quint32 i = 0; i < count; ++i) {
+		qint16 x, y;
+		stream >> x;
+		stream >> y;
+		aPoints.append( QPoint( x, y ) );
+		}
+		mOutput->polyBezierTo16( bounds, aPoints );
+	}
+		break;
+	case EMR_POLYLINETO16:
+	{
+		QRect bounds;
+		stream >> bounds;
+		quint32 count;
+		stream >> count;
+		QList<QPoint> aPoints;
+		for (quint32 i = 0; i < count; ++i) {
+		qint16 x, y;
+		stream >> x;
+		stream >> y;
+		aPoints.append( QPoint( x, y ) );
+		}
+		mOutput->polyLineTo16( bounds, aPoints );
+	}
+		break;
+	case EMR_POLYPOLYLINE16:
+		{
+			QRect bounds;
+			stream >> bounds;
+			quint32 numberOfPolylines;
+			stream >> numberOfPolylines;
+			quint32 count; // number of points in all polylines
+			stream >> count;
+			QList< QVector< QPoint > > aPoints;
+			for ( quint32 i = 0; i < numberOfPolylines; ++i ) {
+				quint32 polylinePointCount;
+				stream >> polylinePointCount;
+				QVector<QPoint> polylinePoints( polylinePointCount );
+				aPoints.append( polylinePoints );
+			}
+			for ( quint32 i = 0; i < numberOfPolylines; ++i ) {
+				for ( int j = 0; j < aPoints[i].size(); ++j ) {
+					qint16 x, y;
+					stream >> x >> y;
+					aPoints[i].replace( j,  QPoint( x, y ) );
+				}
+			}
+			mOutput->polyPolyLine16( bounds, aPoints );
+		}
+		break;
+	case EMR_POLYPOLYGON16:
+		{
+			QRect bounds;
+			stream >> bounds;
+			quint32 numberOfPolygons;
+			stream >> numberOfPolygons;
+			quint32 count; // number of points in all polygons
+			stream >> count;
+			QList< QVector< QPoint > > aPoints;
+			for ( quint32 i = 0; i < numberOfPolygons; ++i ) {
+				quint32 polygonPointCount;
+				stream >> polygonPointCount;
+				QVector<QPoint> polygonPoints( polygonPointCount );
+				aPoints.append( polygonPoints );
+			}
+			for ( quint32 i = 0; i < numberOfPolygons; ++i ) {
+				for ( int j = 0; j < aPoints[i].size(); ++j ) {
+					qint16 x, y;
+					stream >> x >> y;
+					aPoints[i].replace( j,  QPoint( x, y ) );
+				}
+			}
+			mOutput->polyPolygon16( bounds, aPoints );
+		}
+		break;
+	case EMR_CREATEMONOBRUSH:
+		// MS-EMF 2.3.7.5: EMR_CREATEMONOBRUSH Record
+		{
+#if DEBUG_EMFPARSER
+			qDebug() << "EMR_CREATEMONOBRUSH ============================";
+#endif
+
+			quint32 ihBrush;    // Index in the EMF Object Table
+			stream >> ihBrush;
+			quint32 usage;      // DIBColors enumeration
+			stream >> usage;
+			quint32 offBmi;     // Offset of the DIB header
+			stream >> offBmi;
+			quint32 cbBmi;      // Size of the DIB header
+			stream >> cbBmi;
+			quint32 offBits;    // Offset of the bitmap
+			stream >> offBits;
+			quint32 cbBits;     // Size of the bitmap
+			stream >> cbBits;
+
+#if DEBUG_EMFPARSER
+			qDebug() << "index:" << ihBrush;
+			qDebug() << "DIBColors enum:" << usage;
+			qDebug() << "header offset:" << offBmi;
+			qDebug() << "header size:  " << cbBmi;
+			qDebug() << "bitmap offset:" << offBits;
+			qDebug() << "bitmap size:  " << cbBits;
+#endif
+
+			// FIXME: Handle the usage DIBColors info.
+			Bitmap bitmap(stream, size, 8 + 6 * 4, // header + 6 ints
+						  offBmi, cbBmi, offBits, cbBits);
+
+		mOutput->createMonoBrush(ihBrush, &bitmap);
+		}
+		break;
+	case EMR_CREATEDIBPATTERNBRUSHPT:// MS-EMF 2.3.7.4: EMR_CREATEDIBPATTERNBRUSHPT Record
+		{
+#if DEBUG_EMFPARSER
+			qDebug() << "EMR_CREATEDIBPATTERNBRUSHPT ============================";
+#endif
+
+			quint32 ihBrush;    // Index in the EMF Object Table
+			stream >> ihBrush;
+			quint32 usage;      // DIBColors enumeration
+			stream >> usage;
+			quint32 offBmi;     // Offset of the DIB header
+			stream >> offBmi;
+			quint32 cbBmi;      // Size of the DIB header
+			stream >> cbBmi;
+			quint32 offBits;    // Offset of the bitmap
+			stream >> offBits;
+			quint32 cbBits;     // Size of the bitmap
+			stream >> cbBits;
+
+#if DEBUG_EMFPARSER
+			qDebug() << "index:" << ihBrush;
+			qDebug() << "DIBColors enum:" << usage;
+			qDebug() << "header offset:" << offBmi;
+			qDebug() << "header size:  " << cbBmi;
+			qDebug() << "bitmap offset:" << offBits;
+			qDebug() << "bitmap size:  " << cbBits;
+#endif
+
+			//qDebug() << "stream position before the image: " << stream.device()->pos();
+			Bitmap bitmap(stream, size, 8 + 6 * 4, // header + 6 ints
+						  offBmi, cbBmi, offBits, cbBits);
+			mOutput->createDibPatternBrushPT(ihBrush, &bitmap);
+			//qDebug() << "stream position at the end: " << stream.device()->pos();
+		}
+		break;
+	case EMR_EXTCREATEPEN:
+	{
+		quint32 ihPen;
+		stream >> ihPen;
+
+		quint32 offBmi, cbBmi, offBits, cbBits;
+		stream >> offBmi >> cbBmi >> offBits >> cbBits;
+
+		quint32 penStyle;
+		stream >> penStyle;
+
+		quint32 width;
+		stream >> width;
+
+		quint32 brushStyle;
+		stream >> brushStyle;
+
+		quint8 red, green, blue, reserved;
+		stream >> red >> green >> blue;
+		stream >> reserved; // unused;
+
+		// TODO: There is more stuff to parse here
+
+		// TODO: this needs to go to an extCreatePen() output method
+		mOutput->createPen(ihPen, penStyle, width, 0, red, green, blue, brushStyle, reserved);
+		soakBytes( stream, size-44 );
+	}
+		break;
+	case EMR_SETICMMODE:
+	{
+			quint32 icmMode;
+			stream >> icmMode;
+	}
+		break;
+	default:
+#if DEBUG_EMFPARSER
+		qDebug() << "unknown record type:" << type;
+#endif
+	soakBytes(stream, size - 8); // because we already took 8.
+	}
+#endif
+
+	return true;
+}
+
+}

--- a/external/libqemf/src/EmfParser.h
+++ b/external/libqemf/src/EmfParser.h
@@ -1,0 +1,104 @@
+/*
+  Copyright 2008 Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFPARSER_H
+#define EMFPARSER_H
+
+#include "EmfOutput.h"
+
+#include <QString>
+#include <QRect> // also provides QSize
+
+/**
+   \file
+
+   Primary definitions for EMF parser
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+/**
+	%Parser for an EMF format file
+ */
+class EmfParser
+{
+public:
+	EmfParser();
+	~EmfParser();
+
+	/**
+	 * Load an EMF file
+	 *
+	 * \param fileName the name of the file to load
+	 *
+	 * \return true on successful load, or false on failure
+	 */
+	bool load( const QString &fileName );
+	/**
+	 * Load an EMF file
+	 *
+	 * \param contents a QByteArray containing the contents of the EMF.
+	 *
+	 * \return true on successful load, or false on failure
+	 */
+	bool load(const QByteArray &contents);
+
+
+	/**
+	 * Load an EMF file from a stream
+	 *
+	 * \param stream the stream to read from
+	 *
+	 * \return true on successful load, or false on failure
+	 */
+	bool loadFromStream(QDataStream &stream);
+
+	/**
+	   Set the output strategy for the parser
+
+	   \param output pointer to a strategy implementation
+	*/
+	void setOutput( AbstractOutput *output );
+
+	/**
+	   Set the parsing strategy
+
+	   \param headerOnly specify if only the header should be parsed
+	*/
+	void setParseHeaderOnly(bool headerOnly = true){mHeaderOnly = headerOnly;}
+
+	/**
+	   The bounding box of the file content, in device units
+	*/
+	QRect bounds() const {return mBounds;}
+
+private:
+	// read a single EMF record
+	bool readRecord( QDataStream &stream );
+
+	// temporary function to soak up unneeded bytes
+	void soakBytes( QDataStream &stream, int numBytes );
+
+	// temporary function to dump output bytes
+	void outputBytes( QDataStream &stream, int numBytes );
+
+	// Pointer to the output strategy
+	AbstractOutput *mOutput;
+
+	// flag specifying if only the header should be parsed
+	bool mHeaderOnly;
+
+	// bounding box of the file content, in device units
+	QRect mBounds;
+};
+
+}
+
+#endif

--- a/external/libqemf/src/EmfRecords.cpp
+++ b/external/libqemf/src/EmfRecords.cpp
@@ -1,0 +1,477 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "EmfRecords.h"
+
+#include "EmfEnums.h"
+#include "EmfObjects.h"
+#include "Bitmap.h"
+
+#include <QDebug>
+
+namespace QEmf
+{
+
+
+/*****************************************************************************/
+
+
+BitBltRecord::BitBltRecord( QDataStream &stream, quint32 recordSize )
+	: m_bitmap(0)
+{
+	//qDebug() << "stream position at the start: " << stream.device()->pos();
+	//qDebug() << "record size: " << recordSize;
+
+	stream >> m_bounds;
+
+	stream >> m_xDest;          // x, y of upper left corner of the destination.
+	stream >> m_yDest;
+	stream >> m_cxDest;         // width, height of the rectangle in logical coords.
+	stream >> m_cyDest;
+	//qDebug() << "Destination" << m_xDest << m_yDest << m_cxDest << m_cyDest;
+
+	stream >> m_BitBltRasterOperation;
+	//qDebug() << "bitblt raster operation:" << hex << m_BitBltRasterOperation << dec;
+
+	stream >> m_xSrc;           // x, y of the source
+	stream >> m_ySrc;
+	//qDebug() << "Source" << m_xSrc << m_ySrc;
+
+	//qDebug() << "position before the matrix: " << stream.device()->pos();
+	stream.setFloatingPointPrecision(QDataStream::SinglePrecision);
+	float M11, M12, M21, M22, Dx, Dy;
+	stream >> M11;              // Transformation matrix
+	stream >> M12;
+	stream >> M21;
+	stream >> M22;
+	stream >> Dx;
+	stream >> Dy;
+	m_XFormSrc = QTransform( M11, M12, M21, M22, Dx, Dy );
+	//qDebug() << "Matrix" << m_XFormSrc;
+	//qDebug() << "position after the matrix: " << stream.device()->pos();
+
+	stream >> m_red >> m_green >> m_blue >> m_reserved;
+	//qDebug() << "Background color" << m_red << m_green << m_blue << m_reserved;
+	//qDebug() << "position after background color: " << stream.device()->pos();
+
+	stream >> m_UsageSrc;
+	//qDebug() << "Color table interpretation" << m_UsageSrc;
+
+	stream >> m_offBmiSrc;      // Offset to start of bitmap header from start of record
+	stream >> m_cbBmiSrc;       // Size of source bitmap header
+	stream >> m_offBitsSrc;     // Offset to source bitmap from start of record
+	stream >> m_cbBitsSrc;      // Size of source bitmap
+#if 0
+	qDebug() << "header offset:" << m_offBmiSrc;
+	qDebug() << "header size:  " << m_cbBmiSrc;
+	qDebug() << "bitmap offset:" << m_offBitsSrc;
+	qDebug() << "bitmap size:  " << m_cbBitsSrc;
+#endif
+
+	//qDebug() << "stream position before the image: " << stream.device()->pos();
+	if (m_cbBmiSrc > 0) {
+		m_bitmap = new Bitmap( stream, recordSize, 8 + 23 * 4, // header + 23 ints
+							   m_offBmiSrc, m_cbBmiSrc,
+							   m_offBitsSrc, m_cbBitsSrc );
+	}
+
+	//qDebug() << "stream position at the end: " << stream.device()->pos();
+}
+
+BitBltRecord::~BitBltRecord()
+{
+	delete m_bitmap;
+}
+
+bool BitBltRecord::hasImage() const
+{
+	return m_bitmap && m_bitmap->hasImage();
+	//return ( ( m_cbBmiSrc != 0 ) && ( m_cbBitsSrc != 0 ) );
+}
+
+QImage BitBltRecord::image()
+{
+	return m_bitmap->image();
+#if 0
+	if ( ! hasImage() ) {
+		return 0;
+	}
+
+	if ( m_image != 0 ) {
+		return m_image;
+	}
+
+	QImage::Format format = QImage::Format_Invalid;
+	if ( m_BmiSrc->bitCount() == BI_BITCOUNT_4 ) {
+		if ( m_BmiSrc->compression() == 0x00 ) {
+			format = QImage::Format_RGB555;
+		} else {
+			qDebug() << "Unexpected compression format for BI_BITCOUNT_4:"
+					 << m_BmiSrc->compression();
+			Q_ASSERT( 0 );
+		}
+	} else if ( m_BmiSrc->bitCount() == BI_BITCOUNT_5 ) {
+		format = QImage::Format_RGB888;
+	} else {
+		qDebug() << "Unexpected format:" << m_BmiSrc->bitCount();
+		Q_ASSERT( 0 );
+	}
+	m_image = new QImage( (const uchar*)m_imageData.constData(),
+						  m_BmiSrc->width(), m_BmiSrc->height(), format );
+
+	return m_image;
+#endif
+}
+
+/*****************************************************************************/
+StretchDiBitsRecord::StretchDiBitsRecord( QDataStream &stream, quint32 recordSize )
+	: m_bitmap(0)
+{
+	//qDebug() << "stream position at the start: " << stream.device()->pos();
+	//qDebug() << "recordSize =" << recordSize;
+
+	stream >> m_Bounds;
+	stream >> m_xDest;
+	stream >> m_yDest;
+	stream >> m_xSrc;
+	stream >> m_ySrc;
+	stream >> m_cxSrc;
+	stream >> m_cySrc;
+
+	stream >> m_offBmiSrc;
+	stream >> m_cbBmiSrc;
+	stream >> m_offBitsSrc;
+	stream >> m_cbBitsSrc;
+
+	stream >> m_UsageSrc;       // How to interpret color table values.
+	stream >> m_BitBltRasterOperation;
+	stream >> m_cxDest;
+	stream >> m_cyDest;
+#if 0
+	qDebug() << "bounds:" << m_Bounds;
+	qDebug() << "destination:" << QPoint(m_xDest, m_yDest) << QSize(m_cxDest, m_cyDest);
+	qDebug() << "source:" << QPoint(m_xSrc, m_ySrc) << QSize(m_cxSrc, m_cySrc);
+	qDebug() << "header offset:" << m_offBmiSrc;
+	qDebug() << "header size:  " << m_cbBmiSrc;
+	qDebug() << "bitmap offset:" << m_offBitsSrc;
+	qDebug() << "bitmap size:  " << m_cbBitsSrc;
+
+	qDebug() << "m_BitBltRasterOperation =" << hex << m_BitBltRasterOperation << dec;
+#endif
+
+	//qDebug() << "stream position before the image: " << stream.device()->pos();
+	if (m_cbBmiSrc > 0) {
+		m_bitmap = new Bitmap( stream, recordSize, 8 + 18 * 4, // header + 18 ints
+							   m_offBmiSrc, m_cbBmiSrc,
+							   m_offBitsSrc, m_cbBitsSrc );
+	}
+	//qDebug() << "stream position at the end: " << stream.device()->pos();
+#if 0
+	// Read away those bytes that preceed the header.  These are undefined
+	// according to the spec.  80 is the size of the record above.
+	qint32 dummy;
+	int    padding = 0;
+	while (m_offBmiSrc - padding > 80) {
+		stream >> dummy;
+		padding += 4;
+	}
+	m_BmiSrc = new BitmapHeader( stream, m_cbBmiSrc );
+
+	// 40 is the size of the header record.
+	while (m_offBitsSrc - padding > 80 + 40) {
+		stream >> dummy;
+		padding += 4;
+	}
+	m_imageData.resize( m_cbBitsSrc );
+	stream.readRawData( m_imageData.data(), m_cbBitsSrc );
+#endif
+}
+
+StretchDiBitsRecord::~StretchDiBitsRecord()
+{
+	if (m_bitmap)
+		delete m_bitmap;
+}
+
+QRect StretchDiBitsRecord::bounds() const
+{
+	return m_Bounds;
+}
+
+bool StretchDiBitsRecord::hasImage() const
+{
+	if (!m_bitmap)
+		return false;
+	return m_bitmap->hasImage();
+}
+
+quint16 StretchDiBitsRecord::bitCount() const
+{
+	if (!m_bitmap)
+		return -1;
+	return m_bitmap->header()->bitCount();
+}
+
+QBitmap StretchDiBitsRecord::mask()
+{
+	return m_bitmap ? m_bitmap->mask() : QBitmap();
+}
+
+QVector<QRgb> StretchDiBitsRecord::maskColorTable()
+{
+	return m_bitmap ? m_bitmap->header()->colorTable() : QVector<QRgb>();
+}
+
+QImage StretchDiBitsRecord::image()
+{
+	return m_bitmap ? m_bitmap->image() : QImage();
+#if 0
+	if ( m_image != 0 ) {
+		return m_image;
+	}
+
+	QImage::Format format = QImage::Format_Invalid;
+
+	// Start by determining which QImage format we are going to use.
+	if (m_BmiSrc->bitCount() == BI_BITCOUNT_1) {
+		format = QImage::Format_Mono;
+	} else if ( m_BmiSrc->bitCount() == BI_BITCOUNT_4 ) {
+		if ( m_BmiSrc->compression() == BI_RGB ) {
+			format = QImage::Format_RGB555;
+		} else {
+			qDebug() << "Unexpected compression format for BI_BITCOUNT_4:"
+						  << m_BmiSrc->compression();
+			Q_ASSERT( 0 );
+		}
+	} else if ( m_BmiSrc->bitCount() == BI_BITCOUNT_5 ) {
+		format = QImage::Format_RGB888;
+	} else {
+		qDebug() << "Unexpected format:" << m_BmiSrc->bitCount();
+		//Q_ASSERT(0);
+	}
+
+	// According to MS-WMF 2.2.2.3, the sign of the height decides if
+	// this is a compressed bitmap or not.
+	if (m_BmiSrc->height() > 0) {
+		// This bitmap is a top-down bitmap without compression.
+		m_image = new QImage( (const uchar*)m_imageData.constData(),
+							  m_BmiSrc->width(), m_BmiSrc->height(), format );
+
+		// The WMF images are in the BGR color order.
+		if (format == QImage::Format_RGB888)
+			*m_image = m_image->rgbSwapped();
+
+		// We have to mirror this bitmap in the X axis since WMF images are stored bottom-up.
+		*m_image = m_image->mirrored(false, true);
+	} else {
+		// This bitmap is a bottom-up bitmap which uses compression.
+		switch (m_BmiSrc->compression()) {
+		case BI_RGB:
+			m_image = new QImage( (const uchar*)m_imageData.constData(),
+								  m_BmiSrc->width(), -m_BmiSrc->height(), format );
+			// The WMF images are in the BGR color order.
+			*m_image = m_image->rgbSwapped();
+			break;
+
+		// These compressions are not yet supported, so return an empty image.
+		case BI_RLE8:
+		case BI_RLE4:
+		case BI_BITFIELDS:
+		case BI_JPEG:
+		case BI_PNG:
+		case BI_CMYK:
+		case BI_CMYKRLE8:
+		case BI_CMYKRLE4:
+		default:
+			m_image = new QImage(m_BmiSrc->width(), m_BmiSrc->height(), format);
+			break;
+		}
+	}
+
+	return m_image;
+#endif
+}
+
+/*****************************************************************************/
+AlphaBlendRecord::AlphaBlendRecord(QDataStream &stream, quint32 recordSize)
+	: m_bitmap(0)
+{
+	qint32 startPos = stream.device()->pos();
+
+	stream >> m_Bounds;
+	stream >> m_xDest;
+	stream >> m_yDest;
+	stream >> m_cxDest;
+	stream >> m_cyDest;
+
+	// Read BLENDFUNCTION structure
+	stream >> m_BlendOp;
+	stream >> m_BlendFlags;
+	stream >> m_SrcConstantAlpha;
+	stream >> m_AlphaFormat;
+
+	stream >> m_xSrc;
+	stream >> m_ySrc;
+
+	// Read XFORM structure
+	stream.setFloatingPointPrecision(QDataStream::SinglePrecision);
+	float M11, M12, M21, M22, Dx, Dy;
+	stream >> M11;              // Transformation matrix
+	stream >> M12;
+	stream >> M21;
+	stream >> M22;
+	stream >> Dx;
+	stream >> Dy;
+	m_XFormSrc = QTransform(M11, M12, M21, M22, Dx, Dy);
+
+	stream >> m_BkColorSrc;
+	stream >> m_UsageSrc;       // How to interpret color table values.
+	stream >> m_offBmiSrc;
+	stream >> m_cbBmiSrc;
+	stream >> m_offBitsSrc;
+	stream >> m_cbBitsSrc;
+	stream >> m_cxSrc;
+	stream >> m_cySrc;
+
+#ifdef DEBUG_EMFPARSER
+	qDebug() << "stream position at the start: " << startPos;
+	qDebug() << "recordSize =" << recordSize;
+	qDebug() << "bounds:" << m_Bounds;
+	qDebug() << "destination:" << QPoint(m_xDest, m_yDest) << QSize(m_cxDest, m_cyDest);
+	qDebug() << "source:" << QPoint(m_xSrc, m_ySrc) << QSize(m_cxSrc, m_cySrc);
+	qDebug() << "SrcConstantAlpha: " << m_SrcConstantAlpha;
+	qDebug() << "UsageSrc:" << m_UsageSrc;
+	qDebug() << "XformSrc" << m_XFormSrc;
+	qDebug() << "header offset (offBmiSrc): " << m_offBmiSrc;
+	qDebug() << "header size (cbBmiSrc): " << m_cbBmiSrc;
+	qDebug() << "bitmap offset (offBitsSrc): " << m_offBitsSrc;
+	qDebug() << "bitmap size (cbBitsSrc): " << m_cbBitsSrc;
+	qDebug() << "stream position before the image: " << stream.device()->pos();
+#endif
+
+	if (m_cbBmiSrc > 0){
+		qint32 usedBytes = stream.device()->pos() - startPos + 8;//we must add the header size (8)
+		m_bitmap = new Bitmap(stream, recordSize, usedBytes, m_offBmiSrc, m_cbBmiSrc, m_offBitsSrc, m_cbBitsSrc);
+	}
+
+#ifdef DEBUG_EMFPARSER
+	qDebug() << "stream position at the end: " << stream.device()->pos();
+#endif
+}
+
+bool AlphaBlendRecord::hasImage() const
+{
+	if (!m_bitmap)
+		return false;
+	return m_bitmap->hasImage();
+}
+
+QImage AlphaBlendRecord::image()
+{
+	return m_bitmap ? m_bitmap->image((m_SrcConstantAlpha == 255) ? QImage::Format_ARGB32_Premultiplied : QImage::Format_ARGB32) : QImage();
+}
+
+AlphaBlendRecord::~AlphaBlendRecord()
+{
+	if (m_bitmap)
+		delete m_bitmap;
+}
+
+/*****************************************************************************/
+ExtCreateFontIndirectWRecord::ExtCreateFontIndirectWRecord( QDataStream &stream, quint32 size )
+{
+	stream >> m_ihFonts;
+	size -= 12;
+
+	// TODO: Check size, we might need to do a LogFontExDv parse
+	stream >> m_height;
+	stream >> m_width;
+	size -= 8;
+
+	stream >> m_escapement;
+	size -= 4;
+
+	stream >> m_orientation;
+	size -= 4;
+
+	stream >> m_weight;
+	size -= 4;
+
+	stream >> m_italic;
+	stream >> m_underline;
+	stream >> m_strikeout;
+	stream >> m_charSet;
+	size -= 4;
+
+	stream >> m_outPrecision;
+	stream >> m_clipPrecision;
+	stream >> m_quality;
+	stream >> m_pitchAndFamily;
+	size -= 4;
+
+	QChar myChar[64];
+	for ( int i = 0; i < 32; ++i ) {
+	stream >> myChar[i];
+	}
+	size -= 64;
+
+	for ( int i = 0; i < 32; ++i ) {
+	if ( ! myChar[i].isNull() ) {
+		m_facename.append( myChar[i] );
+	}
+	}
+
+#if 0
+	for ( int i = 0; i < 64; ++i ) {
+	stream >> myChar[i];
+	}
+	size -= 128;
+
+	for ( int i = 0; i < 64; ++i ) {
+	if ( ! myChar[i].isNull() ) {
+		m_fullName.append( myChar[i] );
+	}
+	}
+	qDebug() << "fullName:" << m_fullName;
+
+	for ( int i = 0; i < 32; ++i ) {
+	stream >> myChar[i];
+	}
+	size -= 64;
+	for ( int i = 0; i < 32; ++i ) {
+	if ( ! myChar[i].isNull() ) {
+		m_style.append( myChar[i] );
+	}
+	}
+	qDebug() << "style:" << m_style;
+
+	for ( int i = 0; i < 32; ++i ) {
+	stream >> myChar[i];
+	}
+	size -= 64;
+	for ( int i = 0; i < 32; ++i ) {
+	if ( ! myChar[i].isNull() ) {
+		m_script.append( myChar[i] );
+	}
+	}
+	qDebug() << "script:" << m_script;
+#endif
+	soakBytes( stream, size ); // rest of the record.
+}
+
+ExtCreateFontIndirectWRecord::~ExtCreateFontIndirectWRecord()
+{
+}
+
+void ExtCreateFontIndirectWRecord::soakBytes( QDataStream &stream, int numBytes )
+{
+	quint8 scratch;
+	for ( int i = 0; i < numBytes; ++i ) {
+		stream >> scratch;
+	}
+}
+
+}

--- a/external/libqemf/src/EmfRecords.h
+++ b/external/libqemf/src/EmfRecords.h
@@ -1,0 +1,451 @@
+/*
+  Copyright 2008 Brad Hards <bradh@frogmouth.net>
+  Copyright 2009 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMFRECORDS_H
+#define EMFRECORDS_H
+
+#include <QDataStream>
+#include <QColor>
+#include <QImage>
+#include <QRect> // also provides QSize
+#include <QString>
+
+#include "Bitmap.h"
+/**
+   \file
+
+   Primary definitions for EMF Records
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+class EmrTextObject;
+
+
+/*****************************************************************************/
+
+/**
+	Simple representation of an EMR_BITBLT record
+
+	See MS-EMF Section 2.3.1.2 for details
+*/
+class BitBltRecord
+{
+public:
+	/**
+	   Constructor for record type
+
+	   \param stream the stream to read the record structure from
+	*/
+	BitBltRecord( QDataStream &stream, quint32 recordSize );
+	~BitBltRecord();
+
+   /**
+	   The X origin of the destination rectangle
+	*/
+	qint32 xDest() const { return m_xDest; };
+
+	/**
+	   The Y origin of the destination rectangle
+	*/
+	qint32 yDest() const { return m_yDest; };
+
+	/**
+	   The width of the destination rectangle
+	*/
+	qint32 cxDest() const { return m_cxDest; };
+
+	/**
+	   The height of the destination rectangle
+	*/
+	qint32 cyDest() const { return m_cyDest; };
+
+	quint32 rasterOperation() const { return m_BitBltRasterOperation; }
+
+	QColor bkColorSrc() const { return QColor(m_red, m_green, m_blue, m_reserved); }
+
+	/**
+	   The destination rectangle
+	*/
+	QRect destinationRectangle() const { return QRect( xDest(), yDest(), cxDest(), cyDest() ); };
+
+	/**
+	   The image to display
+	*/
+	QImage image();
+
+	/**
+	   Whether there is a valid image in this BitBlt record
+	*/
+	bool hasImage() const;
+
+private:
+	// No copying for now, because we will get into trouble with the pointers.
+	// The remedy is to write a real operator=() and BitBltRecord(BitBltRecord&).
+	explicit BitBltRecord(BitBltRecord&);
+	BitBltRecord &operator=(BitBltRecord&);
+
+private:
+	QRect m_bounds;
+	qint32 m_xDest;
+	qint32 m_yDest;
+	qint32 m_cxDest;
+	qint32 m_cyDest;
+	quint32 m_BitBltRasterOperation;
+	qint32 m_xSrc;
+	qint32 m_ySrc;
+	QTransform m_XFormSrc;
+
+	// Background color - elements below
+	quint8 m_red;
+	quint8 m_green;
+	quint8 m_blue;
+	quint8 m_reserved;
+
+	// Color table interpretation
+	quint32 m_UsageSrc;
+
+	// The source bitmap meta data
+	quint32 m_offBmiSrc;
+	quint32 m_cbBmiSrc;
+	quint32 m_offBitsSrc;
+	quint32 m_cbBitsSrc;
+
+	Bitmap *m_bitmap; // The source bitmap
+
+	//QByteArray m_imageData;
+	//QImage *m_image;
+};
+
+/*****************************************************************************/
+
+/**
+	Simple representation of an EMR_STRETCHDIBITS record
+
+	See MS-EMF Section 2.3.1.7 for details
+*/
+class StretchDiBitsRecord
+{
+public:
+	/**
+	   Constructor for record type
+
+	   \param stream the stream to read the record structure from
+	*/
+	StretchDiBitsRecord( QDataStream &stream, quint32 recordSize );
+	~StretchDiBitsRecord();
+
+	/**
+	   The bounds of the affected area, in device units
+	*/
+	QRect bounds() const;
+
+	/**
+	   The X origin of the destination rectangle
+	*/
+	qint32 xDest() const { return m_xDest; };
+
+	/**
+	   The Y origin of the destination rectangle
+	*/
+	qint32 yDest() const { return m_yDest; };
+
+	/**
+	   The width of the destination rectangle
+	*/
+	qint32 cxDest() const { return m_cxDest; };
+
+	/**
+	   The height of the destination rectangle
+	*/
+	qint32 cyDest() const { return m_cyDest; };
+
+	/**
+	   The destination rectangle
+	*/
+	QRect destinationRectangle() const { return QRect( xDest(), yDest(), cxDest(), cyDest() ); };
+
+	/**
+	   The X origin of the source rectangle
+	*/
+	qint32 xSrc() const { return m_xSrc; };
+
+	/**
+	   The Y origin of the source rectangle
+	*/
+	qint32 ySrc() const { return m_ySrc; };
+
+	/**
+	   The width of the source rectangle
+	*/
+	qint32 cxSrc() const { return m_cxSrc; };
+
+	/**
+	   The height of the source rectangle
+	*/
+	qint32 cySrc() const { return m_cySrc; };
+
+	/**
+	   The source rectangle
+	*/
+	QRect sourceRectangle() const { return QRect( xSrc(), ySrc(), cxSrc(), cySrc() ); };
+
+	/**
+	   The raster operation
+	*/
+	qint32 rasterOperation() const { return m_BitBltRasterOperation; };
+
+	quint32 usageSrc() const { return m_UsageSrc; };
+
+	/**
+	   The image to display
+	*/
+	QImage image();
+	/**
+	   Whether there is a valid image in this StretchDiBitsRecord record
+	*/
+	bool hasImage() const;
+
+	QBitmap mask();
+	QVector<QRgb> maskColorTable();
+
+	/**
+	   The number of bits that make up a pixel
+	*/
+	quint16 bitCount() const;
+
+private:
+	// No copying for now, because we will get into trouble with the pointers.
+	// The remedy is to write a real operator=() and StretchDiBitsRecord(StretchDiBitsRecord&).
+	explicit StretchDiBitsRecord(StretchDiBitsRecord&);
+	StretchDiBitsRecord &operator=(StretchDiBitsRecord&);
+
+private:
+	QRect m_Bounds;
+	qint32 m_xDest;
+	qint32 m_yDest;
+	qint32 m_xSrc;
+	qint32 m_ySrc;
+	qint32 m_cxSrc;
+	qint32 m_cySrc;
+	quint32 m_offBmiSrc;
+	quint32 m_cbBmiSrc;
+	quint32 m_offBitsSrc;
+	quint32 m_cbBitsSrc;
+	quint32 m_UsageSrc;
+	quint32 m_BitBltRasterOperation;
+	qint32 m_cxDest;
+	qint32 m_cyDest;
+
+	Bitmap *m_bitmap; // The source bitmap
+};
+
+/**
+	Simple representation of an EMR_ALPHABLEND record
+	See MS-EMF Section 2.3.1.1 for details
+*/
+class AlphaBlendRecord
+{
+public:
+	/**
+	   Constructor for record type
+	   \param stream the stream to read the record structure from
+	*/
+	AlphaBlendRecord(QDataStream &stream, quint32 recordSize);
+	~AlphaBlendRecord();
+
+	/**
+	   The bounds of the affected area, in device units
+	*/
+	QRect bounds() const;
+
+	/**
+	   The X origin of the destination rectangle
+	*/
+	qint32 xDest() const {return m_xDest;}
+
+	/**
+	   The Y origin of the destination rectangle
+	*/
+	qint32 yDest() const {return m_yDest;}
+
+	/**
+	   The width of the destination rectangle
+	*/
+	qint32 cxDest() const {return m_cxDest;}
+
+	/**
+	   The height of the destination rectangle
+	*/
+	qint32 cyDest() const {return m_cyDest;}
+
+	/**
+	   The destination rectangle
+	*/
+	QRect destinationRectangle() const {return QRect(xDest(), yDest(), cxDest(), cyDest());}
+
+	/**
+	   The X origin of the source rectangle
+	*/
+	qint32 xSrc() const { return m_xSrc;}
+
+	/**
+	   The Y origin of the source rectangle
+	*/
+	qint32 ySrc() const {return m_ySrc;}
+
+	/**
+	   The width of the source rectangle
+	*/
+	qint32 cxSrc() const {return m_cxSrc;}
+
+	/**
+	   The height of the source rectangle
+	*/
+	qint32 cySrc() const {return m_cySrc;}
+
+	/**
+	   The source rectangle
+	*/
+	QRect sourceRectangle() const {return QRect(xSrc(), ySrc(), cxSrc(), cySrc());}
+
+	/**
+	   The image to display
+	*/
+	QImage image();
+	/**
+	   Whether there is a valid image in this record
+	*/
+	bool hasImage() const;
+	/**
+	 * An 8-bit unsigned integer that specifies alpha transparency, which determines the blend of the source and destination bitmaps.
+	 * This value MUST be used on the entire source bitmap. The minimum alpha transparency value, zero, corresponds to completely
+	 * transparent; the maximum value, 0xFF, corresponds to completely opaque.
+	 */
+	unsigned char sourceConstantAlpha() const {return m_SrcConstantAlpha;}
+	/**
+	 * Specifies how source and destination pixels are interpreted with respect to alpha transparency.
+	 * A value equal to 1 (AC_SRC_ALPHA) indicates that the source bitmap is 32 bits-per-pixel and specifies an alpha transparency value for each pixel.
+	*/
+	unsigned char alphaFormat() const {return m_AlphaFormat;}
+
+private:
+	// No copying for now, because we will get into trouble with the pointers.
+	// The remedy is to write a real operator=() and AlphaBlendRecord(AlphaBlendRecord&).
+	explicit AlphaBlendRecord(AlphaBlendRecord&);
+	AlphaBlendRecord &operator=(AlphaBlendRecord&);
+
+private:
+	QRect m_Bounds;
+	qint32 m_xDest;
+	qint32 m_yDest;
+	qint32 m_cxDest;
+	qint32 m_cyDest;
+	unsigned char m_BlendOp;
+	unsigned char m_BlendFlags;
+	unsigned char m_SrcConstantAlpha;
+	unsigned char m_AlphaFormat;
+	qint32 m_xSrc;
+	qint32 m_ySrc;
+	QTransform m_XFormSrc;
+	qint32 m_BkColorSrc;
+	qint32 m_UsageSrc;
+	quint32 m_offBmiSrc;
+	quint32 m_cbBmiSrc;
+	quint32 m_offBitsSrc;
+	quint32 m_cbBitsSrc;
+	qint32 m_cxSrc;
+	qint32 m_cySrc;
+	Bitmap *m_bitmap; // The source bitmap
+};
+
+/*****************************************************************************/
+
+/**
+	Simple representation of an EMR_EXTCREATEFONTINDIRECTW record
+
+	See MS-EMF Section 2.3.7.8 for details
+*/
+class ExtCreateFontIndirectWRecord
+{
+public:
+	/**
+	   Constructor for record type
+
+	   \param stream the stream to read the record structure from
+	   \param size the number of bytes in this record
+	*/
+	ExtCreateFontIndirectWRecord( QDataStream &stream, quint32 size );
+	~ExtCreateFontIndirectWRecord();
+
+
+	/**
+	   The font handle index
+	*/
+	quint32 ihFonts() const { return m_ihFonts; };
+
+	/**
+	   The height of the font
+	*/
+	qint32 height() const { return m_height; };
+
+	/**
+	   The height of the font
+	*/
+	qint32 orientation() const { return -0.1*m_orientation;};
+
+	/**
+	   Whether this is a italic font
+	*/
+	quint8 italic() const { return m_italic; };
+
+	/**
+	   Whether this is a underlined font
+	*/
+	quint8 underline() const { return m_underline; };
+
+	/**
+	   The weight of this font
+	*/
+	quint32 weight() const { return m_weight; };
+
+	/**
+	   The name of the font face
+	*/
+	QString fontFace() const { return m_facename; };
+
+private:
+	quint32 m_ihFonts;
+
+	qint32 m_height;
+	qint32 m_width;
+	qint32 m_escapement;
+	qint32 m_orientation;
+	qint32 m_weight;
+	quint8 m_italic;
+	quint8 m_underline;
+	quint8 m_strikeout;
+	quint8 m_charSet;
+	quint8 m_outPrecision;
+	quint8 m_clipPrecision;
+	quint8 m_quality;
+	quint8 m_pitchAndFamily;
+	QString m_facename;
+	QString m_fullName;
+	QString m_style;
+	QString m_script;
+
+	// Routine to throw away a specific number of bytes
+	void soakBytes( QDataStream &stream, int numBytes );
+};
+
+}
+
+#endif

--- a/external/libqemf/src/QEmfRenderer.cpp
+++ b/external/libqemf/src/QEmfRenderer.cpp
@@ -1,0 +1,1648 @@
+/*
+  Copyright 2008        Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009 - 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#include "QEmfRenderer.h"
+#include "EmfObjects.h"
+
+#ifdef Q_OS_WIN
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif
+
+#include <math.h>
+#include <QDebug>
+#include <QPoint>
+
+#define DEBUG_EMFPAINT 0
+#define DEBUG_PAINTER_TRANSFORM 0
+
+namespace QEmf
+{
+
+
+static QPainter::CompositionMode  rasteropToQtComposition(long rop);
+
+// ================================================================
+//                         Class QEmfRenderer
+
+
+QEmfRenderer::QEmfRenderer()
+	: m_header( 0 )
+	, m_path( 0 )
+	, m_currentlyBuildingPath(false)
+	, m_fillRule(Qt::OddEvenFill)
+	, m_mapMode(MM_TEXT)
+	, m_textAlignMode(TA_NOUPDATECP) // == TA_TOP == TA_LEFT
+	, m_currentCoords()
+	, m_current_bitmap_mask(QBitmap())
+	,m_current_mask_color(QColor(Qt::color1))
+{
+	m_painter         = 0;
+	m_painterSaves    = 0;
+	m_outputSize      = QSize();
+	m_keepAspectRatio = true;
+}
+
+QEmfRenderer::QEmfRenderer(QPainter &painter, QSize &size, bool keepAspectRatio)
+	: m_header( 0 )
+	, m_path( 0 )
+	, m_currentlyBuildingPath(false)
+	, m_windowExtIsSet(false)
+	, m_viewportExtIsSet(false)
+	, m_windowViewportIsSet(false)
+	, m_fillRule(Qt::OddEvenFill)
+	, m_mapMode(MM_TEXT)
+	, m_textAlignMode(TA_NOUPDATECP) // == TA_TOP == TA_LEFT
+	, m_currentCoords()
+	, m_current_bitmap_mask(QBitmap())
+	,m_current_mask_color(QColor(Qt::color1))
+{
+	m_painter         = &painter;
+	m_painterSaves    = 0;
+	m_outputSize      = size;
+	m_keepAspectRatio = keepAspectRatio;
+}
+
+QEmfRenderer::~QEmfRenderer()
+{
+	delete m_header;
+	delete m_path;
+}
+
+void QEmfRenderer::paintBounds(const Header *header)
+{
+	// The rectangle is in device coordinates.
+	QRectF  rect(header->bounds());
+	m_painter->save();
+
+	// Draw a simple cross in a rectangle to show the bounds.
+	m_painter->setPen(QPen(QColor(172, 196, 206)));
+	m_painter->drawRect(rect);
+	m_painter->drawLine(rect.topLeft(), rect.bottomRight());
+	m_painter->drawLine(rect.bottomLeft(), rect.topRight());
+
+	m_painter->restore();
+}
+
+void QEmfRenderer::init( const Header *header )
+{
+	// Save the header since we need the frame and bounds inside the drawing.
+	m_header = new Header(*header);
+
+	QSize headerBoundsSize = header->bounds().size();
+
+#if DEBUG_EMFPAINT
+	qDebug() << "----------------------------------------------------------------------";
+	qDebug() << "Shape size               =" << m_outputSize.width() << m_outputSize.height() << " pt";
+	qDebug() << "----------------------------------------------------------------------";
+	qDebug() << "Boundary box (dev units) =" << header->bounds().x() << header->bounds().y()
+				  << header->bounds().width() << header->bounds().height();
+	qDebug() << "Frame (phys size)        =" << header->frame().x() << header->frame().y()
+				  << header->frame().width() << header->frame().height() << " *0.01 mm";
+
+	qDebug() << "Device =" << header->device().width() << header->device().height();
+	qDebug() << "Millimeters =" << header->millimeters().width()
+				  << header->millimeters().height();
+#endif
+
+#if DEBUG_PAINTER_TRANSFORM
+	printPainterTransform("In init, before save:");
+#endif
+
+	// This is restored in cleanup().
+	m_painter->save();
+
+	// Calculate how much the painter should be resized to fill the
+	// outputSize with output.
+	qreal scaleX = qreal( m_outputSize.width() ) / headerBoundsSize.width();
+	qreal scaleY = qreal( m_outputSize.height() ) / headerBoundsSize.height();
+	if ( m_keepAspectRatio ) {
+		// Use the smaller value so that we don't get an overflow in
+		// any direction.
+		if ( scaleX > scaleY )
+			scaleX = scaleY;
+		else
+			scaleY = scaleX;
+	}
+#if DEBUG_EMFPAINT
+	qDebug() << "scale = " << scaleX << ", " << scaleY;
+#endif
+
+	// Transform the EMF object so that it fits in the shape.  The
+	// topleft of the EMF will be the top left of the shape.
+	m_painter->scale( scaleX, scaleY );
+	m_painter->translate(-header->bounds().left(), -header->bounds().top());
+#if DEBUG_PAINTER_TRANSFORM
+	printPainterTransform("after fitting into shape");
+#endif
+
+	// Save the scale so that we can use it when setting lineWidth.
+	m_outputScale = (scaleX + scaleY) / 2;
+	m_textRotation = .0;
+
+	// Calculate translation if we should center the EMF in the
+	// area and keep the aspect ratio.
+#if 0 // Should apparently be upper left.  See bug 265868
+	if ( m_keepAspectRatio ) {
+		m_painter->translate((m_outputSize.width() / scaleX - headerBoundsSize.width()) / 2,
+							 (m_outputSize.height() / scaleY - headerBoundsSize.height()) / 2);
+#if DEBUG_PAINTER_TRANSFORM
+		printPainterTransform("after translation for keeping center in the shape");
+#endif
+	}
+#endif
+
+	m_outputTransform = m_painter->transform();
+	m_worldTransform = QTransform();
+	m_pathTransform = QTransform();
+
+	// For calculations of window / viewport during the painting
+	m_windowOrg = QPoint(0, 0);
+	m_viewportOrg = QPoint(0, 0);
+	m_windowExtIsSet = false;
+	m_viewportExtIsSet = false;
+	m_windowViewportIsSet = false;
+
+#if DEBUG_EMFPAINT
+	paintBounds(header);
+#endif
+}
+
+void QEmfRenderer::cleanup( const Header *header )
+{
+	Q_UNUSED( header );
+
+#if DEBUG_EMFPAINT
+	if (m_painterSaves > 0)
+		qDebug() << "WARNING: UNRESTORED DC's:" << m_painterSaves;
+#endif
+
+	// Restore all the save()s that were done during the processing.
+	for (int i = 0; i < m_painterSaves; ++i)
+		m_painter->restore();
+	m_painterSaves = 0;
+
+	// Restore the painter to what it was before init() was called.
+	m_painter->restore();
+}
+
+
+void QEmfRenderer::eof()
+{
+}
+
+void QEmfRenderer::setPixelV( QPoint &point, quint8 red, quint8 green, quint8 blue, quint8 reserved )
+{
+	Q_UNUSED( reserved );
+
+#if DEBUG_EMFPAINT
+	qDebug() << point << red << green << blue;
+#endif
+
+	m_painter->save();
+
+	QPen pen;
+	pen.setColor( QColor( red, green, blue ) );
+	m_painter->setPen( pen );
+	m_painter->drawPoint( point );
+
+	m_painter->restore();
+}
+
+
+void QEmfRenderer::beginPath()
+{
+#if DEBUG_EMFPAINT
+	qDebug();
+#endif
+
+	if (m_path)
+		delete m_path;
+	m_path = new QPainterPath;
+	m_currentlyBuildingPath = true;
+}
+
+void QEmfRenderer::closeFigure()
+{
+#if DEBUG_EMFPAINT
+	qDebug();
+#endif
+
+	m_path->closeSubpath();
+}
+
+void QEmfRenderer::endPath()
+{
+#if DEBUG_EMFPAINT
+	qDebug();
+#endif
+
+	m_path->setFillRule( m_fillRule );
+	m_currentlyBuildingPath = false;
+}
+
+void QEmfRenderer::saveDC()
+{
+#if DEBUG_EMFPAINT
+	qDebug();
+#endif
+
+	// A little trick here: Save the worldTransform in the painter.
+	// If we didn't do this, we would have to create a separate stack
+	// for these.
+	//
+	// FIXME: We should collect all the parts of the DC that are not
+	//        stored in the painter and save them separately.
+	QTransform  savedTransform = m_painter->worldTransform();
+	m_painter->setWorldTransform(m_worldTransform);
+
+	m_painter->save();
+	++m_painterSaves;
+
+	m_painter->setWorldTransform(savedTransform);
+}
+
+void QEmfRenderer::restoreDC( const qint32 savedDC )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << savedDC;
+#endif
+
+	// Note that savedDC is always negative
+	for (int i = 0; i < -savedDC; ++i) {
+		if (m_painterSaves > 0) {
+			m_painter->restore();
+			--m_painterSaves;
+		}
+		else {
+			qDebug() << "restoreDC(): try to restore painter without save" << savedDC - i;
+			break;
+		}
+	}
+
+	// We used a trick in saveDC() and stored the worldTransform in
+	// the painter.  Now restore the full transformation.
+	m_worldTransform = m_painter->worldTransform();
+	QTransform newMatrix = m_worldTransform * m_outputTransform;
+	m_painter->setWorldTransform( newMatrix );
+}
+
+void QEmfRenderer::setMetaRgn()
+{
+	qDebug() << "EMR_SETMETARGN not yet implemented";
+}
+
+
+// ----------------------------------------------------------------
+//                 World Transform, Window and Viewport
+
+
+// General note about coordinate spaces and transforms:
+//
+// There are several coordinate spaces in use when drawing an EMF file:
+//  1. The object space, in which the objects' coordinates are expressed inside the EMF.
+//     In general there are several of these.
+//  2. The page space, which is where they end up being painted in the EMF picture.
+//     The union of these form the bounding box of the EMF.
+//  3. (possibly) the output space, where the EMF picture itself is placed
+//     and/or scaled, rotated, etc
+//
+// The transform between spaces 1. and 2. is called the World Transform.
+// The world transform can be changed either through calls to change
+// the window or viewport or through calls to setWorldTransform() or
+// modifyWorldTransform().
+//
+// The transform between spaces 2. and 3. is the transform that the QPainter
+// already contains when it is given to us.  We need to save this and reapply
+// it after the world transform has changed. We call this transform the Output
+// Transform in lack of a better word. (Some sources call it the Device Transform.)
+//
+
+// An unanswered question:
+//
+// The file mp07_embedded_ppt.pptx in the test files contains the
+// following sequence of records:
+// - SetWorldTransform
+// - ModifyWorldTransform
+// - SetViewportOrg  <-- doesn't change anything
+// - SetWindowOrg    <-- doesn't change anything
+// - ExtTextOutw
+//
+// I was previously under the impression that whenever a
+// Set{Window,Viewport}{Org,Ext} record was encountered, the world
+// transform was supposed to be recalculated. But in this file, it
+// destroys the world transform. The question is which of the
+// following alternatives is true:
+//
+// 1. The world transform should only be recalculated if the
+//    Set{Window,Viewport}{Org,Ext} record actually changes anything.
+//
+// 2. The transformations set by {Set,Modify}WorldTransform records
+//    should always be reapplied after a change in window or viewport.
+//
+// 3. Something else
+//
+// I have for now implemented option 1. See the FIXME's in
+// SetWindowOrg et al.
+//
+
+
+// Set Window and Viewport
+void QEmfRenderer::recalculateWorldTransform()
+{
+	m_worldTransform = QTransform();
+
+	// If neither the window nor viewport extension is set, then there
+	// is no way to perform the calculation.  Just give up.
+	if (!m_windowExtIsSet && !m_viewportExtIsSet)
+		return;
+
+	// Negative window extensions mean flip the picture.  Handle this here.
+	bool  flip = false;
+	qreal midpointX = 0.0;
+	qreal midpointY = 0.0;
+	qreal scaleX = 1.0;
+	qreal scaleY = 1.0;
+	if (m_windowExt.width() < 0) {
+		midpointX = m_windowOrg.x() + m_windowExt.width() / qreal(2.0);
+		scaleX = -1.0;
+		flip = true;
+	}
+	if (m_windowExt.height() < 0) {
+		midpointY = m_windowOrg.y() + m_windowExt.height() / qreal(2.0);
+		scaleY = -1.0;
+		flip = true;
+	}
+	if (flip) {
+		//qDebug() << "Flipping" << midpointX << midpointY << scaleX << scaleY;
+		m_worldTransform.translate(midpointX, midpointY);
+		m_worldTransform.scale(scaleX, scaleY);
+		m_worldTransform.translate(-midpointX, -midpointY);
+		//qDebug() << "After flipping for window" << mWorldTransform;
+	}
+
+	// Update the world transform if both window and viewport are set...
+	// FIXME: Check windowExt == 0 in any direction
+	if (m_windowExtIsSet && m_viewportExtIsSet) {
+		// Both window and viewport are set.
+		qreal windowViewportScaleX = qreal(m_viewportExt.width()) / qreal(m_windowExt.width());
+		qreal windowViewportScaleY = qreal(m_viewportExt.height()) / qreal(m_windowExt.height());
+
+		m_worldTransform.translate(-m_windowOrg.x(), -m_windowOrg.y());
+		m_worldTransform.scale(windowViewportScaleX, windowViewportScaleY);
+		m_worldTransform.translate(m_viewportOrg.x(), m_viewportOrg.y());
+	}
+
+	// ...and apply it to the painter
+	m_painter->setWorldTransform(m_worldTransform);
+	m_windowViewportIsSet = true;
+
+	// Apply the output transform.
+	QTransform newMatrix = m_worldTransform * m_outputTransform;
+	m_painter->setWorldTransform( newMatrix );
+}
+
+
+void QEmfRenderer::setWindowOrgEx( const QPoint &origin )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << origin;
+#endif
+
+	// FIXME: See unanswered question at the start of this section.
+	if (m_windowOrg == origin) {
+		//qDebug() << "same origin as before";
+		return;
+	}
+
+	m_windowOrg = origin;
+
+	recalculateWorldTransform();
+}
+
+void QEmfRenderer::setWindowExtEx( const QSize &size )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << size;
+#endif
+
+	// FIXME: See unanswered question at the start of this section.
+	if (m_windowExt == size) {
+		//qDebug() << "same extension as before";
+		return;
+	}
+
+	m_windowExt = size;
+	m_windowExtIsSet = true;
+
+	recalculateWorldTransform();
+}
+
+void QEmfRenderer::setViewportOrgEx( const QPoint &origin )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << origin;
+#endif
+
+	// FIXME: See unanswered question at the start of this section.
+	if (m_viewportOrg == origin) {
+		//qDebug() << "same origin as before";
+		return;
+	}
+
+	m_viewportOrg = origin;
+
+	recalculateWorldTransform();
+}
+
+void QEmfRenderer::setViewportExtEx( const QSize &size )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << size;
+#endif
+
+	// FIXME: See unanswered question at the start of this section.
+	if (m_viewportExt == size) {
+		//qDebug() << "same extension as before";
+		return;
+	}
+
+	m_viewportExt = size;
+	m_viewportExtIsSet = true;
+
+	recalculateWorldTransform();
+}
+
+
+
+void QEmfRenderer::modifyWorldTransform( quint32 mode, float M11, float M12,
+												  float M21, float M22, float Dx, float Dy )
+{
+#if DEBUG_EMFPAINT
+	if (mode == MWT_IDENTITY)
+		qDebug() << "Identity matrix";
+	else
+		qDebug() << mode << M11 << M12 << M21 << M22 << Dx << Dy;
+#endif
+
+	QTransform matrix( M11, M12, M21, M22, Dx, Dy);
+
+	if ( mode == MWT_IDENTITY ) {
+		m_worldTransform = QTransform();
+	} else if ( mode == MWT_LEFTMULTIPLY ) {
+		m_worldTransform = matrix * m_worldTransform;
+	} else if ( mode == MWT_RIGHTMULTIPLY ) {
+		m_worldTransform = m_worldTransform * matrix;
+	} else if ( mode == MWT_SET ) {
+		m_worldTransform = matrix;
+	} else {
+	qWarning() << "Unimplemented transform mode" << mode;
+	}
+
+	m_pathTransform = m_currentlyBuildingPath ? m_worldTransform : QTransform();
+
+	// Apply the output transform.
+	QTransform newMatrix = m_worldTransform * m_outputTransform;
+	m_painter->setWorldTransform( newMatrix );
+}
+
+void QEmfRenderer::setWorldTransform( float M11, float M12, float M21,
+											   float M22, float Dx, float Dy )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << M11 << M12 << M21 << M22 << Dx << Dy;
+#endif
+
+	QTransform matrix( M11, M12, M21, M22, Dx, Dy);
+
+	m_worldTransform = matrix;
+
+	// Apply the output transform.
+	QTransform newMatrix = m_worldTransform * m_outputTransform;
+	m_painter->setWorldTransform( newMatrix );
+}
+
+
+// ----------------------------------------------------------------
+
+
+void QEmfRenderer::createPen(quint32 ihPen, quint32 penStyle, quint32 x, quint32 y, quint8 red, quint8 green, quint8 blue,
+							quint32 brushStyle, quint8 reserved)
+{
+	Q_UNUSED(y);
+	Q_UNUSED(brushStyle);
+	Q_UNUSED(reserved);
+
+#if DEBUG_EMFPAINT
+	qDebug() << ihPen << hex << penStyle << dec << x << y << red << green << blue << reserved;
+#endif
+
+	QPen pen;
+	pen.setColor(QColor(red, green, blue));
+
+	switch (penStyle & PS_STYLE_MASK){
+	case PS_SOLID:
+		pen.setStyle(Qt::SolidLine);
+		break;
+	case PS_DASH:
+		pen.setStyle(Qt::DashLine);
+		break;
+	case PS_DOT:
+		pen.setStyle(Qt::DotLine);
+		break;
+	case PS_DASHDOT:
+		pen.setStyle(Qt::DashDotLine);
+		break;
+	case PS_DASHDOTDOT:
+		pen.setStyle(Qt::DashDotDotLine);
+		break;
+	case PS_NULL:
+		pen.setStyle(Qt::NoPen);
+		break;
+	case PS_INSIDEFRAME:
+		// FIXME: We don't properly support this
+		pen.setStyle(Qt::SolidLine);
+		break;
+	case PS_USERSTYLE:
+		qDebug() << "UserStyle pen not yet supported, using SolidLine";
+		pen.setStyle(Qt::SolidLine);
+		break;
+	case PS_ALTERNATE:
+		qDebug() << "Alternate pen not yet supported, using DashLine";
+		pen.setStyle(Qt::DashLine);
+		break;
+	default:
+		qDebug() << "unexpected pen type, using SolidLine" << (penStyle & PS_STYLE_MASK);
+		pen.setStyle(Qt::SolidLine);
+	}
+
+	switch (penStyle & PS_ENDCAP_MASK){
+	case PS_ENDCAP_ROUND:
+		pen.setCapStyle(Qt::RoundCap);
+		break;
+	case PS_ENDCAP_SQUARE:
+		pen.setCapStyle(Qt::SquareCap);
+		break;
+	case PS_ENDCAP_FLAT:
+		pen.setCapStyle(Qt::FlatCap);
+		break;
+	default:
+		qDebug() << "unexpected cap style, using SquareCap" << (penStyle & PS_ENDCAP_MASK);
+		pen.setCapStyle(Qt::SquareCap);
+	}
+
+	switch (penStyle & PS_JOIN_MASK){
+	case PS_JOIN_ROUND:
+		pen.setJoinStyle(Qt::RoundJoin);
+		break;
+	case PS_JOIN_BEVEL:
+		pen.setJoinStyle(Qt::BevelJoin);
+		break;
+	case PS_JOIN_MITER:
+		pen.setJoinStyle(Qt::MiterJoin);
+		break;
+	default:
+		qDebug() << "unexpected join style: " << (penStyle & PS_JOIN_MASK);
+	}
+
+	if (x > INT_MAX){
+		qDebug() << "Warning: ignored pen width larger than maximum allowed value, x:" << x;
+		pen.setWidthF((m_outputScale < 1.0) ? m_outputScale : 1.0);
+	} else
+		pen.setWidthF((m_outputScale < 1.0) ? x*m_outputScale : x);
+
+	bool cosmetic = false;
+	switch (penStyle & PS_TYPE_MASK){
+	case PS_COSMETIC:
+		cosmetic = true;
+	break;
+	case PS_GEOMETRIC:
+	break;
+	default:
+		qDebug() << "unexpected pen type: " << (penStyle & PS_TYPE_MASK);
+	}
+	pen.setCosmetic(cosmetic);
+
+	m_objectTable.insert(ihPen, pen);
+}
+
+void QEmfRenderer::createBrushIndirect( quint32 ihBrush, quint32 brushStyle,
+										 quint8 red, quint8 green, quint8 blue, quint8 reserved, quint32 brushHatch)
+{
+	Q_UNUSED( reserved );
+	Q_UNUSED( brushHatch );
+
+#if DEBUG_EMFPAINT
+	qDebug() << ihBrush << hex << brushStyle << dec << red << green << blue << reserved << brushHatch;
+#endif
+
+	QBrush brush;
+
+	switch ( brushStyle ) {
+	case BS_SOLID:
+		brush.setStyle( Qt::SolidPattern );
+	break;
+	case BS_NULL:
+		brush.setStyle( Qt::NoBrush );
+	break;
+	case BS_HATCHED:
+			switch (brushHatch){
+			case HS_BDIAGONAL:
+				brush.setStyle(Qt::BDiagPattern);
+			break;
+			case HS_CROSS:
+				brush.setStyle(Qt::CrossPattern);
+			break;
+			case HS_DIAGCROSS:
+				brush.setStyle(Qt::DiagCrossPattern);
+			break;
+			case HS_FDIAGONAL:
+				brush.setStyle(Qt::FDiagPattern);
+			break;
+			case HS_HORIZONTAL:
+				brush.setStyle(Qt::HorPattern);
+			break;
+			case HS_VERTICAL:
+				brush.setStyle(Qt::VerPattern);
+			break;
+			}
+	break;
+	case BS_PATTERN:
+		Q_ASSERT( 0 );
+	break;
+	case BS_INDEXED:
+		Q_ASSERT( 0 );
+	break;
+	case BS_DIBPATTERN:
+		Q_ASSERT( 0 );
+	break;
+	case BS_DIBPATTERNPT:
+		Q_ASSERT( 0 );
+	break;
+	case BS_PATTERN8X8:
+		Q_ASSERT( 0 );
+	break;
+	case BS_DIBPATTERN8X8:
+		Q_ASSERT( 0 );
+	break;
+	case BS_MONOPATTERN:
+		Q_ASSERT( 0 );
+	break;
+	default:
+		Q_ASSERT( 0 );
+	}
+
+	brush.setColor(QColor(red, green, blue));
+
+	// TODO: Handle the BrushHatch enum.
+
+	m_objectTable.insert( ihBrush, brush );
+}
+
+void QEmfRenderer::createMonoBrush( quint32 ihBrush, Bitmap *bitmap )
+{
+	m_objectTable.insert(ihBrush, QBrush(bitmap->image()));
+}
+
+void QEmfRenderer::createDibPatternBrushPT(quint32 ihBrush, Bitmap *bitmap)
+{
+	m_objectTable.insert(ihBrush, QBrush(bitmap->image()));
+}
+
+void QEmfRenderer::extCreateFontIndirectW( const ExtCreateFontIndirectWRecord &extCreateFontIndirectW )
+{
+	QFont font(extCreateFontIndirectW.fontFace());
+	font.setWeight( convertFontWeight( extCreateFontIndirectW.weight() ) );
+
+	if ( extCreateFontIndirectW.height() < 0 ) {
+		font.setPixelSize( -1 * extCreateFontIndirectW.height() );
+	} else if ( extCreateFontIndirectW.height() > 0 ) {
+		font.setPixelSize( extCreateFontIndirectW.height() );
+	} // zero is "use a default size" which is effectively no-op here.
+
+	// .snp files don't always provide 0x01 for italics
+	if ( extCreateFontIndirectW.italic() != 0x00 ) {
+	font.setItalic( true );
+	}
+
+	if ( extCreateFontIndirectW.underline() != 0x00 ) {
+	font.setUnderline( true );
+	}
+
+	m_textRotation = extCreateFontIndirectW.orientation();
+
+	m_objectTable.insert( extCreateFontIndirectW.ihFonts(), font );
+}
+
+void QEmfRenderer::selectStockObject( const quint32 ihObject )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << ihObject;
+#endif
+
+	switch ( ihObject ) {
+	case WHITE_BRUSH:
+	m_painter->setBrush( QBrush(QColor(Qt::white)));
+	break;
+	case LTGRAY_BRUSH:
+	m_painter->setBrush( QBrush(QColor(Qt::lightGray)));
+	break;
+	case GRAY_BRUSH:
+	m_painter->setBrush( QBrush(QColor(Qt::gray)));
+	break;
+	case DKGRAY_BRUSH:
+	m_painter->setBrush( QBrush(QColor(Qt::darkGray)));
+	break;
+	case BLACK_BRUSH:
+	m_painter->setBrush( QBrush(QColor(Qt::black)));
+	break;
+	case NULL_BRUSH:
+	m_painter->setBrush( QBrush() );
+	break;
+	case WHITE_PEN:
+	m_painter->setPen( QPen(QColor(Qt::white)));
+	break;
+	case BLACK_PEN:
+	m_painter->setPen( QPen(QColor(Qt::black)));
+	break;
+	case NULL_PEN:
+	m_painter->setPen( QPen( Qt::NoPen ) );
+	break;
+	case OEM_FIXED_FONT:
+	case ANSI_FIXED_FONT:
+	case SYSTEM_FIXED_FONT:
+		{
+			QFont  font(QString("Fixed"));
+			m_painter->setFont(font);
+			break;
+		}
+	case ANSI_VAR_FONT:
+	case DEFAULT_GUI_FONT:      // Not sure if this is true, but it should work well
+		{
+			QFont  font(QString("Helvetica")); // Could also be "System"
+			m_painter->setFont(font);
+			break;
+		}
+	break;
+	case SYSTEM_FONT:
+	// TODO: handle this
+	break;
+	case DEVICE_DEFAULT_FONT:
+	// TODO: handle this
+	break;
+	case DEFAULT_PALETTE:
+	break;
+	case DC_BRUSH:
+		// FIXME
+	break;
+	case DC_PEN:
+		// FIXME
+	break;
+	default:
+	qWarning() << "Unexpected stock object:" << ( ihObject & 0x8000000 );
+	}
+}
+
+void QEmfRenderer::selectObject( const quint32 ihObject )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << hex << ihObject << dec;
+#endif
+
+	if ( ihObject & 0x80000000 ) {
+	selectStockObject( ihObject );
+	} else {
+		if (m_objectTable.isEmpty())
+			return;
+
+	QVariant obj = m_objectTable.value( ihObject );
+
+	switch ( obj.type() ) {
+	case QVariant::Pen :
+		m_painter->setPen( obj.value<QPen>() );
+	break;
+	case QVariant::Brush :
+		m_painter->setBrush( obj.value<QBrush>() );
+	break;
+	case QVariant::Font :
+		m_painter->setFont( obj.value<QFont>() );
+	break;
+	default:
+		qDebug() << "Unexpected type:" << obj.typeName() << ihObject;
+		break;
+	}
+	}
+}
+
+void QEmfRenderer::deleteObject( const quint32 ihObject )
+{
+	m_objectTable.take( ihObject );
+}
+
+void QEmfRenderer::arc( const QRect &box, const QPoint &start, const QPoint &end )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << box << start << end;
+#endif
+
+	QPoint centrePoint = box.center();
+
+	qreal startAngle = angleFromArc( centrePoint, start );
+	qreal endAngle   = angleFromArc( centrePoint, end );
+	qreal spanAngle  = angularSpan( startAngle, endAngle );
+
+	m_painter->drawArc( box, startAngle*16, spanAngle*16 );
+}
+
+void QEmfRenderer::chord( const QRect &box, const QPoint &start, const QPoint &end )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << box << start << end;
+#endif
+
+	QPoint centrePoint = box.center();
+
+	qreal startAngle = angleFromArc( centrePoint, start );
+	qreal endAngle   = angleFromArc( centrePoint, end );
+	qreal spanAngle  = angularSpan( startAngle, endAngle );
+
+	m_painter->drawChord( box, startAngle*16, spanAngle*16 );
+}
+
+void QEmfRenderer::pie( const QRect &box, const QPoint &start, const QPoint &end )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << box << start << end;
+#endif
+
+	QPoint centrePoint = box.center();
+
+	qreal startAngle = angleFromArc( centrePoint, start );
+	qreal endAngle   = angleFromArc( centrePoint, end );
+	qreal spanAngle  = angularSpan( startAngle, endAngle );
+
+	m_painter->drawPie( box, startAngle*16, spanAngle*16 );
+}
+
+void QEmfRenderer::ellipse( const QRect &box )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << box;
+#endif
+
+	m_painter->drawEllipse( box );
+}
+
+void QEmfRenderer::rectangle( const QRect &box )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << box;
+#endif
+
+	m_painter->drawRect( box );
+}
+
+void QEmfRenderer::setMapMode( const quint32 mapMode )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << "Set map mode:" << mapMode;
+#endif
+
+	m_mapMode = (MapMode)mapMode;
+}
+
+void QEmfRenderer::setBkMode( const quint32 backgroundMode )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << backgroundMode;
+#endif
+
+	if ( backgroundMode == TRANSPARENT ) {
+		m_painter->setBackgroundMode( Qt::TransparentMode );
+	} else if ( backgroundMode == OPAQUE ) {
+		m_painter->setBackgroundMode( Qt::OpaqueMode );
+	} else {
+		qDebug() << "EMR_SETBKMODE: Unexpected value -" << backgroundMode;
+		Q_ASSERT( 0 );
+	}
+}
+
+void QEmfRenderer::setPolyFillMode( const quint32 polyFillMode )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << polyFillMode;
+#endif
+
+	if ( polyFillMode == ALTERNATE ) {
+	m_fillRule = Qt::OddEvenFill;
+	} else if ( polyFillMode == WINDING ) {
+	m_fillRule = Qt::WindingFill;
+	} else {
+	qDebug() << "EMR_SETPOLYFILLMODE: Unexpected value -" << polyFillMode;
+	Q_ASSERT( 0 );
+	}
+}
+
+void QEmfRenderer::setLayout( const quint32 layoutMode )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << layoutMode;
+#endif
+
+	if ( layoutMode == LAYOUT_LTR ) {
+		m_painter->setLayoutDirection( Qt::LeftToRight );
+	} else if ( layoutMode == LAYOUT_RTL ) {
+		m_painter->setLayoutDirection( Qt::RightToLeft );
+	} else {
+		qDebug() << "EMR_SETLAYOUT: Unexpected value -" << layoutMode;
+		Q_ASSERT( 0 );
+	}
+}
+
+void QEmfRenderer::setTextAlign( const quint32 textAlignMode )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << textAlignMode;
+#endif
+
+	m_textAlignMode = textAlignMode;
+}
+
+void QEmfRenderer::setTextColor( const quint8 red, const quint8 green, const quint8 blue,
+										  const quint8 reserved )
+{
+	Q_UNUSED( reserved );
+
+#if DEBUG_EMFPAINT
+	qDebug() << red << green << blue << reserved;
+#endif
+
+	m_textPen.setColor( QColor( red, green, blue ) );
+}
+
+void QEmfRenderer::setBkColor( const quint8 red, const quint8 green, const quint8 blue,
+										const quint8 reserved )
+{
+	Q_UNUSED( reserved );
+
+#if DEBUG_EMFPAINT
+	qDebug() << red << green << blue << reserved;
+#endif
+
+	m_painter->setBackground( QBrush( QColor( red, green, blue ) ) );
+}
+
+
+#define DEBUG_TEXTOUT 0
+
+void QEmfRenderer::extTextOut( const QRect &bounds, const EmrTextObject &textObject )
+{
+	const QPoint  &referencePoint = textObject.referencePoint();
+	const QString &text = textObject.textString();
+
+#if DEBUG_EMFPAINT
+	qDebug() << "Ref point: " << referencePoint
+				  << "options: " << hex << textObject.options() << dec
+				  << "rectangle: " << bounds
+				  << "text: " << textObject.textString();
+#endif
+
+	int x = referencePoint.x();
+	int y = referencePoint.y();
+
+	// The TA_UPDATECP flag tells us to use the current position
+	if (m_textAlignMode & TA_UPDATECP){
+		// (left, top) position = current logical position
+		x = m_currentCoords.x();
+		y = m_currentCoords.y();
+	#if DEBUG_EMFPAINT
+		qDebug() << "TA_UPDATECP: use current logical position" << x << y;
+	#endif
+	} else if (bounds.isNull()){// (left, top) position = current logical position
+		if (referencePoint == QPoint(0, -1))
+			x = m_currentCoords.x();
+		if (y < 0)
+			y = m_currentCoords.y();
+	#if DEBUG_EMFPAINT
+		qDebug() << "Invalid bounds -> use current logical position" << x << y;
+	#endif
+	}
+
+	QFontMetrics fm = m_painter->fontMetrics();
+	int textWidth  = fm.width(text);
+	int textHeight = fm.height();
+
+	// Make (x, y) be the coordinates of the upper left corner of the
+	// rectangle surrounding the text.
+	//
+	// FIXME: Handle RTL text.
+
+	// Horizontal align.  Default is TA_LEFT.
+	if ((m_textAlignMode & TA_HORZMASK) == TA_CENTER)
+		x -= (textWidth / 2);
+	else if ((m_textAlignMode & TA_HORZMASK) == TA_RIGHT)
+		x -= textWidth;
+
+	// Vertical align.  Default is TA_TOP
+	if ((m_textAlignMode & TA_VERTMASK) == TA_BASELINE)
+		y -= (textHeight - fm.descent());
+	else if ((m_textAlignMode & TA_VERTMASK) == TA_BOTTOM) {
+		y -= textHeight;
+	}
+
+#if DEBUG_EMFPAINT
+	qDebug() << "textWidth = " << textWidth << "height = " << textHeight;
+
+	qDebug() << "font = " << m_painter->font()
+				  << "pointSize = " << m_painter->font().pointSize()
+				  << "ascent = " << fm.ascent() << "descent = " << fm.descent()
+				  << "height = " << fm.height()
+				  << "leading = " << fm.leading();
+	qDebug() << "actual point = " << x << y;
+#endif
+
+	// Debug code that paints a rectangle around the output area.
+#if DEBUG_TEXTOUT
+	m_painter->save();
+	m_painter->setPen(Qt::black);
+	m_painter->drawRect(QRect(x, y, textWidth, textHeight));
+	if (bounds.isValid()){
+		m_painter->setPen(Qt::red);
+		m_painter->drawRect(bounds);
+	}
+	m_painter->restore();
+#endif
+
+	// Actual painting starts here.
+	m_painter->save();
+
+	// Find out how much we have to scale the text to make it fit into
+	// the output rectangle.  Normally this wouldn't be necessary, but
+	// when fonts are switched, the replacement fonts are sometimes
+	// wider than the original fonts.
+	//QRect worldRect(m_worldTransform.mapRect(QRect(x, y, textWidth, textHeight)));
+	//qDebug() << "rects:" << QRect(x, y, textWidth, textHeight) << bounds;
+	qreal scaleX = qreal(1.0);
+	qreal scaleY = qreal(1.0);
+	if (bounds.isValid()){
+		/*if ((bounds.width() < worldRect.width()))
+			scaleX = qreal(bounds.width()) / qreal(worldRect.width());
+		if (bounds.height() < worldRect.height())
+			scaleY = qreal(bounds.height()) / qreal(worldRect.height());*/
+		if ((bounds.width() < textWidth))
+			scaleX = qreal(bounds.width()) / qreal(textWidth);
+		if (bounds.height() < textHeight)
+			scaleY = qreal(bounds.height()) / qreal(textHeight);
+	}
+#if DEBUG_EMFPAINT
+	qDebug() << "scale:" << scaleX << scaleY;
+#endif
+
+	if ((m_textRotation == .0) && (scaleX < qreal(1.0) || scaleY < qreal(1.0))){
+		m_painter->translate(-x, -y);
+		m_painter->scale(scaleX, scaleY);
+		m_painter->translate(x / scaleX, y / scaleY);
+	}
+
+	// Use the special pen defined by mTextPen for text.
+	QPen savePen = m_painter->pen();
+	m_painter->setPen(m_textPen);
+	if (m_textRotation != .0){
+		m_painter->setWorldTransform(m_outputTransform);
+		m_painter->translate(referencePoint.x(), referencePoint.y());
+		m_painter->rotate(m_textRotation);
+		if (scaleX < qreal(1.0))
+			m_painter->scale((1.0 - scaleX), 1.0);
+		m_painter->drawText(0, 0, text);
+	} else
+		m_painter->drawText(int(x / scaleX), int(y / scaleY), textWidth, textHeight, Qt::AlignLeft | Qt::AlignTop, text);
+	m_painter->setPen(savePen);
+
+	m_painter->restore();
+}
+
+void QEmfRenderer::moveToEx( const qint32 x, const qint32 y )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << x << y;
+#endif
+
+	if ( m_currentlyBuildingPath ){
+		if (!m_pathTransform.isIdentity())
+			m_path->moveTo(m_pathTransform.map(QPoint(x, y)));
+		else
+			m_path->moveTo( QPoint( x, y ) );
+	} else
+		m_currentCoords = QPoint( x, y );
+}
+
+void QEmfRenderer::lineTo( const QPoint &finishPoint )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << finishPoint;
+#endif
+
+	if ( m_currentlyBuildingPath )
+		m_path->lineTo(m_pathTransform.map(finishPoint));
+	else {
+		m_painter->drawLine( m_currentCoords, finishPoint );
+		m_currentCoords = finishPoint;
+	}
+}
+
+void QEmfRenderer::arcTo( const QRect &box, const QPoint &start, const QPoint &end )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << box << start << end;
+#endif
+
+	QPoint centrePoint = box.center();
+
+	qreal startAngle = angleFromArc( centrePoint, start );
+	qreal endAngle   = angleFromArc( centrePoint, end );
+	qreal spanAngle  = angularSpan( startAngle, endAngle );
+
+	m_path->arcTo( box, startAngle, spanAngle );
+}
+
+void QEmfRenderer::polygon16( const QRect &bounds, const QList<QPoint> points )
+{
+	Q_UNUSED( bounds );
+
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	QVector<QPoint> pointVector = points.toVector();
+
+	if (m_currentlyBuildingPath && !m_pathTransform.isIdentity())
+		m_path->addPolygon(m_pathTransform.map(pointVector));
+
+	m_painter->drawPolygon(pointVector.constData(), pointVector.size(), m_fillRule);
+}
+
+void QEmfRenderer::polyLine( const QRect &bounds, const QList<QPoint> points )
+{
+	Q_UNUSED( bounds );
+
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	QVector<QPoint> pointVector = points.toVector();
+	m_painter->drawPolyline( pointVector.constData(), pointVector.size() );
+}
+
+void QEmfRenderer::polyLine16( const QRect &bounds, const QList<QPoint> points )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	polyLine( bounds, points );
+}
+
+void QEmfRenderer::polyPolygon16( const QRect &bounds, const QList< QVector< QPoint > > &points )
+{
+	Q_UNUSED( bounds );
+
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	for ( int i = 0; i < points.size(); ++i ) {
+		m_painter->drawPolygon( points[i].constData(), points[i].size(), m_fillRule );
+	}
+}
+
+void QEmfRenderer::polyPolyLine16( const QRect &bounds, const QList< QVector< QPoint > > &points )
+{
+	Q_UNUSED( bounds );
+
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	for ( int i = 0; i < points.size(); ++i ) {
+		m_painter->drawPolyline( points[i].constData(), points[i].size() );
+	}
+}
+
+void QEmfRenderer::polyLineTo16( const QRect &bounds, const QList<QPoint> points )
+{
+	Q_UNUSED( bounds );
+
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	for ( int i = 0; i < points.count(); ++i ) {
+	m_path->lineTo( points[i] );
+	}
+}
+
+void QEmfRenderer::polyBezier16( const QRect &bounds, const QList<QPoint> points )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	Q_UNUSED( bounds );
+
+	if (m_currentlyBuildingPath){
+		QTransform m = m_pathTransform;
+		if (!m.isIdentity()){
+			m_path->moveTo(m.map(points[0]));
+			for (int i = 1; i < points.count(); i += 3){
+				m_path->cubicTo(m.map(points[i]), m.map(points[i + 1]), m.map(points[i + 2]));
+			}
+		} else {
+			m_path->moveTo(points[0]);
+			for (int i = 1; i < points.count(); i += 3){
+				m_path->cubicTo(points[i], points[i + 1], points[i + 2]);
+			}
+		}
+	} else {
+		QPainterPath path;
+		path.moveTo( points[0] );
+		for ( int i = 1; i < points.count(); i+=3 ) {
+			path.cubicTo( points[i], points[i+1], points[i+2] );
+		}
+		m_painter->drawPath( path );
+	}
+}
+
+void QEmfRenderer::polyBezierTo16( const QRect &bounds, const QList<QPoint> points )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bounds << points;
+#endif
+
+	Q_UNUSED( bounds );
+
+	if (m_currentlyBuildingPath && !m_pathTransform.isIdentity()){
+		QList<QPoint> mappedPoints;
+        for (QPoint p : points)
+			mappedPoints.append(m_pathTransform.map(p));
+		for (int i = 0; i < points.count(); i += 3)
+			m_path->cubicTo(mappedPoints[i], mappedPoints[i + 1], mappedPoints[i + 2]);
+	} else {
+		for ( int i = 0; i < points.count(); i+=3 ){
+			m_path->cubicTo( points[i], points[i+1], points[i+2] );
+		}
+	}
+}
+
+void QEmfRenderer::fillPath( const QRect &bounds )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bounds;
+#endif
+
+	Q_UNUSED(bounds);
+
+	QBrush br = m_painter->brush();
+
+	if (m_worldTransform.isScaling()){
+		QTransform m = br.transform();
+		m.scale(1.0/m_worldTransform.m11(), 1.0/m_worldTransform.m22());
+		br.setTransform(m);
+	}
+
+	m_painter->fillPath(*m_path, br);
+}
+
+void QEmfRenderer::strokeAndFillPath( const QRect &bounds )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bounds;
+#endif
+
+	Q_UNUSED(bounds);
+
+	m_painter->drawPath(*m_path);
+}
+
+void QEmfRenderer::strokePath( const QRect &bounds )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bounds;
+#endif
+
+	Q_UNUSED( bounds );
+	m_painter->strokePath(*m_path, m_painter->pen());
+}
+
+void QEmfRenderer::setMitterLimit(const quint32 limit)
+{
+#if DEBUG_EMFPAINT
+	qDebug() << limit;
+#endif
+
+	QPen pen = m_painter->pen();
+	pen.setMiterLimit(limit);
+	m_painter->setPen(pen);
+}
+
+void QEmfRenderer::setClipPath( const quint32 regionMode )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << hex << regionMode << dec;
+#endif
+
+	switch (regionMode){
+	case RGN_AND:
+		m_painter->setClipPath(*m_path, Qt::IntersectClip);
+		break;
+	case RGN_OR:
+	#if QT_VERSION < 0x050000
+		m_painter->setClipPath(*m_path, Qt::UniteClip);
+	#else
+		qWarning() <<  "Unexpected / unsupported clip region mode:" << regionMode;
+	#endif
+		break;
+	case RGN_COPY:
+		m_painter->setClipPath(*m_path, Qt::ReplaceClip);
+		break;
+	default:
+		qWarning() <<  "Unexpected / unsupported clip region mode:" << regionMode;
+		Q_ASSERT( 0 );
+	}
+}
+
+void QEmfRenderer::bitBlt( BitBltRecord &bitBltRecord )
+{
+#if DEBUG_EMFPAINT
+	qDebug() << bitBltRecord.xDest() << bitBltRecord.yDest()
+				  << bitBltRecord.cxDest() << bitBltRecord.cyDest()
+				  << hex << bitBltRecord.rasterOperation() << dec
+				  << bitBltRecord.bkColorSrc();
+#endif
+
+	QRect target(bitBltRecord.xDest(), bitBltRecord.yDest(), bitBltRecord.cxDest(), bitBltRecord.cyDest());
+	// 0x00f00021 is the PatCopy raster operation which just fills a rectangle with a brush.
+	// This seems to be the most common one.
+	//
+	// FIXME: Implement the rest of the raster operations.
+
+	quint32 rasterOp = bitBltRecord.rasterOperation();
+	if (rasterOp == 0x00f00021){
+		// Would have been nice if we didn't have to pull out the
+		// brush to use it with fillRect()...
+		QBrush brush = m_painter->brush();
+		m_painter->fillRect(target, brush);
+	} else if (rasterOp == 0x00AA0029){
+		QBrush brush = m_painter->brush();
+		//if (brush.style() != Qt::NoBrush)
+			//printf("rasterOperation = 0x%X style: %d\n", bitBltRecord.rasterOperation(), brush.style());
+		//m_painter->fillRect(target, brush);
+	} else if (bitBltRecord.hasImage())
+		m_painter->drawImage(target, bitBltRecord.image());
+}
+
+void QEmfRenderer::setStretchBltMode( const quint32 stretchMode )
+{
+	Q_UNUSED(stretchMode);
+
+#if DEBUG_EMFPAINT
+	qDebug() << hex << stretchMode << dec;
+
+	switch ( stretchMode ) {
+	case 0x01:
+		qDebug() << "EMR_STRETCHBLTMODE: STRETCH_ANDSCANS";
+		break;
+	case 0x02:
+		qDebug() << "EMR_STRETCHBLTMODE: STRETCH_ORSCANS";
+		break;
+	case 0x03:
+		qDebug() << "EMR_STRETCHBLTMODE: STRETCH_DELETESCANS";
+		break;
+	case 0x04:
+		qDebug() << "EMR_STRETCHBLTMODE: STRETCH_HALFTONE";
+		break;
+	default:
+		qDebug() << "EMR_STRETCHBLTMODE - unknown stretch mode:" << stretchMode;
+	}
+#endif
+}
+
+void QEmfRenderer::stretchDiBits(StretchDiBitsRecord &record)
+{
+	if (record.bitCount() == BI_BITCOUNT_1){
+		m_current_bitmap_mask = record.mask();
+
+		QVector<QRgb> maskColorTable = record.maskColorTable();
+		if (!maskColorTable.isEmpty())
+			m_current_mask_color = QColor(maskColorTable.first());
+
+		return;
+	}
+
+#if DEBUG_EMFPAINT
+	qDebug() << "Bounds:    " << record.bounds();
+	qDebug() << "Dest rect: "
+				  << record.xDest() << record.yDest() << record.cxDest() << record.cyDest();
+	qDebug() << "Src rect:  "
+				  << record.xSrc() << record.ySrc() << record.cxSrc() << record.cySrc();
+	qDebug() << "Raster op: " << hex << record.rasterOperation() << dec;
+				  //<< record.bkColorSrc();
+	qDebug() << "usageSrc: " << record.usageSrc();
+#endif
+
+	QPoint targetPosition( record.xDest(), record.yDest() );
+	QSize  targetSize( record.cxDest(), record.cyDest() );
+
+	QPoint sourcePosition( record.xSrc(), record.ySrc() );
+	QSize  sourceSize( record.cxSrc(), record.cySrc() );
+
+	// special cases, from [MS-EMF] Section 2.3.1.7:
+	// "This record specifies a mirror-image copy of the source bitmap to the
+	// destination if the signs of the height or width fields differ. That is,
+	// if cxSrc and cxDest have different signs, this record specifies a mirror
+	// image of the source bitmap along the x-axis. If cySrc and cyDest have
+	// different signs, this record specifies a mirror image of the source
+	//  bitmap along the y-axis."
+	QRect target( targetPosition, targetSize );
+	QRect source( sourcePosition, sourceSize );
+
+	QImage image = record.image();
+
+#if DEBUG_EMFPAINT
+	qDebug() << "image size" << image.size();
+	qDebug() << "Before transformation:";
+	qDebug() << "    target" << target;
+	qDebug() << "    source" << source;
+#endif
+	if ( source.width() < 0 && target.width() > 0 ) {
+		sourceSize.rwidth() *= -1;
+		sourcePosition.rx() -= sourceSize.width();
+		source = QRect( sourcePosition, sourceSize );
+	}
+	if ( source.width() > 0 && target.width() < 0 ) {
+		targetSize.rwidth() *= -1;
+		targetPosition.rx() -= targetSize.width();
+		target = QRect( targetPosition, targetSize );
+	}
+	if ( source.height() < 0 && target.height() > 0 ) {
+		sourceSize.rheight() *= -1;
+		sourcePosition.ry() -= sourceSize.height();
+		source = QRect( sourcePosition, sourceSize );
+	}
+	if ( source.height() > 0 && target.height() < 0 ) {
+		targetSize.rheight() *= -1;
+		targetPosition.ry() -= targetSize.height();
+		target = QRect( targetPosition, targetSize );
+	}
+
+#if DEBUG_EMFPAINT
+	qDebug() << "After transformation:";
+	qDebug() << "    target" << target;
+	qDebug() << "    source" << source;
+	qDebug() << "Image" << image.size();
+#endif
+
+/*
+#ifndef Q_OS_LINUX //otherwise on Linux images are all black: need to investigate composition modes
+	QPainter::RenderHints      oldRenderHints = m_painter->renderHints();
+	QPainter::CompositionMode  oldCompMode    = m_painter->compositionMode();
+	m_painter->setRenderHints(0);// Antialiasing makes composition modes invalid
+	m_painter->setCompositionMode(rasteropToQtComposition(record.rasterOperation()));
+#endif
+*/
+	if (!m_current_bitmap_mask.isNull()){
+		QPixmap pix = QPixmap::fromImage(image);
+		pix.setMask(m_current_bitmap_mask.createMaskFromColor(m_current_mask_color));
+		m_painter->drawPixmap(target, pix, source);
+		m_current_bitmap_mask.clear();
+	} else if (record.hasImage())
+		m_painter->drawImage(target, image, source);
+
+/*
+#ifndef Q_OS_LINUX
+	m_painter->setCompositionMode(oldCompMode);
+	m_painter->setRenderHints(oldRenderHints);
+#endif
+*/
+}
+
+void QEmfRenderer::alphaBlend(AlphaBlendRecord& record)
+{
+	QImage image = record.image();
+	QRect target = record.destinationRectangle();
+	QRect source = record.sourceRectangle();
+
+#if DEBUG_EMFPAINT
+	qDebug() << "image size" << image.size();
+	qDebug() << "    target" << target;
+	qDebug() << "    source" << source;
+#endif
+
+	if (record.hasImage())
+		m_painter->drawImage(target, image, source);
+}
+
+// ----------------------------------------------------------------
+//                         Private functions
+
+
+void QEmfRenderer::printPainterTransform(const char *leadText)
+{
+	QTransform  transform;
+
+	recalculateWorldTransform();
+
+	qDebug() << leadText << "world transform " << m_worldTransform
+				  << "incl output transform: " << m_painter->transform();
+}
+
+
+qreal QEmfRenderer::angleFromArc( const QPoint &centrePoint, const QPoint &radialPoint )
+{
+	double dX = radialPoint.x() - centrePoint.x();
+	double dY = centrePoint.y() - radialPoint.y();
+	// Qt angles are in degrees. atan2 returns radians
+	return ( atan2( dY, dX ) * 180 / M_PI );
+}
+
+qreal QEmfRenderer::angularSpan( const qreal startAngle, const qreal endAngle )
+{
+	qreal spanAngle = endAngle - startAngle;
+
+	if ( spanAngle <= 0 ) {
+		spanAngle += 360;
+	}
+
+	return spanAngle;
+}
+
+int QEmfRenderer::convertFontWeight( quint32 emfWeight )
+{
+	// FIXME: See how it's done in the wmf library and check if this is suitable here.
+
+	if ( emfWeight == 0 ) {
+		return QFont::Normal;
+	} else if ( emfWeight <= 200 ) {
+		return QFont::Light;
+	} else if ( emfWeight <= 450 ) {
+		return QFont::Normal;
+	} else if ( emfWeight <= 650 ) {
+		return QFont::DemiBold;
+	} else if ( emfWeight <= 850 ) {
+		return QFont::Bold;
+	} else {
+		return QFont::Black;
+	}
+}
+
+static QPainter::CompositionMode  rasteropToQtComposition(long rop)
+{
+	// Code copied from filters/libkowmf/qwmf.cc
+	// FIXME: Should be cleaned up
+
+	/* TODO: Ternary raster operations
+	0x00C000CA  dest = (source AND pattern)
+	0x00F00021  dest = pattern
+	0x00FB0A09  dest = DPSnoo
+	0x005A0049  dest = pattern XOR dest   */
+	static const struct OpTab {
+		long winRasterOp;
+		QPainter::CompositionMode qtRasterOp;
+	}
+
+	opTab[] = {
+		// ### untested (conversion from Qt::RasterOp)
+		{ 0x00CC0020, QPainter::CompositionMode_Source }, // CopyROP
+		{ 0x00EE0086, QPainter::RasterOp_SourceOrDestination }, // OrROP
+		{ 0x008800C6, QPainter::RasterOp_SourceAndDestination }, // AndROP
+		{ 0x00660046, QPainter::RasterOp_SourceXorDestination }, // XorROP
+		// ----------------------------------------------------------------
+		// FIXME: Checked above this, below is still todo
+		// ----------------------------------------------------------------
+		{ 0x00440328, QPainter::CompositionMode_DestinationOut }, // AndNotROP
+		{ 0x00330008, QPainter::CompositionMode_DestinationOut }, // NotCopyROP
+		{ 0x001100A6, QPainter::CompositionMode_SourceOut }, // NandROP
+		{ 0x00C000CA, QPainter::CompositionMode_Source }, // CopyROP
+		{ 0x00BB0226, QPainter::CompositionMode_Destination }, // NotOrROP
+		{ 0x00F00021, QPainter::CompositionMode_Source }, // CopyROP
+		{ 0x00FB0A09, QPainter::CompositionMode_Source }, // CopyROP
+		{ 0x005A0049, QPainter::CompositionMode_Source }, // CopyROP
+		{ 0x00550009, QPainter::CompositionMode_DestinationOut }, // NotROP
+		{ 0x00000042, QPainter::CompositionMode_Clear }, // ClearROP
+		{ 0x00FF0062, QPainter::CompositionMode_Source } // SetROP
+	};
+
+	int i;
+	for (i = 0 ; i < 15 ; i++)
+		if (opTab[i].winRasterOp == rop)
+			break;
+
+	if (i < 15)
+		return opTab[i].qtRasterOp;
+	else
+		return QPainter::CompositionMode_Source;
+}
+
+} // xnamespace...

--- a/external/libqemf/src/QEmfRenderer.h
+++ b/external/libqemf/src/QEmfRenderer.h
@@ -1,0 +1,252 @@
+/*
+  Copyright 2008        Brad Hards  <bradh@frogmouth.net>
+  Copyright 2009 - 2010 Inge Wallin <inge@lysator.liu.se>
+  Copyright 2015 Ion Vasilief <ion_vasilief@yahoo.fr>
+*/
+
+#ifndef EMF_RENDERER_H
+#define EMF_RENDERER_H
+
+#include <QList>
+#include <QPainter>
+#include <QRect> // also provides QSize, QPoint
+#include <QString>
+#include <QVariant>
+
+#include "EmfEnums.h"
+#include "EmfHeader.h"
+#include "EmfRecords.h"
+#include "EmfOutput.h"
+
+
+/**
+   \file
+
+   Primary definitions for EMF output strategies
+*/
+
+/**
+   Namespace for Enhanced Metafile (EMF) classes
+*/
+namespace QEmf
+{
+
+class EmrTextObject;
+
+/**
+	QPainter based output strategy for EMF Parser.
+
+	This class allows rendering of an EMF file to a QPixmap or any other QPaintDevice.
+*/
+class QEmfRenderer : public AbstractOutput
+{
+public:
+	/**
+	   Constructor.
+
+	   This will probably need to take an enum to say what sort of output
+	   we want.
+	*/
+	QEmfRenderer();
+	QEmfRenderer( QPainter &painter, QSize &size, bool keepAspectRatio = false );
+	~QEmfRenderer();
+
+	void init( const Header *header );
+	void cleanup( const Header *header );
+	void eof();
+
+	/**
+	   The image that has been rendered to.
+	*/
+	QImage *image();
+
+	void createPen( quint32 ihPen, quint32 penStyle, quint32 x, quint32 y,
+			quint8 red, quint8 green, quint8 blue, quint32 brushStyle, quint8 reserved );
+	void createBrushIndirect( quint32 ihBrush, quint32 BrushStyle, quint8 red,
+				  quint8 green, quint8 blue, quint8 reserved,
+				  quint32 BrushHatch );
+	void createMonoBrush( quint32 ihBrush, Bitmap *bitmap );
+	void createDibPatternBrushPT( quint32 ihBrush, Bitmap *bitmap );
+	void selectObject( const quint32 ihObject );
+	void deleteObject( const quint32 ihObject );
+	void arc( const QRect &box, const QPoint &start, const QPoint &end );
+	void chord( const QRect &box, const QPoint &start, const QPoint &end );
+	void pie( const QRect &box, const QPoint &start, const QPoint &end );
+	void ellipse( const QRect &box );
+	void rectangle( const QRect &box );
+	void setMapMode( const quint32 mapMode );
+	void setMetaRgn();
+	void setWindowOrgEx( const QPoint &origin );
+	void setWindowExtEx( const QSize &size );
+	void setViewportOrgEx( const QPoint &origin );
+	void setViewportExtEx( const QSize &size );
+	void beginPath();
+	void closeFigure();
+	void endPath();
+	void setBkMode( const quint32 backgroundMode );
+	void setPolyFillMode( const quint32 polyFillMode );
+	void setLayout( const quint32 layoutMode );
+	void extCreateFontIndirectW( const ExtCreateFontIndirectWRecord &extCreateFontIndirectW );
+	void setTextAlign( const quint32 textAlignMode );
+	void setTextColor( const quint8 red, const quint8 green, const quint8 blue,
+			   const quint8 reserved );
+	void setBkColor( const quint8 red, const quint8 green, const quint8 blue,
+					 const quint8 reserved );
+	void setPixelV( QPoint &point, quint8 red, quint8 green, quint8 blue, quint8 reserved );
+	void modifyWorldTransform( quint32 mode, float M11, float M12,
+				   float M21, float M22, float Dx, float Dy );
+	void setWorldTransform( float M11, float M12, float M21,
+				float M22, float Dx, float Dy );
+	void extTextOut( const QRect &bounds, const EmrTextObject &textObject );
+	void moveToEx( const qint32 x, const qint32 y );
+	void saveDC();
+	void restoreDC( const qint32 savedDC );
+	void lineTo( const QPoint &finishPoint );
+	void arcTo( const QRect &box, const QPoint &start, const QPoint &end );
+	void polygon16( const QRect &bounds, const QList<QPoint> points );
+	void polyLine16( const QRect &bounds, const QList<QPoint> points );
+	void polyPolygon16( const QRect &bounds, const QList< QVector< QPoint > > &points );
+	void polyPolyLine16( const QRect &bounds, const QList< QVector< QPoint > > &points );
+	void polyLine( const QRect &bounds, const QList<QPoint> points );
+	void polyLineTo16( const QRect &bounds, const QList<QPoint> points );
+	void polyBezier16( const QRect &bounds, const QList<QPoint> points );
+	void polyBezierTo16( const QRect &bounds, const QList<QPoint> points );
+	void fillPath( const QRect &bounds );
+	void strokeAndFillPath( const QRect &bounds );
+	void strokePath( const QRect &bounds );
+	void setMitterLimit(const quint32 limit);
+	void setClipPath( const quint32 regionMode );
+	void bitBlt( BitBltRecord &bitBltRecord );
+	void setStretchBltMode( const quint32 stretchMode );
+	void stretchDiBits( StretchDiBitsRecord &stretchDiBitsRecord );
+	void alphaBlend(AlphaBlendRecord&);
+
+private:
+	void printPainterTransform(const char *leadText);
+
+	/// For debugging purposes: Draw the boundary box.
+	void paintBounds(const Header *header);
+
+	/// Recalculate the world transform and then apply it to the painter
+	/// This must be called at the end of every function that changes the transform.
+	void recalculateWorldTransform();
+
+	/**
+	   Select a stock object.
+
+	   See [MS-EMF] Section 2.1.31.
+
+	   \param ihObject the stock object value
+	*/
+	void selectStockObject( const quint32 ihObject );
+
+
+	/**
+	   Helper routine to convert the EMF angle (centrepoint + radial endpoint) into
+	   the Qt format (in degress - may need to multiply by 16 for some purposes)
+	*/
+	qreal angleFromArc( const QPoint &centrePoint, const QPoint &radialPoint );
+
+	/**
+	  Calculate the angular difference (span) between two angles
+
+	  This should always be positive.
+	*/
+	qreal angularSpan( const qreal startAngle, const qreal endAngle );
+
+	/**
+	   Convert the EMF font weight scale (0..1000) to Qt equivalent.
+
+	   This is a bit rough - the EMF spec only says 400 is normal, and
+	   700 is bold.
+	*/
+	int convertFontWeight( quint32 emfWeight );
+
+
+	Header                  *m_header;   // Save to be able to retain scaling.
+	int                      m_painterSaves; // The number of times that save() was called.
+	QSize                    m_outputSize;
+	bool                     m_keepAspectRatio;
+
+	QMap<quint32, QVariant>  m_objectTable;
+
+	QPainterPath *m_path;
+	bool          m_currentlyBuildingPath;
+
+	QPainter                *m_painter;
+	QTransform               m_worldTransform; // The transform inside the EMF.
+	QTransform               m_pathTransform; // The transform inside the EMF to be applied only to the path under construction
+	QTransform               m_outputTransform; // The transform that the painter already had
+	qreal                    m_outputScale;
+	qreal                    m_textRotation;
+
+	// Everything that has to do with window and viewport calculation
+	QPoint        m_windowOrg;
+	QSize         m_windowExt;
+	QPoint        m_viewportOrg;
+	QSize         m_viewportExt;
+	bool          m_windowExtIsSet;
+	bool          m_viewportExtIsSet;
+	bool          m_windowViewportIsSet;
+
+#if 0
+	// This matrix is needed because the window / viewport calculation
+	// is not the last one in the chain. After that one comes the
+	// transform that the painter already has when the painting
+	// starts, and that one has to be saved and reapplied again after
+	// the window / viewport calculation is redone.
+	QTransform    m_outputTransform;
+#endif
+
+	// ----------------------------------------------------------------
+	//                     The playback device context
+
+	// The Playback Device Context (PDC) contains the following:
+	//  - bitmap
+	//  - brush	(part of the painter)
+	//  - palette
+	//  - font	(part of the painter)
+	//  - pen	(part of the painter)
+	//  - region
+	//  - drawing mode
+	//  - mapping mode
+	// FIXME: what more?  textalign?  textpen?
+
+	/**
+	   The current text pen
+	*/
+	QPen m_textPen;
+
+	/**
+	   The current fill rule
+	*/
+	enum Qt::FillRule m_fillRule;
+
+	/**
+	   The current map mode
+	*/
+	MapMode  m_mapMode;
+	/**
+		The current text alignment mode
+	*/
+	quint32 m_textAlignMode;
+
+	/**
+	   The current coordinates
+	*/
+	QPoint  m_currentCoords;
+
+	/**
+		The current bitmap mask
+	*/
+	QBitmap  m_current_bitmap_mask;
+
+	/**
+		The current bitmap mask-in color
+	*/
+	QColor m_current_mask_color;
+};
+
+}
+
+#endif

--- a/external/libqemf/src/src.pro
+++ b/external/libqemf/src/src.pro
@@ -1,0 +1,40 @@
+# qmake project file for building libqemf
+
+include( ../config.pri )
+
+TARGET       = qemf
+TEMPLATE     = lib
+
+MOC_DIR      = ../tmp
+OBJECTS_DIR  = ../tmp
+DESTDIR      = ../
+
+contains(CONFIG, QEmfDll){
+    CONFIG  += dll
+    DEFINES += QEMF_DLL QEMF_DLL_BUILD
+} else {
+    CONFIG  += staticlib
+}
+
+INCLUDEPATH += .
+
+HEADERS = Bitmap.h\
+	BitmapHeader.h\
+	EmfEnums.h\
+	EmfHeader.h\
+	EmfLogger.h\
+	EmfObjects.h\
+	EmfOutput.h\
+	EmfParser.h\
+	EmfRecords.h\
+	QEmfRenderer.h
+
+SOURCES = Bitmap.cpp\
+	BitmapHeader.cpp\
+	EmfHeader.cpp\
+	EmfLogger.cpp\
+	EmfObjects.cpp\
+	EmfOutput.cpp\
+	EmfParser.cpp\
+	EmfRecords.cpp\
+	QEmfRenderer.cpp

--- a/ms-windows/mxe/build-mxe.sh
+++ b/ms-windows/mxe/build-mxe.sh
@@ -44,9 +44,8 @@ RELEASE_DIR=${PWD}/qgis-mxe-release
 
 # End configuration
 
-# Original target (does not support posix threads)
-# TARGET=${TARGET}
-TARGET=i686-w64-mingw32.shared.posix
+# Windows 64 bit with posix threads
+TARGET=x86_64-w64-mingw32.shared.posix
 
 # Set base path for all tools
 export PATH=${PATH}:/mxe/usr/bin

--- a/ms-windows/mxe/mxe.Dockerfile
+++ b/ms-windows/mxe/mxe.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y --no-install-recommends autopoint bison flex gperf libtoo
 WORKDIR /mxe
 
 RUN git clone https://github.com/mxe/mxe . || git pull origin master
-RUN make MXE_TARGETS=i686-w64-mingw32.shared.posix -j 16 \
+RUN make MXE_TARGETS=x86_64-w64-mingw32.shared.posix -j 16 \
     qca \
     qtlocation  \
     qscintilla2  \
@@ -22,5 +22,5 @@ RUN make MXE_TARGETS=i686-w64-mingw32.shared.posix -j 16 \
     libspatialindex \
     exiv2
 
-RUN chmod -R a+rw /mxe/usr/i686-w64-mingw32.shared.posix
+RUN chmod -R a+rw /mxe/usr/x86_64-w64-mingw32.shared.posix
 

--- a/python/core/auto_generated/qgsemfrenderer.sip.in
+++ b/python/core/auto_generated/qgsemfrenderer.sip.in
@@ -1,0 +1,53 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsemfrenderer.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsEmfRenderer
+{
+%Docstring
+
+Utility class for rendering EMF picture content to QPainter devices.
+
+.. versionadded:: 3.10.2
+%End
+
+%TypeHeaderCode
+#include "qgsemfrenderer.h"
+%End
+  public:
+
+    QgsEmfRenderer( const QString &filename );
+%Docstring
+Constructor for QgsEmfRenderer, using the EMF file with the specified ``filename``.
+%End
+
+    QgsEmfRenderer( const QByteArray &contents );
+%Docstring
+Constructor for QgsEmfRenderer, using the EMF content from a byte array.
+%End
+
+    bool render( QPainter *painter, QSizeF size, bool keepAspectRatio = false );
+%Docstring
+Renders the EMF content to the specified ``painter``.
+
+Returns ``True`` if the rendering was successful.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsemfrenderer.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -51,6 +51,7 @@
 %Include auto_generated/qgseditformconfig.sip
 %Include auto_generated/qgseditorwidgetsetup.sip
 %Include auto_generated/qgsellipsoidutils.sip
+%Include auto_generated/qgsemfrenderer.sip
 %Include auto_generated/qgserror.sip
 %Include auto_generated/qgsexpressioncontext.sip
 %Include auto_generated/qgsexpressioncontextgenerator.sip

--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -89,7 +89,7 @@ astyleit() {
 
 for f in "$@"; do
 	case "$f" in
-                src/plugins/grass/qtermwidget/*|external/o2/*|external/qt-unix-signals/*|external/astyle/*|external/kdbush/*|external/wintoast/*|external/qt3dextra-headers/*|python/ext-libs/*|ui_*.py|*.astyle|tests/testdata/*|editors/*)
+                src/plugins/grass/qtermwidget/*|external/o2/*|external/qt-unix-signals/*|external/astyle/*|external/kdbush/*|external/libqemf/*|external/wintoast/*|external/qt3dextra-headers/*|python/ext-libs/*|ui_*.py|*.astyle|tests/testdata/*|editors/*)
 			echo -ne "$f skipped $elcr"
 			continue
 			;;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,6 +17,16 @@ SET(QGIS_CORE_SRCS
   ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep_context.cc
   ${CMAKE_SOURCE_DIR}/external/poly2tri/sweep/sweep.cc
 
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/Bitmap.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/BitmapHeader.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/EmfHeader.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/EmfLogger.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/EmfObjects.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/EmfOutput.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/EmfParser.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/EmfRecords.cpp
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src/QEmfRenderer.cpp
+
   callouts/qgscallout.cpp
   callouts/qgscalloutsregistry.cpp
 
@@ -230,6 +240,7 @@ SET(QGIS_CORE_SRCS
   qgsdistancearea.cpp
   qgseditformconfig.cpp
   qgsellipsoidutils.cpp
+  qgsemfrenderer.cpp
   qgserror.cpp
   qgseventtracing.cpp
   qgsexpressioncontext.cpp
@@ -711,6 +722,7 @@ SET(QGIS_CORE_HDRS
   qgseditformconfig.h
   qgseditorwidgetsetup.h
   qgsellipsoidutils.h
+  qgsemfrenderer.h
   qgserror.h
   qgseventtracing.h
   qgsexception.h
@@ -1325,6 +1337,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/external/kdbush/include
   ${CMAKE_SOURCE_DIR}/external/nmea
   ${CMAKE_SOURCE_DIR}/external/poly2tri
+  ${CMAKE_SOURCE_DIR}/external/libqemf/src
 )
 
 INCLUDE_DIRECTORIES(SYSTEM

--- a/src/core/qgsemfrenderer.cpp
+++ b/src/core/qgsemfrenderer.cpp
@@ -1,0 +1,46 @@
+/***************************************************************************
+                             qgsemfrenderer.cpp
+                             ------------------
+    begin                : December 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsemfrenderer.h"
+#include "QEmfRenderer.h"
+
+
+QgsEmfRenderer::QgsEmfRenderer( const QString &filename )
+  : mFilename( filename )
+{
+
+}
+
+QgsEmfRenderer::QgsEmfRenderer( const QByteArray &contents )
+  : mContents( contents )
+{
+
+}
+
+bool QgsEmfRenderer::render( QPainter *painter, QSizeF size, bool keepAspectRatio )
+{
+  if ( !painter )
+    return false;
+
+  QSize s( size.width(), size.height() );
+  QEmf::QEmfRenderer renderer( *painter, s, keepAspectRatio );
+
+  if ( !mFilename.isEmpty() )
+    return renderer.load( mFilename );
+  else
+    return renderer.load( mContents );
+}

--- a/src/core/qgsemfrenderer.h
+++ b/src/core/qgsemfrenderer.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+                             qgsemfrenderer.h
+                             -----------------
+    begin                : December 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSEMFRENDERER_H
+#define QGSEMFRENDERER_H
+
+
+#include "qgis_core.h"
+#include <QString>
+
+class QPainter;
+class QSizeF;
+
+/**
+ * \class QgsEmfRenderer
+ * \ingroup core
+ *
+ * Utility class for rendering EMF picture content to QPainter devices.
+ *
+ * \since QGIS 3.10.2
+*/
+class CORE_EXPORT QgsEmfRenderer
+{
+  public:
+
+    /**
+     * Constructor for QgsEmfRenderer, using the EMF file with the specified \a filename.
+     */
+    QgsEmfRenderer( const QString &filename );
+
+    /**
+     * Constructor for QgsEmfRenderer, using the EMF content from a byte array.
+     */
+    QgsEmfRenderer( const QByteArray &contents );
+
+    /**
+     * Renders the EMF content to the specified \a painter.
+     *
+     * Returns TRUE if the rendering was successful.
+     */
+    bool render( QPainter *painter, QSizeF size, bool keepAspectRatio = false );
+
+  private:
+
+    QString mFilename;
+    QByteArray mContents;
+
+};
+
+#endif //QGSEMFRENDERER_H


### PR DESCRIPTION
(based on a libqemf backend, with upstreams at https://iondev.ro/qemf/ and https://github.com/KDE/calligra/tree/master/libs/vectorimage/libemf)

(Opened for comment only -- do not merge. If this is deemed fit for inclusion I'll create a fork of libqemf and collate some fixes floating around in various other forks first, and then modernise and cleanup that code)

This adds a new class QgsEmfRenderer which allows for rendering EMF picture files to a QPainter device. This is API only, added to give plugins and scripts the capability to read EMF files (e.g. to allow interoperability with windows clipboard and windows applications which heavily use this format).

I've searched widely but can't find any alternative to this approach -- while there's some pure python emf parsing libraries, they don't provide any hooks into qt's painter classes. So by the time those are added, I'd have ended up just rewriting libqemf anyway...!


