### PR TITLE
[FEATURE][expressions] allow to seed random functions

### DIFF
--- a/resources/function_help/json/rand
+++ b/resources/function_help/json/rand
@@ -1,8 +1,9 @@
 {
   "name": "rand",
   "type": "function",
-  "description": "Returns a random integer within the range specified by the minimum and maximum argument (inclusive).",
+  "description": "Returns a random integer within the range specified by the minimum and maximum argument (inclusive). If a seed is provided, the returned will always be the same, depending on the seed.",
   "arguments": [ {"arg":"min","description":"an integer representing the smallest possible random number desired"},
-                 {"arg":"max","description":"an integer representing the largest possible random number desired"}],
+                 {"arg":"max","description":"an integer representing the largest possible random number desired"},
+                 {"arg":"seed","optional":true,"default":"null","description":"any value to use as seed"}],
   "examples": [ { "expression":"rand(1, 10)", "returns":"8"}]
 }

--- a/resources/function_help/json/randf
+++ b/resources/function_help/json/randf
@@ -1,8 +1,9 @@
 {
   "name": "randf",
   "type": "function",
-  "description": "Returns a random float within the range specified by the minimum and maximum argument (inclusive).",
+  "description": "Returns a random float within the range specified by the minimum and maximum argument (inclusive). If a seed is provided, the returned will always be the same, depending on the seed.",
   "arguments": [ {"arg":"min","optional":true,"default":"0.0","description":"an float representing the smallest possible random number desired"},
-                 {"arg":"max","optional":true,"default":"1.0","description":"an float representing the largest possible random number desired"}],
-  "examples": [ { "expression":"randf(1, 10)", "returns":"4.59258286403147"}]
+                 {"arg":"max","optional":true,"default":"1.0","description":"an float representing the largest possible random number desired"},
+                 {"arg":"seed","optional":true,"default":"null","description":"any value to use as seed"}],
+  "examples": [ { "expression":"randf(1, 10)", "returns":"4.59258286403147"} ]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -369,8 +369,8 @@ static QVariant fcnLog( const QVariantList &values, const QgsExpressionContext *
 }
 static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  double min = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
-  double max = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+  double min = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
+  double max = QgsExpressionUtils::getDoubleValue( values.at( 1 ), parent );
   if ( max < min )
     return QVariant();
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -376,7 +376,6 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
 
   std::random_device rd;
   std::mt19937_64 generator( rd() );
-  std::uniform_real_distribution<double> dist( min, max );
 
   if ( !QgsExpressionUtils::isNull( values.at( 2 ) ) )
   {
@@ -397,7 +396,8 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
   }
 
   // Return a random integer in the range [min, max] (inclusive)
-  return QVariant( dist( generator ) );
+  double f = static_cast< double >( generator() ) / generator.max();
+  return QVariant( min + f * ( max - min ) );
 }
 static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
@@ -408,7 +408,6 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
 
   std::random_device rd;
   std::mt19937_64 generator( rd() );
-  std::uniform_int_distribution<qlonglong> dist( min, max );
 
   if ( !QgsExpressionUtils::isNull( values.at( 2 ) ) )
   {
@@ -429,7 +428,7 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
   }
 
   // Return a random integer in the range [min, max] (inclusive)
-  return QVariant( dist( generator ) );
+  return QVariant( min + ( generator() % ( max - min + 1 ) ) );
 }
 
 static QVariant fcnLinearScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -395,7 +395,7 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
     generator.seed( seed );
   }
 
-  // Return a random integer in the range [min, max] (inclusive)
+  // Return a random double in the range [min, max] (inclusive)
   double f = static_cast< double >( generator() ) / generator.max();
   return QVariant( min + f * ( max - min ) );
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -400,8 +400,8 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
 }
 static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
-  quint32 min = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
-  quint32 max = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+  qlonglong min = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
+  qlonglong max = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
   if ( max < min )
     return QVariant();
 
@@ -429,7 +429,7 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
   }
 
   // Return a random integer in the range [min, max] (inclusive)
-  return QVariant( generator->bounded( min, max + 1 ) );
+  return QVariant( min + static_cast< qlonglong >(generator->bounded( static_cast< quint32 >(max - min + 1) ) ) );
 }
 
 static QVariant fcnLinearScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -375,8 +375,8 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
     return QVariant();
 
   std::random_device rd;
-  std::mt19937_64 generator(rd());
-  std::uniform_real_distribution<double> dist(min, max);
+  std::mt19937_64 generator( rd() );
+  std::uniform_real_distribution<double> dist( min, max );
 
   if ( !QgsExpressionUtils::isNull( values.at( 2 ) ) )
   {
@@ -397,7 +397,7 @@ static QVariant fcnRndF( const QVariantList &values, const QgsExpressionContext 
   }
 
   // Return a random integer in the range [min, max] (inclusive)
-  return QVariant( dist(generator) );
+  return QVariant( dist( generator ) );
 }
 static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
@@ -407,8 +407,8 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
     return QVariant();
 
   std::random_device rd;
-  std::mt19937_64 generator(rd());
-  std::uniform_int_distribution<qlonglong> dist(min, max);
+  std::mt19937_64 generator( rd() );
+  std::uniform_int_distribution<qlonglong> dist( min, max );
 
   if ( !QgsExpressionUtils::isNull( values.at( 2 ) ) )
   {
@@ -429,7 +429,7 @@ static QVariant fcnRnd( const QVariantList &values, const QgsExpressionContext *
   }
 
   // Return a random integer in the range [min, max] (inclusive)
-  return QVariant( dist(generator) );
+  return QVariant( dist( generator ) );
 }
 
 static QVariant fcnLinearScale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2179,20 +2179,17 @@ class TestQgsExpression: public QObject
       QCOMPARE( v7.toInt() <= 10, true );
       QCOMPARE( v7.toInt() >= 1, true );
 
-      // Two calls with the same seed return the same number
+      // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "rand(1,1000000000,1)" ) );
       QVariant v8 = exp8.evaluate();
       QCOMPARE( v8.toInt() == 546311529, true );
-      QgsExpression exp9( QStringLiteral( "rand(1,1000000000,1)" ) );
-      QVariant v9 = exp9.evaluate();
-      QCOMPARE( v9.toInt() == 546311529, true );
 
       // Two calls with a different seed return a different number
-      QgsExpression exp10( QStringLiteral( "rand(1,100000000000,1)" ) );
+      QgsExpression exp9( QStringLiteral( "rand(1,100000000000,1)" ) );
+      QVariant v9 = exp9.evaluate();
+      QgsExpression exp10( QStringLiteral( "rand(1,100000000000,2)" ) );
       QVariant v10 = exp10.evaluate();
-      QgsExpression exp11( QStringLiteral( "rand(1,100000000000,2)" ) );
-      QVariant v11 = exp11.evaluate();
-      QCOMPARE( v10.toInt() != v11.toInt(), true );
+      QCOMPARE( v9.toInt() != v10.toInt(), true );
     }
 
     void eval_randf()
@@ -2229,20 +2226,17 @@ class TestQgsExpression: public QObject
       QCOMPARE( v7.toDouble() <= 9.5, true );
       QCOMPARE( v7.toDouble() >= 1.5, true );
 
-      // Two calls with the same seed return the same number
+      // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v8 = exp8.evaluate();
       QCOMPARE( v8.toFloat() == 0.13387664401253274, true );
-      QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );
-      QVariant v9 = exp9.evaluate();
-      QCOMPARE( v9.toFloat() == 0.13387664401253274, true );
 
       // Two calls with a different seed return a different number
-      QgsExpression exp10( QStringLiteral( "randf(seed:=1)" ) );
+      QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );
+      QVariant v9 = exp9.evaluate();
+      QgsExpression exp10( QStringLiteral( "randf(seed:=2)" ) );
       QVariant v10 = exp10.evaluate();
-      QgsExpression exp11( QStringLiteral( "randf(seed:=2)" ) );
-      QVariant v11 = exp11.evaluate();
-      QCOMPARE( v10.toFloat() != v11.toFloat(), true );
+      QCOMPARE( v9.toFloat() != v10.toFloat(), true );
     }
 
     void referenced_columns()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2162,18 +2162,22 @@ class TestQgsExpression: public QObject
       QCOMPARE( v3.type(),  QVariant::Invalid );
 
       // Supports multiple type of seeds
-      QgsExpression exp4( QStringLiteral( "rand(1,100,123)" ) );
+      QgsExpression exp4( QStringLiteral( "rand(1,10,123)" ) );
       QVariant v4 = exp4.evaluate();
-      QCOMPARE( v4.type(), QVariant::Int );
-      QgsExpression exp5( QStringLiteral( "rand(1,100,1.23)" ) );
+      QCOMPARE( v4.toInt() <= 10, true );
+      QCOMPARE( v4.toInt() >= 1, true );
+      QgsExpression exp5( QStringLiteral( "rand(1,10,1.23)" ) );
       QVariant v5 = exp5.evaluate();
-      QCOMPARE( v5.type(), QVariant::Int );
-      QgsExpression exp6( QStringLiteral( "rand(1,100,'123')" ) );
+      QCOMPARE( v5.toInt() <= 10, true );
+      QCOMPARE( v5.toInt() >= 1, true );
+      QgsExpression exp6( QStringLiteral( "rand(1,10,'123')" ) );
       QVariant v6 = exp6.evaluate();
-      QCOMPARE( v6.type(), QVariant::Int );
-      QgsExpression exp7( QStringLiteral( "rand(1,100,'abc')" ) );
+      QCOMPARE( v6.toInt() <= 10, true );
+      QCOMPARE( v6.toInt() >= 1, true );
+      QgsExpression exp7( QStringLiteral( "rand(1,10,'abc')" ) );
       QVariant v7 = exp7.evaluate();
-      QCOMPARE( v7.type(), QVariant::Int );
+      QCOMPARE( v7.toInt() <= 10, true );
+      QCOMPARE( v7.toInt() >= 1, true );
 
       // Two calls with the same seed return the same number
       QgsExpression exp8( QStringLiteral( "rand(1,1000000000,1)" ) );
@@ -2208,18 +2212,22 @@ class TestQgsExpression: public QObject
       QCOMPARE( v3.type(),  QVariant::Invalid );
 
       // Supports multiple type of seeds
-      QgsExpression exp4( QStringLiteral( "randf(1,100,123)" ) );
+      QgsExpression exp4( QStringLiteral( "randf(1.5,9.5,123)" ) );
       QVariant v4 = exp4.evaluate();
-      QCOMPARE( v4.type(), QVariant::LongLong );
-      QgsExpression exp5( QStringLiteral( "randf(1,100,1.23)" ) );
+      QCOMPARE( v4.toDouble() <= 9.5, true );
+      QCOMPARE( v4.toDouble() >= 1.5, true );
+      QgsExpression exp5( QStringLiteral( "randf(1.5,9.5,1.23)" ) );
       QVariant v5 = exp5.evaluate();
-      QCOMPARE( v5.type(), QVariant::LongLong );
-      QgsExpression exp6( QStringLiteral( "randf(1,100,'123')" ) );
+      QCOMPARE( v5.toDouble() <= 9.5, true );
+      QCOMPARE( v5.toDouble() >= 1.5, true );
+      QgsExpression exp6( QStringLiteral( "randf(1.5,9.5,'123')" ) );
       QVariant v6 = exp6.evaluate();
-      QCOMPARE( v6.type(), QVariant::LongLong );
-      QgsExpression exp7( QStringLiteral( "randf(1,100,'abc')" ) );
+      QCOMPARE( v6.toDouble() <= 9.5, true );
+      QCOMPARE( v6.toDouble() >= 1.5, true );
+      QgsExpression exp7( QStringLiteral( "randf(1.5,9.5,'abc')" ) );
       QVariant v7 = exp7.evaluate();
-      QCOMPARE( v7.type(), QVariant::LongLong );
+      QCOMPARE( v7.toDouble() <= 9.5, true );
+      QCOMPARE( v7.toDouble() >= 1.5, true );
 
       // Two calls with the same seed return the same number
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2229,14 +2229,14 @@ class TestQgsExpression: public QObject
       // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v8 = exp8.evaluate();
-      QCOMPARE( v8.toFloat() == 0.13387664401253274, true );
+      QCOMPARE( v8.toDouble() == 0.13387664401253274, true );
 
       // Two calls with a different seed return a different number
       QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v9 = exp9.evaluate();
       QgsExpression exp10( QStringLiteral( "randf(seed:=2)" ) );
       QVariant v10 = exp10.evaluate();
-      QCOMPARE( v9.toFloat() != v10.toFloat(), true );
+      QCOMPARE( v9.toDouble() != v10.toDouble(), true );
     }
 
     void referenced_columns()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2160,6 +2160,34 @@ class TestQgsExpression: public QObject
       QgsExpression exp3( QStringLiteral( "rand(10,1)" ) );
       QVariant v3 = exp3.evaluate();
       QCOMPARE( v3.type(),  QVariant::Invalid );
+
+      // Supports multiple type of seeds
+      QgsExpression exp4( QStringLiteral( "rand(1,100,123)" ) );
+      QVariant v4 = exp4.evaluate();
+      QCOMPARE( v4.type(), QVariant::Int );
+      QgsExpression exp5( QStringLiteral( "rand(1,100,1.23)" ) );
+      QVariant v5 = exp5.evaluate();
+      QCOMPARE( v5.type(), QVariant::Int );
+      QgsExpression exp6( QStringLiteral( "rand(1,100,'123')" ) );
+      QVariant v6 = exp6.evaluate();
+      QCOMPARE( v6.type(), QVariant::Int );
+      QgsExpression exp7( QStringLiteral( "rand(1,100,'abc')" ) );
+      QVariant v7 = exp7.evaluate();
+      QCOMPARE( v7.type(), QVariant::Int );
+
+      // Two calls with the same seed return the same numer
+      QgsExpression exp8( QStringLiteral( "rand(1,100000000000,1)" ) );
+      QVariant v8 = exp8.evaluate();
+      QgsExpression exp9( QStringLiteral( "rand(1,100000000000,1)" ) );
+      QVariant v9 = exp9.evaluate();
+      QCOMPARE( v8.toInt() == v9.toInt(), true );
+
+      // Two calls with a different seed return a different number
+      QgsExpression exp10( QStringLiteral( "rand(1,100000000000,1)" ) );
+      QVariant v10 = exp10.evaluate();
+      QgsExpression exp11( QStringLiteral( "rand(1,100000000000,2)" ) );
+      QVariant v11 = exp11.evaluate();
+      QCOMPARE( v10.toInt() != v11.toInt(), true );
     }
 
     void eval_randf()
@@ -2177,6 +2205,34 @@ class TestQgsExpression: public QObject
       QgsExpression exp3( QStringLiteral( "randf(9.3333,1.784)" ) );
       QVariant v3 = exp3.evaluate();
       QCOMPARE( v3.type(),  QVariant::Invalid );
+
+      // Supports multiple type of seeds
+      QgsExpression exp4( QStringLiteral( "randf(1,100,123)" ) );
+      QVariant v4 = exp4.evaluate();
+      QCOMPARE( v4.type(), QVariant::Float );
+      QgsExpression exp5( QStringLiteral( "randf(1,100,1.23)" ) );
+      QVariant v5 = exp5.evaluate();
+      QCOMPARE( v5.type(), QVariant::Float );
+      QgsExpression exp6( QStringLiteral( "randf(1,100,'123')" ) );
+      QVariant v6 = exp6.evaluate();
+      QCOMPARE( v6.type(), QVariant::Float );
+      QgsExpression exp7( QStringLiteral( "randf(1,100,'abc')" ) );
+      QVariant v7 = exp7.evaluate();
+      QCOMPARE( v7.type(), QVariant::Float );
+
+      // Two calls with the same seed return the same numer
+      QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );
+      QVariant v8 = exp8.evaluate();
+      QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );
+      QVariant v9 = exp9.evaluate();
+      QCOMPARE( v8.toFloat() == v9.toFloat(), true );
+
+      // Two calls with a different seed return a different number
+      QgsExpression exp10( QStringLiteral( "randf(seed:=1)" ) );
+      QVariant v10 = exp10.evaluate();
+      QgsExpression exp11( QStringLiteral( "randf(seed:=2)" ) );
+      QVariant v11 = exp11.evaluate();
+      QCOMPARE( v10.toFloat() != v11.toFloat(), true );
     }
 
     void referenced_columns()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2209,16 +2209,16 @@ class TestQgsExpression: public QObject
       // Supports multiple type of seeds
       QgsExpression exp4( QStringLiteral( "randf(1,100,123)" ) );
       QVariant v4 = exp4.evaluate();
-      QCOMPARE( v4.type(), QVariant::Float );
+      QCOMPARE( v4.type(), QVariant::Double );
       QgsExpression exp5( QStringLiteral( "randf(1,100,1.23)" ) );
       QVariant v5 = exp5.evaluate();
-      QCOMPARE( v5.type(), QVariant::Float );
+      QCOMPARE( v5.type(), QVariant::Double );
       QgsExpression exp6( QStringLiteral( "randf(1,100,'123')" ) );
       QVariant v6 = exp6.evaluate();
-      QCOMPARE( v6.type(), QVariant::Float );
+      QCOMPARE( v6.type(), QVariant::Double );
       QgsExpression exp7( QStringLiteral( "randf(1,100,'abc')" ) );
       QVariant v7 = exp7.evaluate();
-      QCOMPARE( v7.type(), QVariant::Float );
+      QCOMPARE( v7.type(), QVariant::Double );
 
       // Two calls with the same seed return the same numer
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2175,12 +2175,13 @@ class TestQgsExpression: public QObject
       QVariant v7 = exp7.evaluate();
       QCOMPARE( v7.type(), QVariant::Int );
 
-      // Two calls with the same seed return the same numer
-      QgsExpression exp8( QStringLiteral( "rand(1,100000000000,1)" ) );
+      // Two calls with the same seed return the same number
+      QgsExpression exp8( QStringLiteral( "rand(1,1000000000,1)" ) );
       QVariant v8 = exp8.evaluate();
-      QgsExpression exp9( QStringLiteral( "rand(1,100000000000,1)" ) );
+      QCOMPARE( v8.toInt() == 546311529, true );
+      QgsExpression exp9( QStringLiteral( "rand(1,1000000000,1)" ) );
       QVariant v9 = exp9.evaluate();
-      QCOMPARE( v8.toInt() == v9.toInt(), true );
+      QCOMPARE( v9.toInt() == 546311529, true );
 
       // Two calls with a different seed return a different number
       QgsExpression exp10( QStringLiteral( "rand(1,100000000000,1)" ) );
@@ -2220,12 +2221,13 @@ class TestQgsExpression: public QObject
       QVariant v7 = exp7.evaluate();
       QCOMPARE( v7.type(), QVariant::LongLong );
 
-      // Two calls with the same seed return the same numer
+      // Two calls with the same seed return the same number
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v8 = exp8.evaluate();
+      QCOMPARE( v8.toFloat() == 0.13387664401253274, true );
       QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v9 = exp9.evaluate();
-      QCOMPARE( v8.toFloat() == v9.toFloat(), true );
+      QCOMPARE( v9.toFloat() == 0.13387664401253274, true );
 
       // Two calls with a different seed return a different number
       QgsExpression exp10( QStringLiteral( "randf(seed:=1)" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2149,8 +2149,8 @@ class TestQgsExpression: public QObject
     {
       QgsExpression exp1( QStringLiteral( "rand(1,10)" ) );
       QVariant v1 = exp1.evaluate();
-      QCOMPARE( v1.toInt() <= 10, true );
-      QCOMPARE( v1.toInt() >= 1, true );
+      QVERIFY2( v1.toInt() <= 10, QString( "Calculated: %1 Expected <= %2" ).arg( QString::number( v1.toInt() ), QString::number( 10 ) ).toUtf8().constData() );
+      QVERIFY2( v1.toInt() >= 1, QString( "Calculated: %1 Expected >= %2" ).arg( QString::number( v1.toInt() ), QString::number( 1 ) ).toUtf8().constData() );
 
       QgsExpression exp2( QStringLiteral( "rand(min:=-5,max:=-5)" ) );
       QVariant v2 = exp2.evaluate();
@@ -2164,20 +2164,20 @@ class TestQgsExpression: public QObject
       // Supports multiple type of seeds
       QgsExpression exp4( QStringLiteral( "rand(1,10,123)" ) );
       QVariant v4 = exp4.evaluate();
-      QCOMPARE( v4.toInt() <= 10, true );
-      QCOMPARE( v4.toInt() >= 1, true );
+      QVERIFY2( v4.toInt() <= 10, QString( "Calculated: %1 > Expected %2" ).arg( QString::number( v4.toInt() ), QString::number( 10 ) ).toUtf8().constData() );
+      QVERIFY2( v4.toInt() >= 1, QString( "Calculated: %1 < Expected %2" ).arg( QString::number( v4.toInt() ), QString::number( 1 ) ).toUtf8().constData() );
       QgsExpression exp5( QStringLiteral( "rand(1,10,1.23)" ) );
       QVariant v5 = exp5.evaluate();
-      QCOMPARE( v5.toInt() <= 10, true );
-      QCOMPARE( v5.toInt() >= 1, true );
+      QVERIFY2( v5.toInt() <= 10, QString( "Calculated: %1 > Expected %2" ).arg( QString::number( v5.toInt() ), QString::number( 10 ) ).toUtf8().constData() );
+      QVERIFY2( v5.toInt() >= 1, QString( "Calculated: %1 < Expected %2" ).arg( QString::number( v5.toInt() ), QString::number( 1 ) ).toUtf8().constData() );
       QgsExpression exp6( QStringLiteral( "rand(1,10,'123')" ) );
       QVariant v6 = exp6.evaluate();
-      QCOMPARE( v6.toInt() <= 10, true );
-      QCOMPARE( v6.toInt() >= 1, true );
+      QVERIFY2( v6.toInt() <= 10, QString( "Calculated: %1 > Expected %2" ).arg( QString::number( v6.toInt() ), QString::number( 10 ) ).toUtf8().constData() );
+      QVERIFY2( v6.toInt() >= 1, QString( "Calculated: %1 < Expected %2" ).arg( QString::number( v6.toInt() ), QString::number( 1 ) ).toUtf8().constData() );
       QgsExpression exp7( QStringLiteral( "rand(1,10,'abc')" ) );
       QVariant v7 = exp7.evaluate();
-      QCOMPARE( v7.toInt() <= 10, true );
-      QCOMPARE( v7.toInt() >= 1, true );
+      QVERIFY2( v7.toInt() <= 10, QString( "Calculated: %1 > Expected %2" ).arg( QString::number( v7.toInt() ), QString::number( 10 ) ).toUtf8().constData() );
+      QVERIFY2( v7.toInt() >= 1, QString( "Calculated: %1 < Expected %2" ).arg( QString::number( v7.toInt() ), QString::number( 1 ) ).toUtf8().constData() );
 
       // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "rand(1,1000000000,1)" ) );
@@ -2189,19 +2189,19 @@ class TestQgsExpression: public QObject
       QVariant v9 = exp9.evaluate();
       QgsExpression exp10( QStringLiteral( "rand(1,100000000000,2)" ) );
       QVariant v10 = exp10.evaluate();
-      QCOMPARE( v9.toInt() != v10.toInt(), true );
+      QVERIFY2( v9.toInt() != v10.toInt(), QStringLiteral( "Calculated: %1 Expected != %2" ).arg( QString::number( v9.toInt() ), QString::number( v10.toInt() ) ).toUtf8().constData() );
     }
 
     void eval_randf()
     {
       QgsExpression exp1( QStringLiteral( "randf(1.5,9.5)" ) );
       QVariant v1 = exp1.evaluate();
-      QCOMPARE( v1.toDouble() <= 9.5, true );
-      QCOMPARE( v1.toDouble() >= 1.5, true );
+      QVERIFY2( v1.toDouble() <= 9.5, QStringLiteral( "Calculated: %1 Expected <= %2" ).arg( QString::number( v1.toDouble() ), QString::number( 9.5 ) ).toUtf8().constData() );
+      QVERIFY2( v1.toDouble() >= 1.5, QStringLiteral( "Calculated: %1 Expected >= %2" ).arg( QString::number( v1.toDouble() ), QString::number( 1.5 ) ).toUtf8().constData() );
 
       QgsExpression exp2( QStringLiteral( "randf(min:=-0.0005,max:=-0.0005)" ) );
       QVariant v2 = exp2.evaluate();
-      QCOMPARE( v2.toDouble(), -0.0005 );
+      QVERIFY2( qgsDoubleNear( v2.toDouble(), -0.0005 ), QStringLiteral( "Calculated: %1 != Expected %2" ).arg( QString::number( v2.toDouble() ), QString::number( -0.0005 ) ).toUtf8().constData() );
 
       // Invalid expression since max<min
       QgsExpression exp3( QStringLiteral( "randf(9.3333,1.784)" ) );
@@ -2211,32 +2211,32 @@ class TestQgsExpression: public QObject
       // Supports multiple type of seeds
       QgsExpression exp4( QStringLiteral( "randf(1.5,9.5,123)" ) );
       QVariant v4 = exp4.evaluate();
-      QCOMPARE( v4.toDouble() <= 9.5, true );
-      QCOMPARE( v4.toDouble() >= 1.5, true );
+      QVERIFY2( v4.toDouble() <= 9.5, QStringLiteral( "Calculated: %1 > Expected %2" ).arg( QString::number( v4.toDouble() ), QString::number( 9.5 ) ).toUtf8().constData() );
+      QVERIFY2( v4.toDouble() >= 1.5, QStringLiteral( "Calculated: %1 < Expected %2" ).arg( QString::number( v4.toDouble() ), QString::number( 1.5 ) ).toUtf8().constData() );
       QgsExpression exp5( QStringLiteral( "randf(1.5,9.5,1.23)" ) );
       QVariant v5 = exp5.evaluate();
-      QCOMPARE( v5.toDouble() <= 9.5, true );
-      QCOMPARE( v5.toDouble() >= 1.5, true );
+      QVERIFY2( v5.toDouble() <= 9.5, QStringLiteral( "Calculated: %1 > Expected %2" ).arg( QString::number( v5.toDouble() ), QString::number( 9.5 ) ).toUtf8().constData() );
+      QVERIFY2( v5.toDouble() >= 1.5, QStringLiteral( "Calculated: %1 < Expected %2" ).arg( QString::number( v5.toDouble() ), QString::number( 1.5 ) ).toUtf8().constData() );
       QgsExpression exp6( QStringLiteral( "randf(1.5,9.5,'123')" ) );
       QVariant v6 = exp6.evaluate();
-      QCOMPARE( v6.toDouble() <= 9.5, true );
-      QCOMPARE( v6.toDouble() >= 1.5, true );
+      QVERIFY2( v6.toDouble() <= 9.5, QStringLiteral( "Calculated: %1 > Expected %2" ).arg( QString::number( v6.toDouble() ), QString::number( 9.5 ) ).toUtf8().constData() );
+      QVERIFY2( v6.toDouble() >= 1.5, QStringLiteral( "Calculated: %1 < Expected %2" ).arg( QString::number( v6.toDouble() ), QString::number( 1.5 ) ).toUtf8().constData() );
       QgsExpression exp7( QStringLiteral( "randf(1.5,9.5,'abc')" ) );
       QVariant v7 = exp7.evaluate();
-      QCOMPARE( v7.toDouble() <= 9.5, true );
-      QCOMPARE( v7.toDouble() >= 1.5, true );
+      QVERIFY2( v7.toDouble() <= 9.5, QStringLiteral( "Calculated: %1 > Expected %2" ).arg( QString::number( v7.toDouble() ), QString::number( 9.5 ) ).toUtf8().constData() );
+      QVERIFY2( v7.toDouble() >= 1.5, QStringLiteral( "Calculated: %1 < Expected %2" ).arg( QString::number( v7.toDouble() ), QString::number( 1.5 ) ).toUtf8().constData() );
 
       // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v8 = exp8.evaluate();
-      QVERIFY( qgsDoubleNear( v8.toDouble(), 0.13387664401253274 ) );
+      QVERIFY2( qgsDoubleNear( v8.toDouble(), 0.13387664401253274 ), QStringLiteral( "Calculated: %1 != Expected %2" ).arg( QString::number( v8.toDouble() ), QString::number( 0.13387664401253274 ) ).toUtf8().constData() );
 
       // Two calls with a different seed return a different number
       QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v9 = exp9.evaluate();
       QgsExpression exp10( QStringLiteral( "randf(seed:=2)" ) );
       QVariant v10 = exp10.evaluate();
-      QCOMPARE( v9.toDouble() != v10.toDouble(), true );
+      QVERIFY2( ! qgsDoubleNear( v9.toDouble(), v10.toDouble() ), QStringLiteral( "Calculated: %1 == Expected %2" ).arg( QString::number( v9.toDouble() ), QString::number( v10.toDouble() ) ).toUtf8().constData() );
     }
 
     void referenced_columns()

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2209,16 +2209,16 @@ class TestQgsExpression: public QObject
       // Supports multiple type of seeds
       QgsExpression exp4( QStringLiteral( "randf(1,100,123)" ) );
       QVariant v4 = exp4.evaluate();
-      QCOMPARE( v4.type(), QVariant::Double );
+      QCOMPARE( v4.type(), QVariant::LongLong );
       QgsExpression exp5( QStringLiteral( "randf(1,100,1.23)" ) );
       QVariant v5 = exp5.evaluate();
-      QCOMPARE( v5.type(), QVariant::Double );
+      QCOMPARE( v5.type(), QVariant::LongLong );
       QgsExpression exp6( QStringLiteral( "randf(1,100,'123')" ) );
       QVariant v6 = exp6.evaluate();
-      QCOMPARE( v6.type(), QVariant::Double );
+      QCOMPARE( v6.type(), QVariant::LongLong );
       QgsExpression exp7( QStringLiteral( "randf(1,100,'abc')" ) );
       QVariant v7 = exp7.evaluate();
-      QCOMPARE( v7.type(), QVariant::Double );
+      QCOMPARE( v7.type(), QVariant::LongLong );
 
       // Two calls with the same seed return the same numer
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2182,7 +2182,7 @@ class TestQgsExpression: public QObject
       // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "rand(1,1000000000,1)" ) );
       QVariant v8 = exp8.evaluate();
-      QCOMPARE( v8.toInt() == 546311529, true );
+      QCOMPARE( v8.toInt(), 546311529 );
 
       // Two calls with a different seed return a different number
       QgsExpression exp9( QStringLiteral( "rand(1,100000000000,1)" ) );
@@ -2229,7 +2229,7 @@ class TestQgsExpression: public QObject
       // Two calls with the same seed always return the same number
       QgsExpression exp8( QStringLiteral( "randf(seed:=1)" ) );
       QVariant v8 = exp8.evaluate();
-      QCOMPARE( v8.toDouble() == 0.13387664401253274, true );
+      QVERIFY( qgsDoubleNear( v8.toDouble(), 0.13387664401253274 ) );
 
       // Two calls with a different seed return a different number
       QgsExpression exp9( QStringLiteral( "randf(seed:=1)" ) );


### PR DESCRIPTION
## Description

This PR adds an optional seed parameter to `rand()` and `randf()` functions, as per issue #20630

This is very useful if you want the result to be deterministic, for instance to assign random but fixed colors to features. Using `color_hsb(rand(0,360,$id),50,50)` for instance yields always the same color for the same feature.

By the way, the PR also improves the `rand()` function, which didn't work for high values (over 32000) by using Qt's QRandomGenerator instead of qrand (which it seems was deprecated in Qt 5.11).

The PR is backwards compatible as the new parameter is optional, and the previous values were random anyway.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
