### PR TITLE
[Bugfix] add guard to prevent crash with mesh layer vector renderer

### DIFF
--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -362,6 +362,7 @@ void QgsMeshLayerRenderer::renderVectorDataset()
         mLayerExtent,
         mOutputSize ) );
 
-  renderer->draw();
+  if ( renderer )
+    renderer->draw();
 }
 


### PR DESCRIPTION
If the vector renderer factory returns a null ptr, this prevents QGIS crashing


- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
