### PR TITLE
Skip right-hand side of AND/OR expression if we already know result

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -298,14 +298,22 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
 
     case boAnd:
     {
-      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent ), tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
+      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent );
+      ENSURE_NO_EVAL_ERROR;
+      if ( tvlL == QgsExpressionUtils::False )
+        return TVL_False;  // shortcut -- no need to evaluate right-hand side
+      QgsExpressionUtils::TVL tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
       ENSURE_NO_EVAL_ERROR;
       return  QgsExpressionUtils::tvl2variant( QgsExpressionUtils::AND[tvlL][tvlR] );
     }
 
     case boOr:
     {
-      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent ), tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
+      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent );
+      ENSURE_NO_EVAL_ERROR;
+      if ( tvlL == QgsExpressionUtils::True )
+        return TVL_True;  // shortcut -- no need to evaluate right-hand side
+      QgsExpressionUtils::TVL tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
       ENSURE_NO_EVAL_ERROR;
       return  QgsExpressionUtils::tvl2variant( QgsExpressionUtils::OR[tvlL][tvlR] );
     }

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -178,6 +178,17 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
 {
   QVariant vL = mOpLeft->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
+
+  if ( mOp == boAnd || mOp == boOr )
+  {
+    QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent );
+    ENSURE_NO_EVAL_ERROR;
+    if ( mOp == boAnd && tvlL == QgsExpressionUtils::False )
+      return TVL_False;  // shortcut -- no need to evaluate right-hand side
+    if ( mOp == boOr && tvlL == QgsExpressionUtils::True )
+      return TVL_True;  // shortcut -- no need to evaluate right-hand side
+  }
+
   QVariant vR = mOpRight->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
 
@@ -298,22 +309,14 @@ QVariant QgsExpressionNodeBinaryOperator::evalNode( QgsExpression *parent, const
 
     case boAnd:
     {
-      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent );
-      ENSURE_NO_EVAL_ERROR;
-      if ( tvlL == QgsExpressionUtils::False )
-        return TVL_False;  // shortcut -- no need to evaluate right-hand side
-      QgsExpressionUtils::TVL tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
+      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent ), tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
       ENSURE_NO_EVAL_ERROR;
       return  QgsExpressionUtils::tvl2variant( QgsExpressionUtils::AND[tvlL][tvlR] );
     }
 
     case boOr:
     {
-      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent );
-      ENSURE_NO_EVAL_ERROR;
-      if ( tvlL == QgsExpressionUtils::True )
-        return TVL_True;  // shortcut -- no need to evaluate right-hand side
-      QgsExpressionUtils::TVL tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
+      QgsExpressionUtils::TVL tvlL = QgsExpressionUtils::getTVLValue( vL, parent ), tvlR = QgsExpressionUtils::getTVLValue( vR, parent );
       ENSURE_NO_EVAL_ERROR;
       return  QgsExpressionUtils::tvl2variant( QgsExpressionUtils::OR[tvlL][tvlR] );
     }


### PR DESCRIPTION
In "A and B" expression, if A evaluates to false, we skip evaluation of B.
In "A or B" expression, if A evaluates to true, we skip evaluation of B.

This is commonly used compilers, it's nearly embarrassing we don't use it in expressions yet :-)

On a test map that more heavily uses expressions I could measure ~5% improvement (on release build).