### PR TITLE
Huge speedup when labels are set to "boundary" obstacle mode

### DIFF
--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -558,8 +558,8 @@ bool LabelPosition::crossesBoundary( PointSet *polygon ) const
   GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
   try
   {
-    if ( GEOSPreparedOverlaps_r( geosctxt, polygon->preparedGeom(), mGeos ) == 1
-         || GEOSPreparedTouches_r( geosctxt, polygon->preparedGeom(), mGeos ) == 1 )
+    if ( GEOSPreparedIntersects_r( geosctxt, polygon->preparedGeom(), mGeos ) == 1
+         && GEOSPreparedContains_r( geosctxt, polygon->preparedGeom(), mGeos ) != 1 )
     {
       return true;
     }


### PR DESCRIPTION
Because GEOS prepared predicates are "stubbed out" for many relation types,
such as overlaps and touches, we can get a HUGE speedup by reworking
the obstacle boundary check to utilise an intersects and within check instead
(with the same results)
