### PR TITLE
iface.newProject() should return False if a new project could not be created

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -687,9 +687,17 @@ Adds a mesh layer to the current project.
 %Docstring
 Adds (opens) a project
 %End
-    virtual void newProject( bool promptToSaveFlag = false ) = 0;
+
+    virtual bool newProject( bool promptToSaveFlag = false ) = 0;
 %Docstring
-Starts a new blank project
+Starts a new blank project.
+
+If ``promptToSaveFlag`` is ``True`` then users will be prompted to save any currently open
+project (if that project has changes). If the flag is ``False``, then the current project will
+be closed without prompting to save (possibly resulting in data loss).
+
+Since QGIS 3.10.1, returns ``True`` if a new project was created, or ``False`` if the operation was not successful (e.g.
+the user opted to cancel when prompted to save the current project).
 %End
 
     virtual void reloadConnections( ) = 0;

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -167,9 +167,9 @@ bool QgisAppInterface::addProject( const QString &projectName )
   return qgis->addProject( projectName );
 }
 
-void QgisAppInterface::newProject( bool promptToSaveFlag )
+bool QgisAppInterface::newProject( bool promptToSaveFlag )
 {
-  qgis->fileNew( promptToSaveFlag );
+  return qgis->fileNew( promptToSaveFlag );
 }
 
 void QgisAppInterface::reloadConnections()

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -71,7 +71,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QgsRasterLayer *addRasterLayer( const QString &url, const QString &baseName, const QString &providerKey ) override;
     QgsMeshLayer *addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) override;
     bool addProject( const QString &projectName ) override;
-    void newProject( bool promptToSaveFlag = false ) override;
+    bool newProject( bool promptToSaveFlag = false ) override;
     void reloadConnections( ) override;
     QgsMapLayer *activeLayer() override;
     bool setActiveLayer( QgsMapLayer *layer ) override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -616,8 +616,18 @@ class GUI_EXPORT QgisInterface : public QObject
 
     //! Adds (opens) a project
     virtual bool addProject( const QString &project ) = 0;
-    //! Starts a new blank project
-    virtual void newProject( bool promptToSaveFlag = false ) = 0;
+
+    /**
+     * Starts a new blank project.
+     *
+     * If \a promptToSaveFlag is TRUE then users will be prompted to save any currently open
+     * project (if that project has changes). If the flag is FALSE, then the current project will
+     * be closed without prompting to save (possibly resulting in data loss).
+     *
+     * Since QGIS 3.10.1, returns TRUE if a new project was created, or FALSE if the operation was not successful (e.g.
+     * the user opted to cancel when prompted to save the current project).
+     */
+    virtual bool newProject( bool promptToSaveFlag = false ) = 0;
 
     /**
      * Triggered when connections have changed.


### PR DESCRIPTION
 (e.g. if the user opts to cancel when prompted to save the current project)
