### PR TITLE
DBManager PostgreSQL backend using core APIs instead of psycopg2

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -73,14 +73,11 @@ class CursorAdapter():
             self._execute()
 
     def _toStrResultSet(self, res):
-        #print("XXX type of QVariant(None) is " + str(type(QVariant(None))))
         newres = []
         for rec in res:
             newrec = []
             for col in rec:
-                #print("XXX col of rec of resultset valued " + str(col)+ " is typed " + str(type(col)))
                 if type(col) == type(QVariant(None)):
-                    #print("XXX qvariant type of " + str(col)+ " is " + str(col.type))
                     if (str(col) == 'NULL'):
                         col = None
                     else:
@@ -97,7 +94,7 @@ class CursorAdapter():
         if (self.sql == None):
             return
         self._debug("execute called with sql " + self.sql)
-        self.result = self._toStrResultSet(self.connection._executeSql(self.sql))
+        self.result = self._toStrResultSet(self.connection.executeSql(self.sql))
         self._debug("execute returned " + str(len(self.result)) + " rows")
         self.cursor = 0
         self.description = []
@@ -1121,7 +1118,7 @@ class PostGisDBConnector(DBConnector):
         if cursor != None:
             cursor._execute(sql)
             return cursor
-        return CursorAdapter(self, sql)
+        return CursorAdapter(self.core_connection, sql)
 
     def _executeSql(self, sql):
         return self.core_connection.executeSql(sql)
@@ -1129,7 +1126,7 @@ class PostGisDBConnector(DBConnector):
     def _get_cursor(self, name=None):
         #if name is not None:
         #   print("XXX _get_cursor called with a Name: " + name)
-        return CursorAdapter(self, name)
+        return CursorAdapter(self.core_connection, name)
 
     def _commit(self):
         pass

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -166,12 +166,12 @@ class PostGisDBConnector(DBConnector):
 
         :param uri: data source URI
         :type uri: QgsDataSourceUri
-        :param dbplugin: the PostGisDBPlugin parent instance
-        :type dbplugin: PostGisDbPlugin
         """
         DBConnector.__init__(self, uri)
 
-        self.dbname = uri.database()
+        username = uri.username() or os.environ.get('PGUSER')
+        self.dbname = uri.database() or os.environ.get('PGDATABASE') or username
+        uri.setDatabase(self.dbname)
 
         #self.connName = connName
         #self.user = uri.username() or os.environ.get('USER')

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -37,7 +37,6 @@ from qgis.core import (
     QgsCredentials,
     QgsDataSourceUri,
     QgsProviderRegistry,
-    QgsAbstractDatabaseProviderConnection,
     QgsProviderConnectionException,
 )
 
@@ -59,7 +58,7 @@ def classFactory():
 class CursorAdapter():
 
     def _debug(self, msg):
-        print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
+        #print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
 
     def __init__(self, connection, sql=None):
         self._debug("Created with sql: " + str(sql))
@@ -1127,8 +1126,8 @@ class PostGisDBConnector(DBConnector):
         return self.core_connection.executeSql(sql)
 
     def _get_cursor(self, name=None):
-        if name is not None:
-            print("XXX _get_cursor called with a Name: " + name)
+        #if name is not None:
+        #   print("XXX _get_cursor called with a Name: " + name)
         return CursorAdapter(self, name)
 
     def _commit(self):

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -95,7 +95,10 @@ class CursorAdapter():
         if (self.sql == None):
             return
         self._debug("execute called with sql " + self.sql)
-        self.result = self._toStrResultSet(self.connection.executeSql(self.sql))
+        try:
+            self.result = self._toStrResultSet(self.connection.executeSql(self.sql))
+        except QgsProviderConnectionException as e:
+            raise DbError(e, self.sql)
         self._debug("execute returned " + str(len(self.result)) + " rows")
         self.cursor = 0
 

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -26,7 +26,12 @@ from builtins import range
 
 from functools import cmp_to_key
 
-from qgis.PyQt.QtCore import QRegExp, QFile, QCoreApplication
+from qgis.PyQt.QtCore import (
+    QRegExp,
+    QFile,
+    QCoreApplication,
+    QVariant
+)
 from qgis.core import (
     Qgis,
     QgsCredentials,
@@ -62,6 +67,21 @@ class CursorProxy():
         if (self.sql != None):
             self._execute()
 
+    def _toStrResultSet(self, res):
+        #print("XXX type of QVariant(None) is " + str(type(QVariant(None))))
+        newres = []
+        for rec in res:
+            newrec = []
+            for col in rec:
+                #print("XXX col of rec of resultset valued " + str(col)+ " is typed " + str(type(col)))
+                if type(col) == type(QVariant(None)):
+                    #print("XXX qvariant type of " + str(col)+ " is " + str(col.type))
+                    if (str(col) == 'NULL'):
+                        col = None
+                newrec.append(col)
+            newres.append(newrec)
+        return newres
+
     def _execute(self, sql=None):
         if self.sql == sql and self.result != None:
             print ("XXX CursorProxy execute called with sql " + sql)
@@ -70,7 +90,7 @@ class CursorProxy():
             self.sql = sql
         if (self.sql == None):
             return
-        self.result = self.connection._executeSql(self.sql)
+        self.result = self._toStrResultSet(self.connection._executeSql(self.sql))
         self.description = []
         if len(self.result):
             for i in range(len(self.result)):

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -60,7 +60,7 @@ class CursorAdapter():
 
     def _debug(self, msg):
         pass
-        print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
+        #print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
 
     def __init__(self, connection, sql=None):
         self._debug("Created with sql: " + str(sql))

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -58,7 +58,8 @@ def classFactory():
 class CursorAdapter():
 
     def _debug(self, msg):
-        #print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
+        pass
+        print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
 
     def __init__(self, connection, sql=None):
         self._debug("Created with sql: " + str(sql))

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -123,7 +123,7 @@ class CursorAdapter():
                 f = fields[i]
                 self._description.append([
                     f.name(),                         # name
-                    str,                              # type_code
+                    f.type(),                         # type_code
                     f.length(),                       # display_size
                     f.length(),                       # internal_size
                     f.precision(),                    # precision

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -56,10 +56,10 @@ def classFactory():
     return PostGisDBConnector
 
 
-class CursorProxy():
+class CursorAdapter():
 
     def _debug(self, msg):
-        print("XXX CursorProxy[" + hex(id(self)) + "]: " + msg)
+        print("XXX CursorAdapter[" + hex(id(self)) + "]: " + msg)
 
     def __init__(self, connection, sql=None):
         self._debug("Created with sql: " + str(sql))
@@ -1119,7 +1119,7 @@ class PostGisDBConnector(DBConnector):
         if cursor != None:
             cursor._execute(sql)
             return cursor
-        return CursorProxy(self, sql)
+        return CursorAdapter(self, sql)
 
     def _executeSql(self, sql):
         return self.core_connection.executeSql(sql)
@@ -1127,7 +1127,7 @@ class PostGisDBConnector(DBConnector):
     def _get_cursor(self, name=None):
         if name is not None:
             print("XXX _get_cursor called with a Name: " + name)
-        return CursorProxy(self, name)
+        return CursorAdapter(self, name)
 
     def _commit(self):
         pass

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -63,7 +63,6 @@ class CursorProxy():
         self.result = None
         self.closed = False
         self.description = None
-        print ("XXX CursorProxy initialized with sql " + sql)
         if (self.sql != None):
             self._execute()
 
@@ -78,6 +77,8 @@ class CursorProxy():
                     #print("XXX qvariant type of " + str(col)+ " is " + str(col.type))
                     if (str(col) == 'NULL'):
                         col = None
+                    else:
+                        col = str(col) # force to string
                 newrec.append(col)
             newres.append(newrec)
         return newres

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -69,7 +69,6 @@ class CursorAdapter():
         self.result = None
         self.cursor = 0
         self.closed = False
-        self.description = None
         if (self.sql != None):
             self._execute()
 
@@ -102,30 +101,38 @@ class CursorAdapter():
         self._debug("execute returned " + str(len(self.result)) + " rows")
         self.cursor = 0
 
-        self.description = []
+        self._description = None # reset description
 
-        uri = QgsDataSourceUri(self.connection.uri())
+    @property
+    def description(self):
 
-        # TODO: make this part provider-agnostic
-        uri.setTable('(SELECT row_number() OVER () AS __rid__, * FROM (' + self.sql + ') as foo)')
-        uri.setKeyColumn('__rid__')
-        # TODO: fetch provider name from connection (QgsAbstractConnectionProvider)
-        # TODO: re-use the VectorLayer for fetching rows in batch mode
-        vl = QgsVectorLayer(uri.uri(False), 'dbmanager_cursor', 'postgres')
+        if self._description is None:
 
-        fields = vl.fields()
-        for i in range(1, len(fields)): # skip first field (__rid__)
-            f = fields[i]
-            self.description.append([
-                f.name(),                         # name
-                str,                              # type_code
-                10,                               # display_size
-                10,                               # internal_size
-                0,                                # precision
-                None,                             # scale
-                True                              # null_ok
-            ])
-        self._debug("execute returned " + str(len(self.description)) + " cols")
+            uri = QgsDataSourceUri(self.connection.uri())
+
+            # TODO: make this part provider-agnostic
+            uri.setTable('(SELECT row_number() OVER () AS __rid__, * FROM (' + self.sql + ') as foo)')
+            uri.setKeyColumn('__rid__')
+            # TODO: fetch provider name from connection (QgsAbstractConnectionProvider)
+            # TODO: re-use the VectorLayer for fetching rows in batch mode
+            vl = QgsVectorLayer(uri.uri(False), 'dbmanager_cursor', 'postgres')
+
+            fields = vl.fields()
+            self._description = []
+            for i in range(1, len(fields)): # skip first field (__rid__)
+                f = fields[i]
+                self._description.append([
+                    f.name(),                         # name
+                    str,                              # type_code
+                    10,                               # display_size
+                    10,                               # internal_size
+                    0,                                # precision
+                    None,                             # scale
+                    True                              # null_ok
+                ])
+            self._debug("get_description returned " + str(len(self._description)) + " cols")
+
+        return self._description
 
     def fetchone(self):
         self._execute()

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -161,7 +161,7 @@ class CursorAdapter():
 
 class PostGisDBConnector(DBConnector):
 
-    def __init__(self, uri, dbplugin):
+    def __init__(self, uri):
         """Creates a new PostgreSQL connector
 
         :param uri: data source URI
@@ -178,11 +178,8 @@ class PostGisDBConnector(DBConnector):
         #self.passwd = uri.password()
         self.host = uri.host()
 
-        self.dbplugin = dbplugin
-        md = QgsProviderRegistry.instance().providerMetadata(dbplugin.providerName())
-        self.core_connection = md.findConnection(dbplugin.connectionName())
-        if self.core_connection is None:
-            self.core_connection = md.createConnection(dbplugin.connectionName(), uri.database())
+        md = QgsProviderRegistry.instance().providerMetadata('postgres')
+        self.core_connection = md.createConnection(uri.database())
 
         c = self._execute(None, u"SELECT current_user,current_database()")
         self.user, self.dbname = self._fetchone(c)

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -170,8 +170,13 @@ class PostGisDBConnector(DBConnector):
         DBConnector.__init__(self, uri)
 
         username = uri.username() or os.environ.get('PGUSER')
-        self.dbname = uri.database() or os.environ.get('PGDATABASE') or username
-        uri.setDatabase(self.dbname)
+
+        # Do not get db and user names from the env if service is used
+        if not uri.service():
+            if username is None:
+                username = os.environ.get('USER')
+            self.dbname = uri.database() or os.environ.get('PGDATABASE') or username
+            uri.setDatabase(self.dbname)
 
         #self.connName = connName
         #self.user = uri.username() or os.environ.get('USER')

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -124,9 +124,9 @@ class CursorAdapter():
                 self._description.append([
                     f.name(),                         # name
                     str,                              # type_code
-                    10,                               # display_size
-                    10,                               # internal_size
-                    0,                                # precision
+                    f.length(),                       # display_size
+                    f.length(),                       # internal_size
+                    f.precision(),                    # precision
                     None,                             # scale
                     True                              # null_ok
                 ])

--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -112,7 +112,7 @@ class PGDatabase(Database):
         Database.__init__(self, connection, uri)
 
     def connectorsFactory(self, uri):
-        return PostGisDBConnector(uri, self.connection())
+        return PostGisDBConnector(uri)
 
     def dataTablesFactory(self, row, db, schema=None):
         return PGTable(row, db, schema)

--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -112,7 +112,7 @@ class PGDatabase(Database):
         Database.__init__(self, connection, uri)
 
     def connectorsFactory(self, uri):
-        return PostGisDBConnector(uri)
+        return PostGisDBConnector(uri, self.connection())
 
     def dataTablesFactory(self, row, db, schema=None):
         return PGTable(row, db, schema)
@@ -183,6 +183,9 @@ class PGDatabase(Database):
 
     def supportsComment(self):
         return True
+
+    def executeSql(self, sql):
+        return self.connector._executeSql(sql)
 
 
 class PGSchema(Schema):

--- a/python/plugins/db_manager/db_plugins/postgis/plugins/qgis_topoview/__init__.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugins/qgis_topoview/__init__.py
@@ -44,10 +44,10 @@ def load(db, mainwindow):
     sql = u"""SELECT count(*)
                 FROM pg_class AS cls JOIN pg_namespace AS nsp ON nsp.oid = cls.relnamespace
                 WHERE cls.relname = 'topology' AND nsp.nspname = 'topology'"""
-    c = db.connector._get_cursor()
-    db.connector._execute(c, sql)
-    res = db.connector._fetchone(c)
-    if res is None or int(res[0]) <= 0:
+    #c = db.connector._get_cursor()
+    #db.connector._execute(c, sql)
+    res = db.executeSql(sql)
+    if res is None or len(res) < 1 or int(res[0][0]) <= 0:
         return
 
     # add the action to the DBManager menu

--- a/python/plugins/db_manager/db_plugins/postgis/plugins/qgis_topoview/__init__.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugins/qgis_topoview/__init__.py
@@ -33,19 +33,18 @@ import os
 
 current_path = os.path.dirname(__file__)
 
-
 # The load function is called when the "db" database or either one of its
 # children db objects (table o schema) is selected by the user.
 # @param db is the selected database
 # @param mainwindow is the DBManager mainwindow
+
+
 def load(db, mainwindow):
     # check whether the selected database supports topology
     # (search for topology.topology)
     sql = u"""SELECT count(*)
                 FROM pg_class AS cls JOIN pg_namespace AS nsp ON nsp.oid = cls.relnamespace
                 WHERE cls.relname = 'topology' AND nsp.nspname = 'topology'"""
-    #c = db.connector._get_cursor()
-    #db.connector._execute(c, sql)
     res = db.executeSql(sql)
     if res is None or len(res) < 1 or int(res[0][0]) <= 0:
         return
@@ -78,10 +77,8 @@ def run(item, action, mainwindow):
 
     if item.schema() is not None:
         sql = u"SELECT srid FROM topology.topology WHERE name = %s" % quoteStr(item.schema().name)
-        c = db.connector._get_cursor()
-        db.connector._execute(c, sql)
-        res = db.connector._fetchone(c)
-        isTopoSchema = res is not None
+        res = db.executeSql(sql)
+        isTopoSchema = len(res) > 0
 
     if not isTopoSchema:
         mainwindow.infoBar.pushMessage("Invalid topology",
@@ -90,11 +87,11 @@ def run(item, action, mainwindow):
                                        mainwindow.iface.messageTimeout())
         return False
 
-    if (res[0] < 0):
+    if (res[0][0] < 0):
         mainwindow.infoBar.pushMessage("WARNING", u'Topology "{0}" is registered as having a srid of {1} in topology.topology, we will assume 0 (for unknown)'.format(item.schema().name, res[0]), Qgis.Warning, mainwindow.iface.messageTimeout())
         toposrid = '0'
     else:
-        toposrid = str(res[0])
+        toposrid = str(res[0][0])
 
     # load layers into the current project
     toponame = item.schema().name

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -95,68 +95,27 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
     nameChanged = pyqtSignal(str)
     QUERY_HISTORY_LIMIT = 20
 
-    def set_connection(self, db):
-
-        # 'db' is a Database class as defined in db_plugins/plugin.py
-        #
-        # We need to hook on the reconnectAction of the Database class
-        # to invoke connectToUri again against the plugin, which is
-        # not yet known how to access from Database itself
-
-        # db parameter is <class 'db_manager.db_plugins.postgis.plugin.PGDatabase'>
-        print("XXX db parameter is " + str(type(db)))
-        print("XXX db uri is " + str(db.uri()))
-        # db_plugins/plugin.py:    def connectToUri(self, uri):
-
-        # db uri is <qgis._core.QgsDataSourceUri object at 0x7f003ac30e58>
-        self.uri = db.uri()
-
-        self.db = db
-
-        self.dbType = db.connection().typeNameString()
-        self.connectionName = db.connection().connectionName()
-        self.allowMultiColumnPk = isinstance(db, PGDatabase)  # at the moment only PostgreSQL allows a primary key to span multiple columns, SpatiaLite doesn't
-        self.aliasSubQuery = isinstance(db, PGDatabase)       # only PostgreSQL requires subqueries to be aliases
-        self.setWindowTitle(
-            self.tr(u"{0} - {1} [{2}]").format(self.windowTitle(), self.connectionName, self.dbType))
-
-        settings = QgsSettings()
-
-        self.history = settings.value('DB_Manager/queryHistory/' + self.dbType, {self.connectionName: []})
-        if self.connectionName not in self.history:
-            self.history[self.connectionName] = []
-        if self.allowMultiColumnPk:
-            self.uniqueColumnCheck.setText(self.tr("Column(s) with unique values"))
-        else:
-            self.uniqueColumnCheck.setText(self.tr("Column with unique values"))
-
-        # hide the load query as layer if feature is not supported
-        self._loadAsLayerAvailable = self.db.connector.hasCustomQuerySupport()
-        self.loadAsLayerGroup.setVisible(self._loadAsLayerAvailable)
-        if self._loadAsLayerAvailable:
-            self.layerTypeWidget.hide()  # show if load as raster is supported
-            self.loadLayerBtn.clicked.connect(self.loadSqlLayer)
-            self.getColumnsBtn.clicked.connect(self.fillColumnCombos)
-            self.loadAsLayerGroup.toggled.connect(self.loadAsLayerToggled)
-            self.loadAsLayerToggled(False)
-
-        self._createViewAvailable = self.db.connector.hasCreateSpatialViewSupport()
-        self.btnCreateView.setVisible(self._createViewAvailable)
-        if self._createViewAvailable:
-            self.btnCreateView.clicked.connect(self.createView)
-
     def __init__(self, iface, db, parent=None):
         QWidget.__init__(self, parent)
         self.mainWindow = parent
         self.iface = iface
-
-        self.setupUi(self)
-
-        self.set_connection(db)
+        self.db = db
+        self.dbType = db.connection().typeNameString()
+        self.connectionName = db.connection().connectionName()
         self.filter = ""
         self.modelAsync = None
+        self.allowMultiColumnPk = isinstance(db, PGDatabase)  # at the moment only PostgreSQL allows a primary key to span multiple columns, SpatiaLite doesn't
+        self.aliasSubQuery = isinstance(db, PGDatabase)       # only PostgreSQL requires subqueries to be aliases
+        self.setupUi(self)
+        self.setWindowTitle(
+            self.tr(u"{0} - {1} [{2}]").format(self.windowTitle(), self.connectionName, self.dbType))
 
         self.defaultLayerName = self.tr('QueryLayer')
+
+        if self.allowMultiColumnPk:
+            self.uniqueColumnCheck.setText(self.tr("Column(s) with unique values"))
+        else:
+            self.uniqueColumnCheck.setText(self.tr("Column with unique values"))
 
         self.editSql.setFocus()
         self.editSql.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
@@ -164,6 +123,9 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         self.initCompleter()
 
         settings = QgsSettings()
+        self.history = settings.value('DB_Manager/queryHistory/' + self.dbType, {self.connectionName: []})
+        if self.connectionName not in self.history:
+            self.history[self.connectionName] = []
 
         self.queryHistoryWidget.setVisible(False)
         self.queryHistoryTableWidget.verticalHeader().hide()
@@ -211,6 +173,21 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             self.uniqueCombo.setItemDelegate(QStyledItemDelegate())
             self.uniqueModel.itemChanged.connect(self.uniqueChanged)                 # react to the (un)checking of an item
             self.uniqueCombo.lineEdit().textChanged.connect(self.uniqueTextChanged)  # there are other events that change the displayed text and some of them can not be caught directly
+
+        # hide the load query as layer if feature is not supported
+        self._loadAsLayerAvailable = self.db.connector.hasCustomQuerySupport()
+        self.loadAsLayerGroup.setVisible(self._loadAsLayerAvailable)
+        if self._loadAsLayerAvailable:
+            self.layerTypeWidget.hide()  # show if load as raster is supported
+            self.loadLayerBtn.clicked.connect(self.loadSqlLayer)
+            self.getColumnsBtn.clicked.connect(self.fillColumnCombos)
+            self.loadAsLayerGroup.toggled.connect(self.loadAsLayerToggled)
+            self.loadAsLayerToggled(False)
+
+        self._createViewAvailable = self.db.connector.hasCreateSpatialViewSupport()
+        self.btnCreateView.setVisible(self._createViewAvailable)
+        if self._createViewAvailable:
+            self.btnCreateView.clicked.connect(self.createView)
 
         self.queryBuilderFirst = True
         self.queryBuilderBtn.setIcon(QIcon(":/db_manager/icons/sql.gif"))
@@ -422,15 +399,11 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             old_model.deleteLater()
 
         try:
-            print("XXX db is still " + str(type(self.db)))
-            print("XXX db uri still " + str(self.db.uri()))
             self.modelAsync = self.db.sqlResultModelAsync(sql, self)
-            print("XXX db.sqlResultModelAsync returned")
             self.modelAsync.done.connect(self.executeSqlCompleted)
             self.updateUiWhileSqlExecution(True)
             QgsApplication.taskManager().addTask(self.modelAsync.task)
         except Exception as e:
-            print("XXX sqlResultModelAsync or subsequent calls threw ", e)
             DlgDbError.showError(e, self)
             self.uniqueModel.clear()
             self.geomCombo.clear()

--- a/src/providers/postgres/qgspostgresproviderconnection.cpp
+++ b/src/providers/postgres/qgspostgresproviderconnection.cpp
@@ -281,6 +281,10 @@ QList<QVariantList> QgsPostgresProviderConnection::executeSqlPrivate( const QStr
             {
               vType = QVariant::Bool;
             }
+            else
+            {
+              QgsDebugMsg( QStringLiteral( "Unhandled PostgreSQL type %1" ).arg( typName ) );
+            }
           }
           typeMap[ rowIdx ] = vType;
         }


### PR DESCRIPTION
The DBManager's SQL window gets stuck when the connection to the (PostgreSQL) database is interrupted (for example on backend restart). This PR is aimed at providing a solution, either as automatic-reconnect or user-requested reconnect action.

See #31994