### PR TITLE
[postgres] Speed up array parsing (fixes #33226)

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -4412,11 +4412,10 @@ static void jumpSpace( const QString &txt, int &i )
 QString QgsPostgresProvider::getNextString( const QString &txt, int &i, const QString &sep )
 {
   jumpSpace( txt, i );
-  QString cur = txt.mid( i );
-  if ( cur.startsWith( '"' ) )
+  if ( i < txt.length() && txt.at( i ) == '"' )
   {
     QRegExp stringRe( "^\"((?:\\\\.|[^\"\\\\])*)\".*" );
-    if ( !stringRe.exactMatch( cur ) )
+    if ( !stringRe.exactMatch( txt.mid( i ) ) )
     {
       QgsMessageLog::logMessage( tr( "Cannot find end of double quoted string: %1" ).arg( txt ), tr( "PostGIS" ) );
       return QString();
@@ -4433,14 +4432,17 @@ QString QgsPostgresProvider::getNextString( const QString &txt, int &i, const QS
   }
   else
   {
-    int sepPos = cur.indexOf( sep );
-    if ( sepPos < 0 )
+    int start = i;
+    for ( ; i < txt.length(); i++ )
     {
-      i += cur.length();
-      return cur.trimmed();
+      if ( txt.midRef( i ).startsWith( sep ) )
+      {
+        QStringRef r( txt.midRef( start, i - start ) );
+        i += sep.length();
+        return r.trimmed().toString();
+      }
     }
-    i += sepPos + sep.length();
-    return cur.left( sepPos ).trimmed();
+    return txt.midRef( start, i - start ).trimmed().toString();
   }
 }
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Speed up the way the PostgreSQL provider parses arrays (of numbers).

With the small benchmark detailed [here](https://github.com/qgis/QGIS/issues/33226), array parsing now takes around 0.2s, which is still slower than raw strings or bytea handling, but way better than before (it was >10s for the same test)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
