### PR TITLE
Add option to auto-rotate canvas to GPS bearing, show GPS bearing as a line over map

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -232,6 +232,7 @@ SET(QGIS_APP_SRCS
   locator/qgsinbuiltlocatorfilters.cpp
   locator/qgslocatoroptionswidget.cpp
 
+  gps/qgsgpsbearingitem.cpp
   gps/qgsgpsinformationwidget.cpp
   gps/qgsgpsmarker.cpp
 

--- a/src/app/gps/qgsgpsbearingitem.cpp
+++ b/src/app/gps/qgsgpsbearingitem.cpp
@@ -1,0 +1,80 @@
+/***************************************************************************
+    qgsgpsbearingitem.cpp
+    ---------------------
+    begin                : December 2019
+    copyright            : (C) 2019 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QPainter>
+#include <QObject>
+
+#include "qgsgpsbearingitem.h"
+#include "qgscoordinatetransform.h"
+#include "qgsmapcanvas.h"
+#include "qgsexception.h"
+#include "qgsproject.h"
+#include "qgsmessagelog.h"
+#include "qgssymbol.h"
+
+
+QgsGpsBearingItem::QgsGpsBearingItem( QgsMapCanvas *mapCanvas )
+  : QgsMapCanvasLineSymbolItem( mapCanvas )
+{
+  mSymbol->setColor( QColor( 255, 0, 0 ) );
+  mWgs84CRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
+
+  connect( mMapCanvas, &QgsMapCanvas::rotationChanged, this, &QgsGpsBearingItem::updateLine );
+  connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsGpsBearingItem::updateLine );
+}
+
+void QgsGpsBearingItem::setGpsPosition( const QgsPointXY &point )
+{
+  //transform to map crs
+  if ( mMapCanvas )
+  {
+    QgsCoordinateTransform t( mWgs84CRS, mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+    try
+    {
+      mCenter = t.transform( point );
+    }
+    catch ( QgsCsException &e ) //silently ignore transformation exceptions
+    {
+      QgsMessageLog::logMessage( QObject::tr( "Error transforming the map center point: %1" ).arg( e.what() ), QStringLiteral( "GPS" ), Qgis::Warning );
+      return;
+    }
+  }
+  else
+  {
+    mCenter = point;
+  }
+  updateLine();
+}
+
+void QgsGpsBearingItem::setGpsBearing( double bearing )
+{
+  mBearing = bearing;
+  updateLine();
+}
+
+void QgsGpsBearingItem::updatePosition()
+{
+  setGpsPosition( mCenter );
+}
+
+void QgsGpsBearingItem::updateLine()
+{
+  QLineF bearingLine;
+  bearingLine.setP1( toCanvasCoordinates( mCenter ) );
+  bearingLine.setLength( 5 * std::max( mMapCanvas->width(), mMapCanvas->height() ) );
+  bearingLine.setAngle( 90 - mBearing  - mMapCanvas->rotation() );
+  setLine( bearingLine );
+}

--- a/src/app/gps/qgsgpsbearingitem.cpp
+++ b/src/app/gps/qgsgpsbearingitem.cpp
@@ -32,6 +32,8 @@ QgsGpsBearingItem::QgsGpsBearingItem( QgsMapCanvas *mapCanvas )
   mSymbol->setColor( QColor( 255, 0, 0 ) );
   mWgs84CRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
 
+  setZValue( 199 );
+
   connect( mMapCanvas, &QgsMapCanvas::rotationChanged, this, &QgsGpsBearingItem::updateLine );
   connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsGpsBearingItem::updateLine );
 }

--- a/src/app/gps/qgsgpsbearingitem.h
+++ b/src/app/gps/qgsgpsbearingitem.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+    qgsgpsbearingitem.h
+    -------------------
+    begin                : December 2019
+    copyright            : (C) 2019 Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGPSBEARINGITEM_H
+#define QGSGPSBEARINGITEM_H
+
+#include "qgspointmarkeritem.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgspointxy.h"
+
+class QPainter;
+class QgsLineSymbol;
+
+/**
+ * \ingroup app
+ * A canvas item for showing the bearing of the GPS device
+ */
+class QgsGpsBearingItem : public QObject, QgsMapCanvasLineSymbolItem
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsGpsBearingItem( QgsMapCanvas *mapCanvas );
+
+    void setGpsPosition( const QgsPointXY &point );
+    void setGpsBearing( double bearing );
+
+    void updatePosition() override;
+
+  protected:
+
+    //! coordinates of the point in the center
+    QgsPointXY mCenter;
+
+  private:
+    void updateLine();
+
+    QgsCoordinateReferenceSystem mWgs84CRS;
+    double mBearing = 0;
+
+};
+
+#endif // QGSGPSBEARINGITEM_H

--- a/src/app/gps/qgsgpsbearingitem.h
+++ b/src/app/gps/qgsgpsbearingitem.h
@@ -27,7 +27,7 @@ class QgsLineSymbol;
  * \ingroup app
  * A canvas item for showing the bearing of the GPS device
  */
-class QgsGpsBearingItem : public QObject, QgsMapCanvasLineSymbolItem
+class QgsGpsBearingItem : public QObject, public QgsMapCanvasLineSymbolItem
 {
     Q_OBJECT
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -71,8 +71,8 @@ const int MAXACQUISITIONINTERVAL = 3000; // max gps information acquisition susp
 const int MAXDISTANCETHRESHOLD = 200; // max gps distance threshold (in meters)
 
 
-QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidget *parent, Qt::WindowFlags f )
-  : QWidget( parent, f )
+QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidget *parent )
+  : QgsPanelWidget( parent )
   , mMapCanvas( mapCanvas )
 {
   Q_ASSERT( mMapCanvas ); // precondition

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -37,6 +37,7 @@ class QgsGpsTrackerThread;
 struct QgsGpsInformation;
 class QgsMapCanvas;
 class QgsFeature;
+class QgsGpsBearingItem;
 
 class QFile;
 class QColor;
@@ -102,6 +103,8 @@ class APP_EXPORT QgsGpsInformationWidget: public QWidget, private Ui::QgsGpsInfo
     QgsGpsConnection *mNmea = nullptr;
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsGpsMarker *mMapMarker = nullptr;
+    QgsGpsBearingItem *mMapBearingItem = nullptr;
+
     QwtPlot *mPlot = nullptr;
     QwtPlotCurve *mCurve = nullptr;
 #ifdef WITH_QWTPOLAR

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -24,6 +24,7 @@
 #include "nmeatime.h"
 #include "qgsgpsmarker.h"
 #include "qgsmaptoolcapture.h"
+#include "qgspanelwidget.h"
 #include <qwt_plot_curve.h>
 #ifdef WITH_QWTPOLAR
 #include <qwt_polar_plot.h>
@@ -46,11 +47,11 @@ class QColor;
  * A dock widget that displays information from a GPS device and
  * allows the user to capture features using gps readings to
  * specify the geometry.*/
-class APP_EXPORT QgsGpsInformationWidget: public QWidget, private Ui::QgsGpsInformationWidgetBase
+class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::QgsGpsInformationWidgetBase
 {
     Q_OBJECT
   public:
-    QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
+    QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr );
     ~QgsGpsInformationWidget() override;
   private slots:
     void mConnectButton_toggled( bool flag );

--- a/src/app/gps/qgsgpsmarker.cpp
+++ b/src/app/gps/qgsgpsmarker.cpp
@@ -30,6 +30,7 @@ QgsGpsMarker::QgsGpsMarker( QgsMapCanvas *mapCanvas )
   mSize = 16;
   mWgs84CRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
   mSvg.load( QStringLiteral( ":/images/north_arrows/gpsarrow2.svg" ) );
+  setZValue( 200 );
 }
 
 void QgsGpsMarker::setSize( int size )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1164,6 +1164,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   // create the GPS tool on starting QGIS - this is like the browser
   mpGpsWidget = new QgsGpsInformationWidget( mMapCanvas );
+  QgsPanelWidgetStack *gpsStack = new QgsPanelWidgetStack();
+  gpsStack->setMainPanel( mpGpsWidget );
+  mpGpsWidget->setDockMode( true );
   //create the dock widget
   mpGpsDock = new QgsDockWidget( tr( "GPS Information" ), this );
 
@@ -1177,7 +1180,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   addDockWidget( Qt::LeftDockWidgetArea, mpGpsDock );
   // add to the Panel submenu
   // now add our widget to the dock - ownership of the widget is passed to the dock
-  mpGpsDock->setWidget( mpGpsWidget );
+  mpGpsDock->setWidget( gpsStack );
   mpGpsDock->hide();
 
   mLastMapToolMessage = nullptr;

--- a/src/app/qgsmaptooloffsetpointsymbol.cpp
+++ b/src/app/qgsmaptooloffsetpointsymbol.cpp
@@ -176,7 +176,7 @@ void QgsMapToolOffsetPointSymbol::createPreviewItem( QgsMarkerSymbol *markerSymb
 
   mOffsetItem = new QgsPointMarkerItem( mCanvas );
   mOffsetItem->setOpacity( 0.7 );
-  mOffsetItem->setSymbol( markerSymbol->clone() );
+  mOffsetItem->setSymbol( std::unique_ptr< QgsSymbol >( markerSymbol->clone() ) );
 }
 
 QMap<int, QVariant> QgsMapToolOffsetPointSymbol::calculateNewOffsetAttributes( const QgsPointXY &startPoint, const QgsPointXY &endPoint ) const

--- a/src/app/qgsmaptooloffsetpointsymbol.cpp
+++ b/src/app/qgsmaptooloffsetpointsymbol.cpp
@@ -174,7 +174,7 @@ void QgsMapToolOffsetPointSymbol::createPreviewItem( QgsMarkerSymbol *markerSymb
     return;
   }
 
-  mOffsetItem = new QgsPointMarkerItem( mCanvas );
+  mOffsetItem = new QgsMapCanvasMarkerSymbolItem( mCanvas );
   mOffsetItem->setOpacity( 0.7 );
   mOffsetItem->setSymbol( std::unique_ptr< QgsSymbol >( markerSymbol->clone() ) );
 }

--- a/src/app/qgsmaptooloffsetpointsymbol.h
+++ b/src/app/qgsmaptooloffsetpointsymbol.h
@@ -21,7 +21,7 @@
 #include "qgis_app.h"
 
 class QgsMarkerSymbol;
-class QgsPointMarkerItem;
+class QgsMapCanvasMarkerSymbolItem;
 
 /**
  * \ingroup app
@@ -59,7 +59,7 @@ class APP_EXPORT QgsMapToolOffsetPointSymbol: public QgsMapToolPointSymbol
     bool mOffsetting;
 
     //! Item that previews the offset during mouse move
-    QgsPointMarkerItem *mOffsetItem = nullptr;
+    QgsMapCanvasMarkerSymbolItem *mOffsetItem = nullptr;
 
     //! Clone of first found marker symbol for feature with offset attribute set
     std::unique_ptr< QgsMarkerSymbol > mMarkerSymbol;

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -22,14 +22,19 @@
 #include <QPainter>
 #include <cmath>
 
-QgsPointMarkerItem::QgsPointMarkerItem( QgsMapCanvas *canvas )
+
+//
+// QgsMapCanvasSymbolItem
+//
+
+QgsMapCanvasSymbolItem::QgsMapCanvasSymbolItem( QgsMapCanvas *canvas )
   : QgsMapCanvasItem( canvas )
   , mOpacityEffect( new QgsDrawSourceEffect() )
 {
   setCacheMode( QGraphicsItem::ItemCoordinateCache );
 }
 
-QgsRenderContext QgsPointMarkerItem::renderContext( QPainter *painter )
+QgsRenderContext QgsMapCanvasSymbolItem::renderContext( QPainter *painter )
 {
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
@@ -56,7 +61,7 @@ QgsRenderContext QgsPointMarkerItem::renderContext( QPainter *painter )
   return rc;
 }
 
-void QgsPointMarkerItem::paint( QPainter *painter )
+void QgsMapCanvasSymbolItem::paint( QPainter *painter )
 {
   if ( !painter )
   {
@@ -73,9 +78,9 @@ void QgsPointMarkerItem::paint( QPainter *painter )
     mOpacityEffect->begin( rc );
   }
 
-  mMarkerSymbol->startRender( rc, mFeature.fields() );
-  mMarkerSymbol->renderPoint( mLocation - pos(), &mFeature, rc );
-  mMarkerSymbol->stopRender( rc );
+  mSymbol->startRender( rc, mFeature.fields() );
+  renderSymbol( rc, mFeature );
+  mSymbol->stopRender( rc );
 
   if ( useEffect )
   {
@@ -83,32 +88,52 @@ void QgsPointMarkerItem::paint( QPainter *painter )
   }
 }
 
+void QgsMapCanvasSymbolItem::setSymbol( std::unique_ptr< QgsSymbol > symbol )
+{
+  mSymbol = std::move( symbol );
+}
+
+const QgsSymbol *QgsMapCanvasSymbolItem::symbol() const
+{
+  return mSymbol.get();
+}
+
+void QgsMapCanvasSymbolItem::setFeature( const QgsFeature &feature )
+{
+  mFeature = feature;
+}
+void QgsMapCanvasSymbolItem::setOpacity( double opacity )
+{
+  mOpacityEffect->setOpacity( opacity );
+}
+
+double QgsMapCanvasSymbolItem::opacity() const
+{
+  return mOpacityEffect->opacity();
+}
+
+
+//
+// QgsPointMarkerItem
+//
+
+QgsPointMarkerItem::QgsPointMarkerItem( QgsMapCanvas *canvas )
+  : QgsMapCanvasSymbolItem( canvas )
+{
+}
+
+
 void QgsPointMarkerItem::setPointLocation( const QgsPointXY &p )
 {
   mLocation = toCanvasCoordinates( p );
 }
 
-void QgsPointMarkerItem::setSymbol( QgsMarkerSymbol *symbol )
-{
-  mMarkerSymbol.reset( symbol );
-}
-
-QgsMarkerSymbol *QgsPointMarkerItem::symbol()
-{
-  return mMarkerSymbol.get();
-}
-
-void QgsPointMarkerItem::setFeature( const QgsFeature &feature )
-{
-  mFeature = feature;
-}
-
 void QgsPointMarkerItem::updateSize()
 {
   QgsRenderContext rc = renderContext( nullptr );
-  mMarkerSymbol->startRender( rc, mFeature.fields() );
-  QRectF bounds = mMarkerSymbol->bounds( mLocation, rc, mFeature );
-  mMarkerSymbol->stopRender( rc );
+  markerSymbol()->startRender( rc, mFeature.fields() );
+  QRectF bounds = markerSymbol()->bounds( mLocation, rc, mFeature );
+  markerSymbol()->stopRender( rc );
   QgsRectangle r( mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( bounds.x() ),
                   static_cast<int>( bounds.y() ) ),
                   mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( bounds.x() + bounds.width() * 2 ),
@@ -116,13 +141,15 @@ void QgsPointMarkerItem::updateSize()
   setRect( r );
 }
 
-void QgsPointMarkerItem::setOpacity( double opacity )
+void QgsPointMarkerItem::renderSymbol( QgsRenderContext &context, const QgsFeature &feature )
 {
-  mOpacityEffect->setOpacity( opacity );
+  markerSymbol()->renderPoint( mLocation - pos(), &feature, context );
 }
 
-double QgsPointMarkerItem::opacity() const
+QgsMarkerSymbol *QgsPointMarkerItem::markerSymbol()
 {
-  return mOpacityEffect->opacity();
+  QgsMarkerSymbol *marker = dynamic_cast< QgsMarkerSymbol * >( mSymbol.get() );
+  Q_ASSERT( marker );
+  return marker;
 }
 

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -117,18 +117,19 @@ double QgsMapCanvasSymbolItem::opacity() const
 // QgsPointMarkerItem
 //
 
-QgsPointMarkerItem::QgsPointMarkerItem( QgsMapCanvas *canvas )
+QgsMapCanvasMarkerSymbolItem::QgsMapCanvasMarkerSymbolItem( QgsMapCanvas *canvas )
   : QgsMapCanvasSymbolItem( canvas )
 {
+  setSymbol( qgis::make_unique< QgsMarkerSymbol >() );
 }
 
 
-void QgsPointMarkerItem::setPointLocation( const QgsPointXY &p )
+void QgsMapCanvasMarkerSymbolItem::setPointLocation( const QgsPointXY &p )
 {
   mLocation = toCanvasCoordinates( p );
 }
 
-void QgsPointMarkerItem::updateSize()
+void QgsMapCanvasMarkerSymbolItem::updateSize()
 {
   QgsRenderContext rc = renderContext( nullptr );
   markerSymbol()->startRender( rc, mFeature.fields() );
@@ -141,15 +142,53 @@ void QgsPointMarkerItem::updateSize()
   setRect( r );
 }
 
-void QgsPointMarkerItem::renderSymbol( QgsRenderContext &context, const QgsFeature &feature )
+void QgsMapCanvasMarkerSymbolItem::renderSymbol( QgsRenderContext &context, const QgsFeature &feature )
 {
   markerSymbol()->renderPoint( mLocation - pos(), &feature, context );
 }
 
-QgsMarkerSymbol *QgsPointMarkerItem::markerSymbol()
+QgsMarkerSymbol *QgsMapCanvasMarkerSymbolItem::markerSymbol()
 {
   QgsMarkerSymbol *marker = dynamic_cast< QgsMarkerSymbol * >( mSymbol.get() );
   Q_ASSERT( marker );
   return marker;
 }
+
+
+
+//
+// QgsLineMarkerItem
+//
+
+QgsMapCanvasLineSymbolItem::QgsMapCanvasLineSymbolItem( QgsMapCanvas *canvas )
+  : QgsMapCanvasSymbolItem( canvas )
+{
+  setSymbol( qgis::make_unique< QgsLineSymbol >() );
+}
+
+void QgsMapCanvasLineSymbolItem::setLine( const QLineF &line )
+{
+  mLine = line;
+  update();
+}
+
+QRectF QgsMapCanvasLineSymbolItem::boundingRect() const
+{
+  return mMapCanvas->rect();
+}
+
+void QgsMapCanvasLineSymbolItem::renderSymbol( QgsRenderContext &context, const QgsFeature &feature )
+{
+  QPolygonF points;
+  points << mLine.p1() << mLine.p2();
+  lineSymbol()->renderPolyline( points, &feature, context );
+}
+
+QgsLineSymbol *QgsMapCanvasLineSymbolItem::lineSymbol()
+{
+  QgsLineSymbol *symbol = dynamic_cast< QgsLineSymbol * >( mSymbol.get() );
+  Q_ASSERT( symbol );
+  return symbol;
+}
+
 

--- a/src/app/qgspointmarkeritem.h
+++ b/src/app/qgspointmarkeritem.h
@@ -99,7 +99,7 @@ class APP_EXPORT QgsMapCanvasSymbolItem: public QgsMapCanvasItem
 
 /**
  * \ingroup app
- * \class QgsPointMarkerItem
+ * \class QgsMapCanvasMarkerSymbolItem
  * \brief An item that shows a point marker symbol centered on a map location.
  */
 class APP_EXPORT QgsMapCanvasMarkerSymbolItem: public QgsMapCanvasSymbolItem
@@ -131,7 +131,7 @@ class APP_EXPORT QgsMapCanvasMarkerSymbolItem: public QgsMapCanvasSymbolItem
 
 /**
  * \ingroup app
- * \class QgsLineMarkerItem
+ * \class QgsMapCanvasLineSymbolItem
  * \brief An item that shows a line symbol over the map.
  */
 class APP_EXPORT QgsMapCanvasLineSymbolItem: public QgsMapCanvasSymbolItem

--- a/src/app/qgspointmarkeritem.h
+++ b/src/app/qgspointmarkeritem.h
@@ -102,11 +102,11 @@ class APP_EXPORT QgsMapCanvasSymbolItem: public QgsMapCanvasItem
  * \class QgsPointMarkerItem
  * \brief An item that shows a point marker symbol centered on a map location.
  */
-class APP_EXPORT QgsPointMarkerItem: public QgsMapCanvasSymbolItem
+class APP_EXPORT QgsMapCanvasMarkerSymbolItem: public QgsMapCanvasSymbolItem
 {
   public:
 
-    QgsPointMarkerItem( QgsMapCanvas *canvas = nullptr );
+    QgsMapCanvasMarkerSymbolItem( QgsMapCanvas *canvas = nullptr );
 
     /**
      * Sets the center point of the marker symbol (in map coordinates)
@@ -127,6 +127,33 @@ class APP_EXPORT QgsPointMarkerItem: public QgsMapCanvasSymbolItem
     QPointF mLocation;
 
     QgsMarkerSymbol *markerSymbol();
+};
+
+/**
+ * \ingroup app
+ * \class QgsLineMarkerItem
+ * \brief An item that shows a line symbol over the map.
+ */
+class APP_EXPORT QgsMapCanvasLineSymbolItem: public QgsMapCanvasSymbolItem
+{
+  public:
+
+    QgsMapCanvasLineSymbolItem( QgsMapCanvas *canvas = nullptr );
+
+    /**
+     * Sets the line to draw (in map coordinates)
+    */
+    void setLine( const QLineF &line );
+
+    QRectF boundingRect() const override;
+
+    void renderSymbol( QgsRenderContext &context, const QgsFeature &feature ) override;
+
+  private:
+
+    QLineF mLine;
+
+    QgsLineSymbol *lineSymbol();
 };
 
 #endif // QGSPOINTMARKERITEM_H

--- a/src/app/qgspointmarkeritem.h
+++ b/src/app/qgspointmarkeritem.h
@@ -27,19 +27,86 @@
 
 class QgsMarkerSymbol;
 
+
+/**
+ * \ingroup app
+ * \class QgsMapCanvasSymbolItem
+ * \brief Base class for map canvas items which are rendered using a QgsSymbol.
+ */
+class APP_EXPORT QgsMapCanvasSymbolItem: public QgsMapCanvasItem
+{
+  public:
+
+    QgsMapCanvasSymbolItem( QgsMapCanvas *canvas = nullptr );
+
+    void paint( QPainter *painter ) override;
+
+    /**
+     * Sets the symbol to use for rendering the item.
+     * \see symbol()
+     */
+    void setSymbol( std::unique_ptr< QgsSymbol > symbol );
+
+    /**
+     * Returns the symbol used for rendering the item.
+     * \see setSymbol()
+     */
+    const QgsSymbol *symbol() const;
+
+    /**
+     * Sets the feature used for rendering the symbol. The feature's attributes
+     * may affect the rendered symbol if data defined overrides are in place.
+     * \param feature feature for symbol
+     * \see feature()
+     */
+    void setFeature( const QgsFeature &feature );
+
+    /**
+     * Returns the feature used for rendering the symbol.
+     * \see setFeature()
+     */
+    QgsFeature feature() const { return mFeature; }
+
+    /**
+     * Sets the \a opacity for the item.
+     * \param opacity double between 0 and 1 inclusive, where 0 is fully transparent
+     * and 1 is fully opaque
+     * \see opacity()
+     */
+    void setOpacity( double opacity );
+
+    /**
+     * Returns the opacity for the item.
+     * \returns opacity value between 0 and 1 inclusive, where 0 is fully transparent
+     * and 1 is fully opaque
+     * \see setOpacity()
+     */
+    double opacity() const;
+
+  protected:
+
+    virtual void renderSymbol( QgsRenderContext &context, const QgsFeature &feature ) = 0;
+
+    QgsRenderContext renderContext( QPainter *painter );
+    std::unique_ptr< QgsSymbol > mSymbol;
+    QgsFeature mFeature;
+
+  private:
+
+    std::unique_ptr< QgsDrawSourceEffect > mOpacityEffect;
+
+};
+
 /**
  * \ingroup app
  * \class QgsPointMarkerItem
  * \brief An item that shows a point marker symbol centered on a map location.
  */
-
-class APP_EXPORT QgsPointMarkerItem: public QgsMapCanvasItem
+class APP_EXPORT QgsPointMarkerItem: public QgsMapCanvasSymbolItem
 {
   public:
 
     QgsPointMarkerItem( QgsMapCanvas *canvas = nullptr );
-
-    void paint( QPainter *painter ) override;
 
     /**
      * Sets the center point of the marker symbol (in map coordinates)
@@ -48,65 +115,18 @@ class APP_EXPORT QgsPointMarkerItem: public QgsMapCanvasItem
     void setPointLocation( const QgsPointXY &p );
 
     /**
-     * Sets the marker symbol to use for rendering the point. Note - you may need to call
-     * updateSize() after setting the symbol.
-     * \param symbol marker symbol. Ownership is transferred to item.
-     * \see symbol()
-     * \see updateSize()
-     */
-    void setSymbol( QgsMarkerSymbol *symbol );
-
-    /**
-     * Returns the marker symbol used for rendering the point.
-     * \see setSymbol()
-     */
-    QgsMarkerSymbol *symbol();
-
-    /**
-     * Sets the feature used for rendering the marker symbol. The feature's attributes
-     * may affect the rendered symbol if data defined overrides are in place.
-     * \param feature feature for symbol
-     * \see feature()
-     * \see updateSize()
-     */
-    void setFeature( const QgsFeature &feature );
-
-    /**
-     * Returns the feature used for rendering the marker symbol.
-     * \see setFeature()
-     */
-    QgsFeature feature() const { return mFeature; }
-
-    /**
      * Must be called after setting the symbol or feature and when the symbol's size may
      * have changed.
      */
     void updateSize();
 
-    /**
-     * Sets the \a opacity for the marker.
-     * \param opacity double between 0 and 1 inclusive, where 0 is fully transparent
-     * and 1 is fully opaque
-     * \see opacity()
-     */
-    void setOpacity( double opacity );
-
-    /**
-     * Returns the opacity for the marker.
-     * \returns opacity value between 0 and 1 inclusive, where 0 is fully transparent
-     * and 1 is fully opaque
-     * \see setOpacity()
-     */
-    double opacity() const;
+    void renderSymbol( QgsRenderContext &context, const QgsFeature &feature ) override;
 
   private:
 
-    QgsFeature mFeature;
-    std::unique_ptr< QgsMarkerSymbol > mMarkerSymbol;
     QPointF mLocation;
-    std::unique_ptr< QgsDrawSourceEffect > mOpacityEffect;
 
-    QgsRenderContext renderContext( QPainter *painter );
+    QgsMarkerSymbol *markerSymbol();
 };
 
 #endif // QGSPOINTMARKERITEM_H

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>QgsGpsInformationWidgetBase</class>
- <widget class="QWidget" name="QgsGpsInformationWidgetBase">
+ <widget class="QgsPanelWidget" name="QgsGpsInformationWidgetBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -1414,14 +1414,14 @@ gray = no data
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsfieldcombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -956,6 +956,16 @@ gray = no data
                 </property>
                </widget>
               </item>
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="radRecenterMap">
+                <property name="text">
+                 <string>Always</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
               <item row="2" column="0">
                <layout class="QHBoxLayout" name="horizontalLayout">
                 <property name="leftMargin">
@@ -998,13 +1008,10 @@ gray = no data
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QRadioButton" name="radRecenterMap">
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="mRotateMapCheckBox">
                 <property name="text">
-                 <string>Always</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
+                 <string>Rotate map to match GPS direction</string>
                 </property>
                </widget>
               </item>
@@ -1412,6 +1419,7 @@ gray = no data
   <tabstop>radRecenterWhenNeeded</tabstop>
   <tabstop>mSpinMapExtentMultiplier</tabstop>
   <tabstop>radNeverRecenter</tabstop>
+  <tabstop>mRotateMapCheckBox</tabstop>
   <tabstop>mLogFileGroupBox</tabstop>
   <tabstop>mTxtLogFile</tabstop>
   <tabstop>mBtnLogFile</tabstop>
@@ -1433,6 +1441,11 @@ gray = no data
   <tabstop>mTxtQuality</tabstop>
   <tabstop>mTxtStatus</tabstop>
   <tabstop>mTxtSatellitesUsed</tabstop>
+  <tabstop>mCboTimestampField</tabstop>
+  <tabstop>mCboTimestampFormat</tabstop>
+  <tabstop>mCboTimeZones</tabstop>
+  <tabstop>mLeapSeconds</tabstop>
+  <tabstop>mCbxLeapSeconds</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -598,6 +598,120 @@ gray = no data
            <property name="verticalSpacing">
             <number>4</number>
            </property>
+           <item row="7" column="0">
+            <widget class="QgsCollapsibleGroupBox" name="mLogFileGroupBox">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>save GPS data (NMEA sentences) to a file</string>
+             </property>
+             <property name="title">
+              <string>Log file</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_13" columnstretch="100,0">
+              <property name="topMargin">
+               <number>2</number>
+              </property>
+              <property name="bottomMargin">
+               <number>4</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLineEdit" name="mTxtLogFile">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="acceptDrops">
+                 <bool>false</bool>
+                </property>
+                <property name="readOnly">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="mBtnLogFile">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>23</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>23</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>browse for log file</string>
+                </property>
+                <property name="text">
+                 <string>…</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QgsCollapsibleGroupBox" name="groupBox_4">
+             <property name="title">
+              <string>Filtering</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_14" columnstretch="0,1">
+              <item row="1" column="1">
+               <widget class="QComboBox" name="mCboDistanceThreshold">
+                <property name="editable">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_9">
+                <property name="text">
+                 <string>Distance threshold (meters)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_8">
+                <property name="text">
+                 <string>Acquisition interval (seconds)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="mCboAcquisitionInterval">
+                <property name="editable">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
            <item row="0" column="0">
             <widget class="QgsCollapsibleGroupBox" name="mDeviceGroupBox">
              <property name="title">
@@ -766,258 +880,6 @@ gray = no data
              </layout>
             </widget>
            </item>
-           <item row="3" column="0">
-            <widget class="QgsCollapsibleGroupBox" name="mGroupShowMarker">
-             <property name="title">
-              <string>Cursor</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_3">
-              <property name="topMargin">
-               <number>4</number>
-              </property>
-              <property name="bottomMargin">
-               <number>4</number>
-              </property>
-              <property name="verticalSpacing">
-               <number>2</number>
-              </property>
-              <item row="1" column="2">
-               <widget class="QLabel" name="label_2">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Large</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>10</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="0" column="0" colspan="3">
-               <widget class="QSlider" name="mSliderMarkerSize">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimum">
-                 <number>8</number>
-                </property>
-                <property name="maximum">
-                 <number>128</number>
-                </property>
-                <property name="singleStep">
-                 <number>4</number>
-                </property>
-                <property name="pageStep">
-                 <number>8</number>
-                </property>
-                <property name="sliderPosition">
-                 <number>10</number>
-                </property>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="tickPosition">
-                 <enum>QSlider::TicksBelow</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Small</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QgsCollapsibleGroupBox" name="mLogFileGroupBox">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>save GPS data (NMEA sentences) to a file</string>
-             </property>
-             <property name="title">
-              <string>Log file</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_13" columnstretch="100,0">
-              <property name="topMargin">
-               <number>2</number>
-              </property>
-              <property name="bottomMargin">
-               <number>4</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLineEdit" name="mTxtLogFile">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="acceptDrops">
-                 <bool>false</bool>
-                </property>
-                <property name="readOnly">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QPushButton" name="mBtnLogFile">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>23</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>23</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string>browse for log file</string>
-                </property>
-                <property name="text">
-                 <string>…</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
-             <property name="title">
-              <string>Map Centering</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_8">
-              <property name="topMargin">
-               <number>2</number>
-              </property>
-              <property name="bottomMargin">
-               <number>4</number>
-              </property>
-              <property name="verticalSpacing">
-               <number>2</number>
-              </property>
-              <item row="1" column="0">
-               <widget class="QRadioButton" name="radRecenterWhenNeeded">
-                <property name="text">
-                 <string>When leaving</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QRadioButton" name="radRecenterMap">
-                <property name="text">
-                 <string>Always</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout">
-                <property name="leftMargin">
-                 <number>20</number>
-                </property>
-                <item>
-                 <widget class="QSpinBox" name="mSpinMapExtentMultiplier">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="suffix">
-                   <string>% of map extent</string>
-                  </property>
-                  <property name="minimum">
-                   <number>5</number>
-                  </property>
-                  <property name="maximum">
-                   <number>100</number>
-                  </property>
-                  <property name="singleStep">
-                   <number>1</number>
-                  </property>
-                  <property name="value">
-                   <number>50</number>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="3" column="0">
-               <widget class="QRadioButton" name="radNeverRecenter">
-                <property name="text">
-                 <string>Never</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="mRotateMapCheckBox">
-                <property name="text">
-                 <string>Rotate map to match GPS direction</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item row="2" column="0">
             <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
              <property name="title">
@@ -1163,37 +1025,207 @@ gray = no data
              </layout>
             </widget>
            </item>
-           <item row="4" column="0">
-            <widget class="QgsCollapsibleGroupBox" name="groupBox_4">
+           <item row="5" column="0">
+            <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
              <property name="title">
-              <string>Filtering</string>
+              <string>Map Centering</string>
              </property>
-             <layout class="QGridLayout" name="gridLayout_14" columnstretch="0,1">
-              <item row="1" column="1">
-               <widget class="QComboBox" name="mCboDistanceThreshold">
-                <property name="editable">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
+             <layout class="QGridLayout" name="gridLayout_8">
+              <property name="topMargin">
+               <number>2</number>
+              </property>
+              <property name="bottomMargin">
+               <number>4</number>
+              </property>
+              <property name="verticalSpacing">
+               <number>2</number>
+              </property>
               <item row="1" column="0">
-               <widget class="QLabel" name="label_9">
+               <widget class="QRadioButton" name="radRecenterWhenNeeded">
                 <property name="text">
-                 <string>Distance threshold (meters)</string>
+                 <string>When leaving</string>
                 </property>
                </widget>
               </item>
               <item row="0" column="0">
-               <widget class="QLabel" name="label_8">
+               <widget class="QRadioButton" name="radRecenterMap">
                 <property name="text">
-                 <string>Acquisition interval (seconds)</string>
+                 <string>Always</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="mCboAcquisitionInterval">
-                <property name="editable">
-                 <bool>true</bool>
+              <item row="2" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <item>
+                 <widget class="QSpinBox" name="mSpinMapExtentMultiplier">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="suffix">
+                   <string>% of map extent</string>
+                  </property>
+                  <property name="minimum">
+                   <number>5</number>
+                  </property>
+                  <property name="maximum">
+                   <number>100</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>50</number>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="3" column="0">
+               <widget class="QRadioButton" name="radNeverRecenter">
+                <property name="text">
+                 <string>Never</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="mRotateMapCheckBox">
+                <property name="text">
+                 <string>Rotate map to match GPS direction</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QgsCollapsibleGroupBox" name="mGroupShowMarker">
+             <property name="title">
+              <string>Cursor</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="topMargin">
+               <number>4</number>
+              </property>
+              <property name="bottomMargin">
+               <number>4</number>
+              </property>
+              <property name="verticalSpacing">
+               <number>2</number>
+              </property>
+              <item row="1" column="2">
+               <widget class="QLabel" name="label_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Large</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>10</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="0" colspan="3">
+               <widget class="QSlider" name="mSliderMarkerSize">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimum">
+                 <number>8</number>
+                </property>
+                <property name="maximum">
+                 <number>128</number>
+                </property>
+                <property name="singleStep">
+                 <number>4</number>
+                </property>
+                <property name="pageStep">
+                 <number>8</number>
+                </property>
+                <property name="sliderPosition">
+                 <number>10</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBelow</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Small</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QgsCollapsibleGroupBox" name="mShowBearingLineCheck">
+             <property name="title">
+              <string>Show Bearing Line</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+              <item>
+               <widget class="QLabel" name="label_11">
+                <property name="text">
+                 <string>Line style</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QgsSymbolButton" name="mBearingLineStyleButton">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -1369,6 +1401,11 @@ gray = no data
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSymbolButton</class>
+   <extends>QToolButton</extends>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>


### PR DESCRIPTION
**Add option to auto-rotate canvas to GPS bearing**:

When enabled, the map canvas will automatically rotate so that it's oriented in the same direction as the GPS bearing

**Show GPS bearing as a line over map**:

Allow showings a bearing line from the GPS location pointed in the GPS's direction. Allows users to view a "current path" directional line as they navigate using a GPS

