### PR TITLE
Show the total pan distance and bearing in the status bar 

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -526,6 +526,7 @@ sets map tile rendering flag
 Ends pan action and redraws the canvas.
 %End
 
+
     void panAction( QMouseEvent *event );
 %Docstring
 Called when mouse is moving and pan is activated
@@ -989,6 +990,18 @@ Emitted whenever an error is encountered during a map render operation.
 The ``layer`` argument indicates the associated map layer, if available.
 
 .. versionadded:: 3.10.0
+%End
+
+    void panDistanceBearingChanged( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );
+%Docstring
+Emitted whenever the distance or bearing of an in-progress panning
+operation is changed.
+
+This signal will be emitted during a pan operation as the user moves the map,
+giving the total distance and bearing between the map position at the
+start of the pan and the current pan position.
+
+.. versionadded:: 3.12
 %End
 
   protected:

--- a/python/gui/auto_generated/qgsmaptoolpan.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolpan.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsMapToolPan : QgsMapTool
 {
 %Docstring
@@ -43,6 +44,20 @@ constructor
 
     virtual bool gestureEvent( QGestureEvent *e );
 
+
+  signals:
+
+    void panDistanceBearingChanged( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );
+%Docstring
+Emitted whenever the distance or bearing of an in-progress panning
+operation is changed.
+
+This signal will be emitted during a pan operation as the user moves the map,
+giving the total distance and bearing between the map position at the
+start of the pan and the current pan position.
+
+.. versionadded:: 3.12
+%End
 
 };
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -349,6 +349,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsvaliditycheckregistry.h"
 #include "qgsappcoordinateoperationhandlers.h"
 #include "qgsprojectviewsettings.h"
+#include "qgscoordinateformatter.h"
 
 #include "qgsuserprofilemanager.h"
 #include "qgsuserprofile.h"
@@ -1566,6 +1567,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   };
   connect( QgsProject::instance(), &QgsProject::isDirtyChanged, mActionRevertProject, toggleRevert );
   connect( QgsProject::instance(), &QgsProject::fileNameChanged, mActionRevertProject, toggleRevert );
+
+  connect( mMapCanvas, &QgsMapCanvas::panDistanceBearingChanged, this, &QgisApp::showPanMessage );
 
   // the most important part of the initialization: make sure that people can play puzzle if they need
   QgsPuzzleWidget *puzzleWidget = new QgsPuzzleWidget( mMapCanvas );
@@ -3939,6 +3942,7 @@ void QgisApp::createCanvasTools()
   mMapTools.mZoomOut = new QgsMapToolZoom( mMapCanvas, true /* zoomOut */ );
   mMapTools.mZoomOut->setAction( mActionZoomOut );
   mMapTools.mPan = new QgsMapToolPan( mMapCanvas );
+  connect( static_cast< QgsMapToolPan * >( mMapTools.mPan ), &QgsMapToolPan::panDistanceBearingChanged, this, &QgisApp::showPanMessage );
   mMapTools.mPan->setAction( mActionPan );
   mMapTools.mIdentify = new QgsMapToolIdentifyAction( mMapCanvas );
   mMapTools.mIdentify->setAction( mActionIdentify );
@@ -12797,7 +12801,13 @@ void QgisApp::showRotation()
   // update the statusbar with the current rotation.
   double myrotation = mMapCanvas->rotation();
   mRotationEdit->setValue( myrotation );
-} // QgisApp::showRotation
+}
+
+void QgisApp::showPanMessage( double distance, QgsUnitTypes::DistanceUnit unit, double bearing )
+{
+  mStatusBar->showMessage( tr( "Pan distance %1 (%2)" ).arg( QgsDistanceArea::formatDistance( distance, 1, unit ),
+                           QgsCoordinateFormatter::formatX( bearing, QgsCoordinateFormatter::FormatDecimalDegrees, 1, QgsCoordinateFormatter::FlagDegreesUseStringSuffix ) ), 2000 );
+}
 
 
 void QgisApp::updateMouseCoordinatePrecision()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1528,6 +1528,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void extentChanged();
     void showRotation();
 
+    void showPanMessage( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );
+
     void displayMapToolMessage( const QString &message, Qgis::MessageLevel level = Qgis::Info );
     void displayMessage( const QString &title, const QString &message, Qgis::MessageLevel level );
     void removeMapToolMessage();

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -490,6 +490,16 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Ends pan action and redraws the canvas.
     void panActionEnd( QPoint releasePoint );
 
+#ifndef SIP_RUN
+
+    /**
+     * Starts a pan action.
+     * \note Not available in Python bindings
+     * \since QGIS 3.12
+     */
+    void panActionStart( QPoint releasePoint );
+#endif
+
     //! Called when mouse is moving and pan is activated
     void panAction( QMouseEvent *event );
 
@@ -880,6 +890,18 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     void renderErrorOccurred( const QString &error, QgsMapLayer *layer );
 
+    /**
+     * Emitted whenever the distance or bearing of an in-progress panning
+     * operation is changed.
+     *
+     * This signal will be emitted during a pan operation as the user moves the map,
+     * giving the total distance and bearing between the map position at the
+     * start of the pan and the current pan position.
+     *
+     * \since QGIS 3.12
+     */
+    void panDistanceBearingChanged( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );
+
   protected:
 
     bool event( QEvent *e ) override;
@@ -1031,6 +1053,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QHash< QString, int > mLastLayerRenderTime;
 
     QVector<QPointer<QgsCustomDropHandler >> mDropHandlers;
+
+    QgsDistanceArea mDa;
 
     /**
      * Returns the last cursor position on the canvas in geographical coordinates

--- a/src/gui/qgsmaptoolpan.h
+++ b/src/gui/qgsmaptoolpan.h
@@ -18,6 +18,9 @@
 
 #include "qgsmaptool.h"
 #include "qgis_gui.h"
+#include "qgspointxy.h"
+#include "qgsdistancearea.h"
+
 class QgsMapCanvas;
 
 
@@ -44,6 +47,20 @@ class GUI_EXPORT QgsMapToolPan : public QgsMapTool
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
     void canvasDoubleClickEvent( QgsMapMouseEvent *e ) override;
     bool gestureEvent( QGestureEvent *e ) override;
+
+  signals:
+
+    /**
+     * Emitted whenever the distance or bearing of an in-progress panning
+     * operation is changed.
+     *
+     * This signal will be emitted during a pan operation as the user moves the map,
+     * giving the total distance and bearing between the map position at the
+     * start of the pan and the current pan position.
+     *
+     * \since QGIS 3.12
+     */
+    void panDistanceBearingChanged( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );
 
   private:
 


### PR DESCRIPTION
...during canvas pan operations

Allows users to know exactly how far (and in what direction) they've dragged the map.
