### PR TITLE
Support for NaN in text edit widget

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -228,10 +228,10 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
     if ( !( field().type() == QVariant::Int || field().type() == QVariant::Double || field().type() == QVariant::LongLong || field().type() == QVariant::Date ) )
       v = QgsApplication::nullRepresentation();
   }
+  else if ( val.type() == QVariant::Double && std::isnan( val.toDouble() ) )
+    v = QgsApplication::nullRepresentation();
   else
-  {
     v = field().displayString( val );
-  }
 
   // For numbers, remove the group separator that might cause validation errors
   // when the user is editing the field value.

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -57,11 +57,14 @@ class TestQgsTextEditWidget(unittest.TestCase):
         editwidget.setValue(NULL)
         self.assertEqual(editwidget.value(), expected[3])
 
+        editwidget.setValue(float('nan'))
+        self.assertEqual(editwidget.value(), expected[4])
+
     def test_SetValue(self):
         self.createLayerWithOnePoint()
 
-        self.doAttributeTest(0, ['value', '123', NULL, NULL])
-        self.doAttributeTest(1, [NULL, 123, NULL, NULL])
+        self.doAttributeTest(0, ['value', '123', NULL, NULL, NULL])
+        self.doAttributeTest(1, [NULL, 123, NULL, NULL, NULL])
 
     def testStringWithMaxLen(self):
         """ tests that text edit wrappers correctly handle string fields with a maximum length """


### PR DESCRIPTION
If one currently snaps to a geometry with undefined z coordinate (`NaN`), and uses a default expression for an attribute `z($geometry)`, the text will be `nan` and QGIS will try to save the attribute as text nan, which won't work on a numeric field.

This will work around the issue by mapping `nan` to `NULL` in the text edit widget.

There would be alternative approaches like mapping nan to NULL at the end of `QgsExpression::evaluate()`.