### PR TITLE
remove invokable because it is already used on another method with same name

### DIFF
--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -564,7 +564,7 @@ class CORE_EXPORT QgsUnitTypes
      *
      * \since QGIS 3.8
      */
-    Q_INVOKABLE static QString toAbbreviatedString( QgsUnitTypes::RenderUnit unit );
+    static QString toAbbreviatedString( QgsUnitTypes::RenderUnit unit );
 
 
     // LAYOUT UNITS


### PR DESCRIPTION
This was introduced in cd5642aca0dab70b104e2325ca0e7448dddbd9a5

You should not define two methods as invokable if they have the same name as the call is uncertain.
Since it's javascript there is no type checking.

If the method must be called, I would suggest to add an extra helper in QgsQuickUtils.