### PR TITLE
[feature] Support datasets with data defined on faces in mesh calculator

### DIFF
--- a/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -22,8 +22,7 @@ Resulting dataset group is added to the mesh layer.
 Result can be filtered by extent or a vector layer mask
 spatially and by selection of times.
 
-Note: only dataset groups defined on vertices are
-implemented and supported
+Resulting dataset is always scalar
 
 .. versionadded:: 3.6
 %End
@@ -46,6 +45,8 @@ implemented and supported
     };
 
     QgsMeshCalculator( const QString &formulaString,
+                       const QString &outputDriver,
+                       const QString &outputGroupName,
                        const QString &outputFile,
                        const QgsRectangle &outputExtent,
                        double startTime,
@@ -55,6 +56,8 @@ implemented and supported
 Creates calculator with bounding box (rectangular) mask
 
 :param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
+:param outputDriver: output driver name
+:param outputGroupName: output group name
 :param outputFile: file to store the resulting dataset group data
 :param outputExtent: spatial filter defined by rectangle
 :param startTime: time filter defining the starting dataset
@@ -63,6 +66,8 @@ Creates calculator with bounding box (rectangular) mask
 %End
 
     QgsMeshCalculator( const QString &formulaString,
+                       const QString &outputDriver,
+                       const QString &outputGroupName,
                        const QString &outputFile,
                        const QgsGeometry &outputMask,
                        double startTime,
@@ -72,6 +77,8 @@ Creates calculator with bounding box (rectangular) mask
 Creates calculator with geometry mask
 
 :param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
+:param outputDriver: output driver name
+:param outputGroupName: output group name
 :param outputFile: file to store the resulting dataset group data
 :param outputMask: spatial filter defined by geometry
 :param startTime: time filter defining the starting dataset
@@ -88,7 +95,8 @@ Starts the calculation, writes new dataset group to file and adds it to the mesh
 :return: QgsMeshCalculator.Success in case of success
 %End
 
-    static Result expression_valid( const QString &formulaString, QgsMeshLayer *layer );
+ static Result expression_valid( const QString &formulaString,
+        QgsMeshLayer *layer ) /Deprecated/;
 %Docstring
 Returns whether formula is valid for particular mesh layer
 
@@ -96,6 +104,24 @@ Returns whether formula is valid for particular mesh layer
 :param layer: mesh layer with dataset groups references in formulaString
 
 :return: QgsMeshCalculator.Success in case of success
+
+.. deprecated::
+   QGIS 3.12 - use expressionIsValid
+%End
+
+    static Result expressionIsValid( const QString &formulaString,
+                                     QgsMeshLayer *layer,
+                                     QgsMeshDriverMetadata::MeshDriverCapability &requiredCapability );
+%Docstring
+Returns whether formula is valid for particular mesh layer
+
+:param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
+:param layer: mesh layer with dataset groups references in formulaString
+:param requiredCapability: returns required capability of driver to store results of the calculation
+
+:return: QgsMeshCalculator.Success in case of success
+
+.. versionadded:: 3.12
 %End
 
 };

--- a/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -44,6 +44,50 @@ Resulting dataset is always scalar
       MemoryError,
     };
 
+ QgsMeshCalculator( const QString &formulaString,
+                                         const QString &outputFile,
+                                         const QgsRectangle &outputExtent,
+                                         double startTime,
+                                         double endTime,
+                                         QgsMeshLayer *layer ) /Deprecated/;
+%Docstring
+Creates calculator with bounding box (rectangular) mask
+
+:param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
+:param outputDriver: output driver name
+:param outputGroupName: output group name
+:param outputFile: file to store the resulting dataset group data
+:param outputExtent: spatial filter defined by rectangle
+:param startTime: time filter defining the starting dataset
+:param endTime: time filter defining the ending dataset
+:param layer: mesh layer with dataset groups references in formulaString
+
+.. deprecated::
+   QGIS 3.12
+%End
+
+ QgsMeshCalculator( const QString &formulaString,
+                                         const QString &outputFile,
+                                         const QgsGeometry &outputMask,
+                                         double startTime,
+                                         double endTime,
+                                         QgsMeshLayer *layer ) /Deprecated/;
+%Docstring
+Creates calculator with geometry mask
+
+:param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
+:param outputDriver: output driver name
+:param outputGroupName: output group name
+:param outputFile: file to store the resulting dataset group data
+:param outputMask: spatial filter defined by geometry
+:param startTime: time filter defining the starting dataset
+:param endTime: time filter defining the ending dataset
+:param layer: mesh layer with dataset groups references in formulaString
+
+.. deprecated::
+   QGIS 3.12
+%End
+
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputDriver,
                        const QString &outputGroupName,
@@ -63,6 +107,8 @@ Creates calculator with bounding box (rectangular) mask
 :param startTime: time filter defining the starting dataset
 :param endTime: time filter defining the ending dataset
 :param layer: mesh layer with dataset groups references in formulaString
+
+.. versionadded:: 3.12
 %End
 
     QgsMeshCalculator( const QString &formulaString,
@@ -84,6 +130,8 @@ Creates calculator with geometry mask
 :param startTime: time filter defining the starting dataset
 :param endTime: time filter defining the ending dataset
 :param layer: mesh layer with dataset groups references in formulaString
+
+.. versionadded:: 3.12
 %End
 
     Result processCalculation( QgsFeedback *feedback = 0 );

--- a/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -54,8 +54,6 @@ Resulting dataset is always scalar
 Creates calculator with bounding box (rectangular) mask
 
 :param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
-:param outputDriver: output driver name
-:param outputGroupName: output group name
 :param outputFile: file to store the resulting dataset group data
 :param outputExtent: spatial filter defined by rectangle
 :param startTime: time filter defining the starting dataset
@@ -76,8 +74,6 @@ Creates calculator with bounding box (rectangular) mask
 Creates calculator with geometry mask
 
 :param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
-:param outputDriver: output driver name
-:param outputGroupName: output group name
 :param outputFile: file to store the resulting dataset group data
 :param outputMask: spatial filter defined by geometry
 :param startTime: time filter defining the starting dataset

--- a/python/core/auto_additions/qgsprovidermetadata.py
+++ b/python/core/auto_additions/qgsprovidermetadata.py
@@ -1,4 +1,7 @@
 # The following has been generated automatically from src/core/qgsprovidermetadata.h
+QgsMeshDriverMetadata.MeshDriverCapability.baseClass = QgsMeshDriverMetadata
+QgsMeshDriverMetadata.MeshDriverCapabilities.baseClass = QgsMeshDriverMetadata
+MeshDriverCapabilities = QgsMeshDriverMetadata  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
 QgsProviderMetadata.FilterType.FilterVector.__doc__ = ""
 QgsProviderMetadata.FilterType.FilterRaster.__doc__ = ""

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -217,6 +217,8 @@ For scalar and vector 2d the behavior is undefined
     QVector<double> values() const;
 %Docstring
 Returns buffer to the array with values
+
+.. versionadded:: 3.12
 %End
 
 

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -214,6 +214,11 @@ For scalar and vector 2d the behavior is undefined
 %End
 
 
+    QVector<double> values() const;
+%Docstring
+Returns buffer to the array with values
+%End
+
 
 };
 
@@ -630,7 +635,7 @@ persists it into a destination path
 
 On success, the mesh's dataset group count is changed
 
-:param path: destination path of the stored file
+:param path: destination path of the stored file in form DRIVER_NAME:path
 :param meta: new group's metadata
 :param datasetValues: scalar/vector values for all datasets and all faces/vertices in the group
 :param datasetActive: active flag values for all datasets in the group. Empty array represents can be used

--- a/python/core/auto_generated/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/qgsprovidermetadata.sip.in
@@ -13,6 +13,66 @@
 
 
 
+class QgsMeshDriverMetadata
+{
+%Docstring
+Holds metadata about mesh driver
+
+.. versionadded:: 3.12
+%End
+
+%TypeHeaderCode
+#include "qgsprovidermetadata.h"
+%End
+  public:
+    static const QMetaObject staticMetaObject;
+
+  public:
+
+    enum MeshDriverCapability
+    {
+      CanWriteFaceDatasets,
+      CanWriteVertexDatasets,
+    };
+
+    typedef QFlags<QgsMeshDriverMetadata::MeshDriverCapability> MeshDriverCapabilities;
+
+
+    QgsMeshDriverMetadata();
+%Docstring
+Constructs default metadata without any capabilities
+%End
+
+    QgsMeshDriverMetadata( const QString &name,
+                           const QString &description,
+                           const MeshDriverCapabilities &capabilities );
+%Docstring
+Constructs driver metadata with selected capabilities
+
+:param name: name/key of the driver
+:param description: short description of the driver
+:param capabilities: driver's capabilities
+%End
+
+    MeshDriverCapabilities capabilities() const;
+%Docstring
+Returns the capabilities for this driver.
+%End
+
+    QString name() const;
+%Docstring
+Returns the name (key) for this driver.
+%End
+
+    QString description() const;
+%Docstring
+Returns the description for this driver.
+%End
+
+};
+
+QFlags<QgsMeshDriverMetadata::MeshDriverCapability> operator|(QgsMeshDriverMetadata::MeshDriverCapability f1, QFlags<QgsMeshDriverMetadata::MeshDriverCapability> f2);
+
 
 class QgsProviderMetadata
 {
@@ -24,10 +84,10 @@ which are native providers that are included in the core QGIS installation
 and accessed through function pointers.
 
 For library based providers, the metadata class is used in a lazy load
-implementation in QgsProviderRegistry.  To save memory, data providers
+implementation in :py:class:`QgsProviderRegistry`.  To save memory, data providers
 are only actually loaded via QLibrary calls if they're to be used.  (Though they're all
 iteratively loaded once to get their metadata information, and then
-unloaded when the QgsProviderRegistry is created.)  QgsProviderMetadata
+unloaded when the QgsProviderRegistry is created.)  :py:class:`QgsProviderMetadata`
 supplies enough information to be able to later load the associated shared
 library object.
 %End
@@ -104,6 +164,13 @@ Builds the list of file filter strings (supported formats)
 Suitable for use in a QFileDialog.getOpenFileNames() call.
 
 .. versionadded:: 3.10
+%End
+
+    virtual QList<QgsMeshDriverMetadata> meshDriversMetadata();
+%Docstring
+Builds the list of available mesh drivers metadata
+
+.. versionadded:: 3.12
 %End
 
     virtual QgsDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options ) /Factory/;

--- a/src/analysis/mesh/qgsmeshcalcnode.cpp
+++ b/src/analysis/mesh/qgsmeshcalcnode.cpp
@@ -113,8 +113,8 @@ bool QgsMeshCalcNode::calculate( const  QgsMeshCalcUtils &dsu, QgsMeshMemoryData
   }
   else if ( mType == tOperator )
   {
-    QgsMeshMemoryDatasetGroup leftDatasetGroup( "left" );
-    QgsMeshMemoryDatasetGroup rightDatasetGroup( "right" );
+    QgsMeshMemoryDatasetGroup leftDatasetGroup( "left", dsu.outputType() );
+    QgsMeshMemoryDatasetGroup rightDatasetGroup( "right", dsu.outputType() );
 
     if ( !mLeft || !mLeft->calculate( dsu, leftDatasetGroup ) )
     {
@@ -125,7 +125,7 @@ bool QgsMeshCalcNode::calculate( const  QgsMeshCalcUtils &dsu, QgsMeshMemoryData
       return false;
     }
 
-    QgsMeshMemoryDatasetGroup condition( "condition" );
+    QgsMeshMemoryDatasetGroup condition( "condition", dsu.outputType() );
     switch ( mOperator )
     {
       case opIF:

--- a/src/analysis/mesh/qgsmeshcalculator.cpp
+++ b/src/analysis/mesh/qgsmeshcalculator.cpp
@@ -26,6 +26,45 @@
 #include "qgis.h"
 
 QgsMeshCalculator::QgsMeshCalculator( const QString &formulaString,
+                                      const QString &outputFile,
+                                      const QgsRectangle &outputExtent,
+                                      double startTime,
+                                      double endTime,
+                                      QgsMeshLayer *layer )
+  : mFormulaString( formulaString )
+  , mOutputDriver( QStringLiteral( "DAT" ) )
+  , mOutputFile( outputFile )
+  , mOutputExtent( outputExtent )
+  , mUseMask( false )
+  , mStartTime( startTime )
+  , mEndTime( endTime )
+  , mMeshLayer( layer )
+{
+  if ( !mOutputFile.isEmpty() )
+    mOutputGroupName = QFileInfo( mOutputFile ).baseName();
+}
+
+QgsMeshCalculator::QgsMeshCalculator( const QString &formulaString,
+                                      const QString &outputFile,
+                                      const QgsGeometry &outputMask,
+                                      double startTime,
+                                      double endTime,
+                                      QgsMeshLayer *layer )
+  : mFormulaString( formulaString )
+  , mOutputDriver( QStringLiteral( "DAT" ) )
+  , mOutputFile( outputFile )
+  , mOutputMask( outputMask )
+  , mUseMask( true )
+  , mStartTime( startTime )
+  , mEndTime( endTime )
+  , mMeshLayer( layer )
+{
+  if ( !mOutputFile.isEmpty() )
+    mOutputGroupName = QFileInfo( mOutputFile ).baseName();
+}
+
+
+QgsMeshCalculator::QgsMeshCalculator( const QString &formulaString,
                                       const QString &outputDriver,
                                       const QString &outputGroupName,
                                       const QString &outputFile,

--- a/src/analysis/mesh/qgsmeshcalculator.h
+++ b/src/analysis/mesh/qgsmeshcalculator.h
@@ -68,8 +68,6 @@ class ANALYSIS_EXPORT QgsMeshCalculator
     /**
      * Creates calculator with bounding box (rectangular) mask
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
-     * \param outputDriver output driver name
-     * \param outputGroupName output group name
      * \param outputFile file to store the resulting dataset group data
      * \param outputExtent spatial filter defined by rectangle
      * \param startTime time filter defining the starting dataset
@@ -88,8 +86,6 @@ class ANALYSIS_EXPORT QgsMeshCalculator
     /**
      * Creates calculator with geometry mask
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
-     * \param outputDriver output driver name
-     * \param outputGroupName output group name
      * \param outputFile file to store the resulting dataset group data
      * \param outputMask spatial filter defined by geometry
      * \param startTime time filter defining the starting dataset

--- a/src/analysis/mesh/qgsmeshcalculator.h
+++ b/src/analysis/mesh/qgsmeshcalculator.h
@@ -20,11 +20,14 @@
 
 #include <QString>
 #include <QVector>
+#include <QStringList>
 
 #include "qgis_analysis.h"
+#include "qgis_sip.h"
 #include "qgsrectangle.h"
 #include "qgsmeshlayer.h"
 #include "qgsmeshdataprovider.h"
+#include "qgsprovidermetadata.h"
 #include "qgsfeedback.h"
 
 struct QgsMeshMemoryDatasetGroup;
@@ -41,8 +44,7 @@ struct QgsMeshMemoryDataset;
  * Result can be filtered by extent or a vector layer mask
  * spatially and by selection of times.
  *
- * Note: only dataset groups defined on vertices are
- * implemented and supported
+ * Resulting dataset is always scalar
  *
  * \since QGIS 3.6
 */
@@ -66,6 +68,8 @@ class ANALYSIS_EXPORT QgsMeshCalculator
     /**
      * Creates calculator with bounding box (rectangular) mask
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
+     * \param outputDriver output driver name
+     * \param outputGroupName output group name
      * \param outputFile file to store the resulting dataset group data
      * \param outputExtent spatial filter defined by rectangle
      * \param startTime time filter defining the starting dataset
@@ -73,6 +77,8 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      * \param layer mesh layer with dataset groups references in formulaString
      */
     QgsMeshCalculator( const QString &formulaString,
+                       const QString &outputDriver,
+                       const QString &outputGroupName,
                        const QString &outputFile,
                        const QgsRectangle &outputExtent,
                        double startTime,
@@ -82,6 +88,8 @@ class ANALYSIS_EXPORT QgsMeshCalculator
     /**
      * Creates calculator with geometry mask
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
+     * \param outputDriver output driver name
+     * \param outputGroupName output group name
      * \param outputFile file to store the resulting dataset group data
      * \param outputMask spatial filter defined by geometry
      * \param startTime time filter defining the starting dataset
@@ -89,6 +97,8 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      * \param layer mesh layer with dataset groups references in formulaString
      */
     QgsMeshCalculator( const QString &formulaString,
+                       const QString &outputDriver,
+                       const QString &outputGroupName,
                        const QString &outputFile,
                        const QgsGeometry &outputMask,
                        double startTime,
@@ -107,13 +117,31 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
      * \param layer mesh layer with dataset groups references in formulaString
      * \returns QgsMeshCalculator::Success in case of success
+     *
+     * \deprecated QGIS 3.12 - use expressionIsValid
      */
-    static Result expression_valid( const QString &formulaString, QgsMeshLayer *layer );
+    Q_DECL_DEPRECATED static Result expression_valid( const QString &formulaString,
+        QgsMeshLayer *layer ) SIP_DEPRECATED;
+
+    /**
+     * Returns whether formula is valid for particular mesh layer
+     * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
+     * \param layer mesh layer with dataset groups references in formulaString
+     * \param requiredCapability returns required capability of driver to store results of the calculation
+     * \returns QgsMeshCalculator::Success in case of success
+     *
+     * \since QGIS 3.12
+     */
+    static Result expressionIsValid( const QString &formulaString,
+                                     QgsMeshLayer *layer,
+                                     QgsMeshDriverMetadata::MeshDriverCapability &requiredCapability );
 
   private:
     QgsMeshCalculator();
 
     QString mFormulaString;
+    QString mOutputDriver;
+    QString mOutputGroupName;
     QString mOutputFile;
     QgsRectangle mOutputExtent;
     QgsGeometry mOutputMask;

--- a/src/analysis/mesh/qgsmeshcalculator.h
+++ b/src/analysis/mesh/qgsmeshcalculator.h
@@ -75,6 +75,48 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      * \param startTime time filter defining the starting dataset
      * \param endTime time filter defining the ending dataset
      * \param layer mesh layer with dataset groups references in formulaString
+     *
+     * \deprecated QGIS 3.12
+     */
+    Q_DECL_DEPRECATED QgsMeshCalculator( const QString &formulaString,
+                                         const QString &outputFile,
+                                         const QgsRectangle &outputExtent,
+                                         double startTime,
+                                         double endTime,
+                                         QgsMeshLayer *layer ) SIP_DEPRECATED;
+
+    /**
+     * Creates calculator with geometry mask
+     * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
+     * \param outputDriver output driver name
+     * \param outputGroupName output group name
+     * \param outputFile file to store the resulting dataset group data
+     * \param outputMask spatial filter defined by geometry
+     * \param startTime time filter defining the starting dataset
+     * \param endTime time filter defining the ending dataset
+     * \param layer mesh layer with dataset groups references in formulaString
+     *
+     * \deprecated QGIS 3.12
+     */
+    Q_DECL_DEPRECATED QgsMeshCalculator( const QString &formulaString,
+                                         const QString &outputFile,
+                                         const QgsGeometry &outputMask,
+                                         double startTime,
+                                         double endTime,
+                                         QgsMeshLayer *layer ) SIP_DEPRECATED;
+
+    /**
+     * Creates calculator with bounding box (rectangular) mask
+     * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
+     * \param outputDriver output driver name
+     * \param outputGroupName output group name
+     * \param outputFile file to store the resulting dataset group data
+     * \param outputExtent spatial filter defined by rectangle
+     * \param startTime time filter defining the starting dataset
+     * \param endTime time filter defining the ending dataset
+     * \param layer mesh layer with dataset groups references in formulaString
+     *
+     * \since QGIS 3.12
      */
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputDriver,
@@ -95,6 +137,8 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      * \param startTime time filter defining the starting dataset
      * \param endTime time filter defining the ending dataset
      * \param layer mesh layer with dataset groups references in formulaString
+     *
+     * \since QGIS 3.12
      */
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputDriver,

--- a/src/analysis/mesh/qgsmeshcalcutils.cpp
+++ b/src/analysis/mesh/qgsmeshcalcutils.cpp
@@ -33,23 +33,30 @@ std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QStri
 {
   const auto dp = mMeshLayer->dataProvider();
   std::shared_ptr<QgsMeshMemoryDatasetGroup> grp;
-  for ( int group_i = 0; group_i < dp->datasetGroupCount(); ++group_i )
+  for ( int groupIndex = 0; groupIndex < dp->datasetGroupCount(); ++groupIndex )
   {
-    const auto meta = dp->datasetGroupMetadata( group_i );
+    const auto meta = dp->datasetGroupMetadata( groupIndex );
     const QString name = meta.name();
     if ( name == datasetGroupName )
     {
+      // we need to convert the native type to the requested type
+      // only possibility that cannot happen is to convert vertex dataset to
+      // face dataset. This would suggest bug in determineResultDataType()
+      Q_ASSERT( !( ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices ) && ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnFaces ) ) );
+
       grp = std::make_shared<QgsMeshMemoryDatasetGroup>();
       grp->isScalar = meta.isScalar();
-      grp->type = meta.dataType();
+      grp->type = mOutputType;
       grp->maximum = meta.maximum();
       grp->minimum = meta.minimum();
       grp->name = meta.name();
 
-      int count = ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
-      for ( int dataset_i = 0; dataset_i < dp->datasetCount( group_i ); ++dataset_i )
+      int nativeCount = ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
+      int resultCount = ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
+
+      for ( int datasetIndex = 0; datasetIndex < dp->datasetCount( groupIndex ); ++datasetIndex )
       {
-        const QgsMeshDatasetIndex index( group_i, dataset_i );
+        const QgsMeshDatasetIndex index( groupIndex, datasetIndex );
         const auto dsMeta = dp->datasetMetadata( index );
         std::shared_ptr<QgsMeshMemoryDataset> ds = create( grp->type );
         ds->maximum = dsMeta.maximum();
@@ -57,10 +64,70 @@ std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QStri
         ds->time = dsMeta.time();
         ds->valid = dsMeta.isValid();
 
-        const QgsMeshDataBlock block = QgsMeshLayerUtils::datasetValues( mMeshLayer, index, 0, count );
-        Q_ASSERT( block.count() == count );
-        for ( int value_i = 0; value_i < count; ++value_i )
-          ds->values[value_i] = block.value( value_i );
+        // the function already averages volume datasets to face dataset values
+        QgsMeshDataBlock block = QgsMeshLayerUtils::datasetValues( mMeshLayer, index, 0, nativeCount );
+        Q_ASSERT( block.count() == nativeCount );
+
+        // for data on faces, there could be request to interpolate the data to vertices
+        if ( ( meta.dataType() != QgsMeshDatasetGroupMetadata::DataOnVertices ) && ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices ) )
+        {
+
+          if ( grp->isScalar )
+          {
+            QVector<double> data =
+              QgsMeshLayerUtils::interpolateFromFacesData(
+                block.values(),
+                nativeMesh(),
+                triangularMesh(),
+                nullptr,
+                QgsMeshRendererScalarSettings::NeighbourAverage
+              );
+            Q_ASSERT( data.size() == resultCount );
+            for ( int valueIndex = 0; valueIndex < resultCount; ++valueIndex )
+              ds->values[valueIndex] = QgsMeshDatasetValue( data[valueIndex] );
+          }
+          else
+          {
+            QVector<double> buf = block.values();
+            QVector<double> x( nativeCount );
+            QVector<double> y( nativeCount );
+            for ( int value_i = 0; value_i < nativeCount; ++value_i )
+            {
+              x[value_i] = buf[2 * value_i];
+              y[value_i] = buf[2 * value_i + 1];
+            }
+
+            QVector<double> dataX =
+              QgsMeshLayerUtils::interpolateFromFacesData(
+                x,
+                mMeshLayer->nativeMesh(),
+                mMeshLayer->triangularMesh(),
+                nullptr,
+                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataInterpolationMethod()
+              );
+            Q_ASSERT( dataX.size() == resultCount );
+            QVector<double> dataY =
+              QgsMeshLayerUtils::interpolateFromFacesData(
+                y,
+                mMeshLayer->nativeMesh(),
+                mMeshLayer->triangularMesh(),
+                nullptr,
+                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataInterpolationMethod()
+              );
+
+            Q_ASSERT( dataY.size() == resultCount );
+
+            for ( int value_i = 0; value_i < resultCount; ++value_i )
+            {
+              ds->values[value_i] = QgsMeshDatasetValue( dataX[value_i], dataY[value_i] );
+            }
+          }
+        }
+        else
+        {
+          for ( int value_i = 0; value_i < resultCount; ++value_i )
+            ds->values[value_i] = block.value( value_i );
+        }
 
         if ( grp->type == QgsMeshDatasetGroupMetadata::DataOnVertices )
         {
@@ -85,9 +152,10 @@ std::shared_ptr<QgsMeshMemoryDataset> QgsMeshCalcUtils::create( const QgsMeshMem
 
 std::shared_ptr<QgsMeshMemoryDataset> QgsMeshCalcUtils::create( const QgsMeshDatasetGroupMetadata::DataType type ) const
 {
+  Q_ASSERT( type != QgsMeshDatasetGroupMetadata::DataOnVolumes );
+
   std::shared_ptr<QgsMeshMemoryDataset> ds = std::make_shared<QgsMeshMemoryDataset>();
-  bool onVertices = type == QgsMeshDatasetGroupMetadata::DataOnVertices;
-  if ( onVertices )
+  if ( type == QgsMeshDatasetGroupMetadata::DataOnVertices )
   {
     ds->values.resize( mMeshLayer->dataProvider()->vertexCount() );
     ds->active.resize( mMeshLayer->dataProvider()->faceCount() );
@@ -107,8 +175,10 @@ QgsMeshCalcUtils:: QgsMeshCalcUtils( QgsMeshLayer *layer,
                                      double endTime )
   : mMeshLayer( layer )
   , mIsValid( false )
-  , mOutputType( QgsMeshDatasetGroupMetadata::DataType::DataOnVertices )
 {
+  // Resolve output type of the calculation
+  mOutputType = determineResultDataType( layer, usedGroupNames );
+
   // First populate group's names map and see if we have all groups present
   // And basically fetch all data from any mesh provider to memory
   for ( const QString &groupName : usedGroupNames )
@@ -211,6 +281,8 @@ std::shared_ptr<const QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::group( const 
 
 void QgsMeshCalcUtils::populateSpatialFilter( QgsMeshMemoryDatasetGroup &filter, const QgsRectangle &extent ) const
 {
+  Q_ASSERT( mOutputType != QgsMeshDatasetGroupMetadata::DataOnVolumes );
+
   filter.clearDatasets();
 
   std::shared_ptr<QgsMeshMemoryDataset> output = create( filter );
@@ -245,6 +317,8 @@ void QgsMeshCalcUtils::populateSpatialFilter( QgsMeshMemoryDatasetGroup &filter,
 
 void QgsMeshCalcUtils::populateMaskFilter( QgsMeshMemoryDatasetGroup &filter, const QgsGeometry &mask ) const
 {
+  Q_ASSERT( mOutputType != QgsMeshDatasetGroupMetadata::DataOnVolumes );
+
   filter.clearDatasets();
   std::shared_ptr<QgsMeshMemoryDataset> output = create( filter );
   output->time = mTimes[0];
@@ -635,6 +709,11 @@ void QgsMeshCalcUtils::updateMesh() const
   }
 }
 
+QgsMeshDatasetGroupMetadata::DataType QgsMeshCalcUtils::outputType() const
+{
+  return mOutputType;
+}
+
 void QgsMeshCalcUtils::addIf( QgsMeshMemoryDatasetGroup &trueGroup,
                               const QgsMeshMemoryDatasetGroup &falseGroup,
                               const QgsMeshMemoryDatasetGroup &condition ) const
@@ -702,7 +781,7 @@ void QgsMeshCalcUtils::activate(
   Q_ASSERT( isValid() );
   Q_ASSERT( dataset );
 
-  // Activate only faces that ha some data and all vertices
+  // Activate only faces that has some data and all vertices
   for ( int idx = 0; idx < mMeshLayer->dataProvider()->faceCount(); ++idx )
   {
     if ( refDataset && !refDataset->active.isEmpty() && ( !refDataset->active[idx] ) )
@@ -1079,16 +1158,41 @@ void QgsMeshCalcUtils::maximum( QgsMeshMemoryDatasetGroup &group1, const QgsMesh
   return func2( group1, group2, std::bind( & QgsMeshCalcUtils::fmax, this, std::placeholders::_1, std::placeholders::_2 ) );
 }
 
+QgsMeshDatasetGroupMetadata::DataType QgsMeshCalcUtils::determineResultDataType( QgsMeshLayer *layer, const QStringList &usedGroupNames )
+{
+  QHash<QString, int> names;
+  const QgsMeshDataProvider *dp = layer->dataProvider();
+  for ( int groupId = 0; groupId < dp->datasetGroupCount(); ++groupId )
+  {
+    const auto meta = dp->datasetGroupMetadata( groupId );
+    const QString name = meta.name();
+    names[ name ] = groupId;
+  }
+  for ( const auto &datasetGroupName : usedGroupNames )
+  {
+    if ( names.contains( datasetGroupName ) )
+    {
+      int groupId = names.value( datasetGroupName );
+      const auto meta = dp->datasetGroupMetadata( groupId );
+      if ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices )
+      {
+        return QgsMeshDatasetGroupMetadata::DataOnVertices;
+      }
+    }
+  }
+  return QgsMeshDatasetGroupMetadata::DataOnFaces;
+}
+
 void QgsMeshCalcUtils::filter( QgsMeshMemoryDatasetGroup &group1, const QgsRectangle &extent ) const
 {
-  QgsMeshMemoryDatasetGroup filter( "filter" );
+  QgsMeshMemoryDatasetGroup filter( "filter", outputType() );
   populateSpatialFilter( filter, extent );
   return func2( group1, filter, std::bind( & QgsMeshCalcUtils::ffilter, this, std::placeholders::_1, std::placeholders::_2 ) );
 }
 
 void QgsMeshCalcUtils::filter( QgsMeshMemoryDatasetGroup &group1, const QgsGeometry &mask ) const
 {
-  QgsMeshMemoryDatasetGroup filter( "filter" );
+  QgsMeshMemoryDatasetGroup filter( "filter", outputType() );
   populateMaskFilter( filter, mask );
   return func2( group1, filter, std::bind( & QgsMeshCalcUtils::ffilter, this, std::placeholders::_1, std::placeholders::_2 ) );
 }

--- a/src/analysis/mesh/qgsmeshcalcutils.h
+++ b/src/analysis/mesh/qgsmeshcalcutils.h
@@ -54,6 +54,9 @@ class ANALYSIS_EXPORT QgsMeshCalcUtils
 
     /**
      * Creates the utils and validates the input
+     *
+     * The constructor fetches all dataset values and creates memory datasets from them.
+     *
      * \param layer mesh layer
      * \param usedGroupNames dataset group's names that are used in the expression
      * \param startTime start time
@@ -175,6 +178,12 @@ class ANALYSIS_EXPORT QgsMeshCalcUtils
     //! Operator maximum
     void maximum( QgsMeshMemoryDatasetGroup &group1, const QgsMeshMemoryDatasetGroup &group2 ) const;
 
+    //! Calculates the data type of result dataset group
+    static QgsMeshDatasetGroupMetadata::DataType determineResultDataType( QgsMeshLayer *layer, const QStringList &usedGroupNames );
+
+    //! Returns the data type of result dataset group
+    QgsMeshDatasetGroupMetadata::DataType outputType() const;
+
   private:
     double ffilter( double val1, double filter ) const;
     double fadd( double val1, double val2 ) const;
@@ -201,9 +210,11 @@ class ANALYSIS_EXPORT QgsMeshCalcUtils
     double faverageAggregated( QVector<double> &vals ) const;
 
     /**
-     * Find dataset group in provider with the name and copy all values to
+     * Clones the dataset data to memory
+     *
+     * Finds dataset group in provider with the name and copies all values to
      * memory dataset group. Returns NULLPTR if no such dataset group
-     * exists
+     * exists. Resulting datasets are guaranteed to have the same mOutputType type
      */
     std::shared_ptr<QgsMeshMemoryDatasetGroup> create( const QString &datasetGroupName ) const;
 

--- a/src/app/mesh/qgsmeshcalculatordialog.h
+++ b/src/app/mesh/qgsmeshcalculatordialog.h
@@ -20,6 +20,7 @@
 
 #include "ui_qgsmeshcalculatordialogbase.h"
 #include "qgsmeshcalculator.h"
+#include "qgsprovidermetadata.h"
 #include "qgshelp.h"
 #include "qgis_app.h"
 
@@ -30,7 +31,7 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
   public:
 
     /**
-     * Constructor for raster calculator dialog
+     * Constructor for mesh calculator dialog
      * \param meshLayer main mesh layer, will be used for default extent and projection
      * \param parent widget
      * \param f window flags
@@ -45,8 +46,8 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
     void mDatasetsListWidget_doubleClicked( QListWidgetItem *item );
     void mCurrentLayerExtentButton_clicked();
     void mAllTimesButton_clicked();
-    void mExpressionTextEdit_textChanged();
     void toggleExtendMask( int state );
+    void updateInfoMessage();
 
     //calculator buttons
     void mPlusPushButton_clicked();
@@ -82,6 +83,8 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
     QString outputFile() const;
     QgsRectangle outputExtent() const;
     QgsGeometry maskGeometry() const;
+    QString driver() const;
+    QString groupName() const;
 
     double startTime() const;
     double endTime() const;
@@ -104,25 +107,24 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
     //! Sets available times from layer
     void repopulateTimeCombos();
 
-    //! Enables OK button if calculator expression is valid and output file path exists
-    void setAcceptButtonState();
-
     //! Quotes the dataset group name for calculator
     QString quoteDatasetGroupEntry( const QString group );
 
     //! Gets all datasets groups from layer and populated list
     void getDatasetGroupNames();
 
-    //! Returns true if mesh calculator expression has valid syntax
-    bool expressionValid() const;
-
-    //! Returns true if file path is valid and writable
-    bool filePathValid() const;
-
     //! Add file suffix if not present
     QString addSuffix( const QString fileName ) const;
 
+    //! Gets all mesh drivers that can persist datasets
+    void getMeshDrivers();
+
+    //! Populates the combo box with output formats
+    void populateDriversComboBox( );
+
     QgsMeshLayer *mLayer;
+    QHash<QString, QgsMeshDriverMetadata> mMeshDrivers;
+
     friend class TestQgsMeshCalculatorDialog;
 };
 

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -309,6 +309,11 @@ void *QgsMeshDataBlock::buffer()
   }
 }
 
+QVector<double> QgsMeshDataBlock::values() const
+{
+  return mDoubleBuffer;
+}
+
 const void *QgsMeshDataBlock::constBuffer() const
 {
   if ( ActiveFlagInteger == mType )

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -211,6 +211,11 @@ class CORE_EXPORT QgsMeshDataBlock
     void *buffer() SIP_SKIP;
 
     /**
+     * Returns buffer to the array with values
+     */
+    QVector<double> values() const;
+
+    /**
      * Returns internal buffer to the array for fast
      * values reading
      *
@@ -637,7 +642,7 @@ class CORE_EXPORT QgsMeshDatasetSourceInterface SIP_ABSTRACT
      *
      * On success, the mesh's dataset group count is changed
      *
-     * \param path destination path of the stored file
+     * \param path destination path of the stored file in form DRIVER_NAME:path
      * \param meta new group's metadata
      * \param datasetValues scalar/vector values for all datasets and all faces/vertices in the group
      * \param datasetActive active flag values for all datasets in the group. Empty array represents can be used

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -212,6 +212,8 @@ class CORE_EXPORT QgsMeshDataBlock
 
     /**
      * Returns buffer to the array with values
+     *
+     * \since QGIS 3.12
      */
     QVector<double> values() const;
 

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -178,16 +178,17 @@ QgsVector QgsMeshLayerUtils::interpolateVectorFromFacesData( const QgsPointXY &p
 }
 
 
-QVector<double> QgsMeshLayerUtils::interpolateFromFacesData( QVector<double> valuesOnFaces, QgsMesh *nativeMesh,
-    QgsTriangularMesh *triangularMesh,
-    QgsMeshDataBlock *active,
-    QgsMeshRendererScalarSettings::DataInterpolationMethod method )
+QVector<double> QgsMeshLayerUtils::interpolateFromFacesData(
+  QVector<double> valuesOnFaces,
+  const QgsMesh *nativeMesh,
+  const QgsTriangularMesh *triangularMesh,
+  QgsMeshDataBlock *active,
+  QgsMeshRendererScalarSettings::DataInterpolationMethod method )
 {
   Q_UNUSED( triangularMesh )
   Q_UNUSED( method )
 
   assert( nativeMesh );
-  assert( active );
   assert( method == QgsMeshRendererScalarSettings::NeighbourAverage );
 
   // assuming that native vertex count = triangular vertex count
@@ -200,7 +201,7 @@ QVector<double> QgsMeshLayerUtils::interpolateFromFacesData( QVector<double> val
 
   for ( int i = 0; i < nativeMesh->faces.size(); ++i )
   {
-    if ( active->active( i ) )
+    if ( !active || active->active( i ) )
     {
       double val = valuesOnFaces[ i ];
       if ( !std::isnan( val ) )

--- a/src/core/mesh/qgsmeshlayerutils.h
+++ b/src/core/mesh/qgsmeshlayerutils.h
@@ -159,8 +159,8 @@ class CORE_EXPORT QgsMeshLayerUtils
     */
     static QVector<double> interpolateFromFacesData(
       QVector<double> valuesOnFaces,
-      QgsMesh *nativeMesh,
-      QgsTriangularMesh *triangularMesh,
+      const QgsMesh *nativeMesh,
+      const QgsTriangularMesh *triangularMesh,
       QgsMeshDataBlock *active,
       QgsMeshRendererScalarSettings::DataInterpolationMethod method
     );

--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
@@ -625,6 +625,11 @@ QgsRectangle QgsMeshMemoryDataProvider::calculateExtent() const
   return rec;
 }
 
+QgsMeshMemoryDatasetGroup::QgsMeshMemoryDatasetGroup( const QString &nm, QgsMeshDatasetGroupMetadata::DataType dataType ):
+  name( nm ), type( dataType )
+{
+}
+
 
 QgsMeshMemoryDatasetGroup::QgsMeshMemoryDatasetGroup( const QString &nm ):
   name( nm )

--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.h
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.h
@@ -46,6 +46,7 @@ struct CORE_EXPORT QgsMeshMemoryDataset
 
 struct CORE_EXPORT QgsMeshMemoryDatasetGroup
 {
+  QgsMeshMemoryDatasetGroup( const QString &nm, QgsMeshDatasetGroupMetadata::DataType dataType );
   QgsMeshMemoryDatasetGroup( const QString &nm );
   QgsMeshMemoryDatasetGroup();
   QgsMeshDatasetGroupMetadata groupMetadata() const;

--- a/src/core/qgsprovidermetadata.cpp
+++ b/src/core/qgsprovidermetadata.cpp
@@ -75,6 +75,11 @@ QString QgsProviderMetadata::filters( FilterType )
   return QString();
 }
 
+QList<QgsMeshDriverMetadata> QgsProviderMetadata::meshDriversMetadata()
+{
+  return QList<QgsMeshDriverMetadata>();
+}
+
 QgsDataProvider *QgsProviderMetadata::createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options )
 {
   if ( mCreateFunction )
@@ -209,8 +214,8 @@ void QgsProviderMetadata::deleteConnection( const QString &name )
 
 void QgsProviderMetadata::saveConnection( const QgsAbstractProviderConnection *connection, const QString &name )
 {
-  Q_UNUSED( connection );
-  Q_UNUSED( name );
+  Q_UNUSED( connection )
+  Q_UNUSED( name )
   throw QgsProviderConnectionException( QObject::tr( "Provider %1 has no %2 method" ).arg( key(), QStringLiteral( "saveConnection" ) ) );
 }
 
@@ -239,6 +244,24 @@ QMap<QString, T *> QgsProviderMetadata::connections( bool cached )
   return result;
 }
 
+QgsMeshDriverMetadata::QgsMeshDriverMetadata() = default;
 
+QgsMeshDriverMetadata::QgsMeshDriverMetadata( const QString &name, const QString &description, const MeshDriverCapabilities &capabilities )
+  : mName( name ), mDescription( description ), mCapabilities( capabilities )
+{
+}
 
+QgsMeshDriverMetadata::MeshDriverCapabilities QgsMeshDriverMetadata::capabilities() const
+{
+  return mCapabilities;
+}
 
+QString QgsMeshDriverMetadata::name() const
+{
+  return mName;
+}
+
+QString QgsMeshDriverMetadata::description() const
+{
+  return mDescription;
+}

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -43,6 +43,67 @@ class QgsTransaction;
 
 class QgsRasterDataProvider;
 
+/**
+ * \ingroup core
+ * Holds metadata about mesh driver
+ *
+ * \since QGIS 3.12
+ */
+class CORE_EXPORT QgsMeshDriverMetadata
+{
+    Q_GADGET
+
+  public:
+
+    /**
+     * Flags for the capabilities of the driver
+     */
+    enum MeshDriverCapability
+    {
+      CanWriteFaceDatasets = 1 << 0, //!< If the driver can persist datasets defined on faces
+      CanWriteVertexDatasets = 1 << 1, //!< If the driver can persist datasets defined on vertices
+    };
+
+    Q_ENUM( MeshDriverCapability )
+    Q_DECLARE_FLAGS( MeshDriverCapabilities, MeshDriverCapability )
+    Q_FLAG( MeshDriverCapabilities )
+
+    //! Constructs default metadata without any capabilities
+    QgsMeshDriverMetadata();
+
+    /**
+     * Constructs driver metadata with selected capabilities
+     *
+     * \param name name/key of the driver
+     * \param description short description of the driver
+     * \param capabilities driver's capabilities
+     */
+    QgsMeshDriverMetadata( const QString &name,
+                           const QString &description,
+                           const MeshDriverCapabilities &capabilities );
+
+    /**
+     * Returns the capabilities for this driver.
+     */
+    MeshDriverCapabilities capabilities() const;
+
+    /**
+     * Returns the name (key) for this driver.
+     */
+    QString name() const;
+
+    /**
+     * Returns the description for this driver.
+     */
+    QString description() const;
+
+  private:
+    QString mName;
+    QString mDescription;
+    MeshDriverCapabilities mCapabilities;
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMeshDriverMetadata::MeshDriverCapabilities )
 
 /**
  * \ingroup core
@@ -154,6 +215,13 @@ class CORE_EXPORT QgsProviderMetadata
      * \since QGIS 3.10
      */
     virtual QString filters( FilterType type );
+
+    /**
+     * Builds the list of available mesh drivers metadata
+     *
+     * \since QGIS 3.12
+     */
+    virtual QList<QgsMeshDriverMetadata> meshDriversMetadata();
 
     /**
      * Class factory to return a pointer to a newly created QgsDataProvider object

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -121,6 +121,7 @@ class QgsMdalProviderMetadata: public QgsProviderMetadata
   public:
     QgsMdalProviderMetadata();
     QString filters( FilterType type ) override;
+    QList<QgsMeshDriverMetadata> meshDriversMetadata() override;
     QgsMdalProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options ) override;
     QList<QgsDataItemProvider *> dataItemProviders() const override;
 };

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -44,8 +44,112 @@
        <property name="title">
         <string>Result Layer</string>
        </property>
-       <layout class="QGridLayout" name="gridLayout_5">
-        <item row="8" column="0">
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="1" column="0">
+           <widget class="QLabel" name="mOutputFormatLabel_2">
+            <property name="text">
+             <string>Group name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="mOutputDatasetLabel">
+            <property name="text">
+             <string>Output dataset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="mOutputFormatLabel">
+            <property name="text">
+             <string>Output format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="mOutputFormatComboBox"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="horizontalWidget" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QCheckBox" name="useExtentCb">
+             <property name="text">
+              <string>Current extent</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="useMaskCb">
+             <property name="text">
+              <string>Mask layer</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="maskBox" native="true">
+          <layout class="QHBoxLayout" name="maskBoxLayout" stretch="0,0">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="minimumSize">
+              <size>
+               <width>206</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Mask Layer       </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QgsMapLayerComboBox" name="cboLayerMask">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editable">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QWidget" name="extendBox" native="true">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -144,78 +248,8 @@
           </layout>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QWidget" name="horizontalWidget" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <item>
-            <widget class="QCheckBox" name="useExtentCb">
-             <property name="text">
-              <string>Current extent</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">buttonGroup</string>
-             </attribute>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="useMaskCb">
-             <property name="text">
-              <string>Mask layer</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">buttonGroup</string>
-             </attribute>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QWidget" name="maskBox" native="true">
-          <layout class="QHBoxLayout" name="maskBoxLayout" stretch="0,0">
-           <property name="spacing">
-            <number>6</number>
-           </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="minimumSize">
-              <size>
-               <width>206</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Mask Layer       </string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QgsMapLayerComboBox" name="cboLayerMask">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="editable">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="16" column="0">
-         <spacer name="verticalSpacer_2">
+        <item>
+         <spacer name="verticalSpacer_3">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -227,21 +261,7 @@
           </property>
          </spacer>
         </item>
-        <item row="0" column="0">
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="mOutputDatasetLabel">
-            <property name="text">
-             <string>Output dataset</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
-          </item>
-         </layout>
-        </item>
-        <item row="12" column="0">
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -254,7 +274,7 @@
           </property>
          </spacer>
         </item>
-        <item row="13" column="0">
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QPushButton" name="mAllTimesButton">
@@ -278,20 +298,7 @@
           </item>
          </layout>
         </item>
-        <item row="9" column="0">
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="15" column="0">
+        <item>
          <layout class="QGridLayout" name="gridLayout_4">
           <item row="2" column="4">
            <widget class="QComboBox" name="mEndTimeComboBox"/>
@@ -328,10 +335,26 @@
           </item>
          </layout>
         </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
        <zorder>maskBox</zorder>
        <zorder>extendBox</zorder>
        <zorder>horizontalWidget</zorder>
+       <zorder>mOutputFormatLabel_2</zorder>
+       <zorder>mOutputGroupNameLineEdit</zorder>
+       <zorder></zorder>
       </widget>
      </widget>
      <widget class="QWidget" name="verticalLayoutWidget">

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -45,7 +45,9 @@ class TestQgsMeshCalculator : public QObject
     void singleOp_data();
     void singleOp(); //test operators which operate on a single value
 
-    void calcWithLayers();
+    void calcWithVertexLayers();
+    void calcWithFaceLayers();
+    void calcWithMixedLayers();
   private:
 
     QgsMeshLayer *mpMeshLayer = nullptr;
@@ -212,11 +214,9 @@ void TestQgsMeshCalculator::singleOp()
   }
 }
 
-void TestQgsMeshCalculator::calcWithLayers()
+void TestQgsMeshCalculator::calcWithVertexLayers()
 {
-  QgsCoordinateReferenceSystem crs;
-  crs.createFromId( 32633, QgsCoordinateReferenceSystem::EpsgCrsId );
-  QgsRectangle extent( 783235, 3348110, 783350, 3347960 );
+  QgsRectangle extent( 1000.000, 1000.000, 3000.000, 3000.000 );
 
   QTemporaryFile tmpFile;
   tmpFile.open(); // fileName is not available until open
@@ -224,6 +224,8 @@ void TestQgsMeshCalculator::calcWithLayers()
   tmpFile.close();
 
   QgsMeshCalculator rc( QStringLiteral( "\"VertexScalarDataset\" + 2" ),
+                        QStringLiteral( "BINARY_DAT" ),
+                        "NewVertexScalarDataset",
                         tmpName,
                         extent,
                         0,
@@ -234,6 +236,60 @@ void TestQgsMeshCalculator::calcWithLayers()
   QCOMPARE( static_cast< int >( rc.processCalculation() ), 0 );
   int newGroupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
   QCOMPARE( newGroupCount, groupCount + 1 );
+  const QgsMeshDatasetValue val = mpMeshLayer->dataProvider()->datasetValue( QgsMeshDatasetIndex( newGroupCount - 1, 0 ), 0 );
+  QCOMPARE( val.scalar(), 3 );
+}
+
+void TestQgsMeshCalculator::calcWithFaceLayers()
+{
+  QgsRectangle extent( 1000.000, 1000.000, 3000.000, 3000.000 );
+
+  QTemporaryFile tmpFile;
+  tmpFile.open(); // fileName is not available until open
+  QString tmpName = tmpFile.fileName();
+  tmpFile.close();
+
+  QgsMeshCalculator rc( QStringLiteral( "\"FaceScalarDataset\" + 2" ),
+                        QStringLiteral( "ASCII_DAT" ),
+                        "NewFaceScalarDataset",
+                        tmpName,
+                        extent,
+                        0,
+                        3600,
+                        mpMeshLayer
+                      );
+  int groupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
+  QCOMPARE( static_cast< int >( rc.processCalculation() ), 0 );
+  int newGroupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
+  QCOMPARE( newGroupCount, groupCount + 1 );
+  const QgsMeshDatasetValue val = mpMeshLayer->dataProvider()->datasetValue( QgsMeshDatasetIndex( newGroupCount - 1, 0 ), 0 );
+  QCOMPARE( val.scalar(), 3 );
+}
+
+void TestQgsMeshCalculator::calcWithMixedLayers()
+{
+  QgsRectangle extent( 1000.000, 1000.000, 3000.000, 3000.000 );
+
+  QTemporaryFile tmpFile;
+  tmpFile.open(); // fileName is not available until open
+  QString tmpName = tmpFile.fileName();
+  tmpFile.close();
+
+  QgsMeshCalculator rc( QStringLiteral( "\"VertexScalarDataset\" + \"FaceScalarDataset\"" ),
+                        QStringLiteral( "BINARY_DAT" ),
+                        "NewMixScalarDataset",
+                        tmpName,
+                        extent,
+                        0,
+                        3600,
+                        mpMeshLayer
+                      );
+  int groupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
+  QCOMPARE( static_cast< int >( rc.processCalculation() ), 0 );
+  int newGroupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
+  QCOMPARE( newGroupCount, groupCount + 1 );
+  const QgsMeshDatasetValue val = mpMeshLayer->dataProvider()->datasetValue( QgsMeshDatasetIndex( newGroupCount - 1, 0 ), 0 );
+  QCOMPARE( val.scalar(), 2 );
 }
 
 QGSTEST_MAIN( TestQgsMeshCalculator )

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -237,7 +237,7 @@ void TestQgsMeshCalculator::calcWithVertexLayers()
   int newGroupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
   QCOMPARE( newGroupCount, groupCount + 1 );
   const QgsMeshDatasetValue val = mpMeshLayer->dataProvider()->datasetValue( QgsMeshDatasetIndex( newGroupCount - 1, 0 ), 0 );
-  QCOMPARE( val.scalar(), 3 );
+  QCOMPARE( val.scalar(), 3.0 );
 }
 
 void TestQgsMeshCalculator::calcWithFaceLayers()
@@ -263,7 +263,7 @@ void TestQgsMeshCalculator::calcWithFaceLayers()
   int newGroupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
   QCOMPARE( newGroupCount, groupCount + 1 );
   const QgsMeshDatasetValue val = mpMeshLayer->dataProvider()->datasetValue( QgsMeshDatasetIndex( newGroupCount - 1, 0 ), 0 );
-  QCOMPARE( val.scalar(), 3 );
+  QCOMPARE( val.scalar(), 3.0 );
 }
 
 void TestQgsMeshCalculator::calcWithMixedLayers()
@@ -289,7 +289,7 @@ void TestQgsMeshCalculator::calcWithMixedLayers()
   int newGroupCount = mpMeshLayer->dataProvider()->datasetGroupCount();
   QCOMPARE( newGroupCount, groupCount + 1 );
   const QgsMeshDatasetValue val = mpMeshLayer->dataProvider()->datasetValue( QgsMeshDatasetIndex( newGroupCount - 1, 0 ), 0 );
-  QCOMPARE( val.scalar(), 2 );
+  QCOMPARE( val.scalar(), 2.0 );
 }
 
 QGSTEST_MAIN( TestQgsMeshCalculator )


### PR DESCRIPTION
fix #30219
fix #30170 

added "driver" and "group name" to the calculator interface. MDAL now supports 3 drivers for storing results, so user must be able to choose appropriate driver and dataset group name (some drivers store multiple groups to 1 file)

![Screenshot 2019-12-05 at 16 14 00](https://user-images.githubusercontent.com/804608/70247995-931fb880-177a-11ea-9b4d-83bfc4fa92ad.png)

