### PR TITLE
Use explicit QgsDataSourceUri username/password/authcfg setters/getters

### DIFF
--- a/src/core/geocms/geonode/qgsgeonodeconnection.cpp
+++ b/src/core/geocms/geonode/qgsgeonodeconnection.cpp
@@ -38,14 +38,14 @@ QgsGeoNodeConnection::QgsGeoNodeConnection( const QString &name )
   QString password = settings.value( credentialsKey + QStringLiteral( "/password" ), QString() ).toString();
   if ( !username.isEmpty() )
   {
-    mUri.setParam( QStringLiteral( "username" ), username );
-    mUri.setParam( QStringLiteral( "password" ), password );
+    mUri.setUsername( username );
+    mUri.setPassword( password );
   }
 
   QString authcfg = settings.value( credentialsKey + QStringLiteral( "/authcfg" ), QString() ).toString();
   if ( !authcfg.isEmpty() )
   {
-    mUri.setParam( QStringLiteral( "authcfg" ), authcfg );
+    mUri.setAuthConfigId( authcfg );
   }
 
   QgsDebugMsgLevel( QStringLiteral( "encodedUri: '%1'." ).arg( QString( mUri.encodedUri() ) ), 4 );

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2144,11 +2144,11 @@ QString QgsRasterLayer::decodedSource( const QString &source, const QString &pro
           QString item = iter.next();
           if ( item.startsWith( QLatin1String( "username=" ) ) )
           {
-            uri.setParam( QStringLiteral( "username" ), item.mid( 9 ) );
+            uri.setUsername( item.mid( 9 ) );
           }
           else if ( item.startsWith( QLatin1String( "password=" ) ) )
           {
-            uri.setParam( QStringLiteral( "password" ), item.mid( 9 ) );
+            uri.setPassword( item.mid( 9 ) );
           }
           else if ( item.startsWith( QLatin1String( "tiled=" ) ) )
           {

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -135,7 +135,7 @@ QVector<QgsDataItem *> QgsAfsConnectionItem::createChildren()
 {
   const QgsOwsConnection connection( QStringLiteral( "ARCGISFEATURESERVER" ), mConnName );
   const QString url = connection.uri().param( QStringLiteral( "url" ) );
-  const QString authcfg = connection.uri().param( QStringLiteral( "authcfg" ) );
+  const QString authcfg = connection.uri().authConfigId();
   const QString referer = connection.uri().param( QStringLiteral( "referer" ) );
   QgsStringMap headers;
   if ( ! referer.isEmpty() )

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -38,7 +38,7 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
 {
   QString errorTitle, errorMessage;
 
-  const QString authcfg = connection.uri().param( QStringLiteral( "authcfg" ) );
+  const QString authcfg = connection.uri().authConfigId();
   const QString baseUrl = connection.uri().param( QStringLiteral( "url" ) );
   const QString referer = connection.uri().param( QStringLiteral( "referer" ) );
   QgsStringMap headers;

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -127,7 +127,7 @@ QVector<QgsDataItem *> QgsAmsConnectionItem::createChildren()
 {
   const QgsOwsConnection connection( QStringLiteral( "ARCGISMAPSERVER" ), mConnName );
   const QString url = connection.uri().param( QStringLiteral( "url" ) );
-  const QString authcfg = connection.uri().param( QStringLiteral( "authcfg" ) );
+  const QString authcfg = connection.uri().authConfigId();
   const QString referer = connection.uri().param( QStringLiteral( "referer" ) );
   QgsStringMap headers;
   if ( ! referer.isEmpty() )

--- a/src/providers/arcgisrest/qgsamssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsamssourceselect.cpp
@@ -38,7 +38,7 @@ bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
 {
   QString errorTitle, errorMessage;
 
-  const QString authcfg = connection.uri().param( QStringLiteral( "authcfg" ) );
+  const QString authcfg = connection.uri().authConfigId();
   const QString baseUrl = connection.uri().param( QStringLiteral( "url" ) );
   const QString referer = connection.uri().param( QStringLiteral( "referer" ) );
   QgsStringMap headers;

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -1234,23 +1234,23 @@ QString QgsWcsCapabilities::lastErrorFormat()
 
 bool QgsWcsCapabilities::setAuthorization( QNetworkRequest &request ) const
 {
-  if ( mUri.hasParam( QStringLiteral( "authcfg" ) ) && !mUri.param( QStringLiteral( "authcfg" ) ).isEmpty() )
+  if ( !mUri.authConfigId().isEmpty() )
   {
-    return QgsApplication::authManager()->updateNetworkRequest( request, mUri.param( QStringLiteral( "authcfg" ) ) );
+    return QgsApplication::authManager()->updateNetworkRequest( request, mUri.authConfigId() );
   }
-  else if ( mUri.hasParam( QStringLiteral( "username" ) ) && mUri.hasParam( QStringLiteral( "password" ) ) )
+  else if ( !mUri.username().isEmpty() && !mUri.password().isEmpty() )
   {
-    QgsDebugMsg( "setAuthorization " + mUri.param( "username" ) );
-    request.setRawHeader( "Authorization", "Basic " + QStringLiteral( "%1:%2" ).arg( mUri.param( QStringLiteral( "username" ) ), mUri.param( QStringLiteral( "password" ) ) ).toLatin1().toBase64() );
+    QgsDebugMsg( "setAuthorization " + mUri.username() );
+    request.setRawHeader( "Authorization", "Basic " + QStringLiteral( "%1:%2" ).arg( mUri.username(), mUri.password() ).toLatin1().toBase64() );
   }
   return true;
 }
 
 bool QgsWcsCapabilities::setAuthorizationReply( QNetworkReply *reply ) const
 {
-  if ( mUri.hasParam( QStringLiteral( "authcfg" ) ) && !mUri.param( QStringLiteral( "authcfg" ) ).isEmpty() )
+  if ( !mUri.authConfigId().isEmpty() )
   {
-    return QgsApplication::authManager()->updateNetworkReply( reply, mUri.param( QStringLiteral( "authcfg" ) ) );
+    return QgsApplication::authManager()->updateNetworkReply( reply, mUri.authConfigId() );
   }
   return true;
 }

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -426,15 +426,15 @@ bool QgsWcsProvider::parseUri( const QString &uriString )
   mIgnoreAxisOrientation = uri.hasParam( QStringLiteral( "IgnoreAxisOrientation" ) ); // must be before parsing!
   mInvertAxisOrientation = uri.hasParam( QStringLiteral( "InvertAxisOrientation" ) ); // must be before parsing!
 
-  mAuth.mUserName = uri.param( QStringLiteral( "username" ) );
+  mAuth.mUserName = uri.username();
   QgsDebugMsg( "set username to " + mAuth.mUserName );
 
-  mAuth.mPassword = uri.param( QStringLiteral( "password" ) );
+  mAuth.mPassword = uri.password();
   QgsDebugMsg( "set password to " + mAuth.mPassword );
 
-  if ( uri.hasParam( QStringLiteral( "authcfg" ) ) )
+  if ( !uri.authConfigId().isEmpty() )
   {
-    mAuth.mAuthCfg = uri.param( QStringLiteral( "authcfg" ) );
+    mAuth.mAuthCfg = uri.authConfigId();
   }
   QgsDebugMsg( "set authcfg to " + mAuth.mAuthCfg );
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -42,12 +42,12 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
   uri.setEncodedUri( uriString );
 
   // Setup authentication
-  mAuth.mUserName = uri.param( QStringLiteral( "username" ) );
-  mAuth.mPassword = uri.param( QStringLiteral( "password" ) );
+  mAuth.mUserName = uri.username();
+  mAuth.mPassword = uri.password();
 
-  if ( uri.hasParam( QStringLiteral( "authcfg" ) ) )
+  if ( !uri.authConfigId().isEmpty() )
   {
-    mAuth.mAuthCfg = uri.param( QStringLiteral( "authcfg" ) );
+    mAuth.mAuthCfg = uri.authConfigId();
   }
 
   mAuth.mReferer = uri.param( QStringLiteral( "referer" ) );

--- a/src/providers/wms/qgsxyzconnection.cpp
+++ b/src/providers/wms/qgsxyzconnection.cpp
@@ -29,11 +29,11 @@ QString QgsXyzConnection::encodedUri() const
   if ( zMax != -1 )
     uri.setParam( QStringLiteral( "zmax" ), QString::number( zMax ) );
   if ( ! authCfg.isEmpty() )
-    uri.setParam( QStringLiteral( "authcfg" ), authCfg );
+    uri.setAuthConfigId( authCfg );
   if ( ! username.isEmpty() )
-    uri.setParam( QStringLiteral( "username" ), username );
+    uri.setUsername( username );
   if ( ! password.isEmpty() )
-    uri.setParam( QStringLiteral( "password" ), password );
+    uri.setPassword( password );
   if ( ! referer.isEmpty() )
     uri.setParam( QStringLiteral( "referer" ), referer );
   if ( tilePixelRatio != 0 )


### PR DESCRIPTION
Now that QgsDataSourceUri username/password/authcfg params are aliases to the direct getters/setters, correctly use the explicit getters and setters wherever possible.

Makes the code easier to read and more consistent -- now params should only ever be used for "extra", context specific stuff instead of commonly user authentication parameters.
