### PR TITLE
Allow saga algorithms to be run under SAGA 7.3, but with large warnings

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -107,6 +107,18 @@ missing external dependencies).
 .. seealso:: :py:func:`isActive`
 %End
 
+    virtual QString warningMessage() const;
+%Docstring
+Returns an optional warning message to show users when running algorithms from this provider.
+
+This can be used to return a translated warning message which should be shown to users
+of this provider. It's intended for use in cases such as a provider which relies on a 3rd-party
+backend, where the version of the backend software is not officially supported, or for
+alerting users to providers in a "beta" or "untrustworthy" state.
+
+.. versionadded:: 3.10.1
+%End
+
     virtual bool isActive() const;
 %Docstring
 Returns ``True`` if the provider is active and able to run algorithms.

--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -40,6 +40,7 @@ pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
 
 REQUIRED_VERSION = '2.3.'
+BETA_SUPPORT_VERSION = '7.3.'
 
 
 class SagaAlgorithmProvider(QgsProcessingProvider):
@@ -78,9 +79,15 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
 
     def canBeActivated(self):
         version = SagaUtils.getInstalledVersion(True)
-        if version is not None and version.startswith(REQUIRED_VERSION):
+        if version is not None and (version.startswith(REQUIRED_VERSION) or version.startswith(BETA_SUPPORT_VERSION)):
             return True
         return False
+
+    def warningMessage(self):
+        version = SagaUtils.getInstalledVersion(True)
+        if version is not None and version.startswith(BETA_SUPPORT_VERSION):
+            return self.tr('SAGA version {} is not officially supported - algorithms may encounter issues').format(version)
+        return ''
 
     def loadAlgorithms(self):
         version = SagaUtils.getInstalledVersion(True)
@@ -89,7 +96,7 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
                                      self.tr('Processing'), Qgis.Critical)
             return
 
-        if not version.startswith(REQUIRED_VERSION):
+        if not version.startswith(REQUIRED_VERSION) and not version.startswith(BETA_SUPPORT_VERSION):
             QgsMessageLog.logMessage(self.tr('Problem with SAGA installation: unsupported SAGA version (found: {}, required: {}).').format(version, REQUIRED_VERSION),
                                      self.tr('Processing'),
                                      Qgis.Critical)

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -202,6 +202,9 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
             self.clearProgress()
             self.feedback.pushVersionInfo(self.algorithm().provider())
+            if self.algorithm().provider().warningMessage():
+                self.feedback.reportError(self.algorithm().provider().warningMessage())
+
             self.setProgressText(QCoreApplication.translate('AlgorithmDialog', 'Processing algorithm…'))
 
             self.setInfo(

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -116,6 +116,18 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     virtual bool canBeActivated() const { return true; }
 
     /**
+     * Returns an optional warning message to show users when running algorithms from this provider.
+     *
+     * This can be used to return a translated warning message which should be shown to users
+     * of this provider. It's intended for use in cases such as a provider which relies on a 3rd-party
+     * backend, where the version of the backend software is not officially supported, or for
+     * alerting users to providers in a "beta" or "untrustworthy" state.
+     *
+     * \since QGIS 3.10.1
+     */
+    virtual QString warningMessage() const { return QString(); }
+
+    /**
      * Returns TRUE if the provider is active and able to run algorithms.
      */
     virtual bool isActive() const { return true; }

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -155,6 +155,12 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
   {
     mButtonBox->removeButton( mButtonBox->button( QDialogButtonBox::Help ) );
   }
+
+  const QString warning = algorithm->provider()->warningMessage();
+  if ( !warning.isEmpty() )
+  {
+    mMessageBar->pushMessage( warning, Qgis::Warning, 0 );
+  }
 }
 
 QgsProcessingAlgorithm *QgsProcessingAlgorithmDialogBase::algorithm()


### PR DESCRIPTION
Trying to unblock the stalemate with PROJ 6/GDAL 3 and the MacOS infrastructure, this PR adds the ability to run the SAGA algorithms under the new SAGA 7.3 LTR release. BUT..... show a huge obnoxious "NOT OFFICIALLY SUPPORTED" warning so that users know they are venturing into uncharted, not supported, dragon-filled territory.

Adding full support for SAGA 7.3 is going to be a painstaking, tedious, heart-breaking process (community, non QGIS-core-dev volunteers welcome to lead this effort!!!), but this should at least hopefully allow the mac builds to upgrade their dependencies without completely breaking SAGA support.

Ping @PeterPetrik @alexbruy 


