### PR TITLE
reloadData / forceReload on data providers

### DIFF
--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -269,8 +269,6 @@ Reloads the data from the source by calling reloadProviderData() implemented
 by providers with data caches to synchronize, changes in the data source, feature
 counts and other specific actions.
 Emits the `dataChanged` signal
-
-.. seealso:: :py:func:`reloadProviderData`
 %End
 
     virtual QDateTime timestamp() const;

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -265,8 +265,11 @@ databases and servers.
 
     virtual void reloadData();
 %Docstring
-Reloads the data from the source. Needs to be implemented by providers with data caches to
-synchronize with changes in the data source
+Reloads the data from the source by calling reloadProviderData() implemented
+by providers with data caches to synchronize, changes in the data source, feature
+counts and other specific actions and it calls the dataChanged signal
+
+.. seealso:: :py:func:`reloadProviderData`
 %End
 
     virtual QDateTime timestamp() const;

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -267,7 +267,8 @@ databases and servers.
 %Docstring
 Reloads the data from the source by calling reloadProviderData() implemented
 by providers with data caches to synchronize, changes in the data source, feature
-counts and other specific actions and it calls the dataChanged signal
+counts and other specific actions.
+Emits the `dataChanged` signal
 
 .. seealso:: :py:func:`reloadProviderData`
 %End

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -548,11 +548,6 @@ Returns the transaction this data provider is included in, if any.
 
  virtual void forceReload() /Deprecated/;
 %Docstring
-Forces a reload of the underlying datasource if the provider implements this
-method.
-In particular on the OGR provider, a pooled connection will be invalidated.
-This forces QGIS to reopen a file or connection.
-This can be required if the underlying file is replaced.
 
 .. deprecated::
    QGIS 3.12 - will be removed in QGIS 4.0 - use reloadData instead

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -546,7 +546,7 @@ providers will return ``None``.
 Returns the transaction this data provider is included in, if any.
 %End
 
- virtual void forceReload();
+ virtual void forceReload() /Deprecated/;
 %Docstring
 Forces a reload of the underlying datasource if the provider implements this
 method.
@@ -555,7 +555,7 @@ This forces QGIS to reopen a file or connection.
 This can be required if the underlying file is replaced.
 
 .. deprecated::
-   Will be removed in QGIS 4.0
+   QGIS 3.12 - will be removed in QGIS 4.0 - use reloadData instead
 %End
 
     virtual QSet<QgsMapLayerDependency> dependencies() const;

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -546,13 +546,16 @@ providers will return ``None``.
 Returns the transaction this data provider is included in, if any.
 %End
 
-    virtual void forceReload();
+ virtual void forceReload();
 %Docstring
 Forces a reload of the underlying datasource if the provider implements this
 method.
 In particular on the OGR provider, a pooled connection will be invalidated.
 This forces QGIS to reopen a file or connection.
 This can be required if the underlying file is replaced.
+
+.. deprecated::
+   Will be removed in QGIS 4.0
 %End
 
     virtual QSet<QgsMapLayerDependency> dependencies() const;

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -817,7 +817,7 @@ void QgsAttributeTableDialog::mActionSaveEdits_triggered()
 
 void QgsAttributeTableDialog::mActionReload_triggered()
 {
-  mMainView->masterModel()->layer()->dataProvider()->forceReload();
+  mMainView->masterModel()->layer()->dataProvider()->reloadData();
 }
 
 void QgsAttributeTableDialog::mActionAddFeature_triggered()

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -522,7 +522,7 @@ void QgsGdalProvider::closeDataset()
   closeCachedGdalHandlesFor( this );
 }
 
-void QgsGdalProvider::reloadData()
+void QgsGdalProvider::reloadProviderData()
 {
   QMutexLocker locker( mpMutex );
   closeDataset();

--- a/src/core/providers/gdal/qgsgdalprovider.h
+++ b/src/core/providers/gdal/qgsgdalprovider.h
@@ -199,8 +199,6 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     bool setNoDataValue( int bandNo, double noDataValue ) override;
     bool remove() override;
 
-    void reloadData() override;
-
     QString validateCreationOptions( const QStringList &createOptions, const QString &format ) override;
     QString validatePyramidsConfigOptions( QgsRaster::RasterPyramidsFormat pyramidsFormat,
                                            const QStringList &configOptions, const QString &fileFormat ) override;
@@ -335,6 +333,11 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     bool worldToPixel( double x, double y, int &col, int &row ) const;
 
     bool mStatisticsAreReliable = false;
+
+    /**
+     * Closes and reinits dataset
+    */
+    void reloadProviderData() override;
 };
 
 /**

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3915,11 +3915,6 @@ QByteArray QgsOgrProvider::quotedIdentifier( const QByteArray &field ) const
   return QgsOgrProviderUtils::quotedIdentifier( field, mGDALDriverName );
 }
 
-void QgsOgrProvider::forceReload()
-{
-  QgsOgrConnPool::instance()->invalidateConnections( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
-}
-
 QString QgsOgrProviderUtils::connectionPoolId( const QString &dataSourceURI, bool shareSameDatasetAmongLayers )
 {
   if ( shareSameDatasetAmongLayers )
@@ -4594,11 +4589,11 @@ void QgsOgrProvider::close()
   invalidateCachedExtent( false );
 }
 
-void QgsOgrProvider::reloadData()
+void QgsOgrProvider::reloadProviderData()
 {
   mFeaturesCounted = QgsVectorDataProvider::Uncounted;
   bool wasValid = mValid;
-  forceReload();
+  QgsOgrConnPool::instance()->invalidateConnections( QgsOgrProviderUtils::connectionPoolId( dataSourceUri( true ), mShareSameDatasetAmongLayers ) );
   close();
   open( OpenModeSameAsCurrent );
   if ( !mValid && wasValid )

--- a/src/core/providers/ogr/qgsogrprovider.h
+++ b/src/core/providers/ogr/qgsogrprovider.h
@@ -165,14 +165,6 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     QByteArray quotedIdentifier( const QByteArray &field ) const;
 
-    /**
-     * A forced reload invalidates the underlying connection.
-     * E.g. in case a shapefile is replaced, the old file will be closed
-     * and the new file will be opened.
-     */
-    void forceReload() override;
-    void reloadData() override;
-
   protected:
     //! Loads fields from input file to member attributeFields
     void loadFields();
@@ -335,6 +327,13 @@ class QgsOgrProvider : public QgsVectorDataProvider
     QgsOgrTransaction *mTransaction = nullptr;
 
     void setTransaction( QgsTransaction *transaction ) override;
+
+    /**
+    * Invalidates and reopens the file and resets the feature count
+    * E.g. in case a shapefile is replaced, the old file will be closed
+    * and the new file will be opened.
+    */
+    void reloadProviderData() override;
 };
 
 class QgsOgrDataset;

--- a/src/core/qgsdataprovider.cpp
+++ b/src/core/qgsdataprovider.cpp
@@ -24,6 +24,12 @@ QgsDataProvider::QgsDataProvider( const QString &uri, const QgsDataProvider::Pro
 {
 }
 
+void QgsDataProvider::reloadData()
+{
+  reloadProviderData();
+  emit dataChanged();
+}
+
 void QgsDataProvider::setProviderProperty( QgsDataProvider::ProviderProperty property, const QVariant &value )
 {
   mProviderProperties.insert( property, value );

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -356,10 +356,12 @@ class CORE_EXPORT QgsDataProvider : public QObject
     }
 
     /**
-     * Reloads the data from the source. Needs to be implemented by providers with data caches to
-     * synchronize with changes in the data source
+     * Reloads the data from the source by calling reloadProviderData() implemented
+     * by providers with data caches to synchronize, changes in the data source, feature
+     * counts and other specific actions and it calls the dataChanged signal
+     * \see reloadProviderData
      */
-    virtual void reloadData() {}
+    virtual void reloadData();
 
     //! Time stamp of data source in the moment when data/metadata were loaded by provider
     virtual QDateTime timestamp() const { return mTimestamp; }
@@ -614,6 +616,10 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     mutable QMutex mOptionsMutex;
 
+    /**
+     * Reloads the data according to the provider
+    */
+    virtual void reloadProviderData() {}
 };
 
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -358,7 +358,8 @@ class CORE_EXPORT QgsDataProvider : public QObject
     /**
      * Reloads the data from the source by calling reloadProviderData() implemented
      * by providers with data caches to synchronize, changes in the data source, feature
-     * counts and other specific actions and it calls the dataChanged signal
+     * counts and other specific actions.
+     * Emits the `dataChanged` signal
      * \see reloadProviderData()
      */
     virtual void reloadData();
@@ -618,6 +619,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
 
     /**
      * Reloads the data according to the provider
+     * \since QGIS 3.12
     */
     virtual void reloadProviderData() {}
 };

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -360,7 +360,6 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * by providers with data caches to synchronize, changes in the data source, feature
      * counts and other specific actions.
      * Emits the `dataChanged` signal
-     * \see reloadProviderData()
      */
     virtual void reloadData();
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -359,7 +359,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * Reloads the data from the source by calling reloadProviderData() implemented
      * by providers with data caches to synchronize, changes in the data source, feature
      * counts and other specific actions and it calls the dataChanged signal
-     * \see reloadProviderData
+     * \see reloadProviderData()
      */
     virtual void reloadData();
 

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -596,11 +596,6 @@ QgsTransaction *QgsVectorDataProvider::transaction() const
   return nullptr;
 }
 
-void QgsVectorDataProvider::forceReload()
-{
-  emit dataChanged();
-}
-
 static bool _compareEncodings( const QString &s1, const QString &s2 )
 {
   return s1.toLower() < s2.toLower();

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -554,8 +554,9 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * In particular on the OGR provider, a pooled connection will be invalidated.
      * This forces QGIS to reopen a file or connection.
      * This can be required if the underlying file is replaced.
-     */
-    virtual void forceReload();
+     * \deprecated Will be removed in QGIS 4.0
+    */
+    Q_DECL_DEPRECATED virtual void forceReload() { reloadData(); }
 
     /**
      * Gets the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
@@ -685,7 +686,6 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * Includes this data provider in the specified transaction. Ownership of transaction is not transferred.
      */
     virtual void setTransaction( QgsTransaction * /*transaction*/ ) {}
-
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorDataProvider::Capabilities )

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -554,9 +554,9 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * In particular on the OGR provider, a pooled connection will be invalidated.
      * This forces QGIS to reopen a file or connection.
      * This can be required if the underlying file is replaced.
-     * \deprecated Will be removed in QGIS 4.0
+     * \deprecated QGIS 3.12 - will be removed in QGIS 4.0 - use reloadData instead
     */
-    Q_DECL_DEPRECATED virtual void forceReload() { reloadData(); }
+    Q_DECL_DEPRECATED virtual void forceReload() SIP_DEPRECATED { reloadData(); }
 
     /**
      * Gets the list of layer ids on which this layer depends. This in particular determines the order of layer loading.

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -549,13 +549,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     virtual QgsTransaction *transaction() const;
 
     /**
-     * Forces a reload of the underlying datasource if the provider implements this
-     * method.
-     * In particular on the OGR provider, a pooled connection will be invalidated.
-     * This forces QGIS to reopen a file or connection.
-     * This can be required if the underlying file is replaced.
      * \deprecated QGIS 3.12 - will be removed in QGIS 4.0 - use reloadData instead
-    */
+     */
     Q_DECL_DEPRECATED virtual void forceReload() SIP_DEPRECATED { reloadData(); }
 
     /**

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -328,7 +328,7 @@ QString QgsAfsProvider::dataComment() const
   return mLayerDescription;
 }
 
-void QgsAfsProvider::reloadData()
+void QgsAfsProvider::reloadProviderData()
 {
   mSharedData->clearCache();
 }

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -74,7 +74,6 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QString name() const override;
     QString description() const override;
     QString dataComment() const override;
-    void reloadData() override;
     QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const override;
     QgsAbstractVectorLayerLabeling *createLabeling( const QVariantMap &configuration = QVariantMap() ) const override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
@@ -89,6 +88,11 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QVariantMap mRendererDataMap;
     QVariantList mLabelingDataList;
     QgsStringMap mRequestHeaders;
+
+    /**
+     * Clears cache
+    */
+    void reloadProviderData() override;
 };
 
 class QgsAfsProviderMetadata: public QgsProviderMetadata

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -392,7 +392,7 @@ void QgsAmsProvider::setSubLayerVisibility( const QString &name, bool vis )
   }
 }
 
-void QgsAmsProvider::reloadData()
+void QgsAmsProvider::reloadProviderData()
 {
   mCachedImage = QImage();
 }

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -85,7 +85,6 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QStringList subLayerStyles() const override;
     void setLayerOrder( const QStringList &layers ) override;
     void setSubLayerVisibility( const QString &name, bool vis ) override;
-    void reloadData() override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
     QgsLayerMetadata layerMetadata() const override;
 
@@ -158,6 +157,11 @@ class QgsAmsProvider : public QgsRasterDataProvider
     int mMaxImageHeight = 4096;
     QgsLayerMetadata mLayerMetadata;
     QList< double > mResolutions;
+
+    /**
+     * Resets cached image
+    */
+    void reloadProviderData() override;
 };
 
 //! Handler for tiled MapServer requests, the data are written to the given image

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -256,7 +256,7 @@ void QgsMdalProvider::loadData()
   }
 }
 
-void QgsMdalProvider::reloadData()
+void QgsMdalProvider::reloadProviderData()
 {
   if ( mMeshH )
     MDAL_CloseMesh( mMeshH );

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -83,8 +83,6 @@ class QgsMdalProvider : public QgsMeshDataProvider
                               const QVector<double> &times
                             ) override;
 
-    void reloadData() override;
-
     /**
      * Returns file filters for meshes and datasets to be used in Open File Dialogs
      * \param fileMeshFiltersString file mesh filters
@@ -114,6 +112,11 @@ class QgsMdalProvider : public QgsMeshDataProvider
     MeshH mMeshH;
     QStringList mExtraDatasetUris;
     QgsCoordinateReferenceSystem mCrs;
+
+    /**
+     * Closes and reloads dataset
+    */
+    void reloadProviderData() override;
 };
 
 class QgsMdalProviderMetadata: public QgsProviderMetadata

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -343,12 +343,10 @@ void QgsPostgresProvider::setListening( bool isListening )
   }
 }
 
-void QgsPostgresProvider::forceReload()
+void QgsPostgresProvider::reloadProviderData()
 {
   mShared->setFeaturesCounted( -1 );
   mLayerExtent.setMinimal();
-
-  QgsVectorDataProvider::forceReload();
 }
 
 
@@ -3332,12 +3330,12 @@ bool QgsPostgresProvider::setSubsetString( const QString &theSQL, bool updateFea
 
   if ( updateFeatureCount )
   {
-    forceReload();
+    reloadData();
   }
   else
   {
     mLayerExtent.setMinimal();
-    QgsVectorDataProvider::forceReload();
+    emit dataChanged();
   }
 
   return true;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -343,6 +343,15 @@ void QgsPostgresProvider::setListening( bool isListening )
   }
 }
 
+void QgsPostgresProvider::forceReload()
+{
+  mShared->setFeaturesCounted( -1 );
+  mLayerExtent.setMinimal();
+
+  QgsVectorDataProvider::forceReload();
+}
+
+
 QgsPostgresConn *QgsPostgresProvider::connectionRW()
 {
   if ( mTransaction )
@@ -3323,11 +3332,13 @@ bool QgsPostgresProvider::setSubsetString( const QString &theSQL, bool updateFea
 
   if ( updateFeatureCount )
   {
-    mShared->setFeaturesCounted( -1 );
+    forceReload();
   }
-  mLayerExtent.setMinimal();
-
-  emit dataChanged();
+  else
+  {
+    mLayerExtent.setMinimal();
+    QgsVectorDataProvider::forceReload();
+  }
 
   return true;
 }

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -240,6 +240,14 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     void setListening( bool isListening ) override;
 
+    /**
+     * Effect a reload including resetting the feature count
+     * and setting the layer extent to minimal
+     *
+     * \since QGIS 3.12
+    */
+    void forceReload() override;
+
   private:
     Relkind relkind() const;
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -240,13 +240,6 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     void setListening( bool isListening ) override;
 
-    /**
-     * Effect a reload including resetting the feature count
-     * and setting the layer extent to minimal
-     *
-     * \since QGIS 3.12
-    */
-    void forceReload() override;
 
   private:
     Relkind relkind() const;
@@ -332,6 +325,14 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      * Search all the layers using the given table.
      */
     static QList<QgsVectorLayer *> searchLayers( const QList<QgsVectorLayer *> &layers, const QString &connectionInfo, const QString &schema, const QString &tableName );
+
+    /**
+     * Effect a reload including resetting the feature count
+     * and setting the layer extent to minimal
+     *
+     * \since QGIS 3.12
+    */
+    void reloadProviderData() override;
 
     //! Old-style mapping of index to name for QgsPalLabeling fix
     QgsAttrPalIndexNameHash mAttrPalIndexName;

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -94,7 +94,7 @@ QgsVirtualLayerProvider::QgsVirtualLayerProvider( QString const &uri, const QgsD
   }
 }
 
-void QgsVirtualLayerProvider::reloadData()
+void QgsVirtualLayerProvider::reloadProviderData()
 {
   if ( mDefinition.sourceLayers().empty() && !mDefinition.filePath().isEmpty() && mDefinition.query().isEmpty() )
   {

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -60,7 +60,6 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     QgsAttributeList pkAttributeIndexes() const override;
     QSet<QgsMapLayerDependency> dependencies() const override;
     bool cancelReload() override;
-    void reloadData() override;
 
   private:
 
@@ -117,6 +116,11 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     bool createIt();
     bool loadSourceLayers();
     void createVirtualTable( QgsVectorLayer *vlayer, const QString &name );
+
+    /**
+     * Opens or creates file
+    */
+    void reloadProviderData() override;
 
     friend class QgsVirtualLayerFeatureSource;
 

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1584,7 +1584,7 @@ QString  QgsWcsProvider::description() const
   return WCS_DESCRIPTION;
 }
 
-void QgsWcsProvider::reloadData()
+void QgsWcsProvider::reloadProviderData()
 {
   clearCache();
 }

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -187,7 +187,6 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QString lastErrorFormat() override;
     QString name() const override;
     QString description() const override;
-    void reloadData() override;
     QList<QgsColorRampShader::ColorRampItem> colorTable( int bandNo )const override;
 
     int colorInterpretation( int bandNo ) const override;
@@ -399,6 +398,11 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     bool mFixRotate = false;
 
     QNetworkRequest::CacheLoadControl mCacheLoadControl = QNetworkRequest::PreferNetwork;
+
+    /**
+     * Clears cache
+    */
+    void reloadProviderData() override;
 
 };
 

--- a/src/providers/wfs/qgsoapifprovider.cpp
+++ b/src/providers/wfs/qgsoapifprovider.cpp
@@ -234,6 +234,7 @@ QgsRectangle QgsOapifProvider::extent() const
 
 void QgsOapifProvider::reloadProviderData()
 {
+  mUpdateFeatureCountAtNextFeatureCountRequest = true;
   mShared->invalidateCache();
 }
 
@@ -301,13 +302,16 @@ bool QgsOapifProvider::setSubsetString( const QString &filter, bool updateFeatur
   if ( !mShared->computeServerFilter( errorMsg ) )
     QgsMessageLog::logMessage( errorMsg, tr( "OAPIF" ) );
 
-  reloadData();
+
   if ( updateFeatureCount )
   {
-    mUpdateFeatureCountAtNextFeatureCountRequest = true;
+    reloadData();
   }
-
-  emit dataChanged();
+  else
+  {
+    mShared->invalidateCache();
+    emit dataChanged();
+  }
 
   return true;
 }

--- a/src/providers/wfs/qgsoapifprovider.cpp
+++ b/src/providers/wfs/qgsoapifprovider.cpp
@@ -232,10 +232,9 @@ QgsRectangle QgsOapifProvider::extent() const
   return mShared->consolidatedExtent();
 }
 
-void QgsOapifProvider::reloadData()
+void QgsOapifProvider::reloadProviderData()
 {
   mShared->invalidateCache();
-  QgsVectorDataProvider::reloadData();
 }
 
 bool QgsOapifProvider::isValid() const

--- a/src/providers/wfs/qgsoapifprovider.h
+++ b/src/providers/wfs/qgsoapifprovider.h
@@ -87,10 +87,6 @@ class QgsOapifProvider : public QgsVectorDataProvider
     //! For QgsWFSSourceSelect::buildQuery()
     const QString &clientSideFilterExpression() const;
 
-  public slots:
-
-    void reloadData() override;
-
   private slots:
 
     void pushErrorSlot( const QString &errorMsg );
@@ -112,6 +108,11 @@ class QgsOapifProvider : public QgsVectorDataProvider
 
     //! Initial requests
     bool init();
+
+    /**
+     * Invalidates cache of shared object
+    */
+    void reloadProviderData() override;
 };
 
 class QgsOapifProviderMetadata: public QgsProviderMetadata

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -773,10 +773,9 @@ QgsAbstractFeatureSource *QgsWFSProvider::featureSource() const
   return fs;
 }
 
-void QgsWFSProvider::reloadData()
+void QgsWFSProvider::reloadProviderData()
 {
   mShared->invalidateCache();
-  QgsVectorDataProvider::reloadData();
 }
 
 QgsWkbTypes::Type QgsWFSProvider::wkbType() const

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -714,6 +714,8 @@ QString QgsWFSProvider::subsetString() const
 
 bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureCount )
 {
+  Q_UNUSED( updateFeatureCount )
+
   QgsDebugMsgLevel( QStringLiteral( "theSql = '%1'" ).arg( theSQL ), 4 );
 
   if ( theSQL == mSubsetString )
@@ -756,12 +758,7 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
   if ( !mShared->computeFilter( errorMsg ) )
     QgsMessageLog::logMessage( errorMsg, tr( "WFS" ) );
 
-
-  mShared->invalidateCache();
-  if ( updateFeatureCount )
-    featureCount();
-
-  emit dataChanged();
+  reloadData();
 
   return true;
 }

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -755,7 +755,9 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
   QString errorMsg;
   if ( !mShared->computeFilter( errorMsg ) )
     QgsMessageLog::logMessage( errorMsg, tr( "WFS" ) );
-  reloadData();
+
+
+  mShared->invalidateCache();
   if ( updateFeatureCount )
     featureCount();
 

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -120,19 +120,21 @@ class QgsWFSProvider : public QgsVectorDataProvider
 
     bool empty() const override;
 
-  public slots:
-
-    void reloadData() override;
-
   private slots:
 
     void featureReceivedAnalyzeOneFeature( QVector<QgsFeatureUniqueIdPair> );
 
     void pushErrorSlot( const QString &errorMsg );
 
+
   private:
     //! Mutable data shared between provider and feature sources
     std::shared_ptr<QgsWFSSharedData> mShared;
+
+    /**
+     * Invalidates cache of shared object
+    */
+    void reloadProviderData() override;
 
     friend class QgsWFSFeatureSource;
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3230,10 +3230,6 @@ QString  QgsWmsProvider::description() const
   return WMS_DESCRIPTION;
 }
 
-void QgsWmsProvider::reloadData()
-{
-}
-
 bool QgsWmsProvider::renderInPreview( const QgsDataProvider::PreviewContext &context )
 {
   if ( mSettings.mTiled || mSettings.mXyz )

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -213,7 +213,6 @@ class QgsWmsProvider : public QgsRasterDataProvider
     QString name() const override;
     static QString providerKey();
     QString description() const override;
-    void reloadData() override;
     bool renderInPreview( const QgsDataProvider::PreviewContext &context ) override;
     QList< double > nativeResolutions() const override;
 
@@ -440,7 +439,6 @@ class QgsWmsProvider : public QgsRasterDataProvider
      * The error message associated with the last WMS error.
      */
     QString mError;
-
 
     /**
      * The mime type of the message


### PR DESCRIPTION
This is especially useful as part of the API when the data are updated in the background (data is entered to the database elsewhere) and QGIS needs to be reloaded (including feature count in the legend).

All calls of `forceReload()` or `reloadData()` target `QgsDataProvider::reloadData()` what calls the implemented `reloadProviderData()` of the provider and `dataChanged()` signal is called always. That this signal is called changes the behavior of the `dataReload()` calls of all providers.

Mostly the featureCount reset is implemented in the `reloadProviderData()` instead of do it separately.
