### PR TITLE
[UX][feature??] add progress bar to the auto layer finder

### DIFF
--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -557,7 +557,7 @@ void QgsHandleBadLayers::autoFind()
     const QString fileType = mLayerList->item( i, 2 )->text();
 
     progressDialog.setValue( i );
-    QChar sentenceEnd = ( name.length() > 15) ? QChar( 0x2026 ) : '.';
+    QChar sentenceEnd = ( name.length() > 15 ) ? QChar( 0x2026 ) : '.';
     progressDialog.setLabelText( QObject::tr( "Searching for file: %1 \n [ %2 of %3 ] " ).arg( name.left( 15 ) + sentenceEnd,
                                  QString::number( i + 1 ), QString::number( layersToFind.size() ) ) );
     progressDialog.open();

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -40,6 +40,7 @@
 #include <QDialogButtonBox>
 #include <QUrl>
 #include <QDir>
+#include <QProgressDialog>
 
 void QgsHandleBadLayersHandler::handleBadLayers( const QList<QDomNode> &layers )
 {
@@ -71,7 +72,6 @@ void QgsHandleBadLayersHandler::handleBadLayers( const QList<QDomNode> &layers )
   delete dialog;
   QApplication::restoreOverrideCursor();
 }
-
 
 QgsHandleBadLayers::QgsHandleBadLayers( const QList<QDomNode> &layers )
   : QDialog( QgisApp::instance() )
@@ -537,6 +537,9 @@ void QgsHandleBadLayers::autoFind()
   }
 
   const QList<int> constLayersToFind = layersToFind;
+
+  QProgressDialog progressDialog( QObject::tr( "Searching files" ), 0, 1, layersToFind.size(), this, Qt::Dialog );
+
   for ( int i : constLayersToFind )
   {
     int idx = mLayerList->item( i, 0 )->data( Qt::UserRole ).toInt();
@@ -552,6 +555,13 @@ void QgsHandleBadLayers::autoFind()
     const QString longName = dataInfo.fileName();
     QString provider = node.namedItem( QStringLiteral( "provider" ) ).toElement().text();
     const QString fileType = mLayerList->item( i, 2 )->text();
+
+    progressDialog.setValue( i );
+    QChar sentenceEnd = ( name.length() > 15) ? QChar( 0x2026 ) : '.';
+    progressDialog.setLabelText( QObject::tr( "Searching for file: %1 \n [ %2 of %3 ] " ).arg( name.left( 15 ) + sentenceEnd,
+                                 QString::number( i + 1 ), QString::number( layersToFind.size() ) ) );
+    progressDialog.open();
+
     if ( provider.toLower() == QStringLiteral( "none" ) )
     {
       if ( fileType == QStringLiteral( "raster" ) )
@@ -643,6 +653,7 @@ void QgsHandleBadLayers::autoFind()
         item->setForeground( QBrush( Qt::red ) );
       }
     }
+
   }
 
   QgsProject::instance()->layerTreeRegistryBridge()->setEnabled( false );

--- a/src/app/qgshandlebadlayers.h
+++ b/src/app/qgshandlebadlayers.h
@@ -43,7 +43,6 @@ class APP_EXPORT QgsHandleBadLayersHandler
 
 };
 
-
 class QPushButton;
 
 class APP_EXPORT QgsHandleBadLayers
@@ -93,6 +92,7 @@ class APP_EXPORT QgsHandleBadLayers
      * \since QGIS 3.12
      */
     QString checkBasepath( const QString &layerId, const QString &newPath, const QString &fileName );
+
 
 };
 


### PR DESCRIPTION
## Description

This simply add a progress bar to the auto layer finder feature, this should prevent some confusion and give a sense of progress to the user instead of an apparent freeze.

![progress](https://user-images.githubusercontent.com/12854129/70343459-54930800-1825-11ea-86b6-3c14a41f2e16.PNG)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
