### PR TITLE
Fix some warnings on invalid layers

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13402,7 +13402,8 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
         mActionAddFeature->setText( addFeatureText );
         mActionAddFeature->setToolTip( addFeatureText );
         QgsGui::shortcutsManager()->unregisterAction( mActionAddFeature );
-        QgsGui::shortcutsManager()->registerAction( mActionAddFeature, mActionAddFeature->shortcut() );
+        if ( !mActionAddFeature->text().isEmpty() ) // The text will be empty on unkown geometry type -> in this case do not create a shortcut
+          QgsGui::shortcutsManager()->registerAction( mActionAddFeature, mActionAddFeature->shortcut() );
       }
       else
       {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13402,7 +13402,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
         mActionAddFeature->setText( addFeatureText );
         mActionAddFeature->setToolTip( addFeatureText );
         QgsGui::shortcutsManager()->unregisterAction( mActionAddFeature );
-        if ( !mActionAddFeature->text().isEmpty() ) // The text will be empty on unkown geometry type -> in this case do not create a shortcut
+        if ( !mActionAddFeature->text().isEmpty() ) // The text will be empty on unknown geometry type -> in this case do not create a shortcut
           QgsGui::shortcutsManager()->registerAction( mActionAddFeature, mActionAddFeature->shortcut() );
       }
       else

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -799,7 +799,7 @@ bool QgsLayoutItemAttributeTable::readPropertiesFromElement( const QDomElement &
 
   //connect to new layer
   if ( QgsVectorLayer *newLayer = sourceLayer() )
-    connect( sourceLayer(), &QgsVectorLayer::layerModified, this, &QgsLayoutTable::refreshAttributes );
+    connect( newLayer, &QgsVectorLayer::layerModified, this, &QgsLayoutTable::refreshAttributes );
 
   refreshAttributes();
 

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -799,7 +799,9 @@ bool QgsLayoutItemAttributeTable::readPropertiesFromElement( const QDomElement &
   mVectorLayer.resolveWeakly( mLayout->project() );
 
   //connect to new layer
-  connect( sourceLayer(), &QgsVectorLayer::layerModified, this, &QgsLayoutTable::refreshAttributes );
+  QgsVectorLayer *newLayer = sourceLayer();
+  if ( newLayer )
+    connect( sourceLayer(), &QgsVectorLayer::layerModified, this, &QgsLayoutTable::refreshAttributes );
 
   refreshAttributes();
 

--- a/src/core/layout/qgslayoutitemattributetable.cpp
+++ b/src/core/layout/qgslayoutitemattributetable.cpp
@@ -754,8 +754,7 @@ bool QgsLayoutItemAttributeTable::writePropertiesToElement( QDomElement &tableEl
 
 bool QgsLayoutItemAttributeTable::readPropertiesFromElement( const QDomElement &itemElem, const QDomDocument &doc, const QgsReadWriteContext &context )
 {
-  QgsVectorLayer *prevLayer = sourceLayer();
-  if ( prevLayer )
+  if ( QgsVectorLayer *prevLayer = sourceLayer() )
   {
     //disconnect from previous layer
     disconnect( prevLayer, &QgsVectorLayer::layerModified, this, &QgsLayoutTable::refreshAttributes );
@@ -799,8 +798,7 @@ bool QgsLayoutItemAttributeTable::readPropertiesFromElement( const QDomElement &
   mVectorLayer.resolveWeakly( mLayout->project() );
 
   //connect to new layer
-  QgsVectorLayer *newLayer = sourceLayer();
-  if ( newLayer )
+  if ( QgsVectorLayer *newLayer = sourceLayer() )
     connect( sourceLayer(), &QgsVectorLayer::layerModified, this, &QgsLayoutTable::refreshAttributes );
 
   refreshAttributes();

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -1342,8 +1342,7 @@ void QgsMarkerSymbol::setAngle( double symbolAngle )
 
 double QgsMarkerSymbol::angle() const
 {
-  const auto constMLayers = mLayers;
-  for ( QgsSymbolLayer *layer : constMLayers )
+  for ( QgsSymbolLayer *layer : qgis::as_const( mLayers ) )
   {
     if ( layer->type() != QgsSymbol::Marker )
       continue;
@@ -1369,8 +1368,8 @@ void QgsMarkerSymbol::setDataDefinedAngle( const QgsProperty &property )
 {
   const double symbolRotation = angle();
 
-  const auto constMLayers = mLayers;
-  for ( QgsSymbolLayer *layer : constMLayers )
+
+  for ( QgsSymbolLayer *layer : qgis::as_const( mLayers ) )
   {
     if ( layer->type() != QgsSymbol::Marker )
       continue;
@@ -1725,8 +1724,8 @@ void QgsMarkerSymbol::renderPoint( QPointF point, const QgsFeature *f, QgsRender
     return;
   }
 
-  const auto constMLayers = mLayers;
-  for ( QgsSymbolLayer *symbolLayer : constMLayers )
+
+  for ( QgsSymbolLayer *symbolLayer : qgis::as_const( mLayers ) )
   {
     if ( context.renderingStopped() )
       break;


### PR DESCRIPTION
When loading old projects that were saved without geometry type in the xml, invalid layers' geometry types cannot be resolved and some warnings are popping up on debug builds.