### PR TITLE
Fail expression evaluation if missing field is referenced

### DIFF
--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -715,7 +715,7 @@ Convenience function for retrieving the fields for the context, if set.
 %Docstring
 Sets the original value variable value for the context.
 
-:param value: value for original value variable. This usually represents the an original widget
+:param value: value for original value variable. This usually represents an original widget
               value before any data defined overrides have been applied.
 
 .. versionadded:: 2.12

--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -1270,7 +1270,8 @@ QVariant QgsExpressionNodeColumnRef::evalNode( QgsExpression *parent, const QgsE
         return feature.attribute( mName );
     }
   }
-  return QVariant( '[' + mName + ']' );
+  parent->setEvalErrorString( QStringLiteral( "Column '%1' not found" ).arg( mName ) );
+  return QVariant();
 }
 
 QgsExpressionNode::NodeType QgsExpressionNodeColumnRef::nodeType() const

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -667,7 +667,7 @@ class CORE_EXPORT QgsExpressionContext
 
     /**
      * Sets the original value variable value for the context.
-     * \param value value for original value variable. This usually represents the an original widget
+     * \param value value for original value variable. This usually represents an original widget
      * value before any data defined overrides have been applied.
      * \since QGIS 2.12
      */

--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -500,7 +500,7 @@ QVariant QgsProperty::propertyValue( const QgsExpressionContext &context, const 
     case InvalidProperty:
       return defaultValue;
 
-  };
+  }
 
   return QVariant();
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -3514,7 +3514,7 @@ class TestQgsExpression: public QObject
       QCOMPARE( e.evaluate( &context ).toString(), QStringLiteral( "[3]" ) );
       e = QgsExpression( QStringLiteral( "'a[3]'" ) );
       QCOMPARE( e.evaluate( &context ).toString(), QStringLiteral( "a[3]" ) );
-      e = QgsExpression( QStringLiteral( "\"a[3]\"" ) );
+      e = QgsExpression( QStringLiteral( "try(\"a[3]\", '[a[3]]')" ) );
       QCOMPARE( e.evaluate( &context ).toString(), QStringLiteral( "[a[3]]" ) );
       e = QgsExpression( QStringLiteral( "(1+2)[0]" ) );
       QVERIFY( !e.evaluate( &context ).isValid() );

--- a/tests/src/core/testqgslayoutlabel.cpp
+++ b/tests/src/core/testqgslayoutlabel.cpp
@@ -140,7 +140,7 @@ void TestQgsLayoutLabel::evaluation()
   {
     // expression evaluation (without feature)
     QString expected = QStringLiteral( "__[NAME_1]42__" );
-    label->setText( QStringLiteral( "__[%\"NAME_1\"%][%21*2%]__" ) );
+    label->setText( QStringLiteral( "__[%try(\"NAME_1\", '[NAME_1]')%][%21*2%]__" ) );
     QString evaluated = label->currentText();
     QCOMPARE( evaluated, expected );
   }

--- a/tests/src/python/test_qgslayoutlabel.py
+++ b/tests/src/python/test_qgslayoutlabel.py
@@ -54,22 +54,22 @@ class TestQgsLayoutItemLabel(unittest.TestCase, LayoutItemTestCase):
     def evaluation_test(self, layout, label):
         # $CURRENT_DATE evaluation
         label.setText("__$CURRENT_DATE__")
-        assert label.currentText() == ("__" + QDate.currentDate().toString() + "__")
+        self.assertEqual(label.currentText(), ("__" + QDate.currentDate().toString() + "__"))
 
         # $CURRENT_DATE() evaluation
         label.setText("__$CURRENT_DATE(dd)(ok)__")
         expected = "__" + QDateTime.currentDateTime().toString("dd") + "(ok)__"
-        assert label.currentText() == expected
+        self.assertEqual(label.currentText(), expected)
 
         # $CURRENT_DATE() evaluation (inside an expression)
         label.setText("__[%$CURRENT_DATE(dd) + 1%](ok)__")
         dd = QDate.currentDate().day()
         expected = "__%d(ok)__" % (dd + 1)
-        assert label.currentText() == expected
+        self.assertEqual(label.currentText(), expected)
 
         # expression evaluation (without associated feature)
-        label.setText("__[%\"NAME_1\"%][%21*2%]__")
-        assert label.currentText() == "__[NAME_1]42__"
+        label.setText("__[%try(\"NAME_1\", '[NAME_1]')%][%21*2%]__")
+        self.assertEqual(label.currentText(), "__[NAME_1]42__")
 
     def feature_evaluation_test(self, layout, label, mVectorLayer):
         atlas = layout.atlas()
@@ -79,21 +79,21 @@ class TestQgsLayoutItemLabel(unittest.TestCase, LayoutItemTestCase):
         label.setText("[%\"NAME_1\"||'_ok'%]")
         atlas.beginRender()
         atlas.seekTo(0)
-        assert label.currentText() == "Basse-Normandie_ok"
+        self.assertEqual(label.currentText(), "Basse-Normandie_ok")
 
         atlas.seekTo(1)
-        assert label.currentText() == "Bretagne_ok"
+        self.assertEqual(label.currentText(), "Bretagne_ok")
 
     def page_evaluation_test(self, layout, label, mVectorLayer):
         page = QgsLayoutItemPage(layout)
         page.setPageSize('A4')
         layout.pageCollection().addPage(page)
         label.setText("[%@layout_page||'/'||@layout_numpages%]")
-        assert label.currentText() == "1/2"
+        self.assertEqual(label.currentText(), "1/2")
 
         # move the the second page and re-evaluate
         label.attemptMove(QgsLayoutPoint(0, 320))
-        assert label.currentText() == "2/2"
+        self.assertEqual(label.currentText(), "2/2")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 When evaluating an expression with a missing referenced field, this was be replaced with a string `[fieldname]`. But `expression.prepare()` would fail already, so this just worked on unprepared expressions.

When calculating data defined values, this will be counterproductive.
A field with a data defined value might work well in the expression builder (because fiels are all present) but fail in the legend, because it's rendered with no feature and hence fields. With this change, we can at least use `try("fieldname", 0)` to fallback to a default value.

