### PR TITLE
v.to.rast: fix va -> val

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.to.rast.txt
+++ b/python/plugins/processing/algs/grass7/description/v.to.rast.txt
@@ -4,7 +4,7 @@ Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input vector layer|-1|None|False
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;area|True|0,1,3|True
 QgsProcessingParameterString|where|WHERE conditions of SQL statement without 'where' keyword|None|True|True
-QgsProcessingParameterEnum|use|Source of raster values|attr;cat;va;z;dir|False|0|False
+QgsProcessingParameterEnum|use|Source of raster values|attr;cat;val;z;dir|False|0|False
 QgsProcessingParameterField|attribute_column|Name of column for 'attr' parameter (data type must be numeric)|None|input|0|False|True
 QgsProcessingParameterField|rgb_column|Name of color definition column (with RRR:GGG:BBB entries)|None|input|0|False|True
 QgsProcessingParameterField|label_column|Name of column used as raster category labels|None|input|0|False|True


### PR DESCRIPTION
## Description
The current "va" is not only unclear to the user but also not the value expected by GRASS GIS' v.to.rast command. Probably it was simply a typo.

Should be backported.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
