### PR TITLE
[processing] use active layer in the widget wrapper only for non-optional params

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -939,7 +939,10 @@ class MapLayerWidgetWrapper(WidgetWrapper):
                 if self.parameterDefinition().flags() & QgsProcessingParameterDefinition.FlagOptional:
                     self.combo.setLayer(self.parameterDefinition().defaultValue())
                 else:
-                    self.combo.setLayer(iface.activeLayer())
+                    if self.parameterDefinition().defaultValue():
+                        self.combo.setLayer(self.parameterDefinition().defaultValue())
+                    else:
+                        self.combo.setLayer(iface.activeLayer())
             except:
                 pass
 

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -937,10 +937,10 @@ class MapLayerWidgetWrapper(WidgetWrapper):
 
             try:
                 if self.parameterDefinition().flags() & QgsProcessingParameterDefinition.FlagOptional:
-                    self.combo.setLayer(self.parameterDefinition().defaultValue())
+                    self.combo.setValue(self.parameterDefinition().defaultValue(), self.context)
                 else:
                     if self.parameterDefinition().defaultValue():
-                        self.combo.setLayer(self.parameterDefinition().defaultValue())
+                        self.combo.setvalue(self.parameterDefinition().defaultValue(), self.context)
                     else:
                         self.combo.setLayer(iface.activeLayer())
             except:

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -936,7 +936,10 @@ class MapLayerWidgetWrapper(WidgetWrapper):
             self.context = dataobjects.createContext()
 
             try:
-                self.combo.setLayer(iface.activeLayer())
+                if self.parameterDefinition().flags() & QgsProcessingParameterDefinition.FlagOptional:
+                    self.combo.setLayer(self.parameterDefinition().defaultValue())
+                else:
+                    self.combo.setLayer(iface.activeLayer())
             except:
                 pass
 


### PR DESCRIPTION
## Description
Making @gioman (and users) a bit more happier.

Currenly layer parameters in the standard processing dialogs prepopulated with active layer. This is not very convenient in case of optional parameters as you need manually re-select empty option for them. Proposed fix prepopulates comboboxes only for non-optional parameres.

Here is how it worked before
![image](https://user-images.githubusercontent.com/776954/70432804-ca4ade00-1a88-11ea-9e0b-1da03f14f597.png)
and after patch
![image](https://user-images.githubusercontent.com/776954/70432998-37f70a00-1a89-11ea-9550-89768fc46058.png)

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
