### PR TITLE
Collapse double slashes in URLs regardless of Qt version

### DIFF
--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -69,17 +69,13 @@ void QgsServerOgcApi::registerHandler( QgsServerOgcApiHandler *handler )
 
 QUrl QgsServerOgcApi::sanitizeUrl( const QUrl &url )
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
-  // Since QT 13 NormalizePathSegments does not collapse double slashes
+  // Since QT 5.12 NormalizePathSegments does not collapse double slashes
   QUrl u { url.adjusted( QUrl::StripTrailingSlash | QUrl::NormalizePathSegments ) };
-  while ( u.path().contains( QLatin1String( "//" ) ) )
+  if ( u.path().contains( QLatin1String( "//" ) ) )
   {
     u.setPath( u.path().replace( QLatin1String( "//" ), QChar( '/' ) ) );
   }
   return u;
-#else
-  return url.adjusted( QUrl::StripTrailingSlash | QUrl::NormalizePathSegments );
-#endif
 }
 
 void QgsServerOgcApi::executeRequest( const QgsServerApiContext &context ) const


### PR DESCRIPTION
Fixes #33203 , followup https://github.com/qgis/QGIS/pull/33280
