### PR TITLE
Fix profile creation and absence of tbl_srs in qgis.db

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1879,12 +1879,13 @@ bool QgsApplication::createDatabase( QString *errorMessage )
     }
 
     char *errmsg = nullptr;
-    int res = sqlite3_exec( database.get(), "SELECT epsg FROM tbl_srs LIMIT 0", nullptr, nullptr, &errmsg );
-    if ( res == SQLITE_OK )
+    int res = sqlite3_exec( database.get(), "SELECT srs_id FROM tbl_srs LIMIT 0", nullptr, nullptr, &errmsg );
+    if ( res != SQLITE_OK )
     {
-      // epsg column exists => need migration
+      sqlite3_free( errmsg );
+
+      // qgis.db is missing tbl_srs, create it
       if ( sqlite3_exec( database.get(),
-                         "ALTER TABLE tbl_srs RENAME TO tbl_srs_bak;"
                          "CREATE TABLE tbl_srs ("
                          "srs_id INTEGER PRIMARY KEY,"
                          "description text NOT NULL,"
@@ -1896,14 +1897,11 @@ bool QgsApplication::createDatabase( QString *errorMessage )
                          "auth_id varchar,"
                          "is_geo integer NOT NULL,"
                          "deprecated boolean);"
-                         "CREATE INDEX idx_srsauthid on tbl_srs(auth_name,auth_id);"
-                         "INSERT INTO tbl_srs(srs_id,description,projection_acronym,ellipsoid_acronym,parameters,srid,auth_name,auth_id,is_geo,deprecated) SELECT srs_id,description,projection_acronym,ellipsoid_acronym,parameters,srid,'','',is_geo,0 FROM tbl_srs_bak;"
-                         "DROP TABLE tbl_srs_bak", nullptr, nullptr, &errmsg ) != SQLITE_OK
-         )
+                         "CREATE INDEX idx_srsauthid on tbl_srs(auth_name,auth_id);", nullptr, nullptr, &errmsg ) != SQLITE_OK )
       {
         if ( errorMessage )
         {
-          *errorMessage = tr( "Migration of private qgis.db failed.\n%1" ).arg( QString::fromUtf8( errmsg ) );
+          *errorMessage = tr( "Creation of missing tbl_srs in the private qgis.db failed.\n%1" ).arg( QString::fromUtf8( errmsg ) );
         }
         sqlite3_free( errmsg );
         return false;
@@ -1911,7 +1909,39 @@ bool QgsApplication::createDatabase( QString *errorMessage )
     }
     else
     {
-      sqlite3_free( errmsg );
+      int res = sqlite3_exec( database.get(), "SELECT epsg FROM tbl_srs LIMIT 0", nullptr, nullptr, &errmsg );
+      if ( res == SQLITE_OK )
+      {
+        // epsg column exists => need migration
+        if ( sqlite3_exec( database.get(),
+                           "ALTER TABLE tbl_srs RENAME TO tbl_srs_bak;"
+                           "CREATE TABLE tbl_srs ("
+                           "srs_id INTEGER PRIMARY KEY,"
+                           "description text NOT NULL,"
+                           "projection_acronym text NOT NULL,"
+                           "ellipsoid_acronym NOT NULL,"
+                           "parameters text NOT NULL,"
+                           "srid integer,"
+                           "auth_name varchar,"
+                           "auth_id varchar,"
+                           "is_geo integer NOT NULL,"
+                           "deprecated boolean);"
+                           "CREATE INDEX idx_srsauthid on tbl_srs(auth_name,auth_id);"
+                           "INSERT INTO tbl_srs(srs_id,description,projection_acronym,ellipsoid_acronym,parameters,srid,auth_name,auth_id,is_geo,deprecated) SELECT srs_id,description,projection_acronym,ellipsoid_acronym,parameters,srid,'','',is_geo,0 FROM tbl_srs_bak;"
+                           "DROP TABLE tbl_srs_bak", nullptr, nullptr, &errmsg ) != SQLITE_OK )
+        {
+          if ( errorMessage )
+          {
+            *errorMessage = tr( "Migration of private qgis.db failed.\n%1" ).arg( QString::fromUtf8( errmsg ) );
+          }
+          sqlite3_free( errmsg );
+          return false;
+        }
+      }
+      else
+      {
+        sqlite3_free( errmsg );
+      }
     }
 
     if ( sqlite3_exec( database.get(), "DROP VIEW vw_srs", nullptr, nullptr, &errmsg ) != SQLITE_OK )
@@ -1932,8 +1962,7 @@ bool QgsApplication::createDatabase( QString *errorMessage )
                        ",a.deprecated AS deprecated"
                        " FROM tbl_srs a"
                        " LEFT OUTER JOIN tbl_projection b ON a.projection_acronym=b.acronym"
-                       " ORDER BY coalesce(b.name,a.projection_acronym),a.description", nullptr, nullptr, &errmsg ) != SQLITE_OK
-       )
+                       " ORDER BY coalesce(b.name,a.projection_acronym),a.description", nullptr, nullptr, &errmsg ) != SQLITE_OK )
     {
       if ( errorMessage )
       {

--- a/src/core/qgsuserprofilemanager.cpp
+++ b/src/core/qgsuserprofilemanager.cpp
@@ -142,7 +142,7 @@ QgsError QgsUserProfileManager::createUserProfile( const QString &name )
   QDir folder( mRootProfilePath + QDir::separator() + name );
   if ( !folder.exists() )
   {
-    QDir().mkdir( folder.absolutePath() );
+    QDir().mkpath( folder.absolutePath() );
   }
 
   QFile qgisPrivateDbFile( folder.absolutePath() + QDir::separator() + "qgis.db" );


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR fixes related issues which leads to - among other things - a broken custom projections dialog.

Long story short, if QGIS starts and its root profiles directory is missing, it'll proceed forward with creating a default profile (and in doing so creating a profiles directory) via QDir().mkdir(). Turns out this doesn't work reliably when one needs to create *multiple* directories in the full path. We're fixing that by moving to QDir().mkpath().

This lingering issue was leading to the second problem being fixed here, whereas qgis.db was not copied properly upon profile creation when QDir().mkdir() failed. That caused an empty qgis.db to eventually be created, with the crucial tbl_srs and tbl_projection (as well as tbl_ellipsoid, which is not really a problem for GDAL > 2) missing.

Without tbl_srs, the custom projection dialog was missing. 

The second commit fixes that situation by creating a tbl_srs table when launching QGIS if we detect its missing from qgis.db.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
