### PR TITLE
Fix escape and enter don't work to close color or symbol selector dialogs

### DIFF
--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -42,6 +42,8 @@ QgsColorDialog::QgsColorDialog( QWidget *parent, Qt::WindowFlags fl, const QColo
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsColorDialog::mButtonBox_rejected );
   connect( mButtonBox, &QDialogButtonBox::clicked, this, &QgsColorDialog::mButtonBox_clicked );
 
+  connect( mColorWidget, &QgsPanelWidget::panelAccepted, this, &QDialog::reject );
+
   if ( mPreviousColor.isValid() )
   {
     QPushButton *resetButton = new QPushButton( tr( "Reset" ) );

--- a/src/gui/qgspanelwidget.cpp
+++ b/src/gui/qgspanelwidget.cpp
@@ -105,6 +105,10 @@ void QgsPanelWidget::keyPressEvent( QKeyEvent *event )
   {
     acceptPanel();
   }
+  else
+  {
+    QWidget::keyPressEvent( event );
+  }
 }
 
 QgsPanelWidgetWrapper::QgsPanelWidgetWrapper( QWidget *widget, QWidget *parent )

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -782,6 +782,8 @@ QgsSymbolSelectorDialog::QgsSymbolSelectorDialog( QgsSymbol *symbol, QgsStyle *s
   layout()->addWidget( mSelectorWidget );
   layout()->addWidget( mButtonBox );
 
+  connect( mSelectorWidget, &QgsPanelWidget::panelAccepted, this, &QDialog::reject );
+
   mSelectorWidget->setMinimumSize( 460, 560 );
   setObjectName( QStringLiteral( "SymbolSelectorDialog" ) );
   QgsGui::instance()->enableAutoGeometryRestore( this );


### PR DESCRIPTION

Fixes #27602
