### PR TITLE
Add expressions is_empty(geom)  is_empty_or_null(geom)

### DIFF
--- a/resources/function_help/json/is_empty
+++ b/resources/function_help/json/is_empty
@@ -4,7 +4,7 @@
   "description": "Returns true if a geometry is empty (without coordinates) or false if a is empty."
   "arguments": [ {"arg":"geom","description":"a geometry"}],
   "examples": [ { "expression":"is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))", "returns":"false"},
-                { "expression":"is_empty(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"}]
-                { "expression":"is_empty(geom_from_wkt('POINT(7 4)'))", "returns":"false"}]
-                { "expression":"is_empty(geom_from_wkt('POINT EMPTY'))", "returns":"true"}]
+                { "expression":"is_empty(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"},
+                { "expression":"is_empty(geom_from_wkt('POINT(7 4)'))", "returns":"false"},
+                { "expression":"is_empty(geom_from_wkt('POINT EMPTY'))", "returns":"true"} ]
 }

--- a/resources/function_help/json/is_empty
+++ b/resources/function_help/json/is_empty
@@ -1,7 +1,7 @@
 {
   "name": "is_empty",
   "type": "function",
-  "description": "Returns true if a geometry is empty (without coordinates), false if the geometry is not empty and NULL if there is no geometry.",
+  "description": "Returns true if a geometry is empty (without coordinates), false if the geometry is not empty and NULL if there is no geometry. See also `is_empty_or_null`.",
   "arguments": [ {"arg":"geom","description":"a geometry"}],
   "examples": [ { "expression":"is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))", "returns":"false"},
                 { "expression":"is_empty(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"},

--- a/resources/function_help/json/is_empty
+++ b/resources/function_help/json/is_empty
@@ -1,7 +1,7 @@
 {
   "name": "is_empty",
   "type": "function",
-  "description": "Returns true if a geometry is empty (without coordinates) or false if a is empty."
+  "description": "Returns true if a geometry is empty (without coordinates) or false if the geometry is empty.",
   "arguments": [ {"arg":"geom","description":"a geometry"}],
   "examples": [ { "expression":"is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))", "returns":"false"},
                 { "expression":"is_empty(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"},

--- a/resources/function_help/json/is_empty
+++ b/resources/function_help/json/is_empty
@@ -1,0 +1,10 @@
+{
+  "name": "is_empty",
+  "type": "function",
+  "description": "Returns true if a geometry is empty (without coordinates) or false if a is empty."
+  "arguments": [ {"arg":"geom","description":"a geometry"}],
+  "examples": [ { "expression":"is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))", "returns":"false"},
+                { "expression":"is_empty(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"}]
+                { "expression":"is_empty(geom_from_wkt('POINT(7 4)'))", "returns":"false"}]
+                { "expression":"is_empty(geom_from_wkt('POINT EMPTY'))", "returns":"true"}]
+}

--- a/resources/function_help/json/is_empty
+++ b/resources/function_help/json/is_empty
@@ -1,7 +1,7 @@
 {
   "name": "is_empty",
   "type": "function",
-  "description": "Returns true if a geometry is empty (without coordinates) or false if the geometry is empty.",
+  "description": "Returns true if a geometry is empty (without coordinates), false if the geometry is not empty and NULL if there is no geometry.",
   "arguments": [ {"arg":"geom","description":"a geometry"}],
   "examples": [ { "expression":"is_empty(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))", "returns":"false"},
                 { "expression":"is_empty(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"},

--- a/resources/function_help/json/is_empty_or_null
+++ b/resources/function_help/json/is_empty_or_null
@@ -1,0 +1,11 @@
+{
+  "name": "is_empty_or_null",
+  "type": "function",
+  "description": "Returns true if a geometry is NULL or empty (without coordinates) or false otherwise. This function is like the expression '$geometry IS NULL or is_empty($geometry)'",
+  "arguments": [ {"arg":"geom","description":"a geometry"}],
+  "examples": [ { "expression":"is_empty_or_null(NULL)", "returns":"true"},
+                { "expression":"is_empty_or_null(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'))", "returns":"false"},
+                { "expression":"is_empty_or_null(geom_from_wkt('LINESTRING EMPTY'))", "returns":"true"},
+                { "expression":"is_empty_or_null(geom_from_wkt('POINT(7 4)'))", "returns":"false"},
+                { "expression":"is_empty_or_null(geom_from_wkt('POINT EMPTY'))", "returns":"true"} ]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3077,6 +3077,15 @@ static QVariant fcnIsEmpty( const QVariantList &values, const QgsExpressionConte
   return QVariant::fromValue( fGeom.isEmpty() );
 }
 
+static QVariant fcnIsEmptyOrNull( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  if ( values.at( 0 ).isNull() )
+    return QVariant::fromValue( true );
+
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  return QVariant::fromValue( fGeom.isNull() || fGeom.isEmpty() );
+}
+
 static QVariant fcnRelate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() < 2 || values.length() > 3 )
@@ -5606,6 +5615,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "bounds_height" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnBoundsHeight, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "is_closed" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnIsClosed, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "is_empty" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnIsEmpty, QStringLiteral( "GeometryGroup" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "is_empty_or_null" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnIsEmptyOrNull, QStringLiteral( "GeometryGroup" ), QString(), false, QSet<QString>(), false, QStringList(), true )
         << new QgsStaticExpressionFunction( QStringLiteral( "convex_hull" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ), fcnConvexHull, QStringLiteral( "GeometryGroup" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "convexHull" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "oriented_bbox" ), QgsExpressionFunction::ParameterList()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ),

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3068,6 +3068,15 @@ static QVariant fcnIsClosed( const QVariantList &values, const QgsExpressionCont
   return QVariant::fromValue( curve->isClosed() );
 }
 
+static QVariant fcnIsEmpty( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
+  if ( fGeom.isNull() )
+    return QVariant();
+
+  return QVariant::fromValue( fGeom.isEmpty() );
+}
+
 static QVariant fcnRelate( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( values.length() < 2 || values.length() > 3 )
@@ -5596,6 +5605,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "bounds_width" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnBoundsWidth, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "bounds_height" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnBoundsHeight, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "is_closed" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnIsClosed, QStringLiteral( "GeometryGroup" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "is_empty" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geom" ) ), fcnIsEmpty, QStringLiteral( "GeometryGroup" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "convex_hull" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ), fcnConvexHull, QStringLiteral( "GeometryGroup" ), QString(), false, QSet<QString>(), false, QStringList() << QStringLiteral( "convexHull" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "oriented_bbox" ), QgsExpressionFunction::ParameterList()
                                             << QgsExpressionFunction::Parameter( QStringLiteral( "geometry" ) ),

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -986,6 +986,12 @@ class TestQgsExpression: public QObject
       QTest::newRow( "is_empty empty point" ) << "is_empty(geom_from_wkt('POINT EMPTY'))" << false << QVariant( true );
       QTest::newRow( "is_empty polygon" ) << "is_empty(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))'))" << false << QVariant( false );
       QTest::newRow( "is_empty empty polygon" ) << "is_empty(geom_from_wkt('POLYGON EMPTY'))" << false << QVariant( true );
+      QTest::newRow( "is_empty_or_null not geom" ) << "is_empty_or_null('g')" << true << QVariant();
+      QTest::newRow( "is_empty_or_null null" ) << "is_empty_or_null(NULL)" << false << QVariant( true );
+      QTest::newRow( "is_empty_or_null point" ) << "is_empty_or_null(geom_from_wkt('POINT(1 2)'))" << false << QVariant( false );
+      QTest::newRow( "is_empty_or_null empty point" ) << "is_empty_or_null(geom_from_wkt('POINT EMPTY'))" << false << QVariant( true );
+      QTest::newRow( "is_empty_or_null polygon" ) << "is_empty_or_null(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))'))" << false << QVariant( false );
+      QTest::newRow( "is_empty_or_null empty polygon" ) << "is_empty_or_null(geom_from_wkt('POLYGON EMPTY'))" << false << QVariant( true );
       QTest::newRow( "collect_geometries none" ) << "geom_to_wkt(collect_geometries())" << false << QVariant( "" );
       QTest::newRow( "collect_geometries not" ) << "geom_to_wkt(collect_geometries(45))" << true << QVariant();
       QTest::newRow( "collect_geometries one" ) << "geom_to_wkt(collect_geometries(make_point(4,5)))" << false << QVariant( "MultiPoint ((4 5))" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -980,6 +980,12 @@ class TestQgsExpression: public QObject
       QTest::newRow( "is_closed multiline" ) << "is_closed(geom_from_wkt('MultiLineString ((6501338.13976828 4850981.51459331, 6501343.09036573 4850984.01453377, 6501338.13976828 4850988.96491092, 6501335.63971657 4850984.01453377, 6501338.13976828 4850981.51459331))'))" << false << QVariant( true );
       QTest::newRow( "is_closed multiline" ) << "is_closed(geom_from_wkt('MultiLineString ((6501338.13976828 4850981.51459331, 6501343.09036573 4850984.01453377, 6501338.13976828 4850988.96491092, 6501335.63971657 4850984.01453377, 6501438.13976828 4850981.51459331))'))" << false << QVariant( false );
       QTest::newRow( "is_closed multiline" ) << "is_closed(geom_from_wkt('MultiLineString EMPTY'))" << false << QVariant();
+      QTest::newRow( "is_empty not geom" ) << "is_empty('g')" << true << QVariant();
+      QTest::newRow( "is_empty null" ) << "is_empty(NULL)" << false << QVariant();
+      QTest::newRow( "is_empty point" ) << "is_empty(geom_from_wkt('POINT(1 2)'))" << false << QVariant( false );
+      QTest::newRow( "is_empty empty point" ) << "is_empty(geom_from_wkt('POINT EMPTY'))" << false << QVariant( true );
+      QTest::newRow( "is_empty polygon" ) << "is_empty(geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))'))" << false << QVariant( false );
+      QTest::newRow( "is_empty empty polygon" ) << "is_empty(geom_from_wkt('POLYGON EMPTY'))" << false << QVariant( true );
       QTest::newRow( "collect_geometries none" ) << "geom_to_wkt(collect_geometries())" << false << QVariant( "" );
       QTest::newRow( "collect_geometries not" ) << "geom_to_wkt(collect_geometries(45))" << true << QVariant();
       QTest::newRow( "collect_geometries one" ) << "geom_to_wkt(collect_geometries(make_point(4,5)))" << false << QVariant( "MultiPoint ((4 5))" );


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Following my work on empty geometries, here is a new expression to catch them.

![image](https://user-images.githubusercontent.com/7521540/70615387-96002a80-1c0c-11ea-8d2c-b6ab9868b658.png)

sponsored by QWAT cc @kandre @haubourg 
## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
