### PR TITLE
[RPM] Remove qgis-zh-Hant.qm from RPM packages

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -309,7 +309,6 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %doc %{_datadir}/%{name}/doc/
 %dir %{_datadir}/%{name}/i18n/
 %lang(zh-Hans) %{_datadir}/%{name}/i18n/%{name}_zh-Hans.qm
-%lang(zh-Hant) %{_datadir}/%{name}/i18n/%{name}_zh-Hant.qm
 %{_libdir}/lib%{name}_native.so.*
 %{_libdir}/lib%{name}_app.so.*
 %{_libdir}/lib%{name}_analysis.so.*


### PR DESCRIPTION
## Description

This language file is not existing in 3.10.1+

https://copr-be.cloud.fedoraproject.org/results/dani/qgis/fedora-31-x86_64/01125601-qgis/builder-live.log.gz
```
RPM build errors:
    File not found: /builddir/build/BUILDROOT/qgis-3.10.1-1.fc31.x86_64/usr/share/qgis/i18n/qgis_zh-Hant.qm
```

Needs backport to 3.10

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
