### PR TITLE
Fix compilation error in qgsdxfexport.cpp

### DIFF
--- a/python/core/auto_additions/qgsdxfexport.py
+++ b/python/core/auto_additions/qgsdxfexport.py
@@ -24,14 +24,3 @@ QgsDxfExport.HAlign.HFit.__doc__ = "Fit into point = (5) (if VAlign==0)"
 QgsDxfExport.HAlign.Undefined.__doc__ = "Undefined"
 QgsDxfExport.HAlign.__doc__ = 'Horizontal alignments.\n\n' + '* ``HLeft``: ' + QgsDxfExport.HAlign.HLeft.__doc__ + '\n' + '* ``HCenter``: ' + QgsDxfExport.HAlign.HCenter.__doc__ + '\n' + '* ``HRight``: ' + QgsDxfExport.HAlign.HRight.__doc__ + '\n' + '* ``HAligned``: ' + QgsDxfExport.HAlign.HAligned.__doc__ + '\n' + '* ``HMiddle``: ' + QgsDxfExport.HAlign.HMiddle.__doc__ + '\n' + '* ``HFit``: ' + QgsDxfExport.HAlign.HFit.__doc__ + '\n' + '* ``Undefined``: ' + QgsDxfExport.HAlign.Undefined.__doc__
 # --
-# monkey patching scoped based enum
-QgsDxfExport.DxfPolylineFlag.Closed.__doc__ = "This is a closed polyline (or a polygon mesh closed in the M direction)"
-QgsDxfExport.DxfPolylineFlag.Curve.__doc__ = "Curve-fit vertices have been added"
-QgsDxfExport.DxfPolylineFlag.Spline.__doc__ = ""
-QgsDxfExport.DxfPolylineFlag.Is3DPolyline.__doc__ = "This is a 3D polyline"
-QgsDxfExport.DxfPolylineFlag.Is3DPolygonMesh.__doc__ = "This is a 3D polygon mesh"
-QgsDxfExport.DxfPolylineFlag.PolygonMesh.__doc__ = "The polygon mesh is closed in the N direction"
-QgsDxfExport.DxfPolylineFlag.PolyfaceMesh.__doc__ = "The polyline is a polyface mesh"
-QgsDxfExport.DxfPolylineFlag.ContinuousPattern.__doc__ = "The linetype pattern is generated continuously around the vertices of this polyline"
-QgsDxfExport.DxfPolylineFlag.__doc__ = 'Flags for polylines\n\n.. versionadded:: 3.12\n\n' + '* ``Closed``: ' + QgsDxfExport.DxfPolylineFlag.Closed.__doc__ + '\n' + '* ``Curve``: ' + QgsDxfExport.DxfPolylineFlag.Curve.__doc__ + '\n' + '* ``Spline``: ' + QgsDxfExport.DxfPolylineFlag.Spline.__doc__ + '\n' + '* ``Is3DPolyline``: ' + QgsDxfExport.DxfPolylineFlag.Is3DPolyline.__doc__ + '\n' + '* ``Is3DPolygonMesh``: ' + QgsDxfExport.DxfPolylineFlag.Is3DPolygonMesh.__doc__ + '\n' + '* ``PolygonMesh``: ' + QgsDxfExport.DxfPolylineFlag.PolygonMesh.__doc__ + '\n' + '* ``PolyfaceMesh``: ' + QgsDxfExport.DxfPolylineFlag.PolyfaceMesh.__doc__ + '\n' + '* ``ContinuousPattern``: ' + QgsDxfExport.DxfPolylineFlag.ContinuousPattern.__doc__
-# --

--- a/python/core/auto_generated/dxf/qgsdxfexport.sip.in
+++ b/python/core/auto_generated/dxf/qgsdxfexport.sip.in
@@ -92,7 +92,7 @@ unique value.
       Undefined
     };
 
-    enum class DxfPolylineFlag
+    enum DxfPolylineFlag
     {
       Closed,
       Curve,
@@ -506,6 +506,8 @@ Register name of layer for feature
 };
 
 QFlags<QgsDxfExport::Flag> operator|(QgsDxfExport::Flag f1, QFlags<QgsDxfExport::Flag> f2);
+
+QFlags<QgsDxfExport::DxfPolylineFlag> operator|(QgsDxfExport::DxfPolylineFlag f1, QFlags<QgsDxfExport::DxfPolylineFlag> f2);
 
 
 /************************************************************************

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -148,7 +148,7 @@ class CORE_EXPORT QgsDxfExport
      *
      * \since QGIS 3.12
      */
-    enum class DxfPolylineFlag : int
+    enum DxfPolylineFlag
     {
       Closed = 1, //!< This is a closed polyline (or a polygon mesh closed in the M direction)
       Curve = 2, //!< Curve-fit vertices have been added
@@ -626,5 +626,6 @@ class CORE_EXPORT QgsDxfExport
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDxfExport::Flags )
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsDxfExport::DxfPolylineFlags )
 
 #endif // QGSDXFEXPORT_H


### PR DESCRIPTION
I'm not sure which of QT 5.9.0 or gcc 5.5.0 is not happy, but with both
of them, I get:
```
/opt/qt59/include/QtCore/qflags.h: In instantiation of ‘QFlags<T>& QFlags<T>::setFlag(Enum, bool) [with Enum = QgsDxfExport::DxfPolylineFlag]’:
/home/even/qgis/QGIS/src/core/dxf/qgsdxfexport.cpp:1102:68:   required from here
/opt/qt59/include/QtCore/qflags.h:153:46: error: no match for ‘operator~’ (operand type is ‘QgsDxfExport::DxfPolylineFlag’)
         return on ? (*this |= f) : (*this &= ~f);
```
