### PR TITLE
Fixes for handling manual coordinate operations specified in projects

### DIFF
--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -295,12 +295,40 @@ coordinates.
 
 .. note::
 
+   The string returned by this method gives the desired coordinate operation string, based on
+   the state of the QgsCoordinateTransformContext object given in the QgsCoordinateTransform's constructor.
+   It may be an empty string if no explicit coordinate operation is required. In order to determine the
+   ACTUAL coordinate operation which is being used by the transform, use the instantiatedCoordinateOperationDetails() call instead.
+
+.. note::
+
    Requires Proj 6.0 or later. Builds based on earlier Proj versions will always return
    an empty string, and the deprecated sourceDatumTransformId() or destinationDatumTransformId() methods should be used instead.
+
+
+.. seealso:: :py:func:`instantiatedCoordinateOperationDetails`
 
 .. seealso:: :py:func:`setCoordinateOperation`
 
 .. versionadded:: 3.8
+%End
+
+    QgsDatumTransform::TransformDetails instantiatedCoordinateOperationDetails() const;
+%Docstring
+Returns the transform details representing the coordinate operation which is being used to transform
+coordinates.
+
+This may differ from the result returned by coordinateOperation() if the desired coordinate
+operation was not successfully instantiated.
+
+.. note::
+
+   Requires Proj 6.0 or later. Builds based on earlier Proj versions will always return
+   an empty result, and the deprecated sourceDatumTransformId() or destinationDatumTransformId() methods should be used instead.
+
+.. seealso:: :py:func:`coordinateOperation`
+
+.. versionadded:: 3.10.2
 %End
 
     void setCoordinateOperation( const QString &operation ) const;

--- a/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
@@ -134,11 +134,19 @@ from the specified ``sourceCrs`` to the specified ``destinationCrs``.
 string. If ``coordinateOperationProjString`` is empty, then the default Proj operation
 will be used when transforming between the coordinate reference systems.
 
+.. warning::
+
+   coordinateOperationProjString MUST be a proj string which has been normalized for
+   visualization, and must be constructed so that coordinates are always input and output
+   with x/y coordinate ordering. (Proj strings output by utilities such as projinfo will NOT
+   automatically normalize the axis order!).
+
 Returns ``True`` if the new coordinate operation was added successfully.
 
 .. seealso:: :py:func:`coordinateOperations`
 
 .. seealso:: :py:func:`removeCoordinateOperation`
+
 
 .. note::
 

--- a/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
@@ -221,7 +221,22 @@ be used.
    an empty string, and the deprecated calculateDatumTransforms() method should be used instead.
 
 
+.. warning::
+
+   Always check the result of mustReverseCoordinateOperation() in order to determine if the
+   proj coordinate operation string returned by this method corresponds to the reverse operation, and
+   must be manually flipped when calculating coordinate transforms.
+
+
 .. versionadded:: 3.8
+%End
+
+    bool mustReverseCoordinateOperation( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
+%Docstring
+Returns ``True`` if the coordinate operation returned by calculateCoordinateOperation() for the ``source`` to ``destination`` pair
+must be inverted.
+
+.. versionadded:: 3.10.2
 %End
 
 

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1314,8 +1314,7 @@ void QgsCoordinateReferenceSystem::setProj4String( const QString &proj4String )
   PJ_CONTEXT *ctx = QgsProjContext::get();
 
   {
-    QgsProjUtils::proj_pj_unique_ptr crs( proj_create( ctx, trimmed.toLatin1().constData() ) );
-    d->mPj = QgsProjUtils::crsToSingleCrs( crs.get() );
+    d->mPj.reset( proj_create( ctx, trimmed.toLatin1().constData() ) );
   }
 
   if ( !d->mPj )
@@ -1377,8 +1376,7 @@ bool QgsCoordinateReferenceSystem::setWktString( const QString &wkt, bool allowP
   PROJ_STRING_LIST warnings = nullptr;
   PROJ_STRING_LIST grammerErrors = nullptr;
   {
-    QgsProjUtils::proj_pj_unique_ptr crs( proj_create_from_wkt( QgsProjContext::get(), wkt.toLatin1().constData(), nullptr, &warnings, &grammerErrors ) );
-    d->mPj = QgsProjUtils::crsToSingleCrs( crs.get() );
+    d->mPj.reset( proj_create_from_wkt( QgsProjContext::get(), wkt.toLatin1().constData(), nullptr, &warnings, &grammerErrors ) );
   }
 
   res = static_cast< bool >( d->mPj );

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -799,6 +799,16 @@ QString QgsCoordinateTransform::coordinateOperation() const
   return d->mProjCoordinateOperation;
 }
 
+QgsDatumTransform::TransformDetails QgsCoordinateTransform::instantiatedCoordinateOperationDetails() const
+{
+#if PROJ_VERSION_MAJOR>=6
+  ProjData projData = d->threadLocalProjData();
+  return QgsDatumTransform::transformDetailsFromPj( projData );
+#else
+  return QgsDatumTransform::TransformDetails();
+#endif
+}
+
 void QgsCoordinateTransform::setCoordinateOperation( const QString &operation ) const
 {
   d.detach();

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -657,7 +657,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
   int projResult = 0;
 #if PROJ_VERSION_MAJOR>=6
   proj_errno_reset( projData );
-  proj_trans_generic( projData, direction == ForwardTransform ? PJ_FWD : PJ_INV,
+  proj_trans_generic( projData, ( direction == ForwardTransform && !d->mIsReversed ) || ( direction == ReverseTransform && d->mIsReversed ) ? PJ_FWD : PJ_INV,
                       x, sizeof( double ), numPoints,
                       y, sizeof( double ), numPoints,
                       z, sizeof( double ), numPoints,
@@ -813,6 +813,7 @@ void QgsCoordinateTransform::setCoordinateOperation( const QString &operation ) 
 {
   d.detach();
   d->mProjCoordinateOperation = operation;
+  d->mShouldReverseCoordinateOperation = false;
 }
 
 const char *finder( const char *name )

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -336,13 +336,34 @@ class CORE_EXPORT QgsCoordinateTransform
      * Returns a Proj string representing the coordinate operation which will be used to transform
      * coordinates.
      *
+     * \note The string returned by this method gives the desired coordinate operation string, based on
+     * the state of the QgsCoordinateTransformContext object given in the QgsCoordinateTransform's constructor.
+     * It may be an empty string if no explicit coordinate operation is required. In order to determine the
+     * ACTUAL coordinate operation which is being used by the transform, use the instantiatedCoordinateOperationDetails() call instead.
+     *
      * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will always return
      * an empty string, and the deprecated sourceDatumTransformId() or destinationDatumTransformId() methods should be used instead.
      *
+     * \see instantiatedCoordinateOperationDetails()
      * \see setCoordinateOperation()
      * \since QGIS 3.8
      */
     QString coordinateOperation() const;
+
+    /**
+     * Returns the transform details representing the coordinate operation which is being used to transform
+     * coordinates.
+     *
+     * This may differ from the result returned by coordinateOperation() if the desired coordinate
+     * operation was not successfully instantiated.
+     *
+     * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will always return
+     * an empty result, and the deprecated sourceDatumTransformId() or destinationDatumTransformId() methods should be used instead.
+     *
+     * \see coordinateOperation()
+     * \since QGIS 3.10.2
+     */
+    QgsDatumTransform::TransformDetails instantiatedCoordinateOperationDetails() const;
 
     /**
      * Sets a Proj string representing the coordinate \a operation which will be used to transform

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -355,17 +355,6 @@ ProjData QgsCoordinateTransformPrivate::threadLocalProjData()
 
       transform.reset();
     }
-    else
-    {
-      // transform may have either the source or destination CRS using swapped axis order. For QGIS, we ALWAYS need regular x/y axis order
-      transform.reset( proj_normalize_for_visualization( context, transform.get() ) );
-      if ( !transform )
-      {
-        const QString err = QObject::tr( "Cannot normalize transform between %1 and %2" ).arg( mSourceCRS.authid(),
-                            mDestCRS.authid() );
-        QgsMessageLog::logMessage( err, QString(), Qgis::Critical );
-      }
-    }
   }
 
   QString nonAvailableError;

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -131,6 +131,10 @@ class QgsCoordinateTransformPrivate : public QSharedData
     Q_DECL_DEPRECATED int mSourceDatumTransform = -1;
     Q_DECL_DEPRECATED int mDestinationDatumTransform = -1;
     QString mProjCoordinateOperation;
+    bool mShouldReverseCoordinateOperation = false;
+
+    //! True if the proj transform corresponds to the reverse direction, and must be flipped when transforming...
+    bool mIsReversed = false;
 
 #if PROJ_VERSION_MAJOR<6
 

--- a/src/core/qgscoordinatetransformcontext.cpp
+++ b/src/core/qgscoordinatetransformcontext.cpp
@@ -189,6 +189,36 @@ QString QgsCoordinateTransformContext::calculateCoordinateOperation( const QgsCo
 #endif
 }
 
+bool QgsCoordinateTransformContext::mustReverseCoordinateOperation( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const
+{
+#if PROJ_VERSION_MAJOR>=6
+  const QString srcKey = source.authid();
+  const QString destKey = destination.authid();
+
+  d->mLock.lockForRead();
+  QString res = d->mSourceDestDatumTransforms.value( qMakePair( srcKey, destKey ), QString() );
+  if ( !res.isEmpty() )
+  {
+    d->mLock.unlock();
+    return false;
+  }
+  // see if the reverse operation is present
+  res = d->mSourceDestDatumTransforms.value( qMakePair( destKey, srcKey ), QString() );
+  if ( !res.isEmpty() )
+  {
+    d->mLock.unlock();
+    return true;
+  }
+
+  d->mLock.unlock();
+  return false;
+#else
+  Q_UNUSED( source )
+  Q_UNUSED( destination )
+  return false;
+#endif
+}
+
 bool QgsCoordinateTransformContext::readXml( const QDomElement &element, const QgsReadWriteContext &, QStringList &missingTransforms )
 {
   d.detach();

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -206,9 +206,21 @@ class CORE_EXPORT QgsCoordinateTransformContext
      * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will always return
      * an empty string, and the deprecated calculateDatumTransforms() method should be used instead.
      *
+     * \warning Always check the result of mustReverseCoordinateOperation() in order to determine if the
+     * proj coordinate operation string returned by this method corresponds to the reverse operation, and
+     * must be manually flipped when calculating coordinate transforms.
+     *
      * \since QGIS 3.8
      */
     QString calculateCoordinateOperation( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
+
+    /**
+     * Returns TRUE if the coordinate operation returned by calculateCoordinateOperation() for the \a source to \a destination pair
+     * must be inverted.
+     *
+     * \since QGIS 3.10.2
+     */
+    bool mustReverseCoordinateOperation( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
 
     // TODO QGIS 4.0 - remove missingTransforms, not used for Proj >= 6.0 builds
 

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -140,6 +140,11 @@ class CORE_EXPORT QgsCoordinateTransformContext
      * string. If \a coordinateOperationProjString is empty, then the default Proj operation
      * will be used when transforming between the coordinate reference systems.
      *
+     * \warning coordinateOperationProjString MUST be a proj string which has been normalized for
+     * visualization, and must be constructed so that coordinates are always input and output
+     * with x/y coordinate ordering. (Proj strings output by utilities such as projinfo will NOT
+     * automatically normalize the axis order!).
+     *
      * Returns TRUE if the new coordinate operation was added successfully.
      *
      * \see coordinateOperations()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -89,6 +89,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void geoCcsDescription();
     void geographicCrsAuthId();
     void noProj();
+    void customProjString();
 
   private:
     void debugPrint( QgsCoordinateReferenceSystem &crs );
@@ -1121,7 +1122,7 @@ void TestQgsCoordinateReferenceSystem::noProj()
 {
 #if PROJ_VERSION_MAJOR>=6
   // test a crs which cannot be represented by a proj string
-  QgsCoordinateReferenceSystem crs( "EPSG:2218" );
+  QgsCoordinateReferenceSystem crs( QStringLiteral( "EPSG:2218" ) );
   QCOMPARE( crs.authid(), QStringLiteral( "EPSG:2218" ) );
   QVERIFY( crs.isValid() );
   QCOMPARE( crs.toWkt(), QStringLiteral( "PROJCS[\"Scoresbysund 1952 / Greenland zone 5 east\",GEOGCS[\"Scoresbysund 1952\",DATUM[\"Scoresbysund_1952\",SPHEROID[\"International 1924\",6378388,297,AUTHORITY[\"EPSG\",\"7022\"]],AUTHORITY[\"EPSG\",\"6195\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4195\"]],PROJECTION[\"Lambert_Conic_Conformal_(West_Orientated)\"],PARAMETER[\"Latitude of natural origin\",70.5],PARAMETER[\"Longitude of natural origin\",-24],PARAMETER[\"Scale factor at natural origin\",1],PARAMETER[\"False easting\",0],PARAMETER[\"False northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AUTHORITY[\"EPSG\",\"2218\"]]" ) );
@@ -1136,5 +1137,16 @@ void TestQgsCoordinateReferenceSystem::noProj()
 #endif
 
 }
+
+void TestQgsCoordinateReferenceSystem::customProjString()
+{
+#if PROJ_VERSION_MAJOR>=6
+  QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=sterea +lat_0=47.4860018439082 +lon_0=19.0491441390302 +k=1 +x_0=500000 +y_0=500000 +ellps=bessel +towgs84=595.75,121.09,515.50,8.2270,-1.5193,5.5971,-2.6729 +units=m +vunits=m +no_defs" ) );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.toProj4(), QStringLiteral( "+proj=sterea +lat_0=47.4860018439082 +lon_0=19.0491441390302 +k=1 +x_0=500000 +y_0=500000 +ellps=bessel +towgs84=595.75,121.09,515.50,8.2270,-1.5193,5.5971,-2.6729 +units=m +vunits=m +no_defs" ) );
+  QCOMPARE( crs.toWkt(), QStringLiteral( R"""(COMPD_CS["unknown",PROJCS["unknown",GEOGCS["unknown",DATUM["Unknown_based_on_Bessel_1841_ellipsoid",SPHEROID["Bessel 1841",6377397.155,299.1528128],TOWGS84[595.75,121.09,515.5,8.227,-1.5193,5.5971,-2.6729]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Oblique_Stereographic"],PARAMETER["latitude_of_origin",47.4860018439082],PARAMETER["central_meridian",19.0491441390302],PARAMETER["scale_factor",1],PARAMETER["false_easting",500000],PARAMETER["false_northing",500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]],VERT_CS["unknown",VERT_DATUM["unknown",2005],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Gravity-related height",UP]]])""" ) );
+#endif
+}
+
 QGSTEST_MAIN( TestQgsCoordinateReferenceSystem )
 #include "testqgscoordinatereferencesystem.moc"

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -534,8 +534,6 @@ void TestQgsCoordinateTransform::transformErrorOnePoint()
   }
 }
 
-#include <proj.h>
-
 void TestQgsCoordinateTransform::testDeprecated4240to4326()
 {
 #if PROJ_VERSION_MAJOR >= 6

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -22,6 +22,7 @@
 #include <QObject>
 #include "qgstest.h"
 #include "qgsexception.h"
+#include "qgslogger.h"
 
 class TestQgsCoordinateTransform: public QObject
 {

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -1296,6 +1296,7 @@ class TestQgsProject(unittest.TestCase):
         spy = QSignalSpy(p.transformContextChanged)
         ctx = QgsCoordinateTransformContext()
         ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+        ctx.addCoordinateOperation(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 'x')
         p.setTransformContext(ctx)
         self.assertEqual(len(spy), 1)
 

--- a/tests/src/python/test_qgsrasterlayer.py
+++ b/tests/src/python/test_qgsrasterlayer.py
@@ -1212,6 +1212,7 @@ class TestQgsRasterLayerTransformContext(unittest.TestCase):
         super(TestQgsRasterLayerTransformContext, self).setUp()
         self.ctx = QgsCoordinateTransformContext()
         self.ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+        self.ctx.addCoordinateOperation(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 'test')
         self.rpath = os.path.join(unitTestDataPath(), 'landsat.tif')
 
     def testTransformContextIsSetInCtor(self):

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3354,6 +3354,8 @@ class TestQgsVectorLayerTransformContext(unittest.TestCase):
         super(TestQgsVectorLayerTransformContext, self).setUp()
         self.ctx = QgsCoordinateTransformContext()
         self.ctx.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857), 1234, 1235)
+        self.ctx.addCoordinateOperation(QgsCoordinateReferenceSystem(4326),
+                                        QgsCoordinateReferenceSystem(3857), 'test')
 
     def testTransformContextIsSetInCtor(self):
         """Test transform context can be set from ctor"""


### PR DESCRIPTION
Refs, and probably fixes, https://github.com/qgis/QGIS/issues/33121

With this branch, loading the project attached to #33121 results in the following default transformation:

![image](https://user-images.githubusercontent.com/1829991/70762847-dcd15a00-1d9d-11ea-85b5-da0d0df69a85.png)

This has been verified upstream at proj as being the correct default transformation result to use in this situation.

If the user manually opts to use an older, deprecated transformation via:

![image](https://user-images.githubusercontent.com/1829991/70762916-130ed980-1d9e-11ea-9c76-50adf255f77c.png)


then the result is:

![image](https://user-images.githubusercontent.com/1829991/70762892-0094a000-1d9e-11ea-825f-eed014661b30.png)

(as desired by the original poster)

