### PR TITLE
When saving and restoring CRS definitions to XML, save wkt definition too

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -308,10 +308,6 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString &definition )
       if ( match.captured( 1 ).compare( QLatin1String( "proj4" ), Qt::CaseInsensitive ) == 0 )
       {
         result = createFromProj4( match.captured( 2 ) );
-        //TODO: createFromProj4 used to save to the user database any new CRS
-        // this behavior was changed in order to separate creation and saving.
-        // Not sure if it necessary to save it here, should be checked by someone
-        // familiar with the code (should also give a more descriptive name to the generated CRS)
         if ( srsid() == 0 )
         {
           QString myName = QStringLiteral( " * %1 (%2)" )
@@ -1801,7 +1797,7 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
 {
   d.detach();
   bool result = true;
-  QDomNode srsNode  = node.namedItem( QStringLiteral( "spatialrefsys" ) );
+  QDomNode srsNode = node.namedItem( QStringLiteral( "spatialrefsys" ) );
 
   if ( ! srsNode.isNull() )
   {
@@ -1810,14 +1806,14 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
     bool ok = false;
     long srsid = srsNode.namedItem( QStringLiteral( "srsid" ) ).toElement().text().toLong( &ok );
 
-    QDomNode myNode;
+    QDomNode node;
 
     if ( ok && srsid > 0 && srsid < USER_CRS_START_ID )
     {
-      myNode = srsNode.namedItem( QStringLiteral( "authid" ) );
-      if ( !myNode.isNull() )
+      node = srsNode.namedItem( QStringLiteral( "authid" ) );
+      if ( !node.isNull() )
       {
-        operator=( QgsCoordinateReferenceSystem::fromOgcWmsCrs( myNode.toElement().text() ) );
+        createFromOgcWmsCrs( node.toElement().text() );
         if ( isValid() )
         {
           initialized = true;
@@ -1826,10 +1822,10 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
 
       if ( !initialized )
       {
-        myNode = srsNode.namedItem( QStringLiteral( "epsg" ) );
-        if ( !myNode.isNull() )
+        node = srsNode.namedItem( QStringLiteral( "epsg" ) );
+        if ( !node.isNull() )
         {
-          operator=( QgsCoordinateReferenceSystem::fromEpsgId( myNode.toElement().text().toLong() ) );
+          operator=( QgsCoordinateReferenceSystem::fromEpsgId( node.toElement().text().toLong() ) );
           if ( isValid() )
           {
             initialized = true;
@@ -1838,60 +1834,66 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
       }
     }
 
+    // if wkt is present, prefer that since it's lossless (unlike proj4 strings)
     if ( !initialized )
     {
-      myNode = srsNode.namedItem( QStringLiteral( "proj4" ) );
-      const QString proj4 = myNode.toElement().text();
+      const QString wkt = srsNode.namedItem( QStringLiteral( "wkt" ) ).toElement().text();
+      initialized = createFromWkt( wkt );
+    }
 
-      if ( !createFromProj4( proj4 ) )
+    if ( !initialized )
+    {
+      node = srsNode.namedItem( QStringLiteral( "proj4" ) );
+      const QString proj4 = node.toElement().text();
+      initialized = createFromProj4( proj4 );
+    }
+
+    if ( !initialized )
+    {
+      // Setting from elements one by one
+      node = srsNode.namedItem( QStringLiteral( "proj4" ) );
+      const QString proj4 = node.toElement().text();
+      if ( !proj4.trimmed().isEmpty() )
+        setProj4String( node.toElement().text() );
+
+      node = srsNode.namedItem( QStringLiteral( "srsid" ) );
+      setInternalId( node.toElement().text().toLong() );
+
+      node = srsNode.namedItem( QStringLiteral( "srid" ) );
+      setSrid( node.toElement().text().toLong() );
+
+      node = srsNode.namedItem( QStringLiteral( "authid" ) );
+      setAuthId( node.toElement().text() );
+
+      node = srsNode.namedItem( QStringLiteral( "description" ) );
+      setDescription( node.toElement().text() );
+
+      node = srsNode.namedItem( QStringLiteral( "projectionacronym" ) );
+      setProjectionAcronym( node.toElement().text() );
+
+      node = srsNode.namedItem( QStringLiteral( "ellipsoidacronym" ) );
+      setEllipsoidAcronym( node.toElement().text() );
+
+      node = srsNode.namedItem( QStringLiteral( "geographicflag" ) );
+      if ( node.toElement().text().compare( QLatin1String( "true" ) ) )
       {
-        // Setting from elements one by one
-        if ( !proj4.trimmed().isEmpty() )
-          setProj4String( myNode.toElement().text() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "srsid" ) );
-        setInternalId( myNode.toElement().text().toLong() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "srid" ) );
-        setSrid( myNode.toElement().text().toLong() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "authid" ) );
-        setAuthId( myNode.toElement().text() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "description" ) );
-        setDescription( myNode.toElement().text() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "projectionacronym" ) );
-        setProjectionAcronym( myNode.toElement().text() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "ellipsoidacronym" ) );
-        setEllipsoidAcronym( myNode.toElement().text() );
-
-        myNode = srsNode.namedItem( QStringLiteral( "geographicflag" ) );
-        if ( myNode.toElement().text().compare( QLatin1String( "true" ) ) )
-        {
-          setGeographicFlag( true );
-        }
-        else
-        {
-          setGeographicFlag( false );
-        }
-
-        //make sure the map units have been set
-        setMapUnits();
+        setGeographicFlag( true );
       }
-      //TODO: createFromProj4 used to save to the user database any new CRS
-      // this behavior was changed in order to separate creation and saving.
-      // Not sure if it necessary to save it here, should be checked by someone
-      // familiar with the code (should also give a more descriptive name to the generated CRS)
-      if ( isValid() && d->mSrsId == 0 )
+      else
       {
-        QString myName = QStringLiteral( " * %1 (%2)" )
-                         .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ),
-                               toProj4() );
-        saveAsUserCrs( myName );
+        setGeographicFlag( false );
       }
 
+      //make sure the map units have been set
+      setMapUnits();
+    }
+
+    if ( isValid() && d->mSrsId == 0 )
+    {
+      QString myName = QStringLiteral( " * %1 (%2)" )
+                       .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ),
+                             toProj4() );
+      saveAsUserCrs( myName );
     }
   }
   else
@@ -1905,54 +1907,55 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
 
 bool QgsCoordinateReferenceSystem::writeXml( QDomNode &node, QDomDocument &doc ) const
 {
+  QDomElement layerNode = node.toElement();
+  QDomElement srsElement = doc.createElement( QStringLiteral( "spatialrefsys" ) );
 
-  QDomElement myLayerNode = node.toElement();
-  QDomElement mySrsElement  = doc.createElement( QStringLiteral( "spatialrefsys" ) );
+  QDomElement wktElement = doc.createElement( QStringLiteral( "wkt" ) );
+  wktElement.appendChild( doc.createTextNode( toWkt() ) );
+  srsElement.appendChild( wktElement );
 
-  QDomElement myProj4Element  = doc.createElement( QStringLiteral( "proj4" ) );
-  myProj4Element.appendChild( doc.createTextNode( toProj4() ) );
-  mySrsElement.appendChild( myProj4Element );
+  QDomElement proj4Element = doc.createElement( QStringLiteral( "proj4" ) );
+  proj4Element.appendChild( doc.createTextNode( toProj4() ) );
+  srsElement.appendChild( proj4Element );
 
-  QDomElement mySrsIdElement  = doc.createElement( QStringLiteral( "srsid" ) );
-  mySrsIdElement.appendChild( doc.createTextNode( QString::number( srsid() ) ) );
-  mySrsElement.appendChild( mySrsIdElement );
+  QDomElement srsIdElement = doc.createElement( QStringLiteral( "srsid" ) );
+  srsIdElement.appendChild( doc.createTextNode( QString::number( srsid() ) ) );
+  srsElement.appendChild( srsIdElement );
 
-  QDomElement mySridElement  = doc.createElement( QStringLiteral( "srid" ) );
-  mySridElement.appendChild( doc.createTextNode( QString::number( postgisSrid() ) ) );
-  mySrsElement.appendChild( mySridElement );
+  QDomElement sridElement = doc.createElement( QStringLiteral( "srid" ) );
+  sridElement.appendChild( doc.createTextNode( QString::number( postgisSrid() ) ) );
+  srsElement.appendChild( sridElement );
 
-  QDomElement myEpsgElement  = doc.createElement( QStringLiteral( "authid" ) );
-  myEpsgElement.appendChild( doc.createTextNode( authid() ) );
-  mySrsElement.appendChild( myEpsgElement );
+  QDomElement authidElement = doc.createElement( QStringLiteral( "authid" ) );
+  authidElement.appendChild( doc.createTextNode( authid() ) );
+  srsElement.appendChild( authidElement );
 
-  QDomElement myDescriptionElement  = doc.createElement( QStringLiteral( "description" ) );
-  myDescriptionElement.appendChild( doc.createTextNode( description() ) );
-  mySrsElement.appendChild( myDescriptionElement );
+  QDomElement descriptionElement = doc.createElement( QStringLiteral( "description" ) );
+  descriptionElement.appendChild( doc.createTextNode( description() ) );
+  srsElement.appendChild( descriptionElement );
 
-  QDomElement myProjectionAcronymElement  = doc.createElement( QStringLiteral( "projectionacronym" ) );
-  myProjectionAcronymElement.appendChild( doc.createTextNode( projectionAcronym() ) );
-  mySrsElement.appendChild( myProjectionAcronymElement );
+  QDomElement projectionAcronymElement = doc.createElement( QStringLiteral( "projectionacronym" ) );
+  projectionAcronymElement.appendChild( doc.createTextNode( projectionAcronym() ) );
+  srsElement.appendChild( projectionAcronymElement );
 
-  QDomElement myEllipsoidAcronymElement  = doc.createElement( QStringLiteral( "ellipsoidacronym" ) );
-  myEllipsoidAcronymElement.appendChild( doc.createTextNode( ellipsoidAcronym() ) );
-  mySrsElement.appendChild( myEllipsoidAcronymElement );
+  QDomElement ellipsoidAcronymElement = doc.createElement( QStringLiteral( "ellipsoidacronym" ) );
+  ellipsoidAcronymElement.appendChild( doc.createTextNode( ellipsoidAcronym() ) );
+  srsElement.appendChild( ellipsoidAcronymElement );
 
-  QDomElement myGeographicFlagElement  = doc.createElement( QStringLiteral( "geographicflag" ) );
-  QString myGeoFlagText = QStringLiteral( "false" );
+  QDomElement geographicFlagElement = doc.createElement( QStringLiteral( "geographicflag" ) );
+  QString geoFlagText = QStringLiteral( "false" );
   if ( isGeographic() )
   {
-    myGeoFlagText = QStringLiteral( "true" );
+    geoFlagText = QStringLiteral( "true" );
   }
 
-  myGeographicFlagElement.appendChild( doc.createTextNode( myGeoFlagText ) );
-  mySrsElement.appendChild( myGeographicFlagElement );
+  geographicFlagElement.appendChild( doc.createTextNode( geoFlagText ) );
+  srsElement.appendChild( geographicFlagElement );
 
-  myLayerNode.appendChild( mySrsElement );
+  layerNode.appendChild( srsElement );
 
   return true;
 }
-
-
 
 //
 // Static helper methods below this point only please!

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -827,9 +827,12 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QgsCoordinateReferenceSystem myCrs7;
   QVERIFY( myCrs7.readXml( node ) );
   QCOMPARE( myCrs7.authid(), QStringLiteral( "EPSG:3111" ) );
-  QCOMPARE( myCrs7.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
 #if PROJ_VERSION_MAJOR>=6
+  QCOMPARE( myCrs7.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
   QCOMPARE( myCrs7.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
+#else
+  QCOMPARE( myCrs7.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37 +lon_0=145 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
+  QCOMPARE( myCrs7.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
 #endif
 
   // valid CRS from proj string
@@ -840,10 +843,15 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QVERIFY( myCrs8.writeXml( node, document ) );
   QgsCoordinateReferenceSystem myCrs9;
   QVERIFY( myCrs9.readXml( node ) );
-  QCOMPARE( myCrs9.authid(), QStringLiteral( "USER:100003" ) );
-  QCOMPARE( myCrs9.toProj4(), QStringLiteral( "+proj=aea +lat_0=4 +lon_0=29 +lat_1=20 +lat_2=-23 +x_0=10.123 +y_0=3 +datum=WGS84 +units=m +no_defs +type=crs" ) );
+
 #if PROJ_VERSION_MAJOR>=6
+  QCOMPARE( myCrs9.toProj4(), QStringLiteral( "+proj=aea +lat_0=4 +lon_0=29 +lat_1=20 +lat_2=-23 +x_0=10.123 +y_0=3 +datum=WGS84 +units=m +no_defs +type=crs" ) );
+  QCOMPARE( myCrs9.authid(), QStringLiteral( "USER:100003" ) );
   QCOMPARE( myCrs9.toWkt(), QStringLiteral( R"""(PROJCS["unknown",GEOGCS["unknown",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["latitude_of_center",4],PARAMETER["longitude_of_center",29],PARAMETER["standard_parallel_1",20],PARAMETER["standard_parallel_2",-23],PARAMETER["false_easting",10.123],PARAMETER["false_northing",3],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]])""" ) );
+#else
+  QCOMPARE( myCrs9.toProj4(), QStringLiteral( "+proj=aea +lat_1=20 +lat_2=-23 +lat_0=4 +lon_0=29 +x_0=10.123 +y_0=3 +datum=WGS84 +units=m +no_defs" ) );
+  QCOMPARE( myCrs9.authid(), QStringLiteral( "USER:100002" ) );
+  QCOMPARE( myCrs9.toWkt(), QStringLiteral( R"""(PROJCS["unnamed",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["standard_parallel_1",20],PARAMETER["standard_parallel_2",-23],PARAMETER["latitude_of_center",4],PARAMETER["longitude_of_center",29],PARAMETER["false_easting",10.123],PARAMETER["false_northing",3],UNIT["Meter",1]])""" ) );
 #endif
 
   // valid CRS from WKT string
@@ -854,19 +862,27 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QVERIFY( myCrs10.writeXml( node, document ) );
   QgsCoordinateReferenceSystem myCrs11;
   QVERIFY( myCrs11.readXml( node ) );
+#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs11.authid(), QStringLiteral( "USER:100005" ) );
   QCOMPARE( myCrs11.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37.2 +lon_0=145.1 +lat_1=-36 +lat_2=-38 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs" ) );
-#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs11.toWkt(), QStringLiteral( R"""(PROJCS["xxx",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]])""" ) );
+#else
+  QCOMPARE( myCrs11.authid(), QStringLiteral( "USER:100003" ) );
+  QCOMPARE( myCrs11.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37.2 +lon_0=145.1 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=1,2,3,4,5,6,7 +units=m +no_defs" ) );
+  QCOMPARE( myCrs11.toWkt(), QStringLiteral( R"""(PROJCS["unnamed",GEOGCS["GRS 1980(IUGG, 1980)",DATUM["unknown",SPHEROID["GRS80",6378137,298.257222101],TOWGS84[1,2,3,4,5,6,7]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["Meter",1]])""" ) );
 #endif
 
   // try reloading, make sure it gets the same user crs assigned
   QgsCoordinateReferenceSystem myCrs11b;
   QVERIFY( myCrs11b.readXml( node ) );
+#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs11b.authid(), QStringLiteral( "USER:100005" ) );
   QCOMPARE( myCrs11b.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37.2 +lon_0=145.1 +lat_1=-36 +lat_2=-38 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs" ) );
-#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs11b.toWkt(), QStringLiteral( R"""(PROJCS["xxx",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]])""" ) );
+#else
+  QCOMPARE( myCrs11b.authid(), QStringLiteral( "USER:100003" ) );
+  QCOMPARE( myCrs11b.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37.2 +lon_0=145.1 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=1,2,3,4,5,6,7 +units=m +no_defs" ) );
+  QCOMPARE( myCrs11b.toWkt(), QStringLiteral( R"""(PROJCS["unnamed",GEOGCS["GRS 1980(IUGG, 1980)",DATUM["unknown",SPHEROID["GRS80",6378137,298.257222101],TOWGS84[1,2,3,4,5,6,7]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["Meter",1]])""" ) );
 #endif
 
   // fudge an dom element without the wkt element
@@ -879,10 +895,14 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   nodeList.at( 0 ).parentNode().removeChild( nodeList.at( 0 ) );
   QgsCoordinateReferenceSystem myCrs13;
   QVERIFY( myCrs13.readXml( node ) );
+#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs13.authid(), QStringLiteral( "USER:100007" ) );
   QCOMPARE( myCrs13.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37.2 +lon_0=145.1 +lat_1=-36 +lat_2=-38 +x_0=2510000 +y_0=2520000 +ellps=GRS80  +units=m +no_defs" ) );
-#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs13.toWkt(), QStringLiteral( R"""(PROJCS["unknown",GEOGCS["unknown",DATUM["Unknown_based_on_GRS80_ellipsoid",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]])""" ) );
+#else
+  QCOMPARE( myCrs13.authid(), QStringLiteral( "USER:100003" ) );
+  QCOMPARE( myCrs13.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37.2 +lon_0=145.1 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=1,2,3,4,5,6,7 +units=m +no_defs" ) );
+  QCOMPARE( myCrs13.toWkt(), QStringLiteral( R"""(PROJCS["unnamed",GEOGCS["GRS 1980(IUGG, 1980)",DATUM["unknown",SPHEROID["GRS80",6378137,298.257222101],TOWGS84[1,2,3,4,5,6,7]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["Meter",1]])""" ) );
 #endif
 
   // fudge a dom element with conflicting proj and wkt, wkt should be preferred
@@ -898,10 +918,14 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   node.toElement().elementsByTagName( QStringLiteral( "spatialrefsys" ) ).at( 0 ).toElement().appendChild( proj4Element );
   QgsCoordinateReferenceSystem myCrs15;
   QVERIFY( myCrs15.readXml( node ) );
+#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs15.authid(), QStringLiteral( "USER:100009" ) );
   QCOMPARE( myCrs15.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37.2 +lon_0=145.1 +lat_1=-36 +lat_2=-38 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs" ) );
-#if PROJ_VERSION_MAJOR>=6
   QCOMPARE( myCrs15.toWkt(), QStringLiteral( R"""(PROJCS["xxx",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]])""" ) );
+#else
+  QCOMPARE( myCrs15.authid(), QStringLiteral( "USER:100003" ) );
+  QCOMPARE( myCrs15.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37.2 +lon_0=145.1 +x_0=2510000 +y_0=2520000 +ellps=GRS80 +towgs84=1,2,3,4,5,6,7 +units=m +no_defs" ) );
+  QCOMPARE( myCrs15.toWkt(), QStringLiteral( R"""(PROJCS["unnamed",GEOGCS["GRS 1980(IUGG, 1980)",DATUM["unknown",SPHEROID["GRS80",6378137,298.257222101],TOWGS84[1,2,3,4,5,6,7]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37.2],PARAMETER["central_meridian",145.1],PARAMETER["false_easting",2510000],PARAMETER["false_northing",2520000],UNIT["Meter",1]])""" ) );
 #endif
 
   // fudge a dom element with auth/code and conflicting proj, auth/code should be preferred
@@ -917,9 +941,12 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QgsCoordinateReferenceSystem myCrs17;
   QVERIFY( myCrs17.readXml( node ) );
   QCOMPARE( myCrs17.authid(), QStringLiteral( "EPSG:3111" ) );
-  QCOMPARE( myCrs17.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
 #if PROJ_VERSION_MAJOR>=6
+  QCOMPARE( myCrs17.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
   QCOMPARE( myCrs17.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
+#else
+  QCOMPARE( myCrs17.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37 +lon_0=145 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
+  QCOMPARE( myCrs17.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
 #endif
 
   // fudge a dom element with auth/code and conflicting wkt, auth/code should be preferred
@@ -935,9 +962,12 @@ void TestQgsCoordinateReferenceSystem::readWriteXml()
   QgsCoordinateReferenceSystem myCrs19;
   QVERIFY( myCrs19.readXml( node ) );
   QCOMPARE( myCrs19.authid(), QStringLiteral( "EPSG:3111" ) );
-  QCOMPARE( myCrs19.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
 #if PROJ_VERSION_MAJOR>=6
+  QCOMPARE( myCrs19.toProj4(), QStringLiteral( "+proj=lcc +lat_0=-37 +lon_0=145 +lat_1=-36 +lat_2=-38 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
   QCOMPARE( myCrs19.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
+#else
+  QCOMPARE( myCrs19.toProj4(), QStringLiteral( "+proj=lcc +lat_1=-36 +lat_2=-38 +lat_0=-37 +lon_0=145 +x_0=2500000 +y_0=2500000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs" ) );
+  QCOMPARE( myCrs19.toWkt(), QStringLiteral( R"""(PROJCS["GDA94 / Vicgrid",GEOGCS["GDA94",DATUM["Geocentric_Datum_of_Australia_1994",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6283"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4283"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",-36],PARAMETER["standard_parallel_2",-38],PARAMETER["latitude_of_origin",-37],PARAMETER["central_meridian",145],PARAMETER["false_easting",2500000],PARAMETER["false_northing",2500000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3111"]])""" ) );
 #endif
 }
 


### PR DESCRIPTION
And prefer rebuilding the CRS from the WKT definition whenever it's available

Proj strings are lossy, so prefer WKT
