### PR TITLE
MDAL 0.4.93 RC1 

### DIFF
--- a/external/mdal/api/mdal.h
+++ b/external/mdal/api/mdal.h
@@ -345,7 +345,7 @@ MDAL_EXPORT void MDAL_G_minimumMaximum( DatasetGroupH group, double *min, double
  * Only for 2D datasets
  *
  * \param group parent group handle
- * \param time time for dataset
+ * \param time time for dataset (hours)
  * \param values For scalar data on vertices, the size must be vertex count
  * For scalar data on faces, the size must be faces count
  * For vector data on vertices, the size must be vertex count * 2 (x1, y1, x2, y2, ..., xN, yN)
@@ -371,10 +371,7 @@ MDAL_EXPORT bool MDAL_G_isInEditMode( DatasetGroupH group );
  */
 MDAL_EXPORT void MDAL_G_closeEditMode( DatasetGroupH group );
 
-/**
- * Returns reference time for dataset group
- * If returned value begins with word JULIAN, following number represents date in Julian format
- */
+//! Returns reference time for dataset group expressed in date with ISO8601 format, return "" if reference time is not defined
 MDAL_EXPORT const char *MDAL_G_referenceTime( DatasetGroupH group );
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -384,7 +381,7 @@ MDAL_EXPORT const char *MDAL_G_referenceTime( DatasetGroupH group );
 //! Returns dataset parent group
 MDAL_EXPORT DatasetGroupH MDAL_D_group( DatasetH dataset );
 
-//! Returns dataset time
+//! Returns dataset time (hours)
 MDAL_EXPORT double MDAL_D_time( DatasetH dataset );
 
 //! Returns volumes count for the mesh (for 3D meshes)

--- a/external/mdal/frmts/mdal_3di.cpp
+++ b/external/mdal/frmts/mdal_3di.cpp
@@ -139,7 +139,7 @@ void MDAL::Driver3Di::addBedElevation( MemoryMesh *mesh )
   group->setIsScalar( true );
 
   std::shared_ptr<MDAL::MemoryDataset2D> dataset = std::make_shared< MemoryDataset2D >( group.get() );
-  dataset->setTime( 0.0 );
+  dataset->setTime( MDAL::RelativeTimestamp() );
   for ( size_t i = 0; i < faceCount; ++i )
   {
     dataset->setScalarValue( i, MDAL::safeValue( coordZ[i], fillZ ) );

--- a/external/mdal/frmts/mdal_ascii_dat.hpp
+++ b/external/mdal/frmts/mdal_ascii_dat.hpp
@@ -70,22 +70,18 @@ namespace MDAL
       //! maximum native index of the vertex in defined in the mesh
       size_t maximumId( const Mesh *mesh ) const;
 
-      void readVertexTimestep(
-        const Mesh *mesh,
-        std::shared_ptr<DatasetGroup> group,
-        double t,
-        bool isVector,
-        bool hasStatus,
-        std::ifstream &stream ) const;
+      void readVertexTimestep( const Mesh *mesh,
+                               std::shared_ptr<DatasetGroup> group,
+                               RelativeTimestamp t,
+                               bool isVector,
+                               bool hasStatus,
+                               std::ifstream &stream ) const;
 
-      void readFaceTimestep(
-        const Mesh *mesh,
-        std::shared_ptr<DatasetGroup> group,
-        double t,
-        bool isVector,
-        std::ifstream &stream ) const;
-
-      double convertTimeDataToHours( double time, const std::string &originalTimeDataUnit ) const;
+      void readFaceTimestep( const Mesh *mesh,
+                             std::shared_ptr<DatasetGroup> group,
+                             RelativeTimestamp t,
+                             bool isVector,
+                             std::ifstream &stream ) const;
 
       std::string mDatFile;
   };

--- a/external/mdal/frmts/mdal_binary_dat.hpp
+++ b/external/mdal/frmts/mdal_binary_dat.hpp
@@ -35,12 +35,11 @@ namespace MDAL
       bool readVertexTimestep( const Mesh *mesh,
                                std::shared_ptr<DatasetGroup> group,
                                std::shared_ptr<DatasetGroup> groupMax,
-                               double time,
+                               RelativeTimestamp time,
                                bool hasStatus,
                                int sflg,
                                std::ifstream &in );
 
-      double convertTimeDataToHours( double time, int originalTimeDataUnit );
       std::string mDatFile;
   };
 

--- a/external/mdal/frmts/mdal_cf.hpp
+++ b/external/mdal/frmts/mdal_cf.hpp
@@ -138,10 +138,10 @@ namespace MDAL
 
       void setProjection( MDAL::Mesh *m );
       cfdataset_info_map parseDatasetGroupInfo();
-      void parseTime( std::vector<double> &times );
+      DateTime parseTime( std::vector<RelativeTimestamp> &times ); //Return the reference time
       void addDatasetGroups( Mesh *mesh,
-                             const std::vector<double> &times,
-                             const cfdataset_info_map &dsinfo_map );
+                             const std::vector<RelativeTimestamp> &times,
+                             const cfdataset_info_map &dsinfo_map, const DateTime &referenceTime );
 
       std::string mFileName;
       std::shared_ptr<NetCDFFile> mNcFile;

--- a/external/mdal/frmts/mdal_driver.cpp
+++ b/external/mdal/frmts/mdal_driver.cpp
@@ -82,7 +82,7 @@ void MDAL::Driver::createDatasetGroup( MDAL::Mesh *mesh, const std::string &grou
   mesh->datasetGroups.push_back( grp );
 }
 
-void MDAL::Driver::createDataset( MDAL::DatasetGroup *group, double time, const double *values, const int *active )
+void MDAL::Driver::createDataset( MDAL::DatasetGroup *group, MDAL::RelativeTimestamp time, const double *values, const int *active )
 {
   bool supportsActiveFlag = ( active != nullptr );
   std::shared_ptr<MDAL::MemoryDataset2D> dataset = std::make_shared< MemoryDataset2D >( group, supportsActiveFlag );

--- a/external/mdal/frmts/mdal_driver.hpp
+++ b/external/mdal/frmts/mdal_driver.hpp
@@ -64,7 +64,7 @@ namespace MDAL
 
       // create new dataset from array
       virtual void createDataset( DatasetGroup *group,
-                                  double time,
+                                  RelativeTimestamp time,
                                   const double *values,
                                   const int *active );
 

--- a/external/mdal/frmts/mdal_gdal.cpp
+++ b/external/mdal/frmts/mdal_gdal.cpp
@@ -214,7 +214,7 @@ void MDAL::DriverGdal::parseRasterBands( const MDAL::GdalDataset *cfGDALDataset 
     metadata_hash metadata = parseMetadata( gdalBand );
 
     std::string band_name;
-    double time = std::numeric_limits<double>::min();
+    MDAL::RelativeTimestamp time;
     bool is_vector;
     bool is_x;
     if ( parseBandInfo( cfGDALDataset, metadata, band_name, &time, &is_vector, &is_x ) )
@@ -235,7 +235,6 @@ void MDAL::DriverGdal::parseRasterBands( const MDAL::GdalDataset *cfGDALDataset 
       raster_bands[data_index] = gdalBand;
       qMap[time] = raster_bands;
       mBands[band_name] = qMap;
-
     }
     else
     {
@@ -247,7 +246,6 @@ void MDAL::DriverGdal::parseRasterBands( const MDAL::GdalDataset *cfGDALDataset 
         std::vector<GDALRasterBandH> raster_bands( data_count );
         raster_bands[data_index] = gdalBand;
         mBands[band_name][time] = raster_bands;
-
       }
       else
       {
@@ -311,6 +309,11 @@ void MDAL::DriverGdal::fixRasterBands()
       }
     }
   }
+}
+
+MDAL::DateTime MDAL::DriverGdal::referenceTime() const
+{
+  return MDAL::DateTime();
 }
 
 void MDAL::DriverGdal::addDataToOutput( GDALRasterBandH raster_band, std::shared_ptr<MemoryDataset2D> tos, bool is_vector, bool is_x )
@@ -429,6 +432,7 @@ void MDAL::DriverGdal::addDatasetGroups()
 
     // TODO use GDALComputeRasterMinMax
     group->setStatistics( MDAL::calculateStatistics( group ) );
+    group->setReferenceTime( referenceTime() );
     mMesh->datasetGroups.push_back( group );
   }
 }

--- a/external/mdal/frmts/mdal_gdal.hpp
+++ b/external/mdal/frmts/mdal_gdal.hpp
@@ -65,16 +65,15 @@ namespace MDAL
 
       /* return true on failure */
       virtual bool parseBandInfo( const GdalDataset *cfGDALDataset,
-                                  const metadata_hash &metadata, std::string &band_name, double *time, bool *is_vector, bool *is_x ) = 0;
+                                  const metadata_hash &metadata, std::string &band_name, MDAL::RelativeTimestamp *time, bool *is_vector, bool *is_x ) = 0;
       virtual double parseMetadataTime( const std::string &time_s );
       virtual std::string GDALFileName( const std::string &fileName ); /* some formats require e.g. adding driver name at the beginning */
       virtual std::vector<std::string> parseDatasetNames( const std::string &fileName );
       virtual void parseGlobals( const metadata_hash &metadata ) {MDAL_UNUSED( metadata );}
-
-      void parseBandIsVector( std::string &band_name, bool *is_vector, bool *is_x );
+      virtual void parseBandIsVector( std::string &band_name, bool *is_vector, bool *is_x );
 
     private:
-      typedef std::map<double, std::vector<GDALRasterBandH> > timestep_map; //TIME (sorted), [X, Y]
+      typedef std::map<MDAL::RelativeTimestamp, std::vector<GDALRasterBandH> > timestep_map; //TIME (sorted), [X, Y]
       typedef std::map<std::string, timestep_map > data_hash; //Data Type, TIME (sorted), [X, Y]
       typedef std::vector<std::shared_ptr<GdalDataset>> gdal_datasets_vector; //GDAL (Sub)Datasets,
 
@@ -94,6 +93,8 @@ namespace MDAL
       void createMesh();
       void parseRasterBands( const GdalDataset *cfGDALDataset );
       void fixRasterBands();
+
+      virtual MDAL::DateTime referenceTime() const;
 
       std::string mFileName;
       const std::string mGdalDriverName; /* GDAL driver name */

--- a/external/mdal/frmts/mdal_gdal_grib.hpp
+++ b/external/mdal/frmts/mdal_gdal_grib.hpp
@@ -26,8 +26,10 @@ namespace MDAL
     private:
       bool parseBandInfo( const MDAL::GdalDataset *cfGDALDataset,
                           const metadata_hash &metadata, std::string &band_name,
-                          double *time, bool *is_vector, bool *is_x
+                          RelativeTimestamp *time, bool *is_vector, bool *is_x
                         ) override;
+
+      MDAL::DateTime referenceTime() const override;
 
       /**
        * ref time (UTC sec)
@@ -36,7 +38,7 @@ namespace MDAL
        * some GRIB files do not use FORECAST_SEC, but VALID_TIME
        * metadata, so ref time varies with dataset-to-dataset
        */
-      double mRefTime;
+      DateTime mRefTime;
   };
 
 } // namespace MDAL

--- a/external/mdal/frmts/mdal_gdal_netcdf.hpp
+++ b/external/mdal/frmts/mdal_gdal_netcdf.hpp
@@ -27,12 +27,15 @@ namespace MDAL
       std::string GDALFileName( const std::string &fileName ) override;
       bool parseBandInfo( const MDAL::GdalDataset *cfGDALDataset,
                           const metadata_hash &metadata, std::string &band_name,
-                          double *time, bool *is_vector, bool *is_x
+                          MDAL::RelativeTimestamp *time, bool *is_vector, bool *is_x
                         ) override;
       void parseGlobals( const metadata_hash &metadata ) override;
 
-      //! delimiter to get time in hours
-      double mTimeDiv;
+      MDAL::DateTime referenceTime() const override;
+
+      RelativeTimestamp::Unit mTimeUnit;
+      //! Take the first reference time parsed
+      DateTime mRefTime;
   };
 
 } // namespace MDAL

--- a/external/mdal/frmts/mdal_hec2d.hpp
+++ b/external/mdal/frmts/mdal_hec2d.hpp
@@ -49,6 +49,9 @@ namespace MDAL
       std::unique_ptr< MDAL::MemoryMesh > mMesh;
       std::string mFileName;
 
+      std::vector<MDAL::RelativeTimestamp> mTimes ;
+      DateTime mReferenceTime;
+
       // Pre 5.0.5 format
       bool canReadOldFormat( const std::string &fileType ) const;
       std::vector<std::string> read2DFlowAreasNamesOld( HdfGroup gGeom2DFlowAreas ) const;
@@ -64,8 +67,8 @@ namespace MDAL
                            const std::vector<std::string> &flowAreaNames,
                            const std::string rawDatasetName,
                            const std::string datasetName,
-                           const std::vector<float> &times,
-                           const std::string &referenceTime );
+                           const std::vector<MDAL::RelativeTimestamp> &times,
+                           const DateTime &referenceTime );
 
       void readFaceResults( const HdfFile &hdfFile,
                             const std::vector<size_t> &areaElemStartIndex,
@@ -77,9 +80,9 @@ namespace MDAL
         const std::vector<std::string> &flowAreaNames,
         const std::string rawDatasetName,
         const std::string datasetName,
-        const std::vector<float> &times,
+        const std::vector<MDAL::RelativeTimestamp> &times,
         std::shared_ptr<MDAL::MemoryDataset2D> bed_elevation,
-        const std::string &referenceTime );
+        const DateTime &referenceTime );
 
       std::shared_ptr<MDAL::MemoryDataset2D> readBedElevation(
         const HdfGroup &gGeom2DFlowAreas,

--- a/external/mdal/frmts/mdal_selafin.hpp
+++ b/external/mdal/frmts/mdal_selafin.hpp
@@ -76,7 +76,10 @@ namespace MDAL
                        std::vector<size_t> &ikle,
                        std::vector<double> &x,
                        std::vector<double> &y );
-      void addData( const std::vector<std::string> &var_names, const std::vector<timestep_map> &data, size_t nPoints );
+      void addData( const std::vector<std::string> &var_names,
+                    const std::vector<timestep_map> &data,
+                    size_t nPoints,
+                    const DateTime &referenceTime );
       void parseFile( std::vector<std::string> &var_names,
                       double *xOrigin,
                       double *yOrigin,
@@ -86,7 +89,8 @@ namespace MDAL
                       std::vector<size_t> &ikle,
                       std::vector<double> &x,
                       std::vector<double> &y,
-                      std::vector<timestep_map> &data );
+                      std::vector<timestep_map> &data,
+                      DateTime &referenceTime );
 
       bool getStreamPrecision( std::ifstream &in );
 

--- a/external/mdal/frmts/mdal_sww.cpp
+++ b/external/mdal/frmts/mdal_sww.cpp
@@ -299,7 +299,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readScalarGroup(
     {
       // TIME INDEPENDENT
       std::shared_ptr<MDAL::MemoryDataset2D> o = std::make_shared<MDAL::MemoryDataset2D>( mds.get() );
-      o->setTime( 0.0 );
+      o->setTime( RelativeTimestamp() );
       std::vector<double> valuesX = ncFile.readDoubleArr( arrName, nPoints );
       for ( size_t i = 0; i < nPoints; ++i )
       {
@@ -314,7 +314,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readScalarGroup(
       for ( size_t t = 0; t < times.size(); ++t )
       {
         std::shared_ptr<MDAL::MemoryDataset2D> mto = std::make_shared<MDAL::MemoryDataset2D>( mds.get() );
-        mto->setTime( static_cast<double>( times[t] ) / 3600. );
+        mto->setTime( static_cast<double>( times[t] ), RelativeTimestamp::seconds ); // Time is always in seconds
         double *values = mto->values();
 
         // fetching data for one timestep
@@ -370,8 +370,6 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readVectorGroup(
     if ( zDimsX != zDimsY )
       throw MDAL_Status::Err_UnknownFormat;
 
-    std::vector<double> valuesX( nPoints ), valuesY( nPoints );
-
     if ( zDimsX == 1 )
     {
       // TIME INDEPENDENT
@@ -388,6 +386,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverSWW::readVectorGroup(
     }
     else
     {
+      std::vector<double> valuesX( nPoints ), valuesY( nPoints );
       // TIME DEPENDENT
       for ( size_t t = 0; t < times.size(); ++t )
       {

--- a/external/mdal/frmts/mdal_ugrid.cpp
+++ b/external/mdal/frmts/mdal_ugrid.cpp
@@ -531,25 +531,27 @@ void MDAL::DriverUgrid::writeVariables( MDAL::Mesh *mesh )
   std::vector<double> verticesCoordinates( verticesCoordCount );
   std::unique_ptr<MDAL::MeshVertexIterator> vertexIterator = mesh->readVertices();
 
-  size_t vertexIndex = 0;
-  size_t vertexFileIndex = 0;
-  while ( vertexIndex < mesh->verticesCount() )
   {
-    size_t verticesRead = vertexIterator->next( bufferSize, verticesCoordinates.data() );
-    if ( verticesRead == 0 )
-      break;
-
-    for ( size_t i = 0; i < verticesRead; i++ )
+    size_t vertexIndex = 0;
+    size_t vertexFileIndex = 0;
+    while ( vertexIndex < mesh->verticesCount() )
     {
-      mNcFile->putDataDouble( mesh2dNodeXId, vertexFileIndex, verticesCoordinates[3 * i] );
-      mNcFile->putDataDouble( mesh2dNodeYId, vertexFileIndex, verticesCoordinates[3 * i + 1] );
-      if ( std::isnan( verticesCoordinates[3 * i + 2] ) )
-        mNcFile->putDataDouble( mesh2dNodeZId, vertexFileIndex, fillNodeZCoodVal );
-      else
-        mNcFile->putDataDouble( mesh2dNodeZId, vertexFileIndex, verticesCoordinates[3 * i + 2] );
-      vertexFileIndex++;
+      size_t verticesRead = vertexIterator->next( bufferSize, verticesCoordinates.data() );
+      if ( verticesRead == 0 )
+        break;
+
+      for ( size_t i = 0; i < verticesRead; i++ )
+      {
+        mNcFile->putDataDouble( mesh2dNodeXId, vertexFileIndex, verticesCoordinates[3 * i] );
+        mNcFile->putDataDouble( mesh2dNodeYId, vertexFileIndex, verticesCoordinates[3 * i + 1] );
+        if ( std::isnan( verticesCoordinates[3 * i + 2] ) )
+          mNcFile->putDataDouble( mesh2dNodeZId, vertexFileIndex, fillNodeZCoodVal );
+        else
+          mNcFile->putDataDouble( mesh2dNodeZId, vertexFileIndex, verticesCoordinates[3 * i + 2] );
+        vertexFileIndex++;
+      }
+      vertexIndex += verticesRead;
     }
-    vertexIndex += verticesRead;
   }
 
   // Write faces

--- a/external/mdal/frmts/mdal_xdmf.cpp
+++ b/external/mdal/frmts/mdal_xdmf.cpp
@@ -20,7 +20,10 @@
 #include "mdal_data_model.hpp"
 #include "mdal_xml.hpp"
 
-MDAL::XdmfDataset::XdmfDataset( MDAL::DatasetGroup *grp, const MDAL::HyperSlab &slab, const HdfDataset &valuesDs, double time )
+MDAL::XdmfDataset::XdmfDataset( MDAL::DatasetGroup *grp,
+                                const MDAL::HyperSlab &slab,
+                                const HdfDataset &valuesDs,
+                                RelativeTimestamp time )
   : MDAL::Dataset2D( grp )
   , mHdf5DatasetValues( valuesDs )
   , mHyperSlab( slab )
@@ -109,7 +112,7 @@ size_t MDAL::XdmfDataset::vectorData( size_t indexStart, size_t count, double *b
 MDAL::XdmfFunctionDataset::XdmfFunctionDataset(
   MDAL::DatasetGroup *grp,
   MDAL::XdmfFunctionDataset::FunctionType type,
-  double time )
+  const RelativeTimestamp &time )
   : MDAL::Dataset2D( grp )
   , mType( type )
   , mBaseReferenceGroup( "XDMF", grp->mesh(), grp->uri() )
@@ -122,7 +125,10 @@ MDAL::XdmfFunctionDataset::XdmfFunctionDataset(
 
 MDAL::XdmfFunctionDataset::~XdmfFunctionDataset() = default;
 
-void MDAL::XdmfFunctionDataset::addReferenceDataset( const HyperSlab &slab, const HdfDataset &hdfDataset, double time )
+void MDAL::XdmfFunctionDataset::addReferenceDataset(
+  const HyperSlab &slab,
+  const HdfDataset &hdfDataset,
+  const MDAL::RelativeTimestamp &time )
 {
   std::shared_ptr<MDAL::XdmfDataset> xdmfDataset = std::make_shared<MDAL::XdmfDataset>(
         &mBaseReferenceGroup,
@@ -273,7 +279,7 @@ MDAL::HyperSlab MDAL::DriverXdmf::parseHyperSlab( const std::string &str, size_t
   }
 
   // sort
-  if ( ( countX < countY ) && ( countY = ! 3 ) )
+  if ( ( countX < countY ) && ( countY != 3 ) )
   {
     std::swap( countX, countY );
     slab.countInFirstColumn = false;
@@ -435,8 +441,7 @@ MDAL::DatasetGroups MDAL::DriverXdmf::parseXdmfXml( )
   {
     ++nTimesteps;
     xmlNodePtr timeNod = xmfFile.getCheckChild( gridNod, "Time" );
-    double time = xmfFile.queryDoubleAttribute( timeNod, "Value" );
-
+    RelativeTimestamp time( xmfFile.queryDoubleAttribute( timeNod, "Value" ), RelativeTimestamp::hours ); //units, supposed to be hours
     xmlNodePtr scalarNod = xmfFile.getCheckChild( gridNod, "Attribute" );
 
     for ( ;

--- a/external/mdal/frmts/mdal_xdmf.hpp
+++ b/external/mdal/frmts/mdal_xdmf.hpp
@@ -61,7 +61,7 @@ namespace MDAL
       XdmfDataset( DatasetGroup *grp,
                    const HyperSlab &slab,
                    const HdfDataset &valuesDs,
-                   double time
+                   MDAL::RelativeTimestamp time
                  );
       ~XdmfDataset() override;
 
@@ -108,15 +108,14 @@ namespace MDAL
         Flow, //!< scalar: flow velocity (abs) = sqrt($0/($2-$3)*$0/($2-$3) + $1/($2-$3)*$1/($2-$3))
       };
 
-      XdmfFunctionDataset(
-        DatasetGroup *grp,
-        FunctionType type,
-        double time
-      );
+      XdmfFunctionDataset( DatasetGroup *grp,
+                           FunctionType type,
+                           const RelativeTimestamp &time
+                         );
       ~XdmfFunctionDataset() override;
 
       //! Adds reference XMDF dataset
-      void addReferenceDataset( const HyperSlab &slab, const HdfDataset &hdfDataset, double time );
+      void addReferenceDataset( const HyperSlab &slab, const HdfDataset &hdfDataset, const RelativeTimestamp &time );
       //! Swaps first and second reference dataset
       void swap();
 

--- a/external/mdal/frmts/mdal_xmdf.cpp
+++ b/external/mdal/frmts/mdal_xmdf.cpp
@@ -248,8 +248,15 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverXmdf::readXmdfGroupAsDatasetGrou
   bool isVector = dimValues.size() == 3;
 
   std::vector<double> times = dsTimes.readArrayDouble();
-  std::string timeUnit = rootGroup.attribute( "TimeUnits" ).readString();
-  convertTimeDataToHours( times, timeUnit );
+  std::string timeUnitString = rootGroup.attribute( "TimeUnits" ).readString();
+  MDAL::RelativeTimestamp::Unit timeUnit = parseDurationTimeUnit( timeUnitString );
+  HdfAttribute refTime = rootGroup.attribute( "Reftime" );
+  if ( refTime.isValid() )
+  {
+    std::string referenceTimeJulianDay = rootGroup.attribute( "Reftime" ).readString();
+    group->setReferenceTime( DateTime( MDAL::toDouble( referenceTimeJulianDay ), DateTime::JulianDay ) );
+  }
+
   // all fine, set group and return
   group = std::make_shared<MDAL::DatasetGroup>(
             name(),
@@ -259,7 +266,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverXmdf::readXmdfGroupAsDatasetGrou
           );
   group->setIsScalar( !isVector );
   group->setDataLocation( MDAL_DataLocation::DataOnVertices2D );
-  group->setMetadata( "TIMEUNITS", timeUnit );
+  group->setMetadata( "TIMEUNITS", timeUnitString );
 
   // lazy loading of min and max of the dataset group
   std::vector<float> mins = dsMins.readArray();
@@ -272,7 +279,7 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverXmdf::readXmdfGroupAsDatasetGrou
   for ( hsize_t i = 0; i < nTimeSteps; ++i )
   {
     std::shared_ptr<XmdfDataset> dataset = std::make_shared< XmdfDataset >( group.get(), dsValues, dsActive, i );
-    dataset->setTime( times[i] );
+    dataset->setTime( times[i], timeUnit );
     Statistics stats;
     stats.minimum = static_cast<double>( mins[i] );
     stats.maximum = static_cast<double>( maxs[i] );
@@ -281,17 +288,4 @@ std::shared_ptr<MDAL::DatasetGroup> MDAL::DriverXmdf::readXmdfGroupAsDatasetGrou
   }
 
   return group;
-}
-
-void MDAL::DriverXmdf::convertTimeDataToHours( std::vector<double> &times, const std::string &originalTimeDataUnit )
-{
-  if ( originalTimeDataUnit != "Hours" )
-  {
-    for ( size_t i = 0; i < times.size(); i++ )
-    {
-      if ( originalTimeDataUnit == "Seconds" ) { times[i] /= 3600.0; }
-      else if ( originalTimeDataUnit == "Minutes" ) { times[i] /= 60.0; }
-      else if ( originalTimeDataUnit == "Days" ) { times[i] *= 24; }
-    }
-  }
 }

--- a/external/mdal/frmts/mdal_xmdf.hpp
+++ b/external/mdal/frmts/mdal_xmdf.hpp
@@ -100,8 +100,6 @@ namespace MDAL
         const std::string &nameSuffix,
         size_t vertexCount,
         size_t faceCount );
-
-      void convertTimeDataToHours( std::vector<double> &times, const std::string &originalTimeDataUnit );
   };
 
 } // namespace MDAL

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -22,7 +22,7 @@ static MDAL_Status sLastStatus;
 
 const char *MDAL_Version()
 {
-  return "0.4.92";
+  return "0.4.93";
 }
 
 MDAL_Status MDAL_LastStatus()
@@ -697,8 +697,9 @@ DatasetH MDAL_G_addDataset( DatasetGroupH group, double time, const double *valu
   }
 
   const size_t index = g->datasets.size();
+  MDAL::RelativeTimestamp t( time, MDAL::RelativeTimestamp::hours );
   dr->createDataset( g,
-                     time,
+                     t,
                      values,
                      active
                    );
@@ -765,7 +766,7 @@ const char *MDAL_G_referenceTime( DatasetGroupH group )
     return EMPTY_STR;
   }
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
-  return _return_str( g->referenceTime() );
+  return _return_str( g->referenceTime().toStandartCalendarISO8601() );
 }
 
 void MDAL_G_setMetadata( DatasetGroupH group, const char *key, const char *val )
@@ -827,8 +828,7 @@ double MDAL_D_time( DatasetH dataset )
     return NODATA;
   }
   MDAL::Dataset *d = static_cast< MDAL::Dataset * >( dataset );
-  return d->time();
-
+  return d->time( MDAL::RelativeTimestamp::hours );
 }
 
 int MDAL_D_volumesCount( DatasetH dataset )
@@ -1064,3 +1064,4 @@ bool MDAL_D_hasActiveFlagCapability( DatasetH dataset )
   MDAL::Dataset *ds = static_cast< MDAL::Dataset * >( dataset );
   return ds->supportsActiveFlag();
 }
+

--- a/external/mdal/mdal_data_model.cpp
+++ b/external/mdal/mdal_data_model.cpp
@@ -56,12 +56,17 @@ MDAL::Mesh *MDAL::Dataset::mesh() const
   return mParent->mesh();
 }
 
-double MDAL::Dataset::time() const
+double MDAL::Dataset::time( RelativeTimestamp::Unit unit ) const
 {
-  return mTime;
+  return mTime.value( unit );
 }
 
-void MDAL::Dataset::setTime( double time )
+void MDAL::Dataset::setTime( double time, RelativeTimestamp::Unit unit )
+{
+  mTime = RelativeTimestamp( time, unit );
+}
+
+void MDAL::Dataset::setTime( const MDAL::RelativeTimestamp &time )
 {
   mTime = time;
 }
@@ -87,7 +92,6 @@ MDAL::Dataset2D::Dataset2D( MDAL::DatasetGroup *parent )
 }
 
 MDAL::Dataset2D::~Dataset2D() = default;
-
 
 size_t MDAL::Dataset2D::volumesCount() const { return 0; }
 
@@ -207,12 +211,12 @@ void MDAL::DatasetGroup::setStatistics( const Statistics &statistics )
   mStatistics = statistics;
 }
 
-std::string MDAL::DatasetGroup::referenceTime() const
+MDAL::DateTime MDAL::DatasetGroup::referenceTime() const
 {
   return mReferenceTime;
 }
 
-void MDAL::DatasetGroup::setReferenceTime( const std::string &referenceTime )
+void MDAL::DatasetGroup::setReferenceTime( const DateTime &referenceTime )
 {
   mReferenceTime = referenceTime;
 }

--- a/external/mdal/mdal_data_model.hpp
+++ b/external/mdal/mdal_data_model.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <limits>
 #include "mdal.h"
+#include "mdal_datetime.hpp"
 
 namespace MDAL
 {
@@ -75,14 +76,15 @@ namespace MDAL
       DatasetGroup *group() const;
       Mesh *mesh() const;
 
-      double time() const;
-      void setTime( double time );
+      double time( RelativeTimestamp::Unit unit ) const;
+      void setTime( double time, RelativeTimestamp::Unit unit = RelativeTimestamp::hours );
+      void setTime( const RelativeTimestamp &time );
 
       bool supportsActiveFlag() const;
       void setSupportsActiveFlag( bool value );
 
     private:
-      double mTime = std::numeric_limits<double>::quiet_NaN();
+      RelativeTimestamp mTime;
       bool mIsValid = true;
       bool mSupportsActiveFlag = false;
       DatasetGroup *mParent = nullptr;
@@ -166,8 +168,8 @@ namespace MDAL
       Statistics statistics() const;
       void setStatistics( const Statistics &statistics );
 
-      std::string referenceTime() const;
-      void setReferenceTime( const std::string &referenceTime );
+      DateTime referenceTime() const;
+      void setReferenceTime( const DateTime &referenceTime );
 
       Mesh *mesh() const;
 
@@ -186,7 +188,7 @@ namespace MDAL
       MDAL_DataLocation mDataLocation = MDAL_DataLocation::DataOnVertices2D;
       std::string mUri; // file/uri from where it came
       Statistics mStatistics;
-      std::string mReferenceTime;
+      DateTime mReferenceTime;
   };
 
   typedef std::vector<std::shared_ptr<DatasetGroup>> DatasetGroups;

--- a/external/mdal/mdal_datetime.cpp
+++ b/external/mdal/mdal_datetime.cpp
@@ -1,0 +1,349 @@
+/*
+ MDAL - Mesh Data Abstraction Library (MIT License)
+ Copyright (C) 2019 Vincent Cloarec (vcloarec at gmail dot com)
+*/
+#include "mdal_datetime.hpp"
+#include "mdal_utils.hpp"
+
+
+constexpr double MILLISECONDS_IN_SECOND = 1000;
+constexpr double MILLISECONDS_IN_MINUTE = 1000 * 60;
+constexpr double MILLISECONDS_IN_HOUR = 1000 * 60 * 60;
+constexpr double MILLISECONDS_IN_DAY = 1000 * 60 * 60 * 24;
+constexpr double MILLISECONDS_IN_WEEK = 1000 * 60 * 60 * 24 * 7;
+
+//https://www.unidata.ucar.edu/software/netcdf-java/current/CDM/CalendarDateTime.html
+constexpr double MILLISECONDS_IN_EXACT_YEAR = 3.15569259747e10; //CF Compliant
+constexpr double MILLISECONDS_IN_MONTH_CF = MILLISECONDS_IN_EXACT_YEAR / 12.0; //CF Compliant
+
+MDAL::DateTime::DateTime() = default;
+
+MDAL::DateTime::DateTime( int year, int month, int day, int hours, int minutes, double seconds, MDAL::DateTime::Calendar calendar )
+{
+  DateTimeValues value{year, month, day, hours, minutes, seconds};
+
+  switch ( calendar )
+  {
+    case MDAL::DateTime::Gregorian:
+      setWithGregorianJulianCalendarDate( value );
+      break;
+    case MDAL::DateTime::ProlepticGregorian:
+      setWithGregorianCalendarDate( value );
+      break;
+    case MDAL::DateTime::Julian:
+      setWithJulianCalendarDate( value );
+      break;
+  }
+}
+
+MDAL::DateTime::DateTime( double value, Epoch epoch ):  mValid( true )
+{
+  switch ( epoch )
+  {
+    case MDAL::DateTime::Unix:
+      mJulianTime = ( DateTime( 1970, 01, 01, 0, 0, 0, Gregorian ) + RelativeTimestamp( value, RelativeTimestamp::seconds ) ).mJulianTime;
+      break;
+    case MDAL::DateTime::JulianDay:
+      mJulianTime = int64_t( value * MILLISECONDS_IN_DAY + 0.5 );
+      break;
+  }
+}
+
+std::string MDAL::DateTime::toStandartCalendarISO8601() const
+{
+  if ( mValid )
+  {
+    DateTimeValues value = dateTimeGregorianProleptic();
+    if ( value.year > 0 )
+      return toString( value );
+  }
+
+  return "";
+}
+
+double MDAL::DateTime::toJulianDay() const
+{
+  return mJulianTime / MILLISECONDS_IN_DAY;
+}
+
+std::string MDAL::DateTime::toJulianDayString() const
+{
+  return std::to_string( toJulianDay() );
+}
+
+
+MDAL::DateTime MDAL::DateTime::operator+( const MDAL::RelativeTimestamp &duration ) const
+{
+  if ( !mValid )
+    return DateTime();
+  return DateTime( mJulianTime + duration.mDuration );
+}
+
+
+MDAL::DateTime MDAL::DateTime::operator-( const MDAL::RelativeTimestamp &duration ) const
+{
+  if ( !mValid )
+    return DateTime();
+  return DateTime( mJulianTime - duration.mDuration );
+}
+
+bool MDAL::DateTime::operator==( const MDAL::DateTime &other ) const
+{
+  if ( !mValid && !other.mValid )
+    return true;
+
+  return ( mValid && other.mValid ) && ( mJulianTime == other.mJulianTime );
+}
+
+bool MDAL::DateTime::operator<( const MDAL::DateTime &other ) const
+{
+  if ( !mValid && !other.mValid )
+    return false;
+  return ( mValid && other.mValid ) && ( mJulianTime < other.mJulianTime );
+}
+
+bool MDAL::DateTime::isValid() const { return mValid; }
+
+MDAL::DateTime::DateTime( int64_t julianTime ): mJulianTime( julianTime ), mValid( true )
+{}
+
+MDAL::DateTime::DateTimeValues MDAL::DateTime::dateTimeGregorianJulianCalendar() const
+{
+  // https://fr.wikipedia.org/wiki/Jour_julien
+  DateTimeValues values;
+  int Z = int( mJulianTime / MILLISECONDS_IN_DAY + 0.5 ); // integer part of julian days count
+  double F = ( mJulianTime - MILLISECONDS_IN_DAY * ( Z - 0.5 ) ) / MILLISECONDS_IN_DAY; // fractional part of julian days count;
+  int S;
+
+  if ( Z < 2299161 )
+    S = Z;
+  else
+  {
+    int alpha = int( ( Z - 1867216.25 ) / 36524.25 );
+    S = Z + 1 + alpha - int( alpha / 4 );
+  }
+
+  int B = S + 1524;
+  int C = int( ( B - 122.1 ) / 365.25 );
+  int D = int( 365.25 * C );
+  int E = int( ( B - D ) / 30.6001 );
+
+  values.day = B - D - int( 30.6001 * E );
+  if ( E < 14 )
+    values.month = E - 1;
+  else
+    values.month = E - 13;
+
+  if ( values.month > 2 )
+    values.year = C - 4716;
+  else
+    values.year = C - 4715;
+
+  values.hours = int( F / MILLISECONDS_IN_HOUR );
+  F = int( F - values.hours * MILLISECONDS_IN_HOUR );
+  values.minutes = int( F / MILLISECONDS_IN_MINUTE );
+  F = int( F  - values.minutes * MILLISECONDS_IN_MINUTE );
+  values.seconds = int( F / MILLISECONDS_IN_SECOND );
+
+  return values;
+}
+
+MDAL::DateTime::DateTimeValues MDAL::DateTime::dateTimeGregorianProleptic() const
+{
+  // https://fr.wikipedia.org/wiki/Jour_julien
+  DateTimeValues values;
+  int Z = int( mJulianTime / MILLISECONDS_IN_DAY + 0.5 ); // integer part of julian days count
+  int F = int( mJulianTime - MILLISECONDS_IN_DAY * ( Z - 0.5 ) ) ; // fractional part of julian days count in ms;
+
+  int alpha = int( ( Z - 1867216.25 ) / 36524.25 );
+  int S = Z + 1 + alpha - int( alpha / 4 );
+
+  int B = S + 1524;
+  int C = int( ( B - 122.1 ) / 365.25 );
+  int D = int( 365.25 * C );
+  int E = int( ( B - D ) / 30.6001 );
+
+  values.day = B - D - int( 30.6001 * E );
+  if ( E < 14 )
+    values.month = E - 1;
+  else
+    values.month = E - 13;
+
+  if ( values.month > 2 )
+    values.year = C - 4716;
+  else
+    values.year = C - 4715;
+
+  values.hours = int( F / MILLISECONDS_IN_HOUR );
+  F = int( F - values.hours * MILLISECONDS_IN_HOUR );
+  values.minutes = int( F / MILLISECONDS_IN_MINUTE );
+  F = int( F  - values.minutes * MILLISECONDS_IN_MINUTE );
+  values.seconds = int( F / MILLISECONDS_IN_SECOND );
+
+  return values;
+}
+
+
+void MDAL::DateTime::setWithGregorianCalendarDate( MDAL::DateTime::DateTimeValues values )
+{
+  // https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+  if ( values.month <= 2 )
+  {
+    values.year--;
+    values.month += 12;
+  }
+
+  int A = values.year / 100;
+  int B = A / 4;
+  int C = 2 - A + B;
+  int E = int( 365.25 * ( values.year + 4716 ) );
+  int F = int( 30.6001 * ( values.month + 1 ) );
+  double julianDay = C + values.day + E + F - 1524.5;
+
+  mValid = true;
+  mJulianTime = int64_t( julianDay * MILLISECONDS_IN_DAY +
+                         ( values.hours ) * MILLISECONDS_IN_HOUR +
+                         values.minutes * MILLISECONDS_IN_MINUTE +
+                         values.seconds * MILLISECONDS_IN_SECOND );
+}
+
+void MDAL::DateTime::setWithJulianCalendarDate( MDAL::DateTime::DateTimeValues values )
+{
+  // https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+  if ( values.month <= 2 )
+  {
+    values.year--;
+    values.month += 12;
+  }
+
+  int E = int( 365.25 * ( values.year + 4716 ) );
+  int F = int( 30.6001 * ( values.month + 1 ) );
+  double julianDay = values.day + E + F - 1524.5;
+
+  mValid = true;
+  mJulianTime = int64_t( julianDay * MILLISECONDS_IN_DAY +
+                         ( values.hours ) * MILLISECONDS_IN_HOUR +
+                         values.minutes * MILLISECONDS_IN_MINUTE +
+                         values.seconds * MILLISECONDS_IN_SECOND );
+}
+
+void MDAL::DateTime::setWithGregorianJulianCalendarDate( MDAL::DateTime::DateTimeValues values )
+{
+  // https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+
+  mValid = true;
+
+  if ( values.year > 1582 ||
+       ( values.year == 1582 && ( values.month > 10 || ( values.month == 10 && values.day >= 15 ) ) ) ) // gregorian calendar
+  {
+    setWithGregorianCalendarDate( values );
+  }
+  else
+    setWithJulianCalendarDate( values );
+}
+
+std::string MDAL::DateTime::toString( MDAL::DateTime::DateTimeValues values ) const
+{
+  int miliseconds = int( ( values.seconds - int( values.seconds ) ) * 1000 + 0.5 );
+  std::string msStr;
+  if ( miliseconds > 0 )
+  {
+    if ( miliseconds < 10 )
+      msStr = prependZero( std::to_string( miliseconds ), 3 );
+    else if ( miliseconds < 100 )
+      msStr = prependZero( std::to_string( miliseconds ), 2 );
+    else if ( miliseconds < 1000 )
+      msStr = std::to_string( miliseconds );
+
+    msStr = std::string( "," ).append( msStr );
+  }
+
+  std::string strDateTime = prependZero( std::to_string( values.year ), 4 ) + "-" +
+                            prependZero( std::to_string( values.month ), 2 ) + "-" +
+                            prependZero( std::to_string( values.day ), 2 ) + "T" +
+                            prependZero( std::to_string( values.hours ), 2 ) + ":" +
+                            prependZero( std::to_string( values.minutes ), 2 ) + ":" +
+                            prependZero( std::to_string( int( values.seconds ) ), 2 ) +
+                            msStr;
+
+  return strDateTime;
+}
+
+MDAL::RelativeTimestamp MDAL::DateTime::operator-( const MDAL::DateTime &other ) const
+{
+  if ( !mValid || !other.mValid )
+    return RelativeTimestamp();
+  return RelativeTimestamp( mJulianTime - other.mJulianTime );
+}
+
+
+MDAL::RelativeTimestamp::RelativeTimestamp() = default;
+
+MDAL::RelativeTimestamp::RelativeTimestamp( double duration, MDAL::RelativeTimestamp::Unit unit )
+{
+  switch ( unit )
+  {
+    case MDAL::RelativeTimestamp::milliseconds:
+      mDuration = int64_t( duration );
+      break;
+    case MDAL::RelativeTimestamp::seconds:
+      mDuration = int64_t( duration * MILLISECONDS_IN_SECOND + 0.5 );
+      break;
+    case MDAL::RelativeTimestamp::minutes:
+      mDuration = int64_t( duration * MILLISECONDS_IN_MINUTE + 0.5 );
+      break;
+    case MDAL::RelativeTimestamp::hours:
+      mDuration = int64_t( duration * MILLISECONDS_IN_HOUR + 0.5 );
+      break;
+    case MDAL::RelativeTimestamp::days:
+      mDuration = int64_t( duration * MILLISECONDS_IN_DAY + 0.5 );
+      break;
+    case MDAL::RelativeTimestamp::weeks:
+      mDuration = int64_t( duration * MILLISECONDS_IN_WEEK + 0.5 );
+      break;
+    case MDAL::RelativeTimestamp::months_CF:
+      mDuration = int64_t( duration * MILLISECONDS_IN_MONTH_CF + 0.5 );
+      break;
+    case MDAL::RelativeTimestamp::exact_years:
+      mDuration = int64_t( duration * MILLISECONDS_IN_EXACT_YEAR + 0.5 );
+      break;
+  }
+}
+
+double MDAL::RelativeTimestamp::value( MDAL::RelativeTimestamp::Unit unit ) const
+{
+  switch ( unit )
+  {
+    case MDAL::RelativeTimestamp::milliseconds:
+      return double( mDuration );
+    case MDAL::RelativeTimestamp::seconds:
+      return mDuration / MILLISECONDS_IN_SECOND;
+    case MDAL::RelativeTimestamp::minutes:
+      return mDuration  / MILLISECONDS_IN_MINUTE;
+    case MDAL::RelativeTimestamp::hours:
+      return mDuration / MILLISECONDS_IN_HOUR;
+    case MDAL::RelativeTimestamp::days:
+      return double( mDuration ) / MILLISECONDS_IN_DAY;
+    case MDAL::RelativeTimestamp::weeks:
+      return double( mDuration )  / MILLISECONDS_IN_WEEK;
+    case MDAL::RelativeTimestamp::months_CF:
+      return double( mDuration ) / MILLISECONDS_IN_MONTH_CF;
+    case MDAL::RelativeTimestamp::exact_years:
+      return double( mDuration )  / MILLISECONDS_IN_EXACT_YEAR;
+  }
+
+  return 0;
+}
+
+bool MDAL::RelativeTimestamp::operator==( const MDAL::RelativeTimestamp &other ) const
+{
+  return mDuration == other.mDuration;
+}
+
+bool MDAL::RelativeTimestamp::operator<( const MDAL::RelativeTimestamp &other ) const
+{
+  return mDuration < other.mDuration;
+}
+
+MDAL::RelativeTimestamp::RelativeTimestamp( int64_t ms ): mDuration( ms )
+{}

--- a/external/mdal/mdal_datetime.hpp
+++ b/external/mdal/mdal_datetime.hpp
@@ -1,0 +1,118 @@
+/*
+ MDAL - Mesh Data Abstraction Library (MIT License)
+ Copyright (C) 2019 Vincent Cloarec (vcloarec at gmail dot com)
+*/
+
+#ifndef MDAL_DATE_TIME_HPP
+#define MDAL_DATE_TIME_HPP
+
+#include <string>
+#include <vector>
+
+#include "mdal.h"
+
+namespace MDAL
+{
+
+  class RelativeTimestamp
+  {
+    public:
+      enum Unit
+      {
+        milliseconds = 0,
+        seconds,
+        minutes,
+        hours,
+        days,
+        weeks,
+        months_CF,
+        exact_years
+      };
+
+      RelativeTimestamp();
+      RelativeTimestamp( double duration, Unit unit );
+
+      double value( Unit unit ) const;
+
+      bool operator==( const RelativeTimestamp &other ) const;
+      bool operator<( const RelativeTimestamp &other ) const;
+
+    private:
+      RelativeTimestamp( int64_t ms );
+      int64_t mDuration = 0; //in ms
+
+      friend class DateTime;
+  };
+
+  class DateTime
+  {
+    public:
+
+      enum Calendar
+      {
+        Gregorian = 0,
+        ProlepticGregorian,
+        Julian,
+      };
+
+      enum Epoch
+      {
+        Unix = 0,
+        JulianDay
+      };
+
+      DateTime();
+      //! Constructor with date/time values and calendar type
+      DateTime( int year, int month, int day, int hours = 0, int minutes = 0, double seconds = 0, Calendar calendar = Gregorian );
+      //! Constructor with Julian day or Unix Epoch
+      DateTime( double value, Epoch epoch );
+
+      //! Returns a string with the date/time expressed in Greogrian proleptic calendar with ISO8601 format (local time zone)
+      //! Do not support negative year
+      std::string toStandartCalendarISO8601() const;
+
+      //! Returns the Julian day value
+      double toJulianDay() const;
+
+      //! Returns the Julain day value expressed with a string
+      std::string toJulianDayString() const;
+
+      //! operators
+      RelativeTimestamp operator-( const DateTime &other ) const;
+      DateTime operator+( const RelativeTimestamp &duration ) const;
+      DateTime operator-( const RelativeTimestamp &duration ) const;
+      bool operator==( const DateTime &other ) const;
+      bool operator<( const DateTime &other ) const;
+
+      bool isValid() const;
+
+    private:
+
+      struct DateTimeValues
+      {
+        int year;
+        int month;
+        int day;
+        int hours;
+        int minutes;
+        double seconds;
+      };
+
+      DateTime( int64_t julianTime );
+
+      DateTimeValues dateTimeGregorianJulianCalendar() const;
+      DateTimeValues dateTimeGregorianProleptic() const;
+
+      void setWithGregorianCalendarDate( DateTimeValues values );
+      void setWithJulianCalendarDate( DateTimeValues values );
+      void setWithGregorianJulianCalendarDate( DateTimeValues values );//Uses the adapted formula depending of the date (< or > 1582-10-15)
+
+      std::string toString( DateTimeValues values ) const;
+
+      int64_t mJulianTime = 0; //Julian day in ms
+
+      bool mValid = false;
+  };
+}
+
+#endif // MDAL_DATE_TIME_HPP

--- a/external/mdal/mdal_utils.hpp
+++ b/external/mdal/mdal_utils.hpp
@@ -6,10 +6,6 @@
 #ifndef MDAL_UTILS_HPP
 #define MDAL_UTILS_HPP
 
-// Macro for exporting symbols
-// for unit tests (on windows)
-#define MDAL_TEST_EXPORT MDAL_EXPORT
-
 #include <string>
 #include <vector>
 #include <stddef.h>
@@ -20,6 +16,7 @@
 
 #include "mdal_data_model.hpp"
 #include "mdal_memory_data_model.hpp"
+#include "mdal_datetime.hpp"
 
 // avoid unused variable warnings
 #define MDAL_UNUSED(x) (void)x;
@@ -83,10 +80,10 @@ namespace MDAL
    * Splits by deliminer and skips empty parts.
    * Faster than version with std::string
    */
-  MDAL_TEST_EXPORT std::vector<std::string> split( const std::string &str, const char delimiter );
+  std::vector<std::string> split( const std::string &str, const char delimiter );
 
   //! Splits by deliminer and skips empty parts
-  MDAL_TEST_EXPORT std::vector<std::string> split( const std::string &str, const std::string &delimiter );
+  std::vector<std::string> split( const std::string &str, const std::string &delimiter );
 
   std::string join( const std::vector<std::string> parts, const std::string &delimiter );
 
@@ -110,7 +107,7 @@ namespace MDAL
 
   // time
   //! Returns a delimiter to get time in hours
-  MDAL_TEST_EXPORT double parseTimeUnits( const std::string &units );
+  double parseTimeUnits( const std::string &units );
   //! Returns current time stamp in YYYY-mm-ddTHH:MM:SSzoneOffset
   std::string getCurrentTimeStamp();
 
@@ -144,6 +141,19 @@ namespace MDAL
 
     return true;
   }
+
+  //! Prepend 0 to string to have n char
+  std::string prependZero( const std::string &str, size_t length );
+
+  RelativeTimestamp::Unit parseDurationTimeUnit( const std::string &timeUnit );
+
+  //! parse the time unit in the CF convention string format "XXXX since 2019-01-01 00:00:00"
+  //! https://www.unidata.ucar.edu/software/netcdf-java/current/CDM/CalendarDateTime.html
+  RelativeTimestamp::Unit parseCFTimeUnit( std::string timeInformation );
+
+  //! parse the reference time in the CF convention string format "XXXX since 2019-01-01 00:00:00"
+  //! https://www.unidata.ucar.edu/software/netcdf-java/current/CDM/CalendarDateTime.html
+  MDAL::DateTime parseCFReferenceTime( const std::string &timeInformation, const std::string &calendarString );
 
 } // namespace MDAL
 #endif //MDAL_UTILS_HPP

--- a/src/providers/mdal/CMakeLists.txt
+++ b/src/providers/mdal/CMakeLists.txt
@@ -30,6 +30,7 @@ IF (WITH_INTERNAL_MDAL)
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_utils.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_data_model.cpp
+    ${CMAKE_SOURCE_DIR}/external/mdal/mdal_datetime.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_memory_data_model.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_driver_manager.cpp
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_driver.cpp
@@ -44,6 +45,7 @@ IF (WITH_INTERNAL_MDAL)
     ${CMAKE_SOURCE_DIR}/external/mdal/api/mdal.h
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_utils.hpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_data_model.hpp
+    ${CMAKE_SOURCE_DIR}/external/mdal/mdal_datetime.hpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_memory_data_model.hpp
     ${CMAKE_SOURCE_DIR}/external/mdal/mdal_driver_manager.hpp
     ${CMAKE_SOURCE_DIR}/external/mdal/frmts/mdal_driver.hpp


### PR DESCRIPTION
no change in QGIS side, only difference is that function MDAL_G_referenceTime returns now correctly ISO8601 format of time . the function in not YET used in qgis, but this is prerequisite for https://github.com/qgis/QGIS/issues/32186 we want to implement for QGIS 3.12