### PR TITLE
Backport to 3.10 of #33378 (Fix the label of the output parameter of the TPI algorithm)

### DIFF
--- a/python/plugins/processing/algs/gdal/tpi.py
+++ b/python/plugins/processing/algs/gdal/tpi.py
@@ -68,7 +68,7 @@ class tpi(GdalAlgorithm):
                 'class': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}})
         self.addParameter(options_param)
 
-        self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr('Terrain Ruggedness Index')))
+        self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr('Topographic Position')))
 
     def name(self):
         return 'tpitopographicpositionindex'


### PR DESCRIPTION


## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Backport to 3.10 of #33378 (Fix the label of the output parameter of the TPI algorithm).

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
