### PR TITLE
[DB Manager] Fix broken geometry type of GeoPackage-based SQL Layers

### DIFF
--- a/python/plugins/db_manager/db_plugins/gpkg/plugin.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/plugin.py
@@ -178,8 +178,7 @@ class GPKGDatabase(Database):
     def toSqlLayer(self, sql, geomCol, uniqueCol, layerName="QueryLayer", layerType=None, avoidSelectById=False, filter=""):
         from qgis.core import QgsVectorLayer
 
-        vl = QgsVectorLayer(self.uri().database(), layerName, 'ogr')
-        vl.setSubsetString(sql)
+        vl = QgsVectorLayer(self.uri().database() + '|subset=' + sql, layerName, 'ogr')
         return vl
 
     def supportsComment(self):


### PR DESCRIPTION
This is a quick fix for #33232. Probably it could be better fixed in the OGR provider, but I don't have enough resources now, while this patch simply works (it's what I recently start SQL trainings from... :/).

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
