### PR TITLE
[needs-docs] Add precision to rotate marker checkbox label

### DIFF
--- a/src/ui/symbollayer/widget_markerline.ui
+++ b/src/ui/symbollayer/widget_markerline.ui
@@ -360,7 +360,7 @@
      <item row="1" column="0" colspan="5">
       <widget class="QCheckBox" name="chkRotateMarker">
        <property name="text">
-        <string>Rotate marker</string>
+        <string>Rotate marker to follow line direction</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
"to follow line direction" and harmonize with hash line symbol layer dialog
currently
![image](https://user-images.githubusercontent.com/7983394/70857639-b3761280-1ef2-11ea-9302-b00beb93c6d4.png)

the hash example 
![image](https://user-images.githubusercontent.com/7983394/70857633-95101700-1ef2-11ea-8f9f-9d4726a913d8.png)


