### PR TITLE
Make sure a TOWGS84 parameter is added when exporting a CRS to a WKT string with Proj6

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -105,6 +105,20 @@ QString getFullProjString( PJ *obj )
 
   return QString( proj_as_proj_string( QgsProjContext::get(), obj, PJ_PROJ_4, nullptr ) );
 }
+
+QString getFullWktString( PJ *obj, PJ_WKT_TYPE type, const char *const options[] )
+{
+  QgsProjUtils::proj_pj_unique_ptr boundCrs( proj_crs_create_bound_crs_to_WGS84( QgsProjContext::get(), obj, nullptr ) );
+  if ( boundCrs )
+  {
+    if ( const char *wkt =  proj_as_wkt( QgsProjContext::get(), boundCrs.get(), type, options ) )
+    {
+      return QString( wkt );
+    }
+  }
+
+  return QString( proj_as_wkt( QgsProjContext::get(), obj, type, options ) );
+}
 #endif
 //--------------------------
 
@@ -1774,7 +1788,7 @@ QString QgsCoordinateReferenceSystem::toWkt( WktVariant variant, bool multiline,
       const QByteArray multiLineOption = QStringLiteral( "MULTILINE=%1" ).arg( multiline ? QStringLiteral( "YES" ) : QStringLiteral( "NO" ) ).toLocal8Bit();
       const QByteArray indentatationWidthOption = QStringLiteral( "INDENTATION_WIDTH=%1" ).arg( multiline ? QString::number( indentationWidth ) : QStringLiteral( "0" ) ).toLocal8Bit();
       const char *const options[] = {multiLineOption.constData(), indentatationWidthOption.constData(), nullptr};
-      d->mWkt = QString( proj_as_wkt( QgsProjContext::get(), d->mPj.get(), type, options ) );
+      d->mWkt = getFullWktString( d->mPj.get(), type, options );
     }
 #else
     Q_UNUSED( variant )


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

This PR insures that CRSes represented as WKT strings have a TOWGS84 parameter present. This ensures that our QgsCoordinateReferenceSystem::toWkt() outputs strings matching the default behavior of gdal3 and proj6's projinfo when creating projections from EPSG codes.

@rouault , is there any downside to forcing a TOWGS84 parameter onto all exported wkt strings?

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
