### PR TITLE
List referenced layer values in Expression Builder

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -484,8 +484,12 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   // if it's a request for the values of the referenced layer
   if ( cbxRelatedLayerValues->isChecked() && setup.config().contains( QStringLiteral( "Relation" ) ) )
   {
-    layer = mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedLayer();
-    layerFieldIndex =  mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedFields().first();
+    QgsVectorLayer *referencedLayer = mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedLayer();
+    if ( referencedLayer )
+    {
+      layer = referencedLayer;
+      layerFieldIndex =  mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedFields().first();
+    }
   }
 
   QList<QVariant> values = layer->uniqueValues( layerFieldIndex, countLimit ).toList();

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -242,8 +242,18 @@ void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const
   if ( isField )
   {
     loadFieldValues( mFieldValues.value( item->text() ) );
+
+    const QgsFields fields = mLayer->fields();
+    int fieldIndex = fields.lookupField( item->text() );
+    if ( fieldIndex != -1 )
+    {
+      const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
+      cbxRelatedLayerValues->setVisible( setup.config().contains( QStringLiteral( "Relation" ) ) );
+      cbxRelatedLayerValues->setChecked( true );
+    }
   }
   mValueGroupBox->setVisible( isField );
+
   mShowHelpButton->setText( isField ? tr( "Show Values" ) : tr( "Show Help" ) );
 
   // Show the help for the current item.
@@ -472,7 +482,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   int layerFieldIndex = fieldIndex;
 
   // if it's a request for the values of the referenced layer
-  if ( setup.config().contains( QStringLiteral( "Relation" ) ) )
+  if ( cbxRelatedLayerValues->isChecked() && setup.config().contains( QStringLiteral( "Relation" ) ) )
   {
     layer = mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedLayer();
     layerFieldIndex =  mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedFields().first();

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -468,7 +468,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
   const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
 
-  const QgsVectorLayer * layer = mLayer;
+  const QgsVectorLayer *layer = mLayer;
   int layerFieldIndex = fieldIndex;
 
   // if it's a request for the values of the referenced layer
@@ -481,6 +481,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   QList<QVariant> values = layer->uniqueValues( layerFieldIndex, countLimit ).toList();
   std::sort( values.begin(), values.end() );
 
+  mValuesModel->clear();
   for ( const QVariant &value : qgis::as_const( values ) )
   {
     QString strValue;

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -468,7 +468,17 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
   const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
 
-  QList<QVariant> values = mLayer->uniqueValues( fieldIndex, countLimit ).toList();
+  const QgsVectorLayer * layer = mLayer;
+  int layerFieldIndex = fieldIndex;
+
+  // if it's a request for the values of the referenced layer
+  if ( setup.config().contains( QStringLiteral( "Relation" ) ) )
+  {
+    layer = mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedLayer();
+    layerFieldIndex =  mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedFields().first();
+  }
+
+  QList<QVariant> values = layer->uniqueValues( layerFieldIndex, countLimit ).toList();
   std::sort( values.begin(), values.end() );
 
   for ( const QVariant &value : qgis::as_const( values ) )

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -481,7 +481,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   const QgsVectorLayer *layer = mLayer;
   int layerFieldIndex = fieldIndex;
 
-  // if it's a request for the values of the referenced layer
+  // request for values of the referenced layer on a relation reference widget field
   if ( cbxRelatedLayerValues->isChecked() && setup.config().contains( QStringLiteral( "Relation" ) ) )
   {
     QgsVectorLayer *referencedLayer = mProject->relationManager()->relation( setup.config()[QStringLiteral( "Relation" )].toString() ).referencedLayer();

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -543,21 +543,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1">
-                   <widget class="QgsFilterLineEdit" name="txtSearchEditValues">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0" colspan="2">
-                   <widget class="QListView" name="mValuesListView">
-                    <property name="editTriggers">
-                     <set>QAbstractItemView::NoEditTriggers</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
+                  <item row="1" column="0" colspan="2">
                    <layout class="QHBoxLayout" name="horizontalLayout_8">
                     <property name="topMargin">
                      <number>0</number>
@@ -577,6 +563,27 @@
                      </widget>
                     </item>
                    </layout>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QgsFilterLineEdit" name="txtSearchEditValues">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0" colspan="2">
+                   <widget class="QListView" name="mValuesListView">
+                    <property name="editTriggers">
+                     <set>QAbstractItemView::NoEditTriggers</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0" colspan="2">
+                   <widget class="QCheckBox" name="cbxRelatedLayerValues">
+                    <property name="text">
+                     <string>Show all values of referenced layer</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
@@ -677,7 +684,7 @@ Change the name of the script and save to allow QGIS to auto load on startup.</s
                 <string/>
                </property>
                <property name="icon">
-                <iconset resource="../../images/images.qrc">
+                <iconset>
                  <normaloff>:/images/themes/default/console/iconNewTabEditorConsole.svg</normaloff>:/images/themes/default/console/iconNewTabEditorConsole.svg</iconset>
                </property>
                <property name="iconSize">
@@ -769,7 +776,7 @@ Saved scripts are auto loaded on QGIS startup.</string>
                 <string>Save and Load Functions</string>
                </property>
                <property name="icon">
-                <iconset resource="../../images/images.qrc">
+                <iconset>
                  <normaloff>:/images/themes/default/mActionStart.svg</normaloff>:/images/themes/default/mActionStart.svg</iconset>
                </property>
               </widget>
@@ -835,8 +842,6 @@ Saved scripts are auto loaded on QGIS startup.</string>
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -581,7 +581,7 @@
                   <item row="2" column="0" colspan="2">
                    <widget class="QCheckBox" name="cbxRelatedLayerValues">
                     <property name="text">
-                     <string>Show all values of referenced layer</string>
+                     <string>Show values of referenced layer</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
When a field is an foreign key and configured as a relation reference widget, there is the possibility not only to show the values of the current layer but also the possible values in the referenced layer.

![referencedfields](https://user-images.githubusercontent.com/28384354/70907299-cf6bd800-2008-11ea-8b2b-184eeb8ace31.gif)

In the example we have the persons:
- George (in Cuba)
- Paul (in Vietnam)
- Ringo (in Venezuela)
- John (in Vietnam as well)

And the entries in the country layer are USSR, Cuba, Vietnam, Burma, Venezuela, North Korea