### PR TITLE
[labelling] Fix masked symbol layers loss when

### DIFF
--- a/python/gui/auto_generated/qgstextformatwidget.sip.in
+++ b/python/gui/auto_generated/qgstextformatwidget.sip.in
@@ -159,6 +159,8 @@ Controls whether data defined alignment buttons are enabled.
 
 
 
+
+
   protected slots:
 
     void updateLinePlacementOptions();

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -843,6 +843,7 @@ void QgsTextFormatWidget::updateWidgetForFormat( const QgsTextFormat &format )
   mBufferEffectWidget->setPaintEffect( mBufferEffect.get() );
 
   // mask
+  mMaskedSymbolLayers = mask.maskedSymbolLayers();
   mEnableMaskChkBx->setChecked( mask.enabled() );
   mMaskBufferSizeSpinBox->setValue( mask.size() );
   mMaskBufferUnitWidget->setUnit( mask.sizeUnit() );
@@ -1021,6 +1022,7 @@ QgsTextFormat QgsTextFormatWidget::format( bool includeDataDefinedProperties ) c
     mask.setPaintEffect( mMaskEffect->clone() );
   else
     mask.setPaintEffect( nullptr );
+  mask.setMaskedSymbolLayers( mMaskedSymbolLayers );
   format.setMask( mask );
 
   // shape background

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -189,6 +189,9 @@ class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionConte
 
     //! Associated vector layer
     QgsVectorLayer *mLayer = nullptr;
+
+    QgsSymbolLayerReferenceList mMaskedSymbolLayers;
+
   protected slots:
 
     //! Updates line placement options to reflect current state of widget

--- a/tests/src/python/test_qgstextformatwidget.py
+++ b/tests/src/python/test_qgstextformatwidget.py
@@ -85,8 +85,8 @@ class PyQgsTextFormatWidget(unittest.TestCase):
         self.assertEqual(s.joinStyle(), Qt.RoundJoin)
         self.assertTrue(s.paintEffect())
         self.assertEqual(s.paintEffect().blurLevel(), 2.0)
-        # Always return an empty list because there is no project (and thus no layers) defined
-        self.assertEqual(s.maskedSymbolLayers(), [])
+        self.assertEqual(s.maskedSymbolLayers(), [QgsSymbolLayerReference("layerid1", QgsSymbolLayerId("symbol", 1)),
+                                                  QgsSymbolLayerReference("layerid2", QgsSymbolLayerId("symbol2", 2))])
 
     def createBackgroundSettings(self):
         s = QgsTextBackgroundSettings()


### PR DESCRIPTION
## Description
Fix masked symbol layers loss when:
- opening layer properties window; or
- changing label settings in style dock

@mhugo , here's a little bit of help bullet proofing the masking feature.

Other than masked layer loss (fixed by the PR) and the canvas flashing / label blending regression (fixed by your PR #33422 ), the other follow up that'd need your attention is the generic implementation issue of force rasterizing vector layers that are not being masked. Every time we're needlessly force rasterizing symbol layers, an angel is crying somewhere :wink: that'd be worth addressing _if_ possible.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
