### PR TITLE
Allow custom projections to be defined using WKT strings instead of just proj strings

### DIFF
--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -696,11 +696,14 @@ Update proj.4 parameters in our database from proj.4
    This is used internally and should not be necessary to call in client code
 %End
 
-    long saveAsUserCrs( const QString &name );
+    long saveAsUserCrs( const QString &name, bool storeWkt = true );
 %Docstring
 Saves the CRS as a custom ("USER") CRS.
 
 Returns the new CRS srsid(), or -1 if the CRS could not be saved.
+
+If ``storeWkt`` is ``True`` then the WKT representation of the CRS will be stored in the database.
+If it is ``False``, then only the lossy PROJ string representation of the CRS will be stored (not recommended).
 %End
 
     QString geographicCrsAuthId() const;

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -46,30 +46,45 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
 
     void updateListFromCurrentItem();
     void validateCurrent();
+    void formatChanged();
 
   private:
+
+    enum class Format
+    {
+      Wkt = 0,
+      Proj
+    };
 
     //helper functions
     void populateList();
     bool deleteCrs( const QString &id );
-    bool saveCrs( QgsCoordinateReferenceSystem parameters, const QString &name, const QString &id, bool newEntry );
+    bool saveCrs( QgsCoordinateReferenceSystem crs, const QString &name, const QString &id, bool newEntry, Format format );
     void insertProjection( const QString &projectionAcronym );
     void showHelp();
 
     //These two QMap store the values as they are on the database when loading
-    QMap <QString, QString> mExistingCRSparameters;
+    QMap <QString, QString> mExistingCRSproj;
+    QMap <QString, QString> mExistingCRSwkt;
     QMap <QString, QString> mExistingCRSnames;
 
-    //These three list store the value updated with the current modifications
-    QStringList mCustomCRSnames;
-    QStringList mCustomCRSids;
-    QStringList mCustomCRSparameters;
+    struct Definition
+    {
+      QString name;
+      QString id;
+      QString wkt;
+      QString proj;
+    };
+
+    QList< Definition > mDefinitions;
 
     //vector saving the CRS to be deleted
     QStringList mDeletedCRSs;
 
     //Columns in the tree widget
     enum Columns { QgisCrsNameColumn, QgisCrsIdColumn, QgisCrsParametersColumn };
+
+
 };
 
 

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -2117,7 +2117,7 @@ QString QgsCoordinateReferenceSystem::validationHint()
 /// Copied from QgsCustomProjectionDialog ///
 /// Please refactor into SQL handler !!!  ///
 
-long QgsCoordinateReferenceSystem::saveAsUserCrs( const QString &name )
+long QgsCoordinateReferenceSystem::saveAsUserCrs( const QString &name, bool storeWkt )
 {
   if ( !d->mIsValid )
   {
@@ -2153,9 +2153,9 @@ long QgsCoordinateReferenceSystem::saveAsUserCrs( const QString &name )
             + ',' + QgsSqliteUtils::quotedString( name )
             + ',' + ( !d->mProjectionAcronym.isEmpty() ? QgsSqliteUtils::quotedString( d->mProjectionAcronym ) : QStringLiteral( "''" ) )
             + ',' + quotedEllipsoidString
-            + ',' + QgsSqliteUtils::quotedString( toProj4() )
+            + ',' + ( !proj4String.isEmpty() ? QgsSqliteUtils::quotedString( proj4String ) : QStringLiteral( "''" ) )
             + ",0,"  // <-- is_geo shamelessly hard coded for now
-            + QgsSqliteUtils::quotedString( wktString )
+            + ( storeWkt ? QgsSqliteUtils::quotedString( wktString ) : QStringLiteral( "''" ) )
             + ')';
   }
   else
@@ -2164,9 +2164,9 @@ long QgsCoordinateReferenceSystem::saveAsUserCrs( const QString &name )
             + QgsSqliteUtils::quotedString( name )
             + ',' + ( !d->mProjectionAcronym.isEmpty() ? QgsSqliteUtils::quotedString( d->mProjectionAcronym ) : QStringLiteral( "''" ) )
             + ',' + quotedEllipsoidString
-            + ',' + QgsSqliteUtils::quotedString( toProj4() )
+            + ',' + ( !proj4String.isEmpty() ? QgsSqliteUtils::quotedString( proj4String ) : QStringLiteral( "''" ) )
             + ",0,"  // <-- is_geo shamelessly hard coded for now
-            + QgsSqliteUtils::quotedString( wktString )
+            + ( storeWkt ? QgsSqliteUtils::quotedString( wktString ) : QStringLiteral( "''" ) )
             + ')';
   }
   sqlite3_database_unique_ptr database;

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -658,8 +658,11 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Saves the CRS as a custom ("USER") CRS.
      *
      * Returns the new CRS srsid(), or -1 if the CRS could not be saved.
+     *
+     * If \a storeWkt is TRUE then the WKT representation of the CRS will be stored in the database.
+     * If it is FALSE, then only the lossy PROJ string representation of the CRS will be stored (not recommended).
      */
-    long saveAsUserCrs( const QString &name );
+    long saveAsUserCrs( const QString &name, bool storeWkt = true );
 
     //! Returns auth id of related geographic CRS
     QString geographicCrsAuthId() const;

--- a/src/ui/qgscustomprojectiondialogbase.ui
+++ b/src/ui/qgscustomprojectiondialogbase.ui
@@ -55,11 +55,65 @@
          <property name="title">
           <string>Define</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,3,0,1">
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_4">
+         <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,3,0,1,0">
+          <item row="0" column="0" colspan="3">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Parameters</string>
+             <string>You can define your own custom Coordinate Reference System (CRS) here. The definition must conform to a WKT or Proj string format for specifying a CRS.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <layout class="QGridLayout" name="gridLayout_4">
+            <item row="0" column="2">
+             <widget class="QPushButton" name="mButtonValidate">
+              <property name="toolTip">
+               <string>Validate the current CRS definition and test whether it is an acceptable projection definition</string>
+              </property>
+              <property name="text">
+               <string>&amp;Validate</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QPushButton" name="pbnCopyCRS">
+              <property name="toolTip">
+               <string>Copy parameters from existing CRS</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset>
+                <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="0" rowspan="2">
+             <widget class="QPlainTextEdit" name="teParameters"/>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Name</string>
             </property>
            </widget>
           </item>
@@ -146,69 +200,25 @@
             </item>
            </layout>
           </item>
-          <item row="3" column="1">
-           <layout class="QGridLayout" name="gridLayout_4">
-            <item row="0" column="2">
-             <widget class="QPushButton" name="mButtonValidate">
-              <property name="toolTip">
-               <string>Validate the current CRS definition and test whether it is an acceptable projection definition</string>
-              </property>
-              <property name="text">
-               <string>&amp;Validate</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QPushButton" name="pbnCopyCRS">
-              <property name="toolTip">
-               <string>Copy parameters from existing CRS</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="0" rowspan="2">
-             <widget class="QPlainTextEdit" name="teParameters"/>
-            </item>
-           </layout>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="3">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>You can define your own custom Coordinate Reference System (CRS) here. The definition must conform to the proj4 format for specifying a CRS.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="1">
            <widget class="QLineEdit" name="leName"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Parameters</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="mFormatComboBox"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Format</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -341,6 +351,7 @@
   <tabstop>pbnAdd</tabstop>
   <tabstop>pbnRemove</tabstop>
   <tabstop>leName</tabstop>
+  <tabstop>mFormatComboBox</tabstop>
   <tabstop>teParameters</tabstop>
   <tabstop>pbnCopyCRS</tabstop>
   <tabstop>mButtonValidate</tabstop>


### PR DESCRIPTION
WKT strings are lossless and allow definition of a much wider range of projections than are possible using proj strings. It's important to expose this option on proj >= 6 builds, where having full support for WKT based CRS definitions is critical.

A new combo box in the Custom Projections dialog allows users to choose whether the new projection is defined using a WKT or PROJ string. If possible, the current projection definition is automatically converted when the combo box is changed by the user.

Also fixes #25918 in the process