### PR TITLE
Add a bit of context to errors in QgsRelationReferenceFieldFormatter

### DIFF
--- a/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
@@ -35,34 +35,38 @@ QString QgsRelationReferenceFieldFormatter::representValue( QgsVectorLayer *laye
     return cache.value<QMap<QVariant, QString>>().value( value );
   }
 
+  const QString fieldName = fieldIndex < layer->fields().size() ? layer->fields().at( fieldIndex ).name() : QObject::tr( "<unknown>" );
+
   // Some sanity checks
   if ( !config.contains( QStringLiteral( "Relation" ) ) )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Missing Relation in configuration" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Missing Relation in configuration" ).arg( layer->name(), fieldName ) );
     return value.toString();
   }
-  QgsRelation relation = QgsProject::instance()->relationManager()->relation( config[QStringLiteral( "Relation" )].toString() );
+
+  const QString relationName = config[QStringLiteral( "Relation" )].toString();
+  QgsRelation relation = QgsProject::instance()->relationManager()->relation( relationName );
   if ( !relation.isValid() )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Invalid relation" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Invalid relation %3" ).arg( layer->name(), fieldName, relationName ) );
     return value.toString();
   }
   QgsVectorLayer *referencingLayer = relation.referencingLayer();
   if ( layer != referencingLayer )
   {
-    QgsMessageLog::logMessage( QObject::tr( "representValue() with inconsistent layer parameter w.r.t relation referencingLayer" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: representValue() with inconsistent layer parameter w.r.t relation referencingLayer" ).arg( layer->name(), fieldName ) );
     return value.toString();
   }
   int referencingFieldIdx = referencingLayer->fields().lookupField( relation.fieldPairs().at( 0 ).first );
   if ( referencingFieldIdx != fieldIndex )
   {
-    QgsMessageLog::logMessage( QObject::tr( "representValue() with inconsistent fieldIndex parameter w.r.t relation referencingFieldIdx" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: representValue() with inconsistent fieldIndex parameter w.r.t relation referencingFieldIdx" ).arg( layer->name(), fieldName ) );
     return value.toString();
   }
   QgsVectorLayer *referencedLayer = relation.referencedLayer();
   if ( !referencedLayer )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Cannot find referenced layer" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Cannot find referenced layer" ).arg( layer->name(), fieldName ) );
     return value.toString();
   }
 
@@ -99,34 +103,37 @@ QVariant QgsRelationReferenceFieldFormatter::createCache( QgsVectorLayer *layer,
   Q_UNUSED( fieldIndex )
   QMap<QVariant, QString> cache;
 
+  const QString fieldName = fieldIndex < layer->fields().size() ? layer->fields().at( fieldIndex ).name() : QObject::tr( "<unknown>" );
+
   // Some sanity checks
   if ( !config.contains( QStringLiteral( "Relation" ) ) )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Missing Relation in configuration" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Missing Relation in configuration" ).arg( layer->name(), fieldName ) );
     return QVariant();
   }
+  const QString relationName = config[QStringLiteral( "Relation" )].toString();
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( config[QStringLiteral( "Relation" )].toString() );
   if ( !relation.isValid() )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Invalid relation" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Invalid relation %3" ).arg( layer->name(), fieldName, relationName ) );
     return QVariant();
   }
   QgsVectorLayer *referencingLayer = relation.referencingLayer();
   if ( layer != referencingLayer )
   {
-    QgsMessageLog::logMessage( QObject::tr( "representValue() with inconsistent layer parameter w.r.t relation referencingLayer" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: representValue() with inconsistent layer parameter w.r.t relation referencingLayer" ).arg( layer->name(), fieldName ) );
     return QVariant();
   }
   QgsVectorLayer *referencedLayer = relation.referencedLayer();
   if ( !referencedLayer )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Cannot find referenced layer" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Cannot find referenced layer" ).arg( layer->name(), fieldName ) );
     return QVariant();
   }
   int referencedFieldIdx = referencedLayer->fields().lookupField( relation.fieldPairs().at( 0 ).second );
   if ( referencedFieldIdx == -1 )
   {
-    QgsMessageLog::logMessage( QObject::tr( "Invalid referenced field (%1) configured in relation %2" ).arg( relation.fieldPairs().at( 0 ).second, relation.name() ) );
+    QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Invalid referenced field (%3) configured in relation %4" ).arg( layer->name(), fieldName, relation.fieldPairs().at( 0 ).second, relation.name() ) );
     return QVariant();
   }
 


### PR DESCRIPTION
## Description

Add a bit of context to errors in QgsRelationReferenceFieldFormatter, to ease debugging with malformed relations

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
