### PR TITLE
use QActionGroup to group style actions and make them radiobuttons (fix #32624)

### DIFF
--- a/src/app/qgsmaplayerstyleguiutils.cpp
+++ b/src/app/qgsmaplayerstyleguiutils.cpp
@@ -62,11 +62,12 @@ QList<QAction *> QgsMapLayerStyleGuiUtils::actionsUseStyle( QgsMapLayer *layer, 
   bool onlyOneStyle = mgr->styles().count() == 1;
 
   QList<QAction *> actions;
+  QActionGroup *styleGroup = new QActionGroup( parent );
   const auto constStyles = mgr->styles();
   for ( const QString &name : constStyles )
   {
     bool active = name == mgr->currentStyle();
-    QAction *actionUse = new QAction( name, parent );
+    QAction *actionUse = new QAction( name, styleGroup );
     connect( actionUse, &QAction::triggered, this, &QgsMapLayerStyleGuiUtils::useStyle );
     actionUse->setCheckable( true );
     actionUse->setChecked( active );


### PR DESCRIPTION
## Description
Replace checkboxes with radiobuttons in the list of styles in layer properties and layer context menu.
Fixes #32624.

![image](https://user-images.githubusercontent.com/776954/71009282-a0ca2c00-20f2-11ea-8c79-69eccb9ebf54.png)

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
