### PR TITLE
[processing] url-encode path to tiles in XYZ algorithm (fix #32589)

### DIFF
--- a/python/plugins/processing/algs/qgis/TilesXYZ.py
+++ b/python/plugins/processing/algs/qgis/TilesXYZ.py
@@ -24,6 +24,7 @@ __copyright__ = '(C) 2019 by Lutra Consulting Limited'
 import os
 import math
 import re
+import urllib.parse
 from uuid import uuid4
 
 import sqlite3
@@ -575,7 +576,7 @@ class TilesXYZAlgorithmDirectory(TilesXYZAlgorithmBase):
         results = {'OUTPUT_DIRECTORY': output_dir}
 
         if output_html:
-            output_dir_safe = output_dir.replace('\\', '/')
+            output_dir_safe = urllib.parse.quote(output_dir.replace('\\', '/'))
             html_code = LEAFLET_TEMPLATE.format(
                 tilesetname="Leaflet Preview",
                 centerx=self.wgs_extent[0] + (self.wgs_extent[2] - self.wgs_extent[0]) / 2,


### PR DESCRIPTION
## Description
If path to tiles contains special characters leaflet viewer won't work because path is not URL-encoded. Fixes #32589.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
