### PR TITLE
appstream: include oars metadata in appstream

### DIFF
--- a/linux/org.qgis.qgis.appdata.xml.in
+++ b/linux/org.qgis.qgis.appdata.xml.in
@@ -25,6 +25,7 @@
     <release version="3.2.0" date="2018-06-22" />
   </releases>
   <launchable type="desktop-id">org.qgis.qgis.desktop</launchable>
+  <content_rating type="oars-1.1"/>
   <provides>
     <binary>qgis</binary>
   </provides>


### PR DESCRIPTION
You can read more about OARS here:
https://hughsie.github.io/oars/

## Description
The patch was merged to release-3.8 but never to master, so it's not in release-3.10.
This PR is to get it on master at least.

See https://github.com/flathub/org.qgis.qgis/issues/35