### PR TITLE
Fix bug in SAGA Raster Buffer algorithm (GridBuffer.txt)

### DIFF
--- a/python/plugins/processing/algs/saga/description/GridBuffer.txt
+++ b/python/plugins/processing/algs/saga/description/GridBuffer.txt
@@ -1,6 +1,6 @@
 Grid Buffer
 grid_tools
 QgsProcessingParameterRasterLayer|FEATURES|Features Grid|None|False
-QgsProcessingParameterNumber|DIST|Distance|QgsProcessingParameterNumber.Integer|1000|False|None|None
-QgsProcessingParameterEnum|BUFFERTYPE|Buffer Distance|[0] Fixed;[1] Cell value
+QgsProcessingParameterNumber|DISTANCE|Distance|QgsProcessingParameterNumber.Double|1000.0|False|0.0|None
+QgsProcessingParameterEnum|TYPE|Buffer Distance|[0] fixed;[1] cell's value
 QgsProcessingParameterRasterDestination|BUFFER|Buffer Grid


### PR DESCRIPTION
## Description
Since SAGA 2.3.0, DIST and BUFFERTYPE parameters for Grid Buffer module were renamed to DISTANCE and TYPE, respectively.

For reference see http://www.saga-gis.org/saga_tool_doc/2.3.0/grid_tools_8.html

This patch should be backported to 3.10 and 3.4 branch.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
