### PR TITLE
[3d] Load 3D vector layer data in background + tiling

### DIFF
--- a/external/poly2tri/common/shapes.h
+++ b/external/poly2tri/common/shapes.h
@@ -132,11 +132,11 @@ struct Edge {
     if (p1.y > p2.y) {
       q = &p1;
       p = &p2;
-    } else if (std::abs(p1.y - p2.y) < 1e-10) {
+    } else if (p1.y == p2.y) {
       if (p1.x > p2.x) {
         q = &p1;
         p = &p2;
-      } else if (std::abs(p1.x - p2.x) < 1e-10) {
+      } else if (p1.x == p2.x) {
         // Repeat points
         throw std::runtime_error("Edge::Edge: p1 == p2");
       }

--- a/python/3d/3d_auto.sip
+++ b/python/3d/3d_auto.sip
@@ -1,5 +1,6 @@
 // Include auto-generated SIP files
 %Include auto_generated/qgs3dtypes.sip
+%Include auto_generated/qgsabstractvectorlayer3drenderer.sip
 %Include auto_generated/qgsphongmaterialsettings.sip
 %Include auto_generated/qgsrulebased3drenderer.sip
 %Include auto_generated/qgsvectorlayer3drenderer.sip

--- a/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -53,7 +53,7 @@ Reads content of the object from XML
 };
 
 
-class QgsAbstractVectorLayer3DRenderer : QgsAbstract3DRenderer
+class QgsAbstractVectorLayer3DRenderer : QgsAbstract3DRenderer /Abstract/
 {
 %Docstring
 Base class for 3D renderers that are based on vector layers.

--- a/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -1,0 +1,113 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgsabstractvectorlayer3drenderer.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsVectorLayer3DTilingSettings
+{
+%Docstring
+This class defines configuration of how a vector layer gets tiled for 3D rendering.
+
+Zoom levels count tells how deep will be the quadtree and thus how many tiles will
+be generated ( 4 ^ (count-1) ). So for example, for count=1 there will be just
+a single tile for the whole layer, for count=3 there will be 16 tiles.
+
+.. versionadded:: 3.12
+%End
+
+%TypeHeaderCode
+#include "qgsabstractvectorlayer3drenderer.h"
+%End
+  public:
+
+    int zoomLevelsCount() const;
+%Docstring
+Returns number of zoom levels. One zoom level means there will be one tile.
+Every extra zoom level multiplies number of tiles by four. For example, three
+zoom levels will produce 16 tiles at the highest zoom level. It is therefore
+recommended to keep the number of zoom levels low to prevent excessive number
+of tiles.
+%End
+
+    void setZoomLevelsCount( int count );
+%Docstring
+Sets number of zoom levels. See zoomLevelsCount() documentation for more details.
+%End
+
+    void writeXml( QDomElement &elem ) const;
+%Docstring
+Writes content of the object to XML
+%End
+    void readXml( const QDomElement &elem );
+%Docstring
+Reads content of the object from XML
+%End
+
+};
+
+
+class QgsAbstractVectorLayer3DRenderer : QgsAbstract3DRenderer
+{
+%Docstring
+Base class for 3D renderers that are based on vector layers.
+
+.. versionadded:: 3.12
+%End
+
+%TypeHeaderCode
+#include "qgsabstractvectorlayer3drenderer.h"
+%End
+  public:
+    QgsAbstractVectorLayer3DRenderer();
+
+    void setLayer( QgsVectorLayer *layer );
+%Docstring
+Sets vector layer associated with the renderer
+%End
+    QgsVectorLayer *layer() const;
+%Docstring
+Returns vector layer associated with the renderer
+%End
+
+    void setTilingSettings( const QgsVectorLayer3DTilingSettings &settings );
+%Docstring
+Sets tiling settings of the renderer
+%End
+    QgsVectorLayer3DTilingSettings tilingSettings() const;
+%Docstring
+Returns tiling settings of the renderer
+%End
+
+    virtual void resolveReferences( const QgsProject &project );
+
+
+  protected:
+    void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
+%Docstring
+copy common properties of this object to another object
+%End
+    void writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const;
+%Docstring
+write common properties of this object to DOM element
+%End
+    void readXmlBaseProperties( const QDomElement &elem, const QgsReadWriteContext &context );
+%Docstring
+read common properties of this object from DOM element
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/3d/qgsabstractvectorlayer3drenderer.h                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -100,15 +100,15 @@ Returns tiling settings of the renderer
   protected:
     void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
 %Docstring
-copy common properties of this object to another object
+Copies common properties of this object to another object
 %End
     void writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const;
 %Docstring
-write common properties of this object to DOM element
+Writes common properties of this object to DOM element
 %End
     void readXmlBaseProperties( const QDomElement &elem, const QgsReadWriteContext &context );
 %Docstring
-read common properties of this object from DOM element
+Reads common properties of this object from DOM element
 %End
 
 };

--- a/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsabstractvectorlayer3drenderer.sip.in
@@ -41,6 +41,15 @@ of tiles.
 Sets number of zoom levels. See zoomLevelsCount() documentation for more details.
 %End
 
+    void setShowBoundingBoxes( bool enabled );
+%Docstring
+Sets whether to display bounding boxes of entity's tiles (for debugging)
+%End
+    bool showBoundingBoxes() const;
+%Docstring
+Returns whether to display bounding boxes of entity's tiles (for debugging)
+%End
+
     void writeXml( QDomElement &elem ) const;
 %Docstring
 Writes content of the object to XML

--- a/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsrulebased3drenderer.sip.in
@@ -39,7 +39,7 @@ Creates an instance of a 3D renderer based on a DOM element with renderer config
 };
 
 
-class QgsRuleBased3DRenderer : QgsAbstract3DRenderer
+class QgsRuleBased3DRenderer : QgsAbstractVectorLayer3DRenderer
 {
 %Docstring
 Rule-based 3D renderer.
@@ -244,15 +244,6 @@ Construct renderer with the given root rule (takes ownership)
 %End
     ~QgsRuleBased3DRenderer();
 
-    void setLayer( QgsVectorLayer *layer );
-%Docstring
-Sets vector layer associated with the renderer
-%End
-    QgsVectorLayer *layer() const;
-%Docstring
-Returns vector layer associated with the renderer
-%End
-
     QgsRuleBased3DRenderer::Rule *rootRule();
 %Docstring
 Returns pointer to the root rule
@@ -265,8 +256,6 @@ Returns pointer to the root rule
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
-
-    virtual void resolveReferences( const QgsProject &project );
 
 
 };

--- a/python/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
+++ b/python/3d/auto_generated/qgsvectorlayer3drenderer.sip.in
@@ -41,7 +41,7 @@ Creates an instance of a 3D renderer based on a DOM element with renderer config
 };
 
 
-class QgsVectorLayer3DRenderer : QgsAbstract3DRenderer
+class QgsVectorLayer3DRenderer : QgsAbstractVectorLayer3DRenderer
 {
 %Docstring
 3D renderer that renders all features of a vector layer with the same 3D symbol.
@@ -57,15 +57,6 @@ The appearance is completely defined by the symbol.
     explicit QgsVectorLayer3DRenderer( QgsAbstract3DSymbol *s /Transfer/ = 0 );
 %Docstring
 Takes ownership of the symbol object
-%End
-
-    void setLayer( QgsVectorLayer *layer );
-%Docstring
-Sets vector layer associated with the renderer
-%End
-    QgsVectorLayer *layer() const;
-%Docstring
-Returns vector layer associated with the renderer
 %End
 
     void setSymbol( QgsAbstract3DSymbol *symbol /Transfer/ );
@@ -84,8 +75,6 @@ Returns 3D symbol associated with the renderer
     virtual void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const;
 
     virtual void readXml( const QDomElement &elem, const QgsReadWriteContext &context );
-
-    virtual void resolveReferences( const QgsProject &project );
 
 
   private:

--- a/python/core/auto_generated/qgstessellator.sip.in
+++ b/python/core/auto_generated/qgstessellator.sip.in
@@ -66,6 +66,20 @@ Returns size of one vertex entry in bytes
 %End
 
 
+    float zMinimum() const;
+%Docstring
+Returns minimal Z value of the data (in world coordinates)
+
+.. versionadded:: 3.12
+%End
+
+    float zMaximum() const;
+%Docstring
+Returns maximal Z value of the data (in world coordinates)
+
+.. versionadded:: 3.12
+%End
+
 };
 
 /************************************************************************

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -4,6 +4,7 @@
 SET(QGIS_3D_SRCS
   qgsaabb.cpp
   qgsabstract3dengine.cpp
+  qgsabstractvectorlayer3drenderer.cpp
   qgs3danimationsettings.cpp
   qgs3dmapscene.cpp
   qgs3dmapsettings.cpp
@@ -72,6 +73,7 @@ SET(QGIS_3D_HDRS
   qgs3dutils.h
   qgsaabb.h
   qgsabstract3dengine.h
+  qgsabstractvectorlayer3drenderer.h
   qgscameracontroller.h
   qgscamerapose.h
   qgslayoutitem3dmap.h

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(QGIS_3D_SRCS
   qgstessellatedpolygongeometry.cpp
   qgstilingscheme.cpp
   qgsvectorlayer3drenderer.cpp
+  qgsvectorlayerchunkloader_p.cpp
   qgsmeshlayer3drenderer.cpp
   qgswindow3dengine.cpp
 
@@ -100,6 +101,7 @@ SET(QGIS_3D_HDRS
 )
 
 SET(QGIS_3D_PRIVATE_HDRS
+  qgsvectorlayerchunkloader_p.h
   chunks/qgschunkboundsentity_p.h
   chunks/qgschunkedentity_p.h
   chunks/qgschunklist_p.h

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(QGIS_3D_SRCS
   qgspointlightsettings.cpp
   qgsraycastingutils_p.cpp
   qgsrulebased3drenderer.cpp
+  qgsrulebasedchunkloader_p.cpp
   qgstessellatedpolygongeometry.cpp
   qgstilingscheme.cpp
   qgsvectorlayer3drenderer.cpp
@@ -101,6 +102,7 @@ SET(QGIS_3D_HDRS
 )
 
 SET(QGIS_3D_PRIVATE_HDRS
+  qgsrulebasedchunkloader_p.h
   qgsvectorlayerchunkloader_p.h
   chunks/qgschunkboundsentity_p.h
   chunks/qgschunkedentity_p.h

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -244,9 +244,9 @@ void QgsChunkedEntity::update( QgsChunkNode *node, const SceneState &state )
     return;
   }
 
-  //qDebug() << node->x << "|" << node->y << "|" << node->z << "  " << tau << "  " << screenSpaceError(node, state);
+  //qDebug() << node->tileX() << "|" << node->tileY() << "|" << node->tileZ() << "  " << mTau << "  " << screenSpaceError(node, state);
 
-  if ( screenSpaceError( node, state ) <= mTau )
+  if ( mTau > 0 && screenSpaceError( node, state ) <= mTau )
   {
     // acceptable error for the current chunk - let's render it
 
@@ -343,6 +343,8 @@ void QgsChunkedEntity::onActiveJobFinished()
       node->setLoaded( entity );
 
       mReplacementQueue->insertFirst( node->replacementQueueEntry() );
+
+      emit newEntityCreated( entity );
     }
     else
     {

--- a/src/3d/chunks/qgschunkedentity_p.cpp
+++ b/src/3d/chunks/qgschunkedentity_p.cpp
@@ -17,12 +17,15 @@
 
 #include <QElapsedTimer>
 #include <QVector4D>
+#include <Qt3DRender/QObjectPicker>
+#include <Qt3DRender/QPickTriangleEvent>
 
 #include "qgs3dutils.h"
 #include "qgschunkboundsentity_p.h"
 #include "qgschunklist_p.h"
 #include "qgschunkloader_p.h"
 #include "qgschunknode_p.h"
+#include "qgstessellatedpolygongeometry.h"
 
 #include "qgseventtracing.h"
 
@@ -344,6 +347,13 @@ void QgsChunkedEntity::onActiveJobFinished()
 
       mReplacementQueue->insertFirst( node->replacementQueueEntry() );
 
+      if ( mPickingEnabled )
+      {
+        Qt3DRender::QObjectPicker *picker = new Qt3DRender::QObjectPicker( node->entity() );
+        node->entity()->addComponent( picker );
+        connect( picker, &Qt3DRender::QObjectPicker::clicked, this, &QgsChunkedEntity::onPickEvent );
+      }
+
       emit newEntityCreated( entity );
     }
     else
@@ -449,6 +459,72 @@ void QgsChunkedEntity::cancelActiveJobs()
   while ( !mActiveJobs.isEmpty() )
   {
     cancelActiveJob( mActiveJobs.takeFirst() );
+  }
+}
+
+
+void QgsChunkedEntity::setPickingEnabled( bool enabled )
+{
+  if ( mPickingEnabled == enabled )
+    return;
+
+  mPickingEnabled = enabled;
+
+  if ( enabled )
+  {
+    QgsChunkListEntry *entry = mReplacementQueue->first();
+    while ( entry )
+    {
+      QgsChunkNode *node = entry->chunk;
+      Qt3DRender::QObjectPicker *picker = new Qt3DRender::QObjectPicker( node->entity() );
+      node->entity()->addComponent( picker );
+      connect( picker, &Qt3DRender::QObjectPicker::clicked, this, &QgsChunkedEntity::onPickEvent );
+
+      entry = entry->next;
+    }
+  }
+  else
+  {
+    for ( Qt3DRender::QObjectPicker *picker : findChildren<Qt3DRender::QObjectPicker *>() )
+      picker->deleteLater();
+  }
+}
+
+void QgsChunkedEntity::onPickEvent( Qt3DRender::QPickEvent *event )
+{
+  Qt3DRender::QPickTriangleEvent *triangleEvent = qobject_cast<Qt3DRender::QPickTriangleEvent *>( event );
+  if ( !triangleEvent )
+    return;
+
+  Qt3DRender::QObjectPicker *picker = qobject_cast<Qt3DRender::QObjectPicker *>( sender() );
+  if ( !picker )
+    return;
+
+  Qt3DCore::QEntity *entity = qobject_cast<Qt3DCore::QEntity *>( picker->parent() );
+  if ( !entity )
+    return;
+
+  // go figure out feature ID from the triangle index
+  QgsFeatureId fid = FID_NULL;
+  for ( Qt3DRender::QGeometryRenderer *geomRenderer : entity->findChildren<Qt3DRender::QGeometryRenderer *>() )
+  {
+    // unfortunately we can't access which sub-entity triggered the pick event
+    // so as a temporary workaround let's just ignore the entity with selection
+    // and hope the event was the main entity (QTBUG-58206)
+    if ( geomRenderer->objectName() != QLatin1String( "main" ) )
+      continue;
+
+    if ( QgsTessellatedPolygonGeometry *g = qobject_cast<QgsTessellatedPolygonGeometry *>( geomRenderer->geometry() ) )
+    {
+      fid = g->triangleIndexToFeatureId( triangleEvent->triangleIndex() );
+      if ( !FID_IS_NULL( fid ) )
+        break;
+    }
+  }
+
+  if ( !FID_IS_NULL( fid ) )
+  {
+    emit pickedObject( event, fid );
   }
 }
 

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -133,7 +133,14 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
     QgsChunkNode *mRootNode = nullptr;
     //! A chunk has been loaded recently? let's display it!
     bool mNeedsUpdate = false;
-    //! max. allowed screen space error
+
+    /**
+     * Maximum allowed screen space error (in pixels).
+     * If the value is negative, it means that the screen space error
+     * does not need to be taken into account. This essentially means that
+     * the chunked entity will try to go deeper into the tree of chunks until
+     * it reaches leafs.
+     */
     float mTau;
     //! maximum allowed depth of quad tree
     int mMaxLevel;

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -42,6 +42,13 @@ class QgsChunkQueueJobFactory;
 
 #include <QTime>
 
+#include "qgsfeatureid.h"
+
+namespace Qt3DRender
+{
+  class QPickEvent;
+}
+
 /**
  * \ingroup 3d
  * Implementation of entity that handles chunks of data organized in quadtree with loading data when necessary
@@ -85,6 +92,11 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
     //! Returns number of jobs pending for this entity until it is fully loaded/updated in the current view
     int pendingJobsCount() const;
 
+    //! Enables or disables object picking on this entity. When enabled, pickedObject() signals will be emitted on mouse clicks
+    void setPickingEnabled( bool enabled );
+    //! Returns whether object picking is currently enabled
+    bool hasPickingEnabled() const { return mPickingEnabled; }
+
   protected:
     //! Cancels the background job that is currently in progress
     void cancelActiveJob( QgsChunkQueueJob *job );
@@ -104,12 +116,17 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
   private slots:
     void onActiveJobFinished();
 
+    void onPickEvent( Qt3DRender::QPickEvent *event );
+
   signals:
     //! Emitted when the number of pending jobs changes (some jobs have finished or some jobs have been just created)
     void pendingJobsCountChanged();
 
     //! Emitted when a new 3D entity has been created. Other components can use that to do extra work
     void newEntityCreated( Qt3DCore::QEntity *entity );
+
+    //! Emitted on mouse clicks when picking is enabled and there is a feature under the cursor
+    void pickedObject( Qt3DRender::QPickEvent *pickEvent, QgsFeatureId fid );
 
   protected:
     //! root node of the quadtree hierarchy
@@ -143,6 +160,9 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
 
     //! jobs that are currently being processed (asynchronously in worker threads)
     QList<QgsChunkQueueJob *> mActiveJobs;
+
+    //! If picking is enabled, QObjectPicker objects will be assigned to chunks and pickedObject() signals fired on mouse click
+    bool mPickingEnabled = false;
 };
 
 /// @endcond

--- a/src/3d/chunks/qgschunkedentity_p.h
+++ b/src/3d/chunks/qgschunkedentity_p.h
@@ -108,6 +108,9 @@ class QgsChunkedEntity : public Qt3DCore::QEntity
     //! Emitted when the number of pending jobs changes (some jobs have finished or some jobs have been just created)
     void pendingJobsCountChanged();
 
+    //! Emitted when a new 3D entity has been created. Other components can use that to do extra work
+    void newEntityCreated( Qt3DCore::QEntity *entity );
+
   protected:
     //! root node of the quadtree hierarchy
     QgsChunkNode *mRootNode = nullptr;

--- a/src/3d/chunks/qgschunknode_p.h
+++ b/src/3d/chunks/qgschunknode_p.h
@@ -194,7 +194,7 @@ class QgsChunkNode
 
   private:
     QgsAABB mBbox;      //!< Bounding box in world coordinates
-    float mError;    //!< Error of the node in world coordinates
+    float mError;    //!< Error of the node in world coordinates (negative error means that chunk at this level has no data, but there may be children that do)
 
     int mTileX, mTileY, mTileZ;  //!< Chunk coordinates (for use with a tiling scheme)
 

--- a/src/3d/chunks/qgschunkqueuejob_p.h
+++ b/src/3d/chunks/qgschunkqueuejob_p.h
@@ -63,8 +63,11 @@ class QgsChunkQueueJob : public QObject
     QgsChunkNode *chunk() { return mNode; }
 
     /**
-     * Request that the job gets canceled.
-     * Returns only after the async job has been stopped.
+     * Requests that the job gets canceled. The implementation should _not_ wait until
+     * the asynchronous job is terminated - it should only indicate to the async code that
+     * is should finish as soon as possible. It is responsibility of the object's destructor
+     * to make sure that the async code has been terminated before deleting the object.
+     *
      * The signal finished() will not be emitted afterwards.
      */
     virtual void cancel();

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -177,6 +177,14 @@ int Qgs3DMapScene::terrainPendingJobsCount() const
   return mTerrain ? mTerrain->pendingJobsCount() : 0;
 }
 
+int Qgs3DMapScene::totalPendingJobsCount() const
+{
+  int count = 0;
+  for ( QgsChunkedEntity *entity : qgis::as_const( mChunkEntities ) )
+    count += entity->pendingJobsCount();
+  return count;
+}
+
 void Qgs3DMapScene::registerPickHandler( Qgs3DMapScenePickHandler *pickHandler )
 {
   if ( mPickHandlers.isEmpty() )
@@ -420,6 +428,7 @@ void Qgs3DMapScene::createTerrainDeferred()
 
   mTerrainUpdateScheduled = false;
 
+  connect( mTerrain, &QgsChunkedEntity::pendingJobsCountChanged, this, &Qgs3DMapScene::totalPendingJobsCountChanged );
   connect( mTerrain, &QgsTerrainEntity::pendingJobsCountChanged, this, &Qgs3DMapScene::terrainPendingJobsCountChanged );
 
   emit terrainEntityChanged();
@@ -567,6 +576,8 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
         {
           finalizeNewEntity( entity );
         } );
+
+        connect( chunkedNewEntity, &QgsChunkedEntity::pendingJobsCountChanged, this, &Qgs3DMapScene::totalPendingJobsCountChanged );
       }
     }
   }

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -536,15 +536,11 @@ void Qgs3DMapScene::addLayerEntity( QgsMapLayer *layer )
     // Fix vector layer's renderer to make sure the renderer is pointing to its layer.
     // It has happened before that renderer pointed to a different layer (probably after copying a style).
     // This is a bit of a hack and it should be handled in QgsMapLayer::setRenderer3D() but in qgis_core
-    // the vector layer 3D renderer class is not available. Maybe we need an intermediate map layer 3D renderer
-    // class in qgis_core that can be used to handle this case nicely.
-    if ( layer->type() == QgsMapLayerType::VectorLayer && renderer->type() == QLatin1String( "vector" ) )
+    // the vector layer 3D renderer classes are not available.
+    if ( layer->type() == QgsMapLayerType::VectorLayer &&
+         ( renderer->type() == QLatin1String( "vector" ) || renderer->type() == QLatin1String( "rulebased" ) ) )
     {
-      static_cast<QgsVectorLayer3DRenderer *>( renderer )->setLayer( static_cast<QgsVectorLayer *>( layer ) );
-    }
-    else if ( layer->type() == QgsMapLayerType::VectorLayer && renderer->type() == QLatin1String( "rulebased" ) )
-    {
-      static_cast<QgsRuleBased3DRenderer *>( renderer )->setLayer( static_cast<QgsVectorLayer *>( layer ) );
+      static_cast<QgsAbstractVectorLayer3DRenderer *>( renderer )->setLayer( static_cast<QgsVectorLayer *>( layer ) );
     }
     else if ( layer->type() == QgsMapLayerType::MeshLayer && renderer->type() == QLatin1String( "mesh" ) )
     {

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -73,6 +73,9 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns number of pending jobs of the terrain entity
     int terrainPendingJobsCount() const;
 
+    //! Returns number of pending jobs for all chunked entities
+    int totalPendingJobsCount() const;
+
     //! Enumeration of possible states of the 3D scene
     enum SceneState
     {
@@ -99,6 +102,8 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void terrainEntityChanged();
     //! Emitted when the number of terrain's pending jobs changes
     void terrainPendingJobsCountChanged();
+    //! Emitted when the total number of pending jobs changes
+    void totalPendingJobsCountChanged();
     //! Emitted when the scene's state has changed
     void sceneStateChanged();
 

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -20,6 +20,8 @@
 
 #include <Qt3DCore/QEntity>
 
+#include "qgsfeatureid.h"
+
 namespace Qt3DRender
 {
   class QRenderSettings;
@@ -47,8 +49,6 @@ class Qgs3DMapSettings;
 class QgsTerrainEntity;
 class QgsChunkedEntity;
 
-#include "qgsfeatureid.h"
-
 
 /**
  * \ingroup 3d
@@ -73,7 +73,10 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns number of pending jobs of the terrain entity
     int terrainPendingJobsCount() const;
 
-    //! Returns number of pending jobs for all chunked entities
+    /**
+     * Returns number of pending jobs for all chunked entities
+     * \since QGIS 3.12
+     */
     int totalPendingJobsCount() const;
 
     //! Enumeration of possible states of the 3D scene
@@ -102,7 +105,11 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void terrainEntityChanged();
     //! Emitted when the number of terrain's pending jobs changes
     void terrainPendingJobsCountChanged();
-    //! Emitted when the total number of pending jobs changes
+
+    /**
+     * Emitted when the total number of pending jobs changes
+     * \since QGIS 3.12
+     */
     void totalPendingJobsCountChanged();
     //! Emitted when the scene's state has changed
     void sceneStateChanged();

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -25,6 +25,7 @@ namespace Qt3DRender
   class QRenderSettings;
   class QCamera;
   class QPickEvent;
+  class QObjectPicker;
 }
 
 namespace Qt3DLogic
@@ -45,6 +46,9 @@ class Qgs3DMapScenePickHandler;
 class Qgs3DMapSettings;
 class QgsTerrainEntity;
 class QgsChunkedEntity;
+
+#include "qgsfeatureid.h"
+
 
 /**
  * \ingroup 3d
@@ -106,7 +110,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onLayersChanged();
     void createTerrainDeferred();
     void onBackgroundColorChanged();
-    void onLayerEntityPickEvent( Qt3DRender::QPickEvent *event );
+    void onLayerEntityPickedObject( Qt3DRender::QPickEvent *pickEvent, QgsFeatureId fid );
     void updateLights();
     void updateCameraLens();
     void onRenderersChanged();

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -456,6 +456,7 @@ static QgsRectangle _tryReprojectExtent2D( const QgsRectangle &extent, const Qgs
     catch ( const QgsCsException & )
     {
       // bad luck, can't reproject for some reason
+      QgsDebugMsg( QStringLiteral( "3D utils: transformation of extent failed: " ) + extentMapCrs.toString( -1 ) );
     }
   }
   return extentMapCrs;

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -442,6 +442,28 @@ QgsVector3D Qgs3DUtils::worldToMapCoordinates( const QgsVector3D &worldCoords, c
                       worldCoords.y() + origin.z() );
 }
 
+QgsAABB Qgs3DUtils::mapToWorldExtent( const QgsRectangle &extent, const QgsCoordinateReferenceSystem &crs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs )
+{
+  // TODO: transform to map coords
+  QgsVector3D extentMin3D( extent.xMinimum(), extent.yMinimum(), 0 );  // TODO: is it OK to have zero min/max elevation?
+  QgsVector3D extentMax3D( extent.xMaximum(), extent.yMaximum(), 500 );
+  QgsVector3D worldExtentMin3D = mapToWorldCoordinates( extentMin3D, mapOrigin );
+  QgsVector3D worldExtentMax3D = mapToWorldCoordinates( extentMax3D, mapOrigin );
+  QgsAABB rootBbox( worldExtentMin3D.x(), worldExtentMin3D.y(), worldExtentMin3D.z(),
+                    worldExtentMax3D.x(), worldExtentMax3D.y(), worldExtentMax3D.z() );
+  return rootBbox;
+}
+
+QgsRectangle Qgs3DUtils::worldToMapExtent( const QgsAABB &bbox, const QgsCoordinateReferenceSystem &crs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs )
+{
+  QgsVector3D worldExtentMin3D = Qgs3DUtils::worldToMapCoordinates( QgsVector3D( bbox.xMin, bbox.yMin, bbox.zMin ), mapOrigin );
+  QgsVector3D worldExtentMax3D = Qgs3DUtils::worldToMapCoordinates( QgsVector3D( bbox.xMax, bbox.yMax, bbox.zMax ), mapOrigin );
+  // TODO: reproject to layer CRS
+  QgsRectangle rect( worldExtentMin3D.x(), worldExtentMin3D.y(), worldExtentMax3D.x(), worldExtentMax3D.y() );
+  return rect;
+}
+
+
 QgsVector3D Qgs3DUtils::transformWorldCoordinates( const QgsVector3D &worldPoint1, const QgsVector3D &origin1, const QgsCoordinateReferenceSystem &crs1, const QgsVector3D &origin2, const QgsCoordinateReferenceSystem &crs2, const QgsCoordinateTransformContext &context )
 {
   QgsVector3D mapPoint1 = worldToMapCoordinates( worldPoint1, origin1 );

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -131,6 +131,11 @@ class _3D_EXPORT Qgs3DUtils
     //! Converts 3D world coordinates to map coordinates (applies offset and turns (x,y,z) into (x,-z,y))
     static QgsVector3D worldToMapCoordinates( const QgsVector3D &worldCoords, const QgsVector3D &origin );
 
+    //! Converts layer extent to axis aligned bounding box in 3D world coordinates
+    static QgsAABB mapToWorldExtent( const QgsRectangle &extent, const QgsCoordinateReferenceSystem &crs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs );
+    //! Converts axis aligned bounding box in 3D world coordinates to extent in map coordinates
+    static QgsRectangle worldToMapExtent( const QgsAABB &bbox, const QgsCoordinateReferenceSystem &crs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs );
+
     //! Transforms a world point from (origin1, crs1) to (origin2, crs2)
     static QgsVector3D transformWorldCoordinates( const QgsVector3D &worldPoint1, const QgsVector3D &origin1, const QgsCoordinateReferenceSystem &crs1, const QgsVector3D &origin2, const QgsCoordinateReferenceSystem &crs2,
         const QgsCoordinateTransformContext &context );

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -131,10 +131,15 @@ class _3D_EXPORT Qgs3DUtils
     //! Converts 3D world coordinates to map coordinates (applies offset and turns (x,y,z) into (x,-z,y))
     static QgsVector3D worldToMapCoordinates( const QgsVector3D &worldCoords, const QgsVector3D &origin );
 
-    //! Converts layer extent to axis aligned bounding box in 3D world coordinates
-    static QgsAABB mapToWorldExtent( const QgsRectangle &extent, const QgsCoordinateReferenceSystem &crs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs );
+    //! Converts extent (in map layer's CRS) to axis aligned bounding box in 3D world coordinates
+    static QgsAABB layerToWorldExtent( const QgsRectangle &extent, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
+    //! Converts axis aligned bounding box in 3D world coordinates to extent in map layer CRS
+    static QgsRectangle worldToLayerExtent( const QgsAABB &bbox, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
+
+    //! Converts map extent to axis aligned bounding box in 3D world coordinates
+    static QgsAABB mapToWorldExtent( const QgsRectangle &extent, double zMin, double zMax, const QgsVector3D &mapOrigin );
     //! Converts axis aligned bounding box in 3D world coordinates to extent in map coordinates
-    static QgsRectangle worldToMapExtent( const QgsAABB &bbox, const QgsCoordinateReferenceSystem &crs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs );
+    static QgsRectangle worldToMapExtent( const QgsAABB &bbox, const QgsVector3D &mapOrigin );
 
     //! Transforms a world point from (origin1, crs1) to (origin2, crs2)
     static QgsVector3D transformWorldCoordinates( const QgsVector3D &worldPoint1, const QgsVector3D &origin1, const QgsCoordinateReferenceSystem &crs1, const QgsVector3D &origin2, const QgsCoordinateReferenceSystem &crs2,

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -131,14 +131,28 @@ class _3D_EXPORT Qgs3DUtils
     //! Converts 3D world coordinates to map coordinates (applies offset and turns (x,y,z) into (x,-z,y))
     static QgsVector3D worldToMapCoordinates( const QgsVector3D &worldCoords, const QgsVector3D &origin );
 
-    //! Converts extent (in map layer's CRS) to axis aligned bounding box in 3D world coordinates
+    /**
+     * Converts extent (in map layer's CRS) to axis aligned bounding box in 3D world coordinates
+     * \since QGIS 3.12
+     */
     static QgsAABB layerToWorldExtent( const QgsRectangle &extent, double zMin, double zMax, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
-    //! Converts axis aligned bounding box in 3D world coordinates to extent in map layer CRS
+
+    /**
+     * Converts axis aligned bounding box in 3D world coordinates to extent in map layer CRS
+     * \since QGIS 3.12
+     */
     static QgsRectangle worldToLayerExtent( const QgsAABB &bbox, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
 
-    //! Converts map extent to axis aligned bounding box in 3D world coordinates
+    /**
+     * Converts map extent to axis aligned bounding box in 3D world coordinates
+     * \since QGIS 3.12
+     */
     static QgsAABB mapToWorldExtent( const QgsRectangle &extent, double zMin, double zMax, const QgsVector3D &mapOrigin );
-    //! Converts axis aligned bounding box in 3D world coordinates to extent in map coordinates
+
+    /**
+     * Converts axis aligned bounding box in 3D world coordinates to extent in map coordinates
+     * \since QGIS 3.12
+     */
     static QgsRectangle worldToMapExtent( const QgsAABB &bbox, const QgsVector3D &mapOrigin );
 
     //! Transforms a world point from (origin1, crs1) to (origin2, crs2)
@@ -150,6 +164,7 @@ class _3D_EXPORT Qgs3DUtils
      * The implementation scans a small amount of features and looks at the Z values of geometries
      * (we don't need exact range, just a rough estimate is fine to know where to expect the data to be).
      * For layers with geometries without Z values, the returned range will be [0, 0].
+     * \since QGIS 3.12
      */
     static void estimateVectorLayerZRange( QgsVectorLayer *layer, double &zMin, double &zMax );
 

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -132,7 +132,7 @@ class _3D_EXPORT Qgs3DUtils
     static QgsVector3D worldToMapCoordinates( const QgsVector3D &worldCoords, const QgsVector3D &origin );
 
     //! Converts extent (in map layer's CRS) to axis aligned bounding box in 3D world coordinates
-    static QgsAABB layerToWorldExtent( const QgsRectangle &extent, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
+    static QgsAABB layerToWorldExtent( const QgsRectangle &extent, double zMin, double zMax, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
     //! Converts axis aligned bounding box in 3D world coordinates to extent in map layer CRS
     static QgsRectangle worldToLayerExtent( const QgsAABB &bbox, const QgsCoordinateReferenceSystem &layerCrs, const QgsVector3D &mapOrigin, const QgsCoordinateReferenceSystem &mapCrs, const QgsCoordinateTransformContext &context );
 
@@ -144,6 +144,14 @@ class _3D_EXPORT Qgs3DUtils
     //! Transforms a world point from (origin1, crs1) to (origin2, crs2)
     static QgsVector3D transformWorldCoordinates( const QgsVector3D &worldPoint1, const QgsVector3D &origin1, const QgsCoordinateReferenceSystem &crs1, const QgsVector3D &origin2, const QgsCoordinateReferenceSystem &crs2,
         const QgsCoordinateTransformContext &context );
+
+    /**
+     * Try to estimate range of Z values used in the given vector layer and store that in zMin and zMax.
+     * The implementation scans a small amount of features and looks at the Z values of geometries
+     * (we don't need exact range, just a rough estimate is fine to know where to expect the data to be).
+     * For layers with geometries without Z values, the returned range will be [0, 0].
+     */
+    static void estimateVectorLayerZRange( QgsVectorLayer *layer, double &zMin, double &zMax );
 
     //! Returns a new 3D symbol based on given geometry type (or NULLPTR if geometry type is not supported)
     static std::unique_ptr<QgsAbstract3DSymbol> symbolForGeometryType( QgsWkbTypes::GeometryType geomType );

--- a/src/3d/qgsabstractvectorlayer3drenderer.cpp
+++ b/src/3d/qgsabstractvectorlayer3drenderer.cpp
@@ -1,0 +1,55 @@
+/***************************************************************************
+  qgsabstractvectorlayer3drenderer.cpp
+  --------------------------------------
+  Date                 : January 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsabstractvectorlayer3drenderer.h"
+
+#include "qgsvectorlayer.h"
+
+
+QgsAbstractVectorLayer3DRenderer::QgsAbstractVectorLayer3DRenderer()
+{
+}
+
+void QgsAbstractVectorLayer3DRenderer::setLayer( QgsVectorLayer *layer )
+{
+  mLayerRef = QgsMapLayerRef( layer );
+}
+
+QgsVectorLayer *QgsAbstractVectorLayer3DRenderer::layer() const
+{
+  return qobject_cast<QgsVectorLayer *>( mLayerRef.layer );
+}
+
+void QgsAbstractVectorLayer3DRenderer::copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const
+{
+  r->mLayerRef = mLayerRef;
+}
+
+void QgsAbstractVectorLayer3DRenderer::writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const
+{
+  Q_UNUSED( context )
+  elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+}
+
+void QgsAbstractVectorLayer3DRenderer::readXmlBaseProperties( const QDomElement &elem, const QgsReadWriteContext &context )
+{
+  Q_UNUSED( context )
+  mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
+}
+
+void QgsAbstractVectorLayer3DRenderer::resolveReferences( const QgsProject &project )
+{
+  mLayerRef.setLayer( project.mapLayer( mLayerRef.layerId ) );
+}

--- a/src/3d/qgsabstractvectorlayer3drenderer.cpp
+++ b/src/3d/qgsabstractvectorlayer3drenderer.cpp
@@ -25,6 +25,7 @@ void QgsVectorLayer3DTilingSettings::writeXml( QDomElement &elem ) const
 
   QDomElement elemTiling = doc.createElement( QStringLiteral( "vector-layer-3d-tiling" ) );
   elemTiling.setAttribute( QStringLiteral( "zoom-levels-count" ), mZoomLevelsCount );
+  elemTiling.setAttribute( QStringLiteral( "show-bounding-boxes" ), mShowBoundingBoxes ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
   elem.appendChild( elemTiling );
 }
 
@@ -34,6 +35,7 @@ void QgsVectorLayer3DTilingSettings::readXml( const QDomElement &elem )
   if ( !elemTiling.isNull() )
   {
     mZoomLevelsCount = elemTiling.attribute( QStringLiteral( "zoom-levels-count" ) ).toInt();
+    mShowBoundingBoxes = elemTiling.attribute( QStringLiteral( "show-bounding-boxes" ) ).toInt();
   }
 }
 

--- a/src/3d/qgsabstractvectorlayer3drenderer.cpp
+++ b/src/3d/qgsabstractvectorlayer3drenderer.cpp
@@ -43,9 +43,7 @@ void QgsVectorLayer3DTilingSettings::readXml( const QDomElement &elem )
 //////////////////
 
 
-QgsAbstractVectorLayer3DRenderer::QgsAbstractVectorLayer3DRenderer()
-{
-}
+QgsAbstractVectorLayer3DRenderer::QgsAbstractVectorLayer3DRenderer() = default;
 
 void QgsAbstractVectorLayer3DRenderer::setLayer( QgsVectorLayer *layer )
 {

--- a/src/3d/qgsabstractvectorlayer3drenderer.cpp
+++ b/src/3d/qgsabstractvectorlayer3drenderer.cpp
@@ -18,6 +18,29 @@
 #include "qgsvectorlayer.h"
 
 
+
+void QgsVectorLayer3DTilingSettings::writeXml( QDomElement &elem ) const
+{
+  QDomDocument doc = elem.ownerDocument();
+
+  QDomElement elemTiling = doc.createElement( QStringLiteral( "vector-layer-3d-tiling" ) );
+  elemTiling.setAttribute( QStringLiteral( "zoom-levels-count" ), mZoomLevelsCount );
+  elem.appendChild( elemTiling );
+}
+
+void QgsVectorLayer3DTilingSettings::readXml( const QDomElement &elem )
+{
+  QDomElement elemTiling = elem.firstChildElement( QStringLiteral( "vector-layer-3d-tiling" ) );
+  if ( !elemTiling.isNull() )
+  {
+    mZoomLevelsCount = elemTiling.attribute( QStringLiteral( "zoom-levels-count" ) ).toInt();
+  }
+}
+
+
+//////////////////
+
+
 QgsAbstractVectorLayer3DRenderer::QgsAbstractVectorLayer3DRenderer()
 {
 }
@@ -35,18 +58,21 @@ QgsVectorLayer *QgsAbstractVectorLayer3DRenderer::layer() const
 void QgsAbstractVectorLayer3DRenderer::copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const
 {
   r->mLayerRef = mLayerRef;
+  r->mTilingSettings = mTilingSettings;
 }
 
 void QgsAbstractVectorLayer3DRenderer::writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const
 {
   Q_UNUSED( context )
   elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+  mTilingSettings.writeXml( elem );
 }
 
 void QgsAbstractVectorLayer3DRenderer::readXmlBaseProperties( const QDomElement &elem, const QgsReadWriteContext &context )
 {
   Q_UNUSED( context )
   mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
+  mTilingSettings.readXml( elem );
 }
 
 void QgsAbstractVectorLayer3DRenderer::resolveReferences( const QgsProject &project )

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -23,6 +23,29 @@
 
 class QgsVectorLayer;
 
+/**
+ * \ingroup 3d
+ * This class defines configuration of how a vector layer gets tiled for 3D rendering.
+ *
+ * Zoom levels count tells how deep will be the quadtree and thus how many tiles will
+ * be generated ( 4 ^ (count-1) ). So for example, for count=1 there will be just
+ * a single tile for the whole layer, for count=3 there will be 16 tiles.
+ *
+ * \since QGIS 3.12
+ */
+class _3D_EXPORT QgsVectorLayer3DTilingSettings
+{
+  public:
+    int zoomLevelsCount() const { return mZoomLevelsCount; }
+    void setZoomLevelsCount( int count ) { mZoomLevelsCount = count; }
+
+    void writeXml( QDomElement &elem ) const;
+    void readXml( const QDomElement &elem );
+
+  private:
+    int mZoomLevelsCount = 3;
+};
+
 
 /**
  * \ingroup 3d
@@ -40,6 +63,9 @@ class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
     //! Returns vector layer associated with the renderer
     QgsVectorLayer *layer() const;
 
+    void setTilingSettings( const QgsVectorLayer3DTilingSettings &settings ) { mTilingSettings = settings; }
+    QgsVectorLayer3DTilingSettings tilingSettings() const { return mTilingSettings; }
+
     void resolveReferences( const QgsProject &project ) override;
 
   protected:
@@ -52,6 +78,7 @@ class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
 
   private:
     QgsMapLayerRef mLayerRef; //!< Layer used to extract polygons from
+    QgsVectorLayer3DTilingSettings mTilingSettings;  //!< How is layer tiled into chunks
 };
 
 #endif // QGSABSTRACTVECTORLAYER3DRENDERER_H

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -52,6 +52,11 @@ class _3D_EXPORT QgsVectorLayer3DTilingSettings
      */
     void setZoomLevelsCount( int count ) { mZoomLevelsCount = count; }
 
+    //! Sets whether to display bounding boxes of entity's tiles (for debugging)
+    void setShowBoundingBoxes( bool enabled ) { mShowBoundingBoxes = enabled; }
+    //! Returns whether to display bounding boxes of entity's tiles (for debugging)
+    bool showBoundingBoxes() const { return mShowBoundingBoxes; }
+
     //! Writes content of the object to XML
     void writeXml( QDomElement &elem ) const;
     //! Reads content of the object from XML
@@ -59,6 +64,7 @@ class _3D_EXPORT QgsVectorLayer3DTilingSettings
 
   private:
     int mZoomLevelsCount = 3;
+    bool mShowBoundingBoxes = false;
 };
 
 

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+  qgsabstractvectorlayer3drenderer.h
+  --------------------------------------
+  Date                 : January 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSABSTRACTVECTORLAYER3DRENDERER_H
+#define QGSABSTRACTVECTORLAYER3DRENDERER_H
+
+#include "qgis_3d.h"
+
+#include "qgsabstract3drenderer.h"
+#include "qgsmaplayerref.h"
+
+class QgsVectorLayer;
+
+
+/**
+ * \ingroup 3d
+ * Base class for 3D renderers that are based on vector layers.
+ *
+ * \since QGIS 3.12
+ */
+class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
+{
+  public:
+    QgsAbstractVectorLayer3DRenderer();
+
+    //! Sets vector layer associated with the renderer
+    void setLayer( QgsVectorLayer *layer );
+    //! Returns vector layer associated with the renderer
+    QgsVectorLayer *layer() const;
+
+    void resolveReferences( const QgsProject &project ) override;
+
+  protected:
+    //! copy common properties of this object to another object
+    void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
+    //! write common properties of this object to DOM element
+    void writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const;
+    //! read common properties of this object from DOM element
+    void readXmlBaseProperties( const QDomElement &elem, const QgsReadWriteContext &context );
+
+  private:
+    QgsMapLayerRef mLayerRef; //!< Layer used to extract polygons from
+};
+
+#endif // QGSABSTRACTVECTORLAYER3DRENDERER_H

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -17,6 +17,7 @@
 #define QGSABSTRACTVECTORLAYER3DRENDERER_H
 
 #include "qgis_3d.h"
+#include "qgis_sip.h"
 
 #include "qgsabstract3drenderer.h"
 #include "qgsmaplayerref.h"
@@ -36,10 +37,24 @@ class QgsVectorLayer;
 class _3D_EXPORT QgsVectorLayer3DTilingSettings
 {
   public:
+
+    /**
+     * Returns number of zoom levels. One zoom level means there will be one tile.
+     * Every extra zoom level multiplies number of tiles by four. For example, three
+     * zoom levels will produce 16 tiles at the highest zoom level. It is therefore
+     * recommended to keep the number of zoom levels low to prevent excessive number
+     * of tiles.
+     */
     int zoomLevelsCount() const { return mZoomLevelsCount; }
+
+    /**
+     * Sets number of zoom levels. See zoomLevelsCount() documentation for more details.
+     */
     void setZoomLevelsCount( int count ) { mZoomLevelsCount = count; }
 
+    //! Writes content of the object to XML
     void writeXml( QDomElement &elem ) const;
+    //! Reads content of the object from XML
     void readXml( const QDomElement &elem );
 
   private:
@@ -63,7 +78,9 @@ class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
     //! Returns vector layer associated with the renderer
     QgsVectorLayer *layer() const;
 
+    //! Sets tiling settings of the renderer
     void setTilingSettings( const QgsVectorLayer3DTilingSettings &settings ) { mTilingSettings = settings; }
+    //! Returns tiling settings of the renderer
     QgsVectorLayer3DTilingSettings tilingSettings() const { return mTilingSettings; }
 
     void resolveReferences( const QgsProject &project ) override;

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -92,11 +92,11 @@ class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
     void resolveReferences( const QgsProject &project ) override;
 
   protected:
-    //! copy common properties of this object to another object
+    //! Copies common properties of this object to another object
     void copyBaseProperties( QgsAbstractVectorLayer3DRenderer *r ) const;
-    //! write common properties of this object to DOM element
+    //! Writes common properties of this object to DOM element
     void writeXmlBaseProperties( QDomElement &elem, const QgsReadWriteContext &context ) const;
-    //! read common properties of this object from DOM element
+    //! Reads common properties of this object from DOM element
     void readXmlBaseProperties( const QDomElement &elem, const QgsReadWriteContext &context );
 
   private:

--- a/src/3d/qgsabstractvectorlayer3drenderer.h
+++ b/src/3d/qgsabstractvectorlayer3drenderer.h
@@ -68,7 +68,7 @@ class _3D_EXPORT QgsVectorLayer3DTilingSettings
  *
  * \since QGIS 3.12
  */
-class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer
+class _3D_EXPORT QgsAbstractVectorLayer3DRenderer : public QgsAbstract3DRenderer SIP_ABSTRACT
 {
   public:
     QgsAbstractVectorLayer3DRenderer();

--- a/src/3d/qgsfeature3dhandler_p.cpp
+++ b/src/3d/qgsfeature3dhandler_p.cpp
@@ -60,4 +60,15 @@ namespace Qgs3DSymbolImpl
 
 }
 
+void QgsFeature3DHandler::updateZRangeFromPositions( const QVector<QVector3D> &positions )
+{
+  for ( const QVector3D &pos : positions )
+  {
+    if ( pos.y() < mZMin )
+      mZMin = pos.y();
+    if ( pos.y() > mZMax )
+      mZMax = pos.y();
+  }
+}
+
 /// @endcond

--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -104,6 +104,26 @@ class QgsFeature3DHandler
      * to a 3D entity object(s) attached to the given parent.
      */
     virtual void finalize( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context ) = 0;
+
+    /**
+     * Returns minimal Z value of the data (in world coordinates).
+     * \note this method should not be called before call to finalize() - it may not be initialized
+     */
+    float zMinimum() const { return mZMin; }
+
+    /**
+     * Returns maximal Z value of the data (in world coordinates).
+     * \note this method should not be called before call to finalize() - it may not be initialized
+     */
+    float zMaximum() const { return mZMax; }
+
+  protected:
+    //! updates zMinimum, zMaximum from the vector of positions in 3D world coordinates
+    void updateZRangeFromPositions( const QVector<QVector3D> &positions );
+
+  protected:
+    float mZMin = std::numeric_limits<double>::max();
+    float mZMax = std::numeric_limits<double>::min();
 };
 
 

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -406,7 +406,10 @@ Qt3DCore::QEntity *QgsRuleBased3DRenderer::createEntity( const Qgs3DMapSettings 
   if ( !vl )
     return nullptr;
 
-  return new QgsRuleBasedChunkedEntity( vl, tilingSettings(), mRootRule, map );
+  double zMin, zMax;
+  Qgs3DUtils::estimateVectorLayerZRange( vl, zMin, zMax );
+
+  return new QgsRuleBasedChunkedEntity( vl, zMin, zMax, tilingSettings(), mRootRule, map );
 }
 
 void QgsRuleBased3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -395,18 +395,8 @@ QgsRuleBased3DRenderer *QgsRuleBased3DRenderer::clone() const
     clonedDescendants[i]->setRuleKey( origDescendants[i]->ruleKey() );
 
   QgsRuleBased3DRenderer *r = new QgsRuleBased3DRenderer( rootRule );
-  r->mLayerRef = mLayerRef;
+  copyBaseProperties( r );
   return r;
-}
-
-void QgsRuleBased3DRenderer::setLayer( QgsVectorLayer *layer )
-{
-  mLayerRef = QgsMapLayerRef( layer );
-}
-
-QgsVectorLayer *QgsRuleBased3DRenderer::layer() const
-{
-  return qobject_cast<QgsVectorLayer *>( mLayerRef.layer );
 }
 
 Qt3DCore::QEntity *QgsRuleBased3DRenderer::createEntity( const Qgs3DMapSettings &map ) const
@@ -423,7 +413,7 @@ void QgsRuleBased3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteCont
 {
   QDomDocument doc = elem.ownerDocument();
 
-  elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+  writeXmlBaseProperties( elem, context );
 
   QDomElement rulesElem = mRootRule->save( doc, context );
   rulesElem.setTagName( QStringLiteral( "rules" ) ); // instead of just "rule"
@@ -432,13 +422,7 @@ void QgsRuleBased3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteCont
 
 void QgsRuleBased3DRenderer::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
-  Q_UNUSED( context )
-  mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
+  readXmlBaseProperties( elem, context );
 
   // root rule is read before class constructed
-}
-
-void QgsRuleBased3DRenderer::resolveReferences( const QgsProject &project )
-{
-  mLayerRef.setLayer( project.mapLayer( mLayerRef.layerId ) );
 }

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -406,7 +406,7 @@ Qt3DCore::QEntity *QgsRuleBased3DRenderer::createEntity( const Qgs3DMapSettings 
   if ( !vl )
     return nullptr;
 
-  return new QgsRuleBasedChunkedEntity( vl, mRootRule, map );
+  return new QgsRuleBasedChunkedEntity( vl, tilingSettings(), mRootRule, map );
 }
 
 void QgsRuleBased3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/qgsrulebased3drenderer.h
+++ b/src/3d/qgsrulebased3drenderer.h
@@ -19,7 +19,7 @@
 #include "qgis_3d.h"
 
 #include "qgs3drendererregistry.h"
-#include "qgsabstract3drenderer.h"
+#include "qgsabstractvectorlayer3drenderer.h"
 #include "qgsabstract3dsymbol.h"
 
 #include "qgsmaplayerref.h"
@@ -58,7 +58,7 @@ class _3D_EXPORT QgsRuleBased3DRendererMetadata : public Qgs3DRendererAbstractMe
  *
  * \since QGIS 3.6
  */
-class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstract3DRenderer
+class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstractVectorLayer3DRenderer
 {
   public:
 
@@ -296,11 +296,6 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstract3DRenderer
     QgsRuleBased3DRenderer( QgsRuleBased3DRenderer::Rule *root SIP_TRANSFER );
     ~QgsRuleBased3DRenderer() override;
 
-    //! Sets vector layer associated with the renderer
-    void setLayer( QgsVectorLayer *layer );
-    //! Returns vector layer associated with the renderer
-    QgsVectorLayer *layer() const;
-
     //! Returns pointer to the root rule
     QgsRuleBased3DRenderer::Rule *rootRule() { return mRootRule; }
     //! Returns pointer to the root rule
@@ -312,10 +307,8 @@ class _3D_EXPORT QgsRuleBased3DRenderer : public QgsAbstract3DRenderer
 
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
-    void resolveReferences( const QgsProject &project ) override;
 
   private:
-    QgsMapLayerRef mLayerRef; //!< Layer used to extract polygons from
     Rule *mRootRule = nullptr;
 
 };

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgsrulebasedchunkloader_p.cpp
+  --------------------------------------
+  Date                 : November 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "qgsrulebasedchunkloader_p.h"
 
 #include "qgs3dutils.h"
@@ -49,7 +64,7 @@ QgsRuleBasedChunkLoader::QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderF
   req.setSubsetOfAttributes( attributeNames, layer->fields() );
 
   // only a subset of data to be queried
-  QgsRectangle rect = Qgs3DUtils::worldToMapExtent( node->bbox(), mFactory->mLayer->crs(), map.origin(), map.crs() );
+  QgsRectangle rect = Qgs3DUtils::worldToLayerExtent( node->bbox(), mFactory->mLayer->crs(), map.origin(), map.crs(), map.transformContext() );
   req.setFilterRect( rect );
 
   //
@@ -133,7 +148,7 @@ QgsChunkLoader *QgsRuleBasedChunkLoaderFactory::createChunkLoader( QgsChunkNode 
 ///////////////
 
 QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map )
-  : QgsChunkedEntity( Qgs3DUtils::mapToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs() ),
+  : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs(), map.transformContext() ),
                       -1,  // rootError  TODO: negative error should mean that the node does not contain anything
                       -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
                       2, // TODO: figure out from the number of features

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -169,12 +169,12 @@ QgsChunkLoader *QgsRuleBasedChunkLoaderFactory::createChunkLoader( QgsChunkNode 
 
 QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map )
   : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), zMin, zMax, vl->crs(), map.origin(), map.crs(), map.transformContext() ),
-                      -1,  // rootError  TODO: negative error should mean that the node does not contain anything
-                      -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
+                      -1, // rootError (negative error means that the node does not contain anything)
+                      -1, // max. allowed screen error (negative tau means that we need to go until leaves are reached)
                       tilingSettings.zoomLevelsCount() - 1,
                       new QgsRuleBasedChunkLoaderFactory( map, vl, rootRule, tilingSettings.zoomLevelsCount() - 1 ) )
 {
-  setShowBoundingBoxes( true );
+  setShowBoundingBoxes( tilingSettings.showBoundingBoxes() );
 }
 
 QgsRuleBasedChunkedEntity::~QgsRuleBasedChunkedEntity()

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -147,12 +147,12 @@ QgsChunkLoader *QgsRuleBasedChunkLoaderFactory::createChunkLoader( QgsChunkNode 
 
 ///////////////
 
-QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map )
+QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map )
   : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs(), map.transformContext() ),
                       -1,  // rootError  TODO: negative error should mean that the node does not contain anything
                       -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
-                      2, // TODO: figure out from the number of features
-                      new QgsRuleBasedChunkLoaderFactory( map, vl, rootRule, 2 ) )
+                      tilingSettings.zoomLevelsCount() - 1,
+                      new QgsRuleBasedChunkLoaderFactory( map, vl, rootRule, tilingSettings.zoomLevelsCount() - 1 ) )
 {
 }
 

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -75,7 +75,7 @@ QgsRuleBasedChunkLoader::QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderF
 
   QFuture<void> future = QtConcurrent::run( [req, this]
   {
-    QgsEventTracing::ScopedEvent e( "3D", "RB chunk load" );
+    QgsEventTracing::ScopedEvent e( QStringLiteral( "3D" ), QStringLiteral( "RB chunk load" ) );
 
     QgsFeature f;
     QgsFeatureIterator fi = mSource->getFeatures( req );
@@ -155,9 +155,7 @@ QgsRuleBasedChunkLoaderFactory::QgsRuleBasedChunkLoaderFactory( const Qgs3DMapSe
 {
 }
 
-QgsRuleBasedChunkLoaderFactory::~QgsRuleBasedChunkLoaderFactory()
-{
-}
+QgsRuleBasedChunkLoaderFactory::~QgsRuleBasedChunkLoaderFactory() = default;
 
 QgsChunkLoader *QgsRuleBasedChunkLoaderFactory::createChunkLoader( QgsChunkNode *node ) const
 {

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -27,6 +27,8 @@
 
 #include <QtConcurrent>
 
+///@cond PRIVATE
+
 
 QgsRuleBasedChunkLoader::QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderFactory *factory, QgsChunkNode *node )
   : QgsChunkLoader( node )
@@ -154,6 +156,7 @@ QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, const 
                       tilingSettings.zoomLevelsCount() - 1,
                       new QgsRuleBasedChunkLoaderFactory( map, vl, rootRule, tilingSettings.zoomLevelsCount() - 1 ) )
 {
+  setShowBoundingBoxes( true );
 }
 
 QgsRuleBasedChunkedEntity::~QgsRuleBasedChunkedEntity()
@@ -161,3 +164,5 @@ QgsRuleBasedChunkedEntity::~QgsRuleBasedChunkedEntity()
   // cancel / wait for jobs
   cancelActiveJobs();
 }
+
+/// @endcond

--- a/src/3d/qgsrulebasedchunkloader_p.cpp
+++ b/src/3d/qgsrulebasedchunkloader_p.cpp
@@ -1,0 +1,129 @@
+#include "qgsrulebasedchunkloader_p.h"
+
+#include "qgs3dutils.h"
+#include "qgschunknode_p.h"
+#include "qgspolygon3dsymbol_p.h"
+#include "qgseventtracing.h"
+
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerfeatureiterator.h"
+
+#include "qgsrulebased3drenderer.h"
+
+#include <QtConcurrent>
+
+
+QgsRuleBasedChunkLoader::QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderFactory *factory, QgsChunkNode *node )
+  : QgsChunkLoader( node )
+  , mFactory( factory )
+  , mContext( factory->mMap )
+{
+  if ( node->level() < mFactory->mLeafLevel )
+  {
+    QTimer::singleShot( 0, this, &QgsRuleBasedChunkLoader::finished );
+    return;
+  }
+
+  QgsVectorLayer *layer = mFactory->mLayer;
+  const Qgs3DMapSettings &map = mFactory->mMap;
+
+  QgsExpressionContext exprContext( Qgs3DUtils::globalProjectLayerExpressionContext( layer ) );
+  exprContext.setFields( layer->fields() );
+  mContext.setExpressionContext( exprContext );
+
+  mFactory->mRootRule->createHandlers( layer, mHandlers );
+
+  QSet<QString> attributeNames;
+  mFactory->mRootRule->prepare( mContext, attributeNames, mHandlers );
+
+  // build the feature request
+  QgsFeatureRequest req;
+  req.setDestinationCrs( map.crs(), map.transformContext() );
+  req.setSubsetOfAttributes( attributeNames, layer->fields() );
+
+  // only a subset of data to be queried
+  QgsRectangle rect = Qgs3DUtils::worldToMapExtent( node->bbox(), mFactory->mLayer->crs(), map.origin(), map.crs() );
+  req.setFilterRect( rect );
+
+  //
+  // this will be run in a background thread
+  //
+
+  QFuture<void> future = QtConcurrent::run( [req, this]
+  {
+    QgsEventTracing::ScopedEvent e( "3D", "RB chunk load" );
+
+    QgsFeature f;
+    QgsFeatureIterator fi = mFactory->mSource->getFeatures( req );
+    while ( fi.nextFeature( f ) )
+    {
+      if ( mCanceled )
+        break;
+      mContext.expressionContext().setFeature( f );
+      mFactory->mRootRule->registerFeature( f, mContext, mHandlers );
+    }
+  } );
+
+  // emit finished() as soon as the handler is populated with features
+  QFutureWatcher<void> *fw = new QFutureWatcher<void>( nullptr );
+  fw->setFuture( future );
+  connect( fw, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
+}
+
+void QgsRuleBasedChunkLoader::cancel()
+{
+  mCanceled = true;
+}
+
+Qt3DCore::QEntity *QgsRuleBasedChunkLoader::createEntity( Qt3DCore::QEntity *parent )
+{
+  if ( mNode->level() < mFactory->mLeafLevel )
+  {
+    return new Qt3DCore::QEntity( parent );  // dummy entity
+  }
+
+  Qt3DCore::QEntity *entity = new Qt3DCore::QEntity( parent );
+  for ( QgsFeature3DHandler *handler : mHandlers.values() )
+    handler->finalize( entity, mContext );
+
+  qDeleteAll( mHandlers );
+  mHandlers.clear();
+
+  return entity;
+}
+
+
+///////////////
+
+
+QgsRuleBasedChunkLoaderFactory::QgsRuleBasedChunkLoaderFactory( const Qgs3DMapSettings &map, QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, int leafLevel )
+  : mMap( map )
+  , mLayer( vl )
+  , mRootRule( rootRule->clone() )
+  , mLeafLevel( leafLevel )
+  , mSource( new QgsVectorLayerFeatureSource( vl ) )
+{
+}
+
+QgsChunkLoader *QgsRuleBasedChunkLoaderFactory::createChunkLoader( QgsChunkNode *node ) const
+{
+  return new QgsRuleBasedChunkLoader( this, node );
+}
+
+
+///////////////
+
+QgsRuleBasedChunkedEntity::QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map )
+  : QgsChunkedEntity( Qgs3DUtils::mapToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs() ),
+                      -1,  // rootError  TODO: negative error should mean that the node does not contain anything
+                      -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
+                      2, // TODO: figure out from the number of features
+                      new QgsRuleBasedChunkLoaderFactory( map, vl, rootRule, 2 ) )
+{
+}
+
+QgsRuleBasedChunkedEntity::~QgsRuleBasedChunkedEntity()
+{
+  // cancel / wait for jobs
+  cancelActiveJobs();
+}

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -17,6 +17,7 @@ class QgsRuleBasedChunkLoaderFactory : public QgsChunkLoaderFactory
 {
   public:
     QgsRuleBasedChunkLoaderFactory( const Qgs3DMapSettings &map, QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, int leafLevel );
+    ~QgsRuleBasedChunkLoaderFactory();
 
     //! Creates loader for the given chunk node. Ownership of the returned is passed to the caller.
     virtual QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const;
@@ -25,7 +26,6 @@ class QgsRuleBasedChunkLoaderFactory : public QgsChunkLoaderFactory
     QgsVectorLayer *mLayer;
     std::unique_ptr<QgsRuleBased3DRenderer::Rule> mRootRule;
     int mLeafLevel;
-    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
 };
 
 
@@ -35,6 +35,7 @@ class QgsRuleBasedChunkLoader : public QgsChunkLoader
 {
   public:
     QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderFactory *factory, QgsChunkNode *node );
+    ~QgsRuleBasedChunkLoader();
 
     virtual void cancel();
     virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
@@ -43,7 +44,10 @@ class QgsRuleBasedChunkLoader : public QgsChunkLoader
     const QgsRuleBasedChunkLoaderFactory *mFactory;
     QgsRuleBased3DRenderer::RuleToHandlerMap mHandlers;
     Qgs3DRenderContext mContext;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
     bool mCanceled = false;
+    QFutureWatcher<void> *mFutureWatcher = nullptr;
+    std::unique_ptr<QgsRuleBased3DRenderer::Rule> mRootRule;
 };
 
 

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -109,7 +109,7 @@ class QgsRuleBasedChunkedEntity : public QgsChunkedEntity
     Q_OBJECT
   public:
     //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
-    explicit QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map );
+    explicit QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map );
 
     ~QgsRuleBasedChunkedEntity();
 };

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -30,14 +30,13 @@
 #include "qgschunkloader_p.h"
 #include "qgsfeature3dhandler_p.h"
 #include "qgschunkedentity_p.h"
+#include "qgsrulebased3drenderer.h"
 
 class Qgs3DMapSettings;
 class QgsVectorLayer;
 class QgsVectorLayerFeatureSource;
 class QgsAbstract3DSymbol;
 class QgsFeature3DHandler;
-
-#include "qgsrulebased3drenderer.h"
 
 
 /**
@@ -50,7 +49,7 @@ class QgsFeature3DHandler;
 class QgsRuleBasedChunkLoaderFactory : public QgsChunkLoaderFactory
 {
   public:
-    //! Constructs the factory
+    //! Constructs the factory (vl and rootRule must not be null)
     QgsRuleBasedChunkLoaderFactory( const Qgs3DMapSettings &map, QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, int leafLevel );
     ~QgsRuleBasedChunkLoaderFactory() override;
 
@@ -75,7 +74,7 @@ class QgsRuleBasedChunkLoaderFactory : public QgsChunkLoaderFactory
 class QgsRuleBasedChunkLoader : public QgsChunkLoader
 {
   public:
-    //! Constructs the loader
+    //! Constructs the loader (factory and node must not be null)
     QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderFactory *factory, QgsChunkNode *node );
     ~QgsRuleBasedChunkLoader() override;
 

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -109,7 +109,7 @@ class QgsRuleBasedChunkedEntity : public QgsChunkedEntity
     Q_OBJECT
   public:
     //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
-    explicit QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map );
+    explicit QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map );
 
     ~QgsRuleBasedChunkedEntity();
 };

--- a/src/3d/qgsrulebasedchunkloader_p.h
+++ b/src/3d/qgsrulebasedchunkloader_p.h
@@ -1,0 +1,68 @@
+#ifndef QGSRULEBASEDCHUNKLOADER_H
+#define QGSRULEBASEDCHUNKLOADER_H
+
+#include "qgschunkloader_p.h"
+#include "qgsfeature3dhandler_p.h"
+
+class Qgs3DMapSettings;
+class QgsVectorLayer;
+class QgsVectorLayerFeatureSource;
+class QgsAbstract3DSymbol;
+class QgsFeature3DHandler;
+
+#include "qgsrulebased3drenderer.h"
+
+
+class QgsRuleBasedChunkLoaderFactory : public QgsChunkLoaderFactory
+{
+  public:
+    QgsRuleBasedChunkLoaderFactory( const Qgs3DMapSettings &map, QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, int leafLevel );
+
+    //! Creates loader for the given chunk node. Ownership of the returned is passed to the caller.
+    virtual QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const;
+
+    const Qgs3DMapSettings &mMap;
+    QgsVectorLayer *mLayer;
+    std::unique_ptr<QgsRuleBased3DRenderer::Rule> mRootRule;
+    int mLeafLevel;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
+};
+
+
+
+
+class QgsRuleBasedChunkLoader : public QgsChunkLoader
+{
+  public:
+    QgsRuleBasedChunkLoader( const QgsRuleBasedChunkLoaderFactory *factory, QgsChunkNode *node );
+
+    virtual void cancel();
+    virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
+
+  private:
+    const QgsRuleBasedChunkLoaderFactory *mFactory;
+    QgsRuleBased3DRenderer::RuleToHandlerMap mHandlers;
+    Qgs3DRenderContext mContext;
+    bool mCanceled = false;
+};
+
+
+
+#include "qgschunkedentity_p.h"
+
+class QgsRuleBasedChunkedEntity : public QgsChunkedEntity
+{
+    Q_OBJECT
+  public:
+
+    // TODO: should use a clone of root rule?
+
+    //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
+    explicit QgsRuleBasedChunkedEntity( QgsVectorLayer *vl, QgsRuleBased3DRenderer::Rule *rootRule, const Qgs3DMapSettings &map );
+
+    ~QgsRuleBasedChunkedEntity();
+};
+
+
+
+#endif // QGSRULEBASEDCHUNKLOADER_H

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -86,6 +86,17 @@ void QgsTessellatedPolygonGeometry::setPolygons( const QList<QgsPolygon *> &poly
     mNormalAttribute->setCount( nVerts );
 }
 
+void QgsTessellatedPolygonGeometry::setData( const QByteArray &vertexBufferData, int vertexCount, const QVector<QgsFeatureId> &triangleIndexFids, const QVector<uint> &triangleIndexStartingIndices )
+{
+  mTriangleIndexStartingIndices = triangleIndexStartingIndices;
+  mTriangleIndexFids = triangleIndexFids;
+
+  mVertexBuffer->setData( vertexBufferData );
+  mPositionAttribute->setCount( vertexCount );
+  if ( mNormalAttribute )
+    mNormalAttribute->setCount( vertexCount );
+}
+
 
 // run binary search on a sorted array, return index i where data[i] <= x < data[i+1]
 static int binary_search( uint v, const uint *data, int count )
@@ -93,7 +104,7 @@ static int binary_search( uint v, const uint *data, int count )
   int idx0 = 0;
   int idx1 = count - 1;
 
-  if ( v < data[0] )
+  if ( v < data[0] || v >= data[count - 1] )
     return -1;  // not in the array
 
   while ( idx0 != idx1 )
@@ -117,6 +128,5 @@ static int binary_search( uint v, const uint *data, int count )
 QgsFeatureId QgsTessellatedPolygonGeometry::triangleIndexToFeatureId( uint triangleIndex ) const
 {
   int i = binary_search( triangleIndex, mTriangleIndexStartingIndices.constData(), mTriangleIndexStartingIndices.count() );
-  Q_ASSERT( i != -1 );
-  return mTriangleIndexFids[i];
+  return i != -1 ? mTriangleIndexFids[i] : FID_NULL;
 }

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -62,7 +62,17 @@ class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
     //! Initializes vertex buffer from given polygons. Takes ownership of passed polygon geometries
     void setPolygons( const QList<QgsPolygon *> &polygons, const QList<QgsFeatureId> &featureIds, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon = QList<float>() );
 
-    //! Returns ID of the feature to which given triangle index belongs (used for picking)
+    /**
+     * Initializes vertex buffer (and other members) from data that were already tessellated.
+     * This is an alternative to setPolygons() - this method does not do any expensive work in the body.
+     * \since QGIS 3.12
+     */
+    void setData( const QByteArray &vertexBufferData, int vertexCount, const QVector<QgsFeatureId> &triangleIndexFids, const QVector<uint> &triangleIndexStartingIndices );
+
+    /**
+     * Returns ID of the feature to which given triangle index belongs (used for picking).
+     * In case such triangle index does not match any feature, FID_NULL is returned.
+     */
     QgsFeatureId triangleIndexToFeatureId( uint triangleIndex ) const;
 
   private:

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -49,18 +49,8 @@ QgsVectorLayer3DRenderer::QgsVectorLayer3DRenderer( QgsAbstract3DSymbol *s )
 QgsVectorLayer3DRenderer *QgsVectorLayer3DRenderer::clone() const
 {
   QgsVectorLayer3DRenderer *r = new QgsVectorLayer3DRenderer( mSymbol ? mSymbol->clone() : nullptr );
-  r->mLayerRef = mLayerRef;
+  copyBaseProperties( r );
   return r;
-}
-
-void QgsVectorLayer3DRenderer::setLayer( QgsVectorLayer *layer )
-{
-  mLayerRef = QgsMapLayerRef( layer );
-}
-
-QgsVectorLayer *QgsVectorLayer3DRenderer::layer() const
-{
-  return qobject_cast<QgsVectorLayer *>( mLayerRef.layer );
 }
 
 void QgsVectorLayer3DRenderer::setSymbol( QgsAbstract3DSymbol *symbol )
@@ -87,7 +77,7 @@ void QgsVectorLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteCo
 {
   QDomDocument doc = elem.ownerDocument();
 
-  elem.setAttribute( QStringLiteral( "layer" ), mLayerRef.layerId );
+  writeXmlBaseProperties( elem, context );
 
   QDomElement elemSymbol = doc.createElement( QStringLiteral( "symbol" ) );
   if ( mSymbol )
@@ -100,7 +90,7 @@ void QgsVectorLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteCo
 
 void QgsVectorLayer3DRenderer::readXml( const QDomElement &elem, const QgsReadWriteContext &context )
 {
-  mLayerRef = QgsMapLayerRef( elem.attribute( QStringLiteral( "layer" ) ) );
+  readXmlBaseProperties( elem, context );
 
   QDomElement elemSymbol = elem.firstChildElement( QStringLiteral( "symbol" ) );
   QString symbolType = elemSymbol.attribute( QStringLiteral( "type" ) );
@@ -115,9 +105,4 @@ void QgsVectorLayer3DRenderer::readXml( const QDomElement &elem, const QgsReadWr
   if ( symbol )
     symbol->readXml( elemSymbol, context );
   mSymbol.reset( symbol );
-}
-
-void QgsVectorLayer3DRenderer::resolveReferences( const QgsProject &project )
-{
-  mLayerRef.setLayer( project.mapLayer( mLayerRef.layerId ) );
 }

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsvectorlayer3drenderer.h"
 
+#include "qgs3dutils.h"
 #include "qgschunkedentity_p.h"
 #include "qgsline3dsymbol.h"
 #include "qgspoint3dsymbol.h"
@@ -70,7 +71,10 @@ Qt3DCore::QEntity *QgsVectorLayer3DRenderer::createEntity( const Qgs3DMapSetting
   if ( !mSymbol || !vl )
     return nullptr;
 
-  return new QgsVectorLayerChunkedEntity( vl, tilingSettings(), mSymbol.get(), map );
+  double zMin, zMax;
+  Qgs3DUtils::estimateVectorLayerZRange( vl, zMin, zMax );
+
+  return new QgsVectorLayerChunkedEntity( vl, zMin, zMax, tilingSettings(), mSymbol.get(), map );
 }
 
 void QgsVectorLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -15,12 +15,11 @@
 
 #include "qgsvectorlayer3drenderer.h"
 
+#include "qgschunkedentity_p.h"
 #include "qgsline3dsymbol.h"
 #include "qgspoint3dsymbol.h"
 #include "qgspolygon3dsymbol.h"
-#include "qgsline3dsymbol_p.h"
-#include "qgspoint3dsymbol_p.h"
-#include "qgspolygon3dsymbol_p.h"
+#include "qgsvectorlayerchunkloader_p.h"
 
 #include "qgsvectorlayer.h"
 #include "qgsxmlutils.h"
@@ -81,14 +80,7 @@ Qt3DCore::QEntity *QgsVectorLayer3DRenderer::createEntity( const Qgs3DMapSetting
   if ( !mSymbol || !vl )
     return nullptr;
 
-  if ( mSymbol->type() == QLatin1String( "polygon" ) )
-    return Qgs3DSymbolImpl::entityForPolygon3DSymbol( map, vl, *static_cast<QgsPolygon3DSymbol *>( mSymbol.get() ) );
-  else if ( mSymbol->type() == QLatin1String( "point" ) )
-    return Qgs3DSymbolImpl::entityForPoint3DSymbol( map, vl, *static_cast<QgsPoint3DSymbol *>( mSymbol.get() ) );
-  else if ( mSymbol->type() == QLatin1String( "line" ) )
-    return Qgs3DSymbolImpl::entityForLine3DSymbol( map, vl, *static_cast<QgsLine3DSymbol *>( mSymbol.get() ) );
-  else
-    return nullptr;
+  return new QgsVectorLayerChunkedEntity( vl, mSymbol.get(), map );
 }
 
 void QgsVectorLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -70,7 +70,7 @@ Qt3DCore::QEntity *QgsVectorLayer3DRenderer::createEntity( const Qgs3DMapSetting
   if ( !mSymbol || !vl )
     return nullptr;
 
-  return new QgsVectorLayerChunkedEntity( vl, mSymbol.get(), map );
+  return new QgsVectorLayerChunkedEntity( vl, tilingSettings(), mSymbol.get(), map );
 }
 
 void QgsVectorLayer3DRenderer::writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const

--- a/src/3d/qgsvectorlayer3drenderer.h
+++ b/src/3d/qgsvectorlayer3drenderer.h
@@ -20,7 +20,7 @@
 #include "qgis_sip.h"
 
 #include "qgs3drendererregistry.h"
-#include "qgsabstract3drenderer.h"
+#include "qgsabstractvectorlayer3drenderer.h"
 #include "qgsabstract3dsymbol.h"
 
 #include "qgsphongmaterialsettings.h"
@@ -57,16 +57,11 @@ class _3D_EXPORT QgsVectorLayer3DRendererMetadata : public Qgs3DRendererAbstract
  * The appearance is completely defined by the symbol.
  * \since QGIS 3.0
  */
-class _3D_EXPORT QgsVectorLayer3DRenderer : public QgsAbstract3DRenderer
+class _3D_EXPORT QgsVectorLayer3DRenderer : public QgsAbstractVectorLayer3DRenderer
 {
   public:
     //! Takes ownership of the symbol object
     explicit QgsVectorLayer3DRenderer( QgsAbstract3DSymbol *s SIP_TRANSFER = nullptr );
-
-    //! Sets vector layer associated with the renderer
-    void setLayer( QgsVectorLayer *layer );
-    //! Returns vector layer associated with the renderer
-    QgsVectorLayer *layer() const;
 
     //! Sets 3D symbol associated with the renderer. Takes ownership of the symbol
     void setSymbol( QgsAbstract3DSymbol *symbol SIP_TRANSFER );
@@ -79,10 +74,8 @@ class _3D_EXPORT QgsVectorLayer3DRenderer : public QgsAbstract3DRenderer
 
     void writeXml( QDomElement &elem, const QgsReadWriteContext &context ) const override;
     void readXml( const QDomElement &elem, const QgsReadWriteContext &context ) override;
-    void resolveReferences( const QgsProject &project ) override;
 
   private:
-    QgsMapLayerRef mLayerRef; //!< Layer used to extract polygons from
     std::unique_ptr<QgsAbstract3DSymbol> mSymbol;  //!< 3D symbol that defines appearance
 
   private:

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -153,8 +153,8 @@ QgsChunkLoader *QgsVectorLayerChunkLoaderFactory::createChunkLoader( QgsChunkNod
 ///////////////
 
 
-QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
-  : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs(), map.transformContext() ),
+QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
+  : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), zMin, zMax, vl->crs(), map.origin(), map.crs(), map.transformContext() ),
                       -1,  // rootError  TODO: negative error should mean that the node does not contain anything
                       -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
                       tilingSettings.zoomLevelsCount() - 1,

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -16,6 +16,7 @@
 #include "qgsvectorlayerchunkloader_p.h"
 
 #include "qgs3dutils.h"
+#include "qgsabstractvectorlayer3drenderer.h"
 #include "qgschunknode_p.h"
 #include "qgspolygon3dsymbol_p.h"
 #include "qgseventtracing.h"
@@ -150,12 +151,12 @@ QgsChunkLoader *QgsVectorLayerChunkLoaderFactory::createChunkLoader( QgsChunkNod
 ///////////////
 
 
-QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
+QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
   : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs(), map.transformContext() ),
                       -1,  // rootError  TODO: negative error should mean that the node does not contain anything
                       -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
-                      2, // TODO: figure out from the number of features
-                      new QgsVectorLayerChunkLoaderFactory( map, vl, symbol, 2 ) )
+                      tilingSettings.zoomLevelsCount() - 1,
+                      new QgsVectorLayerChunkLoaderFactory( map, vl, symbol, tilingSettings.zoomLevelsCount() - 1 ) )
 {
 }
 

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -34,6 +34,8 @@
 
 #include <QtConcurrent>
 
+///@cond PRIVATE
+
 
 QgsVectorLayerChunkLoader::QgsVectorLayerChunkLoader( const QgsVectorLayerChunkLoaderFactory *factory, QgsChunkNode *node )
   : QgsChunkLoader( node )
@@ -165,3 +167,5 @@ QgsVectorLayerChunkedEntity::~QgsVectorLayerChunkedEntity()
   // cancel / wait for jobs
   cancelActiveJobs();
 }
+
+/// @endcond

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -72,7 +72,7 @@ QgsVectorLayerChunkLoader::QgsVectorLayerChunkLoader( const QgsVectorLayerChunkL
   req.setSubsetOfAttributes( attributeNames, layer->fields() );
 
   // only a subset of data to be queried
-  QgsRectangle rect = Qgs3DUtils::worldToMapExtent( node->bbox(), mFactory->mLayer->crs(), map.origin(), map.crs() );
+  QgsRectangle rect = Qgs3DUtils::worldToLayerExtent( node->bbox(), mFactory->mLayer->crs(), map.origin(), map.crs(), map.transformContext() );
   req.setFilterRect( rect );
 
   //
@@ -151,7 +151,7 @@ QgsChunkLoader *QgsVectorLayerChunkLoaderFactory::createChunkLoader( QgsChunkNod
 
 
 QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
-  : QgsChunkedEntity( Qgs3DUtils::mapToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs() ),
+  : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs(), map.transformContext() ),
                       -1,  // rootError  TODO: negative error should mean that the node does not contain anything
                       -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
                       2, // TODO: figure out from the number of features

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -155,11 +155,12 @@ QgsChunkLoader *QgsVectorLayerChunkLoaderFactory::createChunkLoader( QgsChunkNod
 
 QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
   : QgsChunkedEntity( Qgs3DUtils::layerToWorldExtent( vl->extent(), zMin, zMax, vl->crs(), map.origin(), map.crs(), map.transformContext() ),
-                      -1,  // rootError  TODO: negative error should mean that the node does not contain anything
-                      -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
+                      -1, // rootError (negative error means that the node does not contain anything)
+                      -1, // max. allowed screen error (negative tau means that we need to go until leaves are reached)
                       tilingSettings.zoomLevelsCount() - 1,
                       new QgsVectorLayerChunkLoaderFactory( map, vl, symbol, tilingSettings.zoomLevelsCount() - 1 ) )
 {
+  setShowBoundingBoxes( tilingSettings.showBoundingBoxes() );
 }
 
 QgsVectorLayerChunkedEntity::~QgsVectorLayerChunkedEntity()

--- a/src/3d/qgsvectorlayerchunkloader_p.cpp
+++ b/src/3d/qgsvectorlayerchunkloader_p.cpp
@@ -1,0 +1,156 @@
+/***************************************************************************
+  qgsvectorlayerchunkloader_p.cpp
+  --------------------------------------
+  Date                 : July 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectorlayerchunkloader_p.h"
+
+#include "qgs3dutils.h"
+#include "qgschunknode_p.h"
+#include "qgspolygon3dsymbol_p.h"
+#include "qgseventtracing.h"
+
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerfeatureiterator.h"
+
+#include "qgsline3dsymbol.h"
+#include "qgspoint3dsymbol.h"
+#include "qgspolygon3dsymbol.h"
+
+#include "qgsline3dsymbol_p.h"
+#include "qgspoint3dsymbol_p.h"
+#include "qgspolygon3dsymbol_p.h"
+
+#include <QtConcurrent>
+
+
+QgsVectorLayerChunkLoader::QgsVectorLayerChunkLoader( const QgsVectorLayerChunkLoaderFactory *factory, QgsChunkNode *node )
+  : QgsChunkLoader( node )
+  , mFactory( factory )
+  , mContext( factory->mMap )
+{
+  if ( node->level() < mFactory->mLeafLevel )
+  {
+    QTimer::singleShot( 0, this, &QgsVectorLayerChunkLoader::finished );
+    return;
+  }
+
+  QgsVectorLayer *layer = mFactory->mLayer;
+  const Qgs3DMapSettings &map = mFactory->mMap;
+
+  if ( mFactory->mSymbol->type() == QLatin1String( "polygon" ) )
+    mHandler = Qgs3DSymbolImpl::handlerForPolygon3DSymbol( layer, *static_cast<QgsPolygon3DSymbol *>( mFactory->mSymbol.get() ) );
+  else if ( mFactory->mSymbol->type() == QLatin1String( "point" ) )
+    mHandler = Qgs3DSymbolImpl::handlerForPoint3DSymbol( layer, *static_cast<QgsPoint3DSymbol *>( mFactory->mSymbol.get() ) );
+  else if ( mFactory->mSymbol->type() == QLatin1String( "line" ) )
+    mHandler = Qgs3DSymbolImpl::handlerForLine3DSymbol( layer, *static_cast<QgsLine3DSymbol *>( mFactory->mSymbol.get() ) );
+  else
+    return;  // TODO: how to handle error
+
+  QgsExpressionContext exprContext( Qgs3DUtils::globalProjectLayerExpressionContext( layer ) );
+  exprContext.setFields( layer->fields() );
+  mContext.setExpressionContext( exprContext );
+
+  QSet<QString> attributeNames;
+  if ( !mHandler->prepare( mContext, attributeNames ) )
+    return;  // TODO: how to handle errors
+
+  // build the feature request
+  QgsFeatureRequest req;
+  req.setDestinationCrs( map.crs(), map.transformContext() );
+  req.setSubsetOfAttributes( attributeNames, layer->fields() );
+
+  // only a subset of data to be queried
+  QgsRectangle rect = Qgs3DUtils::worldToMapExtent( node->bbox(), mFactory->mLayer->crs(), map.origin(), map.crs() );
+  req.setFilterRect( rect );
+
+  //
+  // this will be run in a background thread
+  //
+
+  QFuture<void> future = QtConcurrent::run( [req, this]
+  {
+    QgsEventTracing::ScopedEvent e( "3D", "VL chunk load" );
+
+    QgsFeature f;
+    QgsFeatureIterator fi = mFactory->mSource->getFeatures( req );
+    while ( fi.nextFeature( f ) )
+    {
+      if ( mCanceled )
+        break;
+      mContext.expressionContext().setFeature( f );
+      mHandler->processFeature( f, mContext );
+    }
+  } );
+
+  // emit finished() as soon as the handler is populated with features
+  QFutureWatcher<void> *fw = new QFutureWatcher<void>( nullptr );
+  fw->setFuture( future );
+  connect( fw, &QFutureWatcher<void>::finished, this, &QgsChunkQueueJob::finished );
+}
+
+void QgsVectorLayerChunkLoader::cancel()
+{
+  mCanceled = true;
+}
+
+Qt3DCore::QEntity *QgsVectorLayerChunkLoader::createEntity( Qt3DCore::QEntity *parent )
+{
+  if ( mNode->level() < mFactory->mLeafLevel )
+  {
+    return new Qt3DCore::QEntity( parent );  // dummy entity
+  }
+
+  Qt3DCore::QEntity *entity = new Qt3DCore::QEntity( parent );
+  mHandler->finalize( entity, mContext );
+  delete mHandler;
+  mHandler = nullptr;
+  return entity;
+}
+
+
+///////////////
+
+
+QgsVectorLayerChunkLoaderFactory::QgsVectorLayerChunkLoaderFactory( const Qgs3DMapSettings &map, QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, int leafLevel )
+  : mMap( map )
+  , mLayer( vl )
+  , mSymbol( symbol->clone() )
+  , mLeafLevel( leafLevel )
+  , mSource( new QgsVectorLayerFeatureSource( vl ) )
+{
+}
+
+QgsChunkLoader *QgsVectorLayerChunkLoaderFactory::createChunkLoader( QgsChunkNode *node ) const
+{
+  return new QgsVectorLayerChunkLoader( this, node );
+}
+
+
+///////////////
+
+
+QgsVectorLayerChunkedEntity::QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map )
+  : QgsChunkedEntity( Qgs3DUtils::mapToWorldExtent( vl->extent(), vl->crs(), map.origin(), map.crs() ),
+                      -1,  // rootError  TODO: negative error should mean that the node does not contain anything
+                      -1, // tau = max. allowed screen error. TODO: negative tau should mean that we need to go until leaves are reached
+                      2, // TODO: figure out from the number of features
+                      new QgsVectorLayerChunkLoaderFactory( map, vl, symbol, 2 ) )
+{
+}
+
+QgsVectorLayerChunkedEntity::~QgsVectorLayerChunkedEntity()
+{
+  // cancel / wait for jobs
+  cancelActiveJobs();
+}

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -33,6 +33,7 @@
 
 class Qgs3DMapSettings;
 class QgsVectorLayer;
+class QgsVectorLayer3DTilingSettings;
 class QgsVectorLayerFeatureSource;
 class QgsAbstract3DSymbol;
 class QgsFeature3DHandler;
@@ -106,7 +107,7 @@ class QgsVectorLayerChunkedEntity : public QgsChunkedEntity
     Q_OBJECT
   public:
     //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
-    explicit QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map );
+    explicit QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map );
 
     ~QgsVectorLayerChunkedEntity();
 };

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+  qgsvectorlayerchunkloader_p.h
+  --------------------------------------
+  Date                 : July 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORLAYERCHUNKLOADER_P_H
+#define QGSVECTORLAYERCHUNKLOADER_P_H
+
+#include "qgschunkloader_p.h"
+#include "qgsfeature3dhandler_p.h"
+
+class Qgs3DMapSettings;
+class QgsVectorLayer;
+class QgsVectorLayerFeatureSource;
+class QgsAbstract3DSymbol;
+class QgsFeature3DHandler;
+
+
+class QgsVectorLayerChunkLoaderFactory : public QgsChunkLoaderFactory
+{
+  public:
+    QgsVectorLayerChunkLoaderFactory( const Qgs3DMapSettings &map, QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, int leafLevel );
+
+    //! Creates loader for the given chunk node. Ownership of the returned is passed to the caller.
+    virtual QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const;
+
+    const Qgs3DMapSettings &mMap;
+    QgsVectorLayer *mLayer;
+    std::unique_ptr<QgsAbstract3DSymbol> mSymbol;
+    int mLeafLevel;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
+};
+
+
+class QgsVectorLayerChunkLoader : public QgsChunkLoader
+{
+  public:
+    QgsVectorLayerChunkLoader( const QgsVectorLayerChunkLoaderFactory *factory, QgsChunkNode *node );
+
+    virtual void cancel();
+    virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
+
+  private:
+    const QgsVectorLayerChunkLoaderFactory *mFactory;
+    QgsFeature3DHandler *mHandler = nullptr;
+    Qgs3DRenderContext mContext;
+    bool mCanceled = false;
+};
+
+#include "qgschunkedentity_p.h"
+class QgsVectorLayerChunkedEntity : public QgsChunkedEntity
+{
+    Q_OBJECT
+  public:
+    //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
+    explicit QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map );
+
+    ~QgsVectorLayerChunkedEntity();
+};
+
+#endif // QGSVECTORLAYERCHUNKLOADER_P_H

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -25,6 +25,8 @@ class QgsVectorLayerFeatureSource;
 class QgsAbstract3DSymbol;
 class QgsFeature3DHandler;
 
+#include <QFutureWatcher>
+
 
 class QgsVectorLayerChunkLoaderFactory : public QgsChunkLoaderFactory
 {
@@ -38,7 +40,6 @@ class QgsVectorLayerChunkLoaderFactory : public QgsChunkLoaderFactory
     QgsVectorLayer *mLayer;
     std::unique_ptr<QgsAbstract3DSymbol> mSymbol;
     int mLeafLevel;
-    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
 };
 
 
@@ -46,6 +47,7 @@ class QgsVectorLayerChunkLoader : public QgsChunkLoader
 {
   public:
     QgsVectorLayerChunkLoader( const QgsVectorLayerChunkLoaderFactory *factory, QgsChunkNode *node );
+    ~QgsVectorLayerChunkLoader();
 
     virtual void cancel();
     virtual Qt3DCore::QEntity *createEntity( Qt3DCore::QEntity *parent );
@@ -54,7 +56,9 @@ class QgsVectorLayerChunkLoader : public QgsChunkLoader
     const QgsVectorLayerChunkLoaderFactory *mFactory;
     QgsFeature3DHandler *mHandler = nullptr;
     Qgs3DRenderContext mContext;
+    std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
     bool mCanceled = false;
+    QFutureWatcher<void> *mFutureWatcher = nullptr;
 };
 
 #include "qgschunkedentity_p.h"

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -107,7 +107,7 @@ class QgsVectorLayerChunkedEntity : public QgsChunkedEntity
     Q_OBJECT
   public:
     //! Constructs the entity. The argument maxLevel determines how deep the tree of tiles will be
-    explicit QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map );
+    explicit QgsVectorLayerChunkedEntity( QgsVectorLayer *vl, double zMin, double zMax, const QgsVectorLayer3DTilingSettings &tilingSettings, QgsAbstract3DSymbol *symbol, const Qgs3DMapSettings &map );
 
     ~QgsVectorLayerChunkedEntity();
 };

--- a/src/3d/qgsvectorlayerchunkloader_p.h
+++ b/src/3d/qgsvectorlayerchunkloader_p.h
@@ -84,7 +84,7 @@ class QgsVectorLayerChunkLoader : public QgsChunkLoader
 
   private:
     const QgsVectorLayerChunkLoaderFactory *mFactory;
-    QgsFeature3DHandler *mHandler = nullptr;
+    std::unique_ptr<QgsFeature3DHandler> mHandler;
     Qgs3DRenderContext mContext;
     std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
     bool mCanceled = false;

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -167,7 +167,7 @@ void QgsBufferedLine3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const 
 
 void QgsBufferedLine3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, LineData &out, bool selected )
 {
-  if ( !out.tessellator->dataVerticesCount() )
+  if ( out.tessellator->dataVerticesCount() == 0 )
     return;  // nothing to show - no need to create the entity
 
   Qt3DExtras::QPhongMaterial *mat = _material( mSymbol );

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -159,6 +159,9 @@ void QgsBufferedLine3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const 
   // create entity for selected and not selected
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
+
+  mZMin = std::min( outNormal.tessellator->zMinimum(), outSelected.tessellator->zMinimum() );
+  mZMax = std::max( outNormal.tessellator->zMaximum(), outSelected.tessellator->zMaximum() );
 }
 
 
@@ -267,6 +270,9 @@ void QgsSimpleLine3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
   // create entity for selected and not selected
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
+
+  updateZRangeFromPositions( outNormal.vertices );
+  updateZRangeFromPositions( outSelected.vertices );
 }
 
 
@@ -379,6 +385,9 @@ void QgsThickLine3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qgs
   // create entity for selected and not selected
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
+
+  updateZRangeFromPositions( outNormal.vertices );
+  updateZRangeFromPositions( outSelected.vertices );
 }
 
 

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -116,6 +116,14 @@ void QgsInstancedPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
 {
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
+
+  updateZRangeFromPositions( outNormal.positions );
+  updateZRangeFromPositions( outSelected.positions );
+
+  // the elevation offset is applied in the vertex shader so let's account for it as well
+  float symbolHeight = mSymbol.transform().data()[13];
+  mZMin += symbolHeight;
+  mZMax += symbolHeight;
 }
 
 void QgsInstancedPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
@@ -388,6 +396,14 @@ void QgsModelPoint3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qg
 {
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
+
+  updateZRangeFromPositions( outNormal.positions );
+  updateZRangeFromPositions( outSelected.positions );
+
+  // the elevation offset is applied separately in QTransform added to sub-entities
+  float symbolHeight = mSymbol.transform().data()[13];
+  mZMin += symbolHeight;
+  mZMax += symbolHeight;
 }
 
 void QgsModelPoint3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )
@@ -520,6 +536,14 @@ void QgsPoint3DBillboardSymbolHandler::finalize( Qt3DCore::QEntity *parent, cons
 {
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
+
+  updateZRangeFromPositions( outNormal.positions );
+  updateZRangeFromPositions( outSelected.positions );
+
+  // the elevation offset is applied externally through a QTransform of QEntity so let's account for it
+  float billboardHeight = mSymbol.transform().data()[13];
+  mZMin += billboardHeight;
+  mZMax += billboardHeight;
 }
 
 void QgsPoint3DBillboardSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PointData &out, bool selected )

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -188,6 +188,9 @@ void QgsPolygon3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qgs3D
   makeEntity( parent, context, outNormal, false );
   makeEntity( parent, context, outSelected, true );
 
+  mZMin = std::min( outNormal.tessellator->zMinimum(), outSelected.tessellator->zMinimum() );
+  mZMax = std::max( outNormal.tessellator->zMaximum(), outSelected.tessellator->zMaximum() );
+
   // add entity for edges
   if ( mSymbol.edgesEnabled() && !outEdges.indexes.isEmpty() )
   {

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -19,6 +19,7 @@
 #include "qgstessellatedpolygongeometry.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dutils.h"
+#include "qgstessellator.h"
 
 #include <Qt3DCore/QTransform>
 #include <Qt3DExtras/QPhongMaterial>
@@ -36,6 +37,8 @@
 
 /// @cond PRIVATE
 
+class QgsTessellator;
+
 
 class QgsPolygon3DSymbolHandler : public QgsFeature3DHandler
 {
@@ -52,12 +55,12 @@ class QgsPolygon3DSymbolHandler : public QgsFeature3DHandler
     //! temporary data we will pass to the tessellator
     struct PolygonData
     {
-      QList<QgsPolygon *> polygons;
-      QList<QgsFeatureId> fids;
-      QList<float> extrusionHeightPerPolygon;  // will stay empty if not needed per polygon
+      std::unique_ptr<QgsTessellator> tessellator;
+      QVector<QgsFeatureId> triangleIndexFids;
+      QVector<uint> triangleIndexStartingIndices;
     };
 
-    void processPolygon( QgsPolygon *polyClone, QgsFeatureId fid, float height, bool hasDDExtrusion, float extrusionHeight, const Qgs3DRenderContext &context, PolygonData &out );
+    void processPolygon( QgsPolygon *polyClone, QgsFeatureId fid, float height, float extrusionHeight, const Qgs3DRenderContext &context, PolygonData &out );
     void makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PolygonData &out, bool selected );
     Qt3DExtras::QPhongMaterial *material( const QgsPolygon3DSymbol &symbol ) const;
 
@@ -79,12 +82,15 @@ bool QgsPolygon3DSymbolHandler::prepare( const Qgs3DRenderContext &context, QSet
   outEdges.withAdjacency = true;
   outEdges.init( mSymbol.altitudeClamping(), mSymbol.altitudeBinding(), mSymbol.height(), &context.map() );
 
+  outNormal.tessellator.reset( new QgsTessellator( context.map().origin().x(), context.map().origin().y(), true, mSymbol.invertNormals(), mSymbol.addBackFaces() ) );
+  outSelected.tessellator.reset( new QgsTessellator( context.map().origin().x(), context.map().origin().y(), true, mSymbol.invertNormals(), mSymbol.addBackFaces() ) );
+
   QSet<QString> attrs = mSymbol.dataDefinedProperties().referencedFields( context.expressionContext() );
   attributeNames.unite( attrs );
   return true;
 }
 
-void QgsPolygon3DSymbolHandler::processPolygon( QgsPolygon *polyClone, QgsFeatureId fid, float height, bool hasDDExtrusion, float extrusionHeight, const Qgs3DRenderContext &context, PolygonData &out )
+void QgsPolygon3DSymbolHandler::processPolygon( QgsPolygon *polyClone, QgsFeatureId fid, float height, float extrusionHeight, const Qgs3DRenderContext &context, PolygonData &out )
 {
   if ( mSymbol.edgesEnabled() )
   {
@@ -109,10 +115,13 @@ void QgsPolygon3DSymbolHandler::processPolygon( QgsPolygon *polyClone, QgsFeatur
   }
 
   Qgs3DUtils::clampAltitudes( polyClone, mSymbol.altitudeClamping(), mSymbol.altitudeBinding(), height, context.map() );
-  out.polygons.append( polyClone );
-  out.fids.append( fid );
-  if ( hasDDExtrusion )
-    out.extrusionHeightPerPolygon.append( extrusionHeight );
+
+  Q_ASSERT( out.tessellator->dataVerticesCount() % 3 == 0 );
+  uint startingTriangleIndex = static_cast<uint>( out.tessellator->dataVerticesCount() / 3 );
+  out.triangleIndexStartingIndices.append( startingTriangleIndex );
+  out.triangleIndexFids.append( fid );
+  out.tessellator->addPolygon( *polyClone, extrusionHeight );
+  delete polyClone;
 }
 
 void QgsPolygon3DSymbolHandler::processFeature( QgsFeature &f, const Qgs3DRenderContext &context )
@@ -144,7 +153,7 @@ void QgsPolygon3DSymbolHandler::processFeature( QgsFeature &f, const Qgs3DRender
   if ( const QgsPolygon *poly = qgsgeometry_cast< const QgsPolygon *>( g ) )
   {
     QgsPolygon *polyClone = poly->clone();
-    processPolygon( polyClone, f.id(), height, hasDDExtrusion, extrusionHeight, context, out );
+    processPolygon( polyClone, f.id(), height, extrusionHeight, context, out );
   }
   else if ( const QgsMultiPolygon *mpoly = qgsgeometry_cast< const QgsMultiPolygon *>( g ) )
   {
@@ -153,7 +162,7 @@ void QgsPolygon3DSymbolHandler::processFeature( QgsFeature &f, const Qgs3DRender
       const QgsAbstractGeometry *g2 = mpoly->geometryN( i );
       Q_ASSERT( QgsWkbTypes::flatType( g2->wkbType() ) == QgsWkbTypes::Polygon );
       QgsPolygon *polyClone = static_cast< const QgsPolygon *>( g2 )->clone();
-      processPolygon( polyClone, f.id(), height, hasDDExtrusion, extrusionHeight, context, out );
+      processPolygon( polyClone, f.id(), height, extrusionHeight, context, out );
     }
   }
   else if ( const QgsGeometryCollection *gc = qgsgeometry_cast< const QgsGeometryCollection *>( g ) )
@@ -164,7 +173,7 @@ void QgsPolygon3DSymbolHandler::processFeature( QgsFeature &f, const Qgs3DRender
       if ( QgsWkbTypes::flatType( g2->wkbType() ) == QgsWkbTypes::Polygon )
       {
         QgsPolygon *polyClone = static_cast< const QgsPolygon *>( g2 )->clone();
-        processPolygon( polyClone, f.id(), height, hasDDExtrusion, extrusionHeight, context, out );
+        processPolygon( polyClone, f.id(), height, extrusionHeight, context, out );
       }
     }
   }
@@ -206,7 +215,7 @@ void QgsPolygon3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qgs3D
 
 void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PolygonData &out, bool selected )
 {
-  if ( out.polygons.isEmpty() )
+  if ( !out.tessellator->dataVerticesCount() )
     return;  // nothing to show - no need to create the entity
 
   Qt3DExtras::QPhongMaterial *mat = material( mSymbol );
@@ -217,11 +226,14 @@ void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs
     mat->setAmbient( context.map().selectionColor().darker() );
   }
 
-  QgsPointXY origin( context.map().origin().x(), context.map().origin().y() );
+  // extract vertex buffer data from tessellator
+  QByteArray data( ( const char * )out.tessellator->data().constData(), out.tessellator->data().count() * sizeof( float ) );
+  int nVerts = data.count() / out.tessellator->stride();
+
   QgsTessellatedPolygonGeometry *geometry = new QgsTessellatedPolygonGeometry;
   geometry->setInvertNormals( mSymbol.invertNormals() );
   geometry->setAddBackFaces( mSymbol.addBackFaces() );
-  geometry->setPolygons( out.polygons, out.fids, origin, mSymbol.extrusionHeight(), out.extrusionHeightPerPolygon );
+  geometry->setData( data, nVerts, out.triangleIndexFids, out.triangleIndexStartingIndices );
 
   Qt3DRender::QGeometryRenderer *renderer = new Qt3DRender::QGeometryRenderer;
   renderer->setGeometry( geometry );

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -37,8 +37,6 @@
 
 /// @cond PRIVATE
 
-class QgsTessellator;
-
 
 class QgsPolygon3DSymbolHandler : public QgsFeature3DHandler
 {
@@ -218,7 +216,7 @@ void QgsPolygon3DSymbolHandler::finalize( Qt3DCore::QEntity *parent, const Qgs3D
 
 void QgsPolygon3DSymbolHandler::makeEntity( Qt3DCore::QEntity *parent, const Qgs3DRenderContext &context, PolygonData &out, bool selected )
 {
-  if ( !out.tessellator->dataVerticesCount() )
+  if ( out.tessellator->dataVerticesCount() == 0 )
     return;  // nothing to show - no need to create the entity
 
   Qt3DExtras::QPhongMaterial *mat = material( mSymbol );

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -57,7 +57,12 @@ Qgs3DMapCanvas::Qgs3DMapCanvas( QWidget *parent )
 
 Qgs3DMapCanvas::~Qgs3DMapCanvas()
 {
+  // make sure the scene is deleted while map settings object is still alive
+  delete mScene;
+  mScene = nullptr;
+
   delete mMap;
+  mMap = nullptr;
 }
 
 void Qgs3DMapCanvas::resizeEvent( QResizeEvent *ev )

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -141,7 +141,7 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
 
   setWidget( contentsWidget );
 
-  onTerrainPendingJobsCountChanged();
+  onTotalPendingJobsCountChanged();
 }
 
 void Qgs3DMapCanvasDockWidget::saveAsImage()
@@ -206,7 +206,7 @@ void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )
 {
   mCanvas->setMap( map );
 
-  connect( mCanvas->scene(), &Qgs3DMapScene::terrainPendingJobsCountChanged, this, &Qgs3DMapCanvasDockWidget::onTerrainPendingJobsCountChanged );
+  connect( mCanvas->scene(), &Qgs3DMapScene::totalPendingJobsCountChanged, this, &Qgs3DMapCanvasDockWidget::onTotalPendingJobsCountChanged );
 
   mAnimationWidget->setCameraController( mCanvas->scene()->cameraController() );
   mAnimationWidget->setMap( map );
@@ -278,9 +278,9 @@ void Qgs3DMapCanvasDockWidget::onMainCanvasColorChanged()
   mCanvas->map()->setBackgroundColor( mMainCanvas->canvasColor() );
 }
 
-void Qgs3DMapCanvasDockWidget::onTerrainPendingJobsCountChanged()
+void Qgs3DMapCanvasDockWidget::onTotalPendingJobsCountChanged()
 {
-  int count = mCanvas->scene() ? mCanvas->scene()->terrainPendingJobsCount() : 0;
+  int count = mCanvas->scene() ? mCanvas->scene()->totalPendingJobsCount() : 0;
   mProgressPendingJobs->setVisible( count );
   mLabelPendingJobs->setVisible( count );
   if ( count )

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -57,7 +57,7 @@ class Qgs3DMapCanvasDockWidget : public QgsDockWidget
 
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();
-    void onTerrainPendingJobsCountChanged();
+    void onTotalPendingJobsCountChanged();
 
   private:
     Qgs3DMapCanvas *mCanvas = nullptr;

--- a/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
+++ b/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
@@ -22,17 +22,20 @@ QgsVectorLayer3DPropertiesWidget::QgsVectorLayer3DPropertiesWidget( QWidget *par
 {
   setupUi( this );
 
+  connect( chkShowBoundingBoxes, &QCheckBox::clicked, this, &QgsVectorLayer3DPropertiesWidget::changed );
   connect( spinZoomLevelsCount, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsVectorLayer3DPropertiesWidget::changed );
 }
 
 void QgsVectorLayer3DPropertiesWidget::load( QgsAbstractVectorLayer3DRenderer *renderer )
 {
   whileBlocking( spinZoomLevelsCount )->setValue( renderer->tilingSettings().zoomLevelsCount() );
+  whileBlocking( chkShowBoundingBoxes )->setChecked( renderer->tilingSettings().showBoundingBoxes() );
 }
 
 void QgsVectorLayer3DPropertiesWidget::apply( QgsAbstractVectorLayer3DRenderer *renderer )
 {
   QgsVectorLayer3DTilingSettings tilingSettings;
   tilingSettings.setZoomLevelsCount( spinZoomLevelsCount->value() );
+  tilingSettings.setShowBoundingBoxes( chkShowBoundingBoxes->isChecked() );
   renderer->setTilingSettings( tilingSettings );
 }

--- a/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
+++ b/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
@@ -22,6 +22,8 @@ QgsVectorLayer3DPropertiesWidget::QgsVectorLayer3DPropertiesWidget( QWidget *par
 {
   setupUi( this );
 
+  groupLayerRendering->setCollapsed( true );
+
   connect( chkShowBoundingBoxes, &QCheckBox::clicked, this, &QgsVectorLayer3DPropertiesWidget::changed );
   connect( spinZoomLevelsCount, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsVectorLayer3DPropertiesWidget::changed );
 }

--- a/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
+++ b/src/app/3d/qgsvectorlayer3dpropertieswidget.cpp
@@ -1,0 +1,38 @@
+/***************************************************************************
+  qgsvectorlayer3dpropertieswidget.cpp
+  --------------------------------------
+  Date                 : January 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectorlayer3dpropertieswidget.h"
+
+#include "qgsabstractvectorlayer3drenderer.h"
+
+QgsVectorLayer3DPropertiesWidget::QgsVectorLayer3DPropertiesWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+
+  connect( spinZoomLevelsCount, qgis::overload<int>::of( &QSpinBox::valueChanged ), this, &QgsVectorLayer3DPropertiesWidget::changed );
+}
+
+void QgsVectorLayer3DPropertiesWidget::load( QgsAbstractVectorLayer3DRenderer *renderer )
+{
+  whileBlocking( spinZoomLevelsCount )->setValue( renderer->tilingSettings().zoomLevelsCount() );
+}
+
+void QgsVectorLayer3DPropertiesWidget::apply( QgsAbstractVectorLayer3DRenderer *renderer )
+{
+  QgsVectorLayer3DTilingSettings tilingSettings;
+  tilingSettings.setZoomLevelsCount( spinZoomLevelsCount->value() );
+  renderer->setTilingSettings( tilingSettings );
+}

--- a/src/app/3d/qgsvectorlayer3dpropertieswidget.h
+++ b/src/app/3d/qgsvectorlayer3dpropertieswidget.h
@@ -35,7 +35,7 @@ class QgsVectorLayer3DPropertiesWidget : public QWidget, private Ui::QgsVectorLa
     void apply( QgsAbstractVectorLayer3DRenderer *renderer );
 
   signals:
-    //! Emitted whenever any paramater gets changed
+    //! Emitted whenever any parameter gets changed
     void changed();
 };
 

--- a/src/app/3d/qgsvectorlayer3dpropertieswidget.h
+++ b/src/app/3d/qgsvectorlayer3dpropertieswidget.h
@@ -1,0 +1,42 @@
+/***************************************************************************
+  qgsvectorlayer3dpropertieswidget.h
+  --------------------------------------
+  Date                 : January 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORLAYER3DPROPERTIESWIDGET_H
+#define QGSVECTORLAYER3DPROPERTIESWIDGET_H
+
+#include <QWidget>
+
+#include "ui_qgsvectorlayer3dpropertieswidget.h"
+
+class QgsAbstractVectorLayer3DRenderer;
+
+
+class QgsVectorLayer3DPropertiesWidget : public QWidget, private Ui::QgsVectorLayer3DPropertiesWidget
+{
+    Q_OBJECT
+  public:
+    QgsVectorLayer3DPropertiesWidget( QWidget *parent = nullptr );
+
+    //! Initializes GUI from the given renderer
+    void load( QgsAbstractVectorLayer3DRenderer *renderer );
+    //! Applies configuration from GUI to the given renderer
+    void apply( QgsAbstractVectorLayer3DRenderer *renderer );
+
+  signals:
+    //! Emitted whenever any paramater gets changed
+    void changed();
+};
+
+#endif // QGSVECTORLAYER3DPROPERTIESWIDGET_H

--- a/src/app/3d/qgsvectorlayer3drendererwidget.h
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.h
@@ -31,6 +31,7 @@ class QgsMapCanvas;
 
 class QgsRuleBased3DRendererWidget;
 class QgsSymbol3DWidget;
+class QgsVectorLayer3DPropertiesWidget;
 
 
 class QgsSingleSymbol3DRendererWidget : public QWidget
@@ -78,6 +79,7 @@ class QgsVectorLayer3DRendererWidget : public QgsMapLayerConfigWidget
   private:
     QComboBox *cboRendererType = nullptr;
     QStackedWidget *widgetRendererStack = nullptr;
+    QgsVectorLayer3DPropertiesWidget *widgetBaseProperties = nullptr;
 
     QLabel *widgetNoRenderer = nullptr;
     QgsSingleSymbol3DRendererWidget *widgetSingleSymbolRenderer = nullptr;

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -283,6 +283,7 @@ IF (WITH_3D)
     3d/qgsphongmaterialwidget.cpp
     3d/qgsrulebased3drendererwidget.cpp
     3d/qgssymbol3dwidget.cpp
+    3d/qgsvectorlayer3dpropertieswidget.cpp
     3d/qgsvectorlayer3drendererwidget.cpp
     3d/qgsmeshlayer3drendererwidget.cpp
     layout/qgslayout3dmapwidget.cpp

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -75,6 +75,18 @@ class CORE_EXPORT QgsTessellator
      */
     std::unique_ptr< QgsMultiPolygon > asMultiPolygon() const SIP_SKIP;
 
+    /**
+     * Returns minimal Z value of the data (in world coordinates)
+     * \since QGIS 3.12
+     */
+    float zMinimum() const { return mZMin; }
+
+    /**
+     * Returns maximal Z value of the data (in world coordinates)
+     * \since QGIS 3.12
+     */
+    float zMaximum() const { return mZMax; }
+
   private:
     void init();
 
@@ -86,6 +98,9 @@ class CORE_EXPORT QgsTessellator
     QVector<float> mData;
     int mStride;
     bool mNoZ = false;
+
+    float mZMin = std::numeric_limits<float>::max();
+    float mZMax = std::numeric_limits<float>::min();
 };
 
 #endif // QGSTESSELLATOR_H

--- a/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
+++ b/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
@@ -6,47 +6,64 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>539</width>
-    <height>145</height>
+    <width>673</width>
+    <height>280</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Zoom levels count</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="spinZoomLevelsCount">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>5</number>
-       </property>
-       <property name="value">
-        <number>3</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="chkShowBoundingBoxes">
-     <property name="text">
-      <string>Show bounding boxes of tiles</string>
+    <widget class="QgsCollapsibleGroupBox" name="groupLayerRendering">
+     <property name="title">
+      <string>Layer Rendering</string>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Zoom levels count</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinZoomLevelsCount">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>5</number>
+          </property>
+          <property name="value">
+           <number>3</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkShowBoundingBoxes">
+        <property name="text">
+         <string>Show bounding boxes of tiles</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
+++ b/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
@@ -29,7 +29,7 @@
         <number>1</number>
        </property>
        <property name="maximum">
-        <number>8</number>
+        <number>5</number>
        </property>
        <property name="value">
         <number>3</number>

--- a/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
+++ b/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorLayer3DPropertiesWidget</class>
+ <widget class="QWidget" name="QgsVectorLayer3DPropertiesWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>539</width>
+    <height>90</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Zoom levels count</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinZoomLevelsCount">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>8</number>
+       </property>
+       <property name="value">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
+++ b/src/ui/3d/qgsvectorlayer3dpropertieswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>539</width>
-    <height>90</height>
+    <height>145</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,6 +37,13 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="chkShowBoundingBoxes">
+     <property name="text">
+      <string>Show bounding boxes of tiles</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -518,13 +518,13 @@ void TestQgs3DRendering::testAnimationExport()
 
 void TestQgs3DRendering::testBillboardRendering()
 {
-  QgsRectangle fullExtent( 0, 0, 1000, 1000 );
+  QgsRectangle fullExtent( 1000, 1000, 2000, 2000 );
 
   std::unique_ptr<QgsVectorLayer> layerPointsZ( new QgsVectorLayer( "PointZ?crs=EPSG:27700", "points Z", "memory" ) );
 
-  QgsPoint *p1 = new QgsPoint( 0, 0, 50 );
-  QgsPoint *p2 = new QgsPoint( 0, 1000, 100 );
-  QgsPoint *p3 = new QgsPoint( 1000, 1000, 200 );
+  QgsPoint *p1 = new QgsPoint( 1000, 1000, 50 );
+  QgsPoint *p2 = new QgsPoint( 1000, 2000, 100 );
+  QgsPoint *p3 = new QgsPoint( 2000, 2000, 200 );
 
   QgsFeature f1( layerPointsZ->fields() );
   QgsFeature f2( layerPointsZ->fields() );

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -453,8 +453,14 @@ void TestQgs3DRendering::testRuleBasedRenderer()
   engine.setRootEntity( scene );
 
   scene->cameraController()->setLookingAtPoint( QgsVector3D( 0, 0, 250 ), 500, 45, 0 );
-  QImage img = Qgs3DUtils::captureSceneImage( engine, scene );
 
+  // When running the test, it would sometimes return partially rendered image.
+  // It is probably based on how fast qt3d manages to upload the data to GPU...
+  // Capturing the initial image and throwing it away fixes that. Hopefully we will
+  // find a better fix in the future.
+  Qgs3DUtils::captureSceneImage( engine, scene );
+
+  QImage img = Qgs3DUtils::captureSceneImage( engine, scene );
   QVERIFY( renderCheck( "rulebased", img, 40 ) );
 }
 

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -138,6 +138,7 @@ class TestQgsTessellator : public QObject
     void testCrashEmptyPolygon();
     void testBoundsScaling();
     void testNoZ();
+    void testTriangulationDoesNotCrash();
 
   private:
 };
@@ -384,6 +385,16 @@ void TestQgsTessellator::testNoZ()
   QgsTessellator t( polygonZ.boundingBox(), false, false, false, true );
   t.addPolygon( polygonZ, 0 );
   QVERIFY( checkTriangleOutput( t.data(), false, tc ) );
+}
+
+void TestQgsTessellator::testTriangulationDoesNotCrash()
+{
+  // a commit in poly2tri has caused a crashing regression - https://github.com/jhasse/poly2tri/issues/11
+  // this code only makes sure that the crash does not come back during another update of poly2tri
+  QgsPolygon polygon;
+  polygon.fromWkt( "Polygon((0 0, -5 -3e-10, -10 -2e-10, -10 -4, 0 -4))" );
+  QgsTessellator t( 0, 0, true );
+  t.addPolygon( polygon, 0 );
 }
 
 


### PR DESCRIPTION
This adds support for background loading of data from vector layers into 3D map views. Until now, loading (and tessellation) would freeze the GUI completely - this could take many seconds depending on the complexity of input data.

The basic vector layer renderer and rule-based renderer were converted to use QgsChunkedEntity which is already used for terrain rendering. There are two more improvements in addition to unlocking of GUI:
- loading process is multi-threaded instead of using just a single core
- loading is done in tiles - so it is possible to see the tiles with 3D data appearing while other data are still being loaded

There is a new configuration option in 3D tab of vector layers - it determines how deep will be the quadtree. For example, one zoom level means there will be a single tile for the whole layer. Three zoom levels means there will be 16 tiles at the leaf level (every extra zoom level multiplies that by 4, so I have limited GUI to max. 8 levels which gives ~16K tiles which is already a lot).

How a vector layer's tiling quadtree gets populated: all internal tree nodes are empty and thus the 3D map scene tries to immediately replace them with their children - this goes until leaf nodes are reached. Only nodes at the leaf level currently hold any data. This may change in the feature when we introduce more elaborate strategies - for example, internal nodes may contain a small percentage of features of the child nodes (this would allow us to show something while zoomed out a lot, not requiring to load all data).

For debugging purposes, there is also a new configuration option "show bounding boxes". This allows you to see bounding box of each tile (especially useful if there are some issues with tiles not showing up when they should).

This work has been sponsored by a QGIS.org grant.