### PR TITLE
Allow dropping a map layer from the layer tree onto a projection selection widget 

### DIFF
--- a/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
@@ -119,6 +119,15 @@ to the preset CRSes shown in the widget.
 Opens the dialog for selecting a new CRS
 %End
 
+  protected:
+
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+    virtual void dragLeaveEvent( QDragLeaveEvent *event );
+
+    virtual void dropEvent( QDropEvent *event );
+
+
 };
 
 /************************************************************************

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -316,6 +316,7 @@ SET(QGIS_GUI_SRCS
   qgsgui.cpp
   qgsguiutils.cpp
   qgshighlight.cpp
+  qgshighlightablecombobox.cpp
   qgshistogramwidget.cpp
   qgshelp.cpp
   qgsidentifymenu.cpp
@@ -518,6 +519,7 @@ SET(QGIS_GUI_HDRS
   qgsguiutils.h
   qgshelp.h
   qgshighlight.h
+  qgshighlightablecombobox.h
   qgshistogramwidget.h
   qgsidentifymenu.h
   qgskeyvaluewidget.h

--- a/src/gui/qgshighlightablecombobox.cpp
+++ b/src/gui/qgshighlightablecombobox.cpp
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgshighlightablecombobox.cpp
+     ---------------------------
+    Date                 : 20/12/2019
+    Copyright            : (C) 2019 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgshighlightablecombobox.h"
+#include <QPainter>
+
+QgsHighlightableComboBox::QgsHighlightableComboBox( QWidget *parent )
+  : QComboBox( parent )
+{}
+
+void QgsHighlightableComboBox::paintEvent( QPaintEvent *e )
+{
+  QComboBox::paintEvent( e );
+  if ( mHighlight )
+  {
+    QPainter p( this );
+    int width = 2;  // width of highlight rectangle inside frame
+    p.setPen( QPen( palette().highlight(), width ) );
+    QRect r = rect().adjusted( width, width, -width, -width );
+    p.drawRect( r );
+  }
+}
+
+void QgsHighlightableComboBox::setHighlighted( bool highlighted )
+{
+  mHighlight = highlighted;
+  update();
+}

--- a/src/gui/qgshighlightablecombobox.h
+++ b/src/gui/qgshighlightablecombobox.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+    qgshighlightablecombobox.h
+     -------------------------
+    Date                 : 20/12/2019
+    Copyright            : (C) 2019 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSHIGHLIGHTABLECOMBOBOX_H
+#define QGSHIGHLIGHTABLECOMBOBOX_H
+
+#include <QComboBox>
+
+#include "qgscoordinatereferencesystem.h"
+#include "qgis_gui.h"
+
+#define SIP_NO_FILE
+
+/**
+ * \class QgsHighlightableComboBox
+ * \ingroup gui
+ *
+ * A QComboBox subclass with the ability to "highlight" the edges of the widget.
+ *
+ * \since QGIS 3.12
+ */
+class GUI_EXPORT QgsHighlightableComboBox : public QComboBox
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for QgsHighlightableComboBox with the specified parent widget.
+     */
+    QgsHighlightableComboBox( QWidget *parent = nullptr );
+
+    /**
+     * Returns TRUE if the combo box is currently highlighted.
+     * \see setHighlighted()
+     */
+    bool isHighlighted() const { return mHighlight; }
+
+    /**
+     * Sets whether the combo box is currently \a highlighted.
+     * \see isHighlighted()
+     */
+    void setHighlighted( bool highlighted );
+
+  protected:
+    void paintEvent( QPaintEvent *e ) override;
+
+  private:
+
+    bool mHighlight = false;
+
+};
+
+#endif // QGSHIGHLIGHTABLECOMBOBOX_H

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -27,6 +27,7 @@
 #include "qgis_gui.h"
 
 class QgsProjectionSelectionDialog;
+class QgsHighlightableComboBox;
 
 /**
  * \class QgsProjectionSelectionWidget
@@ -132,13 +133,19 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      */
     void selectCrs();
 
+  protected:
+
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dragLeaveEvent( QDragLeaveEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
+
   private:
 
     QgsCoordinateReferenceSystem mCrs;
     QgsCoordinateReferenceSystem mLayerCrs;
     QgsCoordinateReferenceSystem mProjectCrs;
     QgsCoordinateReferenceSystem mDefaultCrs;
-    QComboBox *mCrsComboBox = nullptr;
+    QgsHighlightableComboBox *mCrsComboBox = nullptr;
     QToolButton *mButton = nullptr;
     QgsProjectionSelectionDialog *mDialog = nullptr;
     QString mNotSetText;
@@ -154,6 +161,8 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
 
     int firstRecentCrsIndex() const;
     void updateTooltip();
+
+    QgsMapLayer *mapLayerFromMimeData( const QMimeData *data ) const;
 
   private slots:
 


### PR DESCRIPTION
...to set the projection to match that layer. Just a little timesaving shortcut!

![Peek 2019-12-20 11-27](https://user-images.githubusercontent.com/1829991/71222288-b7070080-231b-11ea-89f4-af856dece4c3.gif)
