### PR TITLE
[server][windows] Fix crash on startup

### DIFF
--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -140,8 +140,6 @@ class SERVER_EXPORT QgsServer
     //! service registry
     static QgsServiceRegistry *sServiceRegistry;
 
-    static QgsServerSettings sSettings;
-
     //! cache
     QgsConfigCache *mConfigCache = nullptr;
 


### PR DESCRIPTION
QGIS server crashes on startup on windows on loading meta enums. Presumably because  QgsServerSettings gets instantiated before the whole QObject (QApplication?) machinery is initialized.

I don't know what originally triggered the issue (it must have been after QGIS server 3.10, because this one runs fine)
And I am also unsure why the same issue is not triggered on Linux.

And is cleaner anyway