### PR TITLE
Make label engine project settings dialog open as an inline panel

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -809,6 +809,7 @@
         <file>themes/default/mActionHandleStoreFilterExpressionUnchecked.svg</file>
         <file>themes/default/stacked-bar.svg</file>
         <file>themes/default/mIconHtml.svg</file>
+        <file>themes/default/mIconHamburgerMenu.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mIconHamburgerMenu.svg
+++ b/images/themes/default/mIconHamburgerMenu.svg
@@ -1,0 +1,1 @@
+<svg height="100" width="100" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1"><path d="M80 28H20a3 3 0 010-6h60a3 3 0 010 6zM80 53H20a3 3 0 010-6h60a3 3 0 010 6zM80 78H20a3 3 0 010-6h60a3 3 0 010 6z"/></svg>

--- a/python/gui/auto_generated/qgspanelwidget.sip.in
+++ b/python/gui/auto_generated/qgspanelwidget.sip.in
@@ -7,6 +7,7 @@
  ************************************************************************/
 
 
+
 class QgsPanelWidget : QWidget
 {
 %Docstring
@@ -104,6 +105,23 @@ widget.
 :return: parent panel widget if found, otherwise ``None``
 
 .. versionadded:: 3.0
+%End
+
+    virtual QString menuButtonTooltip() const;
+%Docstring
+Returns the (translated) tooltip text to use for the menu button for this panel.
+
+This is only used when the panel returns a menuButtonMenu().
+
+.. versionadded:: 3.12
+%End
+
+    virtual QMenu *menuButtonMenu();
+%Docstring
+Returns the menu to use for the menu button for this panel, or ``None`` if
+no menu button is required.
+
+.. versionadded:: 3.12
 %End
 
   signals:

--- a/src/app/labeling/qgslabelengineconfigdialog.cpp
+++ b/src/app/labeling/qgslabelengineconfigdialog.cpp
@@ -22,6 +22,7 @@
 #include "qgisapp.h"
 #include "qgsmapcanvas.h"
 #include "qgsgui.h"
+#include "qgsapplication.h"
 #include <QPushButton>
 #include <QMessageBox>
 
@@ -83,6 +84,24 @@ QgsLabelEngineConfigWidget::QgsLabelEngineConfigWidget( QWidget *parent )
   connect( mTextRenderFormatComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsLabelEngineConfigWidget::widgetChanged );
   connect( mUnplacedColorButton, &QgsColorButton::colorChanged, this, &QgsLabelEngineConfigWidget::widgetChanged );
   connect( mPlacementVersionComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &QgsLabelEngineConfigWidget::widgetChanged );
+
+  mWidgetMenu = new QMenu( this );
+  QAction *resetAction = new QAction( tr( "Restore Defaults" ), this );
+  mWidgetMenu->addAction( resetAction );
+  connect( resetAction, &QAction::triggered, this, &QgsLabelEngineConfigWidget::setDefaults );
+  QAction *helpAction = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionHelpContents.svg" ) ), tr( "Help…" ), this );
+  mWidgetMenu->addAction( helpAction );
+  connect( helpAction, &QAction::triggered, this, &QgsLabelEngineConfigWidget::showHelp );
+}
+
+QMenu *QgsLabelEngineConfigWidget::menuButtonMenu()
+{
+  return mWidgetMenu;
+}
+
+QString QgsLabelEngineConfigWidget::menuButtonTooltip() const
+{
+  return tr( "Additional Options" );
 }
 
 void QgsLabelEngineConfigWidget::apply()

--- a/src/app/labeling/qgslabelengineconfigdialog.h
+++ b/src/app/labeling/qgslabelengineconfigdialog.h
@@ -23,24 +23,35 @@
 
 class QgsMessageBar;
 
-class APP_EXPORT QgsLabelEngineConfigDialog : public QDialog, private Ui::QgsLabelEngineConfigDialog
+class APP_EXPORT QgsLabelEngineConfigWidget : public QgsPanelWidget, private Ui::QgsLabelEngineConfigDialog
 {
     Q_OBJECT
   public:
-    QgsLabelEngineConfigDialog( QWidget *parent = nullptr );
+    QgsLabelEngineConfigWidget( QWidget *parent = nullptr );
 
   public slots:
-    void onOK();
+    void apply();
     void setDefaults();
-
-
-  private slots:
     void showHelp();
 
   private:
     QgsMessageBar *mMessageBar = nullptr;
 
     QgsLabelingEngineSettings::PlacementEngineVersion mPreviousEngineVersion = QgsLabelingEngineSettings::PlacementEngineVersion2;
+};
+
+class APP_EXPORT QgsLabelEngineConfigDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+
+    QgsLabelEngineConfigDialog( QWidget *parent = nullptr );
+
+    void accept() override;
+  private:
+    QgsLabelEngineConfigWidget *mWidget = nullptr;
+
 };
 
 #endif // QGSLABELENGINECONFIGDIALOG_H

--- a/src/app/labeling/qgslabelengineconfigdialog.h
+++ b/src/app/labeling/qgslabelengineconfigdialog.h
@@ -29,6 +29,9 @@ class APP_EXPORT QgsLabelEngineConfigWidget : public QgsPanelWidget, private Ui:
   public:
     QgsLabelEngineConfigWidget( QWidget *parent = nullptr );
 
+    QMenu *menuButtonMenu() override;
+    QString menuButtonTooltip() const override;
+
   public slots:
     void apply();
     void setDefaults();
@@ -36,6 +39,7 @@ class APP_EXPORT QgsLabelEngineConfigWidget : public QgsPanelWidget, private Ui:
 
   private:
     QgsMessageBar *mMessageBar = nullptr;
+    QMenu *mWidgetMenu = nullptr;
 
     QgsLabelingEngineSettings::PlacementEngineVersion mPreviousEngineVersion = QgsLabelingEngineSettings::PlacementEngineVersion2;
 };

--- a/src/app/labeling/qgslabelingwidget.cpp
+++ b/src/app/labeling/qgslabelingwidget.cpp
@@ -280,7 +280,18 @@ void QgsLabelingWidget::labelModeChanged( int index )
 
 void QgsLabelingWidget::showEngineConfigDialog()
 {
-  QgsLabelEngineConfigDialog dlg( this );
-  dlg.exec();
-  emit widgetChanged();
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsLabelEngineConfigWidget *widget = new QgsLabelEngineConfigWidget();
+    connect( widget, &QgsLabelEngineConfigWidget::widgetChanged, widget, &QgsLabelEngineConfigWidget::apply );
+    panel->openPanel( widget );
+  }
+  else
+  {
+    QgsLabelEngineConfigDialog dialog( this );
+    dialog.exec();
+    // reactivate button's window
+    activateWindow();
+  }
 }

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -752,8 +752,20 @@ void QgsDiagramProperties::mDiagramAttributesTreeWidget_itemDoubleClicked( QTree
 
 void QgsDiagramProperties::mEngineSettingsButton_clicked()
 {
-  QgsLabelEngineConfigDialog dlg( this );
-  dlg.exec();
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsLabelEngineConfigWidget *widget = new QgsLabelEngineConfigWidget();
+    connect( widget, &QgsLabelEngineConfigWidget::widgetChanged, widget, &QgsLabelEngineConfigWidget::apply );
+    panel->openPanel( widget );
+  }
+  else
+  {
+    QgsLabelEngineConfigDialog dialog( this );
+    dialog.exec();
+    // reactivate button's window
+    activateWindow();
+  }
 }
 
 void QgsDiagramProperties::apply()

--- a/src/gui/qgspanelwidget.cpp
+++ b/src/gui/qgspanelwidget.cpp
@@ -66,6 +66,16 @@ QgsPanelWidget *QgsPanelWidget::findParentPanel( QWidget *widget )
   return nullptr;
 }
 
+QString QgsPanelWidget::menuButtonTooltip() const
+{
+  return QString();
+}
+
+QMenu *QgsPanelWidget::menuButtonMenu()
+{
+  return nullptr;
+}
+
 void QgsPanelWidget::openPanel( QgsPanelWidget *panel )
 {
   //panel dock mode inherits from this panel

--- a/src/gui/qgspanelwidget.h
+++ b/src/gui/qgspanelwidget.h
@@ -20,6 +20,8 @@
 #include <QStack>
 #include "qgis_gui.h"
 
+class QMenu;
+
 /**
  * \ingroup gui
  * \brief Base class for any widget that can be shown as a inline panel
@@ -104,6 +106,23 @@ class GUI_EXPORT QgsPanelWidget : public QWidget
      * \since QGIS 3.0
      */
     static QgsPanelWidget *findParentPanel( QWidget *widget );
+
+    /**
+     * Returns the (translated) tooltip text to use for the menu button for this panel.
+     *
+     * This is only used when the panel returns a menuButtonMenu().
+     *
+     * \since QGIS 3.12
+     */
+    virtual QString menuButtonTooltip() const;
+
+    /**
+     * Returns the menu to use for the menu button for this panel, or NULLPTR if
+     * no menu button is required.
+     *
+     * \since QGIS 3.12
+     */
+    virtual QMenu *menuButtonMenu();
 
   signals:
 

--- a/src/gui/qgspanelwidgetstack.cpp
+++ b/src/gui/qgspanelwidgetstack.cpp
@@ -29,7 +29,9 @@ QgsPanelWidgetStack::QgsPanelWidgetStack( QWidget *parent )
   setupUi( this );
   clear();
 
-  connect( mBackButton, &QAbstractButton::pressed, this, &QgsPanelWidgetStack::acceptCurrentPanel );
+  connect( mBackButton, &QAbstractButton::clicked, this, &QgsPanelWidgetStack::acceptCurrentPanel );
+
+  mMenuButton->setStyleSheet( QStringLiteral( "QToolButton::menu-indicator { image: none; }" ) );
 }
 
 void QgsPanelWidgetStack::setMainPanel( QgsPanelWidget *panel )
@@ -79,6 +81,7 @@ void QgsPanelWidgetStack::clear()
   mTitles.clear();
   mTitleText->hide();
   mBackButton->hide();
+  mMenuButton->hide();
   this->updateBreadcrumb();
 }
 
@@ -126,7 +129,8 @@ void QgsPanelWidgetStack::showPanel( QgsPanelWidget *panel )
   mBackButton->show();
   mTitleText->show();
 
-  this->updateBreadcrumb();
+  updateMenuButton();
+  updateBreadcrumb();
 }
 
 void QgsPanelWidgetStack::closePanel( QgsPanelWidget *panel )
@@ -143,6 +147,11 @@ void QgsPanelWidgetStack::closePanel( QgsPanelWidget *panel )
   {
     mBackButton->hide();
     mTitleText->hide();
+    mMenuButton->hide();
+  }
+  else
+  {
+    updateMenuButton();
   }
   this->updateBreadcrumb();
 }
@@ -174,4 +183,18 @@ void QgsPanelWidgetStack::updateBreadcrumb()
   // Remove the last
   breadcrumb.chop( 1 );
   mTitleText->setText( breadcrumb );
+}
+
+void QgsPanelWidgetStack::updateMenuButton()
+{
+  if ( QMenu *menu = currentPanel()->menuButtonMenu() )
+  {
+    mMenuButton->setVisible( true );
+    mMenuButton->setToolTip( currentPanel()->menuButtonTooltip() );
+    mMenuButton->setMenu( menu );
+  }
+  else
+  {
+    mMenuButton->setVisible( false );
+  }
 }

--- a/src/gui/qgspanelwidgetstack.h
+++ b/src/gui/qgspanelwidgetstack.h
@@ -130,6 +130,7 @@ class GUI_EXPORT QgsPanelWidgetStack : public QWidget, private Ui::QgsRendererWi
 
   private:
     void updateBreadcrumb();
+    void updateMenuButton();
     QStack<QString> mTitles;
 };
 

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -39,6 +39,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMessageBox>
+#include <QPushButton>
 
 /// @cond PRIVATE
 ///

--- a/src/gui/symbology/qgsrendererpropertiesdialog.cpp
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.cpp
@@ -316,15 +316,12 @@ void QgsRendererPropertiesDialog::onOK()
 
 void QgsRendererPropertiesDialog::openPanel( QgsPanelWidget *panel )
 {
-  QgsDebugMsg( QStringLiteral( "Open panel!!!" ) );
   if ( mDockMode )
   {
-    QgsDebugMsg( QStringLiteral( "DOCK MODE" ) );
     emit showPanel( panel );
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "DIALOG MODE" ) );
     // Show the dialog version if no one is connected
     QDialog *dlg = new QDialog();
     QString key = QStringLiteral( "/UI/paneldialog/%1" ).arg( panel->panelTitle() );

--- a/src/ui/labeling/qgslabelengineconfigdialog.ui
+++ b/src/ui/labeling/qgslabelengineconfigdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>QgsLabelEngineConfigDialog</class>
- <widget class="QDialog" name="QgsLabelEngineConfigDialog">
+ <widget class="QgsPanelWidget" name="QgsLabelEngineConfigDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -47,7 +47,7 @@
         </size>
        </property>
        <property name="title">
-        <string>Number of candidates</string>
+        <string>Number of Candidates</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
@@ -271,16 +271,6 @@
      </property>
     </spacer>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -288,6 +278,12 @@
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -303,22 +299,5 @@
   <tabstop>chkShowCandidates</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsLabelEngineConfigDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/ui/styledock/qgsrenderercontainerbase.ui
+++ b/src/ui/styledock/qgsrenderercontainerbase.ui
@@ -20,7 +20,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="mBackButton">
+      <widget class="QToolButton" name="mBackButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -40,6 +40,9 @@
        <property name="autoRepeat">
         <bool>false</bool>
        </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
+       </property>
       </widget>
      </item>
      <item>
@@ -52,6 +55,32 @@
        </property>
        <property name="text">
         <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mMenuButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Go back</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>:/images/themes/default/mIconHamburgerMenu.svg</normaloff>:/images/themes/default/mIconHamburgerMenu.svg</iconset>
+       </property>
+       <property name="autoRepeat">
+        <bool>false</bool>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Means that you can get instant feedback on changes without having to close the dialog and refresh the map

Also adds the api to allow panel widgets to show a "hamburger" style menu in the top right, giving them a place to add actions for Help and similar actions.

(deliberately no needs-docs tags here, I don't think the changes warrant documentation)