### PR TITLE
[pal] Scale coordinates stored in pal rtrees to full float ranges

### DIFF
--- a/src/core/pal/palrtree.h
+++ b/src/core/pal/palrtree.h
@@ -36,6 +36,20 @@ class PalRtree : public RTree<T *, float, 2, float>
   public:
 
     /**
+     * Constructor for PalRtree. The \a maxBounds argument specifies the maximum bounding box
+     * for all coordinates which will be stored in the index.
+     */
+    PalRtree( const QgsRectangle &maxBounds )
+      : mXMin( maxBounds.xMinimum() )
+      , mYMin( maxBounds.yMinimum() )
+      , mXRes( ( std::numeric_limits< float >::max() - 1 ) / ( maxBounds.xMaximum() - maxBounds.xMinimum() ) )
+      , mYRes( ( std::numeric_limits< float >::max() - 1 ) / ( maxBounds.yMaximum() - maxBounds.yMinimum() ) )
+      , mMaxBounds( maxBounds )
+    {
+
+    }
+
+    /**
      * Inserts new \a data into the spatial index, with the specified \a bounds.
      *
      * Ownership of \a data is not transferred, and it is the caller's responsibility to ensure that
@@ -43,14 +57,13 @@ class PalRtree : public RTree<T *, float, 2, float>
      */
     void insert( T *data, const QgsRectangle &bounds )
     {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
       this->Insert(
       {
-        static_cast< float >( bounds.xMinimum() ),
-        static_cast< float >( bounds.yMinimum() )
+        scaledBounds[0], scaledBounds[ 1]
       },
       {
-        static_cast< float>( bounds.xMaximum() ),
-        static_cast< float >( bounds.yMaximum() )
+        scaledBounds[2], scaledBounds[3]
       },
       data );
     }
@@ -63,14 +76,13 @@ class PalRtree : public RTree<T *, float, 2, float>
      */
     void remove( T *data, const QgsRectangle &bounds )
     {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
       this->Remove(
       {
-        static_cast< float >( bounds.xMinimum() ),
-        static_cast< float >( bounds.yMinimum() )
+        scaledBounds[0], scaledBounds[ 1]
       },
       {
-        static_cast< float>( bounds.xMaximum() ),
-        static_cast< float >( bounds.yMaximum() )
+        scaledBounds[2], scaledBounds[3]
       },
       data );
     }
@@ -82,17 +94,35 @@ class PalRtree : public RTree<T *, float, 2, float>
      */
     bool intersects( const QgsRectangle &bounds, const std::function< bool( T *data )> &callback ) const
     {
+      std::array< float, 4 > scaledBounds = scaleBounds( bounds );
       this->Search(
       {
-        static_cast< float >( bounds.xMinimum() ),
-        static_cast< float >( bounds.yMinimum() )
+        scaledBounds[0], scaledBounds[ 1]
       },
       {
-        static_cast< float>( bounds.xMaximum() ),
-        static_cast< float >( bounds.yMaximum() )
+        scaledBounds[2], scaledBounds[3]
       },
       callback );
       return true;
+    }
+
+  private:
+
+    // Coordinates are scaled inside the index so that they cover the maximum range for float values
+    double mXMin = 0;
+    double mYMin = 0;
+    double mXRes = 1;
+    double mYRes = 1;
+    const QgsRectangle mMaxBounds;
+    std::array<float, 4> scaleBounds( const QgsRectangle &bounds ) const
+    {
+      return
+      {
+        static_cast< float >( ( std::max( bounds.xMinimum(), mMaxBounds.xMinimum() ) - mXMin ) / mXRes ),
+        static_cast< float >( ( std::max( bounds.yMinimum(), mMaxBounds.yMinimum() ) - mYMin ) / mYRes ),
+        static_cast< float >( ( std::min( bounds.xMaximum(), mMaxBounds.xMaximum() ) - mXMin ) / mXRes ),
+        static_cast< float >( ( std::min( bounds.yMaximum(), mMaxBounds.yMaximum() ) - mYMin ) / mYRes )
+      };
     }
 };
 

--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -54,7 +54,12 @@ inline void delete_chain( Chain *chain )
   }
 }
 
-Problem::Problem() = default;
+Problem::Problem( const QgsRectangle &extent )
+  : mAllCandidatesIndex( extent )
+  , mActiveCandidatesIndex( extent )
+{
+
+}
 
 Problem::~Problem() = default;
 

--- a/src/core/pal/problem.h
+++ b/src/core/pal/problem.h
@@ -71,7 +71,13 @@ namespace pal
       friend class Pal;
 
     public:
-      Problem();
+
+      /**
+       * Constructor for Problem.
+       *
+       * The \a extent argument specifies the bounds of the incoming coordinates.
+       */
+      Problem( const QgsRectangle &extent );
 
       //Problem(char *lorena_file, bool displayAll);
 


### PR DESCRIPTION
Avoids crashes caused by super-heavy labeling jobs, where a huge number of candidates causes the rtree to branch out to a level where the leaf size becomes comparable to float epsilon values

only seen on master... maybe also an issue on earlier versions, but until it's reproduced I don't feel comfortable backporting