### PR TITLE
[dxf export] Improve dxf alignment

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -1265,6 +1265,13 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
   double lblX = label->getX();
   double lblY = label->getY();
 
+  QgsLabelFeature *labelFeature = label->getFeaturePart()->feature();
+  if ( labelFeature->hasFixedPosition() )
+  {
+    lblX = labelFeature->fixedPosition().x();
+    lblY = labelFeature->fixedPosition().y();
+  }
+
   HAlign hali = HAlign::Undefined;
   VAlign vali = VAlign::Undefined;
 
@@ -1272,13 +1279,13 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
 
   if ( props.isActive( QgsPalLayerSettings::OffsetQuad ) )
   {
+    lblX -= label->dX();
+    lblY -= label->dY();
+
     const QVariant exprVal = props.value( QgsPalLayerSettings::OffsetQuad, expressionContext );
     if ( exprVal.isValid() )
     {
       int offsetQuad = exprVal.toInt();
-
-      lblX -= label->dX();
-      lblY -= label->dY();
 
       switch ( offsetQuad )
       {
@@ -1328,6 +1335,9 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
 
   if ( props.isActive( QgsPalLayerSettings::Hali ) )
   {
+    lblX -= label->dX();
+    lblY -= label->dY();
+
     hali = HAlign::HLeft;
     QVariant exprVal = props.value( QgsPalLayerSettings::Hali, expressionContext );
     if ( exprVal.isValid() )
@@ -1343,8 +1353,6 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
       }
     }
   }
-
-  std::unique_ptr<QFontMetricsF> labelFontMetrics( new QFontMetricsF( layerSettings.format().font() ) );
 
   //vertical alignment
   if ( props.isActive( QgsPalLayerSettings::Vali ) )

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -1266,11 +1266,6 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
   double lblY = label->getY();
 
   QgsLabelFeature *labelFeature = label->getFeaturePart()->feature();
-  if ( labelFeature->hasFixedPosition() )
-  {
-    lblX = labelFeature->fixedPosition().x();
-    lblY = labelFeature->fixedPosition().y();
-  }
 
   HAlign hali = HAlign::Undefined;
   VAlign vali = VAlign::Undefined;
@@ -1279,8 +1274,8 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
 
   if ( props.isActive( QgsPalLayerSettings::OffsetQuad ) )
   {
-    lblX -= label->dX();
-    lblY -= label->dY();
+    lblX = labelFeature->anchorPosition().x();
+    lblY = labelFeature->anchorPosition().y();
 
     const QVariant exprVal = props.value( QgsPalLayerSettings::OffsetQuad, expressionContext );
     if ( exprVal.isValid() )
@@ -1335,8 +1330,8 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
 
   if ( props.isActive( QgsPalLayerSettings::Hali ) )
   {
-    lblX -= label->dX();
-    lblY -= label->dY();
+    lblX = labelFeature->anchorPosition().x();
+    lblY = labelFeature->anchorPosition().y();
 
     hali = HAlign::HLeft;
     QVariant exprVal = props.value( QgsPalLayerSettings::Hali, expressionContext );

--- a/src/core/labeling/qgslabelfeature.cpp
+++ b/src/core/labeling/qgslabelfeature.cpp
@@ -80,6 +80,11 @@ QSizeF QgsLabelFeature::size( double angle ) const
   return ( angle >= 0.785398 && angle <= 2.35619 ) || ( angle >= 3.92699 && angle <= 5.49779 ) ? mRotatedSize : mSize;
 }
 
+QgsPointXY QgsLabelFeature::anchorPosition() const
+{
+  return mAnchorPosition;
+}
+
 void QgsLabelFeature::setFeature( const QgsFeature &feature )
 {
   mFeature = feature;
@@ -115,22 +120,7 @@ void QgsLabelFeature::setObstacleSettings( const QgsLabelObstacleSettings &setti
   mObstacleSettings = settings;
 }
 
-double QgsLabelFeature::dX() const
+void QgsLabelFeature::setAnchorPosition( const QgsPointXY &anchorPosition )
 {
-  return mDX;
-}
-
-void QgsLabelFeature::setDX( double dX )
-{
-  mDX = dX;
-}
-
-double QgsLabelFeature::dY() const
-{
-  return mDY;
-}
-
-void QgsLabelFeature::setDY( double dY )
-{
-  mDY = dY;
+  mAnchorPosition = anchorPosition;
 }

--- a/src/core/labeling/qgslabelfeature.cpp
+++ b/src/core/labeling/qgslabelfeature.cpp
@@ -114,3 +114,23 @@ void QgsLabelFeature::setObstacleSettings( const QgsLabelObstacleSettings &setti
 {
   mObstacleSettings = settings;
 }
+
+double QgsLabelFeature::dX() const
+{
+  return mDX;
+}
+
+void QgsLabelFeature::setDX( double dX )
+{
+  mDX = dX;
+}
+
+double QgsLabelFeature::dY() const
+{
+  return mDY;
+}
+
+void QgsLabelFeature::setDY( double dY )
+{
+  mDY = dY;
+}

--- a/src/core/labeling/qgslabelfeature.h
+++ b/src/core/labeling/qgslabelfeature.h
@@ -174,8 +174,25 @@ class CORE_EXPORT QgsLabelFeature
     void setHasFixedPosition( bool enabled ) { mHasFixedPosition = enabled; }
     //! Coordinates of the fixed position (relevant only if hasFixedPosition() returns TRUE)
     QgsPointXY fixedPosition() const { return mFixedPosition; }
+
     //! Sets coordinates of the fixed position (relevant only if hasFixedPosition() returns TRUE)
     void setFixedPosition( const QgsPointXY &point ) { mFixedPosition = point; }
+
+    /**
+     * In case of quadrand or aligned positioning, this is set to the anchor point.
+     * This can be used for proper vector based output like DXF.
+     *
+     * \since QGIS 3.12
+     */
+    QgsPointXY anchorPosition() const;
+
+    /**
+     * In case of quadrand or aligned positioning, this is set to the anchor point.
+     * This can be used for proper vector based output like DXF.
+     *
+     * \since QGIS 3.12
+     */
+    void setAnchorPosition( const QgsPointXY &anchorPosition );
 
     //! Whether the label should use a fixed angle instead of using angle from automatic placement
     bool hasFixedAngle() const { return mHasFixedAngle; }
@@ -434,47 +451,6 @@ class CORE_EXPORT QgsLabelFeature
      */
     void setObstacleSettings( const QgsLabelObstacleSettings &settings );
 
-    /**
-     * The deltas (dX and dY) are the difference by which the fixed position deviates
-     * from the original position because of alignment.
-     *
-     * This can be used to restore the original position.
-     *
-     * \since QGIS 3.12
-     */
-    double dX() const;
-
-    /**
-     * The deltas (dX and dY) are the difference by which the fixed position deviates
-     * from the original position because of alignment.
-     *
-     * This can be used to restore the original position.
-     *
-     * \since QGIS 3.12
-     */
-    void setDX( double dX );
-
-    /**
-     * The deltas (dX and dY) are the difference by which the fixed position deviates
-     * from the original position because of alignment.
-     *
-     * This can be used to restore the original position.
-     *
-     * \since QGIS 3.12
-     */
-    double dY() const;
-
-
-    /**
-     * The deltas (dX and dY) are the difference by which the fixed position deviates
-     * from the original position because of alignment.
-     *
-     * This can be used to restore the original position.
-     *
-     * \since QGIS 3.12
-     */
-    void setDY( double dY );
-
   protected:
     //! Pointer to PAL layer (assigned when registered to PAL)
     pal::Layer *mLayer = nullptr;
@@ -549,8 +525,7 @@ class CORE_EXPORT QgsLabelFeature
 
     QgsLabelObstacleSettings mObstacleSettings;
 
-    double mDX = 0.0;
-    double mDY = 0.0;
+    QgsPointXY mAnchorPosition;
 };
 
 #endif // QGSLABELFEATURE_H

--- a/src/core/labeling/qgslabelfeature.h
+++ b/src/core/labeling/qgslabelfeature.h
@@ -434,6 +434,47 @@ class CORE_EXPORT QgsLabelFeature
      */
     void setObstacleSettings( const QgsLabelObstacleSettings &settings );
 
+    /**
+     * The deltas (dX and dY) are the difference by which the fixed position deviates
+     * from the original position because of alignment.
+     *
+     * This can be used to restore the original position.
+     *
+     * \since QGIS 3.12
+     */
+    double dX() const;
+
+    /**
+     * The deltas (dX and dY) are the difference by which the fixed position deviates
+     * from the original position because of alignment.
+     *
+     * This can be used to restore the original position.
+     *
+     * \since QGIS 3.12
+     */
+    void setDX( double dX );
+
+    /**
+     * The deltas (dX and dY) are the difference by which the fixed position deviates
+     * from the original position because of alignment.
+     *
+     * This can be used to restore the original position.
+     *
+     * \since QGIS 3.12
+     */
+    double dY() const;
+
+
+    /**
+     * The deltas (dX and dY) are the difference by which the fixed position deviates
+     * from the original position because of alignment.
+     *
+     * This can be used to restore the original position.
+     *
+     * \since QGIS 3.12
+     */
+    void setDY( double dY );
+
   protected:
     //! Pointer to PAL layer (assigned when registered to PAL)
     pal::Layer *mLayer = nullptr;
@@ -508,6 +549,8 @@ class CORE_EXPORT QgsLabelFeature
 
     QgsLabelObstacleSettings mObstacleSettings;
 
+    double mDX = 0.0;
+    double mDY = 0.0;
 };
 
 #endif // QGSLABELFEATURE_H

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2012,6 +2012,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   bool ddXPos = false, ddYPos = false;
   double quadOffsetX = 0.0, quadOffsetY = 0.0;
   double offsetX = 0.0, offsetY = 0.0;
+  QgsPointXY anchorPosition = geom.centroid().asPoint();
 
   //x/y shift in case of alignment
   double xdiff = 0.0;
@@ -2242,11 +2243,15 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
               yPos = static_cast< const QgsPoint * >( ddPoint.constGet() )->y();
             }
 
+            anchorPosition = QgsPointXY( xPos, yPos );
+
             xPos += xdiff;
             yPos += ydiff;
           }
           else
           {
+            anchorPosition = QgsPointXY( xPos, yPos );
+
             // only rotate non-pinned OverPoint placements until other placements are supported in pal::Feature
             if ( dataDefinedRotation && placement != QgsPalLayerSettings::OverPoint )
             {
@@ -2331,8 +2336,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
   //  feature to the layer
   QgsTextLabelFeature *lf = new QgsTextLabelFeature( feature.id(), std::move( geos_geom_clone ), QSizeF( labelX, labelY ) );
-  lf->setDX( xdiff );
-  lf->setDY( ydiff );
+  lf->setAnchorPosition( anchorPosition );
   lf->setFeature( feature );
   lf->setSymbol( symbol );
   if ( !qgsDoubleNear( rotatedLabelX, 0.0 ) && !qgsDoubleNear( rotatedLabelY, 0.0 ) )

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2013,6 +2013,10 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   double quadOffsetX = 0.0, quadOffsetY = 0.0;
   double offsetX = 0.0, offsetY = 0.0;
 
+  //x/y shift in case of alignment
+  double xdiff = 0.0;
+  double ydiff = 0.0;
+
   //data defined quadrant offset?
   bool ddFixedQuad = false;
   QuadrantPosition quadOff = quadOffset;
@@ -2167,10 +2171,6 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
             {
               angle = 0.0;
             }
-
-            //x/y shift in case of alignment
-            double xdiff = 0.0;
-            double ydiff = 0.0;
 
             //horizontal alignment
             if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::Hali ) )
@@ -2331,6 +2331,8 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
 
   //  feature to the layer
   QgsTextLabelFeature *lf = new QgsTextLabelFeature( feature.id(), std::move( geos_geom_clone ), QSizeF( labelX, labelY ) );
+  lf->setDX( xdiff );
+  lf->setDY( ydiff );
   lf->setFeature( feature );
   lf->setSymbol( symbol );
   if ( !qgsDoubleNear( rotatedLabelX, 0.0 ) && !qgsDoubleNear( rotatedLabelY, 0.0 ) )

--- a/src/core/labeling/qgstextlabelfeature.cpp
+++ b/src/core/labeling/qgstextlabelfeature.cpp
@@ -23,7 +23,6 @@
 
 QgsTextLabelFeature::QgsTextLabelFeature( QgsFeatureId id, geos::unique_ptr geometry, QSizeF size )
   : QgsLabelFeature( id, std::move( geometry ), size )
-
 {
   mDefinedFont = QFont();
 }

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -249,6 +249,8 @@ std::size_t FeaturePart::createCandidatesOverPoint( double x, double y, std::vec
   double xdiff = -labelW / 2.0;
   double ydiff = -labelH / 2.0;
 
+  feature()->setAnchorPosition( QgsPointXY( x, y ) );
+
   if ( !qgsDoubleNear( mLF->quadOffset().x(), 0.0 ) )
   {
     xdiff += labelW / 2.0 * mLF->quadOffset().x();
@@ -310,7 +312,7 @@ std::size_t FeaturePart::createCandidatesOverPoint( double x, double y, std::vec
     }
   }
 
-  lPos.emplace_back( qgis::make_unique< LabelPosition >( id, lx, ly, labelW, labelH, angle, cost, this, false, quadrantFromOffset(), xdiff, ydiff ) );
+  lPos.emplace_back( qgis::make_unique< LabelPosition >( id, lx, ly, labelW, labelH, angle, cost, this, false, quadrantFromOffset() ) );
   return nbp;
 }
 
@@ -1615,7 +1617,7 @@ std::vector< std::unique_ptr< LabelPosition > > FeaturePart::createCandidates( P
 
   if ( mLF->hasFixedPosition() )
   {
-    lPos.emplace_back( qgis::make_unique< LabelPosition> ( 0, mLF->fixedPosition().x(), mLF->fixedPosition().y(), getLabelWidth( angle ), getLabelHeight( angle ), angle, 0.0, this, false, LabelPosition::Quadrant::QuadrantOver, mLF->dX(), mLF->dY() ) );
+    lPos.emplace_back( qgis::make_unique< LabelPosition> ( 0, mLF->fixedPosition().x(), mLF->fixedPosition().y(), getLabelWidth( angle ), getLabelHeight( angle ), angle, 0.0, this, false, LabelPosition::Quadrant::QuadrantOver ) );
   }
   else
   {

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -1615,7 +1615,7 @@ std::vector< std::unique_ptr< LabelPosition > > FeaturePart::createCandidates( P
 
   if ( mLF->hasFixedPosition() )
   {
-    lPos.emplace_back( qgis::make_unique< LabelPosition> ( 0, mLF->fixedPosition().x(), mLF->fixedPosition().y(), getLabelWidth( angle ), getLabelHeight( angle ), angle, 0.0, this ) );
+    lPos.emplace_back( qgis::make_unique< LabelPosition> ( 0, mLF->fixedPosition().x(), mLF->fixedPosition().y(), getLabelWidth( angle ), getLabelHeight( angle ), angle, 0.0, this, false, LabelPosition::Quadrant::QuadrantOver, mLF->dX(), mLF->dY() ) );
   }
   else
   {

--- a/src/core/pal/labelposition.cpp
+++ b/src/core/pal/labelposition.cpp
@@ -40,7 +40,7 @@
 
 using namespace pal;
 
-LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, double alpha, double cost, FeaturePart *feature, bool isReversed, Quadrant quadrant, double dX, double dY )
+LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, double alpha, double cost, FeaturePart *feature, bool isReversed, Quadrant quadrant )
   : id( id )
   , feature( feature )
   , probFeat( 0 )
@@ -55,8 +55,6 @@ LabelPosition::LabelPosition( int id, double x1, double y1, double w, double h, 
   , mCost( cost )
   , mHasObstacleConflict( false )
   , mUpsideDownCharCount( 0 )
-  , mDx( dX )
-  , mDy( dY )
 {
   type = GEOS_POLYGON;
   nbPoints = 4;
@@ -162,8 +160,6 @@ LabelPosition::LabelPosition( const LabelPosition &other )
   quadrant = other.quadrant;
   mHasObstacleConflict = other.mHasObstacleConflict;
   mUpsideDownCharCount = other.mUpsideDownCharCount;
-  mDx = other.mDx;
-  mDy = other.mDy;
 }
 
 bool LabelPosition::isIn( double *bbox )
@@ -321,16 +317,6 @@ bool LabelPosition::isInConflictMultiPart( const LabelPosition *lp ) const
     tmp1 = tmp1->nextPart;
   }
   return false; // no conflict found
-}
-
-double LabelPosition::dY() const
-{
-  return mDy;
-}
-
-double LabelPosition::dX() const
-{
-  return mDx;
 }
 
 int LabelPosition::partCount() const

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -94,8 +94,7 @@ namespace pal
       LabelPosition( int id, double x1, double y1,
                      double w, double h,
                      double alpha, double cost,
-                     FeaturePart *feature, bool isReversed = false, Quadrant quadrant = QuadrantOver,
-                     double dX = 0.0, double dY = 0.0 );
+                     FeaturePart *feature, bool isReversed = false, Quadrant quadrant = QuadrantOver );
 
       //! Copy constructor
       LabelPosition( const LabelPosition &other );
@@ -295,20 +294,6 @@ namespace pal
        */
       void insertIntoIndex( PalRtree<LabelPosition> &index );
 
-      /**
-       * The offset of the anchor point in x direction.
-       *
-       * \since QGIS 3.12
-       */
-      double dX() const;
-
-      /**
-       * The offset of the anchor point in y direction.
-       *
-       * \since QGIS 3.12
-       */
-      double dY() const;
-
     protected:
 
       int id;
@@ -341,8 +326,6 @@ namespace pal
       bool mHasObstacleConflict;
       bool mHasHardConflict = false;
       int mUpsideDownCharCount;
-      double mDx = 0.0;
-      double mDy = 0.0;
 
       /**
        * Calculates the total number of parts for this label position

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -88,8 +88,6 @@ namespace pal
        * \param feature labelpos owners
        * \param isReversed label is reversed
        * \param quadrant relative position of label to feature
-       * \param dX the correction of the anchor point in x direction
-       * \param dY the correction of the anchor point in y direction
        */
       LabelPosition( int id, double x1, double y1,
                      double w, double h,

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -560,7 +560,7 @@ void TestQgsDxfExport::testTextAlign()
   valignProp.setStaticValue( vali );
   props.setProperty( QgsPalLayerSettings::Vali, valignProp );
   QgsProperty posYProp = QgsProperty();
-  posXProp.setExpressionString( QStringLiteral( "y($geometry)" ) );
+  posYProp.setExpressionString( QStringLiteral( "y($geometry)" ) );
   props.setProperty( QgsPalLayerSettings::PositionY, posYProp );
   settings.setDataDefinedProperties( props );
 

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -554,13 +554,13 @@ void TestQgsDxfExport::testTextAlign()
   halignProp.setStaticValue( hali );
   props.setProperty( QgsPalLayerSettings::Hali, halignProp );
   QgsProperty posXProp = QgsProperty();
-  posXProp.setExpressionString( QStringLiteral( "x($geometry)" ) );
+  posXProp.setExpressionString( QStringLiteral( "x($geometry) + 1" ) );
   props.setProperty( QgsPalLayerSettings::PositionX, posXProp );
   QgsProperty valignProp = QgsProperty();
   valignProp.setStaticValue( vali );
   props.setProperty( QgsPalLayerSettings::Vali, valignProp );
   QgsProperty posYProp = QgsProperty();
-  posYProp.setExpressionString( QStringLiteral( "y($geometry)" ) );
+  posYProp.setExpressionString( QStringLiteral( "y($geometry) + 1" ) );
   props.setProperty( QgsPalLayerSettings::PositionY, posYProp );
   settings.setDataDefinedProperties( props );
 
@@ -616,13 +616,13 @@ void TestQgsDxfExport::testTextAlign()
                               "420\n"
                               "**no check**\n"
                               " 10\n"
-                              "REGEX ^2684679\\.39\\d*\n"
+                              "REGEX ^2684680\\.39\\d*\n"
                               " 20\n"
-                              "REGEX ^1292182\\.52\\d*\n"
+                              "REGEX ^1292183\\.52\\d*\n"
                               " 11\n"
-                              "REGEX ^2684679\\.39\\d*\n"
+                              "REGEX ^2684680\\.39\\d*\n"
                               " 21\n"
-                              "REGEX ^1292182\\.52\\d*\n"
+                              "REGEX ^1292183\\.52\\d*\n"
                               " 40\n"
                               "**no check**\n"
                               "  1\n"
@@ -1155,7 +1155,7 @@ bool TestQgsDxfExport::fileContainsText( const QString &path, const QString &tex
           bool ok = false;
           if ( searchLine.startsWith( QLatin1String( "REGEX " ) ) )
           {
-            QRegularExpression re( searchLine.right( 7 ) );
+            QRegularExpression re( searchLine.mid( 6 ) );
             if ( re.match( line ).hasMatch() )
               ok = true;
           }


### PR DESCRIPTION
Alignment for dxf was not working properly when the data defined point did not match the feature's geometry.
Also fixes issues in the dxf tests themselves.