### PR TITLE
[RPM] fix broken -u flag in buildrmps.sh

### DIFF
--- a/rpm/buildrpms.sh
+++ b/rpm/buildrpms.sh
@@ -165,7 +165,7 @@ then
 fi
 
 srpm=$(grep -e 'Wrote: .*\.src\.rpm' $OUTDIR/build.log 2>/dev/null |
-       sed 's_Wrote: /builddir/build/SRPMS/\(.*\)_\1_')
+       sed 's_Wrote: /builddir/build/SRPMS/\(.*\.rpm\).*_\1_')
 
 if [ "$srpm_only" -eq "1" ]
 then


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

When using `buildrpms.sh -u`, the script fails with:

```
Wrote: /builddir/build/SRPMS/qgis-*.src.rpm
Finish: rpmbuild -bs
Finish: buildsrpm
INFO: Done(qgis.spec) Config(default) 0 minutes 22 seconds
INFO: Results and/or logs in: result
INFO: Cleaning up build root ('cleanup_on_success=True')
Start: clean chroot
Finish: clean chroot
Finish: run
Source package created
Source package unavailable. Abort
```

The reason was because a wrong src.rpm file name was extracted by sed.
Instead of `qgis-*.src.rpm`, what was being extracted is
`qgis-*.src.rpm\r` which includes a carriage return. This change removes
any character at the end of the `.rpm` string when extracting the file name.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/dev`elopers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
