### PR TITLE
Simplify and optimise pal label candidate costing code, fix some bugs

### DIFF
--- a/src/core/pal/costcalculator.cpp
+++ b/src/core/pal/costcalculator.cpp
@@ -116,8 +116,7 @@ void CostCalculator::calculateCandidatePolygonRingDistanceCosts( std::vector< st
   double maxCandidateRingDistanceCost = std::numeric_limits< double >::lowest();
   for ( std::unique_ptr< LabelPosition > &pos : lPos )
   {
-    // 4* multiplier came from original pal library logic - TODO: evaluate if this is still appropriate
-    const double candidatePolygonRingDistanceCost = 4 * calculatePolygonRingDistance( pos.get(), obstacles, bbx, bby );
+    const double candidatePolygonRingDistanceCost = calculatePolygonRingDistance( pos.get(), obstacles, bbx, bby );
 
     minCandidateRingDistanceCost = std::min( minCandidateRingDistanceCost, candidatePolygonRingDistanceCost );
     maxCandidateRingDistanceCost = std::max( maxCandidateRingDistanceCost, candidatePolygonRingDistanceCost );

--- a/src/core/pal/costcalculator.cpp
+++ b/src/core/pal/costcalculator.cpp
@@ -188,6 +188,9 @@ void CostCalculator::finalizeCandidatesCosts( Feats *feat, PalRtree<FeaturePart>
   // "try to exclude all conflitual labels (good ones have cost < 1 by pruning)"
   // my interpretation: it appears this scans through the candidates and chooses some threshold
   // based on the candidate cost, after which all remaining candidates are simply discarded
+  // my suspicion: I don't think this is needed (or wanted) here, and is reflective of the fact
+  // that obstacle costs are too low vs inferior candidate placement costs (i.e. without this,
+  // an "around point" label would rather be placed over an obstacle then be placed in a position > 6 o'clock
   double discrim = 0.0;
   std::size_t stop = 0;
   do

--- a/src/core/pal/costcalculator.h
+++ b/src/core/pal/costcalculator.h
@@ -74,18 +74,21 @@ namespace pal
       explicit CandidatePolygonRingDistanceCalculator( LabelPosition *candidate );
 
       /**
-       * Updates distance.
+       * Adds a \a ring to the calculation, updating the minimumDistance() value if
+       * the rings is closer to the candidate then previously added rings.
        */
-      void update( const pal::PointSet *pset );
+      void addRing( const pal::PointSet *ring );
 
-      double getCost();
+      /**
+       * Returns the minimum distance between the candidate and all added rings.
+       */
+      double minimumDistance() const;
 
     private:
 
       double mPx;
       double mPy;
       double mMinDistance = std::numeric_limits<double>::max();
-      bool mOk = false;
   };
 }
 

--- a/src/core/pal/costcalculator.h
+++ b/src/core/pal/costcalculator.h
@@ -44,13 +44,13 @@ namespace pal
        * Updates the costs for polygon label candidates by considering the distance between the
        * candidates and the nearest polygon ring (i.e. prefer labels closer to the pole of inaccessibility).
        */
-      static void calculateCandidatePolygonRingDistanceCosts( std::vector<std::unique_ptr<pal::LabelPosition> > &lPos, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
+      static void calculateCandidatePolygonRingDistanceCosts( std::vector<std::unique_ptr<pal::LabelPosition> > &lPos, double bbx[4], double bby[4] );
 
       //! Calculates the distance between a label candidate and the closest ring for a polygon feature
-      static double calculatePolygonRingDistance( LabelPosition *candidate, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
+      static double calculatePolygonRingDistance( LabelPosition *candidate, double bbx[4], double bby[4] );
 
       //! Sort candidates by costs, skip the worse ones, evaluate polygon candidates
-      static void finalizeCandidatesCosts( Feats *feat, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
+      static void finalizeCandidatesCosts( Feats *feat, double bbx[4], double bby[4] );
 
       /**
        * Sorts label candidates in ascending order of cost

--- a/src/core/pal/costcalculator.h
+++ b/src/core/pal/costcalculator.h
@@ -61,6 +61,7 @@ namespace pal
   /**
    * \ingroup core
    * \brief Calculates distance from a label candidate to nearest polygon ring.
+   * \since QGIS 3.12
    * \note not available in Python bindings
    */
   class CandidatePolygonRingDistanceCalculator

--- a/src/core/pal/costcalculator.h
+++ b/src/core/pal/costcalculator.h
@@ -61,8 +61,8 @@ namespace pal
   /**
    * \ingroup core
    * \brief Calculates distance from a label candidate to nearest polygon ring.
-   * \since QGIS 3.12
    * \note not available in Python bindings
+   * \since QGIS 3.12
    */
   class CandidatePolygonRingDistanceCalculator
   {

--- a/src/core/pal/costcalculator.h
+++ b/src/core/pal/costcalculator.h
@@ -41,13 +41,13 @@ namespace pal
       static void addObstacleCostPenalty( pal::LabelPosition *lp, pal::FeaturePart *obstacle, Pal *pal );
 
       //! Calculates the costs for polygon label candidates
-      static void setPolygonCandidatesCost( std::size_t nblp, std::vector<std::unique_ptr<pal::LabelPosition> > &lPos, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
+      static void setPolygonCandidatesCost( std::vector<std::unique_ptr<pal::LabelPosition> > &lPos, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
 
       //! Sets cost to the smallest distance between lPos's centroid and a polygon stored in geometry field
       static void setCandidateCostFromPolygon( LabelPosition *lp, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
 
       //! Sort candidates by costs, skip the worse ones, evaluate polygon candidates
-      static std::size_t finalizeCandidatesCosts( Feats *feat, std::size_t max_p, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
+      static void finalizeCandidatesCosts( Feats *feat, PalRtree< FeaturePart > *obstacles, double bbx[4], double bby[4] );
 
       /**
        * Sorts label candidates in ascending order of cost

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -1729,7 +1729,7 @@ std::vector< std::unique_ptr< LabelPosition > > FeaturePart::createCandidates( P
   return lPos;
 }
 
-void FeaturePart::addSizePenalty( std::size_t nbp, std::vector< std::unique_ptr< LabelPosition > > &lPos, double bbx[4], double bby[4] )
+void FeaturePart::addSizePenalty( std::vector< std::unique_ptr< LabelPosition > > &lPos, double bbx[4], double bby[4] )
 {
   if ( !mGeos )
     createGeosGeom();
@@ -1780,9 +1780,8 @@ void FeaturePart::addSizePenalty( std::size_t nbp, std::vector< std::unique_ptr<
     return; // no size penalty for points
 
   // apply the penalty
-  for ( std::size_t i = 0; i < nbp; i++ )
+  for ( std::unique_ptr< LabelPosition > &pos : lPos )
   {
-    LabelPosition *pos = lPos[ i ].get();
     pos->setCost( pos->cost() + sizeCost / 100 );
   }
 }

--- a/src/core/pal/feature.h
+++ b/src/core/pal/feature.h
@@ -324,7 +324,7 @@ namespace pal
        *
        * E.g. small lines or polygons get higher cost so that larger features are more likely to be labeled.
        */
-      void addSizePenalty( std::size_t nbp, std::vector<std::unique_ptr<LabelPosition> > &lPos, double bbx[4], double bby[4] );
+      void addSizePenalty( std::vector<std::unique_ptr<LabelPosition> > &lPos, double bbx[4], double bby[4] );
 
       /**
        * Calculates the priority for the feature. This will be the feature's priority if set,

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -316,9 +316,6 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
           break;
       }
 
-      // sort candidates by cost, skip less interesting ones, calculate polygon costs (if using polygons)
-      max_p = CostCalculator::finalizeCandidatesCosts( feat.get(), max_p, &obstacles, bbx, bby );
-
       if ( isCanceled() )
         return nullptr;
 
@@ -352,10 +349,16 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
         }
       }
 
+      // calculate final costs
+      CostCalculator::finalizeCandidatesCosts( feat.get(), &obstacles, bbx, bby );
+
+      // sort candidates list, best label to worst
+      std::sort( feat->candidates.begin(), feat->candidates.end(), CostCalculator::candidateSortGrow );
+
       // only keep the 'max_p' best candidates
-      while ( feat->candidates.size() > max_p )
+      if ( feat->candidates.size() > max_p )
       {
-        feat->candidates.pop_back();
+        feat->candidates.resize( max_p );
       }
 
       if ( isCanceled() )

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -353,7 +353,7 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
         continue;
 
       // calculate final costs
-      CostCalculator::finalizeCandidatesCosts( feat.get(), &obstacles, bbx, bby );
+      CostCalculator::finalizeCandidatesCosts( feat.get(), bbx, bby );
 
       // sort candidates list, best label to worst
       std::sort( feat->candidates.begin(), feat->candidates.end(), CostCalculator::candidateSortGrow );

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -369,10 +369,10 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
       prob->mTotalCandidates += static_cast< int >( feat->candidates.size() );
 
       // add all candidates into a rtree (to speed up conflicts searching)
-      for ( std::size_t j = 0; j < feat->candidates.size(); j++, idlp++ )
+      for ( std::unique_ptr< LabelPosition > &candidate : feat->candidates )
       {
-        feat->candidates[ j ]->insertIntoIndex( prob->allCandidatesIndex() );
-        feat->candidates[ j ]->setProblemIds( static_cast< int >( i ), idlp );
+        candidate->insertIntoIndex( prob->allCandidatesIndex() );
+        candidate->setProblemIds( static_cast< int >( i ), idlp++ );
       }
       features.emplace_back( std::move( feat ) );
     }

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -349,6 +349,9 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
         }
       }
 
+      if ( feat->candidates.empty() )
+        continue;
+
       // calculate final costs
       CostCalculator::finalizeCandidatesCosts( feat.get(), &obstacles, bbx, bby );
 

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -299,20 +299,20 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
       prob->mFeatStartId[i] = idlp;
       prob->mInactiveCost[i] = std::pow( 2, 10 - 10 * feat->priority );
 
-      std::size_t max_p = 0;
+      std::size_t maxCandidates = 0;
       switch ( feat->feature->getGeosType() )
       {
         case GEOS_POINT:
           // this is usually 0, i.e. no maximum
-          max_p = feat->feature->maximumPointCandidates();
+          maxCandidates = feat->feature->maximumPointCandidates();
           break;
 
         case GEOS_LINESTRING:
-          max_p = feat->feature->maximumLineCandidates();
+          maxCandidates = feat->feature->maximumLineCandidates();
           break;
 
         case GEOS_POLYGON:
-          max_p = feat->feature->maximumPolygonCandidates();
+          maxCandidates = feat->feature->maximumPolygonCandidates();
           break;
       }
 
@@ -355,10 +355,10 @@ std::unique_ptr<Problem> Pal::extract( const QgsRectangle &extent, const QgsGeom
       // sort candidates list, best label to worst
       std::sort( feat->candidates.begin(), feat->candidates.end(), CostCalculator::candidateSortGrow );
 
-      // only keep the 'max_p' best candidates
-      if ( feat->candidates.size() > max_p )
+      // only keep the 'maxCandidates' best candidates
+      if ( maxCandidates > 0 && feat->candidates.size() > maxCandidates )
       {
-        feat->candidates.resize( max_p );
+        feat->candidates.resize( maxCandidates );
       }
 
       if ( isCanceled() )


### PR DESCRIPTION
Fixes a logic bug which has existed in the pal polygon costing code since ... forever, and makes this code incrementally more readable and understandable.