### PR TITLE
Expose QgsBearingUtils to QML

### DIFF
--- a/python/core/auto_generated/qgsbearingutils.sip.in
+++ b/python/core/auto_generated/qgsbearingutils.sip.in
@@ -22,10 +22,13 @@ Utilities for calculating bearings and directions.
 #include "qgsbearingutils.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     static double bearingTrueNorth( const QgsCoordinateReferenceSystem &crs,
-                                    const QgsCoordinateTransformContext  &transformContext,
-                                    const QgsPointXY &point );
+        const QgsCoordinateTransformContext  &transformContext,
+        const QgsPointXY &point );
 %Docstring
 Returns the direction to true north from a specified point and for a specified
 coordinate reference system. The returned value is in degrees clockwise from

--- a/src/core/qgsbearingutils.h
+++ b/src/core/qgsbearingutils.h
@@ -23,6 +23,7 @@ class QgsCoordinateTransformContext;
 class QgsPointXY;
 
 #include "qgis_core.h"
+#include <QObject>
 
 /**
  * \class QgsBearingUtils
@@ -32,6 +33,8 @@ class QgsPointXY;
 */
 class CORE_EXPORT QgsBearingUtils
 {
+    Q_GADGET
+
   public:
 
     /**
@@ -39,9 +42,9 @@ class CORE_EXPORT QgsBearingUtils
      * coordinate reference system. The returned value is in degrees clockwise from
      * vertical. An exception will be thrown if the bearing could not be calculated.
      */
-    static double bearingTrueNorth( const QgsCoordinateReferenceSystem &crs,
-                                    const QgsCoordinateTransformContext  &transformContext,
-                                    const QgsPointXY &point );
+    Q_INVOKABLE static double bearingTrueNorth( const QgsCoordinateReferenceSystem &crs,
+        const QgsCoordinateTransformContext  &transformContext,
+        const QgsPointXY &point );
 
 };
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

Needed to figure out where the true north is from within QML apps.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
