### PR TITLE
[HIG] Remove colon from widget label in status bar

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -269,7 +269,7 @@ void QgsStatusBarCoordinatesWidget::extentsViewToggled( bool flag )
     mToggleExtentsViewButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "tracking.svg" ) ) );
     mLineEdit->setToolTip( tr( "Map coordinates at mouse cursor position" ) );
     mLineEdit->setReadOnly( false );
-    mLabel->setText( tr( "Coordinate:" ) );
+    mLabel->setText( tr( "Coordinate" ) );
   }
 }
 
@@ -306,7 +306,7 @@ void QgsStatusBarCoordinatesWidget::showExtent()
 
   // update the statusbar with the current extents.
   QgsRectangle myExtents = mMapCanvas->extent();
-  mLabel->setText( tr( "Extents:" ) );
+  mLabel->setText( tr( "Extents" ) );
   mLineEdit->setText( myExtents.toString( true ) );
 
   ensureCoordinatesVisible();


### PR DESCRIPTION
A before (bottom) /after (top) preview
![image](https://user-images.githubusercontent.com/7983394/71482584-b41c7c00-2803-11ea-9b7a-b4777d13e816.png)