### PR TITLE
Add native affine transform algorithm for vectors

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/affine_transform.gml
+++ b/python/plugins/processing/tests/testdata/expected/affine_transform.gml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ affine_transform.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0.7878679656440366</gml:X><gml:Y>-2.242640687119285</gml:Y><gml:Z>9.5</gml:Z></gml:coord>
+      <gml:coord><gml:X>8.071067811865476</gml:X><gml:Y>7.586143571373726</gml:Y><gml:Z>9.5</gml:Z></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                          
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.929289321881345,3.62634559672906,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.787867965644037,6.87903679018718,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.858578643762691,5.25269119345812,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.1920310216783,7.58614357137373,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.26274169979695,5.95979797464467,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.24264068711928,-2.24264068711928,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8.07106781186548,7.37401153701776,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7.29325035256027,6.59619407771256,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:affine_transform fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1.84852813742386,1.15147186257614,9.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:affine_transform>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/affine_transform.xsd
+++ b/python/plugins/processing/tests/testdata/expected/affine_transform.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="affine_transform" type="ogr:affine_transform_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="affine_transform_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2305,4 +2305,25 @@ tests:
         name: expected/split_by_char_regex.gml
         type: vector
 
+  - algorithm: native:affinetransform
+    name: Affine transform
+    params:
+      DELTA_M: 4.0
+      DELTA_X: 1.0
+      DELTA_Y: 2.0
+      DELTA_Z: 3.0
+      INPUT:
+        name: custom/pointszm.shp
+        type: vector
+      ROTATION_Z: 45.0
+      SCALE_M: 1.4
+      SCALE_X: 1.1
+      SCALE_Y: 1.2
+      SCALE_Z: 1.3
+    results:
+      OUTPUT:
+        name: expected/affine_transform.gml
+        type: vector
+
+
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmaddincrementalfield.cpp
   processing/qgsalgorithmaddtablefield.cpp
   processing/qgsalgorithmaddxyfields.cpp
+  processing/qgsalgorithmaffinetransform.cpp
   processing/qgsalgorithmapplylayerstyle.cpp
   processing/qgsalgorithmarraytranslatedfeatures.cpp
   processing/qgsalgorithmaspect.cpp

--- a/src/analysis/processing/qgsalgorithmaffinetransform.cpp
+++ b/src/analysis/processing/qgsalgorithmaffinetransform.cpp
@@ -1,0 +1,275 @@
+/***************************************************************************
+                         qgsalgorithmaffinetransform.cpp
+                         ---------------------
+    begin                : December 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmaffinetransform.h"
+#include "qgsvectorlayer.h"
+
+///@cond PRIVATE
+
+QString QgsAffineTransformationAlgorithm::name() const
+{
+  return QStringLiteral( "affinetransform" );
+}
+
+QString QgsAffineTransformationAlgorithm::displayName() const
+{
+  return QObject::tr( "Affine transform" );
+}
+
+QStringList QgsAffineTransformationAlgorithm::tags() const
+{
+  return QObject::tr( "move,shift,transform,affine,scale,rotate,resize,matrix" ).split( ',' );
+}
+
+QString QgsAffineTransformationAlgorithm::group() const
+{
+  return QObject::tr( "Vector geometry" );
+}
+
+QString QgsAffineTransformationAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorgeometry" );
+}
+
+QString QgsAffineTransformationAlgorithm::outputName() const
+{
+  return QObject::tr( "Transformed" );
+}
+
+QString QgsAffineTransformationAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Applies an affine transformation to the geometries from a layer. Affine transformations can include "
+                      "translation, scaling and rotation. The operations are performed in a scale, rotation, translation order." )
+         + QStringLiteral( "\n\n" )
+         + QObject::tr( "Z and M values present in the geometry can also be translated and scaled independently." );
+}
+
+QString QgsAffineTransformationAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Applies an affine transformation to geometries." );
+}
+
+QgsAffineTransformationAlgorithm *QgsAffineTransformationAlgorithm::createInstance() const
+{
+  return new QgsAffineTransformationAlgorithm();
+}
+
+void QgsAffineTransformationAlgorithm::initParameters( const QVariantMap & )
+{
+  std::unique_ptr< QgsProcessingParameterDistance > xOffset = qgis::make_unique< QgsProcessingParameterDistance >( QStringLiteral( "DELTA_X" ),
+      QObject::tr( "Translation (x-axis)" ),
+      0.0, QStringLiteral( "INPUT" ) );
+  xOffset->setIsDynamic( true );
+  xOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_X" ), QObject::tr( "Offset distance (x-axis)" ), QgsPropertyDefinition::Double ) );
+  xOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( xOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterDistance > yOffset = qgis::make_unique< QgsProcessingParameterDistance >( QStringLiteral( "DELTA_Y" ),
+      QObject::tr( "Translation (y-axis)" ),
+      0.0, QStringLiteral( "INPUT" ) );
+  yOffset->setIsDynamic( true );
+  yOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_Y" ), QObject::tr( "Offset distance (y-axis)" ), QgsPropertyDefinition::Double ) );
+  yOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( yOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > zOffset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DELTA_Z" ),
+      QObject::tr( "Translation (z-axis)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  zOffset->setIsDynamic( true );
+  zOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_Z" ), QObject::tr( "Offset distance (z-axis)" ), QgsPropertyDefinition::Double ) );
+  zOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( zOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > mOffset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DELTA_M" ),
+      QObject::tr( "Translation (m values)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  mOffset->setIsDynamic( true );
+  mOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_M" ), QObject::tr( "Offset distance (m values)" ), QgsPropertyDefinition::Double ) );
+  mOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( mOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > xScale = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "SCALE_X" ),
+      QObject::tr( "Scale factor (x-axis)" ), QgsProcessingParameterNumber::Double,
+      1.0 );
+  xScale->setIsDynamic( true );
+  xScale->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "SCALE_X" ), QObject::tr( "Scale factor (x-axis)" ), QgsPropertyDefinition::Double ) );
+  xScale->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( xScale.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > yScale = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "SCALE_Y" ),
+      QObject::tr( "Scale factor (y-axis)" ), QgsProcessingParameterNumber::Double,
+      1.0 );
+  yScale->setIsDynamic( true );
+  yScale->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "SCALE_Y" ), QObject::tr( "Scale factor (y-axis)" ), QgsPropertyDefinition::Double ) );
+  yScale->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( yScale.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > zScale = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "SCALE_Z" ),
+      QObject::tr( "Scale factor (z-axis)" ), QgsProcessingParameterNumber::Double,
+      1.0 );
+  zScale->setIsDynamic( true );
+  zScale->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "SCALE_Z" ), QObject::tr( "Scale factor (z-axis)" ), QgsPropertyDefinition::Double ) );
+  zScale->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( zScale.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > mScale = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "SCALE_M" ),
+      QObject::tr( "Scale factor (m values)" ), QgsProcessingParameterNumber::Double,
+      1.0 );
+  mScale->setIsDynamic( true );
+  mScale->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "SCALE_M" ), QObject::tr( "Scale factor (m values)" ), QgsPropertyDefinition::Double ) );
+  mScale->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( mScale.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > rotation = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ROTATION_Z" ),
+      QObject::tr( "Rotation around z-axis (degrees counter-clockwise)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  rotation->setIsDynamic( true );
+  rotation->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "ROTATION_Z" ), QObject::tr( "Rotation around z-axis (degrees counter-clockwise)" ), QgsPropertyDefinition::Double ) );
+  rotation->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( rotation.release() );
+}
+
+bool QgsAffineTransformationAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mDeltaX = parameterAsDouble( parameters, QStringLiteral( "DELTA_X" ), context );
+  mDynamicDeltaX = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_X" ) );
+  if ( mDynamicDeltaX )
+    mDeltaXProperty = parameters.value( QStringLiteral( "DELTA_X" ) ).value< QgsProperty >();
+
+  mDeltaY = parameterAsDouble( parameters, QStringLiteral( "DELTA_Y" ), context );
+  mDynamicDeltaY = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_Y" ) );
+  if ( mDynamicDeltaY )
+    mDeltaYProperty = parameters.value( QStringLiteral( "DELTA_Y" ) ).value< QgsProperty >();
+
+  mDeltaZ = parameterAsDouble( parameters, QStringLiteral( "DELTA_Z" ), context );
+  mDynamicDeltaZ = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_Z" ) );
+  if ( mDynamicDeltaZ )
+    mDeltaZProperty = parameters.value( QStringLiteral( "DELTA_Z" ) ).value< QgsProperty >();
+
+  mDeltaM = parameterAsDouble( parameters, QStringLiteral( "DELTA_M" ), context );
+  mDynamicDeltaM = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_M" ) );
+  if ( mDynamicDeltaM )
+    mDeltaMProperty = parameters.value( QStringLiteral( "DELTA_M" ) ).value< QgsProperty >();
+
+  mScaleX = parameterAsDouble( parameters, QStringLiteral( "SCALE_X" ), context );
+  mDynamicScaleX = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "SCALE_X" ) );
+  if ( mDynamicScaleX )
+    mScaleXProperty = parameters.value( QStringLiteral( "SCALE_X" ) ).value< QgsProperty >();
+
+  mScaleY = parameterAsDouble( parameters, QStringLiteral( "SCALE_Y" ), context );
+  mDynamicScaleY = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "SCALE_Y" ) );
+  if ( mDynamicScaleY )
+    mScaleYProperty = parameters.value( QStringLiteral( "SCALE_Y" ) ).value< QgsProperty >();
+
+  mScaleZ = parameterAsDouble( parameters, QStringLiteral( "SCALE_Z" ), context );
+  mDynamicScaleZ = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "SCALE_Z" ) );
+  if ( mDynamicScaleZ )
+    mScaleZProperty = parameters.value( QStringLiteral( "SCALE_Z" ) ).value< QgsProperty >();
+
+  mScaleM = parameterAsDouble( parameters, QStringLiteral( "SCALE_M" ), context );
+  mDynamicScaleM = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "SCALE_M" ) );
+  if ( mDynamicScaleM )
+    mScaleMProperty = parameters.value( QStringLiteral( "SCALE_M" ) ).value< QgsProperty >();
+
+  mRotationZ = parameterAsDouble( parameters, QStringLiteral( "ROTATION_Z" ), context );
+  mDynamicRotationZ = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "ROTATION_Z" ) );
+  if ( mDynamicRotationZ )
+    mRotationZProperty = parameters.value( QStringLiteral( "ROTATION_Z" ) ).value< QgsProperty >();
+
+  return true;
+}
+
+QgsFeatureList QgsAffineTransformationAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsFeature f = feature;
+  if ( f.hasGeometry() )
+  {
+    QgsGeometry geometry = f.geometry();
+
+    double deltaX = mDeltaX;
+    if ( mDynamicDeltaX )
+      deltaX = mDeltaXProperty.valueAsDouble( context.expressionContext(), deltaX );
+    double deltaY = mDeltaY;
+    if ( mDynamicDeltaY )
+      deltaY = mDeltaYProperty.valueAsDouble( context.expressionContext(), deltaY );
+    double deltaZ = mDeltaZ;
+    if ( mDynamicDeltaZ )
+      deltaZ = mDeltaZProperty.valueAsDouble( context.expressionContext(), deltaZ );
+    double deltaM = mDeltaM;
+    if ( mDynamicDeltaM )
+      deltaM = mDeltaMProperty.valueAsDouble( context.expressionContext(), deltaM );
+
+    if ( deltaZ != 0.0 && !geometry.constGet()->is3D() )
+      geometry.get()->addZValue( 0 );
+    if ( deltaM != 0.0 && !geometry.constGet()->isMeasure() )
+      geometry.get()->addMValue( 0 );
+
+    double scaleX = mScaleX;
+    if ( mDynamicScaleX )
+      scaleX = mScaleXProperty.valueAsDouble( context.expressionContext(), scaleX );
+    double scaleY = mScaleY;
+    if ( mDynamicScaleY )
+      scaleY = mScaleYProperty.valueAsDouble( context.expressionContext(), scaleY );
+    double scaleZ = mScaleZ;
+    if ( mDynamicScaleZ )
+      scaleZ = mScaleZProperty.valueAsDouble( context.expressionContext(), scaleZ );
+    double scaleM = mScaleM;
+    if ( mDynamicScaleM )
+      scaleM = mScaleMProperty.valueAsDouble( context.expressionContext(), scaleM );
+
+    double rotationZ = mRotationZ;
+    if ( mDynamicRotationZ )
+      rotationZ = mRotationZProperty.valueAsDouble( context.expressionContext(), rotationZ );
+
+    QTransform transform;
+    transform.translate( deltaX, deltaY );
+    transform.rotate( rotationZ );
+    transform.scale( scaleX, scaleY );
+
+    geometry.transform( transform, deltaZ, scaleZ, deltaM, scaleM );
+    f.setGeometry( geometry );
+  }
+  return QgsFeatureList() << f;
+}
+
+QgsWkbTypes::Type QgsAffineTransformationAlgorithm::outputWkbType( QgsWkbTypes::Type inputWkbType ) const
+{
+  QgsWkbTypes::Type wkb = inputWkbType;
+  if ( mDeltaZ != 0.0 )
+    wkb = QgsWkbTypes::addZ( wkb );
+  if ( mDeltaM != 0.0 )
+    wkb = QgsWkbTypes::addM( wkb );
+  return wkb;
+}
+
+
+bool QgsAffineTransformationAlgorithm::supportInPlaceEdit( const QgsMapLayer *l ) const
+{
+  const QgsVectorLayer *layer = qobject_cast< const QgsVectorLayer * >( l );
+  if ( !layer )
+    return false;
+
+  if ( ! QgsProcessingFeatureBasedAlgorithm::supportInPlaceEdit( layer ) )
+    return false;
+
+  // If the type differs there is no sense in executing the algorithm and drop the result
+  QgsWkbTypes::Type inPlaceWkbType = layer->wkbType();
+  return inPlaceWkbType == outputWkbType( inPlaceWkbType );
+}
+///@endcond
+
+

--- a/src/analysis/processing/qgsalgorithmaffinetransform.h
+++ b/src/analysis/processing/qgsalgorithmaffinetransform.h
@@ -1,0 +1,99 @@
+/***************************************************************************
+                         qgsalgorithmaffinetransform.h
+                         ---------------------
+    begin                : December 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMAFFINETRANSFORM_H
+#define QGSALGORITHMAFFINETRANSFORM_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native affine transformation algorithm.
+ */
+class QgsAffineTransformationAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsAffineTransformationAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsAffineTransformationAlgorithm *createInstance() const override SIP_FACTORY;
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  protected:
+    QString outputName() const override;
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
+
+  private:
+
+    double mDeltaX = 0.0;
+    bool mDynamicDeltaX = false;
+    QgsProperty mDeltaXProperty;
+
+    double mDeltaY = 0.0;
+    bool mDynamicDeltaY = false;
+    QgsProperty mDeltaYProperty;
+
+    double mDeltaZ = 0.0;
+    bool mDynamicDeltaZ = false;
+    QgsProperty mDeltaZProperty;
+
+    double mDeltaM = 0.0;
+    bool mDynamicDeltaM = false;
+    QgsProperty mDeltaMProperty;
+
+    double mScaleX = 0.0;
+    bool mDynamicScaleX = false;
+    QgsProperty mScaleXProperty;
+
+    double mScaleY = 0.0;
+    bool mDynamicScaleY = false;
+    QgsProperty mScaleYProperty;
+
+    double mScaleZ = 0.0;
+    bool mDynamicScaleZ = false;
+    QgsProperty mScaleZProperty;
+
+    double mScaleM = 0.0;
+    bool mDynamicScaleM = false;
+    QgsProperty mScaleMProperty;
+
+    double mRotationZ = 0.0;
+    bool mDynamicRotationZ = false;
+    QgsProperty mRotationZProperty;
+
+};
+
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMAFFINETRANSFORM_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -19,6 +19,7 @@
 #include "qgsalgorithmaddincrementalfield.h"
 #include "qgsalgorithmaddtablefield.h"
 #include "qgsalgorithmaddxyfields.h"
+#include "qgsalgorithmaffinetransform.h"
 #include "qgsalgorithmapplylayerstyle.h"
 #include "qgsalgorithmarraytranslatedfeatures.h"
 #include "qgsalgorithmaspect.h"
@@ -196,6 +197,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsAddTableFieldAlgorithm() );
   addAlgorithm( new QgsAddXYFieldsAlgorithm() );
   addAlgorithm( new QgsAddUniqueValueIndexAlgorithm() );
+  addAlgorithm( new QgsAffineTransformationAlgorithm() );
   addAlgorithm( new QgsApplyLayerStyleAlgorithm() );
   addAlgorithm( new QgsArrayTranslatedFeaturesAlgorithm() );
   addAlgorithm( new QgsAspectAlgorithm() );

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -194,6 +194,7 @@ class TestQgsProcessingInPlace(unittest.TestCase):
         self._support_inplace_edit_tester('native:splitlinesbylength', LINESTRING_ONLY)
         self._support_inplace_edit_tester('native:buffer', POLYGON_ONLY_NOT_M_NOT_Z)
         self._support_inplace_edit_tester('native:antimeridiansplit', LINESTRING_ONLY)
+        self._support_inplace_edit_tester('native:affinetransform', GEOMETRY_ONLY)
 
     def _make_compatible_tester(self, feature_wkt, layer_wkb_name, attrs=[1]):
         layer = self._make_layer(layer_wkb_name)


### PR DESCRIPTION
Offers the following benefits over the GRASS/SAGA versions:
- Full support for z/m values and handling curved geometries without loss
of curves
- Works with all native data types, no need for format transformation
- Supports dynamic (data defined, per feature) translate/scale/rotate parameters
- Allows transformation and scaling of both Z and M values (if present)
- Supports in-place edit mode

Fixes #33550
