### PR TITLE
Fix validity mask filename quoting in Sieve and Fillnodata algorithms

### DIFF
--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -133,7 +133,8 @@ class fillnodata(GdalAlgorithm):
 
         mask = self.parameterAsRasterLayer(parameters, self.MASK_LAYER, context)
         if mask:
-            arguments.append('-mask {}'.format(mask.source()))
+            arguments.append('-mask')
+            arguments.append(mask.source())
 
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)

--- a/python/plugins/processing/algs/gdal/sieve.py
+++ b/python/plugins/processing/algs/gdal/sieve.py
@@ -112,7 +112,8 @@ class sieve(GdalAlgorithm):
 
         mask = self.parameterAsRasterLayer(parameters, self.MASK_LAYER, context)
         if mask:
-            arguments.append('-mask {}'.format(mask.source()))
+            arguments.append('-mask')
+            arguments.append(mask.source())
 
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         self.setOutputValue(self.OUTPUT, out)


### PR DESCRIPTION
## Description
Fixes validity mask filename quoting in Sieve algorithm (Fixes #33562)

It also fixes a similar unreported bug in Fillnodata algorithm.

The patch could be backported to 3.10 and 3.4 branchs.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
