### PR TITLE
Fix missing flags in r.reclass.area GRASS algorithm

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.reclass.area.txt
+++ b/python/plugins/processing/algs/grass7/description/r.reclass.area.txt
@@ -1,8 +1,10 @@
 r.reclass.area
-Reclassifies a raster layer, selecting areas lower than a user specified size
+Reclassifies a raster layer, greater or less than user specified area size (in hectares)
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
 QgsProcessingParameterNumber|value|Value option that sets the area size limit [hectares]|QgsProcessingParameterNumber.Double|1.0|False|0|None
 QgsProcessingParameterEnum|mode|Lesser or greater than specified value|lesser;greater|False|0|False
 QgsProcessingParameterEnum|method|Method used for reclassification|reclass;rmarea|False|0|True
+*QgsProcessingParameterBoolean|-c|Input map is clumped|False
+*QgsProcessingParameterBoolean|-d|Clumps including diagonal neighbors|False
 QgsProcessingParameterRasterDestination|output|Reclassified


### PR DESCRIPTION
## Description
Adds -c ("Input map is clumped") and -d ("Clumps including diagonal neighbors") missing flags in r.reclass.area GRASS algorithm.
Fixes also the algorithm description. See r.reclass.area [7.6](https://grass.osgeo.org/grass76/manuals/r.reclass.area.html) and [7.8](https://grass.osgeo.org/grass78/manuals/r.reclass.area.html).

The patch could be backported to 3.10 branch.

Fixes #33569

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
