### PR TITLE
Add constructor for QgsSpatialIndex which allows for a callback during bulk load

### DIFF
--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -63,6 +63,7 @@ that of the spatial index construction.
 .. versionadded:: 2.8
 %End
 
+
     explicit QgsSpatialIndex( const QgsFeatureSource &source, QgsFeedback *feedback = 0, QgsSpatialIndex::Flags flags = 0 );
 %Docstring
 Constructor - creates R-tree and bulk loads it with features from the source.

--- a/python/plugins/processing/tests/testdata/expected/nearest_lines_to_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/nearest_lines_to_polys.gml
@@ -10,7 +10,7 @@
       <gml:coord><gml:X>10</gml:X><gml:Y>5</gml:Y></gml:coord>
     </gml:Box>
   </gml:boundedBy>
-                                                                                                                                                             
+
   <gml:featureMember>
     <ogr:nearest_lines_to_polys fid="polys.0">
       <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -0.784492588369441,2.79526795895097 2.84914481185861,2.77371721778791 2.97844925883694,2.0 2.30005017001229,2.31222976119276 1.7306157354618,2.18318129988597 1.8047712914227,1.30692158433784 1.67006135290115,0.930982619199196 1.75463252921878,0.447776631639586 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
@@ -48,7 +48,7 @@
       <ogr:intval>0</ogr:intval>
       <ogr:floatval xsi:nil="true"/>
       <ogr:fid_2>lines.4</ogr:fid_2>
-      <ogr:n>1</ogr:n>
+      <ogr:n>2</ogr:n>
       <ogr:distance>0</ogr:distance>
       <ogr:feature_x>7</ogr:feature_x>
       <ogr:feature_y>-3</ogr:feature_y>
@@ -63,7 +63,7 @@
       <ogr:intval>0</ogr:intval>
       <ogr:floatval xsi:nil="true"/>
       <ogr:fid_2>lines.5</ogr:fid_2>
-      <ogr:n>2</ogr:n>
+      <ogr:n>1</ogr:n>
       <ogr:distance>0</ogr:distance>
       <ogr:feature_x>10</ogr:feature_x>
       <ogr:feature_y>0.751595020683033</ogr:feature_y>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -1991,6 +1991,7 @@ tests:
       OUTPUT:
         name: expected/nearest_lines_to_polys.gml
         type: vector
+        pk: [fid,fid_2]
 
   - algorithm: native:joinbynearest
     name: Nearest points to lines, with max distance

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -102,7 +102,6 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
   if ( !sink )
     throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
 
-  QgsSpatialIndex spatialIndex;
   QMap< QgsFeatureId, QgsGeometry > splitGeoms;
   QgsFeatureRequest request;
   request.setNoAttributes();
@@ -110,16 +109,17 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
 
   QgsFeatureIterator splitLines = linesSource->getFeatures( request );
   QgsFeature aSplitFeature;
-  while ( splitLines.nextFeature( aSplitFeature ) )
+
+  QgsSpatialIndex spatialIndex( splitLines, [&]( const QgsFeature & aSplitFeature )-> bool
   {
     if ( feedback->isCanceled() )
     {
-      break;
+      return false;
     }
 
     splitGeoms.insert( aSplitFeature.id(), aSplitFeature.geometry() );
-    spatialIndex.addFeature( aSplitFeature );
-  }
+    return true;
+  } );
 
   QgsFeature outFeat;
   QgsFeatureIterator features = source->getFeatures();

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -348,10 +348,12 @@ QgsSpatialIndex::QgsSpatialIndex( const QgsFeatureIterator &fi, QgsFeedback *fee
   d = new QgsSpatialIndexData( fi, feedback, flags );
 }
 
+///@cond PRIVATE // else throws a doxygen warning?
 QgsSpatialIndex::QgsSpatialIndex( const QgsFeatureIterator &fi, const std::function< bool( const QgsFeature & )> &callback, QgsSpatialIndex::Flags flags )
 {
   d = new QgsSpatialIndexData( fi, nullptr, flags, &callback );
 }
+///@endcond
 
 QgsSpatialIndex::QgsSpatialIndex( const QgsFeatureSource &source, QgsFeedback *feedback, QgsSpatialIndex::Flags flags )
 {

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -95,6 +95,23 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
      */
     explicit QgsSpatialIndex( const QgsFeatureIterator &fi, QgsFeedback *feedback = nullptr, QgsSpatialIndex::Flags flags = nullptr );
 
+#ifndef SIP_RUN
+
+    /**
+     * Constructor - creates R-tree and bulk loads it with features from the iterator.
+     * This is much faster approach than creating an empty index and then inserting features one by one.
+     *
+     * This construct and bulk load variant allows for a \a callback function to be specified, which is
+     * called for each added feature in turn. It allows for bulk spatial index load along with other feature
+     * based operations on a single iteration through a feature source. If \a callback returns FALSE, the
+     * load and iteration is canceled.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 2.12
+     */
+    explicit QgsSpatialIndex( const QgsFeatureIterator &fi, const std::function< bool( const QgsFeature & ) > &callback, QgsSpatialIndex::Flags flags = nullptr );
+#endif
+
     /**
      * Constructor - creates R-tree and bulk loads it with features from the source.
      * This is much faster approach than creating an empty index and then inserting features one by one.


### PR DESCRIPTION
... and use this in some c++ processing algorithms which populate a spatial index direct from an iterator.

Quick benchmarks: cuts processing time for Delete Duplicate Geometries to 70% of original for a 3 million point input file (debug build)