### PR TITLE
Fix rule-based renderer widgets swallow copy/paste/delete shortcut keys

### DIFF
--- a/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrendererwidget.sip.in
@@ -69,6 +69,9 @@ Returns the vector layer associated with the widget.
 This method should be called whenever the renderer is actually set on the layer.
 %End
 
+    virtual void setDockMode( bool dockMode );
+
+
   signals:
 
     void layerVariablesChanged();

--- a/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
+++ b/python/gui/auto_generated/symbology/qgsrulebasedrendererwidget.sip.in
@@ -104,6 +104,8 @@ class QgsRuleBasedRendererWidget : QgsRendererWidget
 
     virtual QgsFeatureRenderer *renderer();
 
+    virtual void setDockMode( bool dockMode );
+
 
   public slots:
 

--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -88,6 +88,21 @@ void QgsRuleBased3DRendererWidget::setLayer( QgsVectorLayer *layer )
   connect( mModel, &QAbstractItemModel::rowsRemoved, this, &QgsRuleBased3DRendererWidget::widgetChanged );
 }
 
+void QgsRuleBased3DRendererWidget::setDockMode( bool dockMode )
+{
+  if ( dockMode )
+  {
+    // when in dock mode, these shortcuts conflict with the main window shortcuts and cannot be used
+    if ( mCopyAction )
+      mCopyAction->setShortcut( QKeySequence() );
+    if ( mPasteAction )
+      mPasteAction->setShortcut( QKeySequence() );
+    if ( mDeleteAction )
+      mDeleteAction->setShortcut( QKeySequence() );
+  }
+  QgsPanelWidget::setDockMode( dockMode );
+}
+
 
 void QgsRuleBased3DRendererWidget::addRule()
 {

--- a/src/app/3d/qgsrulebased3drendererwidget.h
+++ b/src/app/3d/qgsrulebased3drendererwidget.h
@@ -86,12 +86,14 @@ class QgsRuleBased3DRendererWidget : public QgsPanelWidget, private Ui::QgsRuleB
 
   public:
     QgsRuleBased3DRendererWidget( QWidget *parent = nullptr );
-    ~QgsRuleBased3DRendererWidget();
+    ~QgsRuleBased3DRendererWidget() override;
 
     //! load renderer from the layer
     void setLayer( QgsVectorLayer *layer );
     //! no transfer of ownership
     QgsRuleBased3DRenderer::Rule *rootRule() { return mRootRule; }
+
+    void setDockMode( bool dockMode ) override;
 
   protected slots:
     void addRule();

--- a/src/app/labeling/qgsrulebasedlabelingwidget.cpp
+++ b/src/app/labeling/qgsrulebasedlabelingwidget.cpp
@@ -115,6 +115,21 @@ QgsRuleBasedLabelingWidget::~QgsRuleBasedLabelingWidget()
   delete mRootRule;
 }
 
+void QgsRuleBasedLabelingWidget::setDockMode( bool dockMode )
+{
+  if ( dockMode )
+  {
+    // when in dock mode, these shortcuts conflict with the main window shortcuts and cannot be used
+    if ( mCopyAction )
+      mCopyAction->setShortcut( QKeySequence() );
+    if ( mPasteAction )
+      mPasteAction->setShortcut( QKeySequence() );
+    if ( mDeleteAction )
+      mDeleteAction->setShortcut( QKeySequence() );
+  }
+  QgsPanelWidget::setDockMode( dockMode );
+}
+
 void QgsRuleBasedLabelingWidget::addRule()
 {
 

--- a/src/app/labeling/qgsrulebasedlabelingwidget.h
+++ b/src/app/labeling/qgsrulebasedlabelingwidget.h
@@ -88,6 +88,8 @@ class QgsRuleBasedLabelingWidget : public QgsPanelWidget, private Ui::QgsRuleBas
     //! Gives access to the internal root of the rule tree
     const QgsRuleBasedLabeling::Rule *rootRule() const { return mRootRule; }
 
+    void setDockMode( bool dockMode ) override;
+
   protected slots:
     void addRule();
     void editRule();

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -348,6 +348,19 @@ void QgsRendererWidget::applyChanges()
   apply();
 }
 
+void QgsRendererWidget::setDockMode( bool dockMode )
+{
+  if ( dockMode )
+  {
+    // when in dock mode, these shortcuts conflict with the main window shortcuts and cannot be used
+    if ( mCopyAction )
+      mCopyAction->setShortcut( QKeySequence() );
+    if ( mPasteAction )
+      mPasteAction->setShortcut( QKeySequence() );
+  }
+  QgsPanelWidget::setDockMode( dockMode );
+}
+
 QgsDataDefinedSizeLegendWidget *QgsRendererWidget::createDataDefinedSizeLegendWidget( const QgsMarkerSymbol *symbol, const QgsDataDefinedSizeLegend *ddsLegend )
 {
   QgsProperty ddSize = symbol->dataDefinedSize();

--- a/src/gui/symbology/qgsrendererwidget.h
+++ b/src/gui/symbology/qgsrendererwidget.h
@@ -79,6 +79,8 @@ class GUI_EXPORT QgsRendererWidget : public QgsPanelWidget
      */
     void applyChanges();
 
+    void setDockMode( bool dockMode ) override;
+
   signals:
 
     /**

--- a/src/gui/symbology/qgsrulebasedrendererwidget.cpp
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.cpp
@@ -143,6 +143,17 @@ QgsFeatureRenderer *QgsRuleBasedRendererWidget::renderer()
   return mRenderer;
 }
 
+void QgsRuleBasedRendererWidget::setDockMode( bool dockMode )
+{
+  if ( dockMode )
+  {
+    // when in dock mode, these shortcuts conflict with the main window shortcuts and cannot be used
+    if ( mDeleteAction )
+      mDeleteAction->setShortcut( QKeySequence() );
+  }
+  QgsRendererWidget::setDockMode( dockMode );
+}
+
 void QgsRuleBasedRendererWidget::addRule()
 {
   QgsSymbol *s = QgsSymbol::defaultSymbol( mLayer->geometryType() );

--- a/src/gui/symbology/qgsrulebasedrendererwidget.h
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.h
@@ -126,6 +126,7 @@ class GUI_EXPORT QgsRuleBasedRendererWidget : public QgsRendererWidget, private 
     ~QgsRuleBasedRendererWidget() override;
 
     QgsFeatureRenderer *renderer() override;
+    void setDockMode( bool dockMode ) override;
 
   public slots:
 


### PR DESCRIPTION
when opened in panel modes

Fixes #33592
