### PR TITLE
Port field parameter widget to new API

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -71,6 +71,26 @@ Returns the map canvas associated with the widget.
 .. seealso:: :py:func:`setMapCanvas`
 %End
 
+    void setMessageBar( QgsMessageBar *bar );
+%Docstring
+Sets the message ``bar`` associated with the widget. This allows the widget to push feedback messages
+to the user.
+
+.. seealso:: :py:func:`messageBar`
+
+.. versionadded:: 3.12
+%End
+
+    QgsMessageBar *messageBar() const;
+%Docstring
+Returns the message bar associated with the widget. This allows the widget to push feedback messages
+to the user.
+
+.. seealso:: :py:func:`setMessageBar`
+
+.. versionadded:: 3.12
+%End
+
     void setProject( QgsProject *project );
 %Docstring
 Sets the ``project`` associated with the widget. This allows the widget to retrieve the map layers

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -495,6 +495,9 @@ class BatchPanel(BASE, WIDGET):
         widget_context.setProject(QgsProject.instance())
         if iface is not None:
             widget_context.setMapCanvas(iface.mapCanvas())
+
+        widget_context.setMessageBar(self.parent.messageBar())
+
         if isinstance(self.alg, QgsProcessingModelAlgorithm):
             widget_context.setModel(self.alg)
         wrapper.setWidgetContext(widget_context)

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -129,6 +129,7 @@ class ParametersPanel(BASE, WIDGET):
         widget_context.setProject(QgsProject.instance())
         if iface is not None:
             widget_context.setMapCanvas(iface.mapCanvas())
+        widget_context.setMessageBar(self.parent.messageBar())
         if isinstance(self.alg, QgsProcessingModelAlgorithm):
             widget_context.setModel(self.alg)
 

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1503,6 +1503,14 @@ class TableFieldWidgetWrapper(WidgetWrapper):
 
     def __init__(self, param, dialog, row=0, col=0, **kwargs):
         super().__init__(param, dialog, row, col, **kwargs)
+        """
+        .. deprecated:: 3.12
+        Do not use, will be removed in QGIS 4.0
+        """
+
+        from warnings import warn
+        warn("TableFieldWidgetWrapper is deprecated and will be removed in QGIS 4.0", DeprecationWarning)
+
         self.context = dataobjects.createContext()
 
     def createWidget(self):
@@ -1846,6 +1854,7 @@ class WidgetWrapperFactory:
         elif param.type() == 'vector':
             wrapper = VectorLayerWidgetWrapper
         elif param.type() == 'field':
+            # deprecated, moved to c++
             wrapper = TableFieldWidgetWrapper
         elif param.type() == 'source':
             wrapper = FeatureSourceWidgetWrapper

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -44,6 +44,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingPointWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingColorWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingCoordinateOperationWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingFieldWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -41,6 +41,16 @@ QgsMapCanvas *QgsProcessingParameterWidgetContext::mapCanvas() const
   return mMapCanvas;
 }
 
+void QgsProcessingParameterWidgetContext::setMessageBar( QgsMessageBar *bar )
+{
+  mMessageBar = bar;
+}
+
+QgsMessageBar *QgsProcessingParameterWidgetContext::messageBar() const
+{
+  return mMessageBar;
+}
+
 void QgsProcessingParameterWidgetContext::setProject( QgsProject *project )
 {
   mProject = project;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -38,6 +38,7 @@ class QgsProcessingModelAlgorithm;
 class QgsMapCanvas;
 class QgsProcessingAlgorithm;
 class QgsProcessingAbstractParameterDefinitionWidget;
+class QgsMessageBar;
 
 /**
  * \class QgsProcessingContextGenerator
@@ -95,6 +96,22 @@ class GUI_EXPORT QgsProcessingParameterWidgetContext
     QgsMapCanvas *mapCanvas() const;
 
     /**
+     * Sets the message \a bar associated with the widget. This allows the widget to push feedback messages
+     * to the user.
+     * \see messageBar()
+     * \since QGIS 3.12
+     */
+    void setMessageBar( QgsMessageBar *bar );
+
+    /**
+     * Returns the message bar associated with the widget. This allows the widget to push feedback messages
+     * to the user.
+     * \see setMessageBar()
+     * \since QGIS 3.12
+     */
+    QgsMessageBar *messageBar() const;
+
+    /**
      * Sets the \a project associated with the widget. This allows the widget to retrieve the map layers
      * and other properties from the correct project.
      * \see project()
@@ -147,6 +164,8 @@ class GUI_EXPORT QgsProcessingParameterWidgetContext
     QString mModelChildAlgorithmId;
 
     QgsMapCanvas *mMapCanvas = nullptr;
+
+    QgsMessageBar *mMessageBar = nullptr;
 
     QgsProject *mProject = nullptr;
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -50,6 +50,7 @@ class QgsSnapIndicator;
 class QgsFilterLineEdit;
 class QgsColorButton;
 class QgsCoordinateOperationWidget;
+class QgsFieldComboBox;
 
 ///@cond PRIVATE
 
@@ -944,6 +945,92 @@ class GUI_EXPORT QgsProcessingCoordinateOperationWidgetWrapper : public QgsAbstr
     QgsCoordinateReferenceSystem mDestCrs;
     friend class TestProcessingGui;
 };
+
+class GUI_EXPORT QgsProcessingFieldPanelWidget : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingFieldPanelWidget( QWidget *parent = nullptr, const QgsProcessingParameterField *param = nullptr );
+
+    void setFields( const QgsFields &fields );
+
+    QgsFields fields() const { return mFields; }
+
+    QVariant value() const { return mValue; }
+    void setValue( const QVariant &value );
+
+  signals:
+
+    void changed();
+
+  private slots:
+
+    void showDialog();
+
+  private:
+
+    void updateSummaryText();
+
+    QgsFields mFields;
+
+    const QgsProcessingParameterField *mParam = nullptr;
+    QLineEdit *mLineEdit = nullptr;
+    QToolButton *mToolButton = nullptr;
+
+    QVariantList mValue;
+
+    friend class TestProcessingGui;
+};
+
+
+class GUI_EXPORT QgsProcessingFieldWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingFieldWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                     QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+    void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers ) override;
+
+  public slots:
+    void setParentLayerWrapperValue( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper );
+
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+
+    QStringList compatibleParameterTypes() const override;
+
+    QStringList compatibleOutputTypes() const override;
+
+    QList< int > compatibleDataTypes() const override;
+    QString modelerExpressionFormatString() const override;
+    const QgsVectorLayer *linkedVectorLayer() const override;
+
+  private:
+
+    QgsFieldComboBox *mComboBox = nullptr;
+    QgsProcessingFieldPanelWidget *mPanel = nullptr;
+    QLineEdit *mLineEdit = nullptr;
+
+    std::unique_ptr< QgsVectorLayer > mParentLayer;
+
+    QgsFields filterFields( const QgsFields &fields ) const;
+
+    friend class TestProcessingGui;
+};
+
 
 ///@endcond PRIVATE
 

--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -56,6 +56,7 @@ QgsVectorLayer *QgsFieldComboBox::layer() const
 
 void QgsFieldComboBox::setField( const QString &fieldName )
 {
+  const QString prevField = currentField();
   QModelIndex idx = mFieldProxyModel->sourceFieldModel()->indexFromName( fieldName );
   if ( idx.isValid() )
   {
@@ -63,11 +64,19 @@ void QgsFieldComboBox::setField( const QString &fieldName )
     if ( proxyIdx.isValid() )
     {
       setCurrentIndex( proxyIdx.row() );
-      emit fieldChanged( currentField() );
-      return;
+    }
+    else
+    {
+      setCurrentIndex( -1 );
     }
   }
-  setCurrentIndex( -1 );
+  else
+  {
+    setCurrentIndex( -1 );
+  }
+
+  if ( prevField != currentField() )
+    emit fieldChanged( currentField() );
 }
 
 QString QgsFieldComboBox::currentField() const

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -64,6 +64,7 @@
 #include "qgscolorbutton.h"
 #include "qgsprocessingparameterdefinitionwidget.h"
 #include "qgscoordinateoperationwidget.h"
+#include "qgsmessagebar.h"
 
 class TestParamType : public QgsProcessingParameterDefinition
 {
@@ -417,6 +418,11 @@ void TestProcessingGui::testWrapperGeneral()
   QgsProcessingParameterWidgetContext widgetContext;
   widgetContext.setMapCanvas( mc.get() );
   QCOMPARE( widgetContext.mapCanvas(), mc.get() );
+
+  std::unique_ptr< QgsMessageBar > mb = qgis::make_unique< QgsMessageBar >();
+  widgetContext.setMessageBar( mb.get() );
+  QCOMPARE( widgetContext.messageBar(), mb.get() );
+
   QgsProject p;
   widgetContext.setProject( &p );
   QCOMPARE( widgetContext.project(), &p );
@@ -428,6 +434,7 @@ void TestProcessingGui::testWrapperGeneral()
 
   wrapper.setWidgetContext( widgetContext );
   QCOMPARE( wrapper.widgetContext().mapCanvas(), mc.get() );
+  QCOMPARE( wrapper.widgetContext().messageBar(), mb.get() );
   QCOMPARE( wrapper.widgetContext().model(), model.get() );
   QCOMPARE( wrapper.widgetContext().modelChildAlgorithmId(), QStringLiteral( "xx" ) );
 }

--- a/tests/src/python/test_qgsfieldcombobox.py
+++ b/tests/src/python/test_qgsfieldcombobox.py
@@ -15,9 +15,9 @@ import qgis  # NOQA
 from qgis.core import QgsFields, QgsVectorLayer, QgsFieldProxyModel
 from qgis.gui import QgsFieldComboBox
 from qgis.PyQt.QtCore import QVariant, Qt
+from qgis.PyQt.QtTest import QSignalSpy
 
 from qgis.testing import start_app, unittest
-
 start_app()
 
 
@@ -57,6 +57,28 @@ class TestQgsFieldComboBox(unittest.TestCase):
 
         w.setField('fldint')
         self.assertEqual(w.currentField(), 'fldint')
+
+    def testSignals(self):
+        l = create_layer()
+        w = QgsFieldComboBox()
+        w.setLayer(l)
+
+        spy = QSignalSpy(w.fieldChanged)
+        w.setField('fldint2')
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1][0], 'fldint2')
+        w.setField('fldint2')
+        self.assertEqual(len(spy), 1)
+        self.assertEqual(spy[-1][0], 'fldint2')
+        w.setField('fldint')
+        self.assertEqual(len(spy), 2)
+        self.assertEqual(spy[-1][0], 'fldint')
+        w.setField(None)
+        self.assertEqual(len(spy), 3)
+        self.assertEqual(spy[-1][0], None)
+        w.setField(None)
+        self.assertEqual(len(spy), 3)
+        self.assertEqual(spy[-1][0], None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Gets it off the deprecated Python based API, and allows models to use expression-based values for field parameters.