### PR TITLE
Move Build Vector VRT to gdal provider

### DIFF
--- a/python/plugins/processing/algs/gdal/Datasources2Vrt.py
+++ b/python/plugins/processing/algs/gdal/Datasources2Vrt.py
@@ -30,27 +30,33 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingParameterVectorDestination,
                        QgsProcessingOutputString
                        )
-from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
+from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 
 
-class Datasources2Vrt(QgisAlgorithm):
+class Datasources2Vrt(GdalAlgorithm):
     INPUT = 'INPUT'
     UNIONED = 'UNIONED'
     OUTPUT = 'OUTPUT'
     VRT_STRING = 'VRT_STRING'
 
+    def createCustomParametersWidget(self, parent):
+        return None
+
     def group(self):
-        return self.tr('Vector general')
+        return self.tr('Vector miscellaneous')
 
     def groupId(self):
-        return 'vectorgeneral'
+        return 'vectormiscellaneous'
 
     def name(self):
         return 'buildvirtualvector'
 
     def displayName(self):
         return self.tr('Build virtual vector')
+
+    def tags(self):
+        return ['ogr', 'gdal', 'vrt', 'create']
 
     def __init__(self):
         super().__init__()

--- a/python/plugins/processing/algs/gdal/Datasources2Vrt.py
+++ b/python/plugins/processing/algs/gdal/Datasources2Vrt.py
@@ -121,3 +121,6 @@ class Datasources2Vrt(GdalAlgorithm):
             f.write(vrt)
 
         return {self.OUTPUT: vrtPath, self.VRT_STRING: vrt}
+
+    def commandName(self):
+        return ''

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -38,6 +38,7 @@ from .ClipRasterByExtent import ClipRasterByExtent
 from .ClipRasterByMask import ClipRasterByMask
 from .ColorRelief import ColorRelief
 from .contour import contour
+from .Datasources2Vrt import Datasources2Vrt
 from .fillnodata import fillnodata
 from .gdalinfo import gdalinfo
 from .gdal2tiles import gdal2tiles
@@ -99,6 +100,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
     def __init__(self):
         super().__init__()
         self.algs = []
+        QgsApplication.processingRegistry().addAlgorithmAlias('qgis:buildvirtualvector', 'gdal:buildvirtualvector')
 
     def load(self):
         ProcessingConfig.settingIcons[self.name()] = self.icon()
@@ -145,6 +147,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             ClipRasterByMask(),
             ColorRelief(),
             contour(),
+            Datasources2Vrt(),
             fillnodata(),
             gdalinfo(),
             gdal2tiles(),

--- a/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
@@ -35,7 +35,6 @@ from .BoxPlot import BoxPlot
 from .CheckValidity import CheckValidity
 from .Climb import Climb
 from .ConcaveHull import ConcaveHull
-from .Datasources2Vrt import Datasources2Vrt
 from .DefineProjection import DefineProjection
 from .Delaunay import Delaunay
 from .DeleteColumn import DeleteColumn
@@ -117,7 +116,6 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
                 CheckValidity(),
                 Climb(),
                 ConcaveHull(),
-                Datasources2Vrt(),
                 DefineProjection(),
                 Delaunay(),
                 DeleteColumn(),

--- a/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsGeneralTest.py
@@ -67,12 +67,17 @@ class TestGdalAlgorithms(unittest.TestCase):
         # Test that algorithms report a valid commandName
         p = QgsApplication.processingRegistry().providerById('gdal')
         for a in p.algorithms():
+            if a.id() in ('gdal:buildvirtualvector'):
+                # build virtual vector is an exception
+                continue
             self.assertTrue(a.commandName(), 'Algorithm {} has no commandName!'.format(a.id()))
 
     def testCommandNameInTags(self):
         # Test that algorithms commandName is present in provided tags
         p = QgsApplication.processingRegistry().providerById('gdal')
         for a in p.algorithms():
+            if not a.commandName():
+                continue
             self.assertTrue(a.commandName() in a.tags(), 'Algorithm {} commandName not found in tags!'.format(a.id()))
 
     def testNoParameters(self):


### PR DESCRIPTION
and setup alias to avoid script/model breakage. This algorithm
uses GDAL utilities and fits better alongside the other GDAL based
algorithm rather than in the qgis provider.
