### PR TITLE
Avoid temporary flashing dialog showing when a distance parameter widget is constructed

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -880,12 +880,13 @@ QWidget *QgsProcessingDistanceWidgetWrapper::createWidget()
       mWarningLabel->setLayout( warningLayout );
       layout->insertWidget( 4, mWarningLabel );
 
-      setUnits( distanceDef->defaultUnit() );
-
       QWidget *w = new QWidget();
       layout->setMargin( 0 );
       layout->setContentsMargins( 0, 0, 0, 0 );
       w->setLayout( layout );
+
+      setUnits( distanceDef->defaultUnit() );
+
       return w;
     }
 


### PR DESCRIPTION
…Fixes a bug I can't find the report for anymore...
