### PR TITLE
Accept newline terminated string as temporary scratch layer

### DIFF
--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -309,6 +309,16 @@ QgsFeatureList QgsClipboard::copyOf( const QgsFields &fields ) const
   QString text = cb->text( QClipboard::Clipboard );
 #endif
 
+  if ( text.endsWith( '\n' ) )
+  {
+    text.chop( 1 );
+    // In case Windows <EOL> marker (CRLF) makes it into the variable "text"
+    if ( text.endsWith( '\r' ) )
+    {
+      text.chop( 1 );
+    }
+  }
+
   return stringToFeatureList( text, fields );
 }
 

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -270,10 +270,10 @@ QgsFields QgsClipboard::retrieveFields() const
     }
 
     //wkt?
-    QStringList lines = string.split( '\n' );
-    if ( !lines.empty() )
+    QString firstLine = string.section( '\n', 0, 0 );
+    if ( !firstLine.isEmpty() )
     {
-      QStringList fieldNames = lines.at( 0 ).split( '\t' );
+      QStringList fieldNames = firstLine.split( '\t' );
       //wkt / text always has wkt_geom as first attribute (however values can be NULL)
       if ( fieldNames.at( 0 ) != QLatin1String( "wkt_geom" ) )
       {

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -331,6 +331,40 @@ void TestQgisAppClipboard::pasteWkt()
   QCOMPARE( features.at( 2 ).attributes().at( 0 ).toString(), QStringLiteral( "2" ) );
   QCOMPARE( features.at( 2 ).attributes().at( 1 ).toString(), QStringLiteral( "b2" ) );
   QCOMPARE( features.at( 2 ).attributes().at( 2 ).toString(), QStringLiteral( "3" ) );
+
+  // when a set of features is built outside of QGIS, last one might be terminated by newline
+  // https://github.com/qgis/QGIS/issues/33617
+  mQgisApp->clipboard()->setText( QStringLiteral( "POINT (125 10)\nPOINT (111 30)\n" ) );
+  features = mQgisApp->clipboard()->copyOf();
+  QCOMPARE( features.length(), 2 );
+  QVERIFY( features.at( 0 ).hasGeometry() && !features.at( 0 ).geometry().isNull() );
+  QCOMPARE( features.at( 0 ).geometry().constGet()->wkbType(), QgsWkbTypes::Point );
+  featureGeom = features.at( 0 ).geometry();
+  point = dynamic_cast< const QgsPoint * >( featureGeom.constGet() );
+  QCOMPARE( point->x(), 125.0 );
+  QCOMPARE( point->y(), 10.0 );
+  QVERIFY( features.at( 1 ).hasGeometry() && !features.at( 1 ).geometry().isNull() );
+  QCOMPARE( features.at( 1 ).geometry().constGet()->wkbType(), QgsWkbTypes::Point );
+  point = dynamic_cast< const QgsPoint * >( features.at( 1 ).geometry().constGet() );
+  QCOMPARE( point->x(), 111.0 );
+  QCOMPARE( point->y(), 30.0 );
+
+  // on MS Windows, the <EOL> marker is CRLF
+  // https://github.com/qgis/QGIS/pull/33618#discussion_r363147854
+  mQgisApp->clipboard()->setText( QStringLiteral( "POINT (125 10)\r\nPOINT (111 30)\r\n" ) );
+  features = mQgisApp->clipboard()->copyOf();
+  QCOMPARE( features.length(), 2 );
+  QVERIFY( features.at( 0 ).hasGeometry() && !features.at( 0 ).geometry().isNull() );
+  QCOMPARE( features.at( 0 ).geometry().constGet()->wkbType(), QgsWkbTypes::Point );
+  featureGeom = features.at( 0 ).geometry();
+  point = dynamic_cast< const QgsPoint * >( featureGeom.constGet() );
+  QCOMPARE( point->x(), 125.0 );
+  QCOMPARE( point->y(), 10.0 );
+  QVERIFY( features.at( 1 ).hasGeometry() && !features.at( 1 ).geometry().isNull() );
+  QCOMPARE( features.at( 1 ).geometry().constGet()->wkbType(), QgsWkbTypes::Point );
+  point = dynamic_cast< const QgsPoint * >( features.at( 1 ).geometry().constGet() );
+  QCOMPARE( point->x(), 111.0 );
+  QCOMPARE( point->y(), 30.0 );
 }
 
 void TestQgisAppClipboard::pasteGeoJson()


### PR DESCRIPTION
This PR adds code to remove the last character of the string pasted from the clipboard if it is a newline character.

Also, I noticed that `QgsClipboard::retrieveFields()` is called three times for the paste action, and, the text in the clipboard is read and split into separate lines each time. If the data in the clipboard is large, wouldn't that be inefficient?

I tested this with 50000 points, and If I am measuring it correctly, it took about 850 ms to parse all those lines (just to extract the names of the fields). Reading only the first line (i.e. the modification in this PR) took about 55 ms on my VM. Any feedback on this point is appreciated.

I haven't written any unit tests because I don't know how [yet].

Fixes #33617