### PR TITLE
GPS fixes and rotation matching follow up

### DIFF
--- a/external/nmea/parse.c
+++ b/external/nmea/parse.c
@@ -133,12 +133,14 @@ int nmea_pack_type( const char *buff, int buff_sz )
     "GPGSV",
     "GPRMC",
     "GPVTG",
+    "HCHDG",
+    "HCHDT",
     "GNRMC",
     "GPGST",
   };
 
   // BUFFER_SIZE = size(P_HEADS) - 1;
-  int buffer_size = 6;
+  int buffer_size = 8;
 
   NMEA_ASSERT( buff );
 
@@ -155,8 +157,12 @@ int nmea_pack_type( const char *buff, int buff_sz )
   else if ( 0 == memcmp( buff, P_HEADS[4], buffer_size ) )
     return GPVTG;
   else if ( 0 == memcmp( buff, P_HEADS[5], buffer_size ) )
-    return GPRMC;
+    return HCHDG;
   else if ( 0 == memcmp( buff, P_HEADS[6], buffer_size ) )
+    return HCHDT;
+  else if ( 0 == memcmp( buff, P_HEADS[7], buffer_size ) )
+    return GPRMC;
+  else if ( 0 == memcmp( buff, P_HEADS[8], buffer_size ) )
     return GPGST;
 
   return GPNON;
@@ -502,6 +508,72 @@ int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack )
        pack->spk_k != 'K' )
   {
     nmea_error( "GPVTG parse error (format error)!" );
+    return 0;
+  }
+
+  return 1;
+}
+
+/**
+ * \brief Parse HCHDG packet from buffer.
+ * @param buff a constant character pointer of packet buffer.
+ * @param buff_sz buffer size.
+ * @param pack a pointer of packet which will filled by function.
+ * @return 1 (true) - if parsed successfully or 0 (false) - if fail.
+ */
+int nmea_parse_HCHDG( const char *buff, int buff_sz, nmeaHCHDG *pack )
+{
+  NMEA_ASSERT( buff && pack );
+
+  memset( pack, 0, sizeof( nmeaHCHDG ) );
+
+  nmea_trace_buff( buff, buff_sz );
+
+  if ( 5 != nmea_scanf( buff, buff_sz,
+                        "$HCHDG,%f,%f,%C,%f,%C*",
+                        &( pack->mag_heading ), &( pack->mag_deviation ),
+                        &( pack->ew_deviation ), &( pack->mag_variation ),
+                        &( pack->ew_variation ) ) )
+  {
+    nmea_error( "HCHDG parse error!" );
+    return 0;
+  }
+
+  if ( pack->ew_deviation != 'E' && pack->ew_deviation != 'W' )
+  {
+    nmea_error( "HCHDG invalid deviation direction" );
+    return 0;
+  }
+
+  if ( pack->ew_variation != 'E' && pack->ew_variation != 'W' )
+  {
+    nmea_error( "HCHDG invalid variation direction" );
+    return 0;
+  }
+
+  return 1;
+}
+
+/**
+ * \brief Parse HDT packet from buffer.
+ * @param buff a constant character pointer of packet buffer.
+ * @param buff_sz buffer size.
+ * @param pack a pointer of packet which will filled by function.
+ * @return 1 (true) - if parsed successfully or 0 (false) - if fail.
+ */
+int nmea_parse_HCHDT( const char *buff, int buff_sz, nmeaHCHDT *pack )
+{
+  NMEA_ASSERT( buff && pack );
+
+  memset( pack, 0, sizeof( nmeaHCHDT ) );
+
+  nmea_trace_buff( buff, buff_sz );
+
+  if ( 2 != nmea_scanf( buff, buff_sz,
+                        "$HCHDT,%f,%C*",
+                        &( pack->direction ), &( pack->t_flag ) ) )
+  {
+    nmea_error( "HCHDT parse error!" );
     return 0;
   }
 

--- a/external/nmea/parse.h
+++ b/external/nmea/parse.h
@@ -38,11 +38,13 @@ int nmea_pack_type( const char *buff, int buff_sz );
 int nmea_find_tail( const char *buff, int buff_sz, int *res_crc );
 
 int nmea_parse_GPGGA( const char *buff, int buff_sz, nmeaGPGGA *pack );
-int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack );
 int nmea_parse_GPGSA( const char *buff, int buff_sz, nmeaGPGSA *pack );
 int nmea_parse_GPGSV( const char *buff, int buff_sz, nmeaGPGSV *pack );
 int nmea_parse_GPRMC( const char *buff, int buff_sz, nmeaGPRMC *pack );
 int nmea_parse_GPVTG( const char *buff, int buff_sz, nmeaGPVTG *pack );
+int nmea_parse_HCHDG( const char *buff, int buff_sz, nmeaHCHDG *pack );
+int nmea_parse_HCHDT( const char *buff, int buff_sz, nmeaHCHDT *pack );
+int nmea_parse_GPGST( const char *buff, int buff_sz, nmeaGPGST *pack );
 int nmea_parse_GPHDT( const char *buff, int buff_sz, nmeaGPHDT *pack );
 
 void nmea_GPGGA2info( nmeaGPGGA *pack, nmeaINFO *info );

--- a/external/nmea/sentence.h
+++ b/external/nmea/sentence.h
@@ -31,7 +31,9 @@ enum nmeaPACKTYPE
   GPGSV   = 0x0004,   //!< GSV - Number of SVs in view, PRN numbers, elevation, azimuth & SNR values.
   GPRMC   = 0x0008,   //!< RMC - Recommended Minimum Specific GPS/TRANSIT Data.
   GPVTG   = 0x0010,   //!< VTG - Actual track made good and speed over ground.
-  GPGST   = 0x0012    //!< GST - GPS Pseudorange Noise Statistics
+  GPGST   = 0x0012,   //!< GST - GPS Pseudorange Noise Statistics
+  HCHDG   = 0x0020,   //!< HDG - Heading, Deviation and Variation
+  HCHDT   = 0x0100,   //!< HDT - Heading reference to true north
 };
 
 /**
@@ -139,10 +141,30 @@ typedef struct _nmeaGPVTG
 typedef struct _nmeaGPHDT
 {
   double  heading;    //!< Heading in degrees
-  char    dir_t;      //!< Fixed text 'T' indicates that heading is relative to true north
+  char    t_flag;      //!< Fixed text 'T' indicates that heading is relative to true north
 
 } nmeaGPHDT;
 
+/**
+ * HCHDG packet information structure (magnetic heading)
+ */
+typedef struct _nmeaHCHDG
+{
+  double mag_heading;   //!< Magnetic sensor heading (degrees)
+  double mag_deviation; //!< Magnetic deviation (degrees)
+  char ew_deviation;     //!< [E]ast or [W]est
+  double mag_variation; //!< Magnetic variation (degrees)
+  char ew_variation;    //!< [E]ast or [W]est
+} nmeaHCHDG;
+
+/**
+ * HDT packet information structure (Heading, )
+ */
+typedef struct _nmeaHCHDT
+{
+  double direction;   //!< Heading respect to true north (degrees)
+  char t_flag;    //!< Static text [T]
+} nmeaHCHDT;
 
 void nmea_zero_GPGGA( nmeaGPGGA *pack );
 void nmea_zero_GPGST( nmeaGPGST *pack );

--- a/python/core/auto_generated/gps/qgsnmeaconnection.sip.in
+++ b/python/core/auto_generated/gps/qgsnmeaconnection.sip.in
@@ -67,6 +67,14 @@ process GST sentence
 %Docstring
 process HDT sentence
 %End
+    void processHchdgSentence( const char *data, int len );
+%Docstring
+process HCHDG sentence
+%End
+    void processHchdtSentence( const char *data, int len );
+%Docstring
+process HCHDT sentence
+%End
 };
 
 /************************************************************************

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -130,6 +130,8 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   mpHistogramLayout->addWidget( mPlot );
   mpHistogramWidget->setLayout( mpHistogramLayout );
 
+  mSpinMapRotateInterval->setClearValue( 0 );
+
   //
   // Set up the polar graph for satellite pos
   //
@@ -276,7 +278,11 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   {
     radRecenterWhenNeeded->setChecked( true );
   }
+
+  connect( mRotateMapCheckBox, &QCheckBox::toggled, mSpinMapRotateInterval, &QSpinBox::setEnabled );
+
   mRotateMapCheckBox->setChecked( mySettings.value( QStringLiteral( "gps/rotateMap" ), false ).toBool() );
+  mSpinMapRotateInterval->setValue( mySettings.value( QStringLiteral( "gps/rotateMapInterval" ), 0 ).toInt() );
   mShowBearingLineCheck->setChecked( mySettings.value( QStringLiteral( "gps/showBearingLine" ), false ).toBool() );
 
   mWgs84CRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
@@ -445,6 +451,7 @@ QgsGpsInformationWidget::~QgsGpsInformationWidget()
     mySettings.setValue( QStringLiteral( "gps/panMode" ), "none" );
   }
   mySettings.setValue( QStringLiteral( "gps/rotateMap" ), mRotateMapCheckBox->isChecked() );
+  mySettings.setValue( QStringLiteral( "gps/rotateMapInterval" ), mSpinMapRotateInterval->value() );
   mySettings.setValue( QStringLiteral( "gps/showBearingLine" ), mShowBearingLineCheck->isChecked() );
 
   QDomDocument doc;
@@ -914,9 +921,10 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
 
     }
 
-    if ( mRotateMapCheckBox->isChecked() )
+    if ( mRotateMapCheckBox->isChecked() && ( !mLastRotateTimer.isValid() || mLastRotateTimer.hasExpired( mSpinMapRotateInterval->value() * 1000 ) ) )
     {
       mMapCanvas->setRotation( trueNorth - info.direction );
+      mLastRotateTimer.restart();
     }
 
     if ( mShowBearingLineCheck )

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -953,7 +953,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
         mMapMarker = new QgsGpsMarker( mMapCanvas );
       }
       mMapMarker->setSize( mSliderMarkerSize->value() );
-      mMapMarker->setCenter( myNewCenter );
+      mMapMarker->setGpsPosition( myNewCenter );
     }
   }
   else

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -137,6 +137,9 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     QMap<QString, QString> mPreferredTimestampFields;
     //! Flag when updating fields
     bool mPopulatingFields = false;
+
+    QElapsedTimer mLastRotateTimer;
+
     friend class TestQgsGpsInformationWidget;
 };
 

--- a/src/app/gps/qgsgpsmarker.cpp
+++ b/src/app/gps/qgsgpsmarker.cpp
@@ -38,7 +38,7 @@ void QgsGpsMarker::setSize( int size )
   mSize = size;
 }
 
-void QgsGpsMarker::setCenter( const QgsPointXY &point )
+void QgsGpsMarker::setGpsPosition( const QgsPointXY &point )
 {
   //transform to map crs
   if ( mMapCanvas )
@@ -88,5 +88,6 @@ QRectF QgsGpsMarker::boundingRect() const
 
 void QgsGpsMarker::updatePosition()
 {
-  setCenter( mCenter );
+  QPointF pt = toCanvasCoordinates( mCenter );
+  setPos( pt );
 }

--- a/src/app/gps/qgsgpsmarker.h
+++ b/src/app/gps/qgsgpsmarker.h
@@ -32,7 +32,10 @@ class QgsGpsMarker : public QgsMapCanvasItem
   public:
     explicit QgsGpsMarker( QgsMapCanvas *mapCanvas );
 
-    void setCenter( const QgsPointXY &point );
+    /**
+     * Sets the current GPS \a position (in WGS84 coordinate reference system).
+     */
+    void setGpsPosition( const QgsPointXY &position );
 
     void paint( QPainter *p ) override;
 
@@ -44,7 +47,7 @@ class QgsGpsMarker : public QgsMapCanvasItem
 
   protected:
 
-    //! coordinates of the point in the center
+    //! Coordinates of the point in the center, in map CRS
     QgsPointXY mCenter;
     //! Size of the marker - e.g. 8 will draw it as 8x8
     int mSize;

--- a/src/core/gps/qgsnmeaconnection.cpp
+++ b/src/core/gps/qgsnmeaconnection.cpp
@@ -143,6 +143,20 @@ void QgsNmeaConnection::processStringBuffer()
           mStatus = GPSDataReceived;
           QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
         }
+        else if ( substring.startsWith( QLatin1String( "$HCHDG" ) ) )
+        {
+          QgsDebugMsgLevel( substring, 2 );
+          processHchdgSentence( ba.data(), ba.length() );
+          mStatus = GPSDataReceived;
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
+        }
+        else if ( substring.startsWith( QLatin1String( "$HCHDT" ) ) )
+        {
+          QgsDebugMsgLevel( substring, 2 );
+          processHchdtSentence( ba.data(), ba.length() );
+          mStatus = GPSDataReceived;
+          QgsDebugMsgLevel( QStringLiteral( "*******************GPS data received****************" ), 2 );
+        }
         else
         {
           QgsDebugMsgLevel( QStringLiteral( "unknown nmea sentence: %1" ).arg( substring ), 2 );
@@ -202,6 +216,28 @@ void QgsNmeaConnection::processHdtSentence( const char *data, int len )
   if ( nmea_parse_GPHDT( data, len, &result ) )
   {
     mLastGPSInformation.direction = result.heading;
+  }
+}
+
+void QgsNmeaConnection::processHchdgSentence( const char *data, int len )
+{
+  nmeaHCHDG result;
+  if ( nmea_parse_HCHDG( data, len, &result ) )
+  {
+    mLastGPSInformation.direction = result.mag_heading;
+    if ( result.ew_variation == 'E' )
+      mLastGPSInformation.direction += result.mag_variation;
+    else
+      mLastGPSInformation.direction -= result.mag_variation;
+  }
+}
+
+void QgsNmeaConnection::processHchdtSentence( const char *data, int len )
+{
+  nmeaHCHDT result;
+  if ( nmea_parse_HCHDT( data, len, &result ) )
+  {
+    mLastGPSInformation.direction = result.direction;
   }
 }
 

--- a/src/core/gps/qgsnmeaconnection.h
+++ b/src/core/gps/qgsnmeaconnection.h
@@ -60,6 +60,10 @@ class CORE_EXPORT QgsNmeaConnection: public QgsGpsConnection
     void processGstSentence( const char *data, int len );
     //! process HDT sentence
     void processHdtSentence( const char *data, int len );
+    //! process HCHDG sentence
+    void processHchdgSentence( const char *data, int len );
+    //! process HCHDT sentence
+    void processHchdtSentence( const char *data, int len );
 };
 
 #endif // QGSNMEACONNECTION_H

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -1028,7 +1028,7 @@ gray = no data
            <item row="5" column="0">
             <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
              <property name="title">
-              <string>Map Centering</string>
+              <string>Map Centering and Rotation</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_8">
               <property name="topMargin">
@@ -1040,23 +1040,6 @@ gray = no data
               <property name="verticalSpacing">
                <number>2</number>
               </property>
-              <item row="1" column="0">
-               <widget class="QRadioButton" name="radRecenterWhenNeeded">
-                <property name="text">
-                 <string>When leaving</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QRadioButton" name="radRecenterMap">
-                <property name="text">
-                 <string>Always</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0">
                <layout class="QHBoxLayout" name="horizontalLayout">
                 <property name="leftMargin">
@@ -1092,6 +1075,23 @@ gray = no data
                 </item>
                </layout>
               </item>
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="radRecenterMap">
+                <property name="text">
+                 <string>Always</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QRadioButton" name="radRecenterWhenNeeded">
+                <property name="text">
+                 <string>When leaving</string>
+                </property>
+               </widget>
+              </item>
               <item row="3" column="0">
                <widget class="QRadioButton" name="radNeverRecenter">
                 <property name="text">
@@ -1105,6 +1105,51 @@ gray = no data
                  <string>Rotate map to match GPS direction</string>
                 </property>
                </widget>
+              </item>
+              <item row="5" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
+                <property name="leftMargin">
+                 <number>20</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="label_12">
+                  <property name="text">
+                   <string>Frequency</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QgsSpinBox" name="mSpinMapRotateInterval">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="specialValueText">
+                   <string>On GPS signal</string>
+                  </property>
+                  <property name="suffix">
+                   <string> s</string>
+                  </property>
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>1000</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>0</number>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>


### PR DESCRIPTION
Fixes some NMEA GPS connection issues, and adds an explicit setting to allow control over the frequency of map rotation to match GPS bearing (Otherwise frequent GPS updates can cause a too many map redraws to occur quickly)

