### PR TITLE
Fix ZM snapping for line/polygon on 2D vertex

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -410,6 +410,10 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       else
       {
         layerPoint = geom.constGet()->vertexAt( vId );
+        if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !layerPoint.is3D() )
+          layerPoint.addZValue( defaultZValue() );
+        if ( QgsWkbTypes::hasM( vlayer->wkbType() ) && !layerPoint.isMeasure() )
+          layerPoint.addMValue( 0.0 );
       }
 
       // ZM support depends on the target layer

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -79,6 +79,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     QgsVectorLayer *mLayerLineZ = nullptr;
     QgsVectorLayer *mLayerPointZM = nullptr;
     QgsVectorLayer *mLayerTopoZ = nullptr;
+    QgsVectorLayer *mLayerLine2D = nullptr;
     QgsFeatureId mFidLineF1 = 0;
 };
 
@@ -169,7 +170,18 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
   mLayerTopoZ->addFeature( topoFeat );
   QCOMPARE( mLayerTopoZ->featureCount(), ( long ) 1 );
 
-  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineZ << mLayerPointZM << mLayerTopoZ );
+  // make 2D layer for snapping with a 3D layer
+  mLayerLine2D = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:27700" ), QStringLiteral( "layer line" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerLine2D->isValid() );
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerLine2D );
+
+  mLayerLine2D->startEditing();
+  QgsFeature lineString2DF;
+  lineString2DF.setGeometry( QgsGeometry::fromWkt( "LineString ((8 8, 9 9))" ) );
+
+  mLayerLine2D->addFeature( lineString2DF );
+  QCOMPARE( mLayerLine2D->featureCount(), ( long )1 );
+  mCanvas->setLayers( QList<QgsMapLayer *>() << mLayerLine << mLayerLineZ << mLayerPointZM << mLayerTopoZ << mLayerLine2D );
 
   mCanvas->setSnappingUtils( new QgsMapCanvasSnappingUtils( mCanvas, this ) );
 
@@ -405,6 +417,27 @@ void TestQgsMapToolAddFeatureLine::testZMSnapping()
   QCOMPARE( mLayerLine->getFeature( newFid ).geometry().get()->isMeasure(), false );
 
   mLayerLine->undoStack()->undo();
+
+  mCanvas->setCurrentLayer( mLayerLineZ );
+  oldFids = utils.existingFeatureIds();
+  // test with default Z value = 222
+  QgsSettings().setValue( QStringLiteral( "/qgis/digitizing/default_z_value" ), 222 );
+  // snap a on a layer without ZM support
+  utils.mouseClick( 9, 9, Qt::LeftButton, Qt::KeyboardModifiers(), true );
+  utils.mouseClick( 8, 7, Qt::LeftButton );
+  utils.mouseClick( 5, 0, Qt::RightButton );
+
+  newFid = utils.newFeatureId( oldFids );
+
+  QCOMPARE( mLayerLineZ->getFeature( newFid ).geometry().get()->is3D(), true );
+
+  QString wkt = "LineStringZ (9 9 222, 8 7 222)";
+  QCOMPARE( mLayerLineZ->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
+  QCOMPARE( mLayerLineZ->getFeature( newFid ).geometry().get()->isMeasure(), false );
+
+  mLayerLine->undoStack()->undo();
+
+  cfg.setEnabled( false );
 
   cfg.setEnabled( false );
   mCanvas->snappingUtils()->setConfig( cfg );


### PR DESCRIPTION
## Description

The snapping on a 2D layer for line/polygon with Z or M values doesn't work as expected. It returns NaN value instead of the default Z Value (or 0.0 for Measure).

before (3.10)
![snap_line_2D_310 webm](https://user-images.githubusercontent.com/7521540/71904653-d2209f80-3166-11ea-9baf-4fe2b86adaa8.gif)

after (master)
![snap_line_2D_master webm](https://user-images.githubusercontent.com/7521540/71904726-f8463f80-3166-11ea-97b1-00b82be3e884.gif)


Sponsored by QWAT Group (cc @ponceta @kandre)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
