### PR TITLE
[Bugfix][Server] QGIS-server 3.X tiles wrong clipped

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1092,6 +1092,9 @@ namespace QgsWms
     // enable rendering optimization
     mapSettings.setFlag( QgsMapSettings::UseRenderingOptimization );
 
+    // disable render partial output
+    mapSettings.setFlag( QgsMapSettings::RenderPartialOutput, false );
+
     // set selection color
     mapSettings.setSelectionColor( mProject->selectionColor() );
   }


### PR DESCRIPTION
## Description

Try to fixed #33078

QGIS Server does not wait for all data retrieved by remote raster layer.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
