### PR TITLE
Add Refresh action to OGC services

### DIFF
--- a/src/providers/wcs/qgswcsdataitemguiprovider.cpp
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.cpp
@@ -33,6 +33,12 @@ void QgsWcsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
   if ( QgsWCSConnectionItem *connItem = qobject_cast< QgsWCSConnectionItem * >( item ) )
   {
+    QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+    connect( actionRefresh, &QAction::triggered, this, [connItem] { refreshConnection( connItem ); } );
+    menu->addAction( actionRefresh );
+
+    menu->addSeparator();
+
     QAction *actionEdit = new QAction( tr( "Edit…" ), this );
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
     menu->addAction( actionEdit );
@@ -73,4 +79,12 @@ void QgsWcsDataItemGuiProvider::deleteConnection( QgsDataItem *item )
   QgsOwsConnection::deleteConnection( QStringLiteral( "WCS" ), item->name() );
   // the parent should be updated
   item->parent()->refreshConnections();
+}
+
+void QgsWcsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
+{
+  item->refresh();
+  // the parent should be updated
+  if ( item->parent() )
+    item->parent()->refreshConnections();
 }

--- a/src/providers/wcs/qgswcsdataitemguiprovider.h
+++ b/src/providers/wcs/qgswcsdataitemguiprovider.h
@@ -32,6 +32,7 @@ class QgsWcsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
+    static void refreshConnection( QgsDataItem *item );
 
 };
 

--- a/src/providers/wfs/qgswfsdataitemguiprovider.cpp
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.cpp
@@ -34,6 +34,12 @@ void QgsWfsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 
   if ( QgsWfsConnectionItem *connItem = qobject_cast< QgsWfsConnectionItem * >( item ) )
   {
+    QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+    connect( actionRefresh, &QAction::triggered, this, [connItem] { refreshConnection( connItem ); } );
+    menu->addAction( actionRefresh );
+
+    menu->addSeparator();
+
     QAction *actionEdit = new QAction( tr( "Edit…" ), this );
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
     menu->addAction( actionEdit );
@@ -76,4 +82,12 @@ void QgsWfsDataItemGuiProvider::deleteConnection( QgsDataItem *item )
   QgsWfsConnection::deleteConnection( item->name() );
   // the parent should be updated
   item->parent()->refreshConnections();
+}
+
+void QgsWfsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
+{
+  item->refresh();
+  // the parent should be updated
+  if ( item->parent() )
+    item->parent()->refreshConnections();
 }

--- a/src/providers/wfs/qgswfsdataitemguiprovider.h
+++ b/src/providers/wfs/qgswfsdataitemguiprovider.h
@@ -32,6 +32,7 @@ class QgsWfsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     static void newConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
+    static void refreshConnection( QgsDataItem *item );
 
 };
 

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -320,6 +320,20 @@ struct QgsWmsLayerProperty
   bool               noSubsets;
   int                fixedWidth;
   int                fixedHeight;
+
+  // TODO need to expand this to cover more of layer properties
+  bool equal( const QgsWmsLayerProperty &layerProperty )
+  {
+    if ( !( name == layerProperty.name ) )
+      return false;
+    if ( !( title == layerProperty.title ) )
+      return false;
+    if ( !( abstract == layerProperty.abstract ) )
+      return false;
+
+    return true;
+  }
+
 };
 
 struct QgsWmtsTheme

--- a/src/providers/wms/qgswmsdataitemguiproviders.cpp
+++ b/src/providers/wms/qgswmsdataitemguiproviders.cpp
@@ -105,10 +105,8 @@ void QgsWmsDataItemGuiProvider::newConnection( QgsDataItem *item )
 
 void QgsWmsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
 {
+  // Updating the item and its children only
   item->refresh();
-  // the parent should be updated
-  if ( item->parent() )
-    item->parent()->refreshConnections();
 }
 
 

--- a/src/providers/wms/qgswmsdataitemguiproviders.cpp
+++ b/src/providers/wms/qgswmsdataitemguiproviders.cpp
@@ -43,6 +43,12 @@ void QgsWmsDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *m
 {
   if ( QgsWMSConnectionItem *connItem = qobject_cast< QgsWMSConnectionItem * >( item ) )
   {
+    QAction *actionRefresh = new QAction( tr( "Refresh" ), this );
+    connect( actionRefresh, &QAction::triggered, this, [connItem] { refreshConnection( connItem ); } );
+    menu->addAction( actionRefresh );
+
+    menu->addSeparator();
+
     QAction *actionEdit = new QAction( tr( "Edit…" ), this );
     connect( actionEdit, &QAction::triggered, this, [connItem] { editConnection( connItem ); } );
     menu->addAction( actionEdit );
@@ -95,6 +101,14 @@ void QgsWmsDataItemGuiProvider::newConnection( QgsDataItem *item )
   {
     item->refreshConnections();
   }
+}
+
+void QgsWmsDataItemGuiProvider::refreshConnection( QgsDataItem *item )
+{
+  item->refresh();
+  // the parent should be updated
+  if ( item->parent() )
+    item->parent()->refreshConnections();
 }
 
 

--- a/src/providers/wms/qgswmsdataitemguiproviders.h
+++ b/src/providers/wms/qgswmsdataitemguiproviders.h
@@ -31,6 +31,7 @@ class QgsWmsDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
     QWidget *createParamWidget( QgsDataItem *root, QgsDataItemGuiContext ) override;
 
   private:
+    static void refreshConnection( QgsDataItem *item );
     static void editConnection( QgsDataItem *item );
     static void deleteConnection( QgsDataItem *item );
     static void newConnection( QgsDataItem *item );

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -96,7 +96,7 @@ QVector<QgsDataItem *> QgsWMSConnectionItem::createChildren()
       // Attention, the name may be empty
       QgsDebugMsgLevel( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title, 2 );
       QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
-      QgsDataItem *layer;
+      QgsDataItem *layer = nullptr;
 
       if ( layerProperty.name.isEmpty() )
         layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
@@ -266,15 +266,13 @@ bool QgsWMSLayerCollectionItem::equal( const QgsDataItem *other )
   {
     return false;
   }
-  const QgsWMSLayerCollectionItem *otherCollectionItem = dynamic_cast<const QgsWMSLayerCollectionItem *>( other );
+  const QgsWMSLayerCollectionItem *otherCollectionItem = qobject_cast<const QgsWMSLayerCollectionItem *>( other );
   if ( !otherCollectionItem )
   {
     return false;
   }
 
   // Check if the children are not the same then they are not equal
-  if ( mChildren.isEmpty() & !otherCollectionItem->mChildren.isEmpty() )
-    return false;
   if ( mChildren.size() != otherCollectionItem->mChildren.size() )
     return false;
 

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -103,7 +103,7 @@ QVector<QgsDataItem *> QgsWMSConnectionItem::createChildren()
       else
         layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
 
-      children << layer ;
+      children.append( layer );
     }
   }
 
@@ -251,12 +251,8 @@ QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QStri
     // Attention, the name may be empty
     QgsDebugMsgLevel( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title, 2 );
     QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
-    QgsDataItem *layer;
 
-    if ( layerProperty.name.isEmpty() )
-      layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, dataSourceUri, layerProperty );
-    else
-      layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );
+    QgsWMSLayerItem *layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );
 
     addChildItem( layer );
   }

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -251,6 +251,7 @@ QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QStri
     // Attention, the name may be empty
     QgsDebugMsgLevel( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title, 2 );
     QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
+    QgsDataItem *layer;
 
     if ( layerProperty.name.isEmpty() )
       layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, dataSourceUri, layerProperty );

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -252,7 +252,12 @@ QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QStri
     QgsDebugMsgLevel( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title, 2 );
     QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
 
-    QgsWMSLayerItem *layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );
+    QgsDataItem *layer = nullptr;
+
+    if ( layerProperty.name.isEmpty() )
+      layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, dataSourceUri, layerProperty );
+    else
+      layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );
 
     addChildItem( layer );
   }

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -371,7 +371,7 @@ bool QgsWMSLayerItem::equal( const QgsDataItem *other )
   {
     return false;
   }
-  const QgsWMSLayerItem *otherLayer = dynamic_cast<const QgsWMSLayerItem *>( other );
+  const QgsWMSLayerItem *otherLayer = qobject_cast<const QgsWMSLayerItem *>( other );
   if ( !otherLayer )
   {
     return false;

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -251,8 +251,12 @@ QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QStri
     // Attention, the name may be empty
     QgsDebugMsgLevel( QString::number( layerProperty.orderId ) + ' ' + layerProperty.name + ' ' + layerProperty.title, 2 );
     QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
-    QgsWMSLayerItem *layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );
-    //mChildren.append( layer );
+
+    if ( layerProperty.name.isEmpty() )
+      layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, dataSourceUri, layerProperty );
+    else
+      layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );
+
     addChildItem( layer );
   }
 

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -226,13 +226,44 @@ bool QgsWMSConnectionItem::equal( const QgsDataItem *other )
   {
     return false;
   }
-  const QgsWMSConnectionItem *o = dynamic_cast<const QgsWMSConnectionItem *>( other );
-  if ( !o )
+  const QgsWMSConnectionItem *otherConnectionItem = qobject_cast<const QgsWMSConnectionItem *>( other );
+  if ( !otherConnectionItem )
   {
     return false;
   }
 
-  return ( mPath == o->mPath && mName == o->mName );
+  bool samePathAndName = ( mPath == otherConnectionItem->mPath && mName == otherConnectionItem->mName );
+
+  if ( samePathAndName )
+  {
+    // Check if the children are not the same then they are not equal
+    if ( mChildren.size() != otherConnectionItem->mChildren.size() )
+      return false;
+
+    // compare children content, if the content differs then the parents are not equal
+    for ( QgsDataItem *child : mChildren )
+    {
+      if ( !child )
+        continue;
+      for ( QgsDataItem *otherChild : otherConnectionItem->mChildren )
+      {
+        if ( !otherChild )
+          continue;
+        // In case they have same path, check if they have same content
+        if ( child->path() == otherChild->path() )
+        {
+          if ( !child->equal( otherChild ) )
+            return false;
+        }
+        else
+        {
+          continue;
+        }
+      }
+    }
+  }
+
+  return samePathAndName;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -41,6 +41,11 @@ class QgsWMSConnectionItem : public QgsDataCollectionItem
     QgsWmsCapabilitiesDownload *mCapabilitiesDownload = nullptr;
 };
 
+/**
+ * \brief WMS Layer Collection.
+ *
+ *  This collection contains a WMS Layer element that can enclose other layers
+ */
 class QgsWMSLayerCollectionItem : public QgsDataCollectionItem
 {
     Q_OBJECT
@@ -52,8 +57,13 @@ class QgsWMSLayerCollectionItem : public QgsDataCollectionItem
 
     bool equal( const QgsDataItem *other ) override;
 
+    //! Stores GetCapabilities response
     QgsWmsCapabilitiesProperty mCapabilitiesProperty;
+
+    //! Stores WMS connection information
     QgsDataSourceUri mDataSourceUri;
+
+    //! WMS Layer properties, can be inherited by subsidiary layers
     QgsWmsLayerProperty mLayerProperty;
 };
 

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -41,6 +41,22 @@ class QgsWMSConnectionItem : public QgsDataCollectionItem
     QgsWmsCapabilitiesDownload *mCapabilitiesDownload = nullptr;
 };
 
+class QgsWMSLayerCollectionItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsWMSLayerCollectionItem( QgsDataItem *parent, QString name, QString path,
+                               const QgsWmsCapabilitiesProperty &capabilitiesProperty,
+                               const QgsDataSourceUri &dataSourceUri,
+                               const QgsWmsLayerProperty &layerProperty );
+
+    bool equal( const QgsDataItem *other ) override;
+
+    QgsWmsCapabilitiesProperty mCapabilitiesProperty;
+    QgsDataSourceUri mDataSourceUri;
+    QgsWmsLayerProperty mLayerProperty;
+};
+
 // WMS Layers may be nested, so that they may be both QgsDataCollectionItem and QgsLayerItem
 // We have to use QgsDataCollectionItem and support layer methods if necessary
 class QgsWMSLayerItem : public QgsLayerItem
@@ -52,6 +68,7 @@ class QgsWMSLayerItem : public QgsLayerItem
                      const QgsDataSourceUri &dataSourceUri,
                      const QgsWmsLayerProperty &layerProperty );
 
+    bool equal( const QgsDataItem *other ) override;
     QString createUri();
 
     QgsWmsCapabilitiesProperty mCapabilitiesProperty;


### PR DESCRIPTION
 This PR adds refresh action to OGC Services and also fixes #33621

 For the #33621, I have override the WMSLayerItem [equal](https://github.com/Samweli/QGIS/blob/5b8759c5cd126b1da11996e19a706beff6d28ba3/src/providers/wms/qgswmsdataitems.h#L81) function from QgsLayerItem, to provide a further layer properties comparison ( leaving out path and name only comparison ), might need others efforts to increase the function layer properties coverage.

 I have also added a new class [QgsWMSLayerCollectionItem](https://github.com/Samweli/QGIS/blob/5b8759c5cd126b1da11996e19a706beff6d28ba3/src/providers/wms/qgswmsdataitems.h#L49) to handle the WMS Layers which enclose other layers. So we can handle them separately. I found it tricky to fix them especially in the #33621 case.

Below is a screenshot showing an example of how this function works in WMS/WMTS connections
![OGC_refresh_on_action](https://user-images.githubusercontent.com/2663775/71974919-cfd04b00-3223-11ea-834d-ff016c70a8c6.gif)
