### PR TITLE
[BUGFIX] Fix ESRI shapefile format listed twice in vector file selector dialog

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -2933,7 +2933,7 @@ QString createFilters( const QString &type )
       {
         sDatabaseDrivers += QObject::tr( "ESRI ArcSDE" ) + ",SDE;";
       }
-      else if ( driverName.startsWith( QLatin1String( "ESRI" ) ) )
+      else if ( driverName.startsWith( QLatin1String( "ESRI Shapefile" ) ) )
       {
         QString exts = GDALGetMetadataItem( driver, GDAL_DMD_EXTENSIONS, "" );
         sFileFilters += createFileFilter_( QObject::tr( "ESRI Shapefiles" ), exts.contains( "shz" ) ? QStringLiteral( "*.shp *.shz *.shp.zip" ) : QStringLiteral( "*.shp" ) );


### PR DESCRIPTION
## Description
In QGIS 3.4.x and 3.10.x with GDAL >= 2.3, in the file source vector dataset selector dialog the drop-down list of the formats shows two consecutive "Esri shapefile" format:

![image](https://user-images.githubusercontent.com/16253859/71934964-e8018500-31a5-11ea-9311-2731e54852e6.png)

Since GDAL 2.3, there are 2 gdal/ogr vector drivers which name starts with the string "ESRI": "**ESRI Shapefile**" and "**ESRIJSON**", so the code in https://github.com/qgis/QGIS/blob/18e9766d5174a70abf244e6b49106bd26f74f63e/src/core/providers/ogr/qgsogrprovider.cpp#L2936-L2943
will be incorrectly executed 2 times.

The [ESRIJSON](https://gdal.org/drivers/vector/esrijson.html) driver (and [TopoJSON](https://gdal.org/drivers/vector/topojson.html) driver), which functionality was available in the GeoJSON driver prior to GDAL 2.3, will need to be added afterwards in the list of supported formats.

The patch should be backported to 3.10 branch.

Fixes #28661
Probably Fixes #27948

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
