### PR TITLE
Fix editing of synchronized same fields in attribute form

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -271,7 +271,7 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
       mPlainTextEdit->setPlainText( v );
   }
 
-  if ( mLineEdit )
+  if ( mLineEdit && val != value() )
     mLineEdit->setText( v );
 }
 


### PR DESCRIPTION
## Description

When the same field exists in attribute form, the synchronization breaks the edition, meaning every time user enters one character, the cursor position is set at the end of the line edit.

![bug_syncfield](https://user-images.githubusercontent.com/14358135/71968150-a18f4300-3204-11ea-9887-d97a83abc6d6.gif)

This PR fixes this.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
