### PR TITLE
[MESH] Fix time formating when time is far from reference

### DIFF
--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -280,7 +280,7 @@ QString QgsMeshLayerUtils::formatTime( double hours, const QgsMeshTimeSettings &
   {
     QString format( settings.absoluteTimeFormat() );
     QDateTime dateTime( settings.absoluteTimeReferenceTime() );
-    int seconds = static_cast<int>( hours * 3600.0 );
+    qint64 seconds = static_cast<qint64>( hours * 3600.0 );
     dateTime = dateTime.addSecs( seconds );
     ret = dateTime.toString( format );
     if ( ret.isEmpty() ) // error


### PR DESCRIPTION
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
