### PR TITLE
[GUI] fix identify panel size when long localized strings used (fix #29546)

### DIFF
--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>355</width>
-    <height>390</height>
+    <width>465</width>
+    <height>490</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -114,14 +114,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="cmbIdentifyMode">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
+          <widget class="QComboBox" name="cmbIdentifyMode"/>
          </item>
          <item>
           <spacer name="horizontalSpacer_43">
@@ -139,7 +132,17 @@
          <item>
           <widget class="QCheckBox" name="cbxAutoFeatureForm">
            <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblAutoFeatureForm">
+           <property name="text">
             <string>Auto open form</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -114,7 +114,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="cmbIdentifyMode"/>
+          <widget class="QComboBox" name="cmbIdentifyMode">
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+           </property>
+           <property name="minimumContentsLength">
+            <number>6</number>
+           </property>
+          </widget>
          </item>
          <item>
           <spacer name="horizontalSpacer_43">


### PR DESCRIPTION
## Description
In some locales "Auto open form" text and some items in the "Mode" combobox in the identify panel translated as very long strings. As result panel takes too much screen space and can not be reduced.

Backport of #33643.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
