### PR TITLE
[bugfix] [saga] Fix saga_cmd command with multiple outputs

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -326,7 +326,7 @@ class SagaAlgorithm(SagaAlgorithmBase):
 
             output_files[out.name()] = filePath
             command += ' -{} "{}"'.format(out.name(), filePath)
-            commands.append(command)
+        commands.append(command)
 
         # special treatment for RGB algorithm
         # TODO: improve this and put this code somewhere else


### PR DESCRIPTION
## Description
Fixes a regression bug accidentally introduced with 40134d6473fcdbd8b6f53c3ea3db01e2dd606419 (PR #8968) since 3.6.0 and backported to 3.4 branch with a887b7d34bfa44a8400bcaa986ede96e15a760c9 (PR #9231) since 3.4.6 : when there are multiple output parameters, processAlgorithm incorrectly generates multiple saga_cmd commands, instead of a single command containing the output parameters.

It should be backported to 3.10 branch.

Fixes #33658

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
