### PR TITLE
Oracle field generated always as identity

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1297,7 +1297,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
                                   "AND a.generation_type = 'ALWAYS'" ).arg( mOwnerName ).arg( mTableName );
     identitytype.prepare( sql );
 
-    if ( identitytype.exec() )
+    if ( exec( identitytype, sql, QVariantList() ) )
     {
       while ( identitytype.next() )
       {
@@ -1306,6 +1306,10 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
           alwaysGenerated.append( flist[0].fields().indexOf( identitytype.value( 0 ).toString() ) );
         }
       }
+    }
+    else
+    {
+      throw OracleException( tr( "Could not check if table has identity field" ), identitytype );
     }
 
     if ( mPrimaryKeyType == PktInt || mPrimaryKeyType == PktFidMap )

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -127,6 +127,11 @@ class QgsOracleProvider : public QgsVectorDataProvider
      */
     bool determinePrimaryKey();
 
+    /**
+     * Determine the always generated identity fields
+     */
+    bool determineAlwaysGeneratedKeys();
+
     QgsFields fields() const override;
     QString dataComment() const override;
 
@@ -250,6 +255,11 @@ class QgsOracleProvider : public QgsVectorDataProvider
      */
     QList<int> mPrimaryKeyAttrs;
     QString mPrimaryKeyDefault;
+
+    /**
+     * List of always generated key attributes
+     */
+    QList<int> mAlwaysGeneratedKeyAttrs;
 
     QString mGeometryColumn;           //!< Name of the geometry column
     mutable QgsRectangle mLayerExtent; //!< Rectangle that contains the extent (bounding box) of the layer

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -142,6 +142,8 @@ class QgsOracleProvider : public QgsVectorDataProvider
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
     QVariant defaultValue( QString fieldName, QString tableName = QString(), QString schemaName = QString() );
     QVariant defaultValue( int fieldId ) const override;
+    QString defaultValueClause( int fieldId ) const override;
+    bool skipConstraintCheck( int fieldIndex, QgsFieldConstraints::Constraint constraint, const QVariant &value = QVariant() ) const override;
     bool addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flags flags = nullptr ) override;
     bool deleteFeatures( const QgsFeatureIds &id ) override;
     bool addAttributes( const QList<QgsField> &attributes ) override;

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -380,7 +380,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         self.assertFalse(ft1.nextFeature(f))
 
     def testTransactionTuple(self):
-        # create a vector layer based on postgres
+        # create a vector layer based on oracle
         vl = QgsVectorLayer(
             self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POLYGON table="QGIS"."SOME_POLY_DATA" (GEOM) sql=',
             'test', 'oracle')
@@ -399,6 +399,24 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
 
         # underlying data has not been modified
         self.assertFalse(vl.isModified())
+
+    def testIdentityCommit(self):
+        # create a vector layer based on oracle
+        vl = QgsVectorLayer(
+            self.dbconn + ' sslmode=disable key=\'pk\' srid=4326 type=POINT table="QGIS"."POINT_DATA_IDENTITY" (GEOM) sql=',
+            'test', 'oracle')
+        self.assertTrue(vl.isValid())
+
+        features = [f for f in vl.getFeatures()]
+
+        # add a new feature
+        newf = QgsFeature(features[0].fields())
+        success, featureAdded = vl.dataProvider().addFeatures([newf])
+        self.assertTrue(success)
+
+        # clean up
+        features = [f for f in vl.getFeatures()]
+        vl.dataProvider().deleteFeatures([features[-1].id()])
 
 
 if __name__ == '__main__':

--- a/tests/testdata/provider/testdata_oracle.sql
+++ b/tests/testdata/provider/testdata_oracle.sql
@@ -65,5 +65,16 @@ CREATE TABLE QGIS.DATE_TIMES ( "id" INTEGER PRIMARY KEY, "date_field" DATE, "dat
 
 INSERT INTO QGIS.DATE_TIMES ("id", "date_field", "datetime_field" ) VALUES (1, DATE '2004-03-04', TIMESTAMP '2004-03-04 13:41:52' );
 
+CREATE TABLE QGIS.POINT_DATA_IDENTITY ( "pk" NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, GEOM SDO_GEOMETRY);
+INSERT INTO QGIS.POINT_DATA_IDENTITY (GEOM)
+ SELECT SDO_GEOMETRY( 2001,4326,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 3001,4326,SDO_POINT_TYPE(1, 2, 3), NULL, NULL) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,1, 4,1,1), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2005,4326,NULL, sdo_elem_info_array (1,1,1, 3,1,1), sdo_ordinate_array (1,2, 3,4)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,2), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (1,2)) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2001,4326, SDO_POINT_TYPE(3, 4, NULL), NULL, NULL) from dual
+  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (5,6)) from dual;
+
 COMMIT;
 

--- a/tests/testdata/provider/testdata_oracle.sql
+++ b/tests/testdata/provider/testdata_oracle.sql
@@ -67,14 +67,7 @@ INSERT INTO QGIS.DATE_TIMES ("id", "date_field", "datetime_field" ) VALUES (1, D
 
 CREATE TABLE QGIS.POINT_DATA_IDENTITY ( "pk" NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY, GEOM SDO_GEOMETRY);
 INSERT INTO QGIS.POINT_DATA_IDENTITY (GEOM)
- SELECT SDO_GEOMETRY( 2001,4326,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 3001,4326,SDO_POINT_TYPE(1, 2, 3), NULL, NULL) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,1, 4,1,1), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2005,4326,NULL, sdo_elem_info_array (1,1,1, 3,1,1), sdo_ordinate_array (1,2, 3,4)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 3005,4326,NULL, sdo_elem_info_array (1,1,2), sdo_ordinate_array (1,2,3, 4,5,6)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (1,2)) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2001,4326, SDO_POINT_TYPE(3, 4, NULL), NULL, NULL) from dual
-  UNION ALL SELECT SDO_GEOMETRY( 2001,4326,NULL, sdo_elem_info_array (1,1,1), sdo_ordinate_array (5,6)) from dual;
+ SELECT SDO_GEOMETRY( 2001,4326,SDO_POINT_TYPE(1, 2, NULL), NULL, NULL) from dual;
 
 COMMIT;
 


### PR DESCRIPTION
## Description
Fix #33681 

It add functions (defaultValueClause and skipConstraintCheck) to evaluate default value for identity field (like "ISEQ$$_75967".nextval).

And in addFeatures function, always generated identity field are listed to be avoid in the insert request.

I add a test to check if the commit passes with an always generated identity field. 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
