### PR TITLE
[processing] use system temporary directory as default temp dir for Processing outputs

### DIFF
--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -22,6 +22,7 @@ __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
 import os
+import tempfile
 
 from qgis.PyQt.QtCore import QCoreApplication, QObject, pyqtSignal
 from qgis.core import (NULL,
@@ -170,7 +171,7 @@ class ProcessingConfig:
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
             ProcessingConfig.TEMP_PATH,
-            ProcessingConfig.tr('Temporary output folder path'), QgsProcessingUtils.tempFolder(),
+            ProcessingConfig.tr('Temporary output folder path'), tempfile.gettempdir(),
             valuetype=Setting.FOLDER))
 
     @staticmethod


### PR DESCRIPTION
## Description
#33086 has added support for configurable temporary directory for Processing outputs. As default option it uses directory, generated by Processing, e.g. `/tmp/processing_601abb2fa9664e5eab9a1ea02370fda5`. IMHO better to use system temporary directory as top-level location and create Processing folders inside it. Also current approach leads to creating extra nested directory once user have saved any change in Processing settings and path looks like `/tmp/processing_601abb2fa9664e5eab9a1ea02370fda5/processing_ee8d7407ab684e66bfd7d1555bd3db49` (see #33641).

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
