### PR TITLE
[processing] Improve temporary directory handling

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -306,11 +306,6 @@ class ProcessingPlugin:
         self.toolbox.deleteLater()
         self.menu.deleteLater()
 
-        # delete temporary output files
-        folder = QgsProcessingUtils.tempFolder()
-        if QDir(folder).exists():
-            shutil.rmtree(folder, True)
-
         # also delete temporary help files
         folder = tempHelpFolder()
         if QDir(folder).exists():

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -62,7 +62,7 @@ class ProcessingConfig:
     MAX_THREADS = 'MAX_THREADS'
     DEFAULT_OUTPUT_RASTER_LAYER_EXT = 'DefaultOutputRasterLayerExt'
     DEFAULT_OUTPUT_VECTOR_LAYER_EXT = 'DefaultOutputVectorLayerExt'
-    TEMP_PATH = 'TEMP_PATH'
+    TEMP_PATH = 'TEMP_PATH2'
 
     settings = {}
     settingIcons = {}
@@ -171,7 +171,7 @@ class ProcessingConfig:
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
             ProcessingConfig.TEMP_PATH,
-            ProcessingConfig.tr('Temporary output folder path'), tempfile.gettempdir(),
+            ProcessingConfig.tr('Override temporary output folder path (leave blank for default)'), None,
             valuetype=Setting.FOLDER))
 
     @staticmethod

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -746,33 +746,35 @@ QVariant QgsProcessingUtils::generateIteratingDestination( const QVariant &input
 
 QString QgsProcessingUtils::tempFolder()
 {
-  static std::unique_ptr< QTemporaryDir > sTempFolder;
+  // we maintain a list of temporary folders -- this allows us to append additional
+  // folders when a setting change causes the base temp folder to change, while deferring
+  // cleanup of ALL these temp folders until session end (we can't cleanup older folders immediately,
+  // because we don't know whether they have data in them which is still wanted)
+  static std::vector< std::unique_ptr< QTemporaryDir > > sTempFolders;
   static QString sFolder;
   static QMutex sMutex;
   QMutexLocker locker( &sMutex );
   const QString basePath = QgsSettings().value( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ) ).toString();
   if ( basePath.isEmpty() )
   {
-    // default setting -- automatically create a temp folder. In this case, we use QTemporaryDir so
-    // that the folder is automatically deleted when QGIS is closed
-    if ( !sTempFolder )
+    // default setting -- automatically create a temp folder
+    if ( sTempFolders.empty() )
     {
       const QString templatePath = QStringLiteral( "%1/processing_XXXXXX" ).arg( QDir::tempPath() );
-      sTempFolder = qgis::make_unique< QTemporaryDir >( templatePath );
-      sFolder = sTempFolder->path();
+      std::unique_ptr< QTemporaryDir > tempFolder = qgis::make_unique< QTemporaryDir >( templatePath );
+      sFolder = tempFolder->path();
+      sTempFolders.emplace_back( std::move( tempFolder ) );
     }
   }
-  else if ( sFolder.isEmpty() || !sFolder.startsWith( basePath ) || !sTempFolder )
+  else if ( sFolder.isEmpty() || !sFolder.startsWith( basePath ) || sTempFolders.empty() )
   {
     if ( !QDir().exists( basePath ) )
       QDir().mkpath( basePath );
 
     const QString templatePath = QStringLiteral( "%1/processing_XXXXXX" ).arg( basePath );
-    // leak the previous folder -- we don't want it to be cleaned up, we don't know what was in it that may still
-    // be required for this session!
-    sTempFolder.release();
-    sTempFolder = qgis::make_unique< QTemporaryDir >( templatePath );
-    sFolder = sTempFolder->path();
+    std::unique_ptr< QTemporaryDir > tempFolder = qgis::make_unique< QTemporaryDir >( templatePath );
+    sFolder = tempFolder->path();
+    sTempFolders.emplace_back( std::move( tempFolder ) );
   }
   return sFolder;
 }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -764,6 +764,9 @@ QString QgsProcessingUtils::tempFolder()
   }
   else if ( sFolder.isEmpty() || !sFolder.startsWith( basePath ) || !sTempFolder )
   {
+    if ( !QDir().exists( basePath ) )
+      QDir().mkpath( basePath );
+
     const QString templatePath = QStringLiteral( "%1/processing_XXXXXX" ).arg( basePath );
     // leak the previous folder -- we don't want it to be cleaned up, we don't know what was in it that may still
     // be required for this session!

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8541,7 +8541,7 @@ void TestQgsProcessing::tempUtils()
   settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ), alternative_tempFolder1 );
   // check folder and if it's constant with alternative temp folder 1
   tempFolder = QgsProcessingUtils::tempFolder();
-  QVERIFY( tempFolder.startsWith( alternative_tempFolder1 ) );
+  QCOMPARE( tempFolder.left( alternative_tempFolder1.length() ), alternative_tempFolder1 );
   QCOMPARE( QgsProcessingUtils::tempFolder(), tempFolder );
   // create file
   QString alternativeTempFile1 = QgsProcessingUtils::generateTempFilename( "alternative_temptest.txt" );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8538,7 +8538,7 @@ void TestQgsProcessing::tempUtils()
   // change temp folder in the settings
   QgsSettings settings;
   QString alternative_tempFolder1 = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/alternative_temp_test_one" );
-  settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH" ), alternative_tempFolder1 );
+  settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ), alternative_tempFolder1 );
   // check folder and if it's constant with alternative temp folder 1
   tempFolder = QgsProcessingUtils::tempFolder();
   QVERIFY( tempFolder.startsWith( alternative_tempFolder1 ) );
@@ -8550,7 +8550,7 @@ void TestQgsProcessing::tempUtils()
   QVERIFY( alternativeTempFile1.startsWith( alternative_tempFolder1 ) );
   // change temp folder in the settings again
   QString alternative_tempFolder2 = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/alternative_temp_test_two" );
-  settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH" ), alternative_tempFolder2 );
+  settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ), alternative_tempFolder2 );
   // check folder and if it's constant constant with alternative temp folder 2
   tempFolder = QgsProcessingUtils::tempFolder();
   QVERIFY( tempFolder.startsWith( alternative_tempFolder2 ) );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8536,8 +8536,12 @@ void TestQgsProcessing::tempUtils()
   QVERIFY( tempFile3.startsWith( tempFolder ) );
 
   // change temp folder in the settings
+  std::unique_ptr< QTemporaryDir > dir = qgis::make_unique< QTemporaryDir >();
+  const QString tempDirPath = dir->path();
+  dir.reset();
+
   QgsSettings settings;
-  QString alternative_tempFolder1 = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/alternative_temp_test_one" );
+  QString alternative_tempFolder1 = tempDirPath + QStringLiteral( "/alternative_temp_test_one" );
   settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ), alternative_tempFolder1 );
   // check folder and if it's constant with alternative temp folder 1
   tempFolder = QgsProcessingUtils::tempFolder();
@@ -8549,17 +8553,19 @@ void TestQgsProcessing::tempUtils()
   QVERIFY( alternativeTempFile1.startsWith( tempFolder ) );
   QVERIFY( alternativeTempFile1.startsWith( alternative_tempFolder1 ) );
   // change temp folder in the settings again
-  QString alternative_tempFolder2 = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/alternative_temp_test_two" );
+  QString alternative_tempFolder2 =  tempDirPath + QStringLiteral( "/alternative_temp_test_two" );
   settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ), alternative_tempFolder2 );
   // check folder and if it's constant constant with alternative temp folder 2
   tempFolder = QgsProcessingUtils::tempFolder();
-  QVERIFY( tempFolder.startsWith( alternative_tempFolder2 ) );
+  QCOMPARE( tempFolder.left( alternative_tempFolder2.length() ), alternative_tempFolder2 );
   QCOMPARE( QgsProcessingUtils::tempFolder(), tempFolder );
   // create file
   QString alternativeTempFile2 = QgsProcessingUtils::generateTempFilename( "alternative_temptest.txt" );
   QVERIFY( alternativeTempFile2.endsWith( "alternative_temptest.txt" ) );
   QVERIFY( alternativeTempFile2.startsWith( tempFolder ) );
   QVERIFY( alternativeTempFile2.startsWith( alternative_tempFolder2 ) );
+  settings.setValue( QStringLiteral( "Processing/Configuration/TEMP_PATH2" ), QString() );
+
 }
 
 void TestQgsProcessing::convertCompatible()


### PR DESCRIPTION
- Make the new Temp Folder setting optional, default to an empty string, and note that empty = use default
- Move responsibility for cleanup of temporary folders to c++ (if Processing Python part crashes, or doesn't exist, then we still want these cleaned up correctly)
