### PR TITLE
[needs-docs][ui] Better placement for the method combobox and auto open action

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -325,10 +325,10 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   connect( cmbIdentifyMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsIdentifyResultsDialog::cmbIdentifyMode_currentIndexChanged );
   connect( cmbViewMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsIdentifyResultsDialog::cmbViewMode_currentIndexChanged );
   connect( mExpandNewAction, &QAction::triggered, this, &QgsIdentifyResultsDialog::mExpandNewAction_triggered );
-  connect( cbxAutoFeatureForm, &QCheckBox::toggled, this, &QgsIdentifyResultsDialog::cbxAutoFeatureForm_toggled );
   connect( mExpandAction, &QAction::triggered, this, &QgsIdentifyResultsDialog::mExpandAction_triggered );
   connect( mCollapseAction, &QAction::triggered, this, &QgsIdentifyResultsDialog::mCollapseAction_triggered );
   connect( mActionCopy, &QAction::triggered, this, &QgsIdentifyResultsDialog::mActionCopy_triggered );
+  connect( mActionAutoFeatureForm, &QAction::toggled, this, &QgsIdentifyResultsDialog::mActionAutoFeatureForm_toggled );
 
   mOpenFormAction->setDisabled( true );
 
@@ -383,7 +383,6 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   cmbIdentifyMode->addItem( tr( "Top down" ), QgsMapToolIdentify::TopDownAll );
   cmbIdentifyMode->addItem( tr( "Layer selection" ), QgsMapToolIdentify::LayerSelection );
   cmbIdentifyMode->setCurrentIndex( cmbIdentifyMode->findData( identifyMode ) );
-  cbxAutoFeatureForm->setChecked( mySettings.value( QStringLiteral( "Map/identifyAutoFeatureForm" ), false ).toBool() );
 
   // view modes
   cmbViewMode->addItem( tr( "Tree" ), 0 );
@@ -417,6 +416,18 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   connect( mHelpToolButton, &QAbstractButton::clicked, this, &QgsIdentifyResultsDialog::showHelp );
 
   initSelectionModes();
+
+  QMenu *settingsMenu = new QMenu();
+  QToolButton *settingsButton = new QToolButton();
+  settingsButton->setAutoRaise( true );
+  settingsButton->setToolTip( tr( "Identify Settings" ) );
+  settingsButton->setMenu( settingsMenu );
+  settingsButton->setPopupMode( QToolButton::InstantPopup );
+  settingsButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOptions.svg" ) ) );
+  mIdentifyToolbar->addWidget( settingsButton );
+
+  settingsMenu->addAction( mActionAutoFeatureForm );
+  mActionAutoFeatureForm->setChecked( mySettings.value( QStringLiteral( "Map/identifyAutoFeatureForm" ), false ).toBool() );
 }
 
 QgsIdentifyResultsDialog::~QgsIdentifyResultsDialog()
@@ -2051,7 +2062,7 @@ void QgsIdentifyResultsDialog::cmbViewMode_currentIndexChanged( int index )
   stackedWidget->setCurrentIndex( index );
 }
 
-void QgsIdentifyResultsDialog::cbxAutoFeatureForm_toggled( bool checked )
+void QgsIdentifyResultsDialog::mActionAutoFeatureForm_toggled( bool checked )
 {
   QgsSettings settings;
   settings.setValue( QStringLiteral( "Map/identifyAutoFeatureForm" ), checked );

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -242,7 +242,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     void mExpandNewAction_triggered( bool checked );
 
-    void cbxAutoFeatureForm_toggled( bool checked );
+    void mActionAutoFeatureForm_toggled( bool checked );
 
     void mExpandAction_triggered( bool checked ) { Q_UNUSED( checked ) expandAll(); }
     void mCollapseAction_triggered( bool checked ) { Q_UNUSED( checked ) collapseAll(); }

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -72,6 +72,7 @@
          <addaction name="separator"/>
          <addaction name="mActionCopy"/>
          <addaction name="mActionPrint"/>
+         <addaction name="separator"/>
         </widget>
        </item>
        <item>
@@ -115,41 +116,17 @@
          </item>
          <item>
           <widget class="QComboBox" name="cmbIdentifyMode">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="sizeAdjustPolicy">
             <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
            </property>
            <property name="minimumContentsLength">
             <number>6</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_43">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="cbxAutoFeatureForm">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblAutoFeatureForm">
-           <property name="text">
-            <string>Auto open form</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -386,6 +363,14 @@
    </property>
    <property name="text">
     <string>Identify Features by Radius</string>
+   </property>
+  </action>
+  <action name="mActionAutoFeatureForm">
+   <property name="text">
+    <string>Auto open form for single feature results</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

@alexbruy , this is a follow up to your PR #33643. I noticed a few UI regressions after the commit was merged:
![image](https://user-images.githubusercontent.com/1728657/72133754-d04c1b80-33b4-11ea-9c69-b0feac6ed982.png)
- the combo box text gets clipped even though there's space for it to display;
- there's a wider-than-normal space between the checkbox and its label, which if the above-mentioned combo box is expanded ends up being closer to the checkbox than the label is; and
- clicking on the label doesn't toggle the checkbox, breaking well established UI expectations.

This PR fixes the regressions by removing the spacer and allowing the combo box to expand to fill available space, and moves the auto open form checkbox to a settings menu accessible via the panel toolbar. The latter is a more disrupting change, but IMHO is the right thing to do. It gives us the space to have a more self-explanatory string, works for all locale, and essentially moves a setting that doesn't need to always be part of the panel into a pop up menu.

It looks like that now:
![image](https://user-images.githubusercontent.com/1728657/72134108-b19a5480-33b5-11ea-9ba0-90c2a6efbe29.png)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
