### PR TITLE
Respect OVERWRITE parameter in package layers algorithm

### DIFF
--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -106,7 +106,13 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
     throw QgsProcessingException( QObject::tr( "GeoPackage driver not found." ) );
   }
 
-  gdal::ogr_datasource_unique_ptr hDS( OGR_Dr_CreateDataSource( hGpkgDriver, packagePath.toUtf8().constData(), nullptr ) );
+  gdal::ogr_datasource_unique_ptr hDS;
+
+  if ( !QFile::exists( packagePath ) )
+    hDS = gdal::ogr_datasource_unique_ptr( OGR_Dr_CreateDataSource( hGpkgDriver, packagePath.toUtf8().constData(), nullptr ) );
+  else
+    hDS = gdal::ogr_datasource_unique_ptr( OGROpen( packagePath.toUtf8().constData(), true, nullptr ) );
+
   if ( !hDS )
     throw QgsProcessingException( QObject::tr( "Creation of database failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
 

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -109,12 +109,18 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
   gdal::ogr_datasource_unique_ptr hDS;
 
   if ( !QFile::exists( packagePath ) )
+  {
     hDS = gdal::ogr_datasource_unique_ptr( OGR_Dr_CreateDataSource( hGpkgDriver, packagePath.toUtf8().constData(), nullptr ) );
+    if ( !hDS )
+      throw QgsProcessingException( QObject::tr( "Creation of database %1 failed (OGR error: %2)" ).arg( packagePath, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+  }
   else
+  {
     hDS = gdal::ogr_datasource_unique_ptr( OGROpen( packagePath.toUtf8().constData(), true, nullptr ) );
+    if ( !hDS )
+      throw QgsProcessingException( QObject::tr( "Opening database %1 failed (OGR error: %2)" ).arg( packagePath, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+  }
 
-  if ( !hDS )
-    throw QgsProcessingException( QObject::tr( "Creation of database failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
 
   bool errored = false;
 


### PR DESCRIPTION
Change in behavior: if the overwrite is set to false and the target gpkg exists, open the gpkg and add new layers.

Old behavior: the target gpkg was recreated in any case

## Documentation changes

Being explicit about the parameter OVERWRITE:

- When it's set to true: the file will be deleted and recreated
- When it's set to false: layers will be added and existing layers left in place
- No guarantee is made with respect to new layers that have a collision with files that already exist inside the file

I would say this also needs to mention that this was fixed in version 3.10.2

------------------

Fix #33721