### PR TITLE
[BUGFIX] Read SLD TextSymbolizer set units to pixels

### DIFF
--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -171,7 +171,7 @@ Encodes a render unit into an SLD unit of measure string.
 .. seealso:: :py:func:`decodeSldUom`
 %End
 
-    static QgsUnitTypes::RenderUnit decodeSldUom( const QString &str, double *scaleFactor );
+    static QgsUnitTypes::RenderUnit decodeSldUom( const QString &str, double *scaleFactor = 0 );
 %Docstring
 Decodes a SLD unit of measure string to a render unit.
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4616,7 +4616,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.xOffset = xOffset;
-            settings.distUnits = QgsUnitTypes::RenderPixels;
+            settings.offsetUnits = QgsUnitTypes::RenderPixels;
           }
         }
         QDomElement anchorPointYElem = anchorPointElem.firstChildElement( QStringLiteral( "AnchorPointY" ) );
@@ -4627,7 +4627,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.yOffset = yOffset;
-            settings.distUnits = QgsUnitTypes::RenderPixels;
+            settings.offsetUnits = QgsUnitTypes::RenderPixels;
           }
         }
       }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4473,6 +4473,12 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
     return false;
   }
 
+  QgsUnitTypes::RenderUnit sldUnitSize = QgsUnitTypes::RenderPixels;
+  if ( textSymbolizerElem.hasAttribute( QStringLiteral( "uom" ) ) )
+  {
+    sldUnitSize = QgsSymbolLayerUtils::decodeSldUom( textSymbolizerElem.attribute( QStringLiteral( "uom" ) ) );
+  }
+
   QString fontFamily = QStringLiteral( "Sans-Serif" );
   int fontPointSize = 10;
   QgsUnitTypes::RenderUnit fontUnitSize = QgsUnitTypes::RenderPoints;
@@ -4504,7 +4510,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
         if ( ok )
         {
           fontPointSize = fontSize;
-          fontUnitSize = QgsUnitTypes::RenderPixels;
+          fontUnitSize = sldUnitSize;
         }
       }
       else if ( it.key() == QLatin1String( "font-weight" ) )
@@ -4554,7 +4560,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
       if ( ok )
       {
         bufferSettings.setSize( bufferSize );
-        bufferSettings.setSizeUnit( QgsUnitTypes::RenderPixels );
+        bufferSettings.setSizeUnit( sldUnitSize );
       }
     }
 
@@ -4590,7 +4596,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.xOffset = xOffset;
-            settings.offsetUnits = QgsUnitTypes::RenderPixels;
+            settings.offsetUnits = sldUnitSize;
           }
         }
         QDomElement displacementYElem = displacementElem.firstChildElement( QStringLiteral( "DisplacementY" ) );
@@ -4601,7 +4607,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.yOffset = yOffset;
-            settings.offsetUnits = QgsUnitTypes::RenderPixels;
+            settings.offsetUnits = sldUnitSize;
           }
         }
       }
@@ -4616,7 +4622,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.xOffset = xOffset;
-            settings.offsetUnits = QgsUnitTypes::RenderPixels;
+            settings.offsetUnits = sldUnitSize;
           }
         }
         QDomElement anchorPointYElem = anchorPointElem.firstChildElement( QStringLiteral( "AnchorPointY" ) );
@@ -4627,7 +4633,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.yOffset = yOffset;
-            settings.offsetUnits = QgsUnitTypes::RenderPixels;
+            settings.offsetUnits = sldUnitSize;
           }
         }
       }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4475,6 +4475,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
 
   QString fontFamily = QStringLiteral( "Sans-Serif" );
   int fontPointSize = 10;
+  QgsUnitTypes::RenderUnit fontUnitSize = QgsUnitTypes::RenderPoints;
   int fontWeight = -1;
   bool fontItalic = false;
   bool fontUnderline = false;
@@ -4501,7 +4502,10 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
         bool ok;
         int fontSize = it.value().toInt( &ok );
         if ( ok )
+        {
           fontPointSize = fontSize;
+          fontUnitSize = QgsUnitTypes::RenderPixels;
+        }
       }
       else if ( it.key() == QLatin1String( "font-weight" ) )
       {
@@ -4520,6 +4524,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
   font.setUnderline( fontUnderline );
   format.setFont( font );
   format.setSize( fontPointSize );
+  format.setSizeUnit( fontUnitSize );
 
   // Fill
   QDomElement fillElem = textSymbolizerElem.firstChildElement( QStringLiteral( "Fill" ) );
@@ -4549,6 +4554,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
       if ( ok )
       {
         bufferSettings.setSize( bufferSize );
+        bufferSettings.setSizeUnit( QgsUnitTypes::RenderPixels );
       }
     }
 
@@ -4584,6 +4590,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.xOffset = xOffset;
+            settings.offsetUnits = QgsUnitTypes::RenderPixels;
           }
         }
         QDomElement displacementYElem = displacementElem.firstChildElement( QStringLiteral( "DisplacementY" ) );
@@ -4594,6 +4601,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.yOffset = yOffset;
+            settings.offsetUnits = QgsUnitTypes::RenderPixels;
           }
         }
       }
@@ -4608,6 +4616,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.xOffset = xOffset;
+            settings.distUnits = QgsUnitTypes::RenderPixels;
           }
         }
         QDomElement anchorPointYElem = anchorPointElem.firstChildElement( QStringLiteral( "AnchorPointY" ) );
@@ -4618,6 +4627,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
           if ( ok )
           {
             settings.yOffset = yOffset;
+            settings.distUnits = QgsUnitTypes::RenderPixels;
           }
         }
       }

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -640,6 +640,12 @@ QgsUnitTypes::RenderUnit QgsSymbolLayerUtils::decodeSldUom( const QString &str, 
       *scaleFactor = 304.8; // from feet to meters
     return QgsUnitTypes::RenderMapUnits;
   }
+  else if ( str == QLatin1String( "http://www.opengeospatial.org/se/units/pixel" ) )
+  {
+    if ( scaleFactor )
+      *scaleFactor = 1.0; // from pixels to pixels
+    return QgsUnitTypes::RenderPixels;
+  }
 
   // pixel is the SLD default uom. The "standardized rendering pixel
   // size" is defined to be 0.28mm x 0.28mm (millimeters).

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \returns matching render unit
      * \see encodeSldUom()
      */
-    static QgsUnitTypes::RenderUnit decodeSldUom( const QString &str, double *scaleFactor );
+    static QgsUnitTypes::RenderUnit decodeSldUom( const QString &str, double *scaleFactor = nullptr );
 
     /**
      * Returns the size scaled in pixels according to the uom attribute.

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -442,10 +442,12 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         self.assertFalse(font.italic())
 
         self.assertEqual(format.size(), 18)
+        self.assertEqual(format.sizeUnit(), QgsUnitTypes.RenderPixels)
 
         self.assertEqual(settings.placement, QgsPalLayerSettings.OverPoint)
         self.assertEqual(settings.xOffset, 1)
         self.assertEqual(settings.yOffset, 0)
+        self.assertEqual(settings.offsetUnits, QgsUnitTypes.RenderPixels)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -14,7 +14,8 @@ import qgis  # NOQA
 
 from qgis.core import (QgsSymbolLayerUtils,
                        QgsMarkerSymbol,
-                       QgsArrowSymbolLayer)
+                       QgsArrowSymbolLayer,
+                       QgsUnitTypes)
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtCore import QSizeF, QPointF
 from qgis.testing import unittest, start_app
@@ -209,6 +210,26 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
         symbol2 = QgsSymbolLayerUtils.symbolFromMimeData(mime)
         self.assertTrue(symbol2 is not None)
         self.assertEqual(symbol2.color().name(), symbol.color().name())
+
+    def testDecodeSldUom(self):
+        """
+        Test Decodes a SLD unit of measure string to a render unit
+        """
+
+        # meter
+        decode = None
+        decode = QgsSymbolLayerUtils.decodeSldUom("http://www.opengeospatial.org/se/units/metre")
+        self.assertEqual(decode, (QgsUnitTypes.RenderMapUnits, 1000.0))
+
+        # foot
+        decode = None
+        decode = QgsSymbolLayerUtils.decodeSldUom("http://www.opengeospatial.org/se/units/foot")
+        self.assertEqual(decode, (QgsUnitTypes.RenderMapUnits, 304.8))
+
+        # pixel
+        decode = None
+        decode = QgsSymbolLayerUtils.decodeSldUom("http://www.opengeospatial.org/se/units/pixel")
+        self.assertEqual(decode, (QgsUnitTypes.RenderPixels, 1.0))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgssymbollayerutils.py
+++ b/tests/src/python/test_qgssymbollayerutils.py
@@ -211,6 +211,21 @@ class PyQgsSymbolLayerUtils(unittest.TestCase):
         self.assertTrue(symbol2 is not None)
         self.assertEqual(symbol2.color().name(), symbol.color().name())
 
+    def testEncodeSldUom(self):
+        """
+        Test Encodes a SLD unit of measure string to a render unit
+        """
+
+        # millimeter
+        encode = None
+        encode = QgsSymbolLayerUtils.encodeSldUom(QgsUnitTypes.RenderMillimeters)
+        self.assertTupleEqual(encode, ('', 3.571428571428571))
+
+        # mapunits
+        encode = None
+        encode = QgsSymbolLayerUtils.encodeSldUom(QgsUnitTypes.RenderMapUnits)
+        self.assertTupleEqual(encode, ('http://www.opengeospatial.org/se/units/metre', 0.001))
+
     def testDecodeSldUom(self):
         """
         Test Decodes a SLD unit of measure string to a render unit


### PR DESCRIPTION
## Description
The SLD unit is pixels so font size unit, buffer unit, offset unit and distance unit have to be set to render pixels unit.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
