### PR TITLE
Improve pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,34 @@
 ## Description
-<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->
 
-## Checklist
+[Replace this with some text explaining the rationale and details about this pull request]
 
-<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
+<!--
+  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
+  ===========================================
+
+  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.
+
+  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
+  Include both: *what* you changed and *why* you changed it.
+
+  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
+  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.
+
+  Also mention if you think this PR needs to be backporte and relevant or fixed issues.
+
+------------------------
+
+  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
+  Feel free to ask in a comment if you have troubles with any of them.
+
+  - Commit messages are descriptive and explain the rationale for changes.
+
+  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.
+
+  - New unit tests have been added for relevant changes
+
+  - You have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
+    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.
+
+  - You have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
 -->
-
-- [ ] Commit messages are descriptive and explain the rationale for changes
-- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
-- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-- [ ] New unit tests have been added for core changes
-- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
-- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
   If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
   In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.
 
-  Also mention if you think this PR needs to be backporte and relevant or fixed issues.
+  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.
 
 ------------------------
 
@@ -27,8 +27,8 @@
 
   - New unit tests have been added for relevant changes
 
-  - You have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
+  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
     If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.
 
-  - You have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
+  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
 -->

--- a/scripts/astyle-all.sh
+++ b/scripts/astyle-all.sh
@@ -37,4 +37,6 @@ find python src tests -type f -print | while read -r f; do
 	astyle.sh "$f" || true
 done
 
+remove_temporary_files.sh
+
 echo


### PR DESCRIPTION
# Description

The current pull request template does not a great job in getting (new) developers where we want them.
Especially the checklist is not 100% applicable. And it doesn't help first timers (which are the main target audience) to fix problems. Let's say you forgot to astyle new code, it doesn't help you to get things right *this time*, it only helps to setup the pre commit hook for the future.

This reduces the printed part of the template to a bare minimum but is more clear on the rest.

Feedback very welcome!