### PR TITLE
Fix missing vector layer subset strings when changing/repairing paths (3.10 backport)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7380,7 +7380,7 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
         QString subsetString;
         // Get the subset string directly from the data provider because
         // layer's method will return a null string from invalid layers
-        if ( !layerWasValid && vlayer && vlayer->dataProvider() &&
+        if ( vlayer && vlayer->dataProvider() &&
              vlayer->dataProvider()->supportsSubsetString() &&
              !vlayer->dataProvider()->subsetString( ).isEmpty() )
         {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7386,6 +7386,13 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
         {
           subsetString = vlayer->dataProvider()->subsetString();
         }
+        if ( subsetString.isEmpty() )
+        {
+          // actually -- the above isn't true in all situations. If a layer was invalid at the time
+          // that the subset string was set, then ONLY the layer has knowledge of this subset string!
+          subsetString = vlayer->subsetString();
+        }
+
         layer->setDataSource( uri.uri, layer->name(), uri.providerKey, QgsDataProvider::ProviderOptions() );
         // Re-apply original style and subset string  when fixing bad layers
         if ( !( layerWasValid || layer->originalXmlProperties().isEmpty() ) )
@@ -7415,6 +7422,10 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
                          .arg( layer->name( ) )
                          .arg( errorMsg ) );
           }
+        }
+        else if ( !subsetString.isEmpty() )
+        {
+          vlayer->setSubsetString( subsetString );
         }
 
         // All the following code is necessary to refresh the layer

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -903,16 +903,22 @@ QString QgsVectorLayer::subsetString() const
   if ( !mValid || !mDataProvider )
   {
     QgsDebugMsgLevel( QStringLiteral( "invoked with invalid layer or null mDataProvider" ), 3 );
-    return QString();
+    return customProperty( QStringLiteral( "storedSubsetString" ) ).toString();
   }
   return mDataProvider->subsetString();
 }
 
 bool QgsVectorLayer::setSubsetString( const QString &subset )
 {
-  if ( !mValid || !mDataProvider || mEditBuffer )
+  if ( !mValid || !mDataProvider )
   {
     QgsDebugMsgLevel( QStringLiteral( "invoked with invalid layer or null mDataProvider or while editing" ), 3 );
+    setCustomProperty( QStringLiteral( "storedSubsetString" ), subset );
+    return false;
+  }
+  else if ( mEditBuffer )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "invoked while editing" ), 3 );
     return false;
   }
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -3412,6 +3412,29 @@ class TestQgsVectorLayerTransformContext(unittest.TestCase):
         self.assertTrue(p.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
         self.assertTrue(vl.transformContext().hasTransform(QgsCoordinateReferenceSystem(4326), QgsCoordinateReferenceSystem(3857)))
 
+    def testSubsetStringInvalidLayer(self):
+        """
+        Test that subset strings can be set on invalid layers, and retrieved later...
+        """
+        vl = QgsVectorLayer(
+            'nope',
+            'test', 'no')
+        self.assertFalse(vl.isValid())
+        self.assertIsNone(vl.dataProvider())
+        vl.setSubsetString('xxxxxxxxx')
+        self.assertEqual(vl.subsetString(), 'xxxxxxxxx')
+
+        # invalid layer subset strings must be persisted via xml
+        doc = QDomDocument("testdoc")
+        elem = doc.createElement("maplayer")
+        self.assertTrue(vl.writeXml(elem, doc, QgsReadWriteContext()))
+
+        vl2 = QgsVectorLayer(
+            'nope',
+            'test', 'no')
+        vl2.readXml(elem, QgsReadWriteContext())
+        self.assertEqual(vl2.subsetString(), 'xxxxxxxxx')
+
 
 # TODO:
 # - fetch rect: feat with changed geometry: 1. in rect, 2. out of rect


### PR DESCRIPTION
Manual backport of https://github.com/qgis/QGIS/pull/33656