### PR TITLE
Fix some Qt 5.13 css parsing warnings

### DIFF
--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -126,11 +126,11 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
   {
     //sidebar style
     QString style = "QListWidget#mOptionsListWidget {"
-                    "    background-color: rgb(69, 69, 69, 0);"
+                    "    background-color: rgba(69, 69, 69, 0);"
                     "    outline: 0;"
                     "}"
                     "QFrame#mOptionsListFrame {"
-                    "    background-color: rgb(69, 69, 69, 220);"
+                    "    background-color: rgba(69, 69, 69, 220);"
                     "}"
                     "QListWidget#mOptionsListWidget::item {"
                     "    color: white;"

--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -576,7 +576,7 @@ QgsTaskManagerFloatingWidget::QgsTaskManagerFloatingWidget( QgsTaskManager *mana
   setMinimumSize( minWidth, minHeight );
   layout()->addWidget( w );
   setStyleSheet( ".QgsTaskManagerFloatingWidget { border-top-left-radius: 8px;"
-                 "border-top-right-radius: 8px; background-color: rgb(0, 0, 0, 70%); }" );
+                 "border-top-right-radius: 8px; background-color: rgba(0, 0, 0, 70%); }" );
 }
 
 


### PR DESCRIPTION
Qt 5.13 throws qt warnings relating to use of rgb with an alpha value 