### PR TITLE
Add new mode to "Join Attributes by Location" to take attributes from matching feature with largest area of overlap only

### DIFF
--- a/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_lines.gml
+++ b/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_lines.gml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_lines_crossing_multiple_lines.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-2</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>8</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_lines fid="join_lines_crossing_multiple_lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-2,7 -2,-3 3,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line2</ogr:name2>
+      <ogr:val2>1</ogr:val2>
+    </ogr:join_lines_crossing_multiple_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_lines fid="join_lines_crossing_multiple_lines.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>5,3 10,3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line3</ogr:name2>
+      <ogr:val2>3</ogr:val2>
+    </ogr:join_lines_crossing_multiple_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_lines fid="join_lines_crossing_multiple_lines.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>7,8 7,5</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line4</ogr:name2>
+      <ogr:val2>4</ogr:val2>
+    </ogr:join_lines_crossing_multiple_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_lines fid="join_lines_crossing_multiple_lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>0,0 6,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line5</ogr:name2>
+      <ogr:val2>5</ogr:val2>
+    </ogr:join_lines_crossing_multiple_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_lines fid="join_lines_crossing_multiple_lines.4">
+      <ogr:name2>line1</ogr:name2>
+      <ogr:val2 xsi:nil="true"/>
+    </ogr:join_lines_crossing_multiple_lines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_lines.xsd
+++ b/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_lines.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_lines_crossing_multiple_lines" type="ogr:join_lines_crossing_multiple_lines_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_lines_crossing_multiple_lines_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_polygons.gml
+++ b/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_polygons.gml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_lines_crossing_multiple_polygons.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-2</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_polygons fid="join_lines_crossing_multiple_polygons.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>1,4 1,0 3,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line4</ogr:name>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_lines_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_polygons fid="join_lines_crossing_multiple_polygons.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>4,0 5,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line2</ogr:name>
+      <ogr:val>3</ogr:val>
+    </ogr:join_lines_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_polygons fid="join_lines_crossing_multiple_polygons.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>1,-3 2,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line3</ogr:name>
+      <ogr:val>4</ogr:val>
+    </ogr:join_lines_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_polygons fid="join_lines_crossing_multiple_polygons.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>9,6 -1,5 -2,5 -2,0 10,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line1</ogr:name>
+      <ogr:val>11</ogr:val>
+    </ogr:join_lines_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_crossing_multiple_polygons fid="join_lines_crossing_multiple_polygons.4">
+      <ogr:name>line5</ogr:name>
+      <ogr:val>1</ogr:val>
+    </ogr:join_lines_crossing_multiple_polygons>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_polygons.xsd
+++ b/python/plugins/processing/tests/testdata/custom/join_lines_crossing_multiple_polygons.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_lines_crossing_multiple_polygons" type="ogr:join_lines_crossing_multiple_polygons_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_lines_crossing_multiple_polygons_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/custom/polygons_crossing_multiple_polygons.gml
+++ b/python/plugins/processing/tests/testdata/custom/polygons_crossing_multiple_polygons.gml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ polygons_crossing_multiple_polygons.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-2</gml:Y></gml:coord>
+      <gml:coord><gml:X>13</gml:X><gml:Y>4</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:polygons_crossing_multiple_polygons fid="polygons_crossing_multiple_polygons.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,4 1,0 3,0 3,4 1,4</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>poly1</ogr:name>
+      <ogr:val>3</ogr:val>
+    </ogr:polygons_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygons_crossing_multiple_polygons fid="polygons_crossing_multiple_polygons.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>11,2 13,2 13,4 11,4 11,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>poly2</ogr:name>
+      <ogr:val>54</ogr:val>
+    </ogr:polygons_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygons_crossing_multiple_polygons fid="polygons_crossing_multiple_polygons.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>0,2 -1,2 -1,1 0,1 0,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>poly3</ogr:name>
+      <ogr:val>7</ogr:val>
+    </ogr:polygons_crossing_multiple_polygons>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polygons_crossing_multiple_polygons fid="polygons_crossing_multiple_polygons.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,-2 1,0 10,0 10,-2 1,-2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>poly4</ogr:name>
+      <ogr:val>6</ogr:val>
+    </ogr:polygons_crossing_multiple_polygons>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/polygons_crossing_multiple_polygons.xsd
+++ b/python/plugins/processing/tests/testdata/custom/polygons_crossing_multiple_polygons.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="polygons_crossing_multiple_polygons" type="ogr:polygons_crossing_multiple_polygons_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="polygons_crossing_multiple_polygons_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_lines_to_lines_largest.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_lines_to_lines_largest.gml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_lines_to_lines_largest.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-2</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>8</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_lines_to_lines_largest fid="join_lines_crossing_multiple_lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-2,7 -2,-3 3,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line2</ogr:name2>
+      <ogr:val2>1</ogr:val2>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name>line1</ogr:name>
+      <ogr:val>11</ogr:val>
+    </ogr:join_lines_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_lines_largest fid="join_lines_crossing_multiple_lines.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>5,3 10,3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line3</ogr:name2>
+      <ogr:val2>3</ogr:val2>
+      <ogr:fid_2 xsi:nil="true"/>
+      <ogr:name xsi:nil="true"/>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_lines_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_lines_largest fid="join_lines_crossing_multiple_lines.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>7,8 7,5</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line4</ogr:name2>
+      <ogr:val2>4</ogr:val2>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name>line1</ogr:name>
+      <ogr:val>11</ogr:val>
+    </ogr:join_lines_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_lines_largest fid="join_lines_crossing_multiple_lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>0,0 6,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name2>line5</ogr:name2>
+      <ogr:val2>5</ogr:val2>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.0</ogr:fid_2>
+      <ogr:name>line4</ogr:name>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_lines_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_lines_largest fid="join_lines_crossing_multiple_lines.4">
+      <ogr:name2>line1</ogr:name2>
+      <ogr:val2 xsi:nil="true"/>
+      <ogr:fid_2 xsi:nil="true"/>
+      <ogr:name xsi:nil="true"/>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_lines_to_lines_largest>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_lines_to_lines_largest.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_lines_to_lines_largest.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_lines_to_lines_largest" type="ogr:join_lines_to_lines_largest_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_lines_to_lines_largest_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="fid_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_lines_to_polys_largest.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_lines_to_polys_largest.gml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_lines_to_polys_largest.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-2</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_lines_to_polys_largest fid="join_lines_crossing_multiple_polygons.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>1,4 1,0 3,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line4</ogr:name>
+      <ogr:val xsi:nil="true"/>
+      <ogr:fid_2>polys.0</ogr:fid_2>
+      <ogr:name_2>aaaaa</ogr:name_2>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+    </ogr:join_lines_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_polys_largest fid="join_lines_crossing_multiple_polygons.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>4,0 5,0</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line2</ogr:name>
+      <ogr:val>3</ogr:val>
+      <ogr:fid_2>polys.5</ogr:fid_2>
+      <ogr:name_2>elim</ogr:name_2>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+    </ogr:join_lines_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_polys_largest fid="join_lines_crossing_multiple_polygons.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>1,-3 2,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line3</ogr:name>
+      <ogr:val>4</ogr:val>
+      <ogr:fid_2 xsi:nil="true"/>
+      <ogr:name_2 xsi:nil="true"/>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval xsi:nil="true"/>
+    </ogr:join_lines_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_polys_largest fid="join_lines_crossing_multiple_polygons.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>9,6 -1,5 -2,5 -2,0 10,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:name>line1</ogr:name>
+      <ogr:val>11</ogr:val>
+      <ogr:fid_2>polys.3</ogr:fid_2>
+      <ogr:name_2>ASDF</ogr:name_2>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+    </ogr:join_lines_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_lines_to_polys_largest fid="join_lines_crossing_multiple_polygons.4">
+      <ogr:name>line5</ogr:name>
+      <ogr:val>1</ogr:val>
+      <ogr:fid_2 xsi:nil="true"/>
+      <ogr:name_2 xsi:nil="true"/>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval xsi:nil="true"/>
+    </ogr:join_lines_to_polys_largest>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_lines_to_polys_largest.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_lines_to_polys_largest.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_lines_to_polys_largest" type="ogr:join_lines_to_polys_largest_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_lines_to_polys_largest_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="fid_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest.gml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_polys_to_lines_largest.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest fid="polys.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.0</ogr:fid_2>
+      <ogr:name_2>line4</ogr:name_2>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_polys_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest fid="polys.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>5,5 6,4 4,4 5,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval>-33</ogr:intval>
+      <ogr:floatval>0</ogr:floatval>
+      <ogr:fid_2 xsi:nil="true"/>
+      <ogr:name_2 xsi:nil="true"/>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_polys_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest fid="polys.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,5 2,6 3,6 3,5 2,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest fid="polys.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest fid="polys.4">
+      <ogr:name xsi:nil="true"/>
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+      <ogr:fid_2 xsi:nil="true"/>
+      <ogr:name_2 xsi:nil="true"/>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_polys_to_lines_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest fid="polys.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 2,2 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_polys_to_lines_largest" type="ogr:join_polys_to_lines_largest_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_polys_to_lines_largest_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="fid_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard.gml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_polys_to_lines_largest_discard.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard fid="polys.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.0</ogr:fid_2>
+      <ogr:name_2>line4</ogr:name_2>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_polys_to_lines_largest_discard>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard fid="polys.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,5 2,6 3,6 3,5 2,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest_discard>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard fid="polys.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest_discard>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard fid="polys.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 2,2 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest_discard>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_polys_to_lines_largest_discard" type="ogr:join_polys_to_lines_largest_discard_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_polys_to_lines_largest_discard_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="fid_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard_no_join.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard_no_join.gml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_polys_to_lines_largest_discard_no_join.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard_no_join fid="polys.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.0</ogr:fid_2>
+      <ogr:name_2>line4</ogr:name_2>
+      <ogr:val xsi:nil="true"/>
+    </ogr:join_polys_to_lines_largest_discard_no_join>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard_no_join fid="polys.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,5 2,6 3,6 3,5 2,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest_discard_no_join>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard_no_join fid="polys.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest_discard_no_join>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_discard_no_join fid="polys.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 2,2 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+      <ogr:fid_2>join_lines_crossing_multiple_polygons.3</ogr:fid_2>
+      <ogr:name_2>line1</ogr:name_2>
+      <ogr:val>11</ogr:val>
+    </ogr:join_polys_to_lines_largest_discard_no_join>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard_no_join.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_discard_no_join.xsd
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_polys_to_lines_largest_discard_no_join" type="ogr:join_polys_to_lines_largest_discard_no_join_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_polys_to_lines_largest_discard_no_join_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="fid_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_unjoined.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_unjoined.gml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_polys_to_lines_largest_unjoined.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>4</gml:X><gml:Y>4</gml:Y></gml:coord>
+      <gml:coord><gml:X>6</gml:X><gml:Y>5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                                
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_unjoined fid="polys.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>5,5 6,4 4,4 5,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval>-33</ogr:intval>
+      <ogr:floatval>0</ogr:floatval>
+    </ogr:join_polys_to_lines_largest_unjoined>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_lines_largest_unjoined fid="polys.4">
+      <ogr:name xsi:nil="true"/>
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+    </ogr:join_polys_to_lines_largest_unjoined>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_unjoined.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_lines_largest_unjoined.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_polys_to_lines_largest_unjoined" type="ogr:join_polys_to_lines_largest_unjoined_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_polys_to_lines_largest_unjoined_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_polys_largest.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_polys_largest.gml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_polys_to_polys_largest.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:join_polys_to_polys_largest fid="polys.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+      <ogr:name_2>poly1</ogr:name_2>
+    </ogr:join_polys_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_polys_largest fid="polys.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>5,5 6,4 4,4 5,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval>-33</ogr:intval>
+      <ogr:floatval>0</ogr:floatval>
+      <ogr:name_2 xsi:nil="true"/>
+    </ogr:join_polys_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_polys_largest fid="polys.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,5 2,6 3,6 3,5 2,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+      <ogr:name_2 xsi:nil="true"/>
+    </ogr:join_polys_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_polys_largest fid="polys.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+      <ogr:name_2>poly4</ogr:name_2>
+    </ogr:join_polys_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_polys_largest fid="polys.4">
+      <ogr:name xsi:nil="true"/>
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+      <ogr:name_2 xsi:nil="true"/>
+    </ogr:join_polys_to_polys_largest>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:join_polys_to_polys_largest fid="polys.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 2,2 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+      <ogr:name_2>poly4</ogr:name_2>
+    </ogr:join_polys_to_polys_largest>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_polys_to_polys_largest.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_polys_to_polys_largest.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_polys_to_polys_largest" type="ogr:join_polys_to_polys_largest_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_polys_to_polys_largest_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="name_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests3.yaml
@@ -1400,6 +1400,122 @@ tests:
         name: expected/join_by_location_equals.gml
         type: vector
 
+  - algorithm: native:joinattributesbylocation
+    name: Join by location, largest overlap, polygons to lines
+    params:
+      DISCARD_NONMATCHING: false
+      INPUT:
+        name: polys.gml|layername=polys2
+        type: vector
+      JOIN:
+        name: custom/join_lines_crossing_multiple_polygons.gml|layername=join_lines_crossing_multiple_polygons
+        type: vector
+      METHOD: 2
+      PREDICATE:
+      - 0
+      PREFIX: ''
+    results:
+      OUTPUT:
+        name: expected/join_polys_to_lines_largest.gml
+        type: vector
+
+  - algorithm: native:joinattributesbylocation
+    name: Join by location, largest overlap, polygons to lines, discard no matching
+    params:
+      DISCARD_NONMATCHING: true
+      INPUT:
+        name: polys.gml|layername=polys2
+        type: vector
+      JOIN:
+        name: custom/join_lines_crossing_multiple_polygons.gml|layername=join_lines_crossing_multiple_polygons
+        type: vector
+      METHOD: 2
+      PREDICATE:
+      - 0
+      PREFIX: ''
+    results:
+      OUTPUT:
+        name: expected/join_polys_to_lines_largest_discard.gml
+        type: vector
+
+  - algorithm: native:joinattributesbylocation
+    name: Join by location, largest overlap, polygons to lines, save no matching
+    params:
+      DISCARD_NONMATCHING: true
+      INPUT:
+        name: polys.gml|layername=polys2
+        type: vector
+      JOIN:
+        name: custom/join_lines_crossing_multiple_polygons.gml|layername=join_lines_crossing_multiple_polygons
+        type: vector
+      METHOD: 2
+      PREDICATE:
+      - 0
+      PREFIX: ''
+    results:
+      NON_MATCHING:
+        name: expected/join_polys_to_lines_largest_unjoined.gml
+        type: vector
+
+  - algorithm: native:joinattributesbylocation
+    name: Join by location, largest overlap, polygons to polygons, subset of fields
+    params:
+      DISCARD_NONMATCHING: false
+      INPUT:
+        name: polys.gml|layername=polys2
+        type: vector
+      JOIN:
+        name: custom/polygons_crossing_multiple_polygons.gml|layername=polygons_crossing_multiple_polygons
+        type: vector
+      JOIN_FIELDS:
+      - name
+      METHOD: 2
+      PREDICATE:
+      - 0
+      PREFIX: ''
+    results:
+      OUTPUT:
+        name: expected/join_polys_to_polys_largest.gml
+        type: vector
+
+  - algorithm: native:joinattributesbylocation
+    name: Join by location, largest overlap, lines to polygons
+    params:
+      DISCARD_NONMATCHING: false
+      INPUT:
+        name: custom/join_lines_crossing_multiple_polygons.gml|layername=join_lines_crossing_multiple_polygons
+        type: vector
+      JOIN:
+        name: polys.gml|layername=polys2
+        type: vector
+      METHOD: 2
+      PREDICATE:
+      - 0
+      PREFIX: ''
+    results:
+      OUTPUT:
+        name: expected/join_lines_to_polys_largest.gml
+        type: vector
+
+  - algorithm: native:joinattributesbylocation
+    name: Join by location, largest overlap, lines to lines
+    params:
+      DISCARD_NONMATCHING: false
+      INPUT:
+        name: custom/join_lines_crossing_multiple_lines.gml|layername=join_lines_crossing_multiple_lines
+        type: vector
+      JOIN:
+        name: custom/join_lines_crossing_multiple_polygons.gml|layername=join_lines_crossing_multiple_polygons
+        type: vector
+      METHOD: 2
+      PREDICATE:
+      - 0
+      PREFIX: ''
+    results:
+      OUTPUT:
+        name: expected/join_lines_to_lines_largest.gml
+        type: vector
+
   - algorithm: qgis:joinbylocationsummary
     name: Join by location (summary), intersects
     params:

--- a/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
@@ -184,11 +184,24 @@ QVariantMap QgsJoinByLocationAlgorithm::processAlgorithm( const QVariantMap &par
   {
     case OneToMany:
     case JoinToFirst:
-      // TODO - consider using some heuristics to determine whether it's always best to iterate over the join
-      // source. It's best when you're doing a many -> few join (e.g. an input of millions of address points joined to hundreds of locality polygons),
-      // but poor in other circumstances (e.g. an input of few polygon boundaries joined to thousands of polygon other polygon features)
-      processAlgorithmByIteratingOverJoinedSource( context, feedback );
+    {
+      if ( mBaseSource->featureCount() > 0 && mJoinSource->featureCount() > 0 && mBaseSource->featureCount() < mJoinSource->featureCount() )
+      {
+        // joining FEWER features to a layer with MORE features. So we iterate over the FEW features and find matches from the MANY
+        processAlgorithmByIteratingOverInputSource( context, feedback );
+      }
+      else
+      {
+        // default -- iterate over the join source and match back to the base source. We do this on the assumption that the most common
+        // use case is joining a points layer to a polygon layer (taking polygon attributes and adding them to the points), so by iterating
+        // over the polygons we can take advantage of prepared geometries for the spatial relationship test.
+
+        // TODO - consider using more heuristics to determine whether it's always best to iterate over the join
+        // source.
+        processAlgorithmByIteratingOverJoinedSource( context, feedback );
+      }
       break;
+    }
 
     case JoinToLargestOverlap:
       processAlgorithmByIteratingOverInputSource( context, feedback );

--- a/src/analysis/processing/qgsalgorithmjoinbylocation.h
+++ b/src/analysis/processing/qgsalgorithmjoinbylocation.h
@@ -50,17 +50,24 @@ class QgsJoinByLocationAlgorithm : public QgsProcessingAlgorithm
 
   protected:
     QVariantMap processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
-    bool processFeatures( QgsFeature &joinFeature, QgsProcessingFeedback *feedback );
-    bool featureFilter( const QgsFeature &feature, QgsGeometryEngine *engine ) const;
+    bool processFeatureFromJoinSource( QgsFeature &joinFeature, QgsProcessingFeedback *feedback );
+    bool processFeatureFromInputSource( QgsFeature &inputFeature, QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    bool featureFilter( const QgsFeature &feature, QgsGeometryEngine *engine, bool comparingToJoinedFeature ) const;
 
   private:
+
+    void processAlgorithmByIteratingOverJoinedSource( QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+    void processAlgorithmByIteratingOverInputSource( QgsProcessingContext &context, QgsProcessingFeedback *feedback );
+
     enum JoinMethod
     {
       OneToMany = 0,
-      OneToOne = 1,
+      JoinToFirst = 1,
+      JoinToLargestOverlap = 2
     };
     long mJoinedCount = 0;
     std::unique_ptr< QgsProcessingFeatureSource > mBaseSource;
+    std::unique_ptr< QgsProcessingFeatureSource > mJoinSource;
     QgsAttributeList mJoinedFieldIndices;
     bool mDiscardNonMatching = false;
     std::unique_ptr< QgsFeatureSink > mJoinedFeatures;


### PR DESCRIPTION
This allows for easy polygon->polygon joins, where you expect there to be
only a single matching feature and don't want to include features which
are just touching or have just tiny sliver polygon overlaps.

Sponsored by SMEC/SJ
