### PR TITLE
add field name when reporting an error in refactorfield algo

### DIFF
--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -108,9 +108,12 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
                 expression.setAreaUnits(context.project().areaUnits())
                 if expression.hasParserError():
                     feedback.reportError(
-                        self.tr(u'Parser error in expression "{}": {}')
-                        .format(expression.expression(),
-                                expression.parserErrorString()))
+                        self.tr('Parser error for field "{}" with expression "{}": {}')
+                        .format(
+                            field_def['name'],
+                            expression.expression(),
+                            expression.parserErrorString()),
+                        True)
                     return False
                 self.expressions.append(expression)
             else:


### PR DESCRIPTION
## Description

Just to have more debug when one expression is failing and you have a lot of fields in the algorithm.

I also added `fatal=True`, is-it correct?
Can-it be backported to 3.10?

**Side question related to this PR**, a few lines below this, there is also:

```python
                    raise QgsProcessingException(
                        self.tr(u'Evaluation error in expression "{}": {}')
                            .format(expression.expression(),
                                    expression.evalErrorString()))
```

When should we raise an exception *or* a fatal message like in the PR? When using the algo with PyQGIS, does-it mean I need both methods at the same time to have **all** errors (try/catch AND custom feedback)?

```python

class RefactorFeedBack(QgsProcessingFeedback):
    def __init__(self, bar):
        self.bar = bar
        super().__init__()
    def reportError(self, error: str, fatalError: bool = ...) -> None:
        if fatalError:
            # To have fatal error message
            LOGGER.critical(error)
            self.bar.pushCritical('Refactor field feedback', error)

try:
    results = runAndLoadResults(alg_name, params, feedback, context)
except QgsProcessingException as e:
    LOGGER.critical(e)
    # To have exceptions from the algo
    self.bar.pushCritical('Refactor field', str(e))
    return
```

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
