### PR TITLE
Fixes #33449 Snapping empty layer when adding new feature

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -834,7 +834,11 @@ void QgsPointLocator::onFeatureAdded( QgsFeatureId fid )
   if ( !mRTree )
   {
     if ( mIsEmptyLayer )
-      init(); // first feature - let's built the index
+    {
+      // layer is not empty any more, let's build the index
+      mIsEmptyLayer = false;
+      init();
+    }
     return; // nothing to do if we are not initialized yet
   }
 


### PR DESCRIPTION
## Description

If the layer is empty and we create a new features, these ones are not indexed. This PR reset the `mIsEmptyLayer` boolean when a feature is added so the index could be build.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
