### PR TITLE
[Server] Throw exception if bad layers are not restricted

### DIFF
--- a/python/server/auto_generated/qgsstorebadlayerinfo.sip.in
+++ b/python/server/auto_generated/qgsstorebadlayerinfo.sip.in
@@ -41,6 +41,13 @@ badLayers
 :return: ids of bad layers
 %End
 
+    QMap<QString, QString> badLayerNames() const;
+%Docstring
+Returns names of bad layers with ids.
+
+.. versionadded:: 3.12
+%End
+
 };
 
 /************************************************************************

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -19,6 +19,7 @@
 #include "qgsmessagelog.h"
 #include "qgsserverexception.h"
 #include "qgsstorebadlayerinfo.h"
+#include "qgsserverprojectutils.h"
 
 #include <QFile>
 
@@ -48,9 +49,29 @@ const QgsProject *QgsConfigCache::project( const QString &path )
     {
       if ( !badLayerHandler->badLayers().isEmpty() )
       {
-        QString errorMsg = QStringLiteral( "Layer(s) %1 not valid" ).arg( badLayerHandler->badLayers().join( ',' ) );
-        QgsMessageLog::logMessage( errorMsg, QStringLiteral( "Server" ), Qgis::Critical );
-        throw QgsServerException( QStringLiteral( "Layer(s) not valid" ) );
+        // if bad layers are not restricted layers so service failed
+        QStringList unrestrictedBadLayers;
+        // test bad layers through restrictedlayers
+        const QStringList badLayerIds = badLayerHandler->badLayers();
+        const QMap<QString, QString> badLayerNames = badLayerHandler->badLayerNames();
+        const QStringList resctrictedLayers = QgsServerProjectUtils::wmsRestrictedLayers( *prj );
+        for ( const QString &badLayerId : badLayerIds )
+        {
+          // if this bad layer is in restricted layers
+          // it doesn't need to be added to unrestricted bad layers
+          if ( badLayerNames.contains( badLayerId ) &&
+               resctrictedLayers.contains( badLayerNames.value( badLayerId ) ) )
+          {
+            continue;
+          }
+          unrestrictedBadLayers.append( badLayerId );
+        }
+        if ( !unrestrictedBadLayers.isEmpty() )
+        {
+          const QString errorMsg = QStringLiteral( "Layer(s) %1 not valid" ).arg( unrestrictedBadLayers.join( ',' ) );
+          QgsMessageLog::logMessage( errorMsg, QStringLiteral( "Server" ), Qgis::Critical );
+          throw QgsServerException( QStringLiteral( "Layer(s) not valid" ) );
+        }
       }
       mProjectCache.insert( path, prj.release() );
       mFileSystemWatcher.addPath( path );
@@ -120,4 +141,3 @@ void QgsConfigCache::removeEntry( const QString &path )
 {
   removeChangedEntry( path );
 }
-

--- a/src/server/qgsstorebadlayerinfo.cpp
+++ b/src/server/qgsstorebadlayerinfo.cpp
@@ -29,7 +29,13 @@ void QgsStoreBadLayerInfo::handleBadLayers( const QList<QDomNode> &layers )
       QDomElement idElem = it->firstChildElement( "id" );
       if ( !idElem.isNull() )
       {
-        mBadLayerIds.append( idElem.text() );
+        const QString badLayerId = idElem.text();
+        mBadLayerIds.append( badLayerId );
+        const QDomElement nameElem = it->firstChildElement( "layername" );
+        if ( !nameElem.isNull() )
+        {
+          mBadLayerNames.insert( badLayerId, nameElem.text() );
+        }
       }
     }
   }

--- a/src/server/qgsstorebadlayerinfo.h
+++ b/src/server/qgsstorebadlayerinfo.h
@@ -21,6 +21,7 @@
 #include "qgsprojectbadlayerhandler.h"
 #include "qgis_server.h"
 #include <QStringList>
+#include <QMap>
 
 /**
  * \ingroup server
@@ -48,8 +49,15 @@ class SERVER_EXPORT QgsStoreBadLayerInfo: public QgsProjectBadLayerHandler
      */
     QStringList badLayers() const { return mBadLayerIds; }
 
+    /**
+     * Returns names of bad layers with ids.
+     * \since QGIS 3.12
+     */
+    QMap<QString, QString> badLayerNames() const { return mBadLayerNames; }
+
   private:
     QStringList mBadLayerIds;
+    QMap<QString, QString> mBadLayerNames;
 };
 
 #endif // QGSSTOREBADLAYERINFO_H


### PR DESCRIPTION
Manually backport #33668 

## Description
QGIS Server throw an exception if the project has bad layers, but the user can defined restricted layers which are unpublished layers.

So restricted layers can be bad layers server side, it is not necessary an error.

This code verified that the bad layers are not restricted. If the project contains unrestricted bad layers, the server throw an exception.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
