### PR TITLE
Assorted maptool management fixes

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1768,13 +1768,13 @@ void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )
 
   // set new map tool and activate it
   mMapTool = tool;
+  emit mapToolSet( mMapTool, oldTool );
   if ( mMapTool )
   {
     connect( mMapTool, &QObject::destroyed, this, &QgsMapCanvas::mapToolDestroyed );
     mMapTool->activate();
   }
 
-  emit mapToolSet( mMapTool, oldTool );
 } // setMapTool
 
 void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1782,9 +1782,9 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
   if ( mMapTool && mMapTool == tool )
   {
     disconnect( mMapTool, &QObject::destroyed, this, &QgsMapCanvas::mapToolDestroyed );
-    mMapTool->deactivate();
     QgsMapTool *oldTool = mMapTool;
     mMapTool = nullptr;
+    oldTool->deactivate();
     emit mapToolSet( nullptr, oldTool );
     setCursor( Qt::ArrowCursor );
   }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1781,6 +1781,7 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
 {
   if ( mMapTool && mMapTool == tool )
   {
+    disconnect( mMapTool, &QObject::destroyed, this, &QgsMapCanvas::mapToolDestroyed );
     mMapTool->deactivate();
     mMapTool = nullptr;
     emit mapToolSet( nullptr, mMapTool );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1783,8 +1783,9 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool *tool )
   {
     disconnect( mMapTool, &QObject::destroyed, this, &QgsMapCanvas::mapToolDestroyed );
     mMapTool->deactivate();
+    QgsMapTool *oldTool = mMapTool;
     mMapTool = nullptr;
-    emit mapToolSet( nullptr, mMapTool );
+    emit mapToolSet( nullptr, oldTool );
     setCursor( Qt::ArrowCursor );
   }
 


### PR DESCRIPTION
* *Emit QgsMapCanvas::mapToolSet before tool is activated*
So that QgisApp::mapToolChanged can connect the relevant signals before the tool is actually activated

* *Disconnect QgsMapTool::destroyed also when tool is unset via QgsMapCanvas::unsetMapTool*
Ensures consistent behaviour with when tool is replaced in QgsMapCanvas::setMapTool.

* *Clear QgsMapCanvas::mMapTool before emitting mapToolSet in QgsMapCanvas::unsetMapTool*
Otherwise, third-parties setting another tool based on the emitted signal will have their tool cleared again immediately

* *Call QgsMapTool::deactivate after clearing QgsMapCanvas::mMapTool*
Ensures that QgsMapCanvas::mapTool does not return tool currently being unset.