### PR TITLE
Install source sip files

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -404,4 +404,9 @@ FOREACH(module ${PY_MODULES})
     )
   ENDFOREACH(pyfile)
   PY_COMPILE(py${module} "${QGIS_PYTHON_OUTPUT_DIRECTORY}/${module}")
+
+  # install source sip files
+  FILE(GLOB sip_files ${CMAKE_CURRENT_BINARY_DIR}/${module}/*.sip)
+  INSTALL(FILES ${sip_files} DESTINATION ${SIP_DEFAULT_SIP_DIR}/qgis/${module})
+  INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${module}/auto_generated DESTINATION ${SIP_DEFAULT_SIP_DIR}/qgis/${module})
 ENDFOREACH(module)


### PR DESCRIPTION
To allow external applications based on QGIS to provide SIP bindings.