### PR TITLE
[processing] Fix constant raster cellsize - prefer cellsize over extent parameter

### DIFF
--- a/src/analysis/processing/qgsalgorithmconstantraster.cpp
+++ b/src/analysis/processing/qgsalgorithmconstantraster.cpp
@@ -82,10 +82,14 @@ QVariantMap QgsConstantRasterAlgorithm::processAlgorithm( const QVariantMap &par
   int rows = std::max( std::ceil( extent.height() / pixelSize ), 1.0 );
   int cols = std::max( std::ceil( extent.width() / pixelSize ), 1.0 );
 
+  //build new raster extent based on number of columns and cellsize
+  //this prevents output cellsize being calculated too small
+  QgsRectangle rasterExtent = QgsRectangle( extent.xMinimum(), extent.yMaximum() - ( rows * pixelSize ), extent.xMinimum() + ( cols * pixelSize ), extent.yMaximum() );
+
   std::unique_ptr< QgsRasterFileWriter > writer = qgis::make_unique< QgsRasterFileWriter >( outputFile );
   writer->setOutputProviderKey( QStringLiteral( "gdal" ) );
   writer->setOutputFormat( outputFormat );
-  std::unique_ptr<QgsRasterDataProvider > provider( writer->createOneBandRaster( Qgis::Float32, cols, rows, extent, crs ) );
+  std::unique_ptr<QgsRasterDataProvider > provider( writer->createOneBandRaster( Qgis::Float32, cols, rows, rasterExtent, crs ) );
   if ( !provider )
     throw QgsProcessingException( QObject::tr( "Could not create raster output: %1" ).arg( outputFile ) );
   if ( !provider->isValid() )


### PR DESCRIPTION
## Description
This PR proposes a fix of a bug in the _Create constant raster layer algorithm_ which leads to rectangular (not square) pixels. The bug is caused because the input extent parameter is favored over the cellsize parameter. 

This PR changes this behaviour and honors the input cellsize in order to achieve square pixels. 
For reference, see [old processing bugticket](https://github.com/qgis/QGIS-Processing/issues/82)

This fix should possibly be backported.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

[x] Commit messages are descriptive and explain the rationale for changes
[x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
[x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
[ ] New unit tests have been added for core changes
[x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
[ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
