### PR TITLE
Fix QgsMapCanvas::xyCoordinates reports incorrect coordinates if a pan operation is in progress

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolpan.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolpan.sip.in
@@ -45,6 +45,13 @@ constructor
     virtual bool gestureEvent( QGestureEvent *e );
 
 
+    bool isDragging() const;
+%Docstring
+Returns ``True`` if a drag operation is in progress.
+
+.. versionadded:: 3.12
+%End
+
   signals:
 
     void panDistanceBearingChanged( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1732,9 +1732,12 @@ void QgsMapCanvas::mouseMoveEvent( QMouseEvent *e )
     }
   }
 
-  // show x y on status bar
-  mCursorPoint = getCoordinateTransform()->toMapCoordinates( mCanvasProperties->mouseLastXY );
-  emit xyCoordinates( mCursorPoint );
+  // show x y on status bar (if we are mid pan operation, then the cursor point hasn't changed!)
+  if ( !panOperationInProgress() )
+  {
+    mCursorPoint = getCoordinateTransform()->toMapCoordinates( mCanvasProperties->mouseLastXY );
+    emit xyCoordinates( mCursorPoint );
+  }
 }
 
 void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )
@@ -2502,4 +2505,18 @@ void QgsMapCanvas::schedulePreviewJob( int number )
     startPreviewJob( number );
   } );
   mPreviewTimer.start();
+}
+
+bool QgsMapCanvas::panOperationInProgress()
+{
+  if ( mCanvasProperties->panSelectorDown )
+    return true;
+
+  if ( QgsMapToolPan *panTool = qobject_cast< QgsMapToolPan *>( mMapTool ) )
+  {
+    if ( panTool->isDragging() )
+      return true;
+  }
+
+  return false;
 }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1097,6 +1097,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void stopPreviewJobs();
     void schedulePreviewJob( int number );
 
+    /**
+     * Returns TRUE if a pan operation is in progress
+     */
+    bool panOperationInProgress();
+
     friend class TestQgsMapCanvas;
 
 }; // class QgsMapCanvas

--- a/src/gui/qgsmaptoolpan.h
+++ b/src/gui/qgsmaptoolpan.h
@@ -48,6 +48,13 @@ class GUI_EXPORT QgsMapToolPan : public QgsMapTool
     void canvasDoubleClickEvent( QgsMapMouseEvent *e ) override;
     bool gestureEvent( QGestureEvent *e ) override;
 
+    /**
+     * Returns TRUE if a drag operation is in progress.
+     *
+     * \since QGIS 3.12
+     */
+    bool isDragging() const { return mDragging; }
+
   signals:
 
     /**


### PR DESCRIPTION
This causes the status bar coordinates widget to show nonsense coordinates during the pan operation. The cursor world position ISN'T changing during a pan operation, it stuck to a fixed location!

Naughty QGIS, go back to school!

![Peek 2020-01-14 15-34](https://user-images.githubusercontent.com/1829991/72317371-c6902400-36e4-11ea-84ef-f4e4763250c2.gif)
