### PR TITLE
Show distance from GPS lock position to current cursor 

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -39,6 +39,7 @@ class QgsGpsInformation;
 class QgsMapCanvas;
 class QgsFeature;
 class QgsGpsBearingItem;
+class QgsBearingNumericFormat;
 
 class QFile;
 class QColor;
@@ -80,6 +81,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     void cboAcquisitionIntervalEdited();
     void cboDistanceThresholdEdited();
     void timestampFormatChanged( int index );
+    void cursorCoordinateChanged( const QgsPointXY &point );
 
     /**
      * Updates compatible fields for timestamp recording
@@ -115,6 +117,8 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
 #endif
     void createRubberBand();
 
+    void updateGpsDistanceStatusMessage();
+
     QgsCoordinateReferenceSystem mWgs84CRS;
     QgsCoordinateTransform mCanvasToWgs84Transform;
 
@@ -139,6 +143,9 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     QMap<QString, QString> mPreferredTimestampFields;
     //! Flag when updating fields
     bool mPopulatingFields = false;
+
+    QgsPointXY mLastCursorPosWgs84;
+    std::unique_ptr< QgsBearingNumericFormat > mBearingNumericFormat;
 
     QElapsedTimer mLastRotateTimer;
 

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -121,6 +121,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
 
     QgsCoordinateReferenceSystem mWgs84CRS;
     QgsCoordinateTransform mCanvasToWgs84Transform;
+    QgsDistanceArea mDistanceCalculator;
 
 // not used    QPointF gpsToPixelPosition( const QgsPoint& point );
     QgsRubberBand *mRubberBand = nullptr;

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -116,6 +116,8 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     void createRubberBand();
 
     QgsCoordinateReferenceSystem mWgs84CRS;
+    QgsCoordinateTransform mCanvasToWgs84Transform;
+
 // not used    QPointF gpsToPixelPosition( const QgsPoint& point );
     QgsRubberBand *mRubberBand = nullptr;
     QgsPointXY mLastGpsPosition;


### PR DESCRIPTION
When a GPS device is connected, whenever the user moves the cursor over the canvas a live status bar message displays the distance and bearing from the cursor to the GPS fix position.

Project distance and bearing settings are respected in this display.

![Peek 2020-01-14 16-06](https://user-images.githubusercontent.com/1829991/72318360-cd6c6600-36e7-11ea-9f2d-9a47d8772623.gif)
