### PR TITLE
fix exporting of the mesh contours for polygons

### DIFF
--- a/tests/src/analysis/testqgsmeshcontours.cpp
+++ b/tests/src/analysis/testqgsmeshcontours.cpp
@@ -168,9 +168,10 @@ void TestQgsMeshContours::testQuadAndTriangleVertexScalarPoly_data()
   QTest::addColumn< double >( "max_value" );
   QTest::addColumn< QgsGeometry >( "expected" );
 
-  QTest::newRow( "left" ) <<  1.0 << 1.5 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1000 2000 20, 1000 3000 10, 2000 3000 50, 2000 2000 30, 1000 2000 20))" ) );
-  QTest::newRow( "middle" ) <<  1.5 << 2.0 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1000 2000 20, 1000 3000 10, 2000 3000 50, 2000 2000 30, 1000 2000 20))" ) );
-  QTest::newRow( "right" ) <<  2.0 << 2.5 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((3000 2000 40, 2000 3000 50, 2000 2000 30, 3000 2000 40))" ) );
+  QTest::newRow( "left" ) <<  1.0 << 1.5 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1500 2500 35, 1500 2000 25, 1000 2000 20, 1000 3000 10, 1500 3000 30, 1500 2500 35))" ) );
+  QTest::newRow( "bothinsquare" ) <<  1.2 << 1.4 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1400 2400 32, 1400 2000 24, 1200 2000 22, 1200 2200 26, 1200 3000 18, 1400 3000 25.99999999999999645, 1400 2400 32))" ) );
+  QTest::newRow( "middle" ) <<  1.5 << 2.0 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((2000 3000 50, 2000 2000 30, 1500 2000 25, 1500 2500 35, 1500 3000 30, 2000 3000 50))" ) );
+  QTest::newRow( "right" ) <<  2.0 << 2.5 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((2500 2500 45, 2000 3000 50, 2000 2000 30, 2500 2000 35, 2500 2500 45))" ) );
 
   QTest::newRow( "outside_left_edge" ) <<  0.0 << 1.0 << QgsGeometry();
   QTest::newRow( "only one point" ) << 3.0 << 3.0 << QgsGeometry();
@@ -198,9 +199,9 @@ void TestQgsMeshContours::testQuadAndTriangleFaceScalarPoly_data()
   QTest::addColumn< double >( "max_value" );
   QTest::addColumn< QgsGeometry >( "expected" );
 
-  QTest::newRow( "left" ) << 1.0 << 1.25 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1000 2000 20, 1000 3000 10, 2000 3000 50, 2000 2000 30, 1000 2000 20))" ) );
-  QTest::newRow( "middle" ) << 1.25 << 1.5 <<  QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1000 2000 20, 1000 3000 10, 2000 3000 50, 2000 2000 30, 1000 2000 20))" ) );
-  QTest::newRow( "right" ) <<  1.5 << 1.75 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((3000 2000 40, 2000 3000 50, 2000 2000 30, 3000 2000 40))" ) );
+  QTest::newRow( "left" ) << 1.0 << 1.25 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((1500 2500 35, 1500 2000 25, 1000 2000 20, 1000 3000 10, 1500 3000 30, 1500 2500 35))" ) );
+  QTest::newRow( "middle" ) << 1.25 << 1.5 <<  QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((2000 3000 50, 2000 2000 30, 1500 2000 25, 1500 2500 35, 1500 3000 30, 2000 3000 50))" ) );
+  QTest::newRow( "right" ) <<  1.5 << 1.75 << QgsGeometry( QgsGeometryFactory::geomFromWkt( "PolygonZ ((2500 2500 45, 2000 3000 50, 2000 2000 30, 2500 2000 35, 2500 2500 45))" ) );
 
   QTest::newRow( "only one point" ) << 2.0 << 2.0 << QgsGeometry();
   QTest::newRow( "outside lower" ) << -3.0 << -4.0 << QgsGeometry();


### PR DESCRIPTION
 fix exporting of the mesh contours for polygons. now the exported polygons does not match triangular mesh

there was copy-paste error when creating polygon from ring, where instead of ring points the triangular mesh coordinates were taken. also fixed bug  for one special case of values on the triangular mesh vertices that are not in min-max range of exported polygon

fixes issue https://github.com/lutraconsulting/qgis-crayfish-plugin/issues/419

before fix (see exported polygons match the triangular mesh)

<img width="722" alt="Screenshot 2020-01-14 at 15 44 21" src="https://user-images.githubusercontent.com/804608/72354321-db20ec00-36e5-11ea-9b43-3ac8aa0bf0ec.png">

with fix (exported polygons match the exported lines)
<img width="748" alt="Screenshot 2020-01-14 at 15 43 00" src="https://user-images.githubusercontent.com/804608/72354336-df4d0980-36e5-11ea-9275-6b03f4e57278.png">
