### PR TITLE
[Bugfix] Allow users to do cell level operation in the attribute table

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -126,12 +126,13 @@ Saves geometry to the settings on close
 
   signals:
 
-    void willShowContextMenu( QMenu *menu, const QgsFeatureId featureId );
+    void willShowContextMenu( QMenu *menu, const QModelIndex &atIndex );
 %Docstring
 Emitted in order to provide a hook to add additional* menu entries to the context menu.
 
 :param menu: If additional QMenuItems are added, they will show up in the context menu.
-:param featureId: The ID of the current feature
+:param atIndex: The QModelIndex, to which the context menu belongs. Relative to the source model.
+                In most cases, this will be a :py:class:`QgsAttributeTableFilterModel`
 %End
 
     void columnResized( int column, int width );

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistview.sip.in
@@ -138,12 +138,12 @@ Emitted whenever the display expression is successfully changed
 %End
 
 
-    void willShowContextMenu( QgsActionMenu *menu, const QgsFeatureId featureId );
+    void willShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
 %Docstring
 Emitted when the context menu is created to add the specific actions to it
 
 :param menu: is the already created context menu
-:param featureId: is the ID of the current feature
+:param atIndex: is the position of the current feature in the model
 %End
 
   public slots:

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -363,7 +363,7 @@ void QgsAttributeTableView::contextMenuEvent( QContextMenuEvent *event )
   mActionPopup->addAction( tr( "Select All" ), this, SLOT( selectAll() ), QKeySequence::SelectAll );
 
   // let some other parts of the application add some actions
-  emit willShowContextMenu( mActionPopup, mFilterModel->rowToId( idx ) );
+  emit willShowContextMenu( mActionPopup, idx );
 
   if ( !mActionPopup->actions().isEmpty() )
   {

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -144,9 +144,10 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
      * Emitted in order to provide a hook to add additional* menu entries to the context menu.
      *
      * \param menu     If additional QMenuItems are added, they will show up in the context menu.
-     * \param  featureId The ID of the current feature
+     * \param atIndex  The QModelIndex, to which the context menu belongs. Relative to the source model.
+     *                 In most cases, this will be a QgsAttributeTableFilterModel
      */
-    void willShowContextMenu( QMenu *menu, const QgsFeatureId featureId );
+    void willShowContextMenu( QMenu *menu, const QModelIndex &atIndex );
 
     /**
      * Emitted when a column in the view has been resized.

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -312,9 +312,9 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
 
     void previewColumnChanged( QAction *previewAction, const QString &expression );
 
-    void viewWillShowContextMenu( QMenu *menu, const QgsFeatureId featureId );
+    void viewWillShowContextMenu( QMenu *menu, const QModelIndex &atIndex );
 
-    void widgetWillShowContextMenu( QgsActionMenu *menu, const QgsFeatureId featureId );
+    void widgetWillShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
 
     void showViewHeaderMenu( QPoint point );
 

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -325,7 +325,11 @@ void QgsFeatureListView::contextMenuEvent( QContextMenuEvent *event )
 
     QgsActionMenu *menu = new QgsActionMenu( mModel->layerCache()->layer(), feature, QStringLiteral( "Feature" ), this );
 
-    emit willShowContextMenu( menu, feature.id() );
+    // Index is from feature list model, but we need an index from the
+    // filter model to be passed to listeners, using fid instead would
+    // have been much better in term of bugs (and headaches) but this
+    // belongs to the API unfortunately.
+    emit willShowContextMenu( menu, mModel->mapToSource( index ) );
 
     menu->exec( event->globalPos() );
   }

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -156,9 +156,9 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     /**
      * Emitted when the context menu is created to add the specific actions to it
      * \param menu is the already created context menu
-     * \param featureId is the ID of the current feature
+     * \param atIndex is the position of the current feature in the model
      */
-    void willShowContextMenu( QgsActionMenu *menu, const QgsFeatureId featureId );
+    void willShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
 
   public slots:
 


### PR DESCRIPTION
Fixes #33439 Fixes #33665 and keep fixed #32933

## Description
Attempt to fix the attribute table bugs introduced by https://github.com/qgis/QGIS/commit/39082474e79b6146d7b268332e5c574ff18d379e

I tested the delete bug and the copy cell bug  and the duplicate one. All were ok.

Backport should be needed to fix the referenced issues.
## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
