### PR TITLE
Fix QgsMapCanvas::xyCoordinates reports incorrect coordinates if a pan operation is in progress

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolpan.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolpan.sip.in
@@ -44,6 +44,13 @@ constructor
     virtual bool gestureEvent( QGestureEvent *e );
 
 
+    bool isDragging() const;
+%Docstring
+Returns ``True`` if a drag operation is in progress.
+
+.. versionadded:: 3.12
+%End
+
 };
 
 /************************************************************************

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1728,9 +1728,12 @@ void QgsMapCanvas::mouseMoveEvent( QMouseEvent *e )
     }
   }
 
-  // show x y on status bar
-  mCursorPoint = getCoordinateTransform()->toMapCoordinates( mCanvasProperties->mouseLastXY );
-  emit xyCoordinates( mCursorPoint );
+  // show x y on status bar (if we are mid pan operation, then the cursor point hasn't changed!)
+  if ( !panOperationInProgress() )
+  {
+    mCursorPoint = getCoordinateTransform()->toMapCoordinates( mCanvasProperties->mouseLastXY );
+    emit xyCoordinates( mCursorPoint );
+  }
 }
 
 void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )
@@ -2485,4 +2488,18 @@ void QgsMapCanvas::schedulePreviewJob( int number )
     startPreviewJob( number );
   } );
   mPreviewTimer.start();
+}
+
+bool QgsMapCanvas::panOperationInProgress()
+{
+  if ( mCanvasProperties->panSelectorDown )
+    return true;
+
+  if ( QgsMapToolPan *panTool = qobject_cast< QgsMapToolPan *>( mMapTool ) )
+  {
+    if ( panTool->isDragging() )
+      return true;
+  }
+
+  return false;
 }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -1073,6 +1073,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void stopPreviewJobs();
     void schedulePreviewJob( int number );
 
+    /**
+     * Returns TRUE if a pan operation is in progress
+     */
+    bool panOperationInProgress();
+
     friend class TestQgsMapCanvas;
 
 }; // class QgsMapCanvas

--- a/src/gui/qgsmaptoolpan.h
+++ b/src/gui/qgsmaptoolpan.h
@@ -45,6 +45,13 @@ class GUI_EXPORT QgsMapToolPan : public QgsMapTool
     void canvasDoubleClickEvent( QgsMapMouseEvent *e ) override;
     bool gestureEvent( QGestureEvent *e ) override;
 
+    /**
+     * Returns TRUE if a drag operation is in progress.
+     *
+     * \since QGIS 3.12
+     */
+    bool isDragging() const { return mDragging; }
+
   private:
 
     //! Flag to indicate a map canvas drag operation is taking place


### PR DESCRIPTION
This causes the status bar coordinates widget to show nonsense coordinates
during the pan operation. The cursor world position ISN'T changing during
a pan operation, it stuck to a fixed location!

(cherry picked from commit 527eca9684caf3269958a6ce98f914a274175931)
