### PR TITLE
Avoid inclusion of pal header in public header

### DIFF
--- a/python/core/auto_additions/qgslabeling.py
+++ b/python/core/auto_additions/qgslabeling.py
@@ -1,0 +1,8 @@
+# The following has been generated automatically from src/core/labeling/qgslabeling.h
+# monkey patching scoped based enum
+QgsLabeling.LinePlacementFlag.OnLine.__doc__ = "Labels can be placed directly over a line feature."
+QgsLabeling.LinePlacementFlag.AboveLine.__doc__ = "Labels can be placed above a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed below the line feature."
+QgsLabeling.LinePlacementFlag.BelowLine.__doc__ = "Labels can be placed below a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed above the line feature."
+QgsLabeling.LinePlacementFlag.MapOrientation.__doc__ = "Signifies that the AboveLine and BelowLine flags should respect the map's orientation rather than the feature's orientation. For example, AboveLine will always result in label's being placed above a line, regardless of the line's direction."
+QgsLabeling.LinePlacementFlag.__doc__ = 'Line placement flags, which control how candidates are generated for a linear feature.\n\n' + '* ``OnLine``: ' + QgsLabeling.LinePlacementFlag.OnLine.__doc__ + '\n' + '* ``AboveLine``: ' + QgsLabeling.LinePlacementFlag.AboveLine.__doc__ + '\n' + '* ``BelowLine``: ' + QgsLabeling.LinePlacementFlag.BelowLine.__doc__ + '\n' + '* ``MapOrientation``: ' + QgsLabeling.LinePlacementFlag.MapOrientation.__doc__
+# --

--- a/python/core/auto_generated/labeling/qgslabeling.sip.in
+++ b/python/core/auto_generated/labeling/qgslabeling.sip.in
@@ -1,0 +1,46 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/labeling/qgslabeling.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsLabeling
+{
+%Docstring
+
+Contains constants and enums relating to labeling.
+
+.. versionadded:: 3.12
+%End
+
+%TypeHeaderCode
+#include "qgslabeling.h"
+%End
+  public:
+
+    enum class LinePlacementFlag
+    {
+      OnLine,
+      AboveLine,
+      BelowLine,
+      MapOrientation,
+    };
+    typedef QFlags<QgsLabeling::LinePlacementFlag> LinePlacementFlags;
+
+
+};
+
+QFlags<QgsLabeling::LinePlacementFlag> operator|(QgsLabeling::LinePlacementFlag f1, QFlags<QgsLabeling::LinePlacementFlag> f2);
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/labeling/qgslabeling.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -312,6 +312,7 @@
 %Include auto_generated/gps/qgsgpsdconnection.sip
 %Include auto_generated/gps/qgsgpsdetector.sip
 %Include auto_generated/gps/qgsnmeaconnection.sip
+%Include auto_generated/labeling/qgslabeling.sip
 %Include auto_generated/labeling/qgslabelingenginesettings.sip
 %Include auto_generated/labeling/qgslabelobstaclesettings.sip
 %Include auto_generated/labeling/qgslabelsearchtree.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1040,6 +1040,7 @@ SET(QGIS_CORE_HDRS
   gps/qgsnmeaconnection.h
 
   labeling/qgslabelfeature.h
+  labeling/qgslabeling.h
   labeling/qgslabelingengine.h
   labeling/qgslabelingenginesettings.h
   labeling/qgslabelobstaclesettings.h

--- a/src/core/labeling/qgslabelfeature.cpp
+++ b/src/core/labeling/qgslabelfeature.cpp
@@ -21,16 +21,6 @@ QgsLabelFeature::QgsLabelFeature( QgsFeatureId id, geos::unique_ptr geometry, QS
   : mId( id )
   , mGeometry( std::move( geometry ) )
   , mSize( size )
-  , mPriority( -1 )
-  , mZIndex( 0 )
-  , mHasFixedPosition( false )
-  , mHasFixedAngle( false )
-  , mFixedAngle( 0 )
-  , mHasFixedQuadrant( false )
-  , mDistLabel( 0 )
-  , mOffsetType( QgsPalLayerSettings::FromPoint )
-  , mRepeatDistance( 0 )
-  , mAlwaysShow( false )
 {
 }
 

--- a/src/core/labeling/qgslabelfeature.h
+++ b/src/core/labeling/qgslabelfeature.h
@@ -23,11 +23,12 @@
 #include "qgsgeos.h"
 #include "qgsmargins.h"
 #include "qgslabelobstaclesettings.h"
-#include "pal.h"
+#include "qgslabeling.h"
 
 namespace pal
 {
   class LabelInfo;
+  class Layer;
 }
 
 class QgsAbstractLabelProvider;
@@ -308,14 +309,14 @@ class CORE_EXPORT QgsLabelFeature
      * Returns the feature's arrangement flags.
      * \see setArrangementFlags
      */
-    pal::LineArrangementFlags arrangementFlags() const { return mArrangementFlags; }
+    QgsLabeling::LinePlacementFlags arrangementFlags() const { return mArrangementFlags; }
 
     /**
      * Sets the feature's arrangement flags.
      * \param flags arrangement flags
      * \see arrangementFlags
      */
-    void setArrangementFlags( pal::LineArrangementFlags flags ) { mArrangementFlags = flags; }
+    void setArrangementFlags( QgsLabeling::LinePlacementFlags flags ) { mArrangementFlags = flags; }
 
 
     /**
@@ -470,33 +471,33 @@ class CORE_EXPORT QgsLabelFeature
     //! Size of associated rendered symbol, if applicable
     QSizeF mSymbolSize;
     //! Priority of the label
-    double mPriority;
+    double mPriority = -1;
     //! Z-index of label (higher z-index labels are rendered on top of lower z-index labels)
-    double mZIndex;
+    double mZIndex = 0;
     //! whether mFixedPosition should be respected
-    bool mHasFixedPosition;
+    bool mHasFixedPosition = false;
     //! fixed position for the label (instead of automatic placement)
     QgsPointXY mFixedPosition;
     //! whether mFixedAngle should be respected
-    bool mHasFixedAngle;
+    bool mHasFixedAngle = false;
     //! fixed rotation for the label (instead of automatic choice)
-    double mFixedAngle;
+    double mFixedAngle = 0;
     //! whether mQuadOffset should be respected (only for "around point" placement)
-    bool mHasFixedQuadrant;
+    bool mHasFixedQuadrant = false;
     //! whether the side of the label is fixed (only for "around point" placement)
     QPointF mQuadOffset;
     //! offset of label from the feature (only for "offset from point" placement)
     QgsPointXY mPositionOffset;
     //! distance of label from the feature (only for "around point" placement or linestrings)
-    double mDistLabel;
+    double mDistLabel = 0;
     //! Offset type for certain placement modes
-    QgsPalLayerSettings::OffsetType mOffsetType;
+    QgsPalLayerSettings::OffsetType mOffsetType = QgsPalLayerSettings::FromPoint;
     //! Ordered list of predefined positions for label (only for OrderedPositionsAroundPoint placement)
     QVector< QgsPalLayerSettings::PredefinedPointPosition > mPredefinedPositionOrder;
     //! distance after which label should be repeated (only for linestrings)
-    double mRepeatDistance;
+    double mRepeatDistance = 0;
     //! whether to always show label - even in case of collisions
-    bool mAlwaysShow;
+    bool mAlwaysShow = false;
     //! text of the label
     QString mLabelText;
     //! extra information for curved labels (may be NULLPTR)
@@ -507,7 +508,7 @@ class CORE_EXPORT QgsLabelFeature
     //! Distance to smooth angle of line start and end when calculating overruns
     double mOverrunSmoothDistance = 0;
 
-    pal::LineArrangementFlags mArrangementFlags = nullptr;
+    QgsLabeling::LinePlacementFlags mArrangementFlags = nullptr;
 
   private:
 

--- a/src/core/labeling/qgslabeling.h
+++ b/src/core/labeling/qgslabeling.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+  qgslabeling.h
+  --------------------------
+  Date                 : January 2020
+  Copyright            : (C) 2020 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLABELING_H
+#define QGSLABELING_H
+
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include <QFlags>
+
+/**
+ * \ingroup core
+ * \class QgsLabeling
+ *
+ * Contains constants and enums relating to labeling.
+ *
+ * \since QGIS 3.12
+ */
+class CORE_EXPORT QgsLabeling
+{
+  public:
+
+    /**
+     * Line placement flags, which control how candidates are generated for a linear feature.
+     */
+    enum class LinePlacementFlag : int
+    {
+      OnLine    = 1,      //!< Labels can be placed directly over a line feature.
+      AboveLine = 2,      //!< Labels can be placed above a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed below the line feature.
+      BelowLine = 4,      //!< Labels can be placed below a line feature. Unless MapOrientation is also specified this mode respects the direction of the line feature, so a line from right to left labels will have labels placed placed above the line feature.
+      MapOrientation = 8, //!< Signifies that the AboveLine and BelowLine flags should respect the map's orientation rather than the feature's orientation. For example, AboveLine will always result in label's being placed above a line, regardless of the line's direction.
+    };
+    Q_DECLARE_FLAGS( LinePlacementFlags, LinePlacementFlag )
+
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLabeling::LinePlacementFlags )
+
+#endif // QGSLABELING_H

--- a/src/core/labeling/qgslabelingengine.cpp
+++ b/src/core/labeling/qgslabelingengine.cpp
@@ -737,39 +737,39 @@ QVector<QgsPalLayerSettings::PredefinedPointPosition> QgsLabelingUtils::decodePr
   return result;
 }
 
-QString QgsLabelingUtils::encodeLinePlacementFlags( pal::LineArrangementFlags flags )
+QString QgsLabelingUtils::encodeLinePlacementFlags( QgsLabeling::LinePlacementFlags flags )
 {
   QStringList parts;
-  if ( flags & pal::FLAG_ON_LINE )
+  if ( flags & QgsLabeling::LinePlacementFlag::OnLine )
     parts << QStringLiteral( "OL" );
-  if ( flags & pal::FLAG_ABOVE_LINE )
+  if ( flags & QgsLabeling::LinePlacementFlag::AboveLine )
     parts << QStringLiteral( "AL" );
-  if ( flags & pal::FLAG_BELOW_LINE )
+  if ( flags & QgsLabeling::LinePlacementFlag::BelowLine )
     parts << QStringLiteral( "BL" );
-  if ( !( flags & pal::FLAG_MAP_ORIENTATION ) )
+  if ( !( flags & QgsLabeling::LinePlacementFlag::MapOrientation ) )
     parts << QStringLiteral( "LO" );
   return parts.join( ',' );
 }
 
-pal::LineArrangementFlags QgsLabelingUtils::decodeLinePlacementFlags( const QString &string )
+QgsLabeling::LinePlacementFlags QgsLabelingUtils::decodeLinePlacementFlags( const QString &string )
 {
-  pal::LineArrangementFlags flags = nullptr;
+  QgsLabeling::LinePlacementFlags flags = nullptr;
   const QStringList flagList = string.split( ',' );
   bool foundLineOrientationFlag = false;
   for ( const QString &flag : flagList )
   {
     QString cleaned = flag.trimmed().toUpper();
     if ( cleaned == QLatin1String( "OL" ) )
-      flags |= pal::FLAG_ON_LINE;
+      flags |= QgsLabeling::LinePlacementFlag::OnLine;
     else if ( cleaned == QLatin1String( "AL" ) )
-      flags |= pal::FLAG_ABOVE_LINE;
+      flags |= QgsLabeling::LinePlacementFlag::AboveLine;
     else if ( cleaned == QLatin1String( "BL" ) )
-      flags |= pal::FLAG_BELOW_LINE;
+      flags |= QgsLabeling::LinePlacementFlag::BelowLine;
     else if ( cleaned == QLatin1String( "LO" ) )
       foundLineOrientationFlag = true;
   }
   if ( !foundLineOrientationFlag )
-    flags |= pal::FLAG_MAP_ORIENTATION;
+    flags |= QgsLabeling::LinePlacementFlag::MapOrientation;
   return flags;
 }
 

--- a/src/core/labeling/qgslabelingengine.h
+++ b/src/core/labeling/qgslabelingengine.h
@@ -23,10 +23,14 @@
 
 #include "qgspallabeling.h"
 #include "qgslabelingenginesettings.h"
-#include "pal.h"
+#include "qgslabeling.h"
 
 class QgsLabelingEngine;
 
+namespace pal
+{
+  class Problem;
+}
 
 /**
  * \ingroup core
@@ -414,13 +418,13 @@ class CORE_EXPORT QgsLabelingUtils
      * Encodes line placement \a flags to a string.
      * \see decodeLinePlacementFlags()
      */
-    static QString encodeLinePlacementFlags( pal::LineArrangementFlags flags );
+    static QString encodeLinePlacementFlags( QgsLabeling::LinePlacementFlags flags );
 
     /**
      * Decodes a \a string to set of line placement flags.
      * \see encodeLinePlacementFlags()
      */
-    static pal::LineArrangementFlags decodeLinePlacementFlags( const QString &string );
+    static QgsLabeling::LinePlacementFlags decodeLinePlacementFlags( const QString &string );
 
 };
 

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2434,7 +2434,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
     ( *labelFeature )->setHasFixedQuadrant( true );
   }
 
-  pal::LineArrangementFlags featureArrangementFlags = static_cast< pal::LineArrangementFlags >( placementFlags );
+  QgsLabeling::LinePlacementFlags featureArrangementFlags = static_cast< QgsLabeling::LinePlacementFlags >( placementFlags );
   if ( mDataDefinedProperties.isActive( QgsPalLayerSettings::LinePlacementOptions ) )
   {
     context.expressionContext().setOriginalValueVariable( QgsLabelingUtils::encodeLinePlacementFlags( featureArrangementFlags ) );

--- a/src/core/labeling/qgspallabeling.h
+++ b/src/core/labeling/qgspallabeling.h
@@ -256,8 +256,7 @@ class CORE_EXPORT QgsPalLayerSettings
       FromSymbolBounds, //!< Offset distance applies from rendered symbol bounds
     };
 
-    //TODO QGIS 4.0 - move to QgsLabelingEngine, rename to LinePlacementFlag, use Q_DECLARE_FLAGS to make
-    //LinePlacementFlags type, and replace use of pal::LineArrangementFlag
+    //TODO QGIS 4.0 - remove, replaced by QgsLabeling::LinePlacementFlags
 
     /**
      * Line placement flags, which control how candidates are generated for a linear feature.

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -40,6 +40,7 @@
 #include "qgsmessagelog.h"
 #include "costcalculator.h"
 #include "qgsgeometryutils.h"
+#include "qgslabeling.h"
 #include <QLinkedList>
 #include <cmath>
 #include <cfloat>
@@ -700,9 +701,9 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
   double labelWidth = getLabelWidth();
   double labelHeight = getLabelHeight();
   double distanceLineToLabel = getLabelDistance();
-  LineArrangementFlags flags = mLF->arrangementFlags();
+  QgsLabeling::LinePlacementFlags flags = mLF->arrangementFlags();
   if ( flags == 0 )
-    flags = FLAG_ON_LINE; // default flag
+    flags = QgsLabeling::LinePlacementFlag::OnLine; // default flag
 
   // first scan through the whole line and look for segments where the angle at a node is greater than 45 degrees - these form a "hard break" which labels shouldn't cross over
   QVector< int > extremeAngleNodes;
@@ -876,9 +877,9 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
         // find out whether the line direction for this candidate is from right to left
         bool isRightToLeft = ( angle > M_PI_2 || angle <= -M_PI_2 );
         // meaning of above/below may be reversed if using map orientation and the line has right-to-left direction
-        bool reversed = ( ( flags & FLAG_MAP_ORIENTATION ) ? isRightToLeft : false );
-        bool aboveLine = ( !reversed && ( flags & FLAG_ABOVE_LINE ) ) || ( reversed && ( flags & FLAG_BELOW_LINE ) );
-        bool belowLine = ( !reversed && ( flags & FLAG_BELOW_LINE ) ) || ( reversed && ( flags & FLAG_ABOVE_LINE ) );
+        bool reversed = ( ( flags & QgsLabeling::LinePlacementFlag::MapOrientation ) ? isRightToLeft : false );
+        bool aboveLine = ( !reversed && ( flags & QgsLabeling::LinePlacementFlag::AboveLine ) ) || ( reversed && ( flags & QgsLabeling::LinePlacementFlag::BelowLine ) );
+        bool belowLine = ( !reversed && ( flags & QgsLabeling::LinePlacementFlag::BelowLine ) ) || ( reversed && ( flags & QgsLabeling::LinePlacementFlag::AboveLine ) );
 
         if ( belowLine )
         {
@@ -896,7 +897,7 @@ std::size_t FeaturePart::createCandidatesAlongLineNearStraightSegments( std::vec
             lPos.emplace_back( qgis::make_unique< LabelPosition >( i, candidateStartX + std::cos( beta ) *distanceLineToLabel, candidateStartY + std::sin( beta ) *distanceLineToLabel, labelWidth, labelHeight, angle, candidateCost, this, isRightToLeft ) ); // Line
           }
         }
-        if ( flags & FLAG_ON_LINE )
+        if ( flags & QgsLabeling::LinePlacementFlag::OnLine )
         {
           if ( !mLF->permissibleZonePrepared() || GeomFunction::containsCandidate( mLF->permissibleZonePrepared(), candidateStartX - labelHeight * std::cos( beta ) / 2, candidateStartY - labelHeight * std::sin( beta ) / 2, labelWidth, labelHeight, angle ) )
           {
@@ -931,9 +932,9 @@ std::size_t FeaturePart::createCandidatesAlongLineNearMidpoint( std::vector< std
   double angle;
   double cost;
 
-  LineArrangementFlags flags = mLF->arrangementFlags();
+  QgsLabeling::LinePlacementFlags flags = mLF->arrangementFlags();
   if ( flags == 0 )
-    flags = FLAG_ON_LINE; // default flag
+    flags = QgsLabeling::LinePlacementFlag::OnLine; // default flag
 
   PointSet *line = mapShape;
   int nbPoints = line->nbPoints;
@@ -1033,9 +1034,9 @@ std::size_t FeaturePart::createCandidatesAlongLineNearMidpoint( std::vector< std
       // find out whether the line direction for this candidate is from right to left
       bool isRightToLeft = ( angle > M_PI_2 || angle <= -M_PI_2 );
       // meaning of above/below may be reversed if using map orientation and the line has right-to-left direction
-      bool reversed = ( ( flags & FLAG_MAP_ORIENTATION ) ? isRightToLeft : false );
-      bool aboveLine = ( !reversed && ( flags & FLAG_ABOVE_LINE ) ) || ( reversed && ( flags & FLAG_BELOW_LINE ) );
-      bool belowLine = ( !reversed && ( flags & FLAG_BELOW_LINE ) ) || ( reversed && ( flags & FLAG_ABOVE_LINE ) );
+      bool reversed = ( ( flags & QgsLabeling::LinePlacementFlag::MapOrientation ) ? isRightToLeft : false );
+      bool aboveLine = ( !reversed && ( flags & QgsLabeling::LinePlacementFlag::AboveLine ) ) || ( reversed && ( flags & QgsLabeling::LinePlacementFlag::BelowLine ) );
+      bool belowLine = ( !reversed && ( flags & QgsLabeling::LinePlacementFlag::BelowLine ) ) || ( reversed && ( flags & QgsLabeling::LinePlacementFlag::AboveLine ) );
 
       if ( aboveLine )
       {
@@ -1053,7 +1054,7 @@ std::size_t FeaturePart::createCandidatesAlongLineNearMidpoint( std::vector< std
           lPos.emplace_back( qgis::make_unique< LabelPosition >( i, candidateStartX - std::cos( beta ) * ( distanceLineToLabel + labelHeight ), candidateStartY - std::sin( beta ) * ( distanceLineToLabel + labelHeight ), labelWidth, labelHeight, angle, candidateCost, this, isRightToLeft ) ); // Line
         }
       }
-      if ( flags & FLAG_ON_LINE )
+      if ( flags & QgsLabeling::LinePlacementFlag::OnLine )
       {
         if ( !mLF->permissibleZonePrepared() || GeomFunction::containsCandidate( mLF->permissibleZonePrepared(), candidateStartX - labelHeight * std::cos( beta ) / 2, candidateStartY - labelHeight * std::sin( beta ) / 2, labelWidth, labelHeight, angle ) )
         {
@@ -1329,9 +1330,9 @@ std::size_t FeaturePart::createCurvedCandidatesAlongLine( std::vector< std::uniq
   const std::size_t candidateTargetCount = maximumLineCandidates();
   double delta = std::max( li->label_height / 6, total_distance / candidateTargetCount );
 
-  pal::LineArrangementFlags flags = mLF->arrangementFlags();
+  QgsLabeling::LinePlacementFlags flags = mLF->arrangementFlags();
   if ( flags == 0 )
-    flags = FLAG_ON_LINE; // default flag
+    flags = QgsLabeling::LinePlacementFlag::OnLine; // default flag
 
   // generate curved labels
   for ( double distanceAlongLineToStartCandidate = 0; distanceAlongLineToStartCandidate < total_distance; distanceAlongLineToStartCandidate += delta )
@@ -1345,7 +1346,7 @@ std::size_t FeaturePart::createCurvedCandidatesAlongLine( std::vector< std::uniq
 
     // an orientation of 0 means try both orientations and choose the best
     int orientation = 0;
-    if ( !( flags & FLAG_MAP_ORIENTATION ) )
+    if ( !( flags & QgsLabeling::LinePlacementFlag::MapOrientation ) )
     {
       //... but if we are using line orientation flags, then we can only accept a single orientation,
       // as we need to ensure that the labels fall inside or outside the polyline or polygon (and not mixed)
@@ -1406,14 +1407,14 @@ std::size_t FeaturePart::createCurvedCandidatesAlongLine( std::vector< std::uniq
     for ( int i = 0; i <= 2; ++i )
     {
       std::unique_ptr< LabelPosition > p;
-      if ( i == 0 && ( ( !localreversed && ( flags & FLAG_ABOVE_LINE ) ) || ( localreversed && ( flags & FLAG_BELOW_LINE ) ) ) )
+      if ( i == 0 && ( ( !localreversed && ( flags & QgsLabeling::LinePlacementFlag::AboveLine ) ) || ( localreversed && ( flags & QgsLabeling::LinePlacementFlag::BelowLine ) ) ) )
         p = _createCurvedCandidate( slp.get(), angle_avg, mLF->distLabel() + li->label_height / 2 );
-      if ( i == 1 && flags & FLAG_ON_LINE )
+      if ( i == 1 && flags & QgsLabeling::LinePlacementFlag::OnLine )
       {
         p = _createCurvedCandidate( slp.get(), angle_avg, 0 );
         p->setCost( p->cost() + 0.002 );
       }
-      if ( i == 2 && ( ( !localreversed && ( flags & FLAG_BELOW_LINE ) ) || ( localreversed && ( flags & FLAG_ABOVE_LINE ) ) ) )
+      if ( i == 2 && ( ( !localreversed && ( flags & QgsLabeling::LinePlacementFlag::BelowLine ) ) || ( localreversed && ( flags & QgsLabeling::LinePlacementFlag::AboveLine ) ) ) )
       {
         p = _createCurvedCandidate( slp.get(), angle_avg, -li->label_height / 2 - mLF->distLabel() );
         p->setCost( p->cost() + 0.001 );

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -67,16 +67,6 @@ namespace pal
     FALP = 4 //!< Only initial solution
   };
 
-  //! Enumeration line arrangement flags. Flags can be combined.
-  enum LineArrangementFlag
-  {
-    FLAG_ON_LINE     = 1,
-    FLAG_ABOVE_LINE  = 2,
-    FLAG_BELOW_LINE  = 4,
-    FLAG_MAP_ORIENTATION = 8
-  };
-  Q_DECLARE_FLAGS( LineArrangementFlags, LineArrangementFlag )
-
   /**
    * \ingroup core
    *  \brief Main Pal labeling class
@@ -347,7 +337,5 @@ namespace pal
   };
 
 } // end namespace pal
-
-Q_DECLARE_OPERATORS_FOR_FLAGS( pal::LineArrangementFlags )
 
 #endif

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -541,17 +541,17 @@ void TestQgsLabelingEngine::testEncodeDecodePositionOrder()
 
 void TestQgsLabelingEngine::testEncodeDecodeLinePlacement()
 {
-  QString encoded = QgsLabelingUtils::encodeLinePlacementFlags( pal::FLAG_ABOVE_LINE | pal::FLAG_ON_LINE );
+  QString encoded = QgsLabelingUtils::encodeLinePlacementFlags( QgsLabeling::LinePlacementFlag::AboveLine | QgsLabeling::LinePlacementFlag::OnLine );
   QVERIFY( !encoded.isEmpty() );
-  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( encoded ), pal::FLAG_ABOVE_LINE | pal::FLAG_ON_LINE );
-  encoded = QgsLabelingUtils::encodeLinePlacementFlags( pal::FLAG_ON_LINE | pal::FLAG_MAP_ORIENTATION );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( encoded ), QgsLabeling::LinePlacementFlag::AboveLine | QgsLabeling::LinePlacementFlag::OnLine );
+  encoded = QgsLabelingUtils::encodeLinePlacementFlags( QgsLabeling::LinePlacementFlag::OnLine | QgsLabeling::LinePlacementFlag::MapOrientation );
   QVERIFY( !encoded.isEmpty() );
-  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( encoded ), pal::FLAG_ON_LINE | pal::FLAG_MAP_ORIENTATION );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( encoded ), QgsLabeling::LinePlacementFlag::OnLine | QgsLabeling::LinePlacementFlag::MapOrientation );
 
   //test decoding with a messy string
-  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,," ) ), pal::FLAG_ON_LINE | pal::FLAG_MAP_ORIENTATION );
-  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,BL,  al" ) ), pal::FLAG_ON_LINE | pal::FLAG_ABOVE_LINE | pal::FLAG_BELOW_LINE | pal::FLAG_MAP_ORIENTATION );
-  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,BL, LO,  al" ) ), pal::FLAG_ON_LINE | pal::FLAG_ABOVE_LINE | pal::FLAG_BELOW_LINE );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,," ) ), QgsLabeling::LinePlacementFlag::OnLine | QgsLabeling::LinePlacementFlag::MapOrientation );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,BL,  al" ) ), QgsLabeling::LinePlacementFlag::OnLine | QgsLabeling::LinePlacementFlag::AboveLine | QgsLabeling::LinePlacementFlag::BelowLine | QgsLabeling::LinePlacementFlag::MapOrientation );
+  QCOMPARE( QgsLabelingUtils::decodeLinePlacementFlags( QStringLiteral( ",ol,BL, LO,  al" ) ), QgsLabeling::LinePlacementFlag::OnLine | QgsLabeling::LinePlacementFlag::AboveLine | QgsLabeling::LinePlacementFlag::BelowLine );
 }
 
 void TestQgsLabelingEngine::testSubstitutions()


### PR DESCRIPTION
Create QgsLabeling class for labeling related enums and constants, and avoid inclusion of pal header in a public QGIS header

pal is an internal implementation detail -- it should not be exposed publicly
