### PR TITLE
New algorithm "Rename table field"

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/renamed_field.gml
+++ b/python/plugins/processing/tests/testdata/expected/renamed_field.gml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ renamed_field.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id_renamed>2</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id_renamed>1</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id_renamed>0</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id_renamed>2</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id_renamed>1</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id_renamed>0</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id_renamed>0</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id_renamed>0</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:renamed_field fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id_renamed>0</ogr:id_renamed>
+    </ogr:renamed_field>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/renamed_field.xsd
+++ b/python/plugins/processing/tests/testdata/expected/renamed_field.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="renamed_field" type="ogr:renamed_field_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="renamed_field_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id_renamed" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2326,5 +2326,18 @@ tests:
         name: expected/affine_transform.gml
         type: vector
 
+  - algorithm: native:renametablefield
+    name: Rename table field
+    params:
+      FIELD: id2
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      NEW_NAME: id_renamed
+    results:
+      OUTPUT:
+        name: expected/renamed_field.gml
+        type: vector
+
 
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -120,6 +120,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmremoveholes.cpp
   processing/qgsalgorithmremovenullgeometry.cpp
   processing/qgsalgorithmrenamelayer.cpp
+  processing/qgsalgorithmrenametablefield.cpp
   processing/qgsalgorithmrepairshapefile.cpp
   processing/qgsalgorithmreverselinedirection.cpp
   processing/qgsalgorithmrotate.cpp

--- a/src/analysis/processing/qgsalgorithmrenametablefield.cpp
+++ b/src/analysis/processing/qgsalgorithmrenametablefield.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+                         qgsalgorithmrenametablefield.cpp
+                         -----------------------------------
+    begin                : January 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmrenametablefield.h"
+
+///@cond PRIVATE
+
+QString QgsRenameTableFieldAlgorithm::name() const
+{
+  return QStringLiteral( "renametablefield" );
+}
+
+QString QgsRenameTableFieldAlgorithm::displayName() const
+{
+  return QObject::tr( "Rename field" );
+}
+
+QString QgsRenameTableFieldAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm renames an existing field from a vector layer." );
+}
+
+QString QgsRenameTableFieldAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Renames an existing field from a vector layer." );
+}
+
+QStringList QgsRenameTableFieldAlgorithm::tags() const
+{
+  return QObject::tr( "rename,attribute,fields,table,change" ).split( ',' );
+}
+
+QString QgsRenameTableFieldAlgorithm::group() const
+{
+  return QObject::tr( "Vector table" );
+}
+
+QString QgsRenameTableFieldAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectortable" );
+}
+
+QString QgsRenameTableFieldAlgorithm::outputName() const
+{
+  return QObject::tr( "Renamed" );
+}
+
+QList<int> QgsRenameTableFieldAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << QgsProcessing::TypeVector;
+}
+
+QgsProcessingFeatureSource::Flag QgsRenameTableFieldAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
+QgsRenameTableFieldAlgorithm *QgsRenameTableFieldAlgorithm::createInstance() const
+{
+  return new QgsRenameTableFieldAlgorithm();
+}
+
+void QgsRenameTableFieldAlgorithm::initParameters( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterField( QStringLiteral( "FIELD" ), QObject::tr( "Field to rename" ), QVariant(), QStringLiteral( "INPUT" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "NEW_NAME" ), QObject::tr( "New field name" ) ) );
+}
+
+QgsFields QgsRenameTableFieldAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  QgsFields outFields = inputFields;
+  const int index = outFields.lookupField( mOriginalName );
+  if ( index < 0 )
+    throw QgsProcessingException( QObject::tr( "Field %1 could not be found in input table" ).arg( mOriginalName ) );
+
+  if ( outFields.lookupField( mNewName ) >= 0 )
+    throw QgsProcessingException( QObject::tr( "A field already exists with the name %1" ).arg( mNewName ) );
+
+  outFields[ index ].setName( mNewName );
+  return outFields;
+}
+
+bool QgsRenameTableFieldAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mOriginalName = parameterAsString( parameters, QStringLiteral( "FIELD" ), context );
+  mNewName = parameterAsString( parameters, QStringLiteral( "NEW_NAME" ), context );
+  return true;
+}
+
+QgsFeatureList QgsRenameTableFieldAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
+{
+  return QgsFeatureList() << feature;
+}
+
+bool QgsRenameTableFieldAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  Q_UNUSED( layer )
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmrenametablefield.h
+++ b/src/analysis/processing/qgsalgorithmrenametablefield.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+                         qgsalgorithmrenametablefield.h
+                         ---------------------
+    begin                : January 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMRENAMETABLEFIELD_H
+#define QGSALGORITHMRENAMETABLEFIELD_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native add table field algorithm.
+ */
+class QgsRenameTableFieldAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsRenameTableFieldAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QList<int> inputLayerTypes() const override;
+    QgsRenameTableFieldAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QString outputName() const override;
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  private:
+
+    QString mOriginalName;
+    QString mNewName;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMRENAMETABLEFIELD_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -114,6 +114,7 @@
 #include "qgsalgorithmremoveholes.h"
 #include "qgsalgorithmremovenullgeometry.h"
 #include "qgsalgorithmrenamelayer.h"
+#include "qgsalgorithmrenametablefield.h"
 #include "qgsalgorithmrepairshapefile.h"
 #include "qgsalgorithmreverselinedirection.h"
 #include "qgsalgorithmrotate.h"
@@ -309,6 +310,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsRemoveHolesAlgorithm() );
   addAlgorithm( new QgsRemoveNullGeometryAlgorithm() );
   addAlgorithm( new QgsRenameLayerAlgorithm() );
+  addAlgorithm( new QgsRenameTableFieldAlgorithm() );
   addAlgorithm( new QgsRepairShapefileAlgorithm() );
   addAlgorithm( new QgsReverseLineDirectionAlgorithm() );
   addAlgorithm( new QgsRotateFeaturesAlgorithm() );


### PR DESCRIPTION
Takes an input layer, existing field and a new name for the field, and
outputs a new layer with the selected field renamed.

While this result could also be achieved with the Refactor Fields
algorithm, Refactor Fields isn't particularly model friendly. It
relies on a constant, fixed table structure, and can't adapt to
input tables with different field structures.

In constrast, this simple Rename Field algorithm adapts nicely for
model use, because it operates on a single field only and leaves
all the other fields untouched.
