### PR TITLE
Fix out-of-sync vector layer extent after a dataChanged was emitted

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4912,6 +4912,8 @@ void QgsVectorLayer::emitDataChanged()
   if ( mDataChangedFired )
     return;
 
+  updateExtents(); // reset cached extent to reflect data changes
+
   mDataChangedFired = true;
   emit dataChanged();
   mDataChangedFired = false;


### PR DESCRIPTION
Cherry pick commit ff96140.