### PR TITLE
Add QgsRenderContext::setCustomRenderFlags

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -213,7 +213,7 @@ Set map of map layer style overrides (key: layer ID, value: style name) where a 
 .. versionadded:: 2.8
 %End
 
-    QString customRenderFlags() const;
+ QString customRenderFlags() const;
 %Docstring
 Gets custom rendering flags. Layers might honour these to alter their rendering.
 
@@ -222,9 +222,12 @@ Gets custom rendering flags. Layers might honour these to alter their rendering.
 .. seealso:: :py:func:`setCustomRenderFlags`
 
 .. versionadded:: 2.16
+
+.. deprecated::
+   use \see customRenderingFlags().
 %End
 
-    void setCustomRenderFlags( const QString &customRenderFlags );
+ void setCustomRenderFlags( const QString &customRenderFlags );
 %Docstring
 Sets the custom rendering flags. Layers might honour these to alter their rendering.
 
@@ -233,6 +236,43 @@ Sets the custom rendering flags. Layers might honour these to alter their render
 .. seealso:: :py:func:`customRenderFlags`
 
 .. versionadded:: 2.16
+
+.. deprecated::
+   use \see setCustomRenderingFlag() instead.
+%End
+
+    QVariantMap customRenderingFlags() const;
+%Docstring
+Gets custom rendering flags. Layers might honour these to alter their rendering.
+
+:return: a map of custom flags
+
+.. seealso:: :py:func:`setCustomRenderingFlag`
+
+.. versionadded:: 3.12
+%End
+
+    void setCustomRenderingFlag( const QString &flag, const QVariant &value );
+%Docstring
+Sets a custom rendering flag. Layers might honour these to alter their rendering.
+
+:param flag: the flag name
+:param value: the flag value
+
+.. seealso:: :py:func:`customRenderingFlags`
+
+.. versionadded:: 3.12
+%End
+
+    void clearCustomRenderingFlag( const QString &flag );
+%Docstring
+Clears the specified custom rendering flag.
+
+:param flag: the flag name
+
+.. seealso:: :py:func:`setCustomRenderingFlag`
+
+.. versionadded:: 3.12
 %End
 
     void setDestinationCrs( const QgsCoordinateReferenceSystem &crs );

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -728,6 +728,40 @@ in a mask painter, which is not meant to be visible, by definition.
 .. versionadded:: 3.12
 %End
 
+    QVariantMap customRenderingFlags() const;
+%Docstring
+Gets custom rendering flags. Layers might honour these to alter their rendering.
+
+:return: a map of custom flags
+
+.. seealso:: :py:func:`setCustomRenderingFlag`
+
+.. versionadded:: 3.12
+%End
+
+    void setCustomRenderingFlag( const QString &flag, const QVariant &value );
+%Docstring
+Sets a custom rendering flag. Layers might honour these to alter their rendering.
+
+:param flag: the flag name
+:param value: the flag value
+
+.. seealso:: :py:func:`customRenderingFlags`
+
+.. versionadded:: 3.12
+%End
+
+    void clearCustomRenderingFlag( const QString &flag );
+%Docstring
+Clears the specified custom rendering flag.
+
+:param flag: the flag name
+
+.. seealso:: :py:func:`setCustomRenderingFlag`
+
+.. versionadded:: 3.12
+%End
+
 };
 
 QFlags<QgsRenderContext::Flag> operator|(QgsRenderContext::Flag f1, QFlags<QgsRenderContext::Flag> f2);

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -217,19 +217,46 @@ class CORE_EXPORT QgsMapSettings
 
     /**
      * Gets custom rendering flags. Layers might honour these to alter their rendering.
-     *  \returns custom flags strings, separated by ';'
+     * \returns custom flags strings, separated by ';'
      * \see setCustomRenderFlags()
      * \since QGIS 2.16
+     * \deprecated use \see customRenderingFlags().
      */
-    QString customRenderFlags() const { return mCustomRenderFlags; }
+    Q_DECL_DEPRECATED QString customRenderFlags() const { return mCustomRenderFlags; }
 
     /**
      * Sets the custom rendering flags. Layers might honour these to alter their rendering.
      * \param customRenderFlags custom flags strings, separated by ';'
      * \see customRenderFlags()
      * \since QGIS 2.16
+     * \deprecated use \see setCustomRenderingFlag() instead.
      */
-    void setCustomRenderFlags( const QString &customRenderFlags ) { mCustomRenderFlags = customRenderFlags; }
+    Q_DECL_DEPRECATED void setCustomRenderFlags( const QString &customRenderFlags ) { mCustomRenderFlags = customRenderFlags; }
+
+    /**
+     * Gets custom rendering flags. Layers might honour these to alter their rendering.
+     * \returns a map of custom flags
+     * \see setCustomRenderingFlag()
+     * \since QGIS 3.12
+     */
+    QVariantMap customRenderingFlags() const { return mCustomRenderingFlags; }
+
+    /**
+     * Sets a custom rendering flag. Layers might honour these to alter their rendering.
+     * \param flag the flag name
+     * \param value the flag value
+     * \see customRenderingFlags()
+     * \since QGIS 3.12
+     */
+    void setCustomRenderingFlag( const QString &flag, const QVariant &value ) { mCustomRenderingFlags[flag] = value; }
+
+    /**
+     * Clears the specified custom rendering flag.
+     * \param flag the flag name
+     * \see setCustomRenderingFlag()
+     * \since QGIS 3.12
+     */
+    void clearCustomRenderingFlag( const QString &flag ) { mCustomRenderingFlags.remove( flag ); }
 
     //! sets destination coordinate reference system
     void setDestinationCrs( const QgsCoordinateReferenceSystem &crs );
@@ -615,6 +642,7 @@ class CORE_EXPORT QgsMapSettings
     QgsWeakMapLayerPointerList mLayers;
     QMap<QString, QString> mLayerStyleOverrides;
     QString mCustomRenderFlags;
+    QVariantMap mCustomRenderingFlags;
     QgsExpressionContext mExpressionContext;
 
     QgsCoordinateReferenceSystem mDestCRS;

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -62,6 +62,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mTextRenderFormat( rh.mTextRenderFormat )
   , mRenderedFeatureHandlers( rh.mRenderedFeatureHandlers )
   , mHasRenderedFeatureHandlers( rh.mHasRenderedFeatureHandlers )
+  , mCustomRenderingFlags( rh.mCustomRenderingFlags )
 #ifdef QGISDEBUG
   , mHasTransformContext( rh.mHasTransformContext )
 #endif
@@ -94,6 +95,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mTextRenderFormat = rh.mTextRenderFormat;
   mRenderedFeatureHandlers = rh.mRenderedFeatureHandlers;
   mHasRenderedFeatureHandlers = rh.mHasRenderedFeatureHandlers;
+  mCustomRenderingFlags = rh.mCustomRenderingFlags;
 #ifdef QGISDEBUG
   mHasTransformContext = rh.mHasTransformContext;
 #endif
@@ -197,6 +199,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   //this flag is only for stopping during the current rendering progress,
   //so must be false at every new render operation
   ctx.setRenderingStopped( false );
+  ctx.mCustomRenderingFlags = mapSettings.customRenderingFlags();
 
   return ctx;
 }

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -723,6 +723,31 @@ class CORE_EXPORT QgsRenderContext
      */
     bool isGuiPreview() const { return mIsGuiPreview; }
 
+    /**
+     * Gets custom rendering flags. Layers might honour these to alter their rendering.
+     * \returns a map of custom flags
+     * \see setCustomRenderingFlag()
+     * \since QGIS 3.12
+     */
+    QVariantMap customRenderingFlags() const { return mCustomRenderingFlags; }
+
+    /**
+     * Sets a custom rendering flag. Layers might honour these to alter their rendering.
+     * \param flag the flag name
+     * \param value the flag value
+     * \see customRenderingFlags()
+     * \since QGIS 3.12
+     */
+    void setCustomRenderingFlag( const QString &flag, const QVariant &value ) { mCustomRenderingFlags[flag] = value; }
+
+    /**
+     * Clears the specified custom rendering flag.
+     * \param flag the flag name
+     * \see setCustomRenderingFlag()
+     * \since QGIS 3.12
+     */
+    void clearCustomRenderingFlag( const QString &flag ) { mCustomRenderingFlags.remove( flag ); }
+
   private:
 
     Flags mFlags;
@@ -810,6 +835,7 @@ class CORE_EXPORT QgsRenderContext
     TextRenderFormat mTextRenderFormat = TextFormatAlwaysOutlines;
     QList< QgsRenderedFeatureHandlerInterface * > mRenderedFeatureHandlers;
     bool mHasRenderedFeatureHandlers = false;
+    QVariantMap mCustomRenderingFlags;
 
     QSet<const QgsSymbolLayer *> mDisabledSymbolLayers;
 

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -60,6 +60,7 @@ class TestQgsMapSettings: public QObject
     void testLabelBoundary();
     void testExpressionContext();
     void testRenderedFeatureHandlers();
+    void testCustomRenderingFlags();
 
   private:
     QString toString( const QPolygonF &p, int decimalPlaces = 2 ) const;
@@ -546,6 +547,22 @@ void TestQgsMapSettings::testRenderedFeatureHandlers()
   //ownership should NOT be transferred, i.e. it won't delete the registered handlers upon QgsMapSettings destruction
   mapSettings.reset();
   // should be no double-delete here
+}
+
+void TestQgsMapSettings::testCustomRenderingFlags()
+{
+  QgsMapSettings settings;
+  settings.setCustomRenderingFlag( QStringLiteral( "myexport" ), true );
+  settings.setCustomRenderingFlag( QStringLiteral( "omitgeometries" ), QStringLiteral( "points" ) );
+  QVERIFY( settings.customRenderingFlags()[ QStringLiteral( "myexport" ) ].toBool() == true );
+  QVERIFY( settings.customRenderingFlags()[ QStringLiteral( "omitgeometries" ) ].toString() == QStringLiteral( "points" ) );
+
+  // Test deprecated API
+  Q_NOWARN_DEPRECATED_PUSH
+  settings.setCustomRenderFlags( QStringLiteral( "myexport;omitpoints" ) );
+  QVERIFY( settings.customRenderFlags().split( ";" ).contains( QStringLiteral( "myexport" ) ) );
+  QVERIFY( settings.customRenderFlags().split( ";" ).contains( QStringLiteral( "omitpoints" ) ) );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 QGSTEST_MAIN( TestQgsMapSettings )

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -464,6 +464,21 @@ class TestQgsRenderContext(unittest.TestCase):
         sf = r.convertToMapUnits(1, QgsUnitTypes.RenderPixels, c)
         self.assertAlmostEqual(sf, 2.0, places=5)
 
+    def testCustomRenderingFlags(self):
+        rc = QgsRenderContext()
+        rc.setCustomRenderingFlag('myexport', True)
+        rc.setCustomRenderingFlag('omitgeometries', 'points')
+        self.assertTrue(rc.customRenderingFlags()['myexport'])
+        self.assertEqual(rc.customRenderingFlags()['omitgeometries'], 'points')
+
+        # test that custom flags are correctly copied from settings
+        settings = QgsMapSettings()
+        settings.setCustomRenderingFlag('myexport', True)
+        settings.setCustomRenderingFlag('omitgeometries', 'points')
+        rc = QgsRenderContext.fromMapSettings(settings)
+        self.assertTrue(rc.customRenderingFlags()['myexport'])
+        self.assertEqual(rc.customRenderingFlags()['omitgeometries'], 'points')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Useful i.e. for external components providing for instance a specialized plugin layer and an export functionality, where rendering of the layer needs to differ between normal rendering and exporting.