### PR TITLE
[Feature] Add support for displaying WMTS legend graphics in layer tree

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1569,6 +1569,20 @@ void QgsWmsCapabilities::parseWMTSContents( const QDomElement &element )
 
         style.legendURLs << legendURL;
       }
+      QDomElement thirdChildElement = secondChildElement.firstChildElement( QStringLiteral( "LegendURL" ) );
+      if ( !thirdChildElement.isNull() )
+      {
+        QgsWmtsLegendURL legendURL;
+
+        legendURL.format   = thirdChildElement.attribute( QStringLiteral( "format" ) );
+        legendURL.minScale = thirdChildElement.attribute( QStringLiteral( "minScaleDenominator" ) ).toDouble();
+        legendURL.maxScale = thirdChildElement.attribute( QStringLiteral( "maxScaleDenominator" ) ).toDouble();
+        legendURL.href     = thirdChildElement.attribute( QStringLiteral( "xlink:href" ) );
+        legendURL.width    = thirdChildElement.attribute( QStringLiteral( "width" ) ).toInt();
+        legendURL.height   = thirdChildElement.attribute( QStringLiteral( "height" ) ).toInt();
+
+        style.legendURLs << legendURL;
+      }
 
       style.isDefault = secondChildElement.attribute( QStringLiteral( "isDefault" ) ) == QLatin1String( "true" );
 


### PR DESCRIPTION
Adds support for displaying WMTS legend graphics directly in the layer tree, as is already the case with WMS legend graphics.

Example:
![image](https://user-images.githubusercontent.com/1298852/72462785-33351c80-37d2-11ea-98f2-ce0d5221e1f5.png)

Sample use case: https://wmts10.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml