### PR TITLE
Make locator prefixes case insensitive

### DIFF
--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -57,7 +57,7 @@ QList<QgsLocatorFilter *> QgsLocator::filters( const QString &prefix )
     QList<QgsLocatorFilter *> filters =  QList<QgsLocatorFilter *>();
     for ( QgsLocatorFilter *filter : mFilters )
     {
-      if ( !filter->activePrefix().isEmpty() && filter->activePrefix() == prefix )
+      if ( !filter->activePrefix().isEmpty() && filter->activePrefix().compare( prefix, Qt::CaseInsensitive ) == 0 )
       {
         filters << filter;
       }
@@ -149,7 +149,7 @@ void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c
   {
     for ( QgsLocatorFilter *filter : qgis::as_const( mFilters ) )
     {
-      if ( filter->activePrefix() == prefix && filter->enabled() )
+      if ( filter->activePrefix().compare( prefix, Qt::CaseInsensitive ) == 0 && filter->enabled() )
       {
         activeFilters << filter;
       }

--- a/tests/src/python/test_qgslocator.py
+++ b/tests/src/python/test_qgslocator.py
@@ -226,6 +226,11 @@ class TestQgsLocator(unittest.TestCase):
             QCoreApplication.processEvents()
         self.assertEqual(got_hit._results_, [])
         got_hit._results_ = []
+        l.fetchResults('AaA a', context)
+        for i in range(100):
+            sleep(0.002)
+            QCoreApplication.processEvents()
+        self.assertEqual(set(got_hit._results_), {'a0', 'a1', 'a2'})
 
         # test with two filters
         filter_b = test_filter('b', 'bbb')
@@ -274,6 +279,13 @@ class TestQgsLocator(unittest.TestCase):
         self.assertEqual(filter_c.activePrefix(), 'xyz')
         got_hit._results_ = []
         l.fetchResults('b', context)
+        for i in range(100):
+            sleep(0.002)
+            QCoreApplication.processEvents()
+        self.assertEqual(set(got_hit._results_), {'custom0', 'custom1', 'custom2'})
+        filter_c.setUseWithoutPrefix(False)
+        got_hit._results_ = []
+        l.fetchResults('XyZ b', context)
         for i in range(100):
             sleep(0.002)
             QCoreApplication.processEvents()


### PR DESCRIPTION
## Description
All searches made with the locator widget are case insensitive but the prefix itself has to be written in lower case. This commit makes the prefix checking case insensitive, allowing for example searching with either f or F, as is also the case (no pun intended) with the similar locator in qtcreator.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes

- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment

I guess backporting depends on whether one sees this as a bug fix or as a new feature. 