### PR TITLE
add userLoginName and userFullName to QGIS project when writing the p…

### DIFF
--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -137,6 +137,16 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     */
     QString title() const;
 
+	/**
+	* Returns the user name that did the last save.
+	*/
+	QString saveUser() const;
+
+	/**
+	* Returns the full user name that did the last save.
+	*/
+	QString saveUserFullname() const;
+
     /**
      * Returns TRUE if the project has been modified since the last write()
      */
@@ -1780,6 +1790,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     std::unique_ptr<QgsAuxiliaryStorage> mAuxiliaryStorage;
 
     QFile mFile;                 // current physical project file
+
+	QString mSaveUser;              // last saved user.
+	QString mSaveUserFull;          // last saved user full name.
 
     /**
      * Manual override for project home path - if empty, home path is automatically


### PR DESCRIPTION
## Description
In order to track changes in project files used by more than one user it is important to know who saved certain changes to these project files. To accomplish this I would like to add the user loginname and the user full name to the QGIS project file while writing the project.
Tracking project files can be done with git and in addition with the username as a part of the QGIS project it allows you to reconstruct any changes of these project files.

http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-saving-username-in-QGIS-projectfile-for-tracking-changes-td5425750.html

I picked up the neccessary parts from the pullrequest 6527 (https://github.com/qgis/QGIS/pull/6527) which contained also changes to add stable id, save id and save count. It turned out that adding stable id's /save id's is quite tricky so this old pull request was closed. The parts to save the username were not mentioned as problematic.

In combination with the "Stable QGIS Projects" plugin from opengis this pullrequest allows better tracking of qgis projects ( https://www.opengis.ch/de/2019/04/09/plugin-for-tracking-qgis-project-files-in-git/ ) 

I don't think that it is neccessary to backport this pullrequest but for upcoming versions it would be great to have this functionality added to QGIS.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
