### PR TITLE
set the first default item when no empty field name is allowed

### DIFF
--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -47,6 +47,8 @@ void QgsFieldComboBox::setLayer( QgsMapLayer *layer )
 {
   QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
   mFieldProxyModel->sourceFieldModel()->setLayer( vl );
+
+  setCurrentIndex( allowEmptyFieldName() ? -1 : 0 );
 }
 
 QgsVectorLayer *QgsFieldComboBox::layer() const


### PR DESCRIPTION
## Description

When a `QgsFieldComboBox` is used with empty field **not** allowed, it should default to the first item.

Before
![Capture d’écran de 2020-01-16 12-12-53](https://user-images.githubusercontent.com/1609292/72520420-bbaad000-3859-11ea-9b10-13f7e0637d58.png)

After
![Peek 16-01-2020 12-17](https://user-images.githubusercontent.com/1609292/72520686-396edb80-385a-11ea-9d75-735ae1feb636.gif)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
