### PR TITLE
[Backport Release-3_10][Server] Add project path to bad layers message

### DIFF
--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -68,8 +68,9 @@ const QgsProject *QgsConfigCache::project( const QString &path )
         }
         if ( !unrestrictedBadLayers.isEmpty() )
         {
-          const QString errorMsg = QStringLiteral( "Layer(s) %1 not valid" ).arg( unrestrictedBadLayers.join( ',' ) );
-          QgsMessageLog::logMessage( errorMsg, QStringLiteral( "Server" ), Qgis::Critical );
+          QgsMessageLog::logMessage(
+            QStringLiteral( "Error, Layer(s) %1 not valid in project %2" ).arg( unrestrictedBadLayers.join( QStringLiteral( ", " ) ), path ),
+            QStringLiteral( "Server" ), Qgis::Critical );
           throw QgsServerException( QStringLiteral( "Layer(s) not valid" ) );
         }
       }
@@ -79,7 +80,7 @@ const QgsProject *QgsConfigCache::project( const QString &path )
     else
     {
       QgsMessageLog::logMessage(
-        tr( "Error when loading project file '%1': %2 " ).arg( path, prj->error() ),
+        QStringLiteral( "Error when loading project file '%1': %2 " ).arg( path, prj->error() ),
         QStringLiteral( "Server" ), Qgis::Critical );
     }
   }


### PR DESCRIPTION
## Description

Manually backport #33849 

The QGIS Server logs can contained the list of bad layers but the project in which these bad layers are found was not in it.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
