### PR TITLE
fix docstring "since" for QGIS_SERVER_WMS_MAX_XXXX to 3.6.2

### DIFF
--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -143,7 +143,7 @@ Returns the server-wide max height of a WMS GetMap request. The lower one of thi
 
 :return: the max height of a WMS GetMap request.
 
-.. versionadded:: 3.8
+.. versionadded:: 3.6.2
 %End
 
     int wmsMaxWidth() const;
@@ -152,7 +152,7 @@ Returns the server-wide max width of a WMS GetMap request. The lower one of this
 
 :return: the max width of a WMS GetMap request.
 
-.. versionadded:: 3.8
+.. versionadded:: 3.6.2
 %End
 
     QString apiResourcesDirectory() const;

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -63,8 +63,8 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_CACHE_SIZE,
       QGIS_SERVER_SHOW_GROUP_SEPARATOR,  //! Show group (thousands) separator when formatting numeric values, defaults to FALSE (since QGIS 3.8)
       QGIS_SERVER_OVERRIDE_SYSTEM_LOCALE,  //! Override system locale (since QGIS 3.8)
-      QGIS_SERVER_WMS_MAX_HEIGHT, //! Maximum height for a WMS request. The most conservative between this and the project one is used (since QGIS 3.8)
-      QGIS_SERVER_WMS_MAX_WIDTH, //! Maximum width for a WMS request. The most conservative between this and the project one is used (since QGIS 3.8)
+      QGIS_SERVER_WMS_MAX_HEIGHT, //! Maximum height for a WMS request. The most conservative between this and the project one is used (since QGIS 3.6.2)
+      QGIS_SERVER_WMS_MAX_WIDTH, //! Maximum width for a WMS request. The most conservative between this and the project one is used (since QGIS 3.6.2)
       QGIS_SERVER_API_RESOURCES_DIRECTORY, //! Base directory where HTML templates and static assets (e.g. images, js and css files) are searched for (since QGIS 3.10).
       QGIS_SERVER_API_WFS3_MAX_LIMIT //! Maximum value for "limit" in a features request, defaults to 10000 (since QGIS 3.10).
     };
@@ -191,14 +191,14 @@ class SERVER_EXPORT QgsServerSettings
     /**
      * Returns the server-wide max height of a WMS GetMap request. The lower one of this and the project configuration is used.
      * \returns the max height of a WMS GetMap request.
-     * \since QGIS 3.8
+     * \since QGIS 3.6.2
      */
     int wmsMaxHeight() const;
 
     /**
      * Returns the server-wide max width of a WMS GetMap request. The lower one of this and the project configuration is used.
      * \returns the max width of a WMS GetMap request.
-     * \since QGIS 3.8
+     * \since QGIS 3.6.2
      */
     int wmsMaxWidth() const;
 


### PR DESCRIPTION
This was backported in #9752

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
