### PR TITLE
Mesh 3d averaging method fixes

### DIFF
--- a/external/mdal/frmts/mdal_cf.cpp
+++ b/external/mdal/frmts/mdal_cf.cpp
@@ -254,6 +254,9 @@ MDAL::DateTime MDAL::DriverCF::parseTime( std::vector<RelativeTimestamp> &times 
   std::string timeUnitInformation = mNcFile->getAttrStr( timeArrName, "units" );
   std::string calendar = mNcFile->getAttrStr( timeArrName, "calendar" );
   MDAL::DateTime referenceTime = parseCFReferenceTime( timeUnitInformation, calendar );
+  if ( !referenceTime.isValid() )
+    referenceTime = defaultReferenceTime();
+
   MDAL::RelativeTimestamp::Unit unit = parseCFTimeUnit( timeUnitInformation );
 
   times = std::vector<RelativeTimestamp>( nTimesteps );
@@ -315,6 +318,12 @@ bool MDAL::DriverCF::canReadMesh( const std::string &uri )
     return false;
   }
   return true;
+}
+
+MDAL::DateTime MDAL::DriverCF::defaultReferenceTime() const
+{
+  // return invalid reference time
+  return DateTime();
 }
 
 void MDAL::DriverCF::setProjection( MDAL::Mesh *mesh )

--- a/external/mdal/frmts/mdal_cf.hpp
+++ b/external/mdal/frmts/mdal_cf.hpp
@@ -136,9 +136,14 @@ namespace MDAL
         const MDAL::CFDatasetGroupInfo &dsi,
         double fill_val_x, double fill_val_y );
 
+      //! Returns the default reference time
+      virtual DateTime defaultReferenceTime() const;
+
       void setProjection( MDAL::Mesh *m );
       cfdataset_info_map parseDatasetGroupInfo();
-      DateTime parseTime( std::vector<RelativeTimestamp> &times ); //Return the reference time
+
+      //! Populates the times array and returns the reference time
+      DateTime parseTime( std::vector<RelativeTimestamp> &times );
       void addDatasetGroups( Mesh *mesh,
                              const std::vector<RelativeTimestamp> &times,
                              const cfdataset_info_map &dsinfo_map, const DateTime &referenceTime );

--- a/external/mdal/frmts/mdal_tuflowfv.cpp
+++ b/external/mdal/frmts/mdal_tuflowfv.cpp
@@ -389,6 +389,11 @@ void MDAL::DriverTuflowFV::populateFaces( MDAL::Faces &faces )
   }
 }
 
+MDAL::DateTime MDAL::DriverTuflowFV::defaultReferenceTime() const
+{
+  return DateTime( 1990, 1, 1 );
+}
+
 void MDAL::DriverTuflowFV::calculateMaximumLevelCount()
 {
   if ( mMaximumLevelsCount < 0 )

--- a/external/mdal/frmts/mdal_tuflowfv.hpp
+++ b/external/mdal/frmts/mdal_tuflowfv.hpp
@@ -140,6 +140,7 @@ namespace MDAL
       void addBedElevationDatasetOnFaces();
       void populateVertices( MDAL::Vertices &vertices );
       void populateFaces( MDAL::Faces &faces );
+      virtual DateTime defaultReferenceTime() const override;
 
       void calculateMaximumLevelCount();
       int mMaximumLevelsCount = -1;

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -22,7 +22,7 @@ static MDAL_Status sLastStatus;
 
 const char *MDAL_Version()
 {
-  return "0.4.94";
+  return "0.4.95";
 }
 
 MDAL_Status MDAL_LastStatus()

--- a/src/core/mesh/qgsmesh3daveraging.h
+++ b/src/core/mesh/qgsmesh3daveraging.h
@@ -120,6 +120,21 @@ class CORE_EXPORT QgsMesh3dAveragingMethod SIP_ABSTRACT
     virtual bool hasValidInputs() const = 0;
 
     /**
+     * For one face, Calculates average of volume values
+     */
+    void averageVolumeValuesForFace(
+      int faceIndex,
+      int volumesBelowFaceCount,
+      int startVolumeIndex,
+      double methodLevelTop,
+      double methodLevelBottom,
+      bool isVector,
+      const QVector<double> &verticalLevelsForFace,
+      const QVector<double> &volumeValues,
+      QVector<double> &valuesFaces
+    ) const;
+
+    /**
      * For one face, calculates absolute vertical levels between which we need to average
      */
     virtual void volumeRangeForFace(

--- a/src/ui/mesh/qgsmeshrenderer3daveragingwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderer3daveragingwidgetbase.ui
@@ -480,7 +480,7 @@
                <double>0.100000000000000</double>
               </property>
               <property name="value">
-               <double>0.250000000000000</double>
+               <double>0.000000000000000</double>
               </property>
              </widget>
             </item>
@@ -504,7 +504,7 @@
                <double>0.100000000000000</double>
               </property>
               <property name="value">
-               <double>0.750000000000000</double>
+               <double>1.000000000000000</double>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
- adds correct default time for TUFLOWFV formats
- change default to sigma method to 0-1 
- fix TESTING bug in averaging method with irregular vertical levels

with bug:
![Screenshot 2020-01-17 at 09 54 40](https://user-images.githubusercontent.com/804608/72598116-721cbc80-390f-11ea-8560-3e5cffe37943.png)


fixed now:
![Screenshot 2020-01-17 at 09 54 48](https://user-images.githubusercontent.com/804608/72598123-7648da00-390f-11ea-9e3c-67b6fb32f3c1.png)

