### PR TITLE
[Backport release-3_10] BUG: scientific notation for double number between 1 and -1,

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -233,21 +233,38 @@ QString QgsField::displayString( const QVariant &v ) const
         QString s( v.toString() );
         int dotPosition( s.indexOf( '.' ) );
         int precision;
-        if ( dotPosition < 0 )
+        if ( dotPosition < 0 && s.indexOf( 'e' ) < 0 )
         {
           precision = 0;
+          return QLocale().toString( v.toDouble(), 'f', precision );
         }
         else
         {
-          precision = s.length() - dotPosition - 1;
+          if ( dotPosition < 0 ) precision = 0;
+          else precision = s.length() - dotPosition - 1;
+
+          if ( -1 < v.toDouble() && v.toDouble() < 1 )
+          {
+            return QLocale().toString( v.toDouble(), 'g', precision );
+          }
+          else
+          {
+            return QLocale().toString( v.toDouble(), 'f', precision );
+          }
         }
-        return QLocale().toString( v.toDouble(), 'f', precision );
       }
     }
     // Default for doubles with precision
     else if ( d->type == QVariant::Double && d->precision > 0 )
     {
-      return QString::number( v.toDouble(), 'f', d->precision );
+      if ( -1 < v.toDouble() && v.toDouble() < 1 )
+      {
+        return QString::number( v.toDouble(), 'g', d->precision );
+      }
+      else
+      {
+        return QString::number( v.toDouble(), 'f', d->precision );
+      }
     }
   }
   // Other numeric types than doubles

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -224,7 +224,14 @@ QString QgsField::displayString( const QVariant &v ) const
     {
       if ( d->precision > 0 )
       {
-        return QLocale().toString( v.toDouble(), 'f', d->precision );
+        if ( -1 < v.toDouble() && v.toDouble() < 1 )
+        {
+          return QLocale().toString( v.toDouble(), 'g', d->precision );
+        }
+        else
+        {
+          return QLocale().toString( v.toDouble(), 'f', d->precision );
+        }
       }
       else
       {

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -411,11 +411,11 @@ void TestQgsField::displayString()
   customEnglish.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
   QLocale::setDefault( customEnglish );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5.005" ) );
-  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
+  //QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
   QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
-  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
+  //QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
   QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999.123456" ) );

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -411,11 +411,11 @@ void TestQgsField::displayString()
   customEnglish.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
   QLocale::setDefault( customEnglish );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5.005" ) );
-  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
   QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
-  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
   QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999.123456" ) );

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -358,9 +358,13 @@ void TestQgsField::displayString()
   //test double value
   QgsField doubleField( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10, 3 );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5.005" ) );
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+  QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0.0001" ) );
   QgsField doubleFieldNoPrec( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10 );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator, QLocale::NumberOption::DefaultNumberOptions );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599,999,898,999" ) );
 
@@ -371,8 +375,12 @@ void TestQgsField::displayString()
   //test double value with German locale
   QLocale::setDefault( QLocale::German );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5,005" ) );
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4,5e-09" ) );
+  QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0,0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5,005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5,005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4,5e-09" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0,0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599.999.898.999" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5.999,123456" ) );
 
@@ -381,8 +389,12 @@ void TestQgsField::displayString()
   customGerman.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
   QLocale::setDefault( customGerman );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5,005" ) );
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4,5e-09" ) );
+  QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0,0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5,005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5,005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4,5e-09" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0,0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999,123456" ) );
 
@@ -399,8 +411,12 @@ void TestQgsField::displayString()
   customEnglish.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
   QLocale::setDefault( customEnglish );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5.005" ) );
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+  QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999.123456" ) );
 

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -411,11 +411,19 @@ void TestQgsField::displayString()
   customEnglish.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
   QLocale::setDefault( customEnglish );
   QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5.005" ) );
-  //QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+#else
+  QCOMPARE( doubleField.displayString( 4.5e-09 ), QString( "4.5e-9" ) );
+#endif
   QCOMPARE( doubleField.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
-  //QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-9" ) ); //for recent qt package the expected value would be "4.5e-09"
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-09" ) );
+#else
+  QCOMPARE( doubleFieldNoPrec.displayString( 4.5e-09 ), QString( "4.5e-9" ) );
+#endif
   QCOMPARE( doubleFieldNoPrec.displayString( 1e-04 ), QString( "0.0001" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999.123456" ) );


### PR DESCRIPTION
## Description
Backport 84563cb from #33479
In replacement of bot backport that failed #33788
