### PR TITLE
Server: combine opacity values from parameter with existing layer opacities

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2708,7 +2708,7 @@ namespace QgsWms
         case QgsMapLayerType::VectorLayer:
         {
           QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
-          vl->setOpacity( opacity / 255. );
+          vl->setOpacity( vl->opacity() * opacity / 255. );
           break;
         }
 
@@ -2716,7 +2716,7 @@ namespace QgsWms
         {
           QgsRasterLayer *rl = qobject_cast<QgsRasterLayer *>( layer );
           QgsRasterRenderer *rasterRenderer = rl->renderer();
-          rasterRenderer->setOpacity( opacity / 255. );
+          rasterRenderer->setOpacity( rasterRenderer->opacity() * opacity / 255. );
           break;
         }
 


### PR DESCRIPTION
In QGIS 2.x, layer opacity values passed by the OPACITY - Parameter were combined with existing layer opacities. Currently, they layer opacities are just replaced, which makes it hard for webclients to present meaningful opacity sliders to the user (since the client cannot know the layer opacity in the project file). This PR restores the old behaviour.