### PR TITLE
Two typo's to be corrected?

### DIFF
--- a/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
+++ b/src/analysis/processing/qgsalgorithmdetectdatasetchanges.cpp
@@ -81,7 +81,7 @@ QString QgsDetectVectorChangesAlgorithm::shortHelpString() const
                       "When comparing features, the original and revised feature geometries will be compared against each other. Depending "
                       "on the Geometry Comparison Behavior setting, the comparison will either be made using an exact comparison (where "
                       "geometries must be an exact match for each other, including the order and count of vertices) or a topological "
-                      "comparison only (where are geometries area considered equal if all of the their component edges overlap. E.g. "
+                      "comparison only (where are geometries area considered equal if all of their component edges overlap. E.g. "
                       "lines with the same vertex locations but opposite direction will be considered equal by this method). If the topological "
                       "comparison is selected then any z or m values present in the geometries will not be compared.\n\n"
                       "By default, the algorithm compares all attributes from the original and revised features. If the Attributes to Consider for Match "
@@ -91,7 +91,7 @@ QString QgsDetectVectorChangesAlgorithm::shortHelpString() const
                       "that these features have a unique set of attributes selected for comparison. If this condition is not met, warnings will be "
                       "raised and the resultant outputs may be misleading.\n\n"
                       "The algorithm outputs three layers, one containing all features which are considered to be unchanged between the revisions, "
-                      "one containing features deleted from the original layer which are not present in the revised layer, and one containing features"
+                      "one containing features deleted from the original layer which are not present in the revised layer, and one containing features "
                       "add to the revised layer which are not present in the original layer." );
 }
 


### PR DESCRIPTION
Line 84        :  "of the their component" should probably be "of their component"
Line 94 - 95:  missing space between "features" in line 94 and "add in line 95

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
