### PR TITLE
Revert "[RPM] Remove qgis-zh-Hant.qm from RPM packages"

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -309,6 +309,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %doc %{_datadir}/%{name}/doc/
 %dir %{_datadir}/%{name}/i18n/
 %lang(zh-Hans) %{_datadir}/%{name}/i18n/%{name}_zh-Hans.qm
+%lang(zh-Hant) %{_datadir}/%{name}/i18n/%{name}_zh-Hant.qm
 %{_libdir}/lib%{name}_native.so.*
 %{_libdir}/lib%{name}_app.so.*
 %{_libdir}/lib%{name}_analysis.so.*


### PR DESCRIPTION
`qgis-zh-Hant.qm` is back in the current `master` and `release-3_10`. 

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/qgis-3.10.2-1.fc31.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/share/qgis/i18n/qgis_zh-Hant.qm
```

It was missing at the time `3.10.1` was released.

Needs backport to `release_3_10`