### PR TITLE
fixed wrong item order in add field dialog, causing wrong focused widget

### DIFF
--- a/src/app/qgsaddattrdialog.cpp
+++ b/src/app/qgsaddattrdialog.cpp
@@ -58,6 +58,8 @@ QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt:
 
   if ( mIsShapeFile )
     mNameEdit->setMaxLength( 10 );
+
+  mNameEdit->setFocus();
 }
 
 void QgsAddAttrDialog::mTypeBox_currentIndexChanged( int idx )

--- a/src/ui/qgsaddattrdialogbase.ui
+++ b/src/ui/qgsaddattrdialogbase.ui
@@ -17,29 +17,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QLabel" name="textLabel2">
-     <property name="text">
-      <string>Type</string>
-     </property>
-     <property name="buddy">
-      <cstring>mTypeBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="mCommentEdit"/>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="mTypeName">
-     <property name="text">
-      <string>Type</string>
-     </property>
-     <property name="buddy">
-      <cstring>mTypeBox</cstring>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="textLabel1">
      <property name="text">
@@ -50,32 +27,8 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="mPrecLabel">
-     <property name="toolTip">
-      <string>Maximum number of digits after the decimal place. For example 123.45 requires a field precision of 2.</string>
-     </property>
-     <property name="text">
-      <string>Precision</string>
-     </property>
-     <property name="buddy">
-      <cstring>mPrec</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QSpinBox" name="mLength">
-     <property name="toolTip">
-      <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
-     </property>
-    </widget>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mNameEdit"/>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="textLabel1_2">
@@ -87,10 +40,36 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QSpinBox" name="mPrec">
-     <property name="toolTip">
-      <string>Maximum number of digits after the decimal place. For example 123.45 requires a field precision of 2.</string>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="mCommentEdit"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="textLabel2">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="buddy">
+      <cstring>mTypeBox</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="mTypeBox"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Provider type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="mTypeName">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="buddy">
+      <cstring>mTypeBox</cstring>
      </property>
     </widget>
    </item>
@@ -107,11 +86,32 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="mNameEdit"/>
+   <item row="4" column="1">
+    <widget class="QSpinBox" name="mLength">
+     <property name="toolTip">
+      <string>Total length of field (including the number of digits after the decimal place for decimal fields).&lt;br&gt;For example 123.45 requires a decimal field length of 5, and 123456 requires an integer field length of 6.</string>
+     </property>
+    </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="mTypeBox"/>
+   <item row="5" column="0">
+    <widget class="QLabel" name="mPrecLabel">
+     <property name="toolTip">
+      <string>Maximum number of digits after the decimal place. For example 123.45 requires a field precision of 2.</string>
+     </property>
+     <property name="text">
+      <string>Precision</string>
+     </property>
+     <property name="buddy">
+      <cstring>mPrec</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QSpinBox" name="mPrec">
+     <property name="toolTip">
+      <string>Maximum number of digits after the decimal place. For example 123.45 requires a field precision of 2.</string>
+     </property>
+    </widget>
    </item>
    <item row="6" column="1">
     <spacer name="verticalSpacer">
@@ -126,10 +126,10 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Provider type</string>
+   <item row="7" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description
When opening the Add Field dialog (New field ctrl+W) the focused widget is the OK button instead of the Name field (first widget in Tab Order) requiring the user to use the mouse to select the name field or press tab until the name field is selected. 
This functionality was not intended but caused by the weird layout item ordering in the ui file (maybe a QT bug?).
The diff looks more complicated than it actually is, it only puts the `<item row=...> ... </item>` blocks in ascending order, which fixes the bug.
I guess this could also be backported.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes

- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them

- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment

