### PR TITLE
[Bugfix][3D][MESH] Fix  color ramp shader settings and flickering triangles for 3D view mesh rendering

### DIFF
--- a/src/3d/mesh/qgsmesh3dentity_p.cpp
+++ b/src/3d/mesh/qgsmesh3dentity_p.cpp
@@ -53,6 +53,7 @@ void QgsMesh3dEntity::buildGeometry()
   }
 
   mesh->setGeometry( new QgsMesh3dGeometry( mTriangularMesh,
+                     mMapSettings.origin(),
                      mExtent,
                      mSymbol.verticaleScale(),
                      mesh ) );
@@ -60,7 +61,7 @@ void QgsMesh3dEntity::buildGeometry()
   addComponent( mesh );
 
   Qt3DCore::QTransform *tform = new Qt3DCore::QTransform;
-  tform->setTranslation( QVector3D( float( -mMapSettings.origin().x() ), 0, float( mMapSettings.origin().y() ) ) );
+  tform->setTranslation( QVector3D( 0, 0, 0 ) ) ;
   addComponent( tform );
 }
 
@@ -93,11 +94,11 @@ void QgsMesh3dTerrainTileEntity::buildGeometry()
 {
   Qt3DRender::QGeometryRenderer *mesh = new Qt3DRender::QGeometryRenderer;
 
-  mesh->setGeometry( new QgsMesh3dGeometry( mTriangularMesh, mExtent, mSymbol.verticaleScale(), mesh ) );
+  mesh->setGeometry( new QgsMesh3dGeometry( mTriangularMesh, mMapSettings.origin(), mExtent, mSymbol.verticaleScale(), mesh ) );
   addComponent( mesh );
 
   Qt3DCore::QTransform *tform = new Qt3DCore::QTransform;
-  tform->setTranslation( QVector3D( float( -mMapSettings.origin().x() ), 0, float( mMapSettings.origin().y() ) ) );
+  tform->setTranslation( QVector3D( 0, 0, 0 ) );
   addComponent( tform );
 }
 

--- a/src/3d/mesh/qgsmesh3dentity_p.cpp
+++ b/src/3d/mesh/qgsmesh3dentity_p.cpp
@@ -59,10 +59,6 @@ void QgsMesh3dEntity::buildGeometry()
                      mesh ) );
 
   addComponent( mesh );
-
-  Qt3DCore::QTransform *tform = new Qt3DCore::QTransform;
-  tform->setTranslation( QVector3D( 0, 0, 0 ) ) ;
-  addComponent( tform );
 }
 
 void QgsMesh3dEntity::applyMaterial()
@@ -96,10 +92,6 @@ void QgsMesh3dTerrainTileEntity::buildGeometry()
 
   mesh->setGeometry( new QgsMesh3dGeometry( mTriangularMesh, mMapSettings.origin(), mExtent, mSymbol.verticaleScale(), mesh ) );
   addComponent( mesh );
-
-  Qt3DCore::QTransform *tform = new Qt3DCore::QTransform;
-  tform->setTranslation( QVector3D( 0, 0, 0 ) );
-  addComponent( tform );
 }
 
 void QgsMesh3dTerrainTileEntity::applyMaterial()

--- a/src/3d/mesh/qgsmesh3dgeometry_p.h
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.h
@@ -22,6 +22,8 @@
 #include <Qt3DRender/qgeometry.h>
 #include <QVector3D>
 
+#include <qgsvector3d.h>
+
 #include "qgstriangularmesh.h"
 
 ///@cond PRIVATE
@@ -51,12 +53,13 @@ class QgsMesh3dGeometry: public  Qt3DRender::QGeometry
   public:
 
     //! Constructs a mesh layer geometry from triangular mesh.
-    explicit QgsMesh3dGeometry( const QgsTriangularMesh &mesh, const QgsRectangle &extent, float verticaleScale, QNode *parent );
+    explicit QgsMesh3dGeometry( const QgsTriangularMesh &mesh, const QgsVector3D &origin, const QgsRectangle &extent, float verticaleScale, QNode *parent );
 
   private:
     void init();
 
     QgsTriangularMesh mTriangularMesh;
+    QgsVector3D mOrigin;
     QgsRectangle mExtent;
     float mVertScale;
 
@@ -66,9 +69,7 @@ class QgsMesh3dGeometry: public  Qt3DRender::QGeometry
     Qt3DRender::QAttribute *mIndexAttribute = nullptr;
     Qt3DRender::QBuffer *mVertexBuffer = nullptr;
     Qt3DRender::QBuffer *mIndexBuffer = nullptr;
-
 };
-
 
 ///@endcond
 

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -81,7 +81,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
     QgsMeshTerrainGenerator *meshTerrain = static_cast<QgsMeshTerrainGenerator *>( terrainGen );
     cboTerrainLayer->setFilters( QgsMapLayerProxyModel::MeshLayer );
     cboTerrainLayer->setLayer( meshTerrain->meshLayer() );
-    mMeshSymbolWidget->setLayer( meshTerrain->meshLayer() );
+    mMeshSymbolWidget->setLayer( meshTerrain->meshLayer(), false );
     mMeshSymbolWidget->setSymbol( meshTerrain->symbol() );
     spinTerrainScale->setValue( meshTerrain->symbol().verticaleScale() );
   }
@@ -277,12 +277,11 @@ void Qgs3DMapConfigWidget::onTerrainLayerChanged()
     QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( cboTerrainLayer->currentLayer() );
     if ( meshLayer )
     {
+      QgsMeshLayer *oldLayer = mMeshSymbolWidget->meshLayer();
 
       mMeshSymbolWidget->setLayer( meshLayer, false );
-      if ( mMeshSymbolWidget->symbol().colorRampShader().colorRampItemList().count() == 0 )
-      {
+      if ( oldLayer != meshLayer )
         mMeshSymbolWidget->reloadColorRampShaderMinMax();
-      }
     }
   }
 }

--- a/src/app/3d/qgsmesh3dsymbolwidget.cpp
+++ b/src/app/3d/qgsmesh3dsymbolwidget.cpp
@@ -63,6 +63,8 @@ void QgsMesh3dSymbolWidget::setSymbol( const QgsMesh3DSymbol &symbol )
   mComboBoxTextureType->setCurrentIndex( symbol.renderingStyle() );
   mMeshSingleColorButton->setColor( symbol.singleMeshColor() );
   mColorRampShaderWidget->setFromShader( symbol.colorRampShader() );
+  mColorRampShaderWidget->setMinimumMaximumAndClassify( symbol.colorRampShader().minimumValue(),
+      symbol.colorRampShader().maximumValue() );
 
   setColorRampMinMax( symbol.colorRampShader().minimumValue(), symbol.colorRampShader().maximumValue() );
 }
@@ -89,6 +91,8 @@ void QgsMesh3dSymbolWidget::setLayer( QgsMeshLayer *meshLayer, bool updateSymbol
   setSymbol( QgsMesh3DSymbol() );
   reloadColorRampShaderMinMax(); //As the symbol is new, the Color ramp shader needs to be initialized with min max value
 }
+
+QgsMeshLayer *QgsMesh3dSymbolWidget::meshLayer() const {return mLayer;}
 
 double QgsMesh3dSymbolWidget::lineEditValue( const QLineEdit *lineEdit ) const
 {

--- a/src/app/3d/qgsmesh3dsymbolwidget.h
+++ b/src/app/3d/qgsmesh3dsymbolwidget.h
@@ -34,6 +34,7 @@ class QgsMesh3dSymbolWidget : public QWidget, private Ui::QgsMesh3dPropsWidget
     QgsMesh3DSymbol symbol() const;
 
     void setLayer( QgsMeshLayer *meshLayer, bool updateSymbol = true );
+    QgsMeshLayer *meshLayer() const;
     void setSymbol( const QgsMesh3DSymbol &symbol );
 
     void enableVerticalSetting( bool isEnable );


### PR DESCRIPTION
There are two bugs in the 3D view rendering for mesh : 
* an issue with the color ramp shader settings 
* when the camera moves, there are some triangles which suffer of flickering.

This PR fixes those issues.
