### PR TITLE
Ensure browser model is initialized when used by QgsDataSourceSelectDialog

### DIFF
--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -35,21 +35,20 @@ QgsDataSourceSelectDialog::QgsDataSourceSelectDialog(
 {
   if ( ! browserModel )
   {
-    mBrowserModel = qgis::make_unique<QgsBrowserGuiModel>();
+    mBrowserModel = new QgsBrowserGuiModel( this );
     mBrowserModel->initialize();
-    mOwnModel = true;
   }
   else
   {
-    mBrowserModel.reset( browserModel );
-    mOwnModel = false;
+    mBrowserModel = browserModel;
+    mBrowserModel->initialize();
   }
 
   setupUi( this );
   setWindowTitle( tr( "Select a Data Source" ) );
   QgsGui::enableAutoGeometryRestore( this );
 
-  mBrowserProxyModel.setBrowserModel( mBrowserModel.get() );
+  mBrowserProxyModel.setBrowserModel( mBrowserModel );
   mBrowserTreeView->setHeaderHidden( true );
 
   if ( setFilterByLayerType )
@@ -63,7 +62,7 @@ QgsDataSourceSelectDialog::QgsDataSourceSelectDialog(
     buttonBox->button( QDialogButtonBox::StandardButton::Ok )->setEnabled( false );
   }
 
-  mBrowserTreeView->setBrowserModel( mBrowserModel.get() );
+  mBrowserTreeView->setBrowserModel( mBrowserModel );
 
   mWidgetFilter->hide();
   mLeFilter->setPlaceholderText( tr( "Type here to filter visible items…" ) );
@@ -116,12 +115,7 @@ QgsDataSourceSelectDialog::QgsDataSourceSelectDialog(
   }
 }
 
-QgsDataSourceSelectDialog::~QgsDataSourceSelectDialog()
-{
-  if ( ! mOwnModel )
-    mBrowserModel.release();
-}
-
+QgsDataSourceSelectDialog::~QgsDataSourceSelectDialog() = default;
 
 void QgsDataSourceSelectDialog::showEvent( QShowEvent *e )
 {

--- a/src/gui/qgsdatasourceselectdialog.h
+++ b/src/gui/qgsdatasourceselectdialog.h
@@ -106,8 +106,7 @@ class GUI_EXPORT QgsDataSourceSelectDialog: public QDialog, private Ui::QgsDataS
     void refreshModel( const QModelIndex &index );
 
     QgsBrowserProxyModel mBrowserProxyModel;
-    std::unique_ptr<QgsBrowserGuiModel> mBrowserModel;
-    bool mOwnModel = true;
+    QgsBrowserGuiModel *mBrowserModel = nullptr;
     QgsMimeDataUtils::Uri mUri;
     QLabel *mDescriptionLabel = nullptr;
 


### PR DESCRIPTION
Otherwise the dialog can show an empty widget if the main app browser
panel isn't visible.

Also cleanup memory management so that we don't use a unique_ptr to
store something we don't own (and use Qt parent memory management instead)
