### PR TITLE
Revert the change from "Value" to "label with"

### DIFF
--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -47,7 +47,7 @@
       <item>
        <widget class="QLabel" name="label_12">
         <property name="text">
-         <string>Label with</string>
+         <string>Value</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
when indicating field/expression selector for labeling (removed in https://github.com/qgis/QGIS/commit/845894b31318ff8bb5eb094cd4a4785b7440fb24#diff-d7e1d30ebca79fa5f85fc9db99d16a08L6486 probably due to a wrong rebase)
Harmonizes with renderers dialog (#31597)