### PR TITLE
[dbmanager] clear create table dialog on succes (fix #25535)

### DIFF
--- a/python/plugins/db_manager/dlg_create_table.py
+++ b/python/plugins/db_manager/dlg_create_table.py
@@ -309,6 +309,19 @@ class DlgCreateTable(QDialog, Ui_Dialog):
 
             except (ConnectionError, DbError) as e:
                 DlgDbError.showError(e, self)
-            return
+
+        # clear UI
+        self.editName.clear()
+        self.fields.model().removeRows(0, self.fields.model().rowCount())
+        self.cboPrimaryKey.clear()
+        self.chkGeomColumn.setChecked(False)
+        self.chkSpatialIndex.setChecked(False)
+        self.editGeomSrid.clear()
+
+        self.cboGeomType.setEnabled(False)
+        self.editGeomColumn.setEnabled(False)
+        self.spinGeomDim.setEnabled(False)
+        self.editGeomSrid.setEnabled(False)
+        self.chkSpatialIndex.setEnabled(False)
 
         QMessageBox.information(self, self.tr("DB Manager"), self.tr("Table created successfully."))


### PR DESCRIPTION
## Description
Reset UI of the DB Manager's "Create table" dialog on success to streamline process of adding multiple tables.

Fixes  #25535.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
