### PR TITLE
Fix pathresolver failure when project is relative

### DIFF
--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -121,6 +121,9 @@ QString QgsPathResolver::readPath( const QString &f ) const
   bool uncPath = projPath.startsWith( "//" );
 #endif
 
+  // Make sure the path is absolute (see GH #33200)
+  projPath = QFileInfo( projPath ).absoluteFilePath();
+
   QStringList srcElems = srcPath.split( '/', QString::SkipEmptyParts );
   QStringList projElems = projPath.split( '/', QString::SkipEmptyParts );
 

--- a/tests/src/python/test_qgspathresolver.py
+++ b/tests/src/python/test_qgspathresolver.py
@@ -144,6 +144,19 @@ class TestQgsPathResolver(unittest.TestCase):
 
         self.assertEqual(QgsPathResolver().writePath(QgsApplication.pkgDataPath() + '/resources/data/world_map.shp'), 'inbuilt:/data/world_map.shp')
 
+    def testRelativeProject(self):
+        """Test relative project paths can still resolve, regression #33200"""
+
+        curdir = os.getcwd()
+        os.chdir(os.path.join(TEST_DATA_DIR, 'qgis_server'))
+        resolver = QgsPathResolver('./test_project.qgs')
+        self.assertEqual(resolver.readPath('./testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
+        self.assertEqual(resolver.readPath('testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
+        resolver = QgsPathResolver('test_project.qgs')
+        self.assertEqual(resolver.readPath('./testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
+        self.assertEqual(resolver.readPath('testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
+        os.chdir(curdir)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgspathresolver.py
+++ b/tests/src/python/test_qgspathresolver.py
@@ -150,11 +150,11 @@ class TestQgsPathResolver(unittest.TestCase):
         curdir = os.getcwd()
         os.chdir(os.path.join(TEST_DATA_DIR, 'qgis_server'))
         resolver = QgsPathResolver('./test_project.qgs')
-        self.assertEqual(resolver.readPath('./testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
-        self.assertEqual(resolver.readPath('testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
+        self.assertEqual(resolver.readPath('./testlayer.shp').replace("\\", "/"), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp').replace("\\", "/"))
+        self.assertEqual(resolver.readPath('testlayer.shp').replace("\\", "/"), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp').replace("\\", "/"))
         resolver = QgsPathResolver('test_project.qgs')
-        self.assertEqual(resolver.readPath('./testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
-        self.assertEqual(resolver.readPath('testlayer.shp'), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp'))
+        self.assertEqual(resolver.readPath('./testlayer.shp').replace("\\", "/"), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp').replace("\\", "/"))
+        self.assertEqual(resolver.readPath('testlayer.shp').replace("\\", "/"), os.path.join(TEST_DATA_DIR, 'qgis_server', 'testlayer.shp').replace("\\", "/"))
         os.chdir(curdir)
 
 


### PR DESCRIPTION
Fixes #33200 when (server) project was loaded from
the FCGI current directory with a relative path
or not path at all: the pathresolver assumed the
project file path was absolute, which wasn't the
case in this issue.

By forcing the project path to absolute, the
problem goes away.
