### PR TITLE
Fix unreported server WFS3 issue with double slashes

### DIFF
--- a/src/server/qgsserverogcapihandler.cpp
+++ b/src/server/qgsserverogcapihandler.cpp
@@ -306,6 +306,11 @@ void QgsServerOgcApiHandler::htmlDump( const json &data, const QgsServerApiConte
       {
         fName.chop( suffix.length() + 1 );
       }
+      // Chop any ending slashes
+      while ( fName.endsWith( '/' ) )
+      {
+        fName.chop( 1 );
+      }
       fName += '/' + QString::number( args.at( 0 )->get<QgsFeatureId>( ) );
       if ( !suffix.isEmpty() )
       {


### PR DESCRIPTION
... in items page when accessing from an item link
without suffix.
