### PR TITLE
[BUGFIX] QgsExpression::referencedAttributeIndexes(): only report valid indices

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -250,7 +250,11 @@ QSet<int> QgsExpression::referencedAttributeIndexes( const QgsFields &fields ) c
       referencedIndexes = fields.allAttributesList().toSet();
       break;
     }
-    referencedIndexes << fields.lookupField( fieldName );
+    const int idx = fields.lookupField( fieldName );
+    if ( idx >= 0 )
+    {
+      referencedIndexes << idx;
+    }
   }
 
   return referencedIndexes;

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -70,23 +70,22 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
     // ensure that all attributes required for expression filter are being fetched
     if ( mRequest.filterType() == QgsFeatureRequest::FilterExpression )
     {
-      const auto constReferencedColumns = mRequest.filterExpression()->referencedColumns();
-      for ( const QString &field : constReferencedColumns )
+      const QSet<int> attributeIndexes = mRequest.filterExpression()->referencedAttributeIndexes( mSource->mFields );
+      for ( int attrIdx : attributeIndexes )
       {
-        int attrIdx = mSource->mFields.lookupField( field );
         if ( !mAttributeList.contains( attrIdx ) )
           mAttributeList << attrIdx;
       }
     }
 
     // ensure that all attributes required for order by are fetched
-    const QSet< QString > orderByAttributes = mRequest.orderBy().usedAttributes();
-    for ( const QString &attr : orderByAttributes )
+    const auto orderByAttributes = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+    for ( int attrIdx : orderByAttributes )
     {
-      int attrIndex = mSource->mFields.lookupField( attr );
-      if ( !mAttributeList.contains( attrIndex ) )
-        mAttributeList << attrIndex;
+      if ( !mAttributeList.contains( attrIdx ) )
+        mAttributeList << attrIdx;
     }
+
   }
   else
     mAttributeList = mSource->mFields.allAttributesList();

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -138,10 +138,9 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       // ensure that all attributes required for expression filter are being fetched
       if ( request.filterType() == QgsFeatureRequest::FilterExpression )
       {
-        const auto constReferencedColumns = request.filterExpression()->referencedColumns();
-        for ( const QString &field : constReferencedColumns )
+        const QSet<int> attributeIndexes = request.filterExpression()->referencedAttributeIndexes( mSource->mFields );
+        for ( int attrIdx : attributeIndexes )
         {
-          int attrIdx = mSource->mFields.lookupField( field );
           if ( !mAttributes.contains( attrIdx ) )
             mAttributes << attrIdx;
         }

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -715,3 +715,10 @@ class FeatureSourceTestCase(object):
     def testAllFeatureIds(self):
         ids = set([f.id() for f in self.source.getFeatures()])
         self.assertEqual(set(self.source.allFeatureIds()), ids)
+
+    def testSubsetOfAttributesWithFilterExprWithNonExistingColumn(self):
+        """ Test fix for https://github.com/qgis/QGIS/issues/33878 """
+        request = QgsFeatureRequest().setSubsetOfAttributes([0])
+        request.setFilterExpression("non_existing = 1")
+        features = [f for f in self.source.getFeatures(request)]
+        self.assertEqual(len(features), 0)

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -15,7 +15,7 @@ import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.testing import unittest
 from qgis.utils import qgsfunction
-from qgis.core import QgsExpression, QgsFeatureRequest, QgsExpressionContext, NULL
+from qgis.core import QgsExpression, QgsFeatureRequest, QgsFields, QgsExpressionContext, NULL
 
 
 class TestQgsExpressionCustomFunctions(unittest.TestCase):
@@ -263,6 +263,12 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         value = True
         res = '"my\'field" = TRUE'
         self.assertEqual(e.createFieldEqualityExpression(field, value), res)
+
+    def testReferencedAttributeIndexesNonExistingField(self):
+        e = QgsExpression()
+        e.setExpression("foo = 1")
+        self.assertTrue(e.isValid())
+        self.assertEqual(len(e.referencedAttributeIndexes(QgsFields())), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the expression was referencing a non-existing field, -1 was returned in the
result set, which caused later crashed in various providers, including the
Spatialite, Postgres, etc..., due to tried to dereference mFields.at(-1)

Discarding invalid indices is what is also done in
QgsFeatureRequest::OrderBy::usedAttributeIndices()

Fixes #33878
