### PR TITLE
Fix crash in rendering on proj 6 builds

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -129,12 +129,14 @@ QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem( const long id, CrsTy
 
 QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &srs )  //NOLINT
   : d( srs.d )
+  , mValidationHint( srs.mValidationHint )
 {
 }
 
 QgsCoordinateReferenceSystem &QgsCoordinateReferenceSystem::operator=( const QgsCoordinateReferenceSystem &srs )  //NOLINT
 {
   d = srs.d;
+  mValidationHint = srs.mValidationHint;
   return *this;
 }
 
@@ -2238,13 +2240,12 @@ void QgsCoordinateReferenceSystem::debugPrint()
 
 void QgsCoordinateReferenceSystem::setValidationHint( const QString &html )
 {
-  d.detach();
-  d->mValidationHint = html;
+  mValidationHint = html;
 }
 
 QString QgsCoordinateReferenceSystem::validationHint()
 {
-  return d->mValidationHint;
+  return mValidationHint;
 }
 
 /// Copied from QgsCustomProjectionDialog ///

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -467,8 +467,6 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
        wmsCrs.compare( QLatin1String( "OGC:CRS84" ), Qt::CaseInsensitive ) == 0 )
   {
     createFromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
-
-    d.detach();
     d->mAxisInverted = false;
     d->mAxisInvertedDirty = false;
 
@@ -492,8 +490,6 @@ void QgsCoordinateReferenceSystem::validate()
 {
   if ( d->mIsValid || !sCustomSrsValidation )
     return;
-
-  d.detach();
 
   // try to validate using custom validation routines
   if ( sCustomSrsValidation )
@@ -1463,30 +1459,6 @@ QgsRectangle QgsCoordinateReferenceSystem::bounds() const
 #endif
 }
 
-
-// Mutators -----------------------------------
-
-
-void QgsCoordinateReferenceSystem::setInternalId( long srsId )
-{
-  d.detach();
-  d->mSrsId = srsId;
-}
-void QgsCoordinateReferenceSystem::setAuthId( const QString &authId )
-{
-  d.detach();
-  d->mAuthId = authId;
-}
-void QgsCoordinateReferenceSystem::setSrid( long srid )
-{
-  d.detach();
-  d->mSRID = srid;
-}
-void QgsCoordinateReferenceSystem::setDescription( const QString &description )
-{
-  d.detach();
-  d->mDescription = description;
-}
 void QgsCoordinateReferenceSystem::setProjString( const QString &proj4String )
 {
   d.detach();
@@ -1682,30 +1654,8 @@ bool QgsCoordinateReferenceSystem::setWktString( const QString &wkt, bool allowP
   return d->mIsValid;
 }
 
-void QgsCoordinateReferenceSystem::setGeographicFlag( bool geoFlag )
-{
-  d.detach();
-  d->mIsGeographic = geoFlag;
-}
-void QgsCoordinateReferenceSystem::setEpsg( long epsg )
-{
-  d.detach();
-  d->mAuthId = QStringLiteral( "EPSG:%1" ).arg( epsg );
-}
-void  QgsCoordinateReferenceSystem::setProjectionAcronym( const QString &projectionAcronym )
-{
-  d.detach();
-  d->mProjectionAcronym = projectionAcronym;
-}
-void  QgsCoordinateReferenceSystem::setEllipsoidAcronym( const QString &ellipsoidAcronym )
-{
-  d.detach();
-  d->mEllipsoidAcronym = ellipsoidAcronym;
-}
-
 void QgsCoordinateReferenceSystem::setMapUnits()
 {
-  d.detach();
   if ( !d->mIsValid )
   {
     d->mMapUnits = QgsUnitTypes::DistanceUnknownUnit;
@@ -2036,32 +1986,25 @@ bool QgsCoordinateReferenceSystem::readXml( const QDomNode &node )
         setProjString( node.toElement().text() );
 
       node = srsNode.namedItem( QStringLiteral( "srsid" ) );
-      setInternalId( node.toElement().text().toLong() );
+      d->mSrsId = node.toElement().text().toLong();
 
       node = srsNode.namedItem( QStringLiteral( "srid" ) );
-      setSrid( node.toElement().text().toLong() );
+      d->mSRID = node.toElement().text().toLong();
 
       node = srsNode.namedItem( QStringLiteral( "authid" ) );
-      setAuthId( node.toElement().text() );
+      d->mAuthId = node.toElement().text();
 
       node = srsNode.namedItem( QStringLiteral( "description" ) );
-      setDescription( node.toElement().text() );
+      d->mDescription = node.toElement().text();
 
       node = srsNode.namedItem( QStringLiteral( "projectionacronym" ) );
-      setProjectionAcronym( node.toElement().text() );
+      d->mProjectionAcronym = node.toElement().text();
 
       node = srsNode.namedItem( QStringLiteral( "ellipsoidacronym" ) );
-      setEllipsoidAcronym( node.toElement().text() );
+      d->mEllipsoidAcronym = node.toElement().text();
 
       node = srsNode.namedItem( QStringLiteral( "geographicflag" ) );
-      if ( node.toElement().text().compare( QLatin1String( "true" ) ) )
-      {
-        setGeographicFlag( true );
-      }
-      else
-      {
-        setGeographicFlag( false );
-      }
+      d->mIsGeographic = node.toElement().text().compare( QLatin1String( "true" ) );
 
       //make sure the map units have been set
       setMapUnits();
@@ -2318,10 +2261,10 @@ long QgsCoordinateReferenceSystem::saveAsUserCrs( const QString &name, Format na
     QgsMessageLog::logMessage( QObject::tr( "Saved user CRS [%1]" ).arg( toProj() ), QObject::tr( "CRS" ) );
 
     returnId = sqlite3_last_insert_rowid( database.get() );
-    setInternalId( returnId );
+    d->mSrsId = returnId;
     if ( authid().isEmpty() )
-      setAuthId( QStringLiteral( "USER:%1" ).arg( returnId ) );
-    setDescription( name );
+      d->mAuthId = QStringLiteral( "USER:%1" ).arg( returnId );
+    d->mDescription = name;
   }
 
   invalidateCache();

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -693,7 +693,7 @@ bool QgsCoordinateReferenceSystem::loadFromDatabase( const QString &db, const QS
 }
 
 #if PROJ_VERSION_MAJOR>=6
-void QgsCoordinateReferenceSystem::removeFromCacheObjectsBelongingToCurrentThread( void *pj_context )
+void QgsCoordinateReferenceSystem::removeFromCacheObjectsBelongingToCurrentThread( PJ_CONTEXT *pj_context )
 {
   // Not completely sure about object order destruction after main() has
   // exited. So it is safer to check sDisableCache before using sCacheLock

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1866,8 +1866,20 @@ long QgsCoordinateReferenceSystem::findMatchingProj()
 
 bool QgsCoordinateReferenceSystem::operator==( const QgsCoordinateReferenceSystem &srs ) const
 {
-  return ( !d->mIsValid && !srs.d->mIsValid ) ||
-         ( d->mIsValid && srs.d->mIsValid && srs.authid() == authid() );
+  // shortcut
+  if ( d == srs.d )
+    return true;
+
+  if ( !d->mIsValid && !srs.d->mIsValid )
+    return true;
+
+  if ( !d->mIsValid || !srs.d->mIsValid )
+    return false;
+
+  if ( !d->mAuthId.isEmpty() && d->mAuthId == srs.d->mAuthId )
+    return true;
+
+  return toWkt( WKT2_2018 ) == srs.toWkt( WKT2_2018 );
 }
 
 bool QgsCoordinateReferenceSystem::operator!=( const QgsCoordinateReferenceSystem &srs ) const

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -466,9 +466,11 @@ bool QgsCoordinateReferenceSystem::createFromOgcWmsCrs( const QString &crs )
   if ( wmsCrs.compare( QLatin1String( "CRS:84" ), Qt::CaseInsensitive ) == 0 ||
        wmsCrs.compare( QLatin1String( "OGC:CRS84" ), Qt::CaseInsensitive ) == 0 )
   {
-    createFromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
-    d->mAxisInverted = false;
-    d->mAxisInvertedDirty = false;
+    if ( loadFromDatabase( QgsApplication::srsDatabaseFilePath(), QStringLiteral( "lower(auth_name||':'||auth_id)" ), QStringLiteral( "epsg:4326" ) ) )
+    {
+      d->mAxisInverted = false;
+      d->mAxisInvertedDirty = false;
+    }
 
     locker.changeMode( QgsReadWriteLocker::Write );
     if ( !sDisableOgcCache )

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -665,7 +665,7 @@ bool QgsCoordinateReferenceSystem::loadFromDatabase( const QString &db, const QS
 
       {
         QgsProjUtils::proj_pj_unique_ptr crs( proj_create_from_database( QgsProjContext::get(), auth.toLatin1(), code.toLatin1(), PJ_CATEGORY_CRS, false, nullptr ) );
-        d->mPj = QgsProjUtils::crsToSingleCrs( crs.get() );
+        d->setPj( QgsProjUtils::crsToSingleCrs( crs.get() ) );
       }
 
       d->mIsValid = static_cast< bool >( d->mPj );
@@ -1498,7 +1498,7 @@ void QgsCoordinateReferenceSystem::setProjString( const QString &proj4String )
   PJ_CONTEXT *ctx = QgsProjContext::get();
 
   {
-    d->mPj.reset( proj_create( ctx, trimmed.toLatin1().constData() ) );
+    d->setPj( QgsProjUtils::proj_pj_unique_ptr( proj_create( ctx, trimmed.toLatin1().constData() ) ) );
   }
 
   if ( !d->mPj )
@@ -1552,7 +1552,7 @@ bool QgsCoordinateReferenceSystem::setWktString( const QString &wkt, bool allowP
   PROJ_STRING_LIST warnings = nullptr;
   PROJ_STRING_LIST grammerErrors = nullptr;
   {
-    d->mPj.reset( proj_create_from_wkt( QgsProjContext::get(), wkt.toLatin1().constData(), nullptr, &warnings, &grammerErrors ) );
+    d->setPj( QgsProjUtils::proj_pj_unique_ptr( proj_create_from_wkt( QgsProjContext::get(), wkt.toLatin1().constData(), nullptr, &warnings, &grammerErrors ) ) );
   }
 
   res = static_cast< bool >( d->mPj );
@@ -2456,7 +2456,7 @@ bool QgsCoordinateReferenceSystem::loadFromAuthCode( const QString &auth, const 
   getOperationAndEllipsoidFromProjString( proj4, operation, ellipsoid );
   d->mProjectionAcronym = operation;
   d->mEllipsoidAcronym.clear();
-  d->mPj = std::move( crs );
+  d->setPj( std::move( crs ) );
 
   const QString dbVals = sAuthIdToQgisSrsIdMap.value( QStringLiteral( "%1:%2" ).arg( auth, code ).toUpper() );
   QString srsId;

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -960,6 +960,8 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     QExplicitlySharedDataPointer<QgsCoordinateReferenceSystemPrivate> d;
 
+    QString mValidationHint;
+
 #if PROJ_VERSION_MAJOR>=6
     friend class QgsProjContext;
 

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -44,6 +44,10 @@ class QgsCoordinateReferenceSystemPrivate;
 #ifndef SIP_RUN
 struct PJconsts;
 typedef struct PJconsts PJ;
+
+struct projCtx_t;
+typedef struct projCtx_t PJ_CONTEXT;
+
 #endif
 #endif
 
@@ -960,7 +964,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     friend class QgsProjContext;
 
     // Only meant to be called by QgsProjContext::~QgsProjContext()
-    static void removeFromCacheObjectsBelongingToCurrentThread( void *pj_context );
+    static void removeFromCacheObjectsBelongingToCurrentThread( PJ_CONTEXT *pj_context );
 #endif
 
     //! Function for CRS validation. May be NULLPTR.

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -956,9 +956,15 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     QExplicitlySharedDataPointer<QgsCoordinateReferenceSystemPrivate> d;
 
+#if PROJ_VERSION_MAJOR>=6
+    friend class QgsProjContext;
+
+    // Only meant to be called by QgsProjContext::~QgsProjContext()
+    static void removeFromCacheObjectsBelongingToCurrentThread( void *pj_context );
+#endif
+
     //! Function for CRS validation. May be NULLPTR.
     static CUSTOM_CRS_VALIDATION sCustomSrsValidation;
-
 
     // cache
 

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -837,24 +837,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     static QString projFromSrsId( int srsId );
 
     /**
-     * Set the QGIS SrsId
-     *  \param srsId The internal sqlite3 srs.db primary key for this CRS
-     */
-    void setInternalId( long srsId );
-
-    /**
-     * Set the PostGIS srid
-     *  \param srid The PostGIS spatial_ref_sys key for this CRS
-     */
-    void setSrid( long srid );
-
-    /**
-     * Set the Description
-     * \param description A textual description of the CRS.
-     */
-    void setDescription( const QString &description );
-
-    /**
      * Set the Proj string.
      * \param projString Proj format specifies
      * (excluding proj and ellips) that define this CRS.
@@ -865,37 +847,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Set the WKT string
      */
     bool setWktString( const QString &wkt, bool allowProjFallback = true );
-
-    /**
-     * Set this Geographic? flag
-     * \param geoFlag Whether this is a geographic or projected coordinate system
-     */
-    void setGeographicFlag( bool geoFlag );
-
-    /**
-     * Set the EpsgCrsId identifier for this CRS
-     * \param epsg the EPSG identifier for this CRS (defaults to 0)
-     */
-    void setEpsg( long epsg );
-
-    /**
-     * Set the authority identifier for this CRS
-     * \param theID the authority identifier for this CRS (defaults to 0)
-     */
-    void setAuthId( const QString &theID );
-
-    /**
-     * Set the projection acronym
-     * \param projectionAcronym the acronym (must be a valid Proj projection acronym)
-     */
-    void setProjectionAcronym( const QString &projectionAcronym );
-
-    /**
-     * Set the ellipsoid acronym
-     * \param ellipsoidAcronym the acronym (must be a valid Proj ellipsoid acronym or
-     * authority:code identifier on Proj version 6+ builds)
-     */
-    void setEllipsoidAcronym( const QString &ellipsoidAcronym );
 
     /**
      * Print the description if debugging

--- a/src/core/qgscoordinatereferencesystem_p.h
+++ b/src/core/qgscoordinatereferencesystem_p.h
@@ -173,7 +173,6 @@ class QgsCoordinateReferenceSystemPrivate : public QSharedData
     OGRSpatialReferenceH mCRS;
 #endif
 
-    QString mValidationHint;
     mutable QString mProj4;
 
     //! True if presence of an inverted axis needs to be recalculated

--- a/src/core/qgsprojutils.cpp
+++ b/src/core/qgsprojutils.cpp
@@ -50,6 +50,7 @@ QgsProjContext::~QgsProjContext()
   // Call removeFromCacheObjectsBelongingToCurrentThread() before
   // destroying the context
   QgsCoordinateTransform::removeFromCacheObjectsBelongingToCurrentThread( mContext );
+  QgsCoordinateReferenceSystem::removeFromCacheObjectsBelongingToCurrentThread( mContext );
   proj_context_destroy( mContext );
 #else
   pj_ctx_free( mContext );

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1205,8 +1205,13 @@ void TestQgsCoordinateReferenceSystem::hasAxisInverted()
 
   crs.createFromOgcWmsCrs( QStringLiteral( "OGC:CRS84" ) ); // WGS 84 without inverted axes
   QVERIFY( !crs.hasAxisInverted() );
-  QCOMPARE( crs.toWkt(), QStringLiteral( R"""(GEOGCS["WGS 84 (CRS84)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["OGC","CRS84"]])""" ) );
+  QgsDebugMsg( crs.toWkt() );
 
+#if PROJ_VERSION_MAJOR>=6
+  QCOMPARE( crs.toWkt(), QStringLiteral( R"""(GEOGCS["WGS 84 (CRS84)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["OGC","CRS84"]])""" ) );
+#else
+  QCOMPARE( crs.toWkt(), QStringLiteral( R"""(GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]])""" ) );
+#endif
   crs.createFromOgcWmsCrs( QStringLiteral( "EPSG:32633" ) ); // "WGS 84 / UTM zone 33N" - projected CRS without invertex axes
   QVERIFY( !crs.hasAxisInverted() );
 }

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -863,6 +863,14 @@ void TestQgsCoordinateReferenceSystem::equality()
 {
   QgsCoordinateReferenceSystem myCrs( QStringLiteral( "EPSG:4326" ) );
   QgsCoordinateReferenceSystem myCrs2( QStringLiteral( "EPSG:4326" ) );
+  QgsCoordinateReferenceSystem myCrs3 = myCrs2;
+  QVERIFY( myCrs == myCrs2 );
+  QVERIFY( myCrs3 == myCrs2 );
+  QVERIFY( QgsCoordinateReferenceSystem() == QgsCoordinateReferenceSystem() );
+
+  // custom crs, no authid
+  myCrs.createFromWkt( QStringLiteral( "PROJCS[\"unnamed\",GEOGCS[\"unnamed\",DATUM[\"Geocentric_Datum_of_Australia_2020\",SPHEROID[\"GRS 80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",147],PARAMETER[\"scale_factor\",0.1996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]" ) );
+  myCrs2.createFromWkt( QStringLiteral( "PROJCS[\"unnamed\",GEOGCS[\"unnamed\",DATUM[\"Geocentric_Datum_of_Australia_2020\",SPHEROID[\"GRS 80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",147],PARAMETER[\"scale_factor\",0.1996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]" ) );
   QVERIFY( myCrs == myCrs2 );
 }
 void TestQgsCoordinateReferenceSystem::noEquality()
@@ -870,6 +878,14 @@ void TestQgsCoordinateReferenceSystem::noEquality()
   QgsCoordinateReferenceSystem myCrs( QStringLiteral( "EPSG:4326" ) );
   QgsCoordinateReferenceSystem myCrs2( QStringLiteral( "EPSG:4327" ) );
   QVERIFY( myCrs != myCrs2 );
+  QVERIFY( myCrs != QgsCoordinateReferenceSystem() );
+  QVERIFY( QgsCoordinateReferenceSystem() != myCrs );
+
+  // custom crs, no authid
+  myCrs.createFromWkt( QStringLiteral( "PROJCS[\"unnamed\",GEOGCS[\"unnamed\",DATUM[\"Geocentric_Datum_of_Australia_2020\",SPHEROID[\"GRS 80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",147],PARAMETER[\"scale_factor\",0.1996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]" ) );
+  myCrs2.createFromWkt( QStringLiteral( "PROJCS[\"unnamed\",GEOGCS[\"unnamed\",DATUM[\"Geocentric_Datum_of_Australia_2020\",SPHEROID[\"GRS 80\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",147],PARAMETER[\"scale_factor\",0.2996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]" ) );
+  QVERIFY( myCrs != myCrs2 );
+
 }
 
 void TestQgsCoordinateReferenceSystem::equalityInvalid()

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -1185,6 +1185,11 @@ void TestQgsCoordinateReferenceSystem::hasAxisInverted()
 
   crs.createFromOgcWmsCrs( QStringLiteral( "CRS:84" ) ); // WGS 84 without inverted axes
   QVERIFY( !crs.hasAxisInverted() );
+  QCOMPARE( crs.toWkt(), QStringLiteral( R"""(GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]])""" ) );
+
+  crs.createFromOgcWmsCrs( QStringLiteral( "OGC:CRS84" ) ); // WGS 84 without inverted axes
+  QVERIFY( !crs.hasAxisInverted() );
+  QCOMPARE( crs.toWkt(), QStringLiteral( R"""(GEOGCS["WGS 84 (CRS84)",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["OGC","CRS84"]])""" ) );
 
   crs.createFromOgcWmsCrs( QStringLiteral( "EPSG:32633" ) ); // "WGS 84 / UTM zone 33N" - projected CRS without invertex axes
   QVERIFY( !crs.hasAxisInverted() );

--- a/tests/src/gui/testqgsdatumtransformdialog.cpp
+++ b/tests/src/gui/testqgsdatumtransformdialog.cpp
@@ -85,8 +85,7 @@ void TestQgsDatumTransformDialog::defaultTransform()
   def = dlg2.defaultDatumTransform();
   QCOMPARE( def.sourceCrs.authid(), QStringLiteral( "EPSG:4326" ) );
   QCOMPARE( def.destinationCrs.authid(), QStringLiteral( "EPSG:26742" ) );
-  QCOMPARE( def.proj,  QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=push +v_3 +step +proj=cart +ellps=WGS84 +step +proj=helmert +x=8 +y=-159 +z=-175 +step +inv +proj=cart +ellps=clrk66 +step +proj=pop +v_3 +step +proj=lcc +lat_0=37.6666666666667 +lon_0=-122 +lat_1=39.8333333333333 +lat_2=38.3333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=unitconvert +xy_in=m +z_in=m +xy_out=us-ft +z_out=us-ft" ) );
-
+  QCOMPARE( def.proj,  QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=push +v_3 +step +proj=cart +ellps=WGS84 +step +proj=helmert +x=8 +y=-159 +z=-175 +step +inv +proj=cart +ellps=clrk66 +step +proj=pop +v_3 +step +proj=lcc +lat_0=37.6666666666667 +lon_0=-122 +lat_1=39.8333333333333 +lat_2=38.3333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=unitconvert +xy_in=m +xy_out=us-ft" ) );
 #else
   Q_NOWARN_DEPRECATED_PUSH
   QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );


### PR DESCRIPTION
Ensure PJ* objects are never reused across threads.

Fixes #33902
