### PR TITLE
Fix geos exceptions during labeling

### DIFF
--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2012,7 +2012,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   bool ddXPos = false, ddYPos = false;
   double quadOffsetX = 0.0, quadOffsetY = 0.0;
   double offsetX = 0.0, offsetY = 0.0;
-  QgsPointXY anchorPosition = geom.centroid().asPoint();
+  QgsPointXY anchorPosition;
 
   //x/y shift in case of alignment
   double xdiff = 0.0;
@@ -2033,6 +2033,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
       {
         quadOff = static_cast< QuadrantPosition >( quadInt );
         ddFixedQuad = true;
+        anchorPosition = geom.centroid().asPoint();
       }
     }
   }

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1957,7 +1957,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   {
     geom = QgsPalLabeling::prepareGeometry( geom, context, ct, doClip ? extentGeom : QgsGeometry(), mergeLines );
 
-    if ( geom.isNull() )
+    if ( geom.isEmpty() )
       return;
   }
   geos_geom_clone = QgsGeos::asGeos( geom );
@@ -3577,7 +3577,7 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
          || ( !qgsDoubleNear( m2p.mapRotation(), 0 ) && !clipGeometry.contains( geom ) ) ) )
   {
     QgsGeometry clipGeom = geom.intersection( clipGeometry ); // creates new geometry
-    if ( clipGeom.isNull() )
+    if ( clipGeom.isEmpty() )
     {
       return QgsGeometry();
     }

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -565,7 +565,7 @@ void TestQgsLabelingEngine::testSubstitutions()
 
   QgsVectorLayerLabelProvider *provider = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test" ), true, &settings );
   QgsFeature f( vl->fields(), 1 );
-  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 2 ) ) );
+  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( -100, 30 ) ) );
 
   // make a fake render context
   QSize size( 640, 480 );
@@ -598,7 +598,7 @@ void TestQgsLabelingEngine::testSubstitutions()
 void TestQgsLabelingEngine::testCapitalization()
 {
   QgsFeature f( vl->fields(), 1 );
-  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 2 ) ) );
+  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( -100, 30 ) ) );
 
   // make a fake render context
   QSize size( 640, 480 );
@@ -663,7 +663,7 @@ void TestQgsLabelingEngine::testCapitalization()
 void TestQgsLabelingEngine::testNumberFormat()
 {
   QgsFeature f( vl->fields(), 1 );
-  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 2 ) ) );
+  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( -100, 30 ) ) );
 
   // make a fake render context
   QSize size( 640, 480 );


### PR DESCRIPTION
Fixes #33931

@m-kuhn can you look over this? I've changed a commit you made which was forcing a centroid calculation for all features during labeling...