### PR TITLE
Disable "Replace theme" menu when a map theme is active

### DIFF
--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -202,6 +202,7 @@ void QgsMapThemes::menuAboutToShow()
   mMenu->insertActions( mMenuSeparator, mMenuPresetActions );
   mReplaceMenu->addActions( mMenuReplaceActions );
 
+  mReplaceMenu->setEnabled( !hasCurrent );
   mActionAddPreset->setEnabled( !hasCurrent );
   mActionRemoveCurrentPreset->setEnabled( hasCurrent );
 }


### PR DESCRIPTION
otherwise you end up with map themes of the same content