### PR TITLE
[feature] Allow renaming of the current map theme

### DIFF
--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -191,11 +191,11 @@ Removes an existing map theme from collection.
 .. versionadded:: 3.0
 %End
 
-    void renameMapTheme( const QString &name, const QString &newName );
+    bool renameMapTheme( const QString &name, const QString &newName );
 %Docstring
-Renames an existing map theme in the collection.
+Retuns whether a map theme is renamed.
 
-.. versionadded:: 3.14
+.. versionadded:: 3.12
 %End
 
     void clear();
@@ -337,7 +337,7 @@ Emitted when a map theme changes definition.
 %Docstring
 Emitted when a map theme within the collection is renamed.
 
-.. versionadded:: 3.14
+.. versionadded:: 3.12
 %End
 
     void projectChanged();

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -195,7 +195,7 @@ Removes an existing map theme from collection.
 %Docstring
 Renames an existing map theme in the collection.
 
-.. versionadded:: 3.12
+.. versionadded:: 3.14
 %End
 
     void clear();
@@ -337,7 +337,7 @@ Emitted when a map theme changes definition.
 %Docstring
 Emitted when a map theme within the collection is renamed.
 
-.. versionadded:: 3.12
+.. versionadded:: 3.14
 %End
 
     void projectChanged();

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -186,14 +186,21 @@ Updates a map theme within the collection.
 
     void removeMapTheme( const QString &name );
 %Docstring
-Remove an existing map theme from collection.
+Removes an existing map theme from collection.
 
 .. versionadded:: 3.0
 %End
 
+    void renameMapTheme( const QString &name, const QString &newName );
+%Docstring
+Renames an existing map theme in the collection.
+
+.. versionadded:: 3.12
+%End
+
     void clear();
 %Docstring
-Remove all map themes from the collection.
+Removes all map themes from the collection.
 %End
 
     QStringList mapThemes() const;
@@ -324,6 +331,13 @@ Emitted when map themes within the collection are changed.
 Emitted when a map theme changes definition.
 
 .. versionadded:: 3.0
+%End
+
+    void mapThemeRenamed( const QString &name, const QString &newName );
+%Docstring
+Emitted when a map theme within the collection is renamed.
+
+.. versionadded:: 3.12
 %End
 
     void projectChanged();

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -193,7 +193,8 @@ Removes an existing map theme from collection.
 
     bool renameMapTheme( const QString &name, const QString &newName );
 %Docstring
-Retuns whether a map theme is renamed.
+Renames the existing map theme called ``name`` to ``newName``.
+Returns ``True`` if the rename was successful, or ``False`` if it failed (e.g. due to a duplicate name for ``newName``).
 
 .. versionadded:: 3.12
 %End

--- a/python/core/auto_generated/qgsmapthemecollection.sip.in
+++ b/python/core/auto_generated/qgsmapthemecollection.sip.in
@@ -196,7 +196,7 @@ Removes an existing map theme from collection.
 Renames the existing map theme called ``name`` to ``newName``.
 Returns ``True`` if the rename was successful, or ``False`` if it failed (e.g. due to a duplicate name for ``newName``).
 
-.. versionadded:: 3.12
+.. versionadded:: 3.14
 %End
 
     void clear();
@@ -338,7 +338,7 @@ Emitted when a map theme changes definition.
 %Docstring
 Emitted when a map theme within the collection is renamed.
 
-.. versionadded:: 3.12
+.. versionadded:: 3.14
 %End
 
     void projectChanged();

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -103,6 +103,7 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   // Map Theme Menu
   mMapThemeMenu = new QMenu();
   connect( mMapThemeMenu, &QMenu::aboutToShow, this, &Qgs3DMapCanvasDockWidget::mapThemeMenuAboutToShow );
+  connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &Qgs3DMapCanvasDockWidget::currentMapThemeRenamed );
 
   mBtnMapThemes = new QToolButton();
   mBtnMapThemes->setAutoRaise( true );
@@ -343,4 +344,12 @@ void Qgs3DMapCanvasDockWidget::mapThemeMenuAboutToShow()
     mMapThemeMenuPresetActions.append( a );
   }
   mMapThemeMenu->addActions( mMapThemeMenuPresetActions );
+}
+
+void Qgs3DMapCanvasDockWidget::currentMapThemeRenamed( const QString &theme, const QString &newTheme )
+{
+  if ( theme == mCanvas->map()->terrainMapTheme() )
+  {
+    mCanvas->map()->setTerrainMapTheme( newTheme );
+  }
 }

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -65,6 +65,7 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     void onMainCanvasColorChanged();
     void onTotalPendingJobsCountChanged();
     void mapThemeMenuAboutToShow();
+    //! Renames the active map theme called \a theme to \a newTheme
     void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
 
   private:

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -65,6 +65,7 @@ class APP_EXPORT Qgs3DMapCanvasDockWidget : public QgsDockWidget
     void onMainCanvasColorChanged();
     void onTotalPendingJobsCountChanged();
     void mapThemeMenuAboutToShow();
+    void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
 
   private:
     Qgs3DMapCanvas *mCanvas = nullptr;

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -227,6 +227,8 @@ QgsMapCanvasDockWidget::QgsMapCanvasDockWidget( const QString &name, QWidget *pa
     if ( mSyncExtentRadio->isChecked() )
       syncViewCenter( mMainCanvas );
   } );
+
+  connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsMapCanvasDockWidget::currentMapThemeRenamed );
 }
 
 void QgsMapCanvasDockWidget::setMainCanvas( QgsMapCanvas *canvas )
@@ -439,6 +441,14 @@ void QgsMapCanvasDockWidget::menuAboutToShow()
     mMenuPresetActions.append( a );
   }
   mMenu->addActions( mMenuPresetActions );
+}
+
+void QgsMapCanvasDockWidget::currentMapThemeRenamed( const QString &theme, const QString &newTheme )
+{
+  if ( theme == mMapCanvas->theme() )
+  {
+    mMapCanvas->setTheme( newTheme );
+  }
 }
 
 void QgsMapCanvasDockWidget::settingsMenuAboutToShow()

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -157,6 +157,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     void mapExtentChanged();
     void mapCrsChanged();
     void menuAboutToShow();
+    //! Renames the active map theme called \a theme to \a newTheme
     void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
     void settingsMenuAboutToShow();
     void syncMarker( const QgsPointXY &p );

--- a/src/app/qgsmapcanvasdockwidget.h
+++ b/src/app/qgsmapcanvasdockwidget.h
@@ -157,6 +157,7 @@ class APP_EXPORT QgsMapCanvasDockWidget : public QgsDockWidget, private Ui::QgsM
     void mapExtentChanged();
     void mapCrsChanged();
     void menuAboutToShow();
+    void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
     void settingsMenuAboutToShow();
     void syncMarker( const QgsPointXY &p );
     void mapScaleChanged();

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -47,6 +47,7 @@ QgsMapThemes::QgsMapThemes()
 
   mReplaceMenu = new QMenu( tr( "Replace Theme" ) );
   mMenu->addMenu( mReplaceMenu );
+  mActionRenameCurrentPreset = mMenu->addAction( tr( "Rename Current Theme…" ), this, &QgsMapThemes::renameCurrentPreset );
   mActionAddPreset = mMenu->addAction( tr( "Add Theme…" ), this, [ = ] { addPreset(); } );
   mMenuSeparator = mMenu->addSeparator();
 
@@ -138,6 +139,32 @@ void QgsMapThemes::applyState( const QString &presetName )
   QgsProject::instance()->mapThemeCollection()->applyTheme( presetName, root, model );
 }
 
+void QgsMapThemes::renameCurrentPreset()
+{
+  QgsMapThemeCollection::MapThemeRecord mapTheme = currentState();
+  QStringList existingNames = QgsProject::instance()->mapThemeCollection()->mapThemes();
+
+  for ( QAction *actionPreset : qgis::as_const( mMenuPresetActions ) )
+  {
+    if ( actionPreset->isChecked() )
+    {
+      QgsNewNameDialog dlg(
+        tr( "theme" ),
+        tr( "%1" ).arg( actionPreset->text() ),
+        QStringList(), existingNames, QRegExp(), Qt::CaseInsensitive, mMenu );
+
+      dlg.setWindowTitle( tr( "Rename Map Theme" ) );
+      dlg.setHintString( tr( "Enter the new name of the map theme" ) );
+      dlg.setOverwriteEnabled( false );
+      dlg.setConflictingNameWarning( tr( "A theme with this name already exists." ) );
+      if ( dlg.exec() != QDialog::Accepted || dlg.name().isEmpty() )
+        return;
+
+      QgsProject::instance()->mapThemeCollection()->renameMapTheme( actionPreset->text(), dlg.name() );
+    }
+  }
+}
+
 void QgsMapThemes::removeCurrentPreset()
 {
   for ( QAction *actionPreset : qgis::as_const( mMenuPresetActions ) )
@@ -187,4 +214,5 @@ void QgsMapThemes::menuAboutToShow()
 
   mActionAddPreset->setEnabled( !hasCurrent );
   mActionRemoveCurrentPreset->setEnabled( hasCurrent );
+  mActionRenameCurrentPreset->setEnabled( hasCurrent );
 }

--- a/src/app/qgsmapthemes.h
+++ b/src/app/qgsmapthemes.h
@@ -65,6 +65,9 @@ class APP_EXPORT QgsMapThemes : public QObject
     //! Handles removal of current preset from the project's collection
     void removeCurrentPreset();
 
+    //! Handles renaming of the current map theme
+    void renameCurrentPreset();
+
     //! Handles creation of preset menu
     void menuAboutToShow();
 
@@ -91,6 +94,7 @@ class APP_EXPORT QgsMapThemes : public QObject
     QAction *mMenuSeparator = nullptr;
     QAction *mActionAddPreset = nullptr;
     QAction *mActionRemoveCurrentPreset = nullptr;
+    QAction *mActionRenameCurrentPreset = nullptr;
     QList<QAction *> mMenuPresetActions;
     QList<QAction *> mMenuReplaceActions;
 };

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1778,6 +1778,17 @@ void QgsLayoutItemMap::mapThemeChanged( const QString &theme )
     mCachedLayerStyleOverridesPresetName.clear(); // force cache regeneration at next redraw
 }
 
+void QgsLayoutItemMap::currentMapThemeRenamed( const QString &theme, const QString &newTheme )
+{
+  if ( mFollowVisibilityPreset )
+  {
+    if ( theme == mFollowVisibilityPresetName )
+    {
+      mFollowVisibilityPresetName = newTheme;
+    }
+  }
+}
+
 void QgsLayoutItemMap::connectUpdateSlot()
 {
   //connect signal from layer registry to update in case of new or deleted layers
@@ -1820,6 +1831,7 @@ void QgsLayoutItemMap::connectUpdateSlot()
   } );
 
   connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, &QgsLayoutItemMap::mapThemeChanged );
+  connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsLayoutItemMap::currentMapThemeRenamed );
 }
 
 QTransform QgsLayoutItemMap::layoutToMapCoordsTransform() const

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1780,12 +1780,9 @@ void QgsLayoutItemMap::mapThemeChanged( const QString &theme )
 
 void QgsLayoutItemMap::currentMapThemeRenamed( const QString &theme, const QString &newTheme )
 {
-  if ( mFollowVisibilityPreset )
+  if ( theme == mFollowVisibilityPresetName )
   {
-    if ( theme == mFollowVisibilityPresetName )
-    {
-      mFollowVisibilityPresetName = newTheme;
-    }
+    mFollowVisibilityPresetName = newTheme;
   }
 }
 

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -622,7 +622,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
 
     void mapThemeChanged( const QString &theme );
 
-    //! Applies current visibility presets to the renamed map theme
+    //! Renames the active map theme called \a theme to \a newTheme
     void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
 
     //! Create cache image

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -622,6 +622,9 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
 
     void mapThemeChanged( const QString &theme );
 
+    //! Applies current visibility presets to the renamed map theme
+    void currentMapThemeRenamed( const QString &theme, const QString &newTheme );
+
     //! Create cache image
     void recreateCachedImageInBackground();
 

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -281,6 +281,19 @@ void QgsMapThemeCollection::update( const QString &name, const MapThemeRecord &s
   emit mapThemesChanged();
 }
 
+
+void QgsMapThemeCollection::renameMapTheme( const QString &name,  const QString &newName ) //, const MapThemeRecord &state )
+{
+  if ( !mMapThemes.contains( name ) || mMapThemes.contains( newName ) )
+    return;
+
+  const MapThemeRecord state = mMapThemes[name];
+  const MapThemeRecord newState = state;
+  insert( newName, newState );
+  emit mapThemeRenamed( name, newName );
+  removeMapTheme( name );
+}
+
 void QgsMapThemeCollection::removeMapTheme( const QString &name )
 {
   if ( !mMapThemes.contains( name ) )

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -281,17 +281,17 @@ void QgsMapThemeCollection::update( const QString &name, const MapThemeRecord &s
   emit mapThemesChanged();
 }
 
-
-void QgsMapThemeCollection::renameMapTheme( const QString &name,  const QString &newName ) //, const MapThemeRecord &state )
+bool QgsMapThemeCollection::renameMapTheme( const QString &name,  const QString &newName )
 {
   if ( !mMapThemes.contains( name ) || mMapThemes.contains( newName ) )
-    return;
+    return false;
 
   const MapThemeRecord state = mMapThemes[name];
   const MapThemeRecord newState = state;
   insert( newName, newState );
   emit mapThemeRenamed( name, newName );
   removeMapTheme( name );
+  return true;
 }
 
 void QgsMapThemeCollection::removeMapTheme( const QString &name )

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -264,7 +264,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
     /**
      * Renames an existing map theme in the collection.
-     * \since QGIS 3.12
+     * \since QGIS 3.14
      */
     void renameMapTheme( const QString &name, const QString &newName );
 
@@ -381,7 +381,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
     /**
      * Emitted when a map theme within the collection is renamed.
-     * \since QGIS 3.12
+     * \since QGIS 3.14
      */
     void mapThemeRenamed( const QString &name, const QString &newName );
 

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -263,7 +263,8 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
     void removeMapTheme( const QString &name );
 
     /**
-     * Retuns whether a map theme is renamed.
+     * Renames the existing map theme called \a name to \a newName.
+     * Returns TRUE if the rename was successful, or FALSE if it failed (e.g. due to a duplicate name for \a newName).
      * \since QGIS 3.12
      */
     bool renameMapTheme( const QString &name, const QString &newName );

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -265,7 +265,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
     /**
      * Renames the existing map theme called \a name to \a newName.
      * Returns TRUE if the rename was successful, or FALSE if it failed (e.g. due to a duplicate name for \a newName).
-     * \since QGIS 3.12
+     * \since QGIS 3.14
      */
     bool renameMapTheme( const QString &name, const QString &newName );
 
@@ -382,7 +382,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
     /**
      * Emitted when a map theme within the collection is renamed.
-     * \since QGIS 3.12
+     * \since QGIS 3.14
      */
     void mapThemeRenamed( const QString &name, const QString &newName );
 

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -257,12 +257,18 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
     void update( const QString &name, const QgsMapThemeCollection::MapThemeRecord &state );
 
     /**
-     * Remove an existing map theme from collection.
+     * Removes an existing map theme from collection.
      * \since QGIS 3.0
      */
     void removeMapTheme( const QString &name );
 
-    //! Remove all map themes from the collection.
+    /**
+     * Renames an existing map theme in the collection.
+     * \since QGIS 3.12
+     */
+    void renameMapTheme( const QString &name, const QString &newName );
+
+    //! Removes all map themes from the collection.
     void clear();
 
     /**
@@ -372,6 +378,12 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
      * \since QGIS 3.0
      */
     void mapThemeChanged( const QString &theme );
+
+    /**
+     * Emitted when a map theme within the collection is renamed.
+     * \since QGIS 3.12
+     */
+    void mapThemeRenamed( const QString &name, const QString &newName );
 
     /**
      * Emitted when the project changes

--- a/src/core/qgsmapthemecollection.h
+++ b/src/core/qgsmapthemecollection.h
@@ -263,10 +263,10 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
     void removeMapTheme( const QString &name );
 
     /**
-     * Renames an existing map theme in the collection.
-     * \since QGIS 3.14
+     * Retuns whether a map theme is renamed.
+     * \since QGIS 3.12
      */
-    void renameMapTheme( const QString &name, const QString &newName );
+    bool renameMapTheme( const QString &name, const QString &newName );
 
     //! Removes all map themes from the collection.
     void clear();
@@ -381,7 +381,7 @@ class CORE_EXPORT QgsMapThemeCollection : public QObject
 
     /**
      * Emitted when a map theme within the collection is renamed.
-     * \since QGIS 3.14
+     * \since QGIS 3.12
      */
     void mapThemeRenamed( const QString &name, const QString &newName );
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -138,6 +138,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
            this, &QgsMapCanvas::writeProject );
 
   connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, &QgsMapCanvas::mapThemeChanged );
+  connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemeRenamed, this, &QgsMapCanvas::mapThemeRenamed );
   connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemesChanged, this, &QgsMapCanvas::projectThemesChanged );
 
   mSettings.setFlag( QgsMapSettings::DrawEditingInfo );
@@ -608,6 +609,17 @@ void QgsMapCanvas::mapThemeChanged( const QString &theme )
     clearCache();
     refresh();
   }
+}
+
+void QgsMapCanvas::mapThemeRenamed( const QString &theme, const QString &newTheme )
+{
+  if ( mTheme.isEmpty() || theme != mTheme )
+  {
+    return;
+  }
+
+  setTheme( newTheme );
+  refresh();
 }
 
 void QgsMapCanvas::rendererJobFinished()

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -827,6 +827,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void refreshMap();
 
     void mapThemeChanged( const QString &theme );
+    //! Renames the active map theme called \a theme to \a newTheme
     void mapThemeRenamed( const QString &theme, const QString &newTheme );
 
   signals:

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -827,6 +827,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void refreshMap();
 
     void mapThemeChanged( const QString &theme );
+    void mapThemeRenamed( const QString &theme, const QString &newTheme );
 
   signals:
 

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -331,6 +331,24 @@ class TestQgsMapCanvas(unittest.TestCase):
         # should be different - we should now render project layers
         self.assertFalse(self.canvasImageCheck('theme4', 'theme4', canvas))
 
+        # set canvas to theme1
+        canvas.setTheme('theme1')
+        canvas.refresh()
+        canvas.waitWhileRendering()
+        self.assertEqual(canvas.theme(), 'theme1')
+        themeLayers = theme1.layerRecords()
+        # rename the active theme
+        QgsProject.instance().mapThemeCollection().renameMapTheme('theme1', 'theme5')
+        # canvas theme should now be set to theme5
+        canvas.refresh()
+        canvas.waitWhileRendering()
+        self.assertEqual(canvas.theme(), 'theme5')
+        # theme5 should render as theme1
+        theme5 = QgsProject.instance().mapThemeCollection().mapThemeState('theme5')
+        theme5Layers = theme5.layerRecords()
+        self.assertEqual(themeLayers, theme5Layers, 'themes are different')
+        #self.assertTrue(self.canvasImageCheck('theme5', 'theme5', canvas))
+
     def canvasImageCheck(self, name, reference_image, canvas):
         self.report += "<h2>Render {}</h2>\n".format(name)
         temp_dir = QDir.tempPath() + '/'


### PR DESCRIPTION
This is an early PR to add ability to rename map theme from the map theme drop-down menu (fixes #26563).
I can't say that the code is the cleanest you could have since there are some coding basis I do not have (and I expect it gets improved before merge) but from a user point of view the feature works. 

![renametheme](https://user-images.githubusercontent.com/7983394/78195435-e29f9800-747f-11ea-95d2-604be58cf229.gif)

