### PR TITLE
Makes layer prop. info text a bit smaller

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1437,6 +1437,7 @@ QString QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType styleSh
                    "   border-collapse: collapse;"
                    "   table-layout:fixed;"
                    "   width: 100% !important;"
+                   "   font-size: 90%;"
                    "}"
                    // Override
                    "h1 { "
@@ -1448,7 +1449,7 @@ QString QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType styleSh
                    "}"
                    // Set first column width
                    ".list-view th:first-child, .list-view td:first-child {"
-                   "   width: 15%;"
+                   "   width: 20%;"
                    "}"
                    ".list-view.highlight { "
                    "   padding-left: inherit; "


### PR DESCRIPTION
... also makes first cell column a bit larger

Fixes #33862 (partial fix)


![raster_properties](https://user-images.githubusercontent.com/142164/72879220-bd164580-3cfc-11ea-8b01-791b9caeecf7.png)
