### PR TITLE
Modified layer prop. info text a bit smaller and first cell column a bit larger.

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1436,7 +1436,7 @@ QString QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType styleSh
                    "table.tabular-view, table.list-view { "
                    "   border-collapse: collapse;"
                    "   table-layout:fixed;"
-                   "   width: 100% !important;"
+                   "   width: 75% !important;"
                    "}"
                    // Override
                    "h1 { "
@@ -1448,7 +1448,7 @@ QString QgsApplication::reportStyleSheet( QgsApplication::StyleSheetType styleSh
                    "}"
                    // Set first column width
                    ".list-view th:first-child, .list-view td:first-child {"
-                   "   width: 15%;"
+                   "   width: 25%;"
                    "}"
                    ".list-view.highlight { "
                    "   padding-left: inherit; "


### PR DESCRIPTION
Modified layer prop. info text a bit smaller and first cell column a bit larger.

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->
I am new to this project even this is my first open source contribution but I know that whats the issue and how to fix it.
Issue #33955:
Makes layer prop. info text a bit smaller.
Issue #48996:
Makes layer prop. info text a bit smaller and first cell column a bit larger.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
