### PR TITLE
Update qgsprojectionselectorbase.ui

### DIFF
--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -42,7 +42,7 @@
       <string>Use this option to treat all coordinates as Cartesian coordinates in an unknown reference system.</string>
      </property>
      <property name="text">
-      <string>No projection (or unknown/non-Earth projection)</string>
+      <string>No CRS (or unknown/non-Earth projection)</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
I think that "No projection" could lead to misunderstandings. 

This flag disable the reprojection of qgis while "projection" in geomatics is a term used to define the operation done to reduce the surface of a three-dimensional planet to a flat map.

