### PR TITLE
Avoid segfaults in providerconnectionbase test

### DIFF
--- a/tests/src/python/test_qgsproviderconnection_base.py
+++ b/tests/src/python/test_qgsproviderconnection_base.py
@@ -145,7 +145,8 @@ class TestPyQgsProviderConnectionBase():
             self.assertEqual(table_property.tableName(), 'myNewTable')
             self.assertEqual(table_property.geometryColumnCount(), 1)
             self.assertEqual(table_property.geometryColumnTypes()[0].wkbType, QgsWkbTypes.LineString)
-            self.assertEqual(table_property.geometryColumnTypes()[0].crs, QgsCoordinateReferenceSystem.fromEpsgId(3857))
+            cols = table_property.geometryColumnTypes()
+            self.assertEqual(cols[0].crs, QgsCoordinateReferenceSystem.fromEpsgId(3857))
             self.assertEqual(table_property.defaultName(), 'myNewTable')
 
             # Check aspatial tables
@@ -158,8 +159,9 @@ class TestPyQgsProviderConnectionBase():
             self.assertEqual(table_property.geometryColumnCount(), 0)
             self.assertEqual(table_property.geometryColumn(), '')
             self.assertEqual(table_property.defaultName(), 'myNewAspatialTable')
-            self.assertEqual(table_property.geometryColumnTypes()[0].wkbType, QgsWkbTypes.NoGeometry)
-            self.assertFalse(table_property.geometryColumnTypes()[0].crs.isValid())
+            cols = table_property.geometryColumnTypes()
+            self.assertEqual(cols[0].wkbType, QgsWkbTypes.NoGeometry)
+            self.assertFalse(cols[0].crs.isValid())
             self.assertFalse(table_property.flags() & QgsAbstractDatabaseProviderConnection.Raster)
             self.assertFalse(table_property.flags() & QgsAbstractDatabaseProviderConnection.Vector)
             self.assertTrue(table_property.flags() & QgsAbstractDatabaseProviderConnection.Aspatial)


### PR DESCRIPTION
Seems like on some python/sip versions the column definitions are going out of scope early, so store a reference to them so that python won't clean them up till we are actually done with them
