### PR TITLE
Make DXF export non-dd quadrant based labeling

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -1262,6 +1262,7 @@ void QgsDxfExport::writeLine( const QgsPoint &pt1, const QgsPoint &pt2, const QS
 
 void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::LabelPosition *label, const QgsPalLayerSettings &layerSettings, const QgsExpressionContext &expressionContext )
 {
+
   double lblX = label->getX();
   double lblY = label->getY();
 
@@ -1272,59 +1273,64 @@ void QgsDxfExport::writeText( const QString &layer, const QString &text, pal::La
 
   const QgsPropertyCollection &props = layerSettings.dataDefinedProperties();
 
-  if ( props.isActive( QgsPalLayerSettings::OffsetQuad ) )
+  if ( layerSettings.placement == QgsPalLayerSettings::Placement::OverPoint )
   {
     lblX = labelFeature->anchorPosition().x();
     lblY = labelFeature->anchorPosition().y();
 
-    const QVariant exprVal = props.value( QgsPalLayerSettings::OffsetQuad, expressionContext );
-    if ( exprVal.isValid() )
-    {
-      int offsetQuad = exprVal.toInt();
+    QgsPalLayerSettings::QuadrantPosition offsetQuad = layerSettings.quadOffset;
 
-      switch ( offsetQuad )
+    if ( props.isActive( QgsPalLayerSettings::OffsetQuad ) )
+    {
+      const QVariant exprVal = props.value( QgsPalLayerSettings::OffsetQuad, expressionContext );
+      if ( exprVal.isValid() )
       {
-        case 0: // Above Left
-          hali = HAlign::HRight;
-          vali = VAlign::VBottom;
-          break;
-        case 1: // Above
-          hali = HAlign::HCenter;
-          vali = VAlign::VBottom;
-          break;
-        case 2: // Above Right
-          hali = HAlign::HLeft;
-          vali = VAlign::VBottom;
-          break;
-        case 3: // Left
-          hali = HAlign::HRight;
-          vali = VAlign::VMiddle;
-          break;
-        case 4: // Over
-          hali = HAlign::HCenter;
-          vali = VAlign::VMiddle;
-          break;
-        case 5: // Right
-          hali = HAlign::HLeft;
-          vali = VAlign::VMiddle;
-          break;
-        case 6: // Below Left
-          hali = HAlign::HRight;
-          vali = VAlign::VTop;
-          break;
-        case 7: // Below
-          hali = HAlign::HCenter;
-          vali = VAlign::VTop;
-          break;
-        case 8: // Below Right
-          hali = HAlign::HLeft;
-          vali = VAlign::VTop;
-          break;
-        default: // OverHali
-          hali = HAlign::HCenter;
-          vali = VAlign::VTop;
-          break;
+        offsetQuad = static_cast<QgsPalLayerSettings::QuadrantPosition>( exprVal.toInt() );
       }
+    }
+
+    switch ( offsetQuad )
+    {
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantAboveLeft:
+        hali = HAlign::HRight;
+        vali = VAlign::VBottom;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantAbove:
+        hali = HAlign::HCenter;
+        vali = VAlign::VBottom;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantAboveRight:
+        hali = HAlign::HLeft;
+        vali = VAlign::VBottom;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantLeft:
+        hali = HAlign::HRight;
+        vali = VAlign::VMiddle;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantOver:
+        hali = HAlign::HCenter;
+        vali = VAlign::VMiddle;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantRight:
+        hali = HAlign::HLeft;
+        vali = VAlign::VMiddle;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantBelowLeft:
+        hali = HAlign::HRight;
+        vali = VAlign::VTop;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantBelow:
+        hali = HAlign::HCenter;
+        vali = VAlign::VTop;
+        break;
+      case QgsPalLayerSettings::QuadrantPosition::QuadrantBelowRight:
+        hali = HAlign::HLeft;
+        vali = VAlign::VTop;
+        break;
+      default: // OverHali
+        hali = HAlign::HCenter;
+        vali = VAlign::VTop;
+        break;
     }
   }
 

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -1957,7 +1957,7 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   {
     geom = QgsPalLabeling::prepareGeometry( geom, context, ct, doClip ? extentGeom : QgsGeometry(), mergeLines );
 
-    if ( geom.isNull() )
+    if ( geom.isEmpty() )
       return;
   }
   geos_geom_clone = QgsGeos::asGeos( geom );
@@ -3577,7 +3577,7 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
          || ( !qgsDoubleNear( m2p.mapRotation(), 0 ) && !clipGeometry.contains( geom ) ) ) )
   {
     QgsGeometry clipGeom = geom.intersection( clipGeometry ); // creates new geometry
-    if ( clipGeom.isNull() )
+    if ( clipGeom.isEmpty() )
     {
       return QgsGeometry();
     }

--- a/src/core/labeling/qgspallabeling.cpp
+++ b/src/core/labeling/qgspallabeling.cpp
@@ -2012,8 +2012,12 @@ void QgsPalLayerSettings::registerFeature( const QgsFeature &f, QgsRenderContext
   bool ddXPos = false, ddYPos = false;
   double quadOffsetX = 0.0, quadOffsetY = 0.0;
   double offsetX = 0.0, offsetY = 0.0;
-  QgsPointXY anchorPosition = geom.centroid().asPoint();
+  QgsPointXY anchorPosition;
 
+  if ( placement == QgsPalLayerSettings::OverPoint )
+  {
+    anchorPosition = geom.centroid().asPoint();
+  }
   //x/y shift in case of alignment
   double xdiff = 0.0;
   double ydiff = 0.0;

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -698,6 +698,7 @@ void TestQgsDxfExport::testTextQuadrant()
 
   QgsPalLayerSettings settings;
   settings.fieldName = QStringLiteral( "text" );
+  settings.placement = QgsPalLayerSettings::Placement::OverPoint;
 
   QgsPropertyCollection props = settings.dataDefinedProperties();
   QgsProperty offsetQuadProp = QgsProperty();

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -565,7 +565,7 @@ void TestQgsLabelingEngine::testSubstitutions()
 
   QgsVectorLayerLabelProvider *provider = new QgsVectorLayerLabelProvider( vl, QStringLiteral( "test" ), true, &settings );
   QgsFeature f( vl->fields(), 1 );
-  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 2 ) ) );
+  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( -100, 30 ) ) );
 
   // make a fake render context
   QSize size( 640, 480 );
@@ -598,7 +598,7 @@ void TestQgsLabelingEngine::testSubstitutions()
 void TestQgsLabelingEngine::testCapitalization()
 {
   QgsFeature f( vl->fields(), 1 );
-  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 2 ) ) );
+  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( -100, 30 ) ) );
 
   // make a fake render context
   QSize size( 640, 480 );
@@ -663,7 +663,7 @@ void TestQgsLabelingEngine::testCapitalization()
 void TestQgsLabelingEngine::testNumberFormat()
 {
   QgsFeature f( vl->fields(), 1 );
-  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 2 ) ) );
+  f.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( -100, 30 ) ) );
 
   // make a fake render context
   QSize size( 640, 480 );


### PR DESCRIPTION
The DXF export currently only takes quadrants into account when they are datadefined (and if datadefined quadrants are configured does not even check if quadrant placement "OverPoint" is activated).
This should match the core PAL behavior now.

Replaces #33944 

Fixes #33931