### PR TITLE
remove duplicate F7 shortcut used to open styling dock (fix #26696, #26697)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4522,7 +4522,6 @@ void QgisApp::initLayerTreeView()
   mActionStyleDock = new QAction( tr( "Layer Styling" ), this );
   mActionStyleDock->setCheckable( true );
   mActionStyleDock->setToolTip( tr( "Open the Layer Styling panel" ) );
-  mActionStyleDock->setShortcut( QStringLiteral( "F7" ) );
   mActionStyleDock->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ) );
   connect( mActionStyleDock, &QAction::toggled, this, &QgisApp::mapStyleDock );
 


### PR DESCRIPTION
## Description
Styling dock can be opened using global `Ctrl+3` shortcut and using `F7` shortcut which works only when Layer tree is visible. This PR removes duplicate F7 shortcut.

Fixes #26696 and #26697.

Not sure about backport to 3.10, probably for LTR better to keep both shortcuts and avoid documentation changes.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
