### PR TITLE
Update cdash parse_dash_results to new API

### DIFF
--- a/scripts/parse_dash_results.py
+++ b/scripts/parse_dash_results.py
@@ -366,11 +366,17 @@ class ResultHandler(QDialog):
 def main():
     app = QApplication(sys.argv)
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('dash_url')
-    args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+            description='''A tool to automatically update test images masks based on results submitted to cdash.
 
-    w = ResultHandler()
+            Will take local control images and rendered images on cdash to create a mask.
+            When using it, make sure that the new masks will only mask regions on the image that indeed allow for variation
+            and do not completely void any tests.
+            ''')
+    parser.add_argument('dash_url', help='URL to a dash result with images. E.g. https://cdash.orfeo-toolbox.org/testDetails.php?test=15052561&build=27712'))
+    args=parser.parse_args()
+
+    w=ResultHandler()
     w.parse_url(args.dash_url)
     w.exec_()
 

--- a/scripts/parse_dash_results.py
+++ b/scripts/parse_dash_results.py
@@ -367,11 +367,15 @@ def main():
     app = QApplication(sys.argv)
 
     parser = argparse.ArgumentParser(
-            description='''A tool to automatically update test images masks based on results submitted to cdash.
+            description='''A tool to automatically update test image masks based on results submitted to cdash.
 
-            Will take local control images and rendered images on cdash to create a mask.
-            When using it, make sure that the new masks will only mask regions on the image that indeed allow for variation
-            and do not completely void any tests.
+            It will take local control images from the QGIS source and rendered images from test results
+            on cdash to create a mask.
+
+            When using it, carefully check, that the rendered images from the test results are acceptable and
+            that the new masks will only mask regions on the image that indeed allow for variation.
+
+            If the resulting mask is too tolerant, consider adding a new control image next to the existing one.
             ''')
     parser.add_argument('dash_url', help='URL to a dash result with images. E.g. https://cdash.orfeo-toolbox.org/testDetails.php?test=15052561&build=27712'))
     args=parser.parse_args()


### PR DESCRIPTION
CDash has completely changed to a new API based on JSON, the old http interface is no longer working (as far as I know).

This updates to the new API.

The layout of the dialog seems to be also broken, but that's a different task.

I also added some help texts to hopefully make it easier to use.

# Documentation update

Refer to this in the unit test section of the developers manual. For starters it would be good to even point to the pure existence of this tool (in your local qgis source code: `./scripts/parse_dash_results.py`) to update test images if travis fails with slight image errors.

Just a sentence like the following would be good to start.

> If travis reports errors for new images which are leftovers of antialiasing or font differences, there is a tool `./scripts/parse_dash_results.py [url]` that helps to update local test masks.