### PR TITLE
Fix issue #33488 Memory layer - Delete field and re-use its name 

### DIFF
--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
@@ -154,7 +154,7 @@ QVariantMap QgsJoinByAttributeAlgorithm::processAlgorithm( const QVariantMap &pa
   {
     for ( int i = 0; i < outFields2.count(); ++i )
     {
-      outFields2[ i ].setName( prefix + outFields2[ i ].name() );
+      outFields2.rename( i, prefix + outFields2[ i ].name() );
     }
   }
 

--- a/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbylocation.cpp
@@ -159,7 +159,7 @@ QVariantMap QgsJoinByLocationAlgorithm::processAlgorithm( const QVariantMap &par
   {
     for ( int i = 0; i < joinFields.count(); ++i )
     {
-      joinFields[ i ].setName( prefix + joinFields[ i ].name() );
+      joinFields.rename( i, prefix + joinFields[ i ].name() );
     }
   }
 

--- a/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbynearest.cpp
@@ -160,7 +160,7 @@ QVariantMap QgsJoinByNearestAlgorithm::processAlgorithm( const QVariantMap &para
   {
     for ( int i = 0; i < outFields2.count(); ++i )
     {
-      outFields2[ i ].setName( prefix + outFields2[ i ].name() );
+      outFields2.rename( i, prefix + outFields2[ i ].name() );
     }
   }
 

--- a/src/analysis/processing/qgsalgorithmrenametablefield.cpp
+++ b/src/analysis/processing/qgsalgorithmrenametablefield.cpp
@@ -90,7 +90,7 @@ QgsFields QgsRenameTableFieldAlgorithm::outputFields( const QgsFields &inputFiel
   if ( outFields.lookupField( mNewName ) >= 0 )
     throw QgsProcessingException( QObject::tr( "A field already exists with the name %1" ).arg( mNewName ) );
 
-  outFields[ index ].setName( mNewName );
+  outFields.rename( index, mNewName );
   return outFields;
 }
 

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -512,7 +512,7 @@ bool QgsMemoryProvider::renameAttributes( const QgsFieldNameMap &renamedAttribut
       continue;
     }
 
-    mFields[ fieldIndex ].setName( renameIt.value() );
+    mFields.rename( fieldIndex, renameIt.value() );
   }
   return result;
 }

--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -276,7 +276,7 @@ QgsVectorLayerExporter::exportLayer( QgsVectorLayer *layer,
     // convert field names to lowercase
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
-      fields[fldIdx].setName( fields.at( fldIdx ).name().toLower() );
+      fields.rename( fldIdx, fields.at( fldIdx ).name().toLower() );
     }
   }
 


### PR DESCRIPTION
## Description

Use QgsFields::rename member function in QgsMemoryProvider::renameAttributes instead of renaming manually.

The fields attribute of QgsMemoryProvider was corrupted when the changes were committed by QgsVectorLayerEditBuffer::commitChanges. 

The crash occured when a new attribute was added with the old name of an attribute that had been renamed previously. Although the field name had been properly renamed, the internal nameToIndex data structure of the field kept the old name in memory.

Fixes #33488

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
