### PR TITLE
Fixes crash when displaying relation editor

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencewidget.sip.in
@@ -77,6 +77,14 @@ Returns the related feature foreign keys
 %End
 
     void setEditorContext( const QgsAttributeEditorContext &context, QgsMapCanvas *canvas, QgsMessageBar *messageBar );
+%Docstring
+Sets the editor ``context``
+
+.. note::
+
+   if context cadDockWidget is null, it won't be possible to digitize
+   the geometry of a referenced feature from this widget
+%End
 
     bool embedForm();
 %Docstring

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -74,6 +74,11 @@ Sets the ``feature`` being edited and updates the UI unless ``update`` is set to
     void setEditorContext( const QgsAttributeEditorContext &context );
 %Docstring
 Sets the editor ``context``
+
+.. note::
+
+   if context cadDockWidget is null, it won't be possible to digitize
+   the geometry of a referencing feature from this widget
 %End
 
     QgsIFeatureSelectionManager *featureSelectionManager();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9275,7 +9275,7 @@ void QgisApp::modifyAttributesOfSelectedFeatures()
 
   //dummy feature
   QgsFeature f;
-  QgsAttributeEditorContext context;
+  QgsAttributeEditorContext context( createAttributeEditorContext() );
   context.setAllowCustomUi( false );
   context.setVectorLayerTools( mVectorLayerTools );
   context.setCadDockWidget( mAdvancedDigitizingDockWidget );
@@ -15556,4 +15556,14 @@ void QgisApp::triggerCrashHandler()
 #ifdef Q_OS_WIN
   RaiseException( 0x12345678, 0, 0, nullptr );
 #endif
+}
+
+QgsAttributeEditorContext QgisApp::createAttributeEditorContext()
+{
+  QgsAttributeEditorContext context;
+  context.setVectorLayerTools( vectorLayerTools() );
+  context.setMapCanvas( mapCanvas() );
+  context.setCadDockWidget( cadDockWidget() );
+  context.setMainMessageBar( messageBar() );
+  return context;
 }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1108,6 +1108,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Create a new spatial bookmark
     void newBookmark( bool inProject = false );
 
+    /**
+     * Creates a default attribute editor context using the main map canvas and the main edit tools and message bar
+     * \since QGIS 3.12
+     */
+    QgsAttributeEditorContext createAttributeEditorContext();
+
   protected:
 
     //! Handle state changes (WindowTitleChange)

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -755,12 +755,8 @@ QgsAttributeDialog *QgisAppInterface::getFeatureForm( QgsVectorLayer *l, QgsFeat
   myDa.setSourceCrs( l->crs(), QgsProject::instance()->transformContext() );
   myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
 
-  QgsAttributeEditorContext context;
+  QgsAttributeEditorContext context( QgisApp::instance()->createAttributeEditorContext() );
   context.setDistanceArea( myDa );
-  context.setVectorLayerTools( qgis->vectorLayerTools() );
-  context.setMapCanvas( qgis->mapCanvas() );
-  context.setCadDockWidget( qgis->cadDockWidget() );
-  context.setMainMessageBar( qgis->messageBar() );
   QgsAttributeDialog *dialog = new QgsAttributeDialog( l, &feature, false, qgis, true, context );
   if ( !feature.isValid() )
   {

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -150,12 +150,9 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   QgsDistanceArea da;
   da.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
   da.setEllipsoid( QgsProject::instance()->ellipsoid() );
-  mEditorContext.setDistanceArea( da );
 
-  mEditorContext.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
-  mEditorContext.setMapCanvas( QgisApp::instance()->mapCanvas() );
-  mEditorContext.setMainMessageBar( QgisApp::instance()->messageBar() );
-  mEditorContext.setCadDockWidget( QgisApp::instance()->cadDockWidget() );
+  QgsAttributeEditorContext editorContext = QgisApp::instance()->createAttributeEditorContext();
+  editorContext.setDistanceArea( da );
 
   QgsFeatureRequest r;
   bool needsGeom = false;
@@ -175,12 +172,12 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
     r.setFlags( QgsFeatureRequest::NoGeometry );
 
   // Initialize dual view
-  mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), r, mEditorContext, false );
+  mMainView->init( mLayer, QgisApp::instance()->mapCanvas(), r, editorContext, false );
 
   QgsAttributeTableConfig config = mLayer->attributeTableConfig();
   mMainView->setAttributeTableConfig( config );
 
-  mFeatureFilterWidget->init( mLayer, mEditorContext, mMainView, QgisApp::instance()->messageBar(), QgisApp::instance()->messageTimeout() );
+  mFeatureFilterWidget->init( mLayer, editorContext, mMainView, QgisApp::instance()->messageBar(), QgisApp::instance()->messageTimeout() );
 
   mActionFeatureActions = new QToolButton();
   mActionFeatureActions->setAutoRaise( false );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -216,7 +216,6 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
 
     QPointer< QgsVectorLayer > mLayer = nullptr;
     QStringList mVisibleFields;
-    QgsAttributeEditorContext mEditorContext;
 
     void updateMultiEditButtonState();
     void deleteFeature( QgsFeatureId fid );

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -53,7 +53,7 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
 {
   QgsFeature *f = cloneFeature ? new QgsFeature( *mFeature ) : mFeature;
 
-  QgsAttributeEditorContext context;
+  QgsAttributeEditorContext context( QgisApp::instance()->createAttributeEditorContext() );
 
   QgsDistanceArea myDa;
 
@@ -61,14 +61,11 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
   myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
 
   context.setDistanceArea( myDa );
-  context.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
-  context.setMapCanvas( QgisApp::instance()->mapCanvas() );
-  context.setCadDockWidget( QgisApp::instance()->cadDockWidget() );
-  context.setMainMessageBar( QgisApp::instance()->messageBar() );
   context.setFormMode( QgsAttributeEditorContext::StandaloneDialog );
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
+
   dialog->setObjectName( QStringLiteral( "featureactiondlg:%1:%2" ).arg( mLayer->id() ).arg( f->id() ) );
 
   QList<QgsAction> actions = mLayer->actions()->actions( QStringLiteral( "Feature" ) );

--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -164,7 +164,11 @@ void QgsMapToolFillRing::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     }
     else
     {
-      QgsAttributeDialog *dialog = new QgsAttributeDialog( vlayer, &ft, false, nullptr, true );
+      QgsAttributeEditorContext context;
+      // don't set cadDockwidget in context because we don't want to be able to create geometries from this dialog
+      // there is one modified and one created feature, so it's a mess of we start to digitize a relation feature geometry
+      context.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
+      QgsAttributeDialog *dialog = new QgsAttributeDialog( vlayer, &ft, false, nullptr, true, context );
       dialog->setMode( QgsAttributeEditorContext::AddFeatureMode );
       res = dialog->exec(); // will also add the feature
     }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -156,6 +156,7 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget *parent )
   mHighlightFeatureButton->hide();
   mAttributeEditorFrame->hide();
   mInvalidLabel->hide();
+  mAddEntryButton->hide();
 
   // connect buttons
   connect( mOpenFormButton, &QAbstractButton::clicked, this, &QgsRelationReferenceWidget::openForm );
@@ -462,8 +463,12 @@ void QgsRelationReferenceWidget::setEditorContext( const QgsAttributeEditorConte
   mMapToolIdentify.reset( new QgsMapToolIdentifyFeature( mCanvas ) );
   mMapToolIdentify->setButton( mMapIdentificationButton );
 
-  mMapToolDigitize.reset( new QgsMapToolDigitizeFeature( mCanvas, context.cadDockWidget() ) );
-  mMapToolDigitize->setButton( mAddEntryButton );
+  if ( mEditorContext.cadDockWidget() )
+  {
+    mMapToolDigitize.reset( new QgsMapToolDigitizeFeature( mCanvas, mEditorContext.cadDockWidget() ) );
+    mMapToolDigitize->setButton( mAddEntryButton );
+    updateAddEntryButton();
+  }
 }
 
 void QgsRelationReferenceWidget::setEmbedForm( bool display )
@@ -1041,7 +1046,7 @@ void QgsRelationReferenceWidget::entryAdded( const QgsFeature &feat )
 
 void QgsRelationReferenceWidget::updateAddEntryButton()
 {
-  mAddEntryButton->setVisible( mAllowAddFeatures );
+  mAddEntryButton->setVisible( mAllowAddFeatures && mMapToolDigitize );
   mAddEntryButton->setEnabled( mReferencedLayer && mReferencedLayer->isEditable() );
 }
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -112,6 +112,11 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     */
     QVariantList foreignKeys() const;
 
+    /**
+     * Sets the editor \a context
+     * \note if context cadDockWidget is null, it won't be possible to digitize
+     * the geometry of a referenced feature from this widget
+     */
     void setEditorContext( const QgsAttributeEditorContext &context, QgsMapCanvas *canvas, QgsMessageBar *messageBar );
 
     //! determines if the form of the related feature will be shown

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -88,6 +88,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
       mWidget->setReadOnlySelector( true );
       mWidget->setAllowMapIdentification( false );
       mWidget->setOpenFormButtonVisible( false );
+      mWidget->setAllowAddFeatures( false );
       break;
     }
     ctx = ctx->parentContext();

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -285,7 +285,7 @@ void QgsRelationEditorWidget::initDualView( QgsVectorLayer *layer, const QgsFeat
     text = tr( "Add Polygon Feature" );
   }
 
-  if ( text.isEmpty() )
+  if ( text.isEmpty() || !mEditorContext.mapCanvas() || !mEditorContext.cadDockWidget() )
   {
     mAddFeatureGeometryButton->setVisible( false );
   }
@@ -368,8 +368,12 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const Q
 void QgsRelationEditorWidget::setEditorContext( const QgsAttributeEditorContext &context )
 {
   mEditorContext = context;
-  mMapToolDigitize.reset( new QgsMapToolDigitizeFeature( context.mapCanvas(), context.cadDockWidget() ) );
-  mMapToolDigitize->setButton( mAddFeatureGeometryButton );
+
+  if ( context.mapCanvas() && context.cadDockWidget() )
+  {
+    mMapToolDigitize.reset( new QgsMapToolDigitizeFeature( context.mapCanvas(), context.cadDockWidget() ) );
+    mMapToolDigitize->setButton( mAddFeatureGeometryButton );
+  }
 }
 
 QgsIFeatureSelectionManager *QgsRelationEditorWidget::featureSelectionManager()
@@ -448,6 +452,9 @@ void QgsRelationEditorWidget::addFeatureGeometry()
     layer = mRelation.referencingLayer();
 
   mMapToolDigitize->setLayer( layer );
+
+  // window is always on top, so we hide it to digitize without seeing it
+  window()->setVisible( false );
   setMapTool( mMapToolDigitize );
 
   connect( mMapToolDigitize, &QgsMapToolDigitizeFeature::digitizingCompleted, this, &QgsRelationEditorWidget::onDigitizingCompleted );
@@ -984,6 +991,7 @@ void QgsRelationEditorWidget::onKeyPressed( QKeyEvent *e )
 
 void QgsRelationEditorWidget::mapToolDeactivated()
 {
+  window()->setVisible( true );
   window()->raise();
   window()->activateWindow();
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -134,6 +134,8 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
 
     /**
      * Sets the editor \a context
+     * \note if context cadDockWidget is null, it won't be possible to digitize
+     * the geometry of a referencing feature from this widget
      */
     void setEditorContext( const QgsAttributeEditorContext &context );
 


### PR DESCRIPTION
## Description

This PR fixes several crashes related to relation editor when attribute table dialog is called
- From the identify results dialog
- From python iface
- From multi edits on selected feature
- From fill ring map tool

The issue is due of uncomplete QgsAttributeEditorContext, so I add a method in QgisApp to create proper one.

Relation editor is able now to create directly related feature geometry in the canvas, which means that the QgsAttributeDialog must be non modal. So I changed the QgsAttributeDialog flags. I'm not sur it's OK regarding the UI, that why the PR is WIP.

For now, creating geometry directly from relation editor when filling a ring is disable because the code should be modified (remove dialog->exec, create the ring and the new feature at the same time when dialog is closed)

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
