### PR TITLE
Set up an OpenGL Context to be shared between threads beforehand

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -884,6 +884,15 @@ int main( int argc, char *argv[] )
   QCoreApplication::setAttribute( Qt::AA_DisableWindowContextHelpButton, true );
 #endif
 
+  // Set up an OpenGL Context to be shared between threads beforehand
+  // for plugins that depend on Qt WebEngine module.
+  // As suggested by Qt documentation at
+  //   - https://doc.qt.io/qt-5/qtwebengine.html
+  //   - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
+#if defined(QT_OS_WIN) && !defined(QT_NO_OPENGL) && (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0) )
+  QCoreApplication::setAttribute( Qt::AA_ShareOpenGLContexts, true );
+#endif
+  
   // Set up the QgsSettings Global Settings:
   // - use the path specified with --globalsettingsfile path,
   // - use the environment if not found

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -886,9 +886,9 @@ int main( int argc, char *argv[] )
 
   // Set up an OpenGL Context to be shared between threads beforehand
   // for plugins that depend on Qt WebEngine module.
-  // As suggested by Qt documentation at
-  //   - https://doc.qt.io/qt-5/qtwebengine.html
-  //   - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
+  // As suggested by Qt documentation at:
+  // - https://doc.qt.io/qt-5/qtwebengine.html
+  // - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
 #if defined(QT_OS_WIN) && !defined(QT_NO_OPENGL) && (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0) )
   QCoreApplication::setAttribute( Qt::AA_ShareOpenGLContexts, true );
 #endif

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -887,12 +887,12 @@ int main( int argc, char *argv[] )
   // Set up an OpenGL Context to be shared between threads beforehand
   // for plugins that depend on Qt WebEngine module.
   // As suggested by Qt documentation at:
-  // - https://doc.qt.io/qt-5/qtwebengine.html
-  // - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
+  //   - https://doc.qt.io/qt-5/qtwebengine.html
+  //   - https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets/api/qtwebenginewidgetsglobal.cpp
 #if defined(QT_OS_WIN) && !defined(QT_NO_OPENGL) && (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0) )
   QCoreApplication::setAttribute( Qt::AA_ShareOpenGLContexts, true );
 #endif
-  
+
   // Set up the QgsSettings Global Settings:
   // - use the path specified with --globalsettingsfile path,
   // - use the environment if not found


### PR DESCRIPTION
for plugins that depend on Qt WebEngine module.

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

[QGIS 3.11.0-61 4a7ea580e9 ] Plugin go2streetview somehow triggers a critical message here

> `CRITICAL    Qt : Qt WebEngine seems to be initialized from a plugin. Please set Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute before constructing QGuiApplication.`

It turns out the plugin depends on Qt WebEngine that suggests setting up a shared opengl context.

- https://doc.qt.io/qt-5/qtwebengine.html
- https://code.qt.io/cgit/qt/qtwebengine.git/plain/src/webenginewidgets

<!-- 
## Checklist
-->

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->
<!--
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
-->