### PR TITLE
[wfs] Fix background cache iterator when using with both subset string and filter on fid(s)

### DIFF
--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
@@ -257,25 +257,27 @@ void QgsThreadedFeatureDownloader::run()
 
 // -------------------------
 
-static QgsFeatureRequest addSubsetToFeatureRequest( const QgsFeatureRequest &requestIn,
-    const QgsBackgroundCachedSharedData *shared )
-{
-  if ( shared->clientSideFilterExpression().isEmpty() )
-  {
-    return requestIn;
-  }
-  QgsFeatureRequest requestOut( requestIn );
-  requestOut.combineFilterExpression( shared->clientSideFilterExpression() );
-  return requestOut;
-}
-
 QgsBackgroundCachedFeatureIterator::QgsBackgroundCachedFeatureIterator(
   QgsBackgroundCachedFeatureSource *source, bool ownSource,
   std::shared_ptr<QgsBackgroundCachedSharedData> shared,
   const QgsFeatureRequest &request )
-  : QgsAbstractFeatureIteratorFromSource<QgsBackgroundCachedFeatureSource>( source, ownSource, addSubsetToFeatureRequest( request, shared.get() ) )
+  : QgsAbstractFeatureIteratorFromSource<QgsBackgroundCachedFeatureSource>( source, ownSource, request )
   , mShared( shared )
 {
+  if ( !shared->clientSideFilterExpression().isEmpty() )
+  {
+    // backup current request because combine filter expression will remove the fid(s) filtering
+    if ( mRequest.filterType() == QgsFeatureRequest::FilterFid || mRequest.filterType() == QgsFeatureRequest::FilterFids )
+    {
+      mAdditionalRequest = mRequest;
+      mRequest = QgsFeatureRequest( shared->clientSideFilterExpression() );
+    }
+    else
+    {
+      mRequest.combineFilterExpression( shared->clientSideFilterExpression() );
+    }
+  }
+
   if ( mRequest.destinationCrs().isValid() && mRequest.destinationCrs() != mShared->sourceCrs() )
   {
     mTransform = QgsCoordinateTransform( mShared->sourceCrs(), mRequest.destinationCrs(), mRequest.transformContext() );
@@ -601,6 +603,11 @@ bool QgsBackgroundCachedFeatureIterator::fetchFeature( QgsFeature &f )
       continue;
     }
 
+    if ( !mAdditionalRequest.acceptFeature( cachedFeature ) )
+    {
+      continue;
+    }
+
     copyFeature( cachedFeature, f, true );
     geometryToDestinationCrs( f, mTransform );
 
@@ -688,6 +695,11 @@ bool QgsBackgroundCachedFeatureIterator::fetchFeature( QgsFeature &f )
         QgsGeometry constGeom = feat.geometry();
         if ( !mFilterRect.isNull() &&
              ( constGeom.isNull() || !constGeom.intersects( mFilterRect ) ) )
+        {
+          continue;
+        }
+
+        if ( !mAdditionalRequest.acceptFeature( feat ) )
         {
           continue;
         }

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.cpp
@@ -269,8 +269,7 @@ QgsBackgroundCachedFeatureIterator::QgsBackgroundCachedFeatureIterator(
     // backup current request because combine filter expression will remove the fid(s) filtering
     if ( mRequest.filterType() == QgsFeatureRequest::FilterFid || mRequest.filterType() == QgsFeatureRequest::FilterFids )
     {
-      mAdditionalRequest = mRequest;
-      mRequest = QgsFeatureRequest( shared->clientSideFilterExpression() );
+      mAdditionalRequest = QgsFeatureRequest( shared->clientSideFilterExpression() );
     }
     else
     {

--- a/src/providers/wfs/qgsbackgroundcachedfeatureiterator.h
+++ b/src/providers/wfs/qgsbackgroundcachedfeatureiterator.h
@@ -320,6 +320,9 @@ class QgsBackgroundCachedFeatureIterator final: public QObject,
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;
 
+    //! typically to save a FilterFid/FilterFids request that will not be captured by mRequest
+    QgsFeatureRequest mAdditionalRequest;
+
     ///////////////// METHODS
 
     //! Translate mRequest to a request compatible of the Spatialite cache

--- a/tests/src/python/provider_python.py
+++ b/tests/src/python/provider_python.py
@@ -78,6 +78,10 @@ class PyFeatureIterator(QgsAbstractFeatureIterator):
         if self._filter_rect is not None and self._source._provider._spatialindex is not None:
             self._feature_id_list = self._source._provider._spatialindex.intersects(self._filter_rect)
 
+        if self._request.filterType() == QgsFeatureRequest.FilterFid or self._request.filterType() == QgsFeatureRequest.FilterFids:
+            fids = [self._request.filterFid()] if self._request.filterType() == QgsFeatureRequest.FilterFid else self._request.filterFids()
+            self._feature_id_list = list(set(self._feature_id_list).intersection(set(fids))) if self._feature_id_list else fids
+
     def fetchFeature(self, f):
         """fetch next feature, return true on success"""
         #virtual bool nextFeature( QgsFeature &f );

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -210,6 +210,29 @@ class ProviderTestCase(FeatureSourceTestCase):
                                                                                                       result, subset)
         self.assertTrue(all_valid)
 
+        # Subset string AND filter fid
+        ids = {f['pk']: f.id() for f in self.source.getFeatures()}
+        self.source.setSubsetString(subset)
+        request = QgsFeatureRequest().setFilterFid(4)
+        result = set([f.id() for f in self.source.getFeatures(request)])
+        all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
+        self.source.setSubsetString(None)
+        expected = set([4])
+        assert set(expected) == result, 'Expected {} and got {} when testing subset string {}'.format(set(expected),
+                                                                                                      result, subset)
+        self.assertTrue(all_valid)
+
+        # Subset string AND filter fids
+        self.source.setSubsetString(subset)
+        request = QgsFeatureRequest().setFilterFids([ids[2], ids[4]])
+        result = set([f.id() for f in self.source.getFeatures(request)])
+        all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
+        self.source.setSubsetString(None)
+        expected = set([ids[2], ids[4]])
+        assert set(expected) == result, 'Expected {} and got {} when testing subset string {}'.format(set(expected),
+                                                                                                      result, subset)
+        self.assertTrue(all_valid)
+
     def getSubsetString(self):
         """Individual providers may need to override this depending on their subset string formats"""
         return '"cnt" > 100 and "cnt" < 410'


### PR DESCRIPTION
#Description

In QgsBackgroundCacheFeatureIterator we combine request and side filter expression request (when a subsetfilter is set on layer) but it removes the fid filter on input request if there is one. This PR fixes this. 

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
