### PR TITLE
PG: fix default value for IDENTITY PKs

### DIFF
--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1420,6 +1420,25 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(vl.isValid())
         self.assertTrue(self.source.featureCount() > 0)
 
+    def testIdentityPk(self):
+        """Test a table with identity pk, see GH #29560"""
+
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'gid\' srid=4326 type=POLYGON table="qgis_test"."b29560"(geom) sql=', 'testb29560', 'postgres')
+        self.assertTrue(vl.isValid())
+
+        feature = QgsFeature(vl.fields())
+        geom = QgsGeometry.fromWkt('POLYGON EMPTY')
+        feature.setGeometry(geom)
+        self.assertTrue(vl.dataProvider().addFeature(feature))
+
+        del(vl)
+
+        # Verify
+        vl = QgsVectorLayer(self.dbconn + ' sslmode=disable key=\'gid\' srid=4326 type=POLYGON table="qgis_test"."b29560"(geom) sql=', 'testb29560', 'postgres')
+        self.assertTrue(vl.isValid())
+        feature = next(vl.getFeatures())
+        self.assertIsNotNone(feature.id())
+
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -671,3 +671,18 @@ CREATE VIEW qgis_test.b31799_test_view_ctid AS (SELECT ctid, geom, random() FROM
 CREATE VIEW qgis_test.b32523 AS
   SELECT pk, random()
   FROM qgis_test.some_poly_data;
+
+----------------------------------------------
+--
+-- IDENTITY pk
+-- See https://github.com/qgis/QGIS/issues/29560
+--
+
+CREATE TABLE qgis_test.b29560 (
+    gid int8 NOT NULL GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    geom geometry(polygon)
+);
+
+INSERT INTO qgis_test.b29560 (geom)
+VALUES ('POLYGON EMPTY'::geometry);
+


### PR DESCRIPTION
Fixes #29560 - PostgreSQL identity column not recognized properly
