### PR TITLE
[RPM] fix automatic rpm build script

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -361,6 +361,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %files server
 %doc src/server/admin.sld src/server/wms_metadata.xml %{name}-server-README.fedora
 %doc %{name}-server-httpd.conf %{name}-server-nginx.conf %{name}-server-fcgi.socket %{name}-server-fcgi.service
+%{_bindir}/%{name}_mapserver
 %{_libdir}/%{name}/server/
 %{_libdir}/lib%{name}_server.so.*
 %{_libexecdir}/%{name}/


### PR DESCRIPTION
Building using `buildrpm.sh` fails due to the unpackaged file
/usr/bin/qgis_mapserver added in d453f7471456c5b2d83626ef8a90a0e24bdd17c0.

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment

Since the changes in d453f7471456c5b2d83626ef8a90a0e24bdd17c0 exist only in master, this change should _not_ be backported.

CC: @daniviga 