### PR TITLE
Fix overflow by assigning double max to float, invalid min

### DIFF
--- a/src/3d/qgsfeature3dhandler_p.h
+++ b/src/3d/qgsfeature3dhandler_p.h
@@ -122,8 +122,8 @@ class QgsFeature3DHandler
     void updateZRangeFromPositions( const QVector<QVector3D> &positions );
 
   protected:
-    float mZMin = std::numeric_limits<double>::max();
-    float mZMax = std::numeric_limits<double>::min();
+    float mZMin = std::numeric_limits<float>::max();
+    float mZMax = std::numeric_limits<float>::lowest();
 };
 
 


### PR DESCRIPTION
Raising a valid warning on msvc builds