### PR TITLE
BUG: fix add vertex from end point for CompoundCurveZ in gpkg, fix #3…

### DIFF
--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -730,6 +730,16 @@ QVector< QPair<int, QgsVertexId> > QgsCompoundCurve::curveVertexId( QgsVertexId 
       }
       break;
     }
+    else if ( id.vertex >= currentVertexIndex && id.vertex == currentVertexIndex + increment + 1 && i == ( mCurves.size() - 1 ) )
+    {
+      int curveVertexId = id.vertex - currentVertexIndex;
+      QgsVertexId vid;
+      vid.part = 0;
+      vid.ring = 0;
+      vid.vertex = curveVertexId;
+      curveIds.append( qMakePair( i, vid ) );
+      break;
+    }
     currentVertexIndex += increment;
   }
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -10740,6 +10740,13 @@ void TestQgsGeometry::compoundCurve()
   QCOMPARE( ls26r->startPoint(), QgsPoint( QgsWkbTypes::PointZM, 1, 2, 2, 3 ) );
   QCOMPARE( ls26r->endPoint(), QgsPoint( QgsWkbTypes::PointZM, 31, 42, 4, 5 ) );
 
+  //add vertex at the end of linestring
+  QVERIFY( c26.insertVertex( QgsVertexId( 0, 0, 2 ), QgsPoint( QgsWkbTypes::PointZM, 35, 43, 4, 5 ) ) );
+  ls26r = dynamic_cast< const QgsLineString * >( c26.curveAt( 0 ) );
+  QCOMPARE( ls26r->numPoints(), 3 );
+  QCOMPARE( ls26r->startPoint(), QgsPoint( QgsWkbTypes::PointZM, 1, 2, 2, 3 ) );
+  QCOMPARE( ls26r->endPoint(), QgsPoint( QgsWkbTypes::PointZM, 35, 43, 4, 5 ) );
+
   c26.clear();
   ls26.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZM, 1, 2, 2, 3 )
                   << QgsPoint( QgsWkbTypes::PointZM, 11, 12, 4, 5 )


### PR DESCRIPTION
## Description
#32080

As described in the issue, using a compound curve layer (in gpkg) it's not possible to extend existing entity from the end point, while it's possible from start point.

This was not possible because compound curve is composed of several part and user shouldn't be able to add an extra vertex in a part that is followed by another part. Extent from start point was available because the vertex index is 0, so we are sure there is no part before.

I fixed it by allowing vertex insert if it is for the last past (``i == mCurves.size() - 1``) of the curve and the vertex index is equal to the existing vertex count + 1

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
