### PR TITLE
Remove add vertex circular

### DIFF
--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -55,7 +55,7 @@ void QgsMapToolAddCircularString::keyPressEvent( QKeyEvent *e )
     createCenterPointRubberBand();
   }
 
-  if ( e && e->key() == Qt::Key_Escape )
+  if ( ( e && e->key() == Qt::Key_Escape ) || ( ( e && e->key() == Qt::Key_Backspace ) && ( mPoints.size() == 1 ) ) )
   {
     mPoints.clear();
     delete mRubberBand;
@@ -66,7 +66,7 @@ void QgsMapToolAddCircularString::keyPressEvent( QKeyEvent *e )
     if ( mParentTool )
       mParentTool->keyPressEvent( e );
   }
-  if ( ( e && e->key() == Qt::Key_Backspace ) && ( ! mPoints.isEmpty() ) )
+  if ( ( e && e->key() == Qt::Key_Backspace ) && ( mPoints.size() > 1 ) )
   {
     mPoints.removeLast();
     std::unique_ptr<QgsCircularString> geomRubberBand( new QgsCircularString() );

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -66,6 +66,33 @@ void QgsMapToolAddCircularString::keyPressEvent( QKeyEvent *e )
     if ( mParentTool )
       mParentTool->keyPressEvent( e );
   }
+  if ( ( e && e->key() == Qt::Key_Backspace ) && ( ! mPoints.isEmpty() ) )
+  {
+    mPoints.removeLast();
+    std::unique_ptr<QgsCircularString> geomRubberBand( new QgsCircularString() );
+    std::unique_ptr<QgsLineString> geomTempRubberBand( new QgsLineString() );
+    const int lastPositionCompleteCircularString = mPoints.size() - 1 - ( mPoints.size() + 1 ) % 2 ;
+
+    geomTempRubberBand->setPoints( mPoints.mid( lastPositionCompleteCircularString ) );
+    mTempRubberBand->setGeometry( geomTempRubberBand.release() );
+
+    if ( mRubberBand )
+    {
+      geomRubberBand->setPoints( mPoints.mid( 0, lastPositionCompleteCircularString + 1 ) );
+      mRubberBand->setGeometry( geomRubberBand.release() );
+    }
+
+    QgsVertexId idx( 0, 0, ( mPoints.size() + 1 ) % 2 );
+    if ( mTempRubberBand )
+    {
+      mTempRubberBand->moveVertex( idx, mPoints.last() );
+      updateCenterPointRubberBand( mPoints.last() );
+    }
+
+    if ( mParentTool )
+      mParentTool->keyPressEvent( e );
+
+  }
 }
 
 void QgsMapToolAddCircularString::keyReleaseEvent( QKeyEvent *e )

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -87,10 +87,14 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasMoveEvent( QgsMapMouseEvent *e
 
   mSnapIndicator->setMatch( e->mapPointMatch() );
 
-  QgsVertexId idx( 0, 0, 1 + ( mPoints.size() + 1 ) % 2 );
   if ( mTempRubberBand )
   {
-    mTempRubberBand->moveVertex( idx, mapPoint );
+    QgsPointSequence mTempPoints = mPoints.mid( mPoints.size() - 1 - ( mPoints.size() + 1 ) % 2 );
+    mTempPoints.append( mapPoint );
+    std::unique_ptr<QgsCircularString> geom( new QgsCircularString() );
+    geom->setPoints( mTempPoints );
+    mTempRubberBand->setGeometry( geom.release() );
+
     updateCenterPointRubberBand( mapPoint );
   }
 }


### PR DESCRIPTION
## Description
From https://github.com/qgis/QGIS/issues/29688 : Tool Add Circular String doesn't delete last vertex with "Del" or "Backspace" Key.

I introduce the backspace key to delete the last vertex

![bug_del_vertex webm](https://user-images.githubusercontent.com/7521540/73190551-75415500-4126-11ea-81a9-b601caad1e59.gif)


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [X] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
