### PR TITLE
allow replacement of invalid variants in TextEditWrapper

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -341,13 +341,13 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
     }
   }
 
-  if ( mPlainTextEdit )
-  {
-    if ( val != value() )
-      mPlainTextEdit->setPlainText( v );
-  }
+// allow replacement of invalid variants with
+// what was there before - e.g for JSON
+  if ( mPlainTextEdit && ( val != value() || !val.isValid() ) )
+    mPlainTextEdit->setPlainText( v );
 
-  if ( mLineEdit && val != value() )
+
+  if ( mLineEdit && ( val != value() || !val.isValid() ) )
     mLineEdit->setText( v );
 }
 


### PR DESCRIPTION
## Description
Post merge of #30758 I noticed some odd behaviour with editing JSON fields - upon entering an invaliid JSON field, the invalid text persisted in the Text Edit when changing records. This was caused by #33660 which overlapped the original PR. This PR attempts to return to the old behaviour without affecting the fix in #33660 

@troopa81 would be good to check this will not affect what you were doing
