### PR TITLE
Fix leaks in geometry generator symbol layer

### DIFF
--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -16,12 +16,7 @@
 #include "qgsgeometrygeneratorsymbollayer.h"
 #include "qgsgeometry.h"
 
-QgsGeometryGeneratorSymbolLayer::~QgsGeometryGeneratorSymbolLayer()
-{
-  delete mMarkerSymbol;
-  delete mLineSymbol;
-  delete mFillSymbol;
-}
+QgsGeometryGeneratorSymbolLayer::~QgsGeometryGeneratorSymbolLayer() = default;
 
 QgsSymbolLayer *QgsGeometryGeneratorSymbolLayer::create( const QgsStringMap &properties )
 {
@@ -67,20 +62,20 @@ void QgsGeometryGeneratorSymbolLayer::setSymbolType( QgsSymbol::SymbolType symbo
   if ( symbolType == QgsSymbol::Fill )
   {
     if ( !mFillSymbol )
-      mFillSymbol = QgsFillSymbol::createSimple( QgsStringMap() );
-    mSymbol = mFillSymbol;
+      mFillSymbol.reset( QgsFillSymbol::createSimple( QgsStringMap() ) );
+    mSymbol = mFillSymbol.get();
   }
   else if ( symbolType == QgsSymbol::Line )
   {
     if ( !mLineSymbol )
-      mLineSymbol = QgsLineSymbol::createSimple( QgsStringMap() );
-    mSymbol = mLineSymbol;
+      mLineSymbol.reset( QgsLineSymbol::createSimple( QgsStringMap() ) );
+    mSymbol = mLineSymbol.get();
   }
   else if ( symbolType == QgsSymbol::Marker )
   {
     if ( !mMarkerSymbol )
-      mMarkerSymbol = QgsMarkerSymbol::createSimple( QgsStringMap() );
-    mSymbol = mMarkerSymbol;
+      mMarkerSymbol.reset( QgsMarkerSymbol::createSimple( QgsStringMap() ) );
+    mSymbol = mMarkerSymbol.get();
   }
   else
     Q_ASSERT( false );
@@ -106,11 +101,11 @@ QgsSymbolLayer *QgsGeometryGeneratorSymbolLayer::clone() const
   QgsGeometryGeneratorSymbolLayer *clone = new QgsGeometryGeneratorSymbolLayer( mExpression->expression() );
 
   if ( mFillSymbol )
-    clone->mFillSymbol = mFillSymbol->clone();
+    clone->mFillSymbol.reset( mFillSymbol->clone() );
   if ( mLineSymbol )
-    clone->mLineSymbol = mLineSymbol->clone();
+    clone->mLineSymbol.reset( mLineSymbol->clone() );
   if ( mMarkerSymbol )
-    clone->mMarkerSymbol = mMarkerSymbol->clone();
+    clone->mMarkerSymbol.reset( mMarkerSymbol->clone() );
 
   clone->setSymbolType( mSymbolType );
 
@@ -155,15 +150,15 @@ bool QgsGeometryGeneratorSymbolLayer::setSubSymbol( QgsSymbol *symbol )
   switch ( symbol->type() )
   {
     case QgsSymbol::Marker:
-      mMarkerSymbol = static_cast<QgsMarkerSymbol *>( symbol );
+      mMarkerSymbol.reset( static_cast<QgsMarkerSymbol *>( symbol ) );
       break;
 
     case QgsSymbol::Line:
-      mLineSymbol = static_cast<QgsLineSymbol *>( symbol );
+      mLineSymbol.reset( static_cast<QgsLineSymbol *>( symbol ) );
       break;
 
     case QgsSymbol::Fill:
-      mFillSymbol = static_cast<QgsFillSymbol *>( symbol );
+      mFillSymbol.reset( static_cast<QgsFillSymbol *>( symbol ) );
       break;
 
     default:

--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.h
@@ -104,9 +104,9 @@ class CORE_EXPORT QgsGeometryGeneratorSymbolLayer : public QgsSymbolLayer
 #endif
 
     std::unique_ptr<QgsExpression> mExpression;
-    QgsFillSymbol *mFillSymbol = nullptr;
-    QgsLineSymbol *mLineSymbol = nullptr;
-    QgsMarkerSymbol *mMarkerSymbol = nullptr;
+    std::unique_ptr<QgsFillSymbol> mFillSymbol;
+    std::unique_ptr<QgsLineSymbol> mLineSymbol;
+    std::unique_ptr<QgsMarkerSymbol> mMarkerSymbol;
     QgsSymbol *mSymbol = nullptr;
 
     /**


### PR DESCRIPTION
When a subsymbol is set for the layer, it was leaking any existing subsymbol.
