### PR TITLE
Fix crash on destruction of QgsPointLocator

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -549,6 +549,7 @@ QgsPointLocator::QgsPointLocator( QgsVectorLayer *layer, const QgsCoordinateRefe
 QgsPointLocator::~QgsPointLocator()
 {
   // don't delete a locator if there is an indexing task running on it
+  mIsDestroying = true;
   if ( mIsIndexing )
     waitForIndexingFinished();
 
@@ -595,6 +596,9 @@ void QgsPointLocator::onInitTaskFinished()
   // Check that we don't call this method twice, when calling waitForFinished
   // for instance (because of taskCompleted signal)
   if ( !mIsIndexing )
+    return;
+
+  if ( mIsDestroying )
     return;
 
   mIsIndexing = false;
@@ -652,7 +656,8 @@ void QgsPointLocator::waitForIndexingFinished()
 {
   mInitTask->waitForFinished();
 
-  onInitTaskFinished();
+  if ( !mIsDestroying )
+    onInitTaskFinished();
 }
 
 bool QgsPointLocator::hasIndex() const

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -389,6 +389,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     std::unique_ptr<QgsVectorLayerFeatureSource> mSource;
     int mMaxFeaturesToIndex = -1;
     bool mIsIndexing = false;
+    bool mIsDestroying = false;
     QgsFeatureIds mAddedFeatures;
     QgsFeatureIds mDeletedFeatures;
     QPointer<QgsPointLocatorInitTask> mInitTask;


### PR DESCRIPTION
if object is destroyed while indexing is happening in the background
