### PR TITLE
Update Grass7Utils.py

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -165,8 +165,8 @@ class Grass7Utils:
                 ]
         else:
             cmdList = [
-                "grass76", "grass74", "grass72", "grass70", "grass",
-                "grass76.sh", "grass74.sh", "grass72.sh", "grass70.sh", "grass.sh"
+                "grass78", "grass76", "grass74", "grass72", "grass70", "grass",
+                "grass78.sh", "grass76.sh", "grass74.sh", "grass72.sh", "grass70.sh", "grass.sh"
             ]
 
         # For MS-Windows there is a difference between GRASS Path and GRASS binary
@@ -224,13 +224,13 @@ class Grass7Utils:
                 else:
                     testfolder = os.path.join(str(QgsApplication.prefixPath()), 'grass')
                     if os.path.isdir(testfolder):
-                        grassfolders = sorted([f for f in os.listdir(testfolder) if f.startswith("grass-7.") and os.path.isdir(os.path.join(testfolder, f))], reverse=True, key=lambda x: [int(v) for v in x[len("grass-"):].split('.') if v != 'svn'])
+                        grassfolders = sorted([f for f in os.listdir(testfolder) if f.startswith("grass7") and os.path.isdir(os.path.join(testfolder, f))], reverse=True, key=lambda x: [int(v) for v in x[len("grass-"):].split('.') if v != 'svn'])
                         if grassfolders:
                             folder = os.path.join(testfolder, grassfolders[0])
             elif isMac():
                 # For MacOSX, we scan some well-known directories
                 # Start with QGIS bundle
-                for version in ['', '7', '76', '74', '72', '70']:
+                for version in ['', '7', '78', '76', '74', '72', '70']:
                     testfolder = os.path.join(str(QgsApplication.prefixPath()),
                                               'grass{}'.format(version))
                     if os.path.isdir(testfolder):


### PR DESCRIPTION
qgis 3.4.15 is compiled with grass 7.8.2.
I declare grass 7.8 at first.
On the other hand, under windows, GRASS is saved in a directory in the form grass + version number without dash or point.

With Windows, in OSGeo4W64 installation, the path to the GRASS executables is in the form: grass + version number without dash or dot.
Example: C:\OSGeo4W64\apps\grass\grass78
And in no case under the name: grass-7.8
In fact, I changed the code for this search to work by replacing "grass-7." by "grass7"

## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
