### PR TITLE
[grass] Add new -e -n flags to r.slope

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.slope.aspect.txt
+++ b/python/plugins/processing/algs/grass7/description/r.slope.aspect.txt
@@ -5,6 +5,8 @@ QgsProcessingParameterRasterLayer|elevation|Elevation|None|False
 QgsProcessingParameterEnum|format|Format for reporting the slope|degrees;percent|False|0|True
 QgsProcessingParameterEnum|precision|Type of output aspect and slope layer|FCELL;CELL;DCELL|False|0|True
 QgsProcessingParameterBoolean|-a|Do not align the current region to the elevation layer|True
+QgsProcessingParameterBoolean|-e|Compute output at edges and near NULL values|False
+QgsProcessingParameterBoolean|-n|Create aspect as degrees clockwise from North (azimuth), with flat = -9999|False
 QgsProcessingParameterNumber|zscale|Multiplicative factor to convert elevation units to meters|QgsProcessingParameterNumber.Double|1.0|True|None|None
 QgsProcessingParameterNumber|min_slope|Minimum slope val. (in percent) for which aspect is computed|QgsProcessingParameterNumber.Double|0.0|True|None|None
 QgsProcessingParameterRasterDestination|slope|Slope|None|True


### PR DESCRIPTION
## Description
New features in GRASS 7.6: Add -n flag to create aspect as degrees clockwise from North (azimuth), with flat = -9999 (like gdaldem); new -e flag to compute values at edges (like gdaldem -compute_edges).

https://grass.osgeo.org/grass78/manuals/r.slope.aspect.html

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
