### PR TITLE
setup travis.ci notifications to #qgis-activity IRC channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,10 +152,13 @@ git:
   depth: 120
 
 notifications:
-  irc: "chat.freenode.net#qgis-test"
-  on_failure: change
-  on_success: change
-  skip_join: true
+  irc: 
+    channels:  
+      - "chat.freenode.net#qgis-test"
+      - "chat.freenode.net#qgis-activity"
+    on_failure: change
+    on_success: change
+    skip_join: true
 
   webhooks:
     urls:


### PR DESCRIPTION
- currently automated notifications are sent to an unregistered channel #qgis-test 
- the proposed change here also sends notifications to the registered channel #qgis-activity
  - registered channel has many benefits, including that we will never lose the channel if we all leave the channel at once
- in (near) future, I believe the #qgis-test channel should be closed (happens automatically when @jef-n leaves it, as he is only user inside channel), and then we can remove the notifications sent to #qgis-test . I will also give "op" powers to @jef-n for the #qgis-activity channel when he enters the room.

(the naming of #qgis-activity follows the existing channel name of #postgis-activity)