### PR TITLE
Remove deprecated QBuffer constructor usage

### DIFF
--- a/src/3d/chunks/qgschunkboundsentity_p.cpp
+++ b/src/3d/chunks/qgschunkboundsentity_p.cpp
@@ -26,7 +26,11 @@
 LineMeshGeometry::LineMeshGeometry( Qt3DCore::QNode *parent )
   : Qt3DRender::QGeometry( parent )
   , mPositionAttribute( new Qt3DRender::QAttribute( this ) )
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   , mVertexBuffer( new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this ) )
+#else
+  , mVertexBuffer( new Qt3DRender::QBuffer( this ) )
+#endif
 {
   mPositionAttribute->setAttributeType( Qt3DRender::QAttribute::VertexAttribute );
   mPositionAttribute->setBuffer( mVertexBuffer );

--- a/src/3d/mesh/qgsmesh3dgeometry_p.cpp
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.cpp
@@ -280,9 +280,14 @@ void QgsMesh3dGeometry::init()
   mNormalAttribute = new QAttribute( this );
   mTexCoordAttribute = new QAttribute( this );
   mIndexAttribute = new QAttribute( this );
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   mVertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
   mIndexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, this );
-
+#else
+  mVertexBuffer = new Qt3DRender::QBuffer( this );
+  mIndexBuffer = new Qt3DRender::QBuffer( this );
+#endif
 
   const int stride = ( 3 /*position*/ +
                        2 /*texture*/  +

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -28,7 +28,11 @@
 QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( QNode *parent )
   : Qt3DRender::QGeometry( parent )
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   mVertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
+#else
+  mVertexBuffer = new Qt3DRender::QBuffer( this );
+#endif
 
   QgsTessellator tmpTess( 0, 0, mWithNormals );
   const int stride = tmpTess.stride();

--- a/src/3d/symbols/qgsbillboardgeometry.cpp
+++ b/src/3d/symbols/qgsbillboardgeometry.cpp
@@ -20,7 +20,11 @@
 QgsBillboardGeometry::QgsBillboardGeometry( Qt3DCore::QNode *parent )
   : Qt3DRender::QGeometry( parent )
   , mPositionAttribute( new Qt3DRender::QAttribute( this ) )
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   , mVertexBuffer( new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this ) )
+#else
+  , mVertexBuffer( new Qt3DRender::QBuffer( this ) )
+#endif
 {
 
   mPositionAttribute->setAttributeType( Qt3DRender::QAttribute::VertexAttribute );

--- a/src/3d/symbols/qgslinevertexdata_p.cpp
+++ b/src/3d/symbols/qgslinevertexdata_p.cpp
@@ -70,10 +70,18 @@ QByteArray QgsLineVertexData::createIndexBuffer()
 
 Qt3DRender::QGeometry *QgsLineVertexData::createGeometry( Qt3DCore::QNode *parent )
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   Qt3DRender::QBuffer *vertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, parent );
+#else
+  Qt3DRender::QBuffer *vertexBuffer = new Qt3DRender::QBuffer( parent );
+#endif
   vertexBuffer->setData( createVertexBuffer() );
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   Qt3DRender::QBuffer *indexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, parent );
+#else
+  Qt3DRender::QBuffer *indexBuffer = new Qt3DRender::QBuffer( parent );
+#endif
   indexBuffer->setData( createIndexBuffer() );
 
   QgsDebugMsg( QString( "vertex buffer %1 MB  index buffer %2 MB " ).arg( vertexBuffer->data().count() / 1024. / 1024. ).arg( indexBuffer->data().count() / 1024. / 1024. ) );

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -229,7 +229,11 @@ Qt3DRender::QGeometryRenderer *QgsInstancedPoint3DSymbolHandler::renderer( const
   ba.resize( byteCount );
   memcpy( ba.data(), positions.constData(), byteCount );
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   Qt3DRender::QBuffer *instanceBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer );
+#else
+  Qt3DRender::QBuffer *instanceBuffer = new Qt3DRender::QBuffer();
+#endif
   instanceBuffer->setData( ba );
 
   Qt3DRender::QAttribute *instanceDataAttribute = new Qt3DRender::QAttribute;

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
@@ -356,8 +356,14 @@ void DemTerrainTileGeometry::init()
   mNormalAttribute = new QAttribute( this );
   mTexCoordAttribute = new QAttribute( this );
   mIndexAttribute = new QAttribute( this );
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
   mVertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
   mIndexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, this );
+#else
+  mVertexBuffer = new Qt3DRender::QBuffer( this );
+  mIndexBuffer = new Qt3DRender::QBuffer( this );
+#endif
+
 
   int nVertsX = mResolution + 2;
   int nVertsZ = mResolution + 2;


### PR DESCRIPTION
Not much info on why this is deprecated -- the only thing I can find is https://codereview.qt-project.org/c/qt/qt3d/+/205392 "Deprecate QBuffer::type. It can also be removed from the backend class, now the renderer doesn't look at it anyway."