### PR TITLE
Find PyQt5 sip files on Archlinux

### DIFF
--- a/cmake/FindPyQt5.py
+++ b/cmake/FindPyQt5.py
@@ -45,7 +45,8 @@ except ImportError:
         sip_dir = sip_dir.replace(py_version, '')
     for p in (os.path.join(sip_dir, "PyQt5"),
               os.path.join(sip_dir, "PyQt5-3"),
-              sip_dir):
+              sip_dir,
+              os.path.join(cfg.default_mod_dir, "PyQt5", "bindings")):
         if os.path.exists(os.path.join(p, "QtCore", "QtCoremod.sip")):
             sip_dir = p
             break


### PR DESCRIPTION
## Description

After my last Archlinux upgrade, QGIS compilation is failing because PyQt5 sip files cannot be found:

``` bash
[9/973] Generating analysis/sip_analysispart0.cpp, analysis/sip_analysispart1.cpp, analysis/sip_analysispart2.cpp, analysis/sip_analysispart3.cpp
FAILED: python/analysis/sip_analysispart0.cpp python/analysis/sip_analysispart1.cpp python/analysis/sip_analysispart2.cpp python/analysis/sip_analysispart3.cpp
cd /home/pblottiere/devel/qgis/qgis_pbl_master/build/python && /usr/bin/cmake -E echo && /usr/bin/cmake -E touch /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis/sip_analysispart0.cpp /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis/sip_analysispart1.cpp /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis/sip_analysispart2.cpp /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis/sip_analysispart3.cpp && /usr/bin/sip -w -e -x ANDROID -x ARM -x MOBILITY_LOCATION -n PyQt5.sip -t Qt_5_14_0 -t WS_X11 -g -o -a /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/qgis.analysis.api -n PyQt5.sip -y /home/pblottiere/devel/qgis/qgis_pbl_master/build/output/python/qgis/_analysis.pyi -j 4 -c /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis -I /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis -I /usr/share/sip -I /home/pblottiere/devel/qgis/qgis_pbl_master/python /home/pblottiere/devel/qgis/qgis_pbl_master/build/python/analysis/analysis.sip
sip: Unable to find file "QtCore/QtCoremod.sip"
```

Actually the default SIP dir for these files is `/usr/share/sip`:

```
 Python 3.8.1 (default, Jan 22 2020, 06:38:00)
[GCC 9.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sipconfig
>>> sipconfig.Configuration().default_sip_dir
'/usr/share/sip'
```

However, sip files are now in `/usr/lib/python3.8/site-packages/PyQt5/bindings/`. So I propose to update the `FindPyQt5.py` script to search in this directory too.
