### PR TITLE
Server standalone lambda disconnect

### DIFF
--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -176,7 +176,7 @@ int main( int argc, char *argv[] )
     }
   }
 
-  // Disable parallel rendering because if its interal loop
+  // Disable parallel rendering because if its internal loop
   qputenv( "QGIS_SERVER_PARALLEL_RENDERING", "0" );
 
   // Create server


### PR DESCRIPTION
This fixes a couple of issues with the development server under load.

There are still too many processEvents in server code that might call the connection destructor while inside the lambda, but with parallel rendering disabled the development server behaves much better.
