### PR TITLE
Fix cppcheck shadowVariable warnings in src/core/

### DIFF
--- a/src/core/annotations/qgsannotation.cpp
+++ b/src/core/annotations/qgsannotation.cpp
@@ -493,13 +493,15 @@ void QgsAnnotation::_readXml( const QDomElement &annotationElem, const QgsReadWr
   }
 
   //marker symbol
-  QDomElement symbolElem = annotationElem.firstChildElement( QStringLiteral( "symbol" ) );
-  if ( !symbolElem.isNull() )
   {
-    QgsMarkerSymbol *symbol = QgsSymbolLayerUtils::loadSymbol<QgsMarkerSymbol>( symbolElem, context );
-    if ( symbol )
+    QDomElement symbolElem = annotationElem.firstChildElement( QStringLiteral( "symbol" ) );
+    if ( !symbolElem.isNull() )
     {
-      mMarkerSymbol.reset( symbol );
+      QgsMarkerSymbol *symbol = QgsSymbolLayerUtils::loadSymbol<QgsMarkerSymbol>( symbolElem, context );
+      if ( symbol )
+      {
+        mMarkerSymbol.reset( symbol );
+      }
     }
   }
 

--- a/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
@@ -135,7 +135,8 @@ QVariant QgsRelationReferenceFieldFormatter::createCache( QgsVectorLayer *layer,
     QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Cannot find referenced layer" ).arg( layer->name(), fieldName ) );
     return QVariant();
   }
-  int referencedFieldIdx = referencedLayer->fields().lookupField( relation.fieldPairs().at( 0 ).second );
+
+  const int referencedFieldIdx = referencedLayer->fields().lookupField( relation.fieldPairs().at( 0 ).second );
   if ( referencedFieldIdx == -1 )
   {
     QgsMessageLog::logMessage( QObject::tr( "Layer %1, field %2: Invalid referenced field (%3) configured in relation %4" ).arg( layer->name(), fieldName, relation.fieldPairs().at( 0 ).second, relation.name() ) );
@@ -163,7 +164,6 @@ QVariant QgsRelationReferenceFieldFormatter::createCache( QgsVectorLayer *layer,
 
     if ( expr.hasEvalError() )
     {
-      int referencedFieldIdx = referencedLayer->fields().lookupField( relation.fieldPairs().at( 0 ).second );
       title = feature.attribute( referencedFieldIdx ).toString();
     }
 

--- a/src/core/gps/qgsqtlocationconnection.cpp
+++ b/src/core/gps/qgsqtlocationconnection.cpp
@@ -124,9 +124,8 @@ void QgsQtLocationConnection::satellitesInUseUpdated(
   mLastGPSInformation.satellitesUsed = QString::number( satellites.count() ).toInt();
 
   mLastGPSInformation.satPrn.clear();
-  for ( int i = 0; i < satellites.size(); ++i )
+  for ( const QGeoSatelliteInfo &currentSatellite : satellites )
   {
-    QGeoSatelliteInfo currentSatellite = satellites.at( i );
     //add pnr to mLastGPSInformation.satPrn
 #if defined(HAVE_QT_MOBILITY_LOCATION )
     mLastGPSInformation.satPrn.append( currentSatellite.prnNumber() );
@@ -135,9 +134,8 @@ void QgsQtLocationConnection::satellitesInUseUpdated(
 #endif
 
     //set QgsSatelliteInfo.inuse to true for the satellites in use
-    for ( int i = 0; i < mLastGPSInformation.satellitesInView.size(); ++i )
+    for ( QgsSatelliteInfo &satInView : mLastGPSInformation.satellitesInView )
     {
-      QgsSatelliteInfo satInView = mLastGPSInformation.satellitesInView.at( i );
 #if defined(HAVE_QT_MOBILITY_LOCATION )
       if ( satInView.id == currentSatellite.prnNumber() )
 #else // QtPositioning

--- a/src/core/mesh/qgsmeshlayerinterpolator.cpp
+++ b/src/core/mesh/qgsmeshlayerinterpolator.cpp
@@ -126,12 +126,12 @@ QgsRasterBlock *QgsMeshLayerInterpolator::block( int, const QgsRectangle &extent
                   p );
         else
         {
-          int face = mTriangularMesh.trianglesToNativeFaces()[i];
+          const int faceIdx = mTriangularMesh.trianglesToNativeFaces()[i];
           val = QgsMeshLayerUtils::interpolateFromFacesData(
                   p1,
                   p2,
                   p3,
-                  mDatasetValues[face],
+                  mDatasetValues[faceIdx],
                   p
                 );
         }

--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -470,8 +470,8 @@ void Layer::chopFeaturesAtRepeatDistance()
         repeatParts.push_back( newfpart );
       }
 
-      for ( FeaturePart *part : repeatParts )
-        part->setTotalRepeats( repeatParts.count() );
+      for ( FeaturePart *partPtr : repeatParts )
+        partPtr->setTotalRepeats( repeatParts.count() );
     }
     else
     {

--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -162,7 +162,6 @@ void ignoreLabel( const LabelPosition *lp, PriorityQueue &list, PalRtree< LabelP
  */
 void Problem::init_sol_falp()
 {
-  int i, j;
   int label;
 
   mSol.init( mFeatureCount );
@@ -174,8 +173,8 @@ void Problem::init_sol_falp()
 
   LabelPosition *lp = nullptr;
 
-  for ( i = 0; i < static_cast< int >( mFeatureCount ); i++ )
-    for ( j = 0; j < mFeatNbLp[i]; j++ )
+  for ( int i = 0; i < static_cast< int >( mFeatureCount ); i++ )
+    for ( int j = 0; j < mFeatNbLp[i]; j++ )
     {
       label = mFeatStartId[i] + j;
       try
@@ -207,7 +206,7 @@ void Problem::init_sol_falp()
     int probFeatId = lp->getProblemFeatureId();
     mSol.activeLabelIds[probFeatId] = label;
 
-    for ( i = mFeatStartId[probFeatId]; i < mFeatStartId[probFeatId] + mFeatNbLp[probFeatId]; i++ )
+    for ( int i = mFeatStartId[probFeatId]; i < mFeatStartId[probFeatId] + mFeatNbLp[probFeatId]; i++ )
     {
       ignoreLabel( mLabelPositions[ i ].get(), list, mAllCandidatesIndex );
     }
@@ -280,9 +279,6 @@ void Problem::init_sol_falp()
 
 inline Chain *Problem::chain( int seed )
 {
-  int i;
-  int j;
-
   int lid;
 
   double delta;
@@ -323,7 +319,7 @@ inline Chain *Problem::chain( int seed )
     else
       delta -= mLabelPositions.at( tmpsol[seed] )->cost();
 
-    for ( i = -1; i < seedNbLp; i++ )
+    for ( int i = -1; i < seedNbLp; i++ )
     {
       try
       {
@@ -387,7 +383,7 @@ inline Chain *Problem::chain( int seed )
                 retainedChain->label = new int[retainedChain->degree];
                 QLinkedList<ElemTrans *>::iterator current = currentChain.begin();
                 ElemTrans *move = nullptr;
-                j = 0;
+                int j = 0;
                 while ( current != currentChain.end() )
                 {
                   move = *current;
@@ -426,7 +422,7 @@ inline Chain *Problem::chain( int seed )
               newChain->label = new int[newChain->degree];
               QLinkedList<ElemTrans *>::iterator current = currentChain.begin();
               ElemTrans *move = nullptr;
-              j = 0;
+              int j = 0;
 
               while ( current != currentChain.end() )
               {
@@ -487,7 +483,7 @@ inline Chain *Problem::chain( int seed )
               retainedChain->label = new int[retainedChain->degree];
               QLinkedList<ElemTrans *>::iterator current = currentChain.begin();
               ElemTrans *move = nullptr;
-              j = 0;
+              int j = 0;
               while ( current != currentChain.end() )
               {
                 move = *current;
@@ -503,9 +499,8 @@ inline Chain *Problem::chain( int seed )
           }
         }
       }
-      catch ( int i )
+      catch ( int )
       {
-        Q_UNUSED( i )
         conflicts.clear();
       }
     } // end foreach labelposition

--- a/src/core/providers/ogr/qgsgeopackageprojectstorage.cpp
+++ b/src/core/providers/ogr/qgsgeopackageprojectstorage.cpp
@@ -255,9 +255,9 @@ bool QgsGeoPackageProjectStorage::writeProject( const QString &uri, QIODevice *d
   errCause = _executeSql( projectUri.database, sql );
   if ( !errCause.isEmpty() )
   {
-    const QString errCause = QObject::tr( "Unable to insert or update project (project=%1) in the destination table on the database: %2" )
-                             .arg( uri,
-                                   errCause );
+    errCause = QObject::tr( "Unable to insert or update project (project=%1) in the destination table on the database: %2" )
+               .arg( uri,
+                     errCause );
 
     context.pushMessage( errCause, Qgis::Critical );
     return false;

--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -110,9 +110,9 @@ bool QgsConditionalLayerStyles::readXml( const QDomNode &node, const QgsReadWrit
     QString fieldName = fieldel.attribute( QStringLiteral( "fieldname" ) );
     QDomNodeList stylenodelist = fieldel.toElement().elementsByTagName( QStringLiteral( "style" ) );
     styles.reserve( stylenodelist.count() );
-    for ( int i = 0; i < stylenodelist.count(); i++ )
+    for ( int j = 0; j < stylenodelist.count(); j++ )
     {
-      QDomElement styleElm = stylenodelist.at( i ).toElement();
+      QDomElement styleElm = stylenodelist.at( j ).toElement();
       QgsConditionalStyle style = QgsConditionalStyle();
       style.readXml( styleElm, context );
       styles.append( style );

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -93,7 +93,7 @@ QgsDataSourceUri::QgsDataSourceUri( const QString &u )
         {
           i++;
 
-          int start = i;
+          start = i;
           while ( i < uri.length() && uri[i] != ')' )
           {
             if ( uri[i] == '\\' )

--- a/src/core/qgsexpressionsorter.h
+++ b/src/core/qgsexpressionsorter.h
@@ -141,21 +141,21 @@ class QgsExpressionSorter
 
       QVector<QgsIndexedFeature> indexedFeatures;
 
-      QgsIndexedFeature indexedFeature;
+      QgsIndexedFeature indexedFeatureToAppend;
 
       for ( const QgsFeature &f : qgis::as_const( features ) )
       {
-        indexedFeature.mIndexes.resize( mPreparedOrderBys.size() );
-        indexedFeature.mFeature = f;
+        indexedFeatureToAppend.mIndexes.resize( mPreparedOrderBys.size() );
+        indexedFeatureToAppend.mFeature = f;
 
-        expressionContext->setFeature( indexedFeature.mFeature );
+        expressionContext->setFeature( indexedFeatureToAppend.mFeature );
 
         int i = 0;
         for ( const QgsFeatureRequest::OrderByClause &orderBy : qgis::as_const( mPreparedOrderBys ) )
         {
-          indexedFeature.mIndexes.replace( i++, orderBy.expression().evaluate( expressionContext ) );
+          indexedFeatureToAppend.mIndexes.replace( i++, orderBy.expression().evaluate( expressionContext ) );
         }
-        indexedFeatures.append( indexedFeature );
+        indexedFeatures.append( indexedFeatureToAppend );
       }
 
       delete expressionContext->popScope();

--- a/src/core/qgsfontutils.cpp
+++ b/src/core/qgsfontutils.cpp
@@ -180,7 +180,6 @@ bool QgsFontUtils::updateFontViaStyle( QFont &f, const QString &fontstyle, bool 
     // fallback to first style found that works
     if ( !foundmatch )
     {
-      const auto constFamily = fontDB.styles( f.family() );
       for ( const QString &style : constFamily )
       {
         styledfont = fontDB.font( f.family(), style, defaultSize );

--- a/src/core/qgsobjectcustomproperties.cpp
+++ b/src/core/qgsobjectcustomproperties.cpp
@@ -135,10 +135,10 @@ void QgsObjectCustomProperties::writeXml( QDomNode &parentNode, QDomDocument &do
     else if ( value.canConvert<QStringList>() )
     {
       const auto constToStringList = value.toStringList();
-      for ( const QString &value : constToStringList )
+      for ( const QString &valueStr : constToStringList )
       {
         QDomElement itemElement = doc.createElement( QStringLiteral( "value" ) );
-        itemElement.appendChild( doc.createTextNode( value ) );
+        itemElement.appendChild( doc.createTextNode( valueStr ) );
         propElement.appendChild( itemElement );
       }
     }

--- a/src/core/qgsprojectviewsettings.cpp
+++ b/src/core/qgsprojectviewsettings.cpp
@@ -86,7 +86,7 @@ bool QgsProjectViewSettings::readXml( const QDomElement &element, const QgsReadW
   if ( !scalesNodes.isEmpty() )
   {
     QDomElement scalesElement = scalesNodes.at( 0 ).toElement();
-    QDomNodeList scalesNodes = scalesElement.elementsByTagName( QStringLiteral( "Scale" ) );
+    scalesNodes = scalesElement.elementsByTagName( QStringLiteral( "Scale" ) );
     for ( int i = 0; i < scalesNodes.count(); i++ )
     {
       QDomElement scaleElement = scalesNodes.at( i ).toElement();

--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -138,8 +138,8 @@ bool QgsZipUtils::zip( const QString &zipFilename, const QStringList &files )
   }
 
   int rc = 0;
-  const QByteArray fileNamePtr = zipFilename.toUtf8();
-  struct zip *z = zip_open( fileNamePtr.constData(), ZIP_CREATE, &rc );
+  const QByteArray zipFileNamePtr = zipFilename.toUtf8();
+  struct zip *z = zip_open( zipFileNamePtr.constData(), ZIP_CREATE, &rc );
 
   if ( rc == ZIP_ER_OK && z )
   {
@@ -159,9 +159,9 @@ bool QgsZipUtils::zip( const QString &zipFilename, const QStringList &files )
       {
         const QByteArray fileInfoPtr = fileInfo.fileName().toUtf8();
 #if LIBZIP_VERSION_MAJOR < 1
-        int rc = ( int ) zip_add( z, fileInfoPtr.constData(), src );
+        rc = ( int ) zip_add( z, fileInfoPtr.constData(), src );
 #else
-        int rc = ( int ) zip_file_add( z, fileInfoPtr.constData(), src, 0 );
+        rc = ( int ) zip_file_add( z, fileInfoPtr.constData(), src, 0 );
 #endif
         if ( rc == -1 )
         {

--- a/src/core/raster/qgscontrastenhancement.cpp
+++ b/src/core/raster/qgscontrastenhancement.cpp
@@ -313,7 +313,7 @@ void QgsContrastEnhancement::toSld( QDomDocument &doc, QDomElement &element ) co
     case NoEnhancement:
       return;
     case UserDefinedEnhancement:
-      QString algName = contrastEnhancementAlgorithmString( contrastEnhancementAlgorithm() );
+      algName = contrastEnhancementAlgorithmString( contrastEnhancementAlgorithm() );
       QgsDebugMsg( QObject::tr( "No SLD1.0 conversion yet for stretch algorithm %1" ).arg( algName ) );
       return;
   }

--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -285,10 +285,10 @@ void QgsSingleBandGrayRenderer::toSld( QDomDocument &doc, QDomElement &element, 
         if ( !qgsDoubleNear( contrastEnhancement()->minimumValue(), myRasterBandStats.minimumValue ) )
         {
           // look for VendorOption tag to look for that with minValue attribute
-          QDomNodeList elements = contrastEnhancementElem.elementsByTagName( QStringLiteral( "sld:VendorOption" ) );
-          for ( int i = 0; i < elements.size(); ++i )
+          const QDomNodeList vendorOptions = contrastEnhancementElem.elementsByTagName( QStringLiteral( "sld:VendorOption" ) );
+          for ( int i = 0; i < vendorOptions.size(); ++i )
           {
-            QDomElement vendorOption = elements.at( i ).toElement();
+            QDomElement vendorOption = vendorOptions.at( i ).toElement();
             if ( vendorOption.attribute( QStringLiteral( "name" ) ) != QStringLiteral( "minValue" ) )
               continue;
 


### PR DESCRIPTION
Found with
~/cppcheck/cppcheck --enable=all --inconclusive  ../src/core --library=$HOME/cppcheck/cfg/qt.cfg -j 8 -DSIP_OUT 2>&1 | grep shadowVariable

I don't think any bug was found, but better avoid such situations.
