### PR TITLE
Fix cppcheck nullPointer/nullPointerRedundantCheck warnings in src/core/

### DIFF
--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -908,7 +908,7 @@ void QgsDxfExport::writePoint( const QgsPoint &pt, const QString &layer, const Q
     const QgsMarkerSymbolLayer *msl = dynamic_cast< const QgsMarkerSymbolLayer * >( symbolLayer );
     if ( msl && symbol )
     {
-      if ( symbolLayer->writeDxf( *this, mapUnitScaleFactor( mSymbologyScale, msl->sizeUnit(), mMapUnits, ctx.renderContext().mapToPixel().mapUnitsPerPixel() ), layer, ctx, QPointF( pt.x(), pt.y() ) ) )
+      if ( msl->writeDxf( *this, mapUnitScaleFactor( mSymbologyScale, msl->sizeUnit(), mMapUnits, ctx.renderContext().mapToPixel().mapUnitsPerPixel() ), layer, ctx, QPointF( pt.x(), pt.y() ) ) )
       {
         return;
       }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -743,8 +743,10 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
     }
   }
 
+  if ( !context->hasFeature() )
+    return QVariant();
+  QgsFeature f = context->feature();
 
-  FEAT_FROM_CONTEXT( context, f )
   parameters.filter = relation.getRelatedFeaturesFilter( f );
 
   QString cacheKey = QStringLiteral( "relagg:%1:%2:%3:%4:%5" ).arg( vl->id(),
@@ -752,7 +754,7 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
                      subExpression,
                      parameters.filter,
                      orderBy );
-  if ( context && context->hasCachedValue( cacheKey ) )
+  if ( context->hasCachedValue( cacheKey ) )
     return context->cachedValue( cacheKey );
 
   QVariant result;
@@ -769,8 +771,7 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
   }
 
   // cache value
-  if ( context )
-    context->setCachedValue( cacheKey, result );
+  context->setCachedValue( cacheKey, result );
   return result;
 }
 
@@ -854,7 +855,7 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
                      subExpression,
                      parameters.filter,
                      orderBy );
-  if ( context && context->hasCachedValue( cacheKey ) )
+  if ( context->hasCachedValue( cacheKey ) )
     return context->cachedValue( cacheKey );
 
   QVariant result;
@@ -870,8 +871,7 @@ static QVariant fcnAggregateGeneric( QgsAggregateCalculator::Aggregate aggregate
   }
 
   // cache value
-  if ( context )
-    context->setCachedValue( cacheKey, result );
+  context->setCachedValue( cacheKey, result );
   return result;
 }
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -1156,6 +1156,7 @@ void QgsDataDefinedSizeLegendNode::cacheImage() const
     if ( !context )
     {
       context.reset( new QgsRenderContext );
+      Q_ASSERT( context ); // to make cppcheck happy
       context->setScaleFactor( 96 / 25.4 );
     }
     mImage = mSettings->collapsedLegendImage( *context );

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -676,6 +676,7 @@ QgsRasterBlock *QgsGdalProvider::block( int bandNo, const QgsRectangle &extent, 
     return block.release();
   }
   // apply scale and offset
+  Q_ASSERT( block ); // to make cppcheck happy
   block->applyScaleOffset( bandScale( bandNo ), bandOffset( bandNo ) );
   block->applyNoDataValues( userNoDataValues( bandNo ) );
   return block.release();

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -166,6 +166,7 @@ QgsRasterBlock *QgsPalettedRasterRenderer::block( int, QgsRectangle  const &exte
 
   //use direct data access instead of QgsRasterBlock::setValue
   //because of performance
+  Q_ASSERT( outputBlock ); // to make cppcheck happy
   unsigned int *outputData = ( unsigned int * )( outputBlock->bits() );
 
   qgssize rasterSize = ( qgssize )width * height;

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -368,20 +368,20 @@ void QgsSingleBandPseudoColorRenderer::toSld( QDomDocument &doc, QDomElement &el
   // basing on interpolation algorithm of the raster shader
   QString rampType = QStringLiteral( "ramp" );
   const QgsColorRampShader *rampShader = dynamic_cast<const QgsColorRampShader *>( mShader->rasterShaderFunction() );
-  if ( rampShader )
+  if ( !rampShader )
+    return;
+
+  switch ( rampShader->colorRampType() )
   {
-    switch ( rampShader->colorRampType() )
-    {
-      case ( QgsColorRampShader::Exact ):
-        rampType = QStringLiteral( "values" );
-        break;
-      case ( QgsColorRampShader::Discrete ):
-        rampType = QStringLiteral( "intervals" );
-        break;
-      case ( QgsColorRampShader::Interpolated ):
-        rampType = QStringLiteral( "ramp" );
-        break;
-    }
+    case ( QgsColorRampShader::Exact ):
+      rampType = QStringLiteral( "values" );
+      break;
+    case ( QgsColorRampShader::Discrete ):
+      rampType = QStringLiteral( "intervals" );
+      break;
+    case ( QgsColorRampShader::Interpolated ):
+      rampType = QStringLiteral( "ramp" );
+      break;
   }
 
   colorMapElem.setAttribute( QStringLiteral( "type" ), rampType );


### PR DESCRIPTION
Found with
~/cppcheck/cppcheck --enable=all --inconclusive ../src/core --library=$HOME/cppcheck/cfg/qt.cfg -j 8 -DSIP_OUT 2>&1 | grep nullPointer

Mostly false positives or indeed redundant check, except perhaps in
QgsSingleBandPseudoColorRenderer::toSld() where a null pointer dereference
could occur in case of failed dynamic_cast.
