### PR TITLE
Friendlier names for input layers when defining model child algorithm inputs

### DIFF
--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -291,8 +291,15 @@ class ModelerParametersDialog(QDialog):
                 return self.model.parameterDefinition(value.parameterName()).description()
             elif value.source() == QgsProcessingModelChildParameterSource.ChildOutput:
                 alg = self.model.childAlgorithm(value.outputChildId())
-                return self.tr("'{0}' from algorithm '{1}'").format(
-                    alg.algorithm().outputDefinition(value.outputName()).description(), alg.description())
+
+                output_name = alg.algorithm().outputDefinition(value.outputName()).description()
+                # see if this output has been named by the model designer -- if so, we use that friendly name
+                for name, output in alg.modelOutputs().items():
+                    if output.childOutputName() == value.outputName():
+                        output_name = name
+                        break
+
+                return self.tr("'{0}' from algorithm '{1}'").format(output_name, alg.description())
 
         return value
 


### PR DESCRIPTION
When listing available layer sources for an input in the model designer, prefer to show the user's defined name for that output instead of the generic one

Makes it easier to associate inputs with the correct outputs when creating models
