### PR TITLE
[Backport release-3_10] Processing script fixes

### DIFF
--- a/python/plugins/processing/script/ScriptAlgorithmProvider.py
+++ b/python/plugins/processing/script/ScriptAlgorithmProvider.py
@@ -111,14 +111,14 @@ class ScriptAlgorithmProvider(QgsProcessingProvider):
             if not folder:
                 continue
 
-            items = [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
-            for entry in items:
-                if entry.lower().endswith(".py"):
-                    moduleName = os.path.splitext(os.path.basename(entry))[0]
-                    filePath = os.path.abspath(os.path.join(folder, entry))
-                    alg = ScriptUtils.loadAlgorithm(moduleName, filePath)
-                    if alg is not None:
-                        self.algs.append(alg)
+            for path, subdirs, files in os.walk(folder):
+                for entry in files:
+                    if entry.lower().endswith(".py"):
+                        moduleName = os.path.splitext(os.path.basename(entry))[0]
+                        filePath = os.path.abspath(os.path.join(path, entry))
+                        alg = ScriptUtils.loadAlgorithm(moduleName, filePath)
+                        if alg is not None:
+                            self.algs.append(alg)
 
         for a in self.algs:
             self.addAlgorithm(a)

--- a/python/plugins/processing/script/ScriptUtils.py
+++ b/python/plugins/processing/script/ScriptUtils.py
@@ -75,7 +75,7 @@ def loadAlgorithm(moduleName, filePath):
                     o = obj()
                     scriptsRegistry[o.name()] = filePath
                     return o
-    except ImportError as e:
+    except (ImportError, AttributeError, TypeError) as e:
         QgsMessageLog.logMessage(QCoreApplication.translate("ScriptUtils", "Could not import script algorithm '{}' from '{}'\n{}").format(moduleName, filePath, str(e)),
                                  QCoreApplication.translate("ScriptUtils", "Processing"),
                                  Qgis.Critical)


### PR DESCRIPTION
## Description
Backport of #34095 

Two bug fixes for Processing script algorithms:

1. Catch AttributeError and TypeError when loading the algorithms. Otherwise an error in decorator of one script prevents all scripts from loading.

2. Look for script algorithm files also in subfolders and not just in the specified folder. This is how it worked in QGIS 2.18 and it allowed the files to be organized in a folder structure.


## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
