### PR TITLE
Image resources in server

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -167,12 +167,16 @@ INSTALL(TARGETS qgis_server
 
 # end qgis_server library
 
+# add image resources
+SET(QGIS_SERVER_IMAGERCCS ../../images/images.qrc)
+QT5_ADD_RESOURCES(QGIS_SERVER_IMAGERCC_SRCS ${QGIS_SERVER_IMAGERCCS})
+
 # add test resources, e.g. standard test font
 SET(QGIS_SERVER_TESTRCCS ../../tests/testdata/testdata.qrc)
 QT5_ADD_RESOURCES(QGIS_SERVER_TESTRCC_SRCS ${QGIS_SERVER_TESTRCCS})
 
-ADD_EXECUTABLE(qgis_mapserv.fcgi qgis_map_serv.cpp ${QGIS_SERVER_TESTRCC_SRCS})
-ADD_EXECUTABLE(qgis_mapserver qgis_mapserver.cpp ${QGIS_SERVER_TESTRCC_SRCS})
+ADD_EXECUTABLE(qgis_mapserv.fcgi qgis_map_serv.cpp ${QGIS_SERVER_TESTRCC_SRCS} ${QGIS_SERVER_IMAGERCC_SRCS})
+ADD_EXECUTABLE(qgis_mapserver qgis_mapserver.cpp ${QGIS_SERVER_TESTRCC_SRCS} ${QGIS_SERVER_IMAGERCC_SRCS})
 
 TARGET_LINK_LIBRARIES(qgis_mapserv.fcgi qgis_server)
 TARGET_LINK_LIBRARIES(qgis_mapserver qgis_server)


### PR DESCRIPTION
Including the `image.qrc` fixes that images like images/composer/missing_image.svg are displayed in e.g. GetPrint requests.