### PR TITLE
Fix widget wrong values 0 doubles

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -58,9 +58,14 @@ QVariant QgsTextEditWrapper::value() const
     v = mLineEdit->text();
   }
 
-  if ( ( v.isEmpty() && ( field().type() == QVariant::Int || field().type() == QVariant::Double || field().type() == QVariant::LongLong || field().type() == QVariant::Date ) ) ||
-       v == QgsApplication::nullRepresentation() )
+  if ( ( v.isEmpty() && ( field().type() == QVariant::Int
+                          || field().type() == QVariant::Double
+                          || field().type() == QVariant::LongLong
+                          || field().type() == QVariant::Date ) )
+       || v == QgsApplication::nullRepresentation() )
+  {
     return QVariant( field().type() );
+  }
 
   if ( !defaultValue().isNull() && v == defaultValue().toString() )
   {
@@ -323,9 +328,14 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
     v = v.remove( QLocale().groupSeparator() );
   }
 
-  if ( mTextEdit )
+  const QVariant currentValue { value( ) };
+  // Note: comparing QVariants leads to funny (and wrong) results:
+  // QVariant(0.0) == QVariant(QVariant.Double) -> True
+  const bool changed { val != currentValue || val.isNull() != currentValue.isNull() };
+
+  if ( changed )
   {
-    if ( val != value() )
+    if ( mTextEdit )
     {
       if ( config( QStringLiteral( "UseHtml" ) ).toBool() )
       {
@@ -337,18 +347,19 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
         }
       }
       else
+      {
         mTextEdit->setPlainText( v );
+      }
+    }
+    else if ( mPlainTextEdit )
+    {
+      mPlainTextEdit->setPlainText( v );
+    }
+    else if ( mLineEdit )
+    {
+      mLineEdit->setText( v );
     }
   }
-
-  if ( mPlainTextEdit )
-  {
-    if ( val != value() )
-      mPlainTextEdit->setPlainText( v );
-  }
-
-  if ( mLineEdit && val != value() )
-    mLineEdit->setText( v );
 }
 
 void QgsTextEditWrapper::setHint( const QString &hintText )

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -54,6 +54,7 @@ class TestQgsAttributeForm : public QObject
     void testDefaultValueUpdate();
     void testDefaultValueUpdateRecursion();
     void testSameFieldSync();
+    void testZeroDoubles();
 
   private:
     QLabel *constraintsLabel( QgsAttributeForm *form, QgsEditorWidgetWrapper *ww )
@@ -1107,6 +1108,21 @@ void TestQgsAttributeForm::testSameFieldSync()
   QCOMPARE( les[0]->cursorPosition(), 3 );
   QCOMPARE( les[1]->text(), QString( "1230" ) );
   QCOMPARE( les[1]->cursorPosition(), 4 );
+}
+
+void TestQgsAttributeForm::testZeroDoubles()
+{
+  // See issue GH #34118
+  QString def = QStringLiteral( "Point?field=col0:double" );
+  QgsVectorLayer layer { def, QStringLiteral( "test" ), QStringLiteral( "memory" ) };
+  layer.setEditorWidgetSetup( 0, QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() ) );
+  QgsFeature ft( layer.dataProvider()->fields(), 1 );
+  ft.setAttribute( QStringLiteral( "col0" ), 0.0 );
+  QgsAttributeForm form( &layer );
+  form.setFeature( ft );
+  QList<QLineEdit *> les = form.findChildren<QLineEdit *>( "col0" );
+  QCOMPARE( les.count(), 1 );
+  QCOMPARE( les.at( 0 )->text(), QStringLiteral( "0" ) );
 }
 
 QGSTEST_MAIN( TestQgsAttributeForm )


### PR DESCRIPTION
Fixes #34118

Because:

QVariant(0.0) == QVariant(QVariant.Double) -> True

but:

QVariant(0.0).isNull() == QVariant(QVariant.Double).isNull() -> False
