### PR TITLE
Fixed vertex tool selection on a rotated map canvas

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -476,7 +476,7 @@ void QgsVertexTool::cadCanvasPressEvent( QgsMapMouseEvent *e )
 
     // the user may have started dragging a rect to select vertices
     if ( !mDraggingVertex && !mDraggingEdge )
-      mSelectionRectStartPos.reset( new QPoint( e->pos() ) );
+      mSelectionRubberBandStartPos.reset( new QPoint( e->pos() ) );
   }
 }
 
@@ -509,14 +509,16 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       mouseMoveNotDragging( e );
     }
   }
-  else if ( mSelectionRect )
+  else if ( mSelectionRubberBand )
   {
     // only handling of selection rect being dragged
-    QgsPointXY pt0 = toMapCoordinates( *mSelectionRectStartPos );
+    QgsPointXY pt0 = toMapCoordinates( *mSelectionRubberBandStartPos );
     QgsPointXY pt1 = toMapCoordinates( e->pos() );
     QgsRectangle map_rect( pt0, pt1 );
     QList<Vertex> vertices;
     QList<Vertex> selectedVertices;
+
+    QgsGeometry rubberBandGeometry = mSelectionRubberBand->asGeometry();
 
     // the logic for selecting vertices using rectangle:
     // - if we have a bound (locked) feature, we only allow selection of its vertices
@@ -534,7 +536,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       if ( mLockedFeature && mLockedFeature->layer() != vlayer )
         continue;  // with locked feature we only allow selection of its vertices
 
-      QgsRectangle layerRect = toLayerCoordinates( vlayer, map_rect );
+      QgsRectangle layerRect = toLayerCoordinates( vlayer, rubberBandGeometry.boundingBox() );
       QgsFeature f;
       QgsFeatureIterator fi = vlayer->getFeatures( QgsFeatureRequest( layerRect ).setNoAttributes() );
       while ( fi.nextFeature( f ) )
@@ -547,7 +549,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         for ( int i = 0; i < g.constGet()->nCoordinates(); ++i )
         {
           QgsPointXY pt = g.vertexAt( i );
-          if ( layerRect.contains( pt ) )
+          if ( rubberBandGeometry.contains( &pt ) )
           {
             vertices << Vertex( vlayer, f.id(), i );
 
@@ -572,7 +574,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 
     setHighlightedVertices( vertices, mode );
 
-    stopSelectionRect();
+    stopSelectionRubberBand();
   }
   else  // selection rect is not being dragged
   {
@@ -601,7 +603,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         // cancel action
         stopDragging();
       }
-      else if ( !mSelectionRect )
+      else if ( !mSelectionRubberBand )
       {
         // Right-click to select/delect a feature for editing (also gets selected in vertex editor).
         // If there are multiple features at one location, cycle through them with subsequent right clicks.
@@ -610,7 +612,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     }
   }
 
-  mSelectionRectStartPos.reset();
+  mSelectionRubberBandStartPos.reset();
 }
 
 void QgsVertexTool::cadCanvasMoveEvent( QgsMapMouseEvent *e )
@@ -636,16 +638,16 @@ void QgsVertexTool::cadCanvasMoveEvent( QgsMapMouseEvent *e )
   {
     mouseMoveDraggingEdge( e );
   }
-  else if ( mSelectionRectStartPos )
+  else if ( mSelectionRubberBandStartPos )
   {
     // the user may be dragging a rect to select vertices
-    if ( !mSelectionRect && ( e->pos() - *mSelectionRectStartPos ).manhattanLength() >= 10 )
+    if ( !mSelectionRubberBand && ( e->pos() - *mSelectionRubberBandStartPos ).manhattanLength() >= 10 )
     {
-      startSelectionRect( *mSelectionRectStartPos );
+      initSelectionRubberBand();
     }
-    if ( mSelectionRect )
+    if ( mSelectionRubberBand )
     {
-      updateSelectionRect( e->pos() );
+      updateSelectionRubberBand( e );
     }
   }
   else
@@ -2430,28 +2432,28 @@ void QgsVertexTool::highlightAdjacentVertex( double offset )
   zoomToVertex( vertex );  // make sure the vertex is visible
 }
 
-void QgsVertexTool::startSelectionRect( QPoint point0 )
+void QgsVertexTool::initSelectionRubberBand()
 {
-  Q_ASSERT( !mSelectionRect );
-  mSelectionRect.reset( new QRect() );
-  mSelectionRect->setTopLeft( point0 );
-  mSelectionRectItem = new QRubberBand( QRubberBand::Rectangle, canvas() );
+  if ( !mSelectionRubberBand )
+  {
+    mSelectionRubberBand = qgis::make_unique<QgsRubberBand>( mCanvas, QgsWkbTypes::PolygonGeometry );
+    QColor fillColor = QColor( 0, 120, 215, 63 );
+    QColor strokeColor = QColor( 0, 102, 204, 100 );
+    mSelectionRubberBand->setFillColor( fillColor );
+    mSelectionRubberBand->setStrokeColor( strokeColor );
+  }
 }
 
-void QgsVertexTool::updateSelectionRect( QPoint point1 )
+void QgsVertexTool::updateSelectionRubberBand( QgsMapMouseEvent *e )
 {
-  Q_ASSERT( mSelectionRect );
-  mSelectionRect->setBottomRight( point1 );
-  mSelectionRectItem->setGeometry( mSelectionRect->normalized() );
-  mSelectionRectItem->show();
+  QRect rect = QRect( e->pos(), *mSelectionRubberBandStartPos );
+  if ( mSelectionRubberBand )
+    mSelectionRubberBand->setToCanvasRectangle( rect );
 }
 
-void QgsVertexTool::stopSelectionRect()
+void QgsVertexTool::stopSelectionRubberBand()
 {
-  Q_ASSERT( mSelectionRect );
-  mSelectionRectItem->deleteLater();
-  mSelectionRectItem = nullptr;
-  mSelectionRect.reset();
+  mSelectionRubberBand.reset();
 }
 
 bool QgsVertexTool::matchEdgeCenterTest( const QgsPointLocator::Match &m, const QgsPointXY &mapPoint, QgsPointXY *edgeCenterPtr )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -512,9 +512,6 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   else if ( mSelectionRubberBand )
   {
     // only handling of selection rect being dragged
-    QgsPointXY pt0 = toMapCoordinates( *mSelectionRubberBandStartPos );
-    QgsPointXY pt1 = toMapCoordinates( e->pos() );
-    QgsRectangle map_rect( pt0, pt1 );
     QList<Vertex> vertices;
     QList<Vertex> selectedVertices;
 

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -253,19 +253,13 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! Allow moving back and forth selected vertex within a feature
     void highlightAdjacentVertex( double offset );
 
-    /**
-     * Initialize rectangle that is being dragged to select vertices.
-     * Argument point0 is in screen coordinates.
-     */
-    void startSelectionRect( QPoint point0 );
+    //! Initialize the rubberband for vertex selection using a rectangle
+    void initSelectionRubberBand();
 
-    /**
-     * Update bottom-right corner of the existing selection rectangle.
-     * Argument point1 is in screen coordinates.
-     */
-    void updateSelectionRect( QPoint point1 );
+    //! Update the rubberband for vertex selection using a rectangle
+    void updateSelectionRubberBand( QgsMapMouseEvent *e );
 
-    void stopSelectionRect();
+    void stopSelectionRubberBand();
 
     /**
      * Using a given edge match and original map point, find out
@@ -409,12 +403,10 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     // members for rectangle for selection
 
-    //! QPoint if user is dragging a selection rect
-    std::unique_ptr<QPoint> mSelectionRectStartPos;
-    //! QRect in screen coordinates or null
-    std::unique_ptr<QRect> mSelectionRect;
-    //! QRubberBand to show mSelectionRect
-    QRubberBand *mSelectionRectItem = nullptr;
+    //! the rubberband for rectangle selection visualization
+    std::unique_ptr<QgsRubberBand> mSelectionRubberBand;
+    //! Initial point (in screen coordinates) when using rectangle selection
+    std::unique_ptr<QPoint> mSelectionRubberBandStartPos;
 
     // members for addition of vertices at the end of a curve
 


### PR DESCRIPTION
## Description
<!-- Include below a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots.-->
The vertex tool rectangular selection selects wrong vertices on a rotated map.

![Peek 2020-02-01 03-27](https://user-images.githubusercontent.com/11358178/73584705-d8264980-44a2-11ea-9eff-45c27b14eef2.gif)

To fix this, the simple select tool logic has been applied to the vertex tool.

## Checklist

<!-- Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.
-->

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [x] I have evaluated whether it is appropriate for this PR to be backported, backport requests are left as label or comment
