### PR TITLE
Set QGIS_CUSTOM_CONFIG_PATH to temporary dir for python tests

### DIFF
--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -26,6 +26,7 @@ import sys
 import difflib
 import functools
 import filecmp
+import tempfile
 
 from qgis.PyQt.QtCore import QVariant
 from qgis.core import QgsApplication, QgsFeatureRequest, NULL
@@ -421,6 +422,7 @@ def start_app(cleanup=True):
         # no need to mess with it here.
         QGISAPP = QgsApplication(argvb, myGuiFlag)
 
+        os.environ['QGIS_CUSTOM_CONFIG_PATH'] = tempfile.mkdtemp('', 'QGIS-PythonTestConfigPath')
         QGISAPP.initQgis()
         print(QGISAPP.showSettings())
 


### PR DESCRIPTION
Fixes #34185 for the python tests

Avoids polluting ~/.local/share