### PR TITLE
Avoid CRS detection via .qpj when using GDAL3/PROJ6 (fixes #34211)

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3687,6 +3687,7 @@ QgsCoordinateReferenceSystem QgsOgrProvider::crs() const
   if ( !mValid || ( mOGRGeomType == wkbNone ) )
     return srs;
 
+#if PROJ_VERSION_MAJOR<6
   if ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) )
   {
     int index = mFilePath.indexOf( QLatin1String( ".shp" ), Qt::CaseInsensitive );
@@ -3708,7 +3709,6 @@ QgsCoordinateReferenceSystem QgsOgrProvider::crs() const
   }
 
   // add towgs84 parameter
-#if PROJ_VERSION_MAJOR<6
   Q_NOWARN_DEPRECATED_PUSH
   QgsCoordinateReferenceSystem::setupESRIWktFix();
   Q_NOWARN_DEPRECATED_POP

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -503,6 +503,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     CPLSetConfigOption( "SHAPE_ENCODING", nullptr );
   }
 
+#if PROJ_VERSION_MAJOR<6
   if ( srs.isValid() )
   {
     if ( mOgrDriverName == QLatin1String( "ESRI Shapefile" ) )
@@ -521,6 +522,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
       }
     }
   }
+#endif
 
   if ( !mLayer )
   {


### PR DESCRIPTION
## Description

The GDAL2/PROJ5 WKT string exported to the QGIS-specific .qpj file for ESRI Shapefile datasets doesn't play well with GDAL3/PROJ6, as described in issue #34211 , leading to newly added layers not having the right EPSG assigned upon adding datasets with such file.

@jef-n , this PR disables the QGIS-specific .qpj workaround introduced 10 years ago when running QGIS built against GDAL3/PROJ6. OK with you?