### PR TITLE
[WIP] BUG: postgres serial id conflict during an upsert join, fix #33148

### DIFF
--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -82,6 +82,11 @@ bool QgsVectorLayerJoinBuffer::addJoin( const QgsVectorLayerJoinInfo &joinInfo )
     cacheJoinLayer( mVectorJoins.last() );
   }
 
+  if ( joinInfo.hasUpsertOnEdit() )
+  {
+    QgsProject::instance()->setEvaluateDefaultValues( true );
+  }
+
   // Wait for notifications about changed fields in joined layer to propagate them.
   // During project load the joined layers possibly do not exist yet so the connection will not be created,
   // but then QgsProject makes sure to call createJoinCaches() which will do the connection.


### PR DESCRIPTION
## Description

fix #33148, @devfaz74 provides data test in it.

As explained in the issue, serial type column causes broken link between parent and child table using the upsert on edit feature.

The default values `nextval('public.parent_id_seq'::regclass)` is used to create the child entity but there is no update when parent entity is commited (and `nextval('public.parent_id_seq'::regclass)` is converted to int value during this step so the link is broken).

The (not obvious for users) solution is to activate the `evaluateDefaultValues` option in the project properties menu.

Maybe we should activate this option by default when a join is added with the `upsertOnEdit` flag. That what I propose in this PR, but I am not sure it's the best solution because : 

- It doesn't keep information about previous state of `evaluateDefaultValues`, if the user remove the join in the future.
- I don't know if there is specific contraindications to the use of `evaluateDefaultValues` option...

I let the subject opened to other solution. If this one is accepted I will create the test in consequence.

## Checklist : 
 - [x] Commit messages are descriptive and explain the rationale for changes.

 - [x] Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

 - [ ] New unit tests have been added for relevant changes

 - [x] You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

 - [x] You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
