### PR TITLE
Close vertex for line when editing. fixes #32359 [needs-docs]

### DIFF
--- a/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
@@ -32,6 +32,8 @@ QgsMapToolDigitizeFeature is a map tool to digitize a feature geometry
 :param mode: type of geometry to capture (point/line/polygon), QgsMapToolCapture.CaptureNone to autodetect geometry
 %End
 
+    virtual void keyPressEvent( QKeyEvent *e );
+
     virtual void cadCanvasReleaseEvent( QgsMapMouseEvent *e );
 
 

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -94,37 +94,42 @@ void QgsMapToolDigitizeFeature::setCheckGeometryType( bool checkGeometryType )
 
 void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
 {
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );
-  if ( !vlayer )
-    //if no given layer take the current from canvas
-    vlayer = currentVectorLayer();
-
-  if ( !vlayer )
+  if ( e && e->key() == Qt::Key_C )
   {
-    notifyNotVectorLayer();
-    return;
-  }
+    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );
+    if ( !vlayer )
+      //if no given layer take the current from canvas
+      vlayer = currentVectorLayer();
 
-  QgsVectorDataProvider *provider = vlayer->dataProvider();
+    if ( !vlayer )
+    {
+      notifyNotVectorLayer();
+      return;
+    }
 
-  if ( !( provider->capabilities() & QgsVectorDataProvider::AddFeatures ) )
-  {
-    emit messageEmitted( tr( "The data provider for this layer does not support the addition of features." ), Qgis::Warning );
-    return;
-  }
+    QgsVectorDataProvider *provider = vlayer->dataProvider();
 
-  if ( !vlayer->isEditable() )
-  {
-    notifyNotEditableLayer();
-    return;
-  }
+    if ( !( provider->capabilities() & QgsVectorDataProvider::AddFeatures ) )
+    {
+      emit messageEmitted( tr( "The data provider for this layer does not support the addition of features." ), Qgis::Warning );
+      return;
+    }
 
-  if ( e && e->key() == Qt::Key_C && mode() == CaptureLine && vlayer->geometryType() == QgsWkbTypes::LineGeometry && mCheckGeometryType )
-  {
-    closePolygon();
-    QgsMapMouseEvent e2( mCanvas, QEvent::MouseButtonRelease, QPoint( ), Qt::RightButton );
-    cadCanvasReleaseEvent( &e2 );
+    if ( !vlayer->isEditable() )
+    {
+      notifyNotEditableLayer();
+      return;
+    }
+
+    if ( ( mode() == CaptureLine && vlayer->geometryType() == QgsWkbTypes::LineGeometry && mCheckGeometryType ) || ( mode() == CapturePolygon && vlayer->geometryType() == QgsWkbTypes::PolygonGeometry && mCheckGeometryType ) )
+    {
+      closePolygon();
+      QgsMapMouseEvent e2( mCanvas, QEvent::MouseButtonRelease, QPoint( ), Qt::RightButton );
+      cadCanvasReleaseEvent( &e2 );
+    }
   }
+  else
+    QgsMapToolCapture::keyPressEvent( e );
 }
 void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 {

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -42,6 +42,7 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCapture
      */
     QgsMapToolDigitizeFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode = QgsMapToolCapture::CaptureNone );
 
+    void keyPressEvent( QKeyEvent *e ) override;
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
     /**

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -68,6 +68,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     void testZ();
     void testZMSnapping();
     void testTopologicalEditingZ();
+    void testCloseLine();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -80,6 +81,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     QgsVectorLayer *mLayerPointZM = nullptr;
     QgsVectorLayer *mLayerTopoZ = nullptr;
     QgsVectorLayer *mLayerLine2D = nullptr;
+    QgsVectorLayer *mLayerCloseLine = nullptr;
     QgsFeatureId mFidLineF1 = 0;
 };
 
@@ -136,6 +138,11 @@ void TestQgsMapToolAddFeatureLine::initTestCase()
   mLayerLineZ->startEditing();
   mLayerLineZ->addFeature( lineF2 );
   QCOMPARE( mLayerLineZ->featureCount(), ( long )1 );
+
+  mLayerCloseLine = new QgsVectorLayer( QStringLiteral( "LineString?crs=EPSG:27700" ), QStringLiteral( "layer line Closed" ), QStringLiteral( "memory" ) );
+  QVERIFY( mLayerCloseLine->isValid() );
+  mLayerCloseLine->startEditing();
+  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << mLayerCloseLine );
 
   mCanvas->setFrameStyle( QFrame::NoFrame );
   mCanvas->resize( 512, 512 );
@@ -481,6 +488,24 @@ void TestQgsMapToolAddFeatureLine::testTopologicalEditingZ()
   cfg.setEnabled( false );
   mCanvas->snappingUtils()->setConfig( cfg );
   cfg.project()->setTopologicalEditing( topologicalEditing );
+}
+
+void TestQgsMapToolAddFeatureLine::testCloseLine()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  mCanvas->setCurrentLayer( mLayerCloseLine );
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+  utils.mouseClick( 1, 1, Qt::LeftButton );
+  utils.mouseClick( 5, 1, Qt::LeftButton );
+  utils.mouseClick( 5, 5, Qt::LeftButton );
+  utils.keyClick( Qt::Key_C );
+  QgsFeatureId newFid = utils.newFeatureId( oldFids );
+
+  QString wkt = "LineString (1 1, 5 1, 5 5, 1 1)";
+  QCOMPARE( mLayerCloseLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
+
+  mLayerCloseLine->undoStack()->undo();
 }
 QGSTEST_MAIN( TestQgsMapToolAddFeatureLine )
 #include "testqgsmaptooladdfeatureline.moc"


### PR DESCRIPTION
## Description

This PR can be considered as a bugfix (by a workaround) or as a feature.

It is not possible to simply fix this problem, @troopa81 will be able to give the details.

However, as a draftsman, not being able to close a line is one of the most annoying things in QGIS. I suggest to close the line by pressing the "C" (close) key as proposed in many drawing tools to fix this problem.

I let you comment if for you it should be merged in master and backported to 3.10 if it's bugfix or not.

Thanks.