### PR TITLE
[Bugfix] Read SLD TextSymbolizer for lines

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4618,6 +4618,10 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
     if ( !pointPlacementElem.isNull() )
     {
       settings.placement = QgsPalLayerSettings::OverPoint;
+      if ( geometryType() == QgsWkbTypes::LineGeometry )
+      {
+        settings.placement = QgsPalLayerSettings::Line;
+      }
 
       QDomElement displacementElem = pointPlacementElem.firstChildElement( QStringLiteral( "Displacement" ) );
       if ( !displacementElem.isNull() )
@@ -4681,6 +4685,15 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
         {
           settings.angleOffset = 360 - rotation;
         }
+      }
+    }
+    else
+    {
+      // PointPlacement
+      QDomElement linePlacementElem = labelPlacementElem.firstChildElement( QStringLiteral( "LinePlacement" ) );
+      if ( !linePlacementElem.isNull() )
+      {
+        settings.placement = QgsPalLayerSettings::Line;
       }
     }
   }

--- a/tests/src/python/test_qgssymbollayer_readsld.py
+++ b/tests/src/python/test_qgssymbollayer_readsld.py
@@ -444,7 +444,12 @@ class TestQgsSymbolLayerReadSld(unittest.TestCase):
         self.assertEqual(format.size(), 18)
         self.assertEqual(format.sizeUnit(), QgsUnitTypes.RenderPixels)
 
+        # the layer contains lines
+        # from qgis.core import QgsWkbTypes
+        # self.assertEqual(layer.geometryType(), QgsWkbTypes.LineGeometry)
+        # the placement should be QgsPalLayerSettings.Line
         self.assertEqual(settings.placement, QgsPalLayerSettings.AroundPoint)
+
         self.assertEqual(settings.xOffset, 1)
         self.assertEqual(settings.yOffset, 0)
         self.assertEqual(settings.offsetUnits, QgsUnitTypes.RenderPixels)


### PR DESCRIPTION
## Description

When reading SLD TextSymbolizer the labeling is well activated but the rendering is not well configured. It seems that placement has to be `QgsPalLayerSettings.Line`.

- [ ] New unit tests have been added for relevant changes
- [x] You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
- [x] You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
