### PR TITLE
Make minimm number of nodes to 2 in subdivide algorithm.

### DIFF
--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -22,7 +22,7 @@
 void QgsSubdivideAlgorithm::initParameters( const QVariantMap & )
 {
   std::unique_ptr< QgsProcessingParameterNumber> nodes = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsProcessingParameterNumber::Integer,
-      256, false, 8, 100000 );
+      256, false, 2, 100000 );
   nodes->setIsDynamic( true );
   nodes->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsPropertyDefinition::Integer ) );
   nodes->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );


### PR DESCRIPTION

was there any reason to make it 8?
use-case: I want to subdivide lines in segments.