### PR TITLE
Follow up 012ee83: delete .qpj file when overwriting pre-existing shapefile dataset

### DIFF
--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -3652,6 +3652,7 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
     {
       QString layerName = uri.left( index );
       QFile prjFile( layerName + ".qpj" );
+#if PROJ_VERSION_MAJOR<6
       if ( prjFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
       {
         QTextStream prjStream( &prjFile );
@@ -3662,6 +3663,10 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
       {
         QgsMessageLog::logMessage( QObject::tr( "Couldn't create file %1.qpj" ).arg( layerName ), QObject::tr( "OGR" ) );
       }
+#else
+      if ( prjFile.exists() )
+        prjFile.remove();
+#endif
     }
   }
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -503,13 +503,13 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     CPLSetConfigOption( "SHAPE_ENCODING", nullptr );
   }
 
-#if PROJ_VERSION_MAJOR<6
   if ( srs.isValid() )
   {
     if ( mOgrDriverName == QLatin1String( "ESRI Shapefile" ) )
     {
       QString layerName = vectorFileName.left( vectorFileName.indexOf( QLatin1String( ".shp" ), Qt::CaseInsensitive ) );
       QFile prjFile( layerName + ".qpj" );
+#if PROJ_VERSION_MAJOR<6
       if ( prjFile.open( QIODevice::WriteOnly  | QIODevice::Truncate ) )
       {
         QTextStream prjStream( &prjFile );
@@ -520,9 +520,12 @@ void QgsVectorFileWriter::init( QString vectorFileName,
       {
         QgsDebugMsg( "Couldn't open file " + layerName + ".qpj" );
       }
+#else
+      if ( prjFile.exists() )
+        prjFile.remove();
+#endif
     }
   }
-#endif
 
   if ( !mLayer )
   {


### PR DESCRIPTION
## Description

@nyalldawson , as you requested, here's the follow up PR which also disables the .qpj workaround in the QgsOgrProviderUtils::createEmptyDataSource function.

It also occurred to me we need to delete pre-existing .qpj when overwriting pre-existing datasets, otherwise worlds might collide :wink: 