### PR TITLE
 Don't force users to make a choice in the datum transform dialog

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -53,7 +53,6 @@ SET(QGIS_APP_SRCS
   qgssourcefieldsproperties.cpp
   qgsattributesformproperties.cpp
   qgsidentifyresultsdialog.cpp
-  qgsinstallgridshiftdialog.cpp
   qgsfeatureaction.cpp
   qgslayercapabilitiesmodel.cpp
   qgslayertreeviewindicatorprovider.cpp

--- a/src/app/qgsdatumtransformtablewidget.cpp
+++ b/src/app/qgsdatumtransformtablewidget.cpp
@@ -27,8 +27,9 @@ QgsDatumTransformTableModel::QgsDatumTransformTableModel( QObject *parent )
 
 void QgsDatumTransformTableModel::setTransformContext( const QgsCoordinateTransformContext &context )
 {
+  beginResetModel();
   mTransformContext = context;
-  reset();
+  endResetModel();
 }
 
 void QgsDatumTransformTableModel::removeTransform( const QModelIndexList &indexes )
@@ -47,8 +48,9 @@ void QgsDatumTransformTableModel::removeTransform( const QModelIndexList &indexe
     }
     if ( sourceCrs.isValid() && destinationCrs.isValid() )
     {
+      beginResetModel();
       mTransformContext.removeCoordinateOperation( sourceCrs, destinationCrs );
-      reset();
+      endResetModel();
       break;
     }
   }
@@ -282,7 +284,7 @@ void QgsDatumTransformTableWidget::editDatumTransform( const QModelIndex &index 
 #endif
 
 #if PROJ_VERSION_MAJOR>=6
-  if ( sourceCrs.isValid() && destinationCrs.isValid() && !proj.isEmpty() )
+  if ( sourceCrs.isValid() && destinationCrs.isValid() )
 #else
   if ( sourceCrs.isValid() && destinationCrs.isValid() &&
        ( sourceTransform != -1 || destinationTransform != -1 ) )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -357,6 +357,7 @@ SET(QGIS_GUI_SRCS
   qgshistogramwidget.cpp
   qgshelp.cpp
   qgsidentifymenu.cpp
+  qgsinstallgridshiftdialog.cpp
   qgskeyvaluewidget.cpp
   qgslistwidget.cpp
   qgslegendfilterbutton.cpp
@@ -561,6 +562,7 @@ SET(QGIS_GUI_HDRS
   qgshighlightablecombobox.h
   qgshistogramwidget.h
   qgsidentifymenu.h
+  qgsinstallgridshiftdialog.h
   qgskeyvaluewidget.h
   qgslegendfilterbutton.h
   qgslimitedrandomcolorrampdialog.h

--- a/src/gui/qgscoordinateoperationwidget.h
+++ b/src/gui/qgscoordinateoperationwidget.h
@@ -159,6 +159,8 @@ class GUI_EXPORT QgsCoordinateOperationWidget : public QWidget, private Ui::QgsC
 
     void showSupersededToggled( bool toggled );
 
+    void installGrid();
+
   private:
 
     enum Roles
@@ -166,7 +168,10 @@ class GUI_EXPORT QgsCoordinateOperationWidget : public QWidget, private Ui::QgsC
       TransformIdRole = Qt::UserRole + 1,
       ProjRole,
       AvailableRole,
-      BoundsRole
+      BoundsRole,
+      MissingGridsRole,
+      MissingGridPackageNamesRole,
+      MissingGridUrlsRole
     };
 
     bool gridShiftTransformation( const QString &itemText ) const;

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -44,7 +44,7 @@ bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs
     return true;
   }
 
-  QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, false, true, true, qMakePair( -1, -1 ), parent, nullptr, QString(), mapCanvas );
+  QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, false, true, false, qMakePair( -1, -1 ), parent, nullptr, QString(), mapCanvas );
   if ( !windowTitle.isEmpty() )
     dlg.setWindowTitle( windowTitle );
 

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -75,7 +75,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
                      QgsMapCanvas *mapCanvas = nullptr,
                      const QString &windowTitle = QString() );
 
-    // TODO QGIS 4.0 - remove selectedDatumTransform
+    // TODO QGIS 4.0 - remove selectedDatumTransform, forceChoice
 
     /**
      * Constructor for QgsDatumTransformDialog.

--- a/src/gui/qgsinstallgridshiftdialog.cpp
+++ b/src/gui/qgsinstallgridshiftdialog.cpp
@@ -23,6 +23,8 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
+///@cond PRIVATE
+
 QgsInstallGridShiftFileDialog::QgsInstallGridShiftFileDialog( const QString &gridName, QWidget *parent )
   : QDialog( parent )
   , mGridName( gridName )
@@ -75,3 +77,5 @@ void QgsInstallGridShiftFileDialog::installFromFile()
     QMessageBox::critical( this, tr( "Install Grid File" ), tr( "Could not copy %1 to %2. Please check folder permissions and retry." ).arg( mGridName, destPath ) );
   }
 }
+
+///@endcond

--- a/src/gui/qgsinstallgridshiftdialog.h
+++ b/src/gui/qgsinstallgridshiftdialog.h
@@ -20,9 +20,12 @@
 
 #include "ui_qgsinstallgridshiftdialog.h"
 #include <QDialog>
-#include "qgis_app.h"
+#include "qgis_gui.h"
 
-class QgsInstallGridShiftFileDialog: public QDialog, private Ui::QgsInstallGridShiftFileDialogBase
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+class GUI_EXPORT QgsInstallGridShiftFileDialog: public QDialog, private Ui::QgsInstallGridShiftFileDialogBase
 {
     Q_OBJECT
   public:
@@ -39,5 +42,6 @@ class QgsInstallGridShiftFileDialog: public QDialog, private Ui::QgsInstallGridS
     QString mGridName;
 
 };
+///@endcond
 
 #endif // QGSINSTALLGRIDSHIFTDIALOG_H

--- a/src/ui/qgscoordinateoperationwidgetbase.ui
+++ b/src/ui/qgscoordinateoperationwidgetbase.ui
@@ -29,23 +29,50 @@
    <item row="1" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,1,0">
      <item>
-      <widget class="QLabel" name="mLabelSrcDescription">
-       <property name="cursor">
-        <cursorShape>IBeamCursor</cursorShape>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string notr="true">Description</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="mInstallGridButton">
+         <property name="text">
+          <string>Install Grid…</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="mLabelSrcDescription">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string notr="true">Description</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <widget class="QLabel" name="mLabelDstDescription">


### PR DESCRIPTION
It's possible to get a situation where none of the options can be
selected, because they all require a grid which isn't available on
the system. So always allow users to close the dialog to dismiss it
(which has the same effect as picking the default selection from
the dialog when possible, or giving null transforms if NO transforms
are available at all...)

Fixes #34234

Also match the UI of the coordinate operation widget with other "missing grid" widgets in QGIS, and offer a user-friendly way to install the required grid.