### PR TITLE
Show "Unknown CRS" entry in crs selector widget and status bar widget for non-standard, non-user CRSes

### DIFF
--- a/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectiontreewidget.sip.in
@@ -91,7 +91,7 @@ Returns whether the bounds preview map is shown.
 Returns ``True`` if the current selection in the widget is a valid choice. Valid
 selections include any projection and also the "no/invalid projection" option
 (if setShowNoProjection() was called). Invalid selections are the group
-headers (such as "Geographic Coordinate Systems"
+headers (such as "Geographic Coordinate Systems")
 %End
 
   public slots:

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12902,12 +12902,16 @@ void QgisApp::removeWebToolBarIcon( QAction *qAction )
 
 void QgisApp::updateCrsStatusBar()
 {
-  if ( QgsProject::instance()->crs().isValid() )
+  const QgsCoordinateReferenceSystem projectCrs = QgsProject::instance()->crs();
+  if ( projectCrs.isValid() )
   {
-    mOnTheFlyProjectionStatusButton->setText( QgsProject::instance()->crs().authid() );
+    if ( !projectCrs.authid().isEmpty() )
+      mOnTheFlyProjectionStatusButton->setText( projectCrs.authid() );
+    else
+      mOnTheFlyProjectionStatusButton->setText( QObject::tr( "Unknown CRS" ) );
 
     mOnTheFlyProjectionStatusButton->setToolTip(
-      tr( "Current CRS: %1" ).arg( QgsProject::instance()->crs().userFriendlyIdentifier() ) );
+      tr( "Current CRS: %1" ).arg( projectCrs.userFriendlyIdentifier() ) );
     mOnTheFlyProjectionStatusButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mIconProjectionEnabled.svg" ) ) );
   }
   else

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -90,7 +90,7 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
      * Returns TRUE if the current selection in the widget is a valid choice. Valid
      * selections include any projection and also the "no/invalid projection" option
      * (if setShowNoProjection() was called). Invalid selections are the group
-     * headers (such as "Geographic Coordinate Systems"
+     * headers (such as "Geographic Coordinate Systems")
      */
     bool hasValidSelection() const;
 
@@ -182,6 +182,9 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
      */
     void loadCrsList( QSet<QString> *crsFilter = nullptr );
 
+
+    void loadUnknownCrs( const QgsCoordinateReferenceSystem &crs );
+
     /**
      * \brief Makes a \a string safe for use in SQL statements.
      *  This involves escaping single quotes, double quotes, backslashes,
@@ -226,10 +229,6 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
 
     QString selectedName();
 
-    QString selectedProj4String();
-
-    QString selectedWktString();
-
     //! Gets the current QGIS projection identfier
     long selectedCrsId();
 
@@ -239,6 +238,8 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     enum Roles
     {
       RoleDeprecated = Qt::UserRole,
+      RoleWkt,
+      RoleProj
     };
 
     // List view nodes for the tree view of projections
@@ -248,6 +249,8 @@ class GUI_EXPORT QgsProjectionSelectionTreeWidget : public QWidget, private Ui::
     QTreeWidgetItem *mGeoList = nullptr;
     //! PROJCS node
     QTreeWidgetItem *mProjList = nullptr;
+
+    QTreeWidgetItem *mUnknownList = nullptr;
 
     //! Users custom coordinate system file
     QString mCustomCsFile;

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -90,7 +90,7 @@
          </font>
         </property>
         <property name="text">
-         <string>Recently used coordinate reference systems</string>
+         <string>Recently Used Coordinate Reference Systems</string>
         </property>
        </widget>
       </item>
@@ -190,7 +190,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Coordinate reference systems of the world</string>
+             <string>Predefined Coordinate Reference Systems</string>
             </property>
            </widget>
           </item>

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -16,7 +16,7 @@ from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import (QgsProjectionSelectionWidget,
                       QgsProjectionSelectionTreeWidget,
                       QgsProjectionSelectionDialog)
-from qgis.core import QgsCoordinateReferenceSystem, QgsProject
+from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsProjUtils
 from qgis.testing import start_app, unittest
 
 
@@ -133,6 +133,17 @@ class TestQgsProjectionSelectionWidgets(unittest.TestCase):
         w.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
         self.assertEqual(w.crs().authid(), 'EPSG:3111')
         self.assertTrue(w.hasValidSelection())
+
+    @unittest.skipIf(QgsProjUtils.projVersionMajor() < 6, 'Not a proj6 build')
+    def testTreeWidgetUnknownCrs(self):
+        w = QgsProjectionSelectionTreeWidget()
+        w.show()
+        self.assertFalse(w.hasValidSelection())
+        w.setCrs(QgsCoordinateReferenceSystem.fromWkt('GEOGCS["WGS 84",DATUM["unknown",SPHEROID["WGS84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'))
+        self.assertTrue(w.crs().isValid())
+        self.assertFalse(w.crs().authid())
+        self.assertTrue(w.hasValidSelection())
+        self.assertEqual(w.crs().toWkt(QgsCoordinateReferenceSystem.WKT2_2018), 'GEOGCRS["WGS 84",DATUM["unknown",ELLIPSOID["WGS84",6378137,298.257223563,LENGTHUNIT["metre",1,ID["EPSG",9001]]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["longitude",east,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["latitude",north,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]]]')
 
     def testTreeWidgetNotSetOption(self):
         """ test allowing no projection option for QgsProjectionSelectionTreeWidget """


### PR DESCRIPTION
Fixes some UX issues when a layer or project is set to a unknown, non-standard CRS.

Refs #33458