### PR TITLE
fix crash in relation editor

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -1023,7 +1023,7 @@ void QgsDualView::setFeatureSelectionManager( QgsIFeatureSelectionManager *featu
   mTableView->setFeatureSelectionManager( featureSelectionManager );
   mFeatureListView->setFeatureSelectionManager( featureSelectionManager );
 
-  if ( mFeatureSelectionManager && mFeatureSelectionManager->parent() == this )
+  if ( !mFeatureSelectionManager.isNull() && mFeatureSelectionManager->parent() == this )
     delete mFeatureSelectionManager;
 
   mFeatureSelectionManager = featureSelectionManager;

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -402,7 +402,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     QgsVectorLayerCache *mLayerCache = nullptr;
     QPointer< QgsVectorLayer > mLayer = nullptr;
     QProgressDialog *mProgressDlg = nullptr;
-    QgsIFeatureSelectionManager *mFeatureSelectionManager = nullptr;
+    QPointer<QgsIFeatureSelectionManager> mFeatureSelectionManager;
     QString mDisplayExpression;
     QgsAttributeTableConfig mConfig;
     QgsScrollArea *mAttributeEditorScrollArea = nullptr;


### PR DESCRIPTION
the crash was happening after digitizing a feature on a layer with a relation
this was a long standing issue on my system (macos, Qt 5.14), no idea why it didn't happen to others.
kudos to @nyalldawson for helping me out

fixes #33120