### PR TITLE
Fix user projection not identified as such

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -653,7 +653,7 @@ bool QgsCoordinateReferenceSystem::loadFromDatabase( const QString &db, const QS
     wkt = statement.columnAsText( 8 );
     d->mAxisInvertedDirty = true;
 
-    if ( d->mSrsId >= USER_CRS_START_ID && d->mAuthId.isEmpty() )
+    if ( d->mSrsId >= USER_CRS_START_ID && ( d->mAuthId.isEmpty() || d->mAuthId == QChar( ':' ) ) )
     {
       d->mAuthId = QStringLiteral( "USER:%1" ).arg( d->mSrsId );
     }


### PR DESCRIPTION
## Description

@nyalldawson , while looking into issue #33458 , I stumbled on a bug whereas user projections are not identified as such. 

Long story short here, the qgis.db provided @Dkrav-UA revealed that the auth_name and auth_id columns for the saved user projections weren't null (just empty strings). In turn, that led the authid column in that statement (https://github.com/qgis/QGIS/blob/master/src/core/qgscoordinatereferencesystem.cpp#L634) to become ':' instead of null.

As a result, the code would return a valid CRS with its authid() function returning ':', which created problems with the custom projection dialog (i.e. since the authid wasn't 'USER:XXXX', the code would not behave properly there).

The PR fixes the situation by adding a ':' check and handle that the same way we handle an empty string when loading a CRS from the user database.