### PR TITLE
Do not replace plus by space in REQUEST_BODY

### DIFF
--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -252,7 +252,7 @@ void QgsRequestHandler::parseInput()
 
           mRequest.setParameter( attrName.toUpper(), attr.value() );
         }
-        mRequest.setParameter( QStringLiteral( "REQUEST_BODY" ), inputString );
+        mRequest.setParameter( QStringLiteral( "REQUEST_BODY" ), inputString.replace( '+', QStringLiteral( "%2B" ) ) );
       }
     }
   }

--- a/tests/src/python/test_qgsserver_request.py
+++ b/tests/src/python/test_qgsserver_request.py
@@ -194,6 +194,21 @@ class QgsServerRequestTest(QgsServerTestBase):
         _check_links(params)
         _check_links(params, 'POST')
 
+    def test_fcgiRequestBody(self):
+        """Test request body"""
+        data = '<Literal>+1</Literal>'
+        self._set_env({
+            'SERVER_NAME': 'www.myserver.com',
+            'SERVICE': 'WFS',
+            'REQUEST_BODY': data,
+            'CONTENT_LENGTH': str(len(data)),
+            'REQUEST_METHOD': 'POST',
+        })
+        request = QgsFcgiServerRequest()
+        response = QgsBufferServerResponse()
+        self.server.handleRequest(request, response)
+        self.assertEqual(request.parameter('REQUEST_BODY'), '<Literal>+1</Literal>')
+
     def test_add_parameters(self):
         request = QgsServerRequest()
         request.setParameter('FOOBAR', 'foobar')


### PR DESCRIPTION
## Description

Actually + signs in request body are replaced by spaces when passing through QgsServerParameters (see: https://github.com/qgis/QGIS/commit/bbf7a78453cca095396f9ee2ca3d037e40f7d208).

As I would prefer not to change the behavior of QgsServerParameters, I just encode plus sign to "%2B" as we would do for an url query string parameter.

This might be backported to all active release since 3.4 (as linked commit was commited in 3.4).

Example affected REQUEST BODY:
```
<GetFeature>
    <Query typeName="feature:mytable" srsName="EPSG:3857">
        <Filter>
            <PropertyIsEqualTo matchCase="true">
                <PropertyName>etage</PropertyName>
                <Literal>+1</Literal>
            </PropertyIsEqualTo>
...
```

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
