### PR TITLE
Fix merge features with PG tables

### DIFF
--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -170,12 +170,6 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
     mTableWidget->setItem( mTableWidget->rowCount() - 1, j, mergedItem );
   }
 
-  //insert currently merged values
-  for ( int i = 0; i < mTableWidget->columnCount(); ++i )
-  {
-    refreshMergedValue( i );
-  }
-
   //initially set any fields with default values/default value clauses to that value
   for ( int j = 0; j < mTableWidget->columnCount(); j++ )
   {
@@ -205,6 +199,12 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
         currentComboBox->blockSignals( false );
       }
     }
+  }
+
+  //insert currently merged values
+  for ( int i = 0; i < mTableWidget->columnCount(); ++i )
+  {
+    refreshMergedValue( i );
   }
 
 }


### PR DESCRIPTION
Fixes #34269

By moving the refreshMergedValue() at the end of
createTableWidgetContents() we set the correct
behavior (skipped, manual etc.) after it has been
possibly changed to "manual" a few lines above.

The previous implementation was settings the values
to "skipped" then calling refreshMergedValue(), then
possibly changing to "manual" without refereshing
the merged values, this was the source of the issue.
