### PR TITLE
Implement "fallback" transformation when selected operation fails

### DIFF
--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -362,6 +362,12 @@ are transformed). See fallbackOperationOccurred() for further details.
 
    Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
 
+.. warning::
+
+   If setBallparkTransformsAreAppropriate() is set to ``True``, this setting will be ignored
+   and fallback transformations will always be permitted.
+
+
 .. seealso:: :py:func:`allowFallbackTransforms`
 
 .. seealso:: :py:func:`setBallparkTransformsAreAppropriate`
@@ -408,7 +414,8 @@ If ``appropriate`` is ``False`` (the default behavior), then transforms MAY STIL
 when the preferred or user-specified operation fails, however whenever this occurs
 a user-visible warning will be generated.
 
-If allowFallbackTransforms() is ``False`` then this setting has no effect.
+If ``appropriate`` is ``True``, then this setting overrides allowFallbackTransforms()
+and fallback transforms will always be allowed when required.
 
 .. warning::
 

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -352,6 +352,36 @@ coordinates.
 .. versionadded:: 3.8
 %End
 
+    void setBallparkTransformsAreAppropriate( bool appropriate );
+%Docstring
+Sets whether approximate "ballpark" results are appropriate for this coordinate transform.
+
+When a coordinate transform is only being used to generate ballpark results then the
+``appropriate`` argument should be set to ``True``. This indicates that its perfectable
+acceptable (and even expected!) for the transform to use fallback coordinate operations
+in the case that the preferred or user-specified operation fails (such as when coordinates
+from outside of a grid shift file's extent are transformed).
+
+When ``appropriate`` is ``True``, then no warnings will be generated when the transform
+falls back to a default operation, which may introduce inaccuracies when compared to
+the default/specified coordinate operation.
+
+This should be set when a transform expects that coordinates outside of the direct
+area of use while be transformed, e.g. when transforming from a global extent to a
+CRS with a localized area of use.
+
+If ``appropriate`` is ``False`` (the default behavior), then transforms MAY STILL fallback to default operations
+when the preferred or user-specified operation fails, however whenever this occurs
+a user-visible warning will be generated.
+
+.. warning::
+
+   This setting applies to a single instance of a coordinate transform only,
+   and is not copied when a coordinate transform object is copied or assigned.
+
+.. versionadded:: 3.12
+%End
+
  int sourceDatumTransformId() const /Deprecated/;
 %Docstring
 Returns the ID of the datum transform to use when projecting from the source

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -382,6 +382,32 @@ a user-visible warning will be generated.
 .. versionadded:: 3.12
 %End
 
+    void disableFallbackOperationHandler( bool disabled );
+%Docstring
+Sets whether the default fallback operation handler is disabled for this transform instance.
+
+If the default handler is ``disabled`` then it is possible to determine whether a fallback
+operation occurred by testing fallbackOperationOccurred() immediately after a transformation.
+
+.. warning::
+
+   This setting applies to a single instance of a coordinate transform only,
+   and is not copied when a coordinate transform object is copied or assigned.
+
+.. seealso:: :py:func:`fallbackOperationOccurred`
+
+.. versionadded:: 3.12
+%End
+
+    bool fallbackOperationOccurred() const;
+%Docstring
+Returns ``True`` if a fallback operation occurred for the most recent transform.
+
+.. seealso:: :py:func:`disableFallbackOperationHandler`
+
+.. versionadded:: 3.12
+%End
+
  int sourceDatumTransformId() const /Deprecated/;
 %Docstring
 Returns the ID of the datum transform to use when projecting from the source

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -352,6 +352,40 @@ coordinates.
 .. versionadded:: 3.8
 %End
 
+    void setAllowFallbackTransforms( bool allowed );
+%Docstring
+Sets whether "ballpark" fallback transformations can be used in the case that the specified
+coordinate operation fails (such as when coordinates from outside a required grid shift file
+are transformed). See fallbackOperationOccurred() for further details.
+
+.. note::
+
+   Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
+
+.. seealso:: :py:func:`allowFallbackTransforms`
+
+.. seealso:: :py:func:`setBallparkTransformsAreAppropriate`
+
+.. versionadded:: 3.12
+%End
+
+    bool allowFallbackTransforms() const;
+%Docstring
+Returns whether "ballpark" fallback transformations will be used in the case that the specified
+coordinate operation fails (such as when coordinates from outside a required grid shift file
+are transformed). See fallbackOperationOccurred() for further details.
+
+.. note::
+
+   Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
+
+.. seealso:: :py:func:`setAllowFallbackTransforms`
+
+.. seealso:: :py:func:`setBallparkTransformsAreAppropriate`
+
+.. versionadded:: 3.12
+%End
+
     void setBallparkTransformsAreAppropriate( bool appropriate );
 %Docstring
 Sets whether approximate "ballpark" results are appropriate for this coordinate transform.
@@ -374,10 +408,17 @@ If ``appropriate`` is ``False`` (the default behavior), then transforms MAY STIL
 when the preferred or user-specified operation fails, however whenever this occurs
 a user-visible warning will be generated.
 
+If allowFallbackTransforms() is ``False`` then this setting has no effect.
+
 .. warning::
 
    This setting applies to a single instance of a coordinate transform only,
    and is not copied when a coordinate transform object is copied or assigned.
+
+.. note::
+
+   Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
+
 
 .. versionadded:: 3.12
 %End
@@ -394,6 +435,11 @@ operation occurred by testing fallbackOperationOccurred() immediately after a tr
    This setting applies to a single instance of a coordinate transform only,
    and is not copied when a coordinate transform object is copied or assigned.
 
+.. note::
+
+   Requires Proj 6.0 or later. Builds based on earlier Proj versions will never perform fallback operations.
+
+
 .. seealso:: :py:func:`fallbackOperationOccurred`
 
 .. versionadded:: 3.12
@@ -402,6 +448,10 @@ operation occurred by testing fallbackOperationOccurred() immediately after a tr
     bool fallbackOperationOccurred() const;
 %Docstring
 Returns ``True`` if a fallback operation occurred for the most recent transform.
+
+.. note::
+
+   Requires Proj 6.0 or later. Builds based on earlier Proj versions will never perform fallback operations.
 
 .. seealso:: :py:func:`disableFallbackOperationHandler`
 

--- a/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
@@ -125,7 +125,7 @@ Returns ``True`` if the new transform pair was added successfully.
    Has no effect on builds based on Proj 6.0 or later, use addCoordinateOperation() instead.
 %End
 
-    bool addCoordinateOperation( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QString &coordinateOperationProjString );
+    bool addCoordinateOperation( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QString &coordinateOperationProjString, bool allowFallback = true );
 %Docstring
 Adds a new ``coordinateOperationProjString`` to use when projecting coordinates
 from the specified ``sourceCrs`` to the specified ``destinationCrs``.
@@ -133,6 +133,14 @@ from the specified ``sourceCrs`` to the specified ``destinationCrs``.
 ``coordinateOperationProjString`` should be set to a valid Proj coordinate operation
 string. If ``coordinateOperationProjString`` is empty, then the default Proj operation
 will be used when transforming between the coordinate reference systems.
+
+If ``allowFallback`` is ``True`` (since QGIS 3.12), then "ballpark" fallback transformations
+will be used in the case that the specified coordinate operation fails (such as when
+coordinates from outside a required grid shift file are transformed). See
+QgsCoordinateTransform.fallbackOperationOccurred() for further details. Note that if an
+existing ``sourceCrs`` and ``destinationCrs`` pair are added with a different ``allowFallback``
+value, that value will replace the existing one (i.e. each combination of ``sourceCrs`` and
+``destinationCrs`` must be unique).
 
 .. warning::
 
@@ -229,6 +237,17 @@ be used.
 
 
 .. versionadded:: 3.8
+%End
+
+    bool allowFallbackTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
+%Docstring
+Returns ``True`` if approximate "ballpark" transforms may be used when transforming
+between a \source and ``destination`` CRS pair, in the case that the preferred
+coordinate operation fails (such as when
+coordinates from outside a required grid shift file are transformed). See
+QgsCoordinateTransform.fallbackOperationOccurred() for further details.
+
+.. versionadded:: 3.12
 %End
 
     bool mustReverseCoordinateOperation( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;

--- a/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
@@ -242,7 +242,7 @@ be used.
     bool allowFallbackTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
 %Docstring
 Returns ``True`` if approximate "ballpark" transforms may be used when transforming
-between a \source and ``destination`` CRS pair, in the case that the preferred
+between a ``source`` and ``destination`` CRS pair, in the case that the preferred
 coordinate operation fails (such as when
 coordinates from outside a required grid shift file are transformed). See
 QgsCoordinateTransform.fallbackOperationOccurred() for further details.

--- a/python/gui/auto_generated/qgscoordinateoperationwidget.sip.in
+++ b/python/gui/auto_generated/qgscoordinateoperationwidget.sip.in
@@ -132,6 +132,13 @@ If no matching operations are found within the context then the defaultOperation
 selected.
 %End
 
+    void setShowFallbackOption( bool visible );
+%Docstring
+Sets whether the "allow fallback" operations option is visible.
+
+.. versionadded:: 3.12
+%End
+
   signals:
 
     void operationChanged();

--- a/python/gui/auto_generated/qgscoordinateoperationwidget.sip.in
+++ b/python/gui/auto_generated/qgscoordinateoperationwidget.sip.in
@@ -32,6 +32,8 @@ a source and destination coordinate reference system.
       QString proj;
 
       bool isAvailable;
+
+      bool allowFallback;
     };
 
     QgsCoordinateOperationWidget( QWidget *parent = 0 );
@@ -115,7 +117,7 @@ Returns the details of the operation currently selected within the widget.
 .. seealso:: :py:func:`setSelectedOperation`
 %End
 
-    void setSelectedOperation( const QgsCoordinateOperationWidget::OperationDetails &operation ) const;
+    void setSelectedOperation( const QgsCoordinateOperationWidget::OperationDetails &operation );
 %Docstring
 Sets the details of the ``operation`` currently selected within the widget.
 

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -102,6 +102,8 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
     if ( !mCoordOp.isEmpty() )
       mTransformContext.addCoordinateOperation( sourceCrs(), mDestCrs, mCoordOp );
     mTransform = QgsCoordinateTransform( sourceCrs(), mDestCrs, mTransformContext );
+
+    mTransform.disableFallbackOperationHandler( true );
   }
 
   if ( feature.hasGeometry() )
@@ -116,6 +118,14 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
       else
       {
         feature.clearGeometry();
+      }
+
+      if ( !mWarnedAboutFallbackTransform && mTransform.fallbackOperationOccurred() )
+      {
+        feedback->reportError( QObject::tr( "An alternative, ballpark-only transform was used when transforming coordinates for one or more features. "
+                                            "(Possibly an incorrect choice of operation was made for transformations between these reference systems - check "
+                                            "that the selected operation is valid for the full extent of the input layer.)" ) );
+        mWarnedAboutFallbackTransform = true; // only warn once to avoid flooding the log
       }
     }
     catch ( QgsCsException & )

--- a/src/analysis/processing/qgsalgorithmtransform.cpp
+++ b/src/analysis/processing/qgsalgorithmtransform.cpp
@@ -100,7 +100,7 @@ QgsFeatureList QgsTransformAlgorithm::processFeature( const QgsFeature &f, QgsPr
   {
     mCreatedTransform = true;
     if ( !mCoordOp.isEmpty() )
-      mTransformContext.addCoordinateOperation( sourceCrs(), mDestCrs, mCoordOp );
+      mTransformContext.addCoordinateOperation( sourceCrs(), mDestCrs, mCoordOp, false );
     mTransform = QgsCoordinateTransform( sourceCrs(), mDestCrs, mTransformContext );
 
     mTransform.disableFallbackOperationHandler( true );

--- a/src/analysis/processing/qgsalgorithmtransform.h
+++ b/src/analysis/processing/qgsalgorithmtransform.h
@@ -59,6 +59,7 @@ class QgsTransformAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsCoordinateTransform mTransform;
     QgsCoordinateTransformContext mTransformContext;
     QString mCoordOp;
+    bool mWarnedAboutFallbackTransform = false;
 
 };
 

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -58,7 +58,7 @@ QgsAppMissingGridHandler::QgsAppMissingGridHandler( QObject *parent )
 
   QgsCoordinateTransform::setFallbackOperationOccurredHandler( [ = ]( const QgsCoordinateReferenceSystem & sourceCrs,
       const QgsCoordinateReferenceSystem & destinationCrs,
-      const QgsDatumTransform::TransformDetails & desired )
+      const QString & desired )
   {
     emit fallbackOperationOccurred( sourceCrs, destinationCrs, desired );
   } );
@@ -273,13 +273,13 @@ void QgsAppMissingGridHandler::onMissingGridUsedByContextHandler( const QgsCoord
   bar->pushWidget( widget, Qgis::Critical, 0 );
 }
 
-void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QgsDatumTransform::TransformDetails &desired )
+void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QString &desired )
 {
   //  if ( !shouldWarnAboutPairForCurrentProject( sourceCrs, destinationCrs ) )
   //    return;
 
   const QString shortMessage = tr( "Used a fallback transform from %1 to %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
-  const QString longMessage = tr( "<p>An alternative transform was used when transforming coordinates between <i>%1</i> and <i>%2</i>.</p><p style=\"color: red\">I wanted to use %3</p>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier(), desired.proj );
+  const QString longMessage = tr( "<p>An alternative transform was used when transforming coordinates between <i>%1</i> and <i>%2</i>.</p><p style=\"color: red\">I wanted to use %3</p>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier(), desired );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
   QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -282,8 +282,8 @@ void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateR
   if ( !shouldWarnAboutBallparkPairForCurrentProject( sourceCrs, destinationCrs ) )
     return;
 
-  const QString shortMessage = tr( "Used a fallback transform from %1 to %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
-  const QString longMessage = tr( "<p>An alternative transform was used when transforming coordinates between <i>%1</i> and <i>%2</i>.</p><p style=\"color: red\">I wanted to use %3</p>" ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier(), desired );
+  const QString shortMessage = tr( "Used a ballpark transform from %1 to %2" ).arg( sourceCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ), destinationCrs.userFriendlyIdentifier( QgsCoordinateReferenceSystem::ShortString ) );
+  const QString longMessage = tr( "<p>An alternative, ballpark-only transform was used when transforming coordinates between <i>%1</i> and <i>%2</i>. The results may not match those obtained by using the preferred operation:</p><code>%3</code><p style=\"font-weight: bold\">Possibly an incorrect choice of operation was made for transformations between these reference systems. Check the Project Properties and ensure that the selected transform operations are applicable over the whole extent of the current project." ).arg( sourceCrs.userFriendlyIdentifier(), destinationCrs.userFriendlyIdentifier(), desired );
 
   QgsMessageBar *bar = QgisApp::instance()->messageBar();
   QgsMessageBarItem *widget = bar->createMessage( QString(), shortMessage );
@@ -292,7 +292,7 @@ void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateR
   {
     // dlg has deleted on close
     QgsMessageOutput * dlg( QgsMessageOutput::createMessageOutput() );
-    dlg->setTitle( tr( "Fallback Transform Occurred" ) );
+    dlg->setTitle( tr( "Ballpark Transform Occurred" ) );
     dlg->setMessage( longMessage, QgsMessageOutput::MessageHtml );
     dlg->showMessage();
   } );

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -298,7 +298,7 @@ void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateR
   } );
 
   widget->layout()->addWidget( detailsButton );
-  bar->pushWidget( widget, Qgis::Critical, 0 );
+  bar->pushWidget( widget, Qgis::Warning, 0 );
 }
 
 bool QgsAppMissingGridHandler::shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest )

--- a/src/app/qgsappcoordinateoperationhandlers.cpp
+++ b/src/app/qgsappcoordinateoperationhandlers.cpp
@@ -58,10 +58,9 @@ QgsAppMissingGridHandler::QgsAppMissingGridHandler( QObject *parent )
 
   QgsCoordinateTransform::setFallbackOperationOccurredHandler( [ = ]( const QgsCoordinateReferenceSystem & sourceCrs,
       const QgsCoordinateReferenceSystem & destinationCrs,
-      const QgsDatumTransform::TransformDetails & desired,
-      const QgsDatumTransform::TransformDetails & used )
+      const QgsDatumTransform::TransformDetails & desired )
   {
-    emit fallbackOperationOccurred( sourceCrs, destinationCrs, desired, used );
+    emit fallbackOperationOccurred( sourceCrs, destinationCrs, desired );
   } );
 
   connect( this, &QgsAppMissingGridHandler::missingRequiredGrid, this, &QgsAppMissingGridHandler::onMissingRequiredGrid, Qt::QueuedConnection );
@@ -274,7 +273,7 @@ void QgsAppMissingGridHandler::onMissingGridUsedByContextHandler( const QgsCoord
   bar->pushWidget( widget, Qgis::Critical, 0 );
 }
 
-void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QgsDatumTransform::TransformDetails &desired, const QgsDatumTransform::TransformDetails &used )
+void QgsAppMissingGridHandler::onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QgsDatumTransform::TransformDetails &desired )
 {
   //  if ( !shouldWarnAboutPairForCurrentProject( sourceCrs, destinationCrs ) )
   //    return;

--- a/src/app/qgsappcoordinateoperationhandlers.h
+++ b/src/app/qgsappcoordinateoperationhandlers.h
@@ -51,7 +51,7 @@ class QgsAppMissingGridHandler : public QObject
 
     void fallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs,
                                     const QgsCoordinateReferenceSystem &destinationCrs,
-                                    const QgsDatumTransform::TransformDetails &desired );
+                                    const QString &desired );
 
   private slots:
 
@@ -74,7 +74,7 @@ class QgsAppMissingGridHandler : public QObject
 
     void onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs,
                                       const QgsCoordinateReferenceSystem &destinationCrs,
-                                      const QgsDatumTransform::TransformDetails &desired );
+                                      const QString &desired );
 
   private:
 

--- a/src/app/qgsappcoordinateoperationhandlers.h
+++ b/src/app/qgsappcoordinateoperationhandlers.h
@@ -49,6 +49,11 @@ class QgsAppMissingGridHandler : public QObject
                                           const QgsCoordinateReferenceSystem &destinationCrs,
                                           const QgsDatumTransform::TransformDetails &desired );
 
+    void fallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs,
+                                    const QgsCoordinateReferenceSystem &destinationCrs,
+                                    const QgsDatumTransform::TransformDetails &desired,
+                                    const QgsDatumTransform::TransformDetails &used );
+
   private slots:
 
     void onMissingRequiredGrid( const QgsCoordinateReferenceSystem &sourceCrs,
@@ -67,6 +72,12 @@ class QgsAppMissingGridHandler : public QObject
     void onMissingGridUsedByContextHandler( const QgsCoordinateReferenceSystem &sourceCrs,
                                             const QgsCoordinateReferenceSystem &destinationCrs,
                                             const QgsDatumTransform::TransformDetails &desired );
+
+    void onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs,
+                                      const QgsCoordinateReferenceSystem &destinationCrs,
+                                      const QgsDatumTransform::TransformDetails &desired,
+                                      const QgsDatumTransform::TransformDetails &used );
+
   private:
 
     bool shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );

--- a/src/app/qgsappcoordinateoperationhandlers.h
+++ b/src/app/qgsappcoordinateoperationhandlers.h
@@ -51,8 +51,7 @@ class QgsAppMissingGridHandler : public QObject
 
     void fallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs,
                                     const QgsCoordinateReferenceSystem &destinationCrs,
-                                    const QgsDatumTransform::TransformDetails &desired,
-                                    const QgsDatumTransform::TransformDetails &used );
+                                    const QgsDatumTransform::TransformDetails &desired );
 
   private slots:
 
@@ -75,17 +74,17 @@ class QgsAppMissingGridHandler : public QObject
 
     void onFallbackOperationOccurred( const QgsCoordinateReferenceSystem &sourceCrs,
                                       const QgsCoordinateReferenceSystem &destinationCrs,
-                                      const QgsDatumTransform::TransformDetails &desired,
-                                      const QgsDatumTransform::TransformDetails &used );
+                                      const QgsDatumTransform::TransformDetails &desired );
 
   private:
 
     bool shouldWarnAboutPair( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
     bool shouldWarnAboutPairForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
+    bool shouldWarnAboutBallparkPairForCurrentProject( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &dest );
 
     QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedPairs;
     QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedPairsForProject;
-
+    QList< QPair< QgsCoordinateReferenceSystem, QgsCoordinateReferenceSystem > > mAlreadyWarnedBallparkPairsForProject;
 };
 
 #endif // QGSAPPCOORDINATEOPERATIONHANDLERS_H

--- a/src/app/qgsdatumtransformtablewidget.cpp
+++ b/src/app/qgsdatumtransformtablewidget.cpp
@@ -73,7 +73,7 @@ int QgsDatumTransformTableModel::columnCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
 #if PROJ_VERSION_MAJOR>=6
-  return 3;
+  return 4;
 #else
   return 4;
 #endif
@@ -148,6 +148,19 @@ QVariant QgsDatumTransformTableModel::data( const QModelIndex &index, int role )
           break;
       }
       break;
+
+    case Qt::CheckStateRole:
+#if PROJ_VERSION_MAJOR>=6
+      switch ( index.column() )
+      {
+        case AllowFallbackColumn:
+          return mTransformContext.allowFallbackTransform( QgsCoordinateReferenceSystem( crses.first ), QgsCoordinateReferenceSystem( crses.second ) ) ? Qt::Checked : Qt::Unchecked;
+        default:
+          break;
+      }
+      break;
+#endif
+
     case Qt::UserRole:
 #if PROJ_VERSION_MAJOR>=6
       return proj;
@@ -189,6 +202,8 @@ QVariant QgsDatumTransformTableModel::headerData( int section, Qt::Orientation o
 #if PROJ_VERSION_MAJOR>=6
         case ProjDefinitionColumn:
           return tr( "Operation" );
+        case AllowFallbackColumn:
+          return tr( "Allow Fallback Transforms" );
 #else
         case SourceTransformColumn:
           return tr( "Source Datum Transform" );
@@ -251,7 +266,7 @@ void QgsDatumTransformTableWidget::addDatumTransform()
     Q_NOWARN_DEPRECATED_PUSH
     context.addSourceDestinationDatumTransform( dt.sourceCrs, dt.destinationCrs, dt.sourceTransformId, dt.destinationTransformId );
     Q_NOWARN_DEPRECATED_POP
-    context.addCoordinateOperation( dt.sourceCrs, dt.destinationCrs, dt.proj );
+    context.addCoordinateOperation( dt.sourceCrs, dt.destinationCrs, dt.proj, dt.allowFallback );
     mModel->setTransformContext( context );
     selectionChanged();
   }
@@ -276,8 +291,10 @@ void QgsDatumTransformTableWidget::editDatumTransform( const QModelIndex &index 
   QgsCoordinateReferenceSystem sourceCrs = QgsCoordinateReferenceSystem( mModel->data( mModel->index( index.row(), QgsDatumTransformTableModel::SourceCrsColumn ), Qt::DisplayRole ).toString() );
   QgsCoordinateReferenceSystem destinationCrs = QgsCoordinateReferenceSystem( mModel->data( mModel->index( index.row(), QgsDatumTransformTableModel::DestinationCrsColumn ), Qt::DisplayRole ).toString() );
 
+  bool allowFallback = true;
 #if PROJ_VERSION_MAJOR>=6
   proj = mModel->data( mModel->index( index.row(), QgsDatumTransformTableModel::ProjDefinitionColumn ), Qt::UserRole ).toString();
+  allowFallback = mModel->data( mModel->index( index.row(), QgsDatumTransformTableModel::AllowFallbackColumn ), Qt::CheckStateRole ) == Qt::Checked;
 #else
   sourceTransform = mModel->data( mModel->index( index.row(), QgsDatumTransformTableModel::SourceTransformColumn ), Qt::UserRole ).toInt();
   destinationTransform = mModel->data( mModel->index( index.row(), QgsDatumTransformTableModel::DestinationTransformColumn ), Qt::UserRole ).toInt();
@@ -290,7 +307,7 @@ void QgsDatumTransformTableWidget::editDatumTransform( const QModelIndex &index 
        ( sourceTransform != -1 || destinationTransform != -1 ) )
 #endif
   {
-    QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, false, qMakePair( sourceTransform, destinationTransform ), nullptr, nullptr, proj, QgisApp::instance()->mapCanvas() );
+    QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, false, qMakePair( sourceTransform, destinationTransform ), nullptr, nullptr, proj, QgisApp::instance()->mapCanvas(), allowFallback );
     if ( dlg.exec() )
     {
       const QgsDatumTransformDialog::TransformInfo dt = dlg.selectedDatumTransform();
@@ -306,7 +323,7 @@ void QgsDatumTransformTableWidget::editDatumTransform( const QModelIndex &index 
       Q_NOWARN_DEPRECATED_PUSH
       context.addSourceDestinationDatumTransform( dt.sourceCrs, dt.destinationCrs, dt.sourceTransformId, dt.destinationTransformId );
       Q_NOWARN_DEPRECATED_POP
-      context.addCoordinateOperation( dt.sourceCrs, dt.destinationCrs, dt.proj );
+      context.addCoordinateOperation( dt.sourceCrs, dt.destinationCrs, dt.proj, dt.allowFallback );
       mModel->setTransformContext( context );
     }
   }

--- a/src/app/qgsdatumtransformtablewidget.h
+++ b/src/app/qgsdatumtransformtablewidget.h
@@ -41,6 +41,7 @@ class APP_EXPORT QgsDatumTransformTableModel : public QAbstractTableModel
       SourceCrsColumn  = 0,
       DestinationCrsColumn,
       ProjDefinitionColumn,
+      AllowFallbackColumn,
 #else
       SourceCrsColumn  = 0,
       SourceTransformColumn,

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1886,8 +1886,8 @@ bool QgsCoordinateReferenceSystem::operator==( const QgsCoordinateReferenceSyste
   if ( !d->mIsValid || !srs.d->mIsValid )
     return false;
 
-  if ( !d->mAuthId.isEmpty() && d->mAuthId == srs.d->mAuthId )
-    return true;
+  if ( ( !d->mAuthId.isEmpty() || !srs.d->mAuthId.isEmpty() ) )
+    return d->mAuthId == srs.d->mAuthId;
 
   return toWkt( WKT2_2018 ) == srs.toWkt( WKT2_2018 );
 }

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -54,8 +54,7 @@ bool QgsCoordinateTransform::sDisableCache = false;
 
 std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                      const QgsCoordinateReferenceSystem &destinationCrs,
-                     const QgsDatumTransform::TransformDetails &desiredOperation,
-                     const QgsDatumTransform::TransformDetails &usedOperation )> QgsCoordinateTransform::sFallbackOperationOccurredHandler = nullptr;
+                     const QgsDatumTransform::TransformDetails &desiredOperation )> QgsCoordinateTransform::sFallbackOperationOccurredHandler = nullptr;
 
 QgsCoordinateTransform::QgsCoordinateTransform()
 {
@@ -778,8 +777,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
       if ( !mBallparkTransformsAreAppropriate && sFallbackOperationOccurredHandler )
       {
         QgsDatumTransform::TransformDetails desired = instantiatedCoordinateOperationDetails();
-        QgsDatumTransform::TransformDetails used = QgsDatumTransform::transformDetailsFromPj( transform );
-        sFallbackOperationOccurredHandler( d->mSourceCRS, d->mDestCRS, desired, used );
+        sFallbackOperationOccurredHandler( d->mSourceCRS, d->mDestCRS, desired );
         const QString warning = QStringLiteral( "A fallback coordinate operation was used between %1 and %2" ).arg( d->mSourceCRS.authid(),
                                 d->mDestCRS.authid() );
         qWarning( "%s", warning.toLatin1().constData() );
@@ -1125,7 +1123,7 @@ void QgsCoordinateTransform::setCustomMissingGridUsedByContextHandler( const std
   QgsCoordinateTransformPrivate::setCustomMissingGridUsedByContextHandler( handler );
 }
 
-void QgsCoordinateTransform::setFallbackOperationOccurredHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem &, const QgsDatumTransform::TransformDetails &, const QgsDatumTransform::TransformDetails & )> &handler )
+void QgsCoordinateTransform::setFallbackOperationOccurredHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem &, const QgsDatumTransform::TransformDetails & )> &handler )
 {
   sFallbackOperationOccurredHandler = handler;
 }

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -780,9 +780,11 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
       if ( !mBallparkTransformsAreAppropriate && sFallbackOperationOccurredHandler )
       {
         sFallbackOperationOccurredHandler( d->mSourceCRS, d->mDestCRS, d->mProjCoordinateOperation );
+#if 0
         const QString warning = QStringLiteral( "A fallback coordinate operation was used between %1 and %2" ).arg( d->mSourceCRS.authid(),
                                 d->mDestCRS.authid() );
         qWarning( "%s", warning.toLatin1().constData() );
+#endif
       }
     }
   }

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -54,7 +54,7 @@ bool QgsCoordinateTransform::sDisableCache = false;
 
 std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                      const QgsCoordinateReferenceSystem &destinationCrs,
-                     const QgsDatumTransform::TransformDetails &desiredOperation )> QgsCoordinateTransform::sFallbackOperationOccurredHandler = nullptr;
+                     const QString &desiredOperation )> QgsCoordinateTransform::sFallbackOperationOccurredHandler = nullptr;
 
 QgsCoordinateTransform::QgsCoordinateTransform()
 {
@@ -776,8 +776,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
       if ( !mBallparkTransformsAreAppropriate && sFallbackOperationOccurredHandler )
       {
-        QgsDatumTransform::TransformDetails desired = instantiatedCoordinateOperationDetails();
-        sFallbackOperationOccurredHandler( d->mSourceCRS, d->mDestCRS, desired );
+        sFallbackOperationOccurredHandler( d->mSourceCRS, d->mDestCRS, d->mProjCoordinateOperation );
         const QString warning = QStringLiteral( "A fallback coordinate operation was used between %1 and %2" ).arg( d->mSourceCRS.authid(),
                                 d->mDestCRS.authid() );
         qWarning( "%s", warning.toLatin1().constData() );
@@ -1123,7 +1122,7 @@ void QgsCoordinateTransform::setCustomMissingGridUsedByContextHandler( const std
   QgsCoordinateTransformPrivate::setCustomMissingGridUsedByContextHandler( handler );
 }
 
-void QgsCoordinateTransform::setFallbackOperationOccurredHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem &, const QgsDatumTransform::TransformDetails & )> &handler )
+void QgsCoordinateTransform::setFallbackOperationOccurredHandler( const std::function<void ( const QgsCoordinateReferenceSystem &, const QgsCoordinateReferenceSystem &, const QString & )> &handler )
 {
   sFallbackOperationOccurredHandler = handler;
 }

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -743,7 +743,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 #if PROJ_VERSION_MAJOR>=6
 
   mFallbackOperationOccurred = false;
-  if ( actualRes != 0 && d->mAllowFallbackTransforms )
+  if ( actualRes != 0 && ( d->mAllowFallbackTransforms || mBallparkTransformsAreAppropriate ) )
   {
     // fail #1 -- try with getting proj to auto-pick an appropriate coordinate operation for the points
     if ( PJ *transform = d->threadLocalFallbackProjData() )

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -808,15 +808,11 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     QString dir = ( direction == ForwardTransform ) ? QObject::tr( "forward transform" ) : QObject::tr( "inverse transform" );
 
 #if PROJ_VERSION_MAJOR>=6
-    QgsProjUtils::proj_pj_unique_ptr src( proj_get_source_crs( QgsProjContext::get(), projData ) );
-    QgsProjUtils::proj_pj_unique_ptr dest( proj_get_source_crs( QgsProjContext::get(), projData ) );
     QString msg = QObject::tr( "%1 of\n"
                                "%2"
-                               "PROJ: %3\n"
-                               "Error: %4" )
+                               "Error: %3" )
                   .arg( dir,
                         points,
-                        proj_as_proj_string( QgsProjContext::get(), projData, PJ_PROJ_5, nullptr ),
                         QString::fromUtf8( proj_errno_string( projResult ) ) );
 #else
     char *srcdef = pj_get_def( sourceProj, 0 );

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -742,6 +742,7 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 
 #if PROJ_VERSION_MAJOR>=6
 
+  mFallbackOperationOccurred = false;
   if ( actualRes != 0 )
   {
     // fail #1 -- try with getting proj to auto-pick an appropriate coordinate operation for the points
@@ -775,9 +776,10 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
         memcpy( x, xprev.data(), sizeof( double ) * numPoints );
         memcpy( y, yprev.data(), sizeof( double ) * numPoints );
         memcpy( z, zprev.data(), sizeof( double ) * numPoints );
+        mFallbackOperationOccurred = true;
       }
 
-      if ( !mBallparkTransformsAreAppropriate && sFallbackOperationOccurredHandler )
+      if ( !mBallparkTransformsAreAppropriate && !mDisableFallbackHandler && sFallbackOperationOccurredHandler )
       {
         sFallbackOperationOccurredHandler( d->mSourceCRS, d->mDestCRS, d->mProjCoordinateOperation );
 #if 0
@@ -902,6 +904,16 @@ void QgsCoordinateTransform::setCoordinateOperation( const QString &operation ) 
 void QgsCoordinateTransform::setBallparkTransformsAreAppropriate( bool appropriate )
 {
   mBallparkTransformsAreAppropriate = appropriate;
+}
+
+void QgsCoordinateTransform::disableFallbackOperationHandler( bool disabled )
+{
+  mDisableFallbackHandler = disabled;
+}
+
+bool QgsCoordinateTransform::fallbackOperationOccurred() const
+{
+  return mFallbackOperationOccurred;
 }
 
 const char *finder( const char *name )

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -381,6 +381,34 @@ class CORE_EXPORT QgsCoordinateTransform
     void setCoordinateOperation( const QString &operation ) const;
 
     /**
+     * Sets whether approximate "ballpark" results are appropriate for this coordinate transform.
+     *
+     * When a coordinate transform is only being used to generate ballpark results then the
+     * \a appropriate argument should be set to TRUE. This indicates that its perfectable
+     * acceptable (and even expected!) for the transform to use fallback coordinate operations
+     * in the case that the preferred or user-specified operation fails (such as when coordinates
+     * from outside of a grid shift file's extent are transformed).
+     *
+     * When \a appropriate is TRUE, then no warnings will be generated when the transform
+     * falls back to a default operation, which may introduce inaccuracies when compared to
+     * the default/specified coordinate operation.
+     *
+     * This should be set when a transform expects that coordinates outside of the direct
+     * area of use while be transformed, e.g. when transforming from a global extent to a
+     * CRS with a localized area of use.
+     *
+     * If \a appropriate is FALSE (the default behavior), then transforms MAY STILL fallback to default operations
+     * when the preferred or user-specified operation fails, however whenever this occurs
+     * a user-visible warning will be generated.
+     *
+     * \warning This setting applies to a single instance of a coordinate transform only,
+     * and is not copied when a coordinate transform object is copied or assigned.
+     *
+     * \since QGIS 3.12
+     */
+    void setBallparkTransformsAreAppropriate( bool appropriate );
+
+    /**
      * Returns the ID of the datum transform to use when projecting from the source
      * CRS.
      *
@@ -591,6 +619,7 @@ class CORE_EXPORT QgsCoordinateTransform
 #endif
 
     mutable QString mLastError;
+    bool mBallparkTransformsAreAppropriate = false;
 
 #if PROJ_VERSION_MAJOR>=6
     bool setFromCache( const QgsCoordinateReferenceSystem &src,

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -555,6 +555,19 @@ class CORE_EXPORT QgsCoordinateTransform
     static void setCustomMissingGridUsedByContextHandler( const std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
         const QgsCoordinateReferenceSystem &destinationCrs,
         const QgsDatumTransform::TransformDetails &desiredOperation )> &handler );
+
+
+    /**
+     * Sets a custom \a handler to use when the desired coordinate operation for use between \a sourceCrs and
+     * \a destinationCrs failed and an alternative fallback \a usedOperation was utilised instead.
+     *
+     * \since QGIS 3.10.3
+     */
+    static void setFallbackOperationOccurredHandler( const std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
+        const QgsCoordinateReferenceSystem &destinationCrs,
+        const QgsDatumTransform::TransformDetails &desiredOperation,
+        const QgsDatumTransform::TransformDetails &usedOperation )> &handler );
+
 #endif
 
 #ifndef SIP_RUN
@@ -595,6 +608,12 @@ class CORE_EXPORT QgsCoordinateTransform
     static QReadWriteLock sCacheLock;
     static QMultiHash< QPair< QString, QString >, QgsCoordinateTransform > sTransforms; //same auth_id pairs might have different datum transformations
     static bool sDisableCache;
+
+
+    static std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
+                                const QgsCoordinateReferenceSystem &destinationCrs,
+                                const QgsDatumTransform::TransformDetails &desiredOperation,
+                                const QgsDatumTransform::TransformDetails &usedOperation )> sFallbackOperationOccurredHandler;
 
 };
 

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -587,14 +587,13 @@ class CORE_EXPORT QgsCoordinateTransform
 
     /**
      * Sets a custom \a handler to use when the desired coordinate operation for use between \a sourceCrs and
-     * \a destinationCrs failed and an alternative fallback \a usedOperation was utilised instead.
+     * \a destinationCrs failed and an alternative fallback operation was utilised instead.
      *
      * \since QGIS 3.10.3
      */
     static void setFallbackOperationOccurredHandler( const std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
         const QgsCoordinateReferenceSystem &destinationCrs,
-        const QgsDatumTransform::TransformDetails &desiredOperation,
-        const QgsDatumTransform::TransformDetails &usedOperation )> &handler );
+        const QgsDatumTransform::TransformDetails &desiredOperation )> &handler );
 
 #endif
 
@@ -641,8 +640,7 @@ class CORE_EXPORT QgsCoordinateTransform
 
     static std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                                 const QgsCoordinateReferenceSystem &destinationCrs,
-                                const QgsDatumTransform::TransformDetails &desiredOperation,
-                                const QgsDatumTransform::TransformDetails &usedOperation )> sFallbackOperationOccurredHandler;
+                                const QgsDatumTransform::TransformDetails &desiredOperation )> sFallbackOperationOccurredHandler;
 
 };
 

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -387,6 +387,9 @@ class CORE_EXPORT QgsCoordinateTransform
      *
      * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
      *
+     * \warning If setBallparkTransformsAreAppropriate() is set to TRUE, this setting will be ignored
+     * and fallback transformations will always be permitted.
+     *
      * \see allowFallbackTransforms()
      * \see setBallparkTransformsAreAppropriate()
      * \since QGIS 3.12
@@ -427,7 +430,8 @@ class CORE_EXPORT QgsCoordinateTransform
      * when the preferred or user-specified operation fails, however whenever this occurs
      * a user-visible warning will be generated.
      *
-     * If allowFallbackTransforms() is FALSE then this setting has no effect.
+     * If \a appropriate is TRUE, then this setting overrides allowFallbackTransforms()
+     * and fallback transforms will always be allowed when required.
      *
      * \warning This setting applies to a single instance of a coordinate transform only,
      * and is not copied when a coordinate transform object is copied or assigned.

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -381,6 +381,32 @@ class CORE_EXPORT QgsCoordinateTransform
     void setCoordinateOperation( const QString &operation ) const;
 
     /**
+     * Sets whether "ballpark" fallback transformations can be used in the case that the specified
+     * coordinate operation fails (such as when coordinates from outside a required grid shift file
+     * are transformed). See fallbackOperationOccurred() for further details.
+     *
+     * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
+     *
+     * \see allowFallbackTransforms()
+     * \see setBallparkTransformsAreAppropriate()
+     * \since QGIS 3.12
+     */
+    void setAllowFallbackTransforms( bool allowed );
+
+    /**
+     * Returns whether "ballpark" fallback transformations will be used in the case that the specified
+     * coordinate operation fails (such as when coordinates from outside a required grid shift file
+     * are transformed). See fallbackOperationOccurred() for further details.
+     *
+     * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
+     *
+     * \see setAllowFallbackTransforms()
+     * \see setBallparkTransformsAreAppropriate()
+     * \since QGIS 3.12
+     */
+    bool allowFallbackTransforms() const;
+
+    /**
      * Sets whether approximate "ballpark" results are appropriate for this coordinate transform.
      *
      * When a coordinate transform is only being used to generate ballpark results then the
@@ -401,8 +427,12 @@ class CORE_EXPORT QgsCoordinateTransform
      * when the preferred or user-specified operation fails, however whenever this occurs
      * a user-visible warning will be generated.
      *
+     * If allowFallbackTransforms() is FALSE then this setting has no effect.
+     *
      * \warning This setting applies to a single instance of a coordinate transform only,
      * and is not copied when a coordinate transform object is copied or assigned.
+     *
+     * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will ignore this setting.
      *
      * \since QGIS 3.12
      */
@@ -417,6 +447,8 @@ class CORE_EXPORT QgsCoordinateTransform
      * \warning This setting applies to a single instance of a coordinate transform only,
      * and is not copied when a coordinate transform object is copied or assigned.
      *
+     * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will never perform fallback operations.
+     *
      * \see fallbackOperationOccurred()
      * \since QGIS 3.12
      */
@@ -424,6 +456,8 @@ class CORE_EXPORT QgsCoordinateTransform
 
     /**
      * Returns TRUE if a fallback operation occurred for the most recent transform.
+     *
+     * \note Requires Proj 6.0 or later. Builds based on earlier Proj versions will never perform fallback operations.
      *
      * \see disableFallbackOperationHandler()
      * \since QGIS 3.12
@@ -647,7 +681,7 @@ class CORE_EXPORT QgsCoordinateTransform
 #if PROJ_VERSION_MAJOR>=6
     bool setFromCache( const QgsCoordinateReferenceSystem &src,
                        const QgsCoordinateReferenceSystem &dest,
-                       const QString &coordinateOperationProj );
+                       const QString &coordinateOperationProj, bool allowFallback );
 #else
     bool setFromCache( const QgsCoordinateReferenceSystem &src,
                        const QgsCoordinateReferenceSystem &dest,

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -681,7 +681,6 @@ class CORE_EXPORT QgsCoordinateTransform
     bool mBallparkTransformsAreAppropriate = false;
     bool mDisableFallbackHandler = false;
     mutable bool mFallbackOperationOccurred = false;
-    mutable QString mLastError;
 
 #if PROJ_VERSION_MAJOR>=6
     bool setFromCache( const QgsCoordinateReferenceSystem &src,

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -593,7 +593,7 @@ class CORE_EXPORT QgsCoordinateTransform
      */
     static void setFallbackOperationOccurredHandler( const std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
         const QgsCoordinateReferenceSystem &destinationCrs,
-        const QgsDatumTransform::TransformDetails &desiredOperation )> &handler );
+        const QString &desiredOperation )> &handler );
 
 #endif
 
@@ -640,7 +640,7 @@ class CORE_EXPORT QgsCoordinateTransform
 
     static std::function< void( const QgsCoordinateReferenceSystem &sourceCrs,
                                 const QgsCoordinateReferenceSystem &destinationCrs,
-                                const QgsDatumTransform::TransformDetails &desiredOperation )> sFallbackOperationOccurredHandler;
+                                const QString &desiredOperation )> sFallbackOperationOccurredHandler;
 
 };
 

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -681,6 +681,7 @@ class CORE_EXPORT QgsCoordinateTransform
     bool mBallparkTransformsAreAppropriate = false;
     bool mDisableFallbackHandler = false;
     mutable bool mFallbackOperationOccurred = false;
+    mutable QString mLastError;
 
 #if PROJ_VERSION_MAJOR>=6
     bool setFromCache( const QgsCoordinateReferenceSystem &src,

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -409,6 +409,28 @@ class CORE_EXPORT QgsCoordinateTransform
     void setBallparkTransformsAreAppropriate( bool appropriate );
 
     /**
+     * Sets whether the default fallback operation handler is disabled for this transform instance.
+     *
+     * If the default handler is \a disabled then it is possible to determine whether a fallback
+     * operation occurred by testing fallbackOperationOccurred() immediately after a transformation.
+     *
+     * \warning This setting applies to a single instance of a coordinate transform only,
+     * and is not copied when a coordinate transform object is copied or assigned.
+     *
+     * \see fallbackOperationOccurred()
+     * \since QGIS 3.12
+     */
+    void disableFallbackOperationHandler( bool disabled );
+
+    /**
+     * Returns TRUE if a fallback operation occurred for the most recent transform.
+     *
+     * \see disableFallbackOperationHandler()
+     * \since QGIS 3.12
+     */
+    bool fallbackOperationOccurred() const;
+
+    /**
      * Returns the ID of the datum transform to use when projecting from the source
      * CRS.
      *
@@ -619,6 +641,8 @@ class CORE_EXPORT QgsCoordinateTransform
 
     mutable QString mLastError;
     bool mBallparkTransformsAreAppropriate = false;
+    bool mDisableFallbackHandler = false;
+    mutable bool mFallbackOperationOccurred = false;
 
 #if PROJ_VERSION_MAJOR>=6
     bool setFromCache( const QgsCoordinateReferenceSystem &src,

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -609,7 +609,7 @@ class CORE_EXPORT QgsCoordinateTransform
 
     /**
      * Sets a custom \a handler to use when the desired coordinate operation for use between \a sourceCrs and
-     * \a destinationCrs failed and an alternative fallback operation was utilised instead.
+     * \a destinationCrs failed and an alternative fallback operation was utilized instead.
      *
      * \since QGIS 3.10.3
      */

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -107,6 +107,7 @@ QgsCoordinateTransformPrivate::QgsCoordinateTransformPrivate( const QgsCoordinat
   , mDestinationDatumTransform( other.mDestinationDatumTransform )
   , mProjCoordinateOperation( other.mProjCoordinateOperation )
   , mShouldReverseCoordinateOperation( other.mShouldReverseCoordinateOperation )
+  , mAllowFallbackTransforms( other.mAllowFallbackTransforms )
   , mIsReversed( other.mIsReversed )
 {
 #if PROJ_VERSION_MAJOR < 6
@@ -263,6 +264,7 @@ void QgsCoordinateTransformPrivate::calculateTransforms( const QgsCoordinateTran
 #if PROJ_VERSION_MAJOR >= 6
   mProjCoordinateOperation = context.calculateCoordinateOperation( mSourceCRS, mDestCRS );
   mShouldReverseCoordinateOperation = context.mustReverseCoordinateOperation( mSourceCRS, mDestCRS );
+  mAllowFallbackTransforms = context.allowFallbackTransform( mSourceCRS, mDestCRS );
 #else
   Q_NOWARN_DEPRECATED_PUSH
   QgsDatumTransform::TransformPair transforms = context.calculateDatumTransforms( mSourceCRS, mDestCRS );

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -103,6 +103,8 @@ class QgsCoordinateTransformPrivate : public QSharedData
     ProjData threadLocalProjData();
 
 #if PROJ_VERSION_MAJOR>=6
+    ProjData threadLocalFallbackProjData();
+
     // Only meant to be called by QgsCoordinateTransform::removeFromCacheObjectsBelongingToCurrentThread()
     bool removeObjectsBelongingToCurrentThread( void *pj_context );
 #endif
@@ -152,6 +154,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
 
     QReadWriteLock mProjLock;
     QMap < uintptr_t, ProjData > mProjProjections;
+    QMap < uintptr_t, ProjData > mProjFallbackProjections;
 
     /**
      * Sets a custom handler to use when a coordinate transform is created between \a sourceCrs and

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -134,6 +134,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
     Q_DECL_DEPRECATED int mDestinationDatumTransform = -1;
     QString mProjCoordinateOperation;
     bool mShouldReverseCoordinateOperation = false;
+    bool mAllowFallbackTransforms = true;
 
     //! True if the proj transform corresponds to the reverse direction, and must be flipped when transforming...
     bool mIsReversed = false;

--- a/src/core/qgscoordinatetransformcontext.cpp
+++ b/src/core/qgscoordinatetransformcontext.cpp
@@ -205,6 +205,11 @@ bool QgsCoordinateTransformContext::allowFallbackTransform( const QgsCoordinateR
 
   d->mLock.lockForRead();
   QgsCoordinateTransformContextPrivate::OperationDetails res = d->mSourceDestDatumTransforms.value( qMakePair( srcKey, destKey ), QgsCoordinateTransformContextPrivate::OperationDetails() );
+  if ( res.operation.isEmpty() )
+  {
+    // try to reverse
+    res = d->mSourceDestDatumTransforms.value( qMakePair( destKey, srcKey ), QgsCoordinateTransformContextPrivate::OperationDetails() );
+  }
   d->mLock.unlock();
   return res.allowFallback;
 #else

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -224,7 +224,7 @@ class CORE_EXPORT QgsCoordinateTransformContext
 
     /**
      * Returns TRUE if approximate "ballpark" transforms may be used when transforming
-     * between a \source and \a destination CRS pair, in the case that the preferred
+     * between a \a source and \a destination CRS pair, in the case that the preferred
      * coordinate operation fails (such as when
      * coordinates from outside a required grid shift file are transformed). See
      * QgsCoordinateTransform::fallbackOperationOccurred() for further details.

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -140,6 +140,14 @@ class CORE_EXPORT QgsCoordinateTransformContext
      * string. If \a coordinateOperationProjString is empty, then the default Proj operation
      * will be used when transforming between the coordinate reference systems.
      *
+     * If \a allowFallback is TRUE (since QGIS 3.12), then "ballpark" fallback transformations
+     * will be used in the case that the specified coordinate operation fails (such as when
+     * coordinates from outside a required grid shift file are transformed). See
+     * QgsCoordinateTransform::fallbackOperationOccurred() for further details. Note that if an
+     * existing \a sourceCrs and \a destinationCrs pair are added with a different \a allowFallback
+     * value, that value will replace the existing one (i.e. each combination of \a sourceCrs and
+     * \a destinationCrs must be unique).
+     *
      * \warning coordinateOperationProjString MUST be a proj string which has been normalized for
      * visualization, and must be constructed so that coordinates are always input and output
      * with x/y coordinate ordering. (Proj strings output by utilities such as projinfo will NOT
@@ -155,7 +163,7 @@ class CORE_EXPORT QgsCoordinateTransformContext
      *
      * \since QGIS 3.8
      */
-    bool addCoordinateOperation( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QString &coordinateOperationProjString );
+    bool addCoordinateOperation( const QgsCoordinateReferenceSystem &sourceCrs, const QgsCoordinateReferenceSystem &destinationCrs, const QString &coordinateOperationProjString, bool allowFallback = true );
 
     /**
      * Removes the source to destination datum transform pair for the specified \a sourceCrs and
@@ -213,6 +221,17 @@ class CORE_EXPORT QgsCoordinateTransformContext
      * \since QGIS 3.8
      */
     QString calculateCoordinateOperation( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
+
+    /**
+     * Returns TRUE if approximate "ballpark" transforms may be used when transforming
+     * between a \source and \a destination CRS pair, in the case that the preferred
+     * coordinate operation fails (such as when
+     * coordinates from outside a required grid shift file are transformed). See
+     * QgsCoordinateTransform::fallbackOperationOccurred() for further details.
+     *
+     * \since QGIS 3.12
+     */
+    bool allowFallbackTransform( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination ) const;
 
     /**
      * Returns TRUE if the coordinate operation returned by calculateCoordinateOperation() for the \a source to \a destination pair

--- a/src/core/qgscoordinatetransformcontext_p.h
+++ b/src/core/qgscoordinatetransformcontext_p.h
@@ -59,7 +59,18 @@ class QgsCoordinateTransformContextPrivate : public QSharedData
      * Mapping for coordinate operation Proj string to use for source/destination CRS pairs.
      */
 #if PROJ_VERSION_MAJOR>=6
-    QMap< QPair< QString, QString >, QString > mSourceDestDatumTransforms;
+    class OperationDetails
+    {
+      public:
+        QString operation;
+        bool allowFallback = true;
+
+        bool operator==( const OperationDetails &other ) const
+        {
+          return operation == other.operation && allowFallback == other.allowFallback;
+        }
+    };
+    QMap< QPair< QString, QString >, OperationDetails > mSourceDestDatumTransforms;
 #else
     QMap< QPair< QString, QString >, QgsDatumTransform::TransformPair > mSourceDestDatumTransforms;
 #endif

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -439,6 +439,7 @@ QgsRectangle QgsMapSettings::layerExtentToOutputExtent( const QgsMapLayer *layer
       QgsDebugMsgLevel( QStringLiteral( "sourceCrs = %1" ).arg( ct.sourceCrs().authid() ), 3 );
       QgsDebugMsgLevel( QStringLiteral( "destCRS = %1" ).arg( ct.destinationCrs().authid() ), 3 );
       QgsDebugMsgLevel( QStringLiteral( "extent %1" ).arg( extent.toString() ), 3 );
+      ct.setBallparkTransformsAreAppropriate( true );
       extent = ct.transformBoundingBox( extent );
     }
   }

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -102,7 +102,9 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
     {
       try
       {
-        myProjectedViewExtent = rendererContext.coordinateTransform().transformBoundingBox( rendererContext.extent() );
+        QgsCoordinateTransform ct = rendererContext.coordinateTransform();
+        ct.setBallparkTransformsAreAppropriate( true );
+        myProjectedViewExtent = ct.transformBoundingBox( rendererContext.extent() );
       }
       catch ( QgsCsException &cs )
       {
@@ -113,7 +115,9 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
 
     try
     {
-      myProjectedLayerExtent = rendererContext.coordinateTransform().transformBoundingBox( layer->extent() );
+      QgsCoordinateTransform ct = rendererContext.coordinateTransform();
+      ct.setBallparkTransformsAreAppropriate( true );
+      myProjectedLayerExtent = ct.transformBoundingBox( layer->extent() );
     }
     catch ( QgsCsException &cs )
     {

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2937,6 +2937,7 @@ QWidget *QgsProcessingCoordinateOperationWidgetWrapper::createWidget()
     {
       mOperationWidget = new QgsCoordinateOperationWidget( nullptr );
       mOperationWidget->setShowMakeDefault( false );
+      mOperationWidget->setShowFallbackOption( false );
       mOperationWidget->setToolTip( parameterDefinition()->toolTip() );
       mOperationWidget->setSourceCrs( mSourceCrs );
       mOperationWidget->setDestinationCrs( mDestCrs );

--- a/src/gui/qgscoordinateoperationwidget.cpp
+++ b/src/gui/qgscoordinateoperationwidget.cpp
@@ -666,6 +666,11 @@ void QgsCoordinateOperationWidget::setSelectedOperationUsingContext( const QgsCo
 #endif
 }
 
+void QgsCoordinateOperationWidget::setShowFallbackOption( bool visible )
+{
+  mAllowFallbackCheckBox->setVisible( visible );
+}
+
 bool QgsCoordinateOperationWidget::gridShiftTransformation( const QString &itemText ) const
 {
   return !itemText.isEmpty() && !itemText.contains( QLatin1String( "towgs84" ), Qt::CaseInsensitive );

--- a/src/gui/qgscoordinateoperationwidget.cpp
+++ b/src/gui/qgscoordinateoperationwidget.cpp
@@ -106,7 +106,7 @@ void QgsCoordinateOperationWidget::setMapCanvas( QgsMapCanvas *canvas )
       // reproject extent
       QgsCoordinateTransform ct( QgsProject::instance()->crs(),
                                  QgsCoordinateReferenceSystem::fromEpsgId( 4326 ), QgsProject::instance() );
-
+      ct.setBallparkTransformsAreAppropriate( true );
       g = g.densifyByCount( 5 );
       try
       {

--- a/src/gui/qgscoordinateoperationwidget.h
+++ b/src/gui/qgscoordinateoperationwidget.h
@@ -49,6 +49,9 @@ class GUI_EXPORT QgsCoordinateOperationWidget : public QWidget, private Ui::QgsC
 
       //! TRUE if operation is available
       bool isAvailable = true;
+
+      //! TRUE if fallback transforms can be used
+      bool allowFallback = true;
     };
 
     /**
@@ -131,7 +134,7 @@ class GUI_EXPORT QgsCoordinateOperationWidget : public QWidget, private Ui::QgsC
      * Sets the details of the \a operation currently selected within the widget.
      * \see selectedOperation()
      */
-    void setSelectedOperation( const QgsCoordinateOperationWidget::OperationDetails &operation ) const;
+    void setSelectedOperation( const QgsCoordinateOperationWidget::OperationDetails &operation );
 
     /**
      * Automatically sets the selected operation using the settings encapsulated in a transform \a context.
@@ -192,6 +195,7 @@ class GUI_EXPORT QgsCoordinateOperationWidget : public QWidget, private Ui::QgsC
     QgsCoordinateReferenceSystem mSourceCrs;
     QgsCoordinateReferenceSystem mDestinationCrs;
     OperationDetails mPreviousOp;
+    int mBlockSignals = 0;
 };
 
 #endif // QGSCOORDINATEOPERATIONWIDGET_H

--- a/src/gui/qgscoordinateoperationwidget.h
+++ b/src/gui/qgscoordinateoperationwidget.h
@@ -144,6 +144,13 @@ class GUI_EXPORT QgsCoordinateOperationWidget : public QWidget, private Ui::QgsC
      */
     void setSelectedOperationUsingContext( const QgsCoordinateTransformContext &context );
 
+    /**
+     * Sets whether the "allow fallback" operations option is visible.
+     *
+     * \since QGIS 3.12
+     */
+    void setShowFallbackOption( bool visible );
+
   signals:
 
     /**

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -57,7 +57,7 @@ bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs
       Q_NOWARN_DEPRECATED_PUSH
       context.addSourceDestinationDatumTransform( dt.sourceCrs, dt.destinationCrs, dt.sourceTransformId, dt.destinationTransformId );
       Q_NOWARN_DEPRECATED_POP
-      context.addCoordinateOperation( dt.sourceCrs, dt.destinationCrs, dt.proj );
+      context.addCoordinateOperation( dt.sourceCrs, dt.destinationCrs, dt.proj, dt.allowFallback );
       QgsProject::instance()->setTransformContext( context );
       return true;
     }
@@ -77,7 +77,7 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
     const QgsCoordinateReferenceSystem &dCrs, const bool allowCrsChanges, const bool showMakeDefault, const bool forceChoice,
     QPair<int, int> selectedDatumTransforms,
     QWidget *parent,
-    Qt::WindowFlags f, const QString &selectedProj, QgsMapCanvas *mapCanvas )
+    Qt::WindowFlags f, const QString &selectedProj, QgsMapCanvas *mapCanvas, bool allowFallback )
   : QDialog( parent, f )
   , mPreviousCursorOverride( qgis::make_unique< QgsTemporaryCursorRestoreOverride >() ) // this dialog is often shown while cursor overrides are in place, so temporarily remove them
 {
@@ -141,6 +141,7 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
   deets.proj = selectedProj;
   deets.sourceTransformId = selectedDatumTransforms.first;
   deets.destinationTransformId = selectedDatumTransforms.second;
+  deets.allowFallback = allowFallback;
   mCoordinateOperationsWidget->setSelectedOperation( deets );
 
   connect( mCoordinateOperationsWidget, &QgsCoordinateOperationWidget::operationDoubleClicked, this, [ = ]
@@ -191,6 +192,7 @@ void QgsDatumTransformDialog::accept()
     settings.setValue( srcAuthId + QStringLiteral( "//" ) + destAuthId + QStringLiteral( "_srcTransform" ), sourceDatumProj );
     settings.setValue( srcAuthId + QStringLiteral( "//" ) + destAuthId + QStringLiteral( "_destTransform" ), destinationDatumProj );
     settings.setValue( srcAuthId + QStringLiteral( "//" ) + destAuthId + QStringLiteral( "_coordinateOp" ), dt.proj );
+    settings.setValue( srcAuthId + QStringLiteral( "//" ) + destAuthId + QStringLiteral( "_allowFallback" ), dt.allowFallback );
   }
   QDialog::accept();
 }
@@ -254,6 +256,7 @@ QgsDatumTransformDialog::TransformInfo QgsDatumTransformDialog::selectedDatumTra
   sdt.sourceTransformId = selected.sourceTransformId;
   sdt.destinationTransformId = selected.destinationTransformId;
   sdt.proj = selected.proj;
+  sdt.allowFallback = selected.allowFallback;
   return sdt;
 }
 

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -53,6 +53,9 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
 
       //! Proj coordinate operation description, for Proj >= 6.0 builds only
       QString proj;
+
+      //! TRUE if fallback transforms can be used
+      bool allowFallback = true;
     };
 
     /**
@@ -89,7 +92,8 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
                              QWidget *parent = nullptr,
                              Qt::WindowFlags f = nullptr,
                              const QString &selectedProj = QString(),
-                             QgsMapCanvas *mapCanvas = nullptr );
+                             QgsMapCanvas *mapCanvas = nullptr,
+                             bool allowFallback = true );
 
     void accept() override;
     void reject() override;

--- a/src/ui/qgscoordinateoperationwidgetbase.ui
+++ b/src/ui/qgscoordinateoperationwidgetbase.ui
@@ -139,7 +139,7 @@
      <item>
       <widget class="QCheckBox" name="mShowSupersededCheckBox">
        <property name="text">
-        <string>Show superseded transformations</string>
+        <string>Show superseded transforms</string>
        </property>
       </widget>
      </item>
@@ -155,6 +155,22 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="mAllowFallbackCheckBox">
+       <property name="toolTip">
+        <string>Sets whether &quot;ballpark&quot; fallback transformations can be
+used in the case that the specified coordinate operation fails
+(such as when coordinates from outside a required grid shift
+file are transformed).</string>
+       </property>
+       <property name="text">
+        <string>Allow fallback transforms if preferred operation fails</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="mMakeDefaultCheckBox">

--- a/tests/src/gui/testqgsdatumtransformdialog.cpp
+++ b/tests/src/gui/testqgsdatumtransformdialog.cpp
@@ -30,6 +30,7 @@ class TestQgsDatumTransformDialog: public QObject
     void cleanup(); // will be called after every testfunction.
 
     void defaultTransform();
+    void fallback();
     void shouldAskUser();
     void applyDefaultTransform();
     void runDialog();
@@ -74,6 +75,7 @@ void TestQgsDatumTransformDialog::defaultTransform()
   QCOMPARE( def.sourceCrs.authid(), QStringLiteral( "EPSG:7844" ) );
   QCOMPARE( def.destinationCrs.authid(), QStringLiteral( "EPSG:4283" ) );
   QCOMPARE( def.proj, QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=push +v_3 +step +proj=cart +ellps=GRS80 +step +inv +proj=helmert +x=0.06155 +y=-0.01087 +z=-0.04019 +rx=-0.0394924 +ry=-0.0327221 +rz=-0.0328979 +s=-0.009994 +convention=coordinate_frame +step +inv +proj=cart +ellps=GRS80 +step +proj=pop +v_3 +step +proj=unitconvert +xy_in=rad +xy_out=deg" ) );
+  QVERIFY( def.allowFallback );
 
   // default should be initially selected
   def = dlg.selectedDatumTransform();
@@ -111,6 +113,20 @@ void TestQgsDatumTransformDialog::defaultTransform()
   QCOMPARE( QgsDatumTransform::datumTransformToProj( def.destinationTransformId ), QStringLiteral( "+towgs84=-10,158,187" ) );
 
   Q_NOWARN_DEPRECATED_POP
+#endif
+}
+
+void TestQgsDatumTransformDialog::fallback()
+{
+#if PROJ_VERSION_MAJOR>=6
+  // don't default to allow fallback
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:7844" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4283" ) ), false, true, false, qMakePair( -1, -1 ), nullptr, nullptr, QString(), nullptr, false );
+
+  QgsDatumTransformDialog::TransformInfo def = dlg.selectedDatumTransform();
+  QCOMPARE( def.sourceCrs.authid(), QStringLiteral( "EPSG:7844" ) );
+  QCOMPARE( def.destinationCrs.authid(), QStringLiteral( "EPSG:4283" ) );
+  QCOMPARE( def.proj, QStringLiteral( "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=push +v_3 +step +proj=cart +ellps=GRS80 +step +inv +proj=helmert +x=0.06155 +y=-0.01087 +z=-0.04019 +rx=-0.0394924 +ry=-0.0327221 +rz=-0.0328979 +s=-0.009994 +convention=coordinate_frame +step +inv +proj=cart +ellps=GRS80 +step +proj=pop +v_3 +step +proj=unitconvert +xy_in=rad +xy_out=deg" ) );
+  QVERIFY( !def.allowFallback );
 #endif
 }
 

--- a/tests/src/python/test_qgscoordinateoperationwidget.py
+++ b/tests/src/python/test_qgscoordinateoperationwidget.py
@@ -65,20 +65,32 @@ class TestQgsCoordinateOperationWidget(unittest.TestCase):
 
         op = QgsCoordinateOperationWidget.OperationDetails()
         op.proj = '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84'
+        op.allowFallback = True
         w.setSelectedOperation(op)
         self.assertEqual(w.selectedOperation().proj,
                          '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
+        self.assertTrue(w.selectedOperation().allowFallback)
         self.assertEqual(len(spy), 2)
         w.setSelectedOperation(op)
         self.assertEqual(w.selectedOperation().proj,
                          '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
+        self.assertTrue(w.selectedOperation().allowFallback)
         self.assertEqual(len(spy), 2)
 
         op.proj = '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=159 +z=175 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84'
+        op.allowFallback = False
         w.setSelectedOperation(op)
         self.assertEqual(w.selectedOperation().proj,
                          '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=159 +z=175 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
+        self.assertFalse(w.selectedOperation().allowFallback)
         self.assertEqual(len(spy), 3)
+
+        op.allowFallback = True
+        w.setSelectedOperation(op)
+        self.assertEqual(w.selectedOperation().proj,
+                         '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=159 +z=175 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
+        self.assertTrue(w.selectedOperation().allowFallback)
+        self.assertEqual(len(spy), 4)
 
         context = QgsCoordinateTransformContext()
         op.proj = '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84'
@@ -87,14 +99,22 @@ class TestQgsCoordinateOperationWidget(unittest.TestCase):
         # should go to default, because there's nothing in the context matching these crs
         self.assertEqual(w.selectedOperation().proj,
                          '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=159 +z=175 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
-        self.assertEqual(len(spy), 5)
+        self.assertEqual(len(spy), 6)
 
         # put something in the context
         context.addCoordinateOperation(w.sourceCrs(), w.destinationCrs(), '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
         w.setSelectedOperationUsingContext(context)
         self.assertEqual(w.selectedOperation().proj,
                          '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
-        self.assertEqual(len(spy), 6)
+        self.assertTrue(w.selectedOperation().allowFallback)
+        self.assertEqual(len(spy), 7)
+
+        context.addCoordinateOperation(w.sourceCrs(), w.destinationCrs(), '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84', False)
+        w.setSelectedOperationUsingContext(context)
+        self.assertEqual(w.selectedOperation().proj,
+                         '+proj=pipeline +step +proj=unitconvert +xy_in=us-ft +xy_out=m +step +inv +proj=lcc +lat_0=33.5 +lon_0=-118 +lat_1=35.4666666666667 +lat_2=34.0333333333333 +x_0=609601.219202438 +y_0=0 +ellps=clrk66 +step +proj=push +v_3 +step +proj=cart +ellps=clrk66 +step +proj=helmert +x=-8 +y=160 +z=176 +step +inv +proj=cart +ellps=WGS84 +step +proj=pop +v_3 +step +proj=webmerc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84')
+        self.assertFalse(w.selectedOperation().allowFallback)
+        self.assertEqual(len(spy), 8)
 
     @unittest.skipIf(os.environ.get('TRAVIS', '') == 'true' or QgsProjUtils.projVersionMajor() >= 6, 'Depends on local environment and grid presence')
     def testOperationsCruftyProj(self):

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -149,9 +149,20 @@ class TestQgsCoordinateTransform(unittest.TestCase):
 
         transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:28354'), QgsCoordinateReferenceSystem('EPSG:28353'), context)
         self.assertEqual(list(transform.context().coordinateOperations().keys()), [('EPSG:28356', 'EPSG:4283')])
-
         # should be no coordinate operation
         self.assertEqual(transform.coordinateOperation(), '')
+        # should default to allowing fallback transforms
+        self.assertTrue(transform.allowFallbackTransforms())
+
+        transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:28356'),
+                                           QgsCoordinateReferenceSystem('EPSG:4283'), context)
+        self.assertTrue(transform.allowFallbackTransforms())
+        context.addCoordinateOperation(QgsCoordinateReferenceSystem('EPSG:28356'),
+                                       QgsCoordinateReferenceSystem('EPSG:4283'),
+                                       'proj', False)
+        transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:28356'),
+                                           QgsCoordinateReferenceSystem('EPSG:4283'), context)
+        self.assertFalse(transform.allowFallbackTransforms())
 
         # matching source
         transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:28356'), QgsCoordinateReferenceSystem('EPSG:28353'), context)
@@ -168,6 +179,10 @@ class TestQgsCoordinateTransform(unittest.TestCase):
         # test manual overwriting
         transform.setCoordinateOperation('proj2')
         self.assertEqual(transform.coordinateOperation(), 'proj2')
+        transform.setAllowFallbackTransforms(False)
+        self.assertFalse(transform.allowFallbackTransforms())
+        transform.setAllowFallbackTransforms(True)
+        self.assertTrue(transform.allowFallbackTransforms())
 
         # test that auto operation setting occurs when updating src/dest crs
         transform.setSourceCrs(QgsCoordinateReferenceSystem('EPSG:28356'))

--- a/tests/src/python/test_qgscoordinatetransformcontext.py
+++ b/tests/src/python/test_qgscoordinatetransformcontext.py
@@ -163,6 +163,8 @@ class TestQgsCoordinateTransformContext(unittest.TestCase):
                                                                QgsCoordinateReferenceSystem('EPSG:3111')))
         self.assertTrue(
             context.allowFallbackTransform(QgsCoordinateReferenceSystem('EPSG:3111'), QgsCoordinateReferenceSystem('EPSG:4283')))
+        self.assertTrue(
+            context.allowFallbackTransform(QgsCoordinateReferenceSystem('EPSG:4283'), QgsCoordinateReferenceSystem('EPSG:3111')))
 
         self.assertTrue(
             context.hasTransform(QgsCoordinateReferenceSystem('EPSG:4283'), QgsCoordinateReferenceSystem('EPSG:3111')))
@@ -186,10 +188,18 @@ class TestQgsCoordinateTransformContext(unittest.TestCase):
                                                               QgsCoordinateReferenceSystem('EPSG:3111')), proj_string_2)
         self.assertFalse(context.mustReverseCoordinateOperation(QgsCoordinateReferenceSystem('EPSG:4283'),
                                                                 QgsCoordinateReferenceSystem('EPSG:3111')))
-        self.assertFalse(
-            context.allowFallbackTransform(QgsCoordinateReferenceSystem('EPSG:4283'), QgsCoordinateReferenceSystem('EPSG:3111')))
         context.removeCoordinateOperation(QgsCoordinateReferenceSystem('EPSG:4283'),
                                           QgsCoordinateReferenceSystem('EPSG:3111'))
+
+        self.assertTrue(context.addCoordinateOperation(QgsCoordinateReferenceSystem('EPSG:4283'),
+                                                       QgsCoordinateReferenceSystem('EPSG:3113'), proj_string_2, False))
+        self.assertFalse(
+            context.allowFallbackTransform(QgsCoordinateReferenceSystem('EPSG:4283'), QgsCoordinateReferenceSystem('EPSG:3113')))
+        self.assertFalse(
+            context.allowFallbackTransform(QgsCoordinateReferenceSystem('EPSG:3113'), QgsCoordinateReferenceSystem('EPSG:4283')))
+
+        context.removeCoordinateOperation(QgsCoordinateReferenceSystem('EPSG:4283'),
+                                          QgsCoordinateReferenceSystem('EPSG:3113'))
 
         proj_string_2 = '+proj=pipeline +step +inv +proj=utm +zone=56 +south +ellps=GRS80 +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1'
         self.assertTrue(context.addCoordinateOperation(QgsCoordinateReferenceSystem('EPSG:28356'),


### PR DESCRIPTION
When the selected coordinate operation fails to project coordinates, try falling back to a default PROJ-provided operation to transform the coordinates

This allows **some** transformation of coordinates to occur in the situation:
- user has selected a coordinate operation utilising a grid shift file
- one or more points which fall OUTSIDE the grid file are transformed

Not for merge -- likely needs some form of user-visible-warning when this occurs

Refs #33929
