### PR TITLE
Add a recenter button to the GPS information panel

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -81,6 +81,8 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   Q_ASSERT( mMapCanvas ); // precondition
   setupUi( this );
   connect( mConnectButton, &QPushButton::toggled, this, &QgsGpsInformationWidget::mConnectButton_toggled );
+  connect( mRecenterButton, &QPushButton::clicked, this, &QgsGpsInformationWidget::recenter );
+  connect( mConnectButton, &QAbstractButton::toggled, mRecenterButton, &QWidget::setEnabled );
   connect( mBtnTrackColor, &QgsColorButton::colorChanged, this, &QgsGpsInformationWidget::trackColorChanged );
   connect( mSpinTrackWidth, qgis::overload< int >::of( &QSpinBox::valueChanged ), this, &QgsGpsInformationWidget::mSpinTrackWidth_valueChanged );
   connect( mBtnPosition, &QToolButton::clicked, this, &QgsGpsInformationWidget::mBtnPosition_clicked );
@@ -94,6 +96,8 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   connect( mBtnResetFeature, &QToolButton::clicked, this, &QgsGpsInformationWidget::mBtnResetFeature_clicked );
   connect( mBtnLogFile, &QPushButton::clicked, this, &QgsGpsInformationWidget::mBtnLogFile_clicked );
   connect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsGpsInformationWidget::cursorCoordinateChanged );
+
+  mRecenterButton->setEnabled( false );
 
   mWgs84CRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
 
@@ -548,6 +552,20 @@ void QgsGpsInformationWidget::mConnectButton_toggled( bool flag )
   else
   {
     disconnectGps();
+  }
+}
+
+void QgsGpsInformationWidget::recenter()
+{
+  try
+  {
+    const QgsPointXY center = mCanvasToWgs84Transform.transform( mLastGpsPosition, QgsCoordinateTransform::ReverseTransform );
+    mMapCanvas->setCenter( center );
+    mMapCanvas->refresh();
+  }
+  catch ( QgsCsException & )
+  {
+
   }
 }
 

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -56,6 +56,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
     ~QgsGpsInformationWidget() override;
   private slots:
     void mConnectButton_toggled( bool flag );
+    void recenter();
     void displayGPSInformation( const QgsGpsInformation &info );
     void logNmeaSentence( const QString &nmeaString ); // added to handle 'raw' data
     void updateCloseFeatureButton( QgsMapLayer *lyr );

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -1415,6 +1415,22 @@ gray = no data
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="mRecenterButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Recenter</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="mConnectButton">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">


### PR DESCRIPTION
There's NO way to recenter the map on the GPS location, which is a HUGE ux limitation in QGIS' GPS handling. This commit adds a new "Recenter" button to the panel to allow users to jump right to
the current GPS position.

It's a borderline feature, but I feel that without this ability the whole QGIS/GPS integration is rather crippled...