### PR TITLE
Add an advanced settings key to allow disabling of the "pan distance" message 

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -54,6 +54,10 @@ maxRecentProjects=20
 # notification to be shown when the task completes.
 minTaskLengthForSystemNotification=5
 
+# Whether to show the distance panned message in the status bar after a map pan operation
+# occurs. Set to false to disable the message.
+showPanDistanceInStatusBar=true
+
 # Whether to prompt users for a selection when multiple possible transformation paths exist
 # when transforming coordinates. If false, a reasonable choice will be estimated by default
 # without asking users. If true, users are always required to make this choice themselves.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13044,6 +13044,10 @@ void QgisApp::showRotation()
 
 void QgisApp::showPanMessage( double distance, QgsUnitTypes::DistanceUnit unit, double bearing )
 {
+  const bool showMessage = QgsSettings().value( QStringLiteral( "showPanDistanceInStatusBar" ), true, QgsSettings::App ).toBool();
+  if ( !showMessage )
+    return;
+
   const double distanceInProjectUnits = distance * QgsUnitTypes::fromUnitToUnitFactor( unit, QgsProject::instance()->distanceUnits() );
   const int distanceDecimalPlaces = QgsSettings().value( QStringLiteral( "qgis/measure/decimalplaces" ), "3" ).toInt();
   const QString distanceString = QgsDistanceArea::formatDistance( distanceInProjectUnits, distanceDecimalPlaces, QgsProject::instance()->distanceUnits() );


### PR DESCRIPTION
...which shows in the status bar after a pan operation
