### PR TITLE
Fix transform errors caused by GPS bearing update

### DIFF
--- a/src/app/gps/qgsgpsbearingitem.cpp
+++ b/src/app/gps/qgsgpsbearingitem.cpp
@@ -40,13 +40,14 @@ QgsGpsBearingItem::QgsGpsBearingItem( QgsMapCanvas *mapCanvas )
 
 void QgsGpsBearingItem::setGpsPosition( const QgsPointXY &point )
 {
+  mCenterWGS84 = point;
   //transform to map crs
   if ( mMapCanvas )
   {
     QgsCoordinateTransform t( mWgs84CRS, mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
     try
     {
-      mCenter = t.transform( point );
+      mCenter = t.transform( mCenterWGS84 );
     }
     catch ( QgsCsException &e ) //silently ignore transformation exceptions
     {
@@ -69,7 +70,7 @@ void QgsGpsBearingItem::setGpsBearing( double bearing )
 
 void QgsGpsBearingItem::updatePosition()
 {
-  setGpsPosition( mCenter );
+  setGpsPosition( mCenterWGS84 );
 }
 
 void QgsGpsBearingItem::updateLine()

--- a/src/app/gps/qgsgpsbearingitem.h
+++ b/src/app/gps/qgsgpsbearingitem.h
@@ -34,6 +34,9 @@ class QgsGpsBearingItem : public QObject, public QgsMapCanvasLineSymbolItem
   public:
     explicit QgsGpsBearingItem( QgsMapCanvas *mapCanvas );
 
+    /**
+     * Point is in WGS84
+     */
     void setGpsPosition( const QgsPointXY &point );
     void setGpsBearing( double bearing );
 
@@ -41,8 +44,11 @@ class QgsGpsBearingItem : public QObject, public QgsMapCanvasLineSymbolItem
 
   protected:
 
-    //! coordinates of the point in the center
+    //! coordinates of the point in the center (map units)
     QgsPointXY mCenter;
+
+    //! coordinates of the point in the center (WGS84)
+    QgsPointXY mCenterWGS84;
 
   private:
     void updateLine();


### PR DESCRIPTION
The center was being double-transformed