### PR TITLE
Fix mouse cursor GPS distance display for touch screen devices

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -1023,6 +1023,13 @@ start of the pan and the current pan position.
 .. versionadded:: 3.12
 %End
 
+    void tapAndHoldGestureOccurred( const QgsPointXY &mapPoint, QTapAndHoldGesture *gesture );
+%Docstring
+Emitted whenever a tap and hold ``gesture`` occurs at the specified map point.
+
+.. versionadded:: 3.12
+%End
+
   protected:
 
     virtual bool event( QEvent *e );

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -94,6 +94,7 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidg
   connect( mBtnResetFeature, &QToolButton::clicked, this, &QgsGpsInformationWidget::mBtnResetFeature_clicked );
   connect( mBtnLogFile, &QPushButton::clicked, this, &QgsGpsInformationWidget::mBtnLogFile_clicked );
   connect( mMapCanvas, &QgsMapCanvas::xyCoordinates, this, &QgsGpsInformationWidget::cursorCoordinateChanged );
+  connect( mMapCanvas, &QgsMapCanvas::tapAndHoldGestureOccurred, this, &QgsGpsInformationWidget::tapAndHold );
 
   mWgs84CRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( QStringLiteral( "EPSG:4326" ) );
 
@@ -1553,6 +1554,22 @@ void QgsGpsInformationWidget::updateTimestampDestinationFields( QgsMapLayer *map
     }
   }
   mPopulatingFields = false;
+}
+
+void QgsGpsInformationWidget::tapAndHold( const QgsPointXY &mapPoint, QTapAndHoldGesture * )
+{
+  if ( !mNmea )
+    return;
+
+  try
+  {
+    mLastCursorPosWgs84 = mCanvasToWgs84Transform.transform( mapPoint );
+    updateGpsDistanceStatusMessage();
+  }
+  catch ( QgsCsException & )
+  {
+
+  }
 }
 
 void QgsGpsInformationWidget::switchAcquisition()

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -54,6 +54,11 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
   public:
     QgsGpsInformationWidget( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr );
     ~QgsGpsInformationWidget() override;
+
+  public slots:
+    void tapAndHold( const QgsPointXY &mapPoint, QTapAndHoldGesture *gesture );
+
+
   private slots:
     void mConnectButton_toggled( bool flag );
     void displayGPSInformation( const QgsGpsInformation &info );
@@ -87,6 +92,7 @@ class APP_EXPORT QgsGpsInformationWidget: public QgsPanelWidget, private Ui::Qgs
      * Updates compatible fields for timestamp recording
      */
     void updateTimestampDestinationFields( QgsMapLayer *mapLayer );
+
   private:
     enum FixStatus  //GPS status
     {

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -194,6 +194,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   // Enable touch event on Windows.
   // Qt on Windows needs to be told it can take touch events or else it ignores them.
   grabGesture( Qt::PinchGesture );
+  grabGesture( Qt::TapAndHoldGesture );
   viewport()->setAttribute( Qt::WA_AcceptTouchEvents );
 #endif
 
@@ -2337,6 +2338,14 @@ bool QgsMapCanvas::event( QEvent *e )
   {
     if ( e->type() == QEvent::Gesture )
     {
+      if ( QTapAndHoldGesture *tapAndHoldGesture = qobject_cast< QTapAndHoldGesture * >( static_cast<QGestureEvent *>( e )->gesture( Qt::TapAndHoldGesture ) ) )
+      {
+        QPointF pos = tapAndHoldGesture->position();
+        pos = mapFromGlobal( QPoint( pos.x(), pos.y() ) );
+        QgsPointXY mapPoint = getCoordinateTransform()->toMapCoordinates( pos.x(), pos.y() );
+        emit tapAndHoldGestureOccurred( mapPoint, tapAndHoldGesture );
+      }
+
       // call handler of current map tool
       if ( mMapTool )
       {

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -916,6 +916,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     void panDistanceBearingChanged( double distance, QgsUnitTypes::DistanceUnit unit, double bearing );
 
+    /**
+     * Emitted whenever a tap and hold \a gesture occurs at the specified map point.
+     * \since QGIS 3.12
+     */
+    void tapAndHoldGestureOccurred( const QgsPointXY &mapPoint, QTapAndHoldGesture *gesture );
+
   protected:
 
     bool event( QEvent *e ) override;

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -115,7 +115,6 @@ bool QgsMapToolPan::gestureEvent( QGestureEvent *event )
   if ( QTouchDevice::devices().isEmpty() )
     return true; // no touch support
 
-  qDebug() << "gesture " << event;
   if ( QGesture *gesture = event->gesture( Qt::PinchGesture ) )
   {
     mPinching = true;


### PR DESCRIPTION
On touch screen devices, we can't show the GPS distance status bar message
as the cursor moves (because there's no "hover" mouse move events to trigger
this from). So for these devices, use a tap-and-hold event to trigger the
"current GPS distance from finger" status bar message.
