### PR TITLE
Fix widget wrong values 0 doubles

### DIFF
--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -54,6 +54,7 @@ class TestQgsAttributeForm : public QObject
     void testDefaultValueUpdate();
     void testDefaultValueUpdateRecursion();
     void testSameFieldSync();
+    void testZeroDoubles();
 
   private:
     QLabel *constraintsLabel( QgsAttributeForm *form, QgsEditorWidgetWrapper *ww )
@@ -1107,6 +1108,21 @@ void TestQgsAttributeForm::testSameFieldSync()
   QCOMPARE( les[0]->cursorPosition(), 3 );
   QCOMPARE( les[1]->text(), QString( "1230" ) );
   QCOMPARE( les[1]->cursorPosition(), 4 );
+}
+
+void TestQgsAttributeForm::testZeroDoubles()
+{
+  // See issue GH #34118
+  QString def = QStringLiteral( "Point?field=col0:double" );
+  QgsVectorLayer layer { def, QStringLiteral( "test" ), QStringLiteral( "memory" ) };
+  layer.setEditorWidgetSetup( 0, QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), QVariantMap() ) );
+  QgsFeature ft( layer.dataProvider()->fields(), 1 );
+  ft.setAttribute( QStringLiteral( "col0" ), 0.0 );
+  QgsAttributeForm form( &layer );
+  form.setFeature( ft );
+  QList<QLineEdit *> les = form.findChildren<QLineEdit *>( "col0" );
+  QCOMPARE( les.count(), 1 );
+  QCOMPARE( les.at( 0 )->text(), QStringLiteral( "0" ) );
 }
 
 QGSTEST_MAIN( TestQgsAttributeForm )


### PR DESCRIPTION
Backport of https://github.com/qgis/QGIS/pull/34152

Fixes #34118

Because:

QVariant(0.0) == QVariant(QVariant.Double) -> True

but:

QVariant(0.0).isNull() == QVariant(QVariant.Double).isNull() -> False

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
