### PR TITLE
Fix row conditional formatting

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -711,14 +711,14 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
     {
       mExpressionContext.setFeature( mFeat );
       QList<QgsConditionalStyle> styles;
-      if ( mRowStylesMap.contains( index.row() ) )
+      if ( mRowStylesMap.contains( mFeat.id() ) )
       {
-        styles = mRowStylesMap[index.row()];
+        styles = mRowStylesMap[mFeat.id()];
       }
       else
       {
         styles = QgsConditionalStyle::matchingConditionalStyles( layer()->conditionalStyles()->rowStyles(), QVariant(),  mExpressionContext );
-        mRowStylesMap.insert( index.row(), styles );
+        mRowStylesMap.insert( mFeat.id(), styles );
       }
 
       QgsConditionalStyle rowstyle = QgsConditionalStyle::compressStyles( styles );
@@ -756,7 +756,7 @@ bool QgsAttributeTableModel::setData( const QModelIndex &index, const QVariant &
   if ( !layer()->isModified() )
     return false;
 
-  mRowStylesMap.remove( index.row() );
+  mRowStylesMap.remove( mFeat.id() );
 
   return true;
 }


### PR DESCRIPTION
Fixes #34122 

The original implementation was storing the styles
in an hash keyed by the row number from the model
index, but that one changes when the table is reloaded.

By using feature id as a key instead, the style association
with the feature is maintained through sort/reload
operations.
