### PR TITLE
[Oracle] Don't crash on getFeature(id) with an invalid id

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -418,11 +418,9 @@ QString QgsOracleUtils::whereClause( QgsFeatureId featureId, const QgsFields &fi
     case PktRowId:
     case PktFidMap:
     {
-      QVariant pkValsVariant = sharedData->lookupKey( featureId );
-      if ( !pkValsVariant.isNull() )
+      QVariantList pkVals = sharedData->lookupKey( featureId );
+      if ( !pkVals.isEmpty() )
       {
-        QList<QVariant> pkVals = pkValsVariant.toList();
-
         if ( primaryKeyType == PktFidMap )
         {
           Q_ASSERT( pkVals.size() == primaryKeyAttrs.size() );

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -626,6 +626,33 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
         features = [f for f in vl.getFeatures()]
         vl.dataProvider().deleteFeatures([features[-1].id()])
 
+    def testGetFeatureFidInvalid(self):
+        """
+        Get feature with an invalid fid
+        https://github.com/qgis/QGIS/issues/31626
+        """
+        self.execSQLCommand('DROP TABLE "QGIS"."TABLE_QGIS_ISSUE_FLOAT_KEY"', ignore_errors=True)
+        self.execSQLCommand("""CREATE TABLE "QGIS"."TABLE_QGIS_ISSUE_FLOAT_KEY" (CODE NUMBER PRIMARY KEY, DESCRIPTION VARCHAR2(25))""")
+        self.execSQLCommand("""INSERT INTO "QGIS"."TABLE_QGIS_ISSUE_FLOAT_KEY" VALUES(1000,'Desc for 1st record')""")
+        self.execSQLCommand("""INSERT INTO "QGIS"."TABLE_QGIS_ISSUE_FLOAT_KEY" VALUES(2000,'Desc for 2nd record')""")
+        self.execSQLCommand("""CREATE OR REPLACE VIEW "QGIS"."VIEW_QGIS_ISSUE_FLOAT_KEY" AS SELECT * FROM "QGIS"."TABLE_QGIS_ISSUE_FLOAT_KEY" """)
+
+        vl = QgsVectorLayer(
+            self.dbconn + ' sslmode=disable key=\'CODE\' table="QGIS"."VIEW_QGIS_ISSUE_FLOAT_KEY" sql=',
+            'test', 'oracle')
+
+        # feature are not loaded yet, mapping between CODE and fid is not built so feature
+        # is invalid
+        feature = vl.getFeature(2)
+        self.assertTrue(not feature.isValid())
+
+        # load all features
+        for f in vl.getFeatures():
+            pass
+
+        feature = vl.getFeature(2)
+        self.assertTrue(feature.isValid())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

In some edge cases, user call getFeature(id) with non existing id. It happens for instance with float or string column as primary key if the mapping fid <-> column value has not being built yet.

This PR fixes this and return an invalid feature in such case.