### PR TITLE
use scope enums for QgsMapLayerAction::Target and Flag

### DIFF
--- a/python/gui/auto_additions/qgsmaplayeractionregistry.py
+++ b/python/gui/auto_additions/qgsmaplayeractionregistry.py
@@ -10,6 +10,7 @@ QgsMapLayerAction.AllActions = QgsMapLayerAction.Target.AllActions
 QgsMapLayerAction.Target.AllActions.__doc__ = ""
 QgsMapLayerAction.Target.__doc__ = '\n\n' + '* ``Layer``: ' + QgsMapLayerAction.Target.Layer.__doc__ + '\n' + '* ``SingleFeature``: ' + QgsMapLayerAction.Target.SingleFeature.__doc__ + '\n' + '* ``MultipleFeatures``: ' + QgsMapLayerAction.Target.MultipleFeatures.__doc__ + '\n' + '* ``AllActions``: ' + QgsMapLayerAction.Target.AllActions.__doc__
 # --
+QgsMapLayerAction.Target.baseClass = QgsMapLayerAction
 QgsMapLayerAction.Targets.baseClass = QgsMapLayerAction
 Targets = QgsMapLayerAction  # dirty hack since SIP seems to introduce the flags in module
 # monkey patching scoped based enum
@@ -17,5 +18,6 @@ QgsMapLayerAction.EnabledOnlyWhenEditable = QgsMapLayerAction.Flag.EnabledOnlyWh
 QgsMapLayerAction.Flag.EnabledOnlyWhenEditable.__doc__ = "Action should be shown only for editable layers"
 QgsMapLayerAction.Flag.__doc__ = 'Flags which control action behavior\n\n.. versionadded:: 3.0\n\n' + '* ``EnabledOnlyWhenEditable``: ' + QgsMapLayerAction.Flag.EnabledOnlyWhenEditable.__doc__
 # --
+QgsMapLayerAction.Flag.baseClass = QgsMapLayerAction
 QgsMapLayerAction.Flags.baseClass = QgsMapLayerAction
 Flags = QgsMapLayerAction  # dirty hack since SIP seems to introduce the flags in module

--- a/python/gui/auto_additions/qgsmaplayeractionregistry.py
+++ b/python/gui/auto_additions/qgsmaplayeractionregistry.py
@@ -1,5 +1,21 @@
 # The following has been generated automatically from src/gui/qgsmaplayeractionregistry.h
+# monkey patching scoped based enum
+QgsMapLayerAction.Layer = QgsMapLayerAction.Target.Layer
+QgsMapLayerAction.Target.Layer.__doc__ = ""
+QgsMapLayerAction.SingleFeature = QgsMapLayerAction.Target.SingleFeature
+QgsMapLayerAction.Target.SingleFeature.__doc__ = ""
+QgsMapLayerAction.MultipleFeatures = QgsMapLayerAction.Target.MultipleFeatures
+QgsMapLayerAction.Target.MultipleFeatures.__doc__ = ""
+QgsMapLayerAction.AllActions = QgsMapLayerAction.Target.AllActions
+QgsMapLayerAction.Target.AllActions.__doc__ = ""
+QgsMapLayerAction.Target.__doc__ = '\n\n' + '* ``Layer``: ' + QgsMapLayerAction.Target.Layer.__doc__ + '\n' + '* ``SingleFeature``: ' + QgsMapLayerAction.Target.SingleFeature.__doc__ + '\n' + '* ``MultipleFeatures``: ' + QgsMapLayerAction.Target.MultipleFeatures.__doc__ + '\n' + '* ``AllActions``: ' + QgsMapLayerAction.Target.AllActions.__doc__
+# --
 QgsMapLayerAction.Targets.baseClass = QgsMapLayerAction
 Targets = QgsMapLayerAction  # dirty hack since SIP seems to introduce the flags in module
+# monkey patching scoped based enum
+QgsMapLayerAction.EnabledOnlyWhenEditable = QgsMapLayerAction.Flag.EnabledOnlyWhenEditable
+QgsMapLayerAction.Flag.EnabledOnlyWhenEditable.__doc__ = "Action should be shown only for editable layers"
+QgsMapLayerAction.Flag.__doc__ = 'Flags which control action behavior\n\n.. versionadded:: 3.0\n\n' + '* ``EnabledOnlyWhenEditable``: ' + QgsMapLayerAction.Flag.EnabledOnlyWhenEditable.__doc__
+# --
 QgsMapLayerAction.Flags.baseClass = QgsMapLayerAction
 Flags = QgsMapLayerAction  # dirty hack since SIP seems to introduce the flags in module

--- a/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
+++ b/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
@@ -20,7 +20,7 @@ An action which can run on map layers
 #include "qgsmaplayeractionregistry.h"
 %End
   public:
-    enum Target
+    enum class Target
     {
       Layer,
       SingleFeature,
@@ -30,15 +30,14 @@ An action which can run on map layers
     typedef QFlags<QgsMapLayerAction::Target> Targets;
 
 
-    enum Flag
+    enum class Flag
     {
       EnabledOnlyWhenEditable,
     };
-
     typedef QFlags<QgsMapLayerAction::Flag> Flags;
 
 
-    QgsMapLayerAction( const QString &name, QObject *parent /TransferThis/, Targets targets = AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = 0 );
+    QgsMapLayerAction( const QString &name, QObject *parent /TransferThis/, Targets targets = QgsMapLayerAction::Target::AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = 0 );
 %Docstring
 Creates a map layer action which can run on any layer
 
@@ -47,12 +46,12 @@ Creates a map layer action which can run on any layer
    using AllActions as a target probably does not make a lot of sense. This default action was settled for API compatibility reasons.
 %End
 
-    QgsMapLayerAction( const QString &name, QObject *parent /TransferThis/, QgsMapLayer *layer, Targets targets = AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = 0 );
+    QgsMapLayerAction( const QString &name, QObject *parent /TransferThis/, QgsMapLayer *layer, Targets targets = QgsMapLayerAction::Target::AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = 0 );
 %Docstring
 Creates a map layer action which can run only on a specific layer
 %End
 
-    QgsMapLayerAction( const QString &name, QObject *parent /TransferThis/, QgsMapLayerType layerType, Targets targets = AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = 0 );
+    QgsMapLayerAction( const QString &name, QObject *parent /TransferThis/, QgsMapLayerType layerType, Targets targets = QgsMapLayerAction::Target::AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = 0 );
 %Docstring
 Creates a map layer action which can run on a specific type of layer
 %End
@@ -150,7 +149,7 @@ QgsMapLayerActionRegistry is not usually directly created, but rather accessed t
 Adds a map layer action to the registry
 %End
 
-    QList<QgsMapLayerAction *> mapLayerActions( QgsMapLayer *layer, QgsMapLayerAction::Targets targets = QgsMapLayerAction::AllActions );
+    QList<QgsMapLayerAction *> mapLayerActions( QgsMapLayer *layer, QgsMapLayerAction::Targets targets = QgsMapLayerAction::Target::AllActions );
 %Docstring
 Returns the map layer actions which can run on the specified layer
 %End

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8941,8 +8941,8 @@ void QgisApp::setupLayoutManagerConnections()
 void QgisApp::setupDuplicateFeaturesAction()
 {
   mDuplicateFeatureAction.reset( new QgsMapLayerAction( tr( "Duplicate Feature" ),
-                                 nullptr, QgsMapLayerAction::SingleFeature,
-                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeature.svg" ) ), QgsMapLayerAction::EnabledOnlyWhenEditable ) );
+                                 nullptr, QgsMapLayerAction::Target::SingleFeature,
+                                 QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeature.svg" ) ), QgsMapLayerAction::Flag::EnabledOnlyWhenEditable ) );
 
   QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureAction.get() );
   connect( mDuplicateFeatureAction.get(), &QgsMapLayerAction::triggeredForFeature, this, [this]( QgsMapLayer * layer, const QgsFeature & feat )
@@ -8952,8 +8952,8 @@ void QgisApp::setupDuplicateFeaturesAction()
          );
 
   mDuplicateFeatureDigitizeAction.reset( new QgsMapLayerAction( tr( "Duplicate Feature and Digitize" ),
-                                         nullptr, QgsMapLayerAction::SingleFeature,
-                                         QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ), QgsMapLayerAction::EnabledOnlyWhenEditable ) );
+                                         nullptr, QgsMapLayerAction::Target::SingleFeature,
+                                         QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateFeatureDigitized.svg" ) ), QgsMapLayerAction::Flag::EnabledOnlyWhenEditable ) );
 
   QgsGui::mapLayerActionRegistry()->addMapLayerAction( mDuplicateFeatureDigitizeAction.get() );
   connect( mDuplicateFeatureDigitizeAction.get(), &QgsMapLayerAction::triggeredForFeature, this, [this]( QgsMapLayer * layer, const QgsFeature & feat )
@@ -8977,7 +8977,7 @@ void QgisApp::setupAtlasMapLayerAction( QgsPrintLayout *layout, bool enableActio
   if ( enableAction )
   {
     action = new QgsMapLayerAction( QString( tr( "Set as Atlas Feature for %1" ) ).arg( layout->name() ),
-                                    this, layout->atlas()->coverageLayer(), QgsMapLayerAction::SingleFeature,
+                                    this, layout->atlas()->coverageLayer(), QgsMapLayerAction::Target::SingleFeature,
                                     QgsApplication::getThemeIcon( QStringLiteral( "/mIconAtlas.svg" ) ) );
     mAtlasFeatureActions.insert( layout, action );
     QgsGui::mapLayerActionRegistry()->addMapLayerAction( action );

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -53,7 +53,7 @@ QgsMapToolIdentifyAction::QgsMapToolIdentifyAction( QgsMapCanvas *canvas )
   setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Identify ) );
   connect( this, &QgsMapToolIdentify::changedRasterResults, this, &QgsMapToolIdentifyAction::handleChangedRasterResults );
   mIdentifyMenu->setAllowMultipleReturn( true );
-  QgsMapLayerAction *attrTableAction = new QgsMapLayerAction( tr( "Show Attribute Table" ), mIdentifyMenu, QgsMapLayerType::VectorLayer, QgsMapLayerAction::MultipleFeatures );
+  QgsMapLayerAction *attrTableAction = new QgsMapLayerAction( tr( "Show Attribute Table" ), mIdentifyMenu, QgsMapLayerType::VectorLayer, QgsMapLayerAction::Target::MultipleFeatures );
   connect( attrTableAction, &QgsMapLayerAction::triggeredForFeatures, this, &QgsMapToolIdentifyAction::showAttributeTable );
   identifyMenu()->addCustomAction( attrTableAction );
   mSelectionHandler = new QgsMapToolSelectionHandler( canvas, QgsMapToolSelectionHandler::SelectSimple );

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -220,7 +220,7 @@ QWidget *QgsAttributeTableView::createActionWidget( QgsFeatureId fid )
       defaultAction = act;
   }
 
-  const auto mapLayerActions {QgsGui::mapLayerActionRegistry()->mapLayerActions( mFilterModel->layer(), QgsMapLayerAction::SingleFeature ) };
+  const auto mapLayerActions {QgsGui::mapLayerActionRegistry()->mapLayerActions( mFilterModel->layer(), QgsMapLayerAction::Target::SingleFeature ) };
   // next add any registered actions for this layer
   for ( QgsMapLayerAction *mapLayerAction : mapLayerActions )
   {

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -706,7 +706,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
     return;
   }
   //add actions from QgsMapLayerActionRegistry to context menu
-  QList<QgsMapLayerAction *> registeredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( mLayer, QgsMapLayerAction::Layer | QgsMapLayerAction::SingleFeature );
+  QList<QgsMapLayerAction *> registeredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( mLayer, QgsMapLayerAction::Target::Layer | QgsMapLayerAction::Target::SingleFeature );
   if ( !registeredActions.isEmpty() )
   {
     //add a separator between user defined and standard actions
@@ -725,7 +725,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
   QgsFeatureId currentFid = masterModel()->rowToId( sourceIndex.row() );
   if ( mLayer->selectedFeatureCount() > 1 && mLayer->selectedFeatureIds().contains( currentFid ) )
   {
-    const QList<QgsMapLayerAction *> constRegisteredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( mLayer, QgsMapLayerAction::MultipleFeatures );
+    const QList<QgsMapLayerAction *> constRegisteredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( mLayer, QgsMapLayerAction::Target::MultipleFeatures );
     if ( !constRegisteredActions.isEmpty() )
     {
       menu->addSeparator();

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -145,7 +145,7 @@ void QgsActionMenu::reloadActions()
     addAction( qAction );
   }
 
-  QList<QgsMapLayerAction *> mapLayerActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( mLayer, QgsMapLayerAction::SingleFeature );
+  QList<QgsMapLayerAction *> mapLayerActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( mLayer, QgsMapLayerAction::Target::SingleFeature );
 
   if ( !mapLayerActions.isEmpty() )
   {

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -173,7 +173,7 @@ void QgsIdentifyMenu::addRasterLayer( QgsMapLayer *layer )
   QMenu *layerMenu = nullptr;
 
   QList<QgsMapLayerAction *> separators = QList<QgsMapLayerAction *>();
-  QList<QgsMapLayerAction *> layerActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::Layer );
+  QList<QgsMapLayerAction *> layerActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::Target::Layer );
   int nCustomActions = layerActions.count();
   if ( nCustomActions )
   {
@@ -181,7 +181,7 @@ void QgsIdentifyMenu::addRasterLayer( QgsMapLayer *layer )
   }
   if ( mShowFeatureActions )
   {
-    layerActions.append( QgsGui::mapLayerActionRegistry()->mapLayerActions( layer, QgsMapLayerAction::Layer ) );
+    layerActions.append( QgsGui::mapLayerActionRegistry()->mapLayerActions( layer, QgsMapLayerAction::Target::Layer ) );
     if ( layerActions.count() > nCustomActions )
     {
       separators.append( layerActions[nCustomActions] );
@@ -238,7 +238,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
 
   // do not add actions with MultipleFeatures as target if only 1 feature is found for this layer
   // targets defines which actions will be shown
-  QgsMapLayerAction::Targets targets = results.count() > 1 ? QgsMapLayerAction::Layer | QgsMapLayerAction::MultipleFeatures : QgsMapLayerAction::Layer;
+  QgsMapLayerAction::Targets targets = results.count() > 1 ? QgsMapLayerAction::Target::Layer | QgsMapLayerAction::Target::MultipleFeatures : QgsMapLayerAction::Target::Layer;
 
   QList<QgsMapLayerAction *> separators = QList<QgsMapLayerAction *>();
   QList<QgsMapLayerAction *> layerActions = mCustomActionRegistry.mapLayerActions( layer, targets );
@@ -268,7 +268,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
   // i.e custom actions or map layer actions at feature level
   if ( !createMenu )
   {
-    createMenu = !mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::SingleFeature ).isEmpty();
+    createMenu = !mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::Target::SingleFeature ).isEmpty();
     if ( !createMenu && mShowFeatureActions )
     {
       QgsActionMenu *featureActionMenu = new QgsActionMenu( layer, results[0].mFeature, QStringLiteral( "Feature" ), this );
@@ -355,7 +355,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
     QMenu *featureMenu = nullptr;
     QgsActionMenu *featureActionMenu = nullptr;
 
-    QList<QgsMapLayerAction *> customFeatureActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::SingleFeature );
+    QList<QgsMapLayerAction *> customFeatureActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::Target::SingleFeature );
     if ( mShowFeatureActions )
     {
       featureActionMenu = new QgsActionMenu( layer, result.mFeature, QStringLiteral( "Feature" ), layerMenu );
@@ -445,7 +445,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
   for ( QgsMapLayerAction *mapLayerAction : constLayerActions )
   {
     QString title = mapLayerAction->text();
-    if ( mapLayerAction->targets().testFlag( QgsMapLayerAction::MultipleFeatures ) )
+    if ( mapLayerAction->targets().testFlag( QgsMapLayerAction::Target::MultipleFeatures ) )
       title.append( QStringLiteral( " (%1)" ).arg( results.count() ) );
     QAction *action = new QAction( mapLayerAction->icon(), title, layerMenu );
     action->setData( QVariant::fromValue<ActionData>( ActionData( layer, mapLayerAction ) ) );
@@ -473,13 +473,13 @@ void QgsIdentifyMenu::triggerMapLayerAction()
   if ( actData.mIsValid && actData.mMapLayerAction )
   {
     // layer
-    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::Layer ) )
+    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::Target::Layer ) )
     {
       actData.mMapLayerAction->triggerForLayer( actData.mLayer );
     }
 
     // multiples features
-    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::MultipleFeatures ) )
+    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::Target::MultipleFeatures ) )
     {
       QList<QgsFeature> featureList;
       const auto results { mLayerIdResults[actData.mLayer] };
@@ -491,7 +491,7 @@ void QgsIdentifyMenu::triggerMapLayerAction()
     }
 
     // single feature
-    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::SingleFeature ) )
+    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::Target::SingleFeature ) )
     {
       const auto results { mLayerIdResults[actData.mLayer] };
       for ( const QgsMapToolIdentify::IdentifyResult &result : results )

--- a/src/gui/qgsmaplayeractionregistry.cpp
+++ b/src/gui/qgsmaplayeractionregistry.cpp
@@ -55,7 +55,7 @@ QgsMapLayerAction::Flags QgsMapLayerAction::flags() const
 
 bool QgsMapLayerAction::canRunUsingLayer( QgsMapLayer *layer ) const
 {
-  if ( mFlags & EnabledOnlyWhenEditable )
+  if ( mFlags & Flag::EnabledOnlyWhenEditable )
   {
     // action is only enabled for editable layers
     if ( !layer )
@@ -104,7 +104,7 @@ void QgsMapLayerAction::triggerForLayer( QgsMapLayer *layer )
 
 bool QgsMapLayerAction::isEnabledOnlyWhenEditable() const
 {
-  return mFlags & EnabledOnlyWhenEditable;
+  return mFlags & Flag::EnabledOnlyWhenEditable;
 }
 
 //

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -44,6 +44,7 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
       MultipleFeatures = 4,
       AllActions = Layer | SingleFeature | MultipleFeatures
     };
+    Q_ENUM( Target )
     Q_DECLARE_FLAGS( Targets, Target )
     Q_FLAG( Targets )
 
@@ -55,6 +56,7 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
     {
       EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
     };
+    Q_ENUM( Flag )
     Q_DECLARE_FLAGS( Flags, Flag )
     Q_FLAG( Flags )
 

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -24,6 +24,7 @@
 
 #include "qgsmaplayer.h"
 #include "qgis_gui.h"
+#include "qgis_sip.h"
 
 class QgsFeature;
 
@@ -36,7 +37,7 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
     Q_OBJECT
 
   public:
-    enum Target
+    enum class Target SIP_MONKEYPATCH_SCOPEENUM : int
     {
       Layer = 1,
       SingleFeature = 2,
@@ -48,17 +49,12 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
 
     /**
      * Flags which control action behavior
-     * /since QGIS 3.0
+     * \since QGIS 3.0
      */
-    enum Flag
+    enum class Flag SIP_MONKEYPATCH_SCOPEENUM : int
     {
       EnabledOnlyWhenEditable = 1 << 1, //!< Action should be shown only for editable layers
     };
-
-    /**
-     * Action behavior flags.
-     * \since QGIS 3.0
-     */
     Q_DECLARE_FLAGS( Flags, Flag )
     Q_FLAG( Flags )
 
@@ -66,13 +62,13 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
      * Creates a map layer action which can run on any layer
      * \note using AllActions as a target probably does not make a lot of sense. This default action was settled for API compatibility reasons.
      */
-    QgsMapLayerAction( const QString &name, QObject *parent SIP_TRANSFERTHIS, Targets targets = AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = nullptr );
+    QgsMapLayerAction( const QString &name, QObject *parent SIP_TRANSFERTHIS, Targets targets = QgsMapLayerAction::Target::AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = nullptr );
 
     //! Creates a map layer action which can run only on a specific layer
-    QgsMapLayerAction( const QString &name, QObject *parent SIP_TRANSFERTHIS, QgsMapLayer *layer, Targets targets = AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = nullptr );
+    QgsMapLayerAction( const QString &name, QObject *parent SIP_TRANSFERTHIS, QgsMapLayer *layer, Targets targets = QgsMapLayerAction::Target::AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = nullptr );
 
     //! Creates a map layer action which can run on a specific type of layer
-    QgsMapLayerAction( const QString &name, QObject *parent SIP_TRANSFERTHIS, QgsMapLayerType layerType, Targets targets = AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = nullptr );
+    QgsMapLayerAction( const QString &name, QObject *parent SIP_TRANSFERTHIS, QgsMapLayerType layerType, Targets targets = QgsMapLayerAction::Target::AllActions, const QIcon &icon = QIcon(), QgsMapLayerAction::Flags flags = nullptr );
 
     ~QgsMapLayerAction() override;
 
@@ -160,7 +156,7 @@ class GUI_EXPORT QgsMapLayerActionRegistry : public QObject
     void addMapLayerAction( QgsMapLayerAction *action );
 
     //! Returns the map layer actions which can run on the specified layer
-    QList<QgsMapLayerAction *> mapLayerActions( QgsMapLayer *layer, QgsMapLayerAction::Targets targets = QgsMapLayerAction::AllActions );
+    QList<QgsMapLayerAction *> mapLayerActions( QgsMapLayer *layer, QgsMapLayerAction::Targets targets = QgsMapLayerAction::Target::AllActions );
 
     //! Removes a map layer action from the registry
     bool removeMapLayerAction( QgsMapLayerAction *action );


### PR DESCRIPTION
because it just looks way better in the PyQGIS docs