### PR TITLE
Fix IN/NOT IN evaluation with very number like strings

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -807,8 +807,11 @@ QVariant QgsExpressionNodeInOperator::evalNode( QgsExpression *parent, const Qgs
     {
       bool equal = false;
       // check whether they are equal
-      if ( QgsExpressionUtils::isDoubleSafe( v1 ) && QgsExpressionUtils::isDoubleSafe( v2 ) )
+      if ( ( v1.type() != QVariant::String || v2.type() != QVariant::String ) &&
+           QgsExpressionUtils::isDoubleSafe( v1 ) && QgsExpressionUtils::isDoubleSafe( v2 ) )
       {
+        // do numeric comparison if both operators can be converted to numbers,
+        // and they aren't both string
         double f1 = QgsExpressionUtils::getDoubleValue( v1, parent );
         ENSURE_NO_EVAL_ERROR;
         double f2 = QgsExpressionUtils::getDoubleValue( v2, parent );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -671,10 +671,26 @@ class TestQgsExpression: public QObject
       QTest::newRow( "in 2" ) << "1 in (1,null,3)" << false << QVariant( 1 );
       QTest::newRow( "in 3" ) << "1 in (null,2,3)" << false << QVariant();
       QTest::newRow( "in 4" ) << "null in (1,2,3)" << false << QVariant();
+      QTest::newRow( "in 5" ) << "'a' in (1,2,3)" << false << QVariant( 0 );
+      QTest::newRow( "in 6" ) << "'a' in (1,'a',3)" << false << QVariant( 1 );
+      QTest::newRow( "in 7" ) << "'b' in (1,'a',3)" << false << QVariant( 0 );
+      QTest::newRow( "in 8" ) << "1.2 in (1,2,3)" << false << QVariant( 0 );
+      QTest::newRow( "in 9" ) << "'010080383000187224' in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 0 );
+      QTest::newRow( "in 10" ) << "'010080383000187219' in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 1 );
+      QTest::newRow( "in 11" ) << "'010080383000187218' in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 1 );
+      QTest::newRow( "in 12" ) << "'010080383000187223' in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 1 );
       QTest::newRow( "not in 1" ) << "1 not in (1,2,3)" << false << QVariant( 0 );
       QTest::newRow( "not in 2" ) << "1 not in (1,null,3)" << false << QVariant( 0 );
       QTest::newRow( "not in 3" ) << "1 not in (null,2,3)" << false << QVariant();
       QTest::newRow( "not in 4" ) << "null not in (1,2,3)" << false << QVariant();
+      QTest::newRow( "not in 5" ) << "'a' not in (1,2,3)" << false << QVariant( 1 );
+      QTest::newRow( "not in 6" ) << "'a' not in (1,'a',3)" << false << QVariant( 0 );
+      QTest::newRow( "not in 7" ) << "'b' not in (1,'a',3)" << false << QVariant( 1 );
+      QTest::newRow( "not in 8" ) << "1.2 not in (1,2,3)" << false << QVariant( 1 );
+      QTest::newRow( "not in 9" ) << "'010080383000187224' not in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 1 );
+      QTest::newRow( "not in 10" ) << "'010080383000187219' not in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 0 );
+      QTest::newRow( "not in 11" ) << "'010080383000187218' not in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 0 );
+      QTest::newRow( "not in 12" ) << "'010080383000187223' not in ('010080383000187219','010080383000187218','010080383000187223')" << false << QVariant( 0 );
 
       // regexp, like
       QTest::newRow( "like 1" ) << "'hello' like '%ll_'" << false << QVariant( 1 );


### PR DESCRIPTION
Only allow evaluation of number-like strings as numbers when
we aren't comparing two strings (matches behavior with other
expression comparison functions like equals)

Fixes #34314
