### PR TITLE
Fix KML/GPX export coordinate transformation not matching context

### DIFF
--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -230,7 +230,7 @@ Creates a clone of the FieldValueConverter.
     };
 
 
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
+ static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
         const QgsCoordinateReferenceSystem &destCRS = QgsCoordinateReferenceSystem(),
@@ -249,7 +249,7 @@ Creates a clone of the FieldValueConverter.
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
-                                                               );
+                                                                                 ) /Deprecated/;
 %Docstring
 Write contents of vector layer to an (OGR supported) vector format
 
@@ -259,7 +259,7 @@ Write contents of vector layer to an (OGR supported) vector format
 :param destCRS: CRS to reproject exported geometries to, or invalid CRS for no reprojection
 :param driverName: OGR driver to use
 :param onlySelected: write only selected features of layer
-:param errorMessage: pointer to buffer fo error message
+:param errorMessage: will be set to the error message text, if an error occurs while writing the layer
 :param datasourceOptions: list of OGR data source creation options
 :param layerOptions: list of OGR layer creation options
 :param skipAttributeCreation: only write geometries
@@ -273,10 +273,13 @@ Write contents of vector layer to an (OGR supported) vector format
 :param includeZ: set to ``True`` to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
 :param attributes: attributes to export (empty means all unless skipAttributeCreation is set)
 :param fieldValueConverter: field value converter (added in QGIS 2.16)
+
+.. deprecated::
+   Use writeAsVectorFormatV2() instead.
 %End
 
 
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
+ static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
         const QgsCoordinateTransform &ct,
@@ -295,7 +298,7 @@ Write contents of vector layer to an (OGR supported) vector format
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
-                                                               );
+                                                                                 ) /Deprecated/;
 %Docstring
 Writes a layer out to a vector file.
 
@@ -306,7 +309,7 @@ Writes a layer out to a vector file.
            for no transformation
 :param driverName: OGR driver to use
 :param onlySelected: write only selected features of layer
-:param errorMessage: pointer to buffer fo error message
+:param errorMessage: will be set to the error message text, if an error occurs while writing the layer
 :param datasourceOptions: list of OGR data source creation options
 :param layerOptions: list of OGR layer creation options
 :param skipAttributeCreation: only write geometries
@@ -322,6 +325,9 @@ Writes a layer out to a vector file.
 :param fieldValueConverter: field value converter (added in QGIS 2.16)
 
 .. versionadded:: 2.2
+
+.. deprecated::
+   Use writeAsVectorFormatV2() instead.
 %End
 
     class SaveVectorOptions
@@ -381,12 +387,12 @@ Constructor
     };
 
 
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
+ static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
         QString *errorMessage /Out/ = 0
-                                                               );
+                                                                                 ) /Deprecated/;
 %Docstring
 Writes a layer out to a vector file.
 
@@ -394,25 +400,76 @@ Writes a layer out to a vector file.
 :param fileName: file name to write to
 :param options: options.
 :param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
-:param errorMessage: pointer to buffer fo error message
+:param errorMessage: will be set to the error message text, if an error occurs while writing the layer
 
 .. versionadded:: 3.0
+
+.. deprecated::
+   Use writeAsVectorFormatV2() instead.
 %End
 
-    QgsVectorFileWriter( const QString &vectorFileName,
-                         const QString &fileEncoding,
-                         const QgsFields &fields,
-                         QgsWkbTypes::Type geometryType,
-                         const QgsCoordinateReferenceSystem &srs = QgsCoordinateReferenceSystem(),
-                         const QString &driverName = "GPKG",
-                         const QStringList &datasourceOptions = QStringList(),
-                         const QStringList &layerOptions = QStringList(),
-                         QString *newFilename = 0,
-                         QgsVectorFileWriter::SymbologyExport symbologyExport = QgsVectorFileWriter::NoSymbology,
-                         QgsFeatureSink::SinkFlags sinkFlags = 0
-                       );
+ QgsVectorFileWriter( const QString &vectorFileName,
+                                           const QString &fileEncoding,
+                                           const QgsFields &fields,
+                                           QgsWkbTypes::Type geometryType,
+                                           const QgsCoordinateReferenceSystem &srs = QgsCoordinateReferenceSystem(),
+                                           const QString &driverName = "GPKG",
+                                           const QStringList &datasourceOptions = QStringList(),
+                                           const QStringList &layerOptions = QStringList(),
+                                           QString *newFilename = 0,
+                                           QgsVectorFileWriter::SymbologyExport symbologyExport = QgsVectorFileWriter::NoSymbology,
+                                           QgsFeatureSink::SinkFlags sinkFlags = 0
+                                         ) /Deprecated/;
 
 
+
+    static QgsVectorFileWriter *create( const QString &fileName,
+                                        const QgsFields &fields,
+                                        QgsWkbTypes::Type geometryType,
+                                        const QgsCoordinateReferenceSystem &srs,
+                                        const QgsCoordinateTransformContext &transformContext,
+                                        const QgsVectorFileWriter::SaveVectorOptions &options,
+                                        QgsFeatureSink::SinkFlags sinkFlags = 0,
+                                        QString *newFilename = 0,
+                                        QString *newLayer = 0 );
+%Docstring
+Create a new vector file writer.
+
+:param fileName: file name to write to
+:param fields: fields to write
+:param geometryType: geometry type of output file
+:param srs: spatial reference system of output file
+:param transformContext: coordinate transform context
+:param options: save options
+:param sinkFlags: feature sink flags
+:param newFilename: potentially modified file name (output parameter)
+:param newLayer: potentially modified layer name (output parameter)
+
+.. versionadded:: 3.10.3
+%End
+
+    static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( QgsVectorLayer *layer,
+        const QString &fileName,
+        const QgsCoordinateTransformContext &transformContext,
+        const QgsVectorFileWriter::SaveVectorOptions &options,
+        QString *newFilename = 0,
+        QString *newLayer = 0,
+        QString *errorMessage /Out/ = 0 );
+%Docstring
+Writes a layer out to a vector file.
+
+:param layer: source layer to write
+:param fileName: file name to write to
+:param transformContext: coordinate transform context
+:param options: save options
+:param newFilename: potentially modified file name (output parameter)
+:param newLayer: potentially modified layer name (output parameter)
+
+:return: - Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
+         - errorMessage: will be set to the error message text, if an error occurs while writing the layer
+
+.. versionadded:: 3.10.3
+%End
 
     struct FilterFormatDetails
     {

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -216,7 +216,7 @@ bool QgsPackageAlgorithm::packageVectorLayer( QgsVectorLayer *layer, const QStri
   QString error;
   QString newFilename;
   QString newLayer;
-  if ( QgsVectorFileWriter::writeAsVectorFormat( layer, path, options, &newFilename, &error, &newLayer ) != QgsVectorFileWriter::NoError )
+  if ( QgsVectorFileWriter::writeAsVectorFormatV2( layer, path, context.transformContext(), options, &newFilename, &newLayer, &error ) != QgsVectorFileWriter::NoError )
   {
     feedback->reportError( QObject::tr( "Packaging layer failed: %1" ).arg( error ) );
     return false;

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -409,21 +409,15 @@ QgsVectorLayerExporter::ExportError QgsOgrProvider::createEmptyLayer( const QStr
 
   QString newLayerName( layerName );
 
-  std::unique_ptr< QgsVectorFileWriter > writer = qgis::make_unique< QgsVectorFileWriter >(
-        uri,
-        encoding,
-        fields,
-        wkbType,
-        srs,
-        driverName,
-        dsOptions,
-        layerOptions,
-        nullptr,
-        QgsVectorFileWriter::NoSymbology,
-        nullptr,
-        layerName,
-        action,
-        &newLayerName );
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.layerName = layerName;
+  saveOptions.fileEncoding = encoding;
+  saveOptions.driverName = driverName;
+  saveOptions.datasourceOptions = dsOptions;
+  saveOptions.layerOptions = layerOptions;
+  saveOptions.actionOnExistingFile = action;
+  saveOptions.symbologyExport = QgsVectorFileWriter::NoSymbology;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( uri, fields, wkbType, srs, QgsCoordinateTransformContext(), saveOptions, nullptr, nullptr, &newLayerName ) );
   layerName = newLayerName;
 
   QgsVectorFileWriter::WriterError error = writer->hasError();

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -104,7 +104,8 @@ QgsVectorFileWriter::QgsVectorFileWriter(
   QString *newFilename,
   SymbologyExport symbologyExport,
   QgsFeatureSink::SinkFlags sinkFlags,
-  QString *newLayer
+  QString *newLayer,
+  QgsCoordinateTransformContext transformContext
 )
   : mError( NoError )
   , mWkbType( geometryType )
@@ -113,23 +114,27 @@ QgsVectorFileWriter::QgsVectorFileWriter(
 {
   init( vectorFileName, fileEncoding, fields,  geometryType,
         srs, driverName, datasourceOptions, layerOptions, newFilename, nullptr,
-        QString(), CreateOrOverwriteFile, newLayer, sinkFlags );
+        QString(), CreateOrOverwriteFile, newLayer, sinkFlags, transformContext );
 }
 
-QgsVectorFileWriter::QgsVectorFileWriter( const QString &vectorFileName,
-    const QString &fileEncoding,
-    const QgsFields &fields,
-    QgsWkbTypes::Type geometryType,
-    const QgsCoordinateReferenceSystem &srs,
-    const QString &driverName,
-    const QStringList &datasourceOptions,
-    const QStringList &layerOptions,
-    QString *newFilename,
-    QgsVectorFileWriter::SymbologyExport symbologyExport,
-    FieldValueConverter *fieldValueConverter,
-    const QString &layerName,
-    ActionOnExistingFile action,
-    QString *newLayer )
+QgsVectorFileWriter::QgsVectorFileWriter(
+  const QString &vectorFileName,
+  const QString &fileEncoding,
+  const QgsFields &fields,
+  QgsWkbTypes::Type geometryType,
+  const QgsCoordinateReferenceSystem &srs,
+  const QString &driverName,
+  const QStringList &datasourceOptions,
+  const QStringList &layerOptions,
+  QString *newFilename,
+  QgsVectorFileWriter::SymbologyExport symbologyExport,
+  FieldValueConverter *fieldValueConverter,
+  const QString &layerName,
+  ActionOnExistingFile action,
+  QString *newLayer,
+  QgsCoordinateTransformContext transformContext,
+  QgsFeatureSink::SinkFlags sinkFlags
+)
   : mError( NoError )
   , mWkbType( geometryType )
   , mSymbologyExport( symbologyExport )
@@ -137,7 +142,27 @@ QgsVectorFileWriter::QgsVectorFileWriter( const QString &vectorFileName,
 {
   init( vectorFileName, fileEncoding, fields, geometryType, srs, driverName,
         datasourceOptions, layerOptions, newFilename, fieldValueConverter,
-        layerName, action, newLayer, nullptr );
+        layerName, action, newLayer, sinkFlags, transformContext );
+}
+
+QgsVectorFileWriter *QgsVectorFileWriter::create(
+  const QString &fileName,
+  const QgsFields &fields,
+  QgsWkbTypes::Type geometryType,
+  const QgsCoordinateReferenceSystem &srs,
+  const QgsCoordinateTransformContext &transformContext,
+  const QgsVectorFileWriter::SaveVectorOptions &options,
+  QgsFeatureSink::SinkFlags sinkFlags,
+  QString *newFilename,
+  QString *newLayer
+)
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  return new QgsVectorFileWriter( fileName, options.fileEncoding, fields, geometryType, srs,
+                                  options.driverName, options.datasourceOptions, options.layerOptions,
+                                  newFilename, options.symbologyExport, options.fieldValueConverter, options.layerName,
+                                  options.actionOnExistingFile, newLayer, transformContext, sinkFlags );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 bool QgsVectorFileWriter::supportsFeatureStyles( const QString &driverName )
@@ -173,7 +198,8 @@ void QgsVectorFileWriter::init( QString vectorFileName,
                                 FieldValueConverter *fieldValueConverter,
                                 const QString &layerNameIn,
                                 ActionOnExistingFile action,
-                                QString *newLayer, SinkFlags sinkFlags )
+                                QString *newLayer, SinkFlags sinkFlags,
+                                const QgsCoordinateTransformContext &transformContext )
 {
   mRenderContext.setRendererScale( mSymbologyScale );
 
@@ -393,6 +419,17 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   }
 
   // consider spatial reference system of the layer
+  if ( driverName == QLatin1String( "KML" ) || driverName == QLatin1String( "GPX" ) )
+  {
+    if ( srs.authid() != QStringLiteral( "EPSG:4326" ) )
+    {
+      // Those drivers outputs WGS84 geometries, let's align our output CRS to have QGIS take charge of geometry transformation
+      QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromEpsgId( 4326 );
+      mCoordinateTransform.reset( new QgsCoordinateTransform( srs, wgs84, transformContext ) );
+      srs = wgs84;
+    }
+  }
+
   if ( srs.isValid() )
   {
     QString srsWkt = srs.toWkt( QgsCoordinateReferenceSystem::WKT2_2018 );
@@ -2499,6 +2536,19 @@ gdal::ogr_feature_unique_ptr QgsVectorFileWriter::createFeature( const QgsFeatur
     {
       // build geometry from WKB
       QgsGeometry geom = feature.geometry();
+      if ( mCoordinateTransform )
+      {
+        // output dataset requires coordinate transform
+        try
+        {
+          geom.transform( *mCoordinateTransform );
+        }
+        catch ( QgsCsException & )
+        {
+          QgsLogger::warning( QObject::tr( "Feature geometry failed to transform" ) );
+          return nullptr;
+        }
+      }
 
       // turn single geometry to multi geometry if needed
       if ( QgsWkbTypes::flatType( geom.wkbType() ) != QgsWkbTypes::flatType( mWkbType ) &&
@@ -2671,12 +2721,24 @@ QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
     ct = QgsCoordinateTransform( layer->crs(), destCRS, layer->transformContext() );
   }
 
-  QgsVectorFileWriter::WriterError error = writeAsVectorFormat( layer, fileName, fileEncoding, ct, driverName, onlySelected,
-      errorMessage, datasourceOptions, layerOptions, skipAttributeCreation,
-      newFilename, symbologyExport, symbologyScale, filterExtent,
-      overrideGeometryType, forceMulti, includeZ, attributes,
-      fieldValueConverter, newLayer );
-  return error;
+  SaveVectorOptions options;
+  options.fileEncoding = fileEncoding;
+  options.ct = ct;
+  options.driverName = driverName;
+  options.onlySelectedFeatures = onlySelected;
+  options.datasourceOptions = datasourceOptions;
+  options.layerOptions = layerOptions;
+  options.skipAttributeCreation = skipAttributeCreation;
+  options.symbologyExport = symbologyExport;
+  options.symbologyScale = symbologyScale;
+  if ( filterExtent )
+    options.filterExtent = *filterExtent;
+  options.overrideGeometryType = overrideGeometryType;
+  options.forceMulti = forceMulti;
+  options.includeZ = includeZ;
+  options.attributes = attributes;
+  options.fieldValueConverter = fieldValueConverter;
+  return writeAsVectorFormatV2( layer, fileName, layer->transformContext(), options, newFilename, newLayer, errorMessage );
 }
 
 QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
@@ -2717,7 +2779,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   options.includeZ = includeZ;
   options.attributes = attributes;
   options.fieldValueConverter = fieldValueConverter;
-  return writeAsVectorFormat( layer, fileName, options, newFilename, errorMessage, newLayer );
+  return writeAsVectorFormatV2( layer, fileName, layer->transformContext(), options, newFilename, newLayer, errorMessage );
 }
 
 
@@ -2734,7 +2796,6 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
   {
     return ErrInvalidLayer;
   }
-
 
   if ( layer->renderer() )
     details.renderer.reset( layer->renderer()->clone() );
@@ -2870,7 +2931,11 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
 
 QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( PreparedWriterDetails &details, const QString &fileName, const QgsVectorFileWriter::SaveVectorOptions &options, QString *newFilename, QString *errorMessage, QString *newLayer )
 {
+  return writeAsVectorFormatV2( details, fileName, QgsCoordinateTransformContext(), options, newFilename, newLayer, errorMessage );
+}
 
+QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( PreparedWriterDetails &details, const QString &fileName, const QgsCoordinateTransformContext &transformContext, const QgsVectorFileWriter::SaveVectorOptions &options, QString *newFilename, QString *newLayer, QString *errorMessage )
+{
   QgsWkbTypes::Type destWkbType = details.destWkbType;
 
   int lastProgressReport = 0;
@@ -2928,18 +2993,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( Prepa
     }
   }
 
-  std::unique_ptr< QgsVectorFileWriter > writer =
-    qgis::make_unique< QgsVectorFileWriter >( fileName,
-        options.fileEncoding, details.outputFields, destWkbType,
-        details.outputCrs, options.driverName,
-        options.datasourceOptions,
-        options.layerOptions,
-        newFilename,
-        options.symbologyExport,
-        options.fieldValueConverter,
-        options.layerName,
-        options.actionOnExistingFile,
-        newLayer );
+  std::unique_ptr< QgsVectorFileWriter > writer( create( fileName, details.outputFields, destWkbType, details.outputCrs, transformContext, options, nullptr, newFilename, newLayer ) );
   writer->setSymbologyScale( options.symbologyScale );
 
   if ( newFilename )
@@ -3085,8 +3139,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( Prepa
   return errors == 0 ? NoError : ErrFeatureWriteFailed;
 }
 
-QgsVectorFileWriter::WriterError
-QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
+QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
     const QString &fileName,
     const SaveVectorOptions &options,
     QString *newFilename,
@@ -3098,9 +3151,24 @@ QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer *layer,
   if ( err != NoError )
     return err;
 
-  return writeAsVectorFormat( details, fileName, options, newFilename, errorMessage, newLayer );
+  return writeAsVectorFormatV2( details, fileName, layer->transformContext(), options, newFilename, newLayer, errorMessage );
 }
 
+QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormatV2( QgsVectorLayer *layer,
+    const QString &fileName,
+    const QgsCoordinateTransformContext &transformContext,
+    const SaveVectorOptions &options,
+    QString *newFilename,
+    QString *newLayer,
+    QString *errorMessage )
+{
+  QgsVectorFileWriter::PreparedWriterDetails details;
+  WriterError err = prepareWriteAsVectorFormat( layer, options, details );
+  if ( err != NoError )
+    return err;
+
+  return writeAsVectorFormatV2( details, fileName, transformContext, options, newFilename, newLayer, errorMessage );
+}
 
 bool QgsVectorFileWriter::deleteShapeFile( const QString &fileName )
 {

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -283,7 +283,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param destCRS CRS to reproject exported geometries to, or invalid CRS for no reprojection
      * \param driverName OGR driver to use
      * \param onlySelected write only selected features of layer
-     * \param errorMessage pointer to buffer fo error message
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \param datasourceOptions list of OGR data source creation options
      * \param layerOptions list of OGR layer creation options
      * \param skipAttributeCreation only write geometries
@@ -298,6 +298,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param attributes attributes to export (empty means all unless skipAttributeCreation is set)
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
      * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
+     * \deprecated Use writeAsVectorFormatV2() instead.
      */
 #else
 
@@ -309,7 +310,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param destCRS CRS to reproject exported geometries to, or invalid CRS for no reprojection
      * \param driverName OGR driver to use
      * \param onlySelected write only selected features of layer
-     * \param errorMessage pointer to buffer fo error message
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \param datasourceOptions list of OGR data source creation options
      * \param layerOptions list of OGR layer creation options
      * \param skipAttributeCreation only write geometries
@@ -323,9 +324,10 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param includeZ set to TRUE to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
      * \param attributes attributes to export (empty means all unless skipAttributeCreation is set)
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
+     * \deprecated Use writeAsVectorFormatV2() instead.
      */
 #endif
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
+    Q_DECL_DEPRECATED static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
         const QgsCoordinateReferenceSystem &destCRS = QgsCoordinateReferenceSystem(),
@@ -347,7 +349,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 #ifndef SIP_RUN
             , QString *newLayer = nullptr );
 #else
-                                                               );
+                                                                                 ) SIP_DEPRECATED;
 #endif
 
 #ifndef SIP_RUN
@@ -361,7 +363,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * for no transformation
      * \param driverName OGR driver to use
      * \param onlySelected write only selected features of layer
-     * \param errorMessage pointer to buffer fo error message
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \param datasourceOptions list of OGR data source creation options
      * \param layerOptions list of OGR layer creation options
      * \param skipAttributeCreation only write geometries
@@ -377,6 +379,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
      * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
      * \since QGIS 2.2
+     * \deprecated Use writeAsVectorFormatV2() instead.
      */
 #else
 
@@ -389,7 +392,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * for no transformation
      * \param driverName OGR driver to use
      * \param onlySelected write only selected features of layer
-     * \param errorMessage pointer to buffer fo error message
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \param datasourceOptions list of OGR data source creation options
      * \param layerOptions list of OGR layer creation options
      * \param skipAttributeCreation only write geometries
@@ -404,9 +407,10 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param attributes attributes to export (empty means all unless skipAttributeCreation is set)
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
      * \since QGIS 2.2
+     * \deprecated Use writeAsVectorFormatV2() instead.
      */
 #endif
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
+    Q_DECL_DEPRECATED static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
         const QgsCoordinateTransform &ct,
@@ -428,7 +432,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 #ifndef SIP_RUN
             , QString *newLayer = nullptr );
 #else
-                                                               );
+                                                                                 ) SIP_DEPRECATED;
 #endif
 
     /**
@@ -516,9 +520,10 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param fileName file name to write to
      * \param options options.
      * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
-     * \param errorMessage pointer to buffer fo error message
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
      * \since QGIS 3.0
+     * \deprecated Use writeAsVectorFormatV2() instead.
      */
 #else
 
@@ -528,11 +533,12 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param fileName file name to write to
      * \param options options.
      * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
-     * \param errorMessage pointer to buffer fo error message
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
      * \since QGIS 3.0
+     * \deprecated Use writeAsVectorFormatV2() instead.
      */
 #endif
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
+    Q_DECL_DEPRECATED static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = nullptr,
@@ -540,25 +546,29 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
 #ifndef SIP_RUN
                                         , QString *newLayer = nullptr );
 #else
-                                                               );
+                                                                                 ) SIP_DEPRECATED;
 #endif
 
-    //! Create a new vector file writer
-    QgsVectorFileWriter( const QString &vectorFileName,
-                         const QString &fileEncoding,
-                         const QgsFields &fields,
-                         QgsWkbTypes::Type geometryType,
-                         const QgsCoordinateReferenceSystem &srs = QgsCoordinateReferenceSystem(),
-                         const QString &driverName = "GPKG",
-                         const QStringList &datasourceOptions = QStringList(),
-                         const QStringList &layerOptions = QStringList(),
-                         QString *newFilename = nullptr,
-                         QgsVectorFileWriter::SymbologyExport symbologyExport = QgsVectorFileWriter::NoSymbology,
-                         QgsFeatureSink::SinkFlags sinkFlags = nullptr
+    /**
+     * Create a new vector file writer
+     * \deprecated Use create() instead.
+     */
+    Q_DECL_DEPRECATED QgsVectorFileWriter( const QString &vectorFileName,
+                                           const QString &fileEncoding,
+                                           const QgsFields &fields,
+                                           QgsWkbTypes::Type geometryType,
+                                           const QgsCoordinateReferenceSystem &srs = QgsCoordinateReferenceSystem(),
+                                           const QString &driverName = "GPKG",
+                                           const QStringList &datasourceOptions = QStringList(),
+                                           const QStringList &layerOptions = QStringList(),
+                                           QString *newFilename = nullptr,
+                                           QgsVectorFileWriter::SymbologyExport symbologyExport = QgsVectorFileWriter::NoSymbology,
+                                           QgsFeatureSink::SinkFlags sinkFlags = nullptr
 #ifndef SIP_RUN
-                             , QString *newLayer = nullptr
+                                               , QString *newLayer = nullptr,
+                                           QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext()
 #endif
-                       );
+                                         ) SIP_DEPRECATED;
 
     /**
      * Create a new vector file writer.
@@ -576,28 +586,76 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param layerName layer name. If let empty, it will be derived from the filename (added in QGIS 3.0)
      * \param action action on existing file (added in QGIS 3.0)
      * \param newLayer potentially modified layer name (output parameter) (added in QGIS 3.4)
+     * \param transformContext transform context, needed if the output file srs is forced to specific crs (added in QGIS 3.10.3)
+     * \param sinkFlags feature sink flags (added in QGIS 3.10.3)
      * \note not available in Python bindings
+     * \deprecated Use create() instead.
      */
-    QgsVectorFileWriter( const QString &vectorFileName,
-                         const QString &fileEncoding,
-                         const QgsFields &fields,
-                         QgsWkbTypes::Type geometryType,
-                         const QgsCoordinateReferenceSystem &srs,
-                         const QString &driverName,
-                         const QStringList &datasourceOptions,
-                         const QStringList &layerOptions,
-                         QString *newFilename,
-                         QgsVectorFileWriter::SymbologyExport symbologyExport,
-                         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter,
-                         const QString &layerName,
-                         QgsVectorFileWriter::ActionOnExistingFile action,
-                         QString *newLayer = nullptr
-                       ) SIP_SKIP;
+    Q_DECL_DEPRECATED QgsVectorFileWriter( const QString &vectorFileName,
+                                           const QString &fileEncoding,
+                                           const QgsFields &fields,
+                                           QgsWkbTypes::Type geometryType,
+                                           const QgsCoordinateReferenceSystem &srs,
+                                           const QString &driverName,
+                                           const QStringList &datasourceOptions,
+                                           const QStringList &layerOptions,
+                                           QString *newFilename,
+                                           QgsVectorFileWriter::SymbologyExport symbologyExport,
+                                           QgsVectorFileWriter::FieldValueConverter *fieldValueConverter,
+                                           const QString &layerName,
+                                           QgsVectorFileWriter::ActionOnExistingFile action,
+                                           QString *newLayer = nullptr,
+                                           QgsCoordinateTransformContext transformContext = QgsCoordinateTransformContext(),
+                                           QgsFeatureSink::SinkFlags sinkFlags = nullptr
+                                         ) SIP_SKIP;
 
     //! QgsVectorFileWriter cannot be copied.
     QgsVectorFileWriter( const QgsVectorFileWriter &rh ) = delete;
     //! QgsVectorFileWriter cannot be copied.
     QgsVectorFileWriter &operator=( const QgsVectorFileWriter &rh ) = delete;
+
+    /**
+     * Create a new vector file writer.
+     * \param fileName file name to write to
+     * \param fields fields to write
+     * \param geometryType geometry type of output file
+     * \param srs spatial reference system of output file
+     * \param transformContext coordinate transform context
+     * \param options save options
+     * \param sinkFlags feature sink flags
+     * \param newFilename potentially modified file name (output parameter)
+     * \param newLayer potentially modified layer name (output parameter)
+     * \since QGIS 3.10.3
+     */
+    static QgsVectorFileWriter *create( const QString &fileName,
+                                        const QgsFields &fields,
+                                        QgsWkbTypes::Type geometryType,
+                                        const QgsCoordinateReferenceSystem &srs,
+                                        const QgsCoordinateTransformContext &transformContext,
+                                        const QgsVectorFileWriter::SaveVectorOptions &options,
+                                        QgsFeatureSink::SinkFlags sinkFlags = nullptr,
+                                        QString *newFilename = nullptr,
+                                        QString *newLayer = nullptr );
+
+    /**
+     * Writes a layer out to a vector file.
+     * \param layer source layer to write
+     * \param fileName file name to write to
+     * \param transformContext coordinate transform context
+     * \param options save options
+     * \param newFilename potentially modified file name (output parameter)
+     * \param newLayer potentially modified layer name (output parameter)
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
+     * \returns Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
+     * \since QGIS 3.10.3
+     */
+    static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( QgsVectorLayer *layer,
+        const QString &fileName,
+        const QgsCoordinateTransformContext &transformContext,
+        const QgsVectorFileWriter::SaveVectorOptions &options,
+        QString *newFilename = nullptr,
+        QString *newLayer = nullptr,
+        QString *errorMessage SIP_OUT = nullptr );
 
     /**
      * Details of available filters and formats.
@@ -867,13 +925,35 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
     /**
      * Writes a previously prepared PreparedWriterDetails \a details object.
      * This is safe to call in a background thread.
+     * \param details writer details
+     * \param fileName file name to write to
+     * \param transformContext coordinate transform context
+     * \param options save options
+     * \param newFilename potentially modified file name (output parameter)
+     * \param newLayer potentially modified layer name (output parameter)
+     * \param errorMessage will be set to the error message text, if an error occurs while writing the layer
+     * \returns Error message code, or QgsVectorFileWriter.NoError if the write operation was successful
+     * \since QGIS 3.10.3
      */
-    static QgsVectorFileWriter::WriterError writeAsVectorFormat( PreparedWriterDetails &details,
+    static QgsVectorFileWriter::WriterError writeAsVectorFormatV2( PreparedWriterDetails &details,
+        const QString &fileName,
+        const QgsCoordinateTransformContext &transformContext,
+        const QgsVectorFileWriter::SaveVectorOptions &options,
+        QString *newFilename = nullptr,
+        QString *newLayer = nullptr,
+        QString *errorMessage SIP_OUT = nullptr );
+
+    /**
+     * Writes a previously prepared PreparedWriterDetails \a details object.
+     * This is safe to call in a background thread.
+     * \deprecated Use writeAsVectorFormatV2() instead.
+     */
+    Q_DECL_DEPRECATED static QgsVectorFileWriter::WriterError writeAsVectorFormat( PreparedWriterDetails &details,
         const QString &fileName,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = nullptr,
         QString *errorMessage SIP_OUT = nullptr,
-        QString *newLayer = nullptr );
+        QString *newLayer = nullptr ) SIP_DEPRECATED;
 
     void init( QString vectorFileName, QString fileEncoding, const QgsFields &fields,
                QgsWkbTypes::Type geometryType, QgsCoordinateReferenceSystem srs,
@@ -881,11 +961,15 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                QStringList layerOptions, QString *newFilename,
                QgsVectorFileWriter::FieldValueConverter *fieldValueConverter,
                const QString &layerName,
-               QgsVectorFileWriter::ActionOnExistingFile action, QString *newLayer, QgsFeatureSink::SinkFlags sinkFlags );
+               QgsVectorFileWriter::ActionOnExistingFile action, QString *newLayer, QgsFeatureSink::SinkFlags sinkFlags,
+               const QgsCoordinateTransformContext &transformContext );
     void resetMap( const QgsAttributeList &attributes );
 
     std::unique_ptr< QgsFeatureRenderer > mRenderer;
     QgsRenderContext mRenderContext;
+
+
+    std::unique_ptr< QgsCoordinateTransform > mCoordinateTransform;
 
     bool mUsingTransaction = false;
     bool supportsStringList = false;

--- a/src/core/qgsvectorfilewritertask.cpp
+++ b/src/core/qgsvectorfilewritertask.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgsvectorfilewritertask.h"
-
+#include "qgsvectorlayer.h"
 
 QgsVectorFileWriterTask::QgsVectorFileWriterTask( QgsVectorLayer *layer, const QString &fileName, const QgsVectorFileWriter::SaveVectorOptions &options )
   : QgsTask( tr( "Saving %1" ).arg( fileName ), QgsTask::CanCancel )
@@ -36,6 +36,11 @@ QgsVectorFileWriterTask::QgsVectorFileWriterTask( QgsVectorLayer *layer, const Q
     mOptions.feedback = mOwnedFeedback.get();
   }
 
+  if ( layer )
+  {
+    mTransformContext = layer->transformContext();
+  }
+
   mError = QgsVectorFileWriter::prepareWriteAsVectorFormat( layer, mOptions, mWriterDetails );
 }
 
@@ -53,8 +58,8 @@ bool QgsVectorFileWriterTask::run()
   connect( mOptions.feedback, &QgsFeedback::progressChanged, this, &QgsVectorFileWriterTask::setProgress );
 
 
-  mError = QgsVectorFileWriter::writeAsVectorFormat(
-             mWriterDetails, mDestFileName, mOptions, &mNewFilename, &mErrorMessage, &mNewLayer );
+  mError = QgsVectorFileWriter::writeAsVectorFormatV2(
+             mWriterDetails, mDestFileName, mTransformContext, mOptions, &mNewFilename, &mNewLayer, &mErrorMessage );
   return mError == QgsVectorFileWriter::NoError;
 }
 

--- a/src/core/qgsvectorfilewritertask.h
+++ b/src/core/qgsvectorfilewritertask.h
@@ -89,6 +89,8 @@ class CORE_EXPORT QgsVectorFileWriterTask : public QgsTask
     QgsVectorFileWriter::SaveVectorOptions mOptions;
     QgsVectorFileWriter::PreparedWriterDetails mWriterDetails;
     std::unique_ptr< QgsVectorFileWriter::FieldValueConverter > mFieldValueConverter;
+
+    QgsCoordinateTransformContext mTransformContext;
 };
 
 #endif

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -316,7 +316,11 @@ void QgsGeometryCheckerSetupTab::runChecks()
 
       // Create output layer
       QString errMsg;
-      QgsVectorFileWriter::WriterError err =  QgsVectorFileWriter::writeAsVectorFormat( layer, outputPath, layer->dataProvider()->encoding(), layer->crs(), outputDriverName, selectedOnly, &errMsg );
+      QgsVectorFileWriter::SaveVectorOptions saveOptions;
+      saveOptions.fileEncoding = layer->dataProvider()->encoding();
+      saveOptions.driverName = outputDriverName;
+      saveOptions.onlySelectedFeatures = selectedOnly;
+      QgsVectorFileWriter::WriterError err =  QgsVectorFileWriter::writeAsVectorFormatV2( layer, outputPath, layer->transformContext(), saveOptions, nullptr, nullptr, &errMsg );
       if ( err != QgsVectorFileWriter::NoError )
       {
         createErrors.append( errMsg );

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -331,7 +331,10 @@ void TestQgsAttributeTable::testRegression15974()
   QString path = QDir::tempPath() + "/testshp15974.shp";
   std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "polygon?crs=epsg:4326&field=id:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
   QVERIFY( tempLayer->isValid() );
-  QgsVectorFileWriter::writeAsVectorFormat( tempLayer.get(), path, QStringLiteral( "system" ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QStringLiteral( "ESRI Shapefile" ) );
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = QStringLiteral( "system" );
+  saveOptions.driverName = QStringLiteral( "ESRI Shapefile" );
+  QgsVectorFileWriter::writeAsVectorFormatV2( tempLayer.get(), path, tempLayer->transformContext(), saveOptions );
   std::unique_ptr< QgsVectorLayer> shpLayer( new QgsVectorLayer( path, QStringLiteral( "test" ),  QStringLiteral( "ogr" ) ) );
   QgsFeature f1( shpLayer->dataProvider()->fields(), 1 );
   QgsGeometry geom;

--- a/tests/src/core/testqgsmaprendererjob.cpp
+++ b/tests/src/core/testqgsmaprendererjob.cpp
@@ -132,11 +132,9 @@ void TestQgsMapRendererJob::initTestCase()
   {
     qDebug( "Creating test dataset: " );
 
-    QgsVectorFileWriter myWriter( myFileName,
-                                  mEncoding,
-                                  mFields,
-                                  QgsWkbTypes::Polygon,
-                                  mCRS );
+    QgsVectorFileWriter::SaveVectorOptions saveOptions;
+    saveOptions.fileEncoding = mEncoding;
+    std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::Polygon, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
     double myInterval = 0.5;
     for ( double i = -180.0; i <= 180.0; i += myInterval )
     {
@@ -168,8 +166,8 @@ void TestQgsMapRendererJob::initTestCase()
         // Write the feature to the filewriter
         // and check for errors
         //
-        QVERIFY( myWriter.addFeature( myFeature ) );
-        mError = myWriter.hasError();
+        QVERIFY( writer->addFeature( myFeature ) );
+        mError = writer->hasError();
         if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
         {
           std::cout << "Driver not found error" << std::endl;

--- a/tests/src/core/testqgsvectorfilewriter.cpp
+++ b/tests/src/core/testqgsvectorfilewriter.cpp
@@ -24,6 +24,7 @@
 #include "qgsgeometry.h" //each feature needs a geometry
 #include "qgspointxy.h" //we will use point geometry
 #include "qgscoordinatereferencesystem.h" //needed for creating a srs
+#include "qgscoordinatetransformcontext.h"
 #include "qgsapplication.h" //search path for srs.db
 #include "qgslogger.h"
 #include "qgsfield.h"
@@ -158,11 +159,10 @@ void TestQgsVectorFileWriter::createPoint()
   QString myFileName = QStringLiteral( "/testpt.shp" );
   myFileName = QDir::tempPath() + myFileName;
   QVERIFY( QgsVectorFileWriter::deleteShapeFile( myFileName ) );
-  QgsVectorFileWriter myWriter( myFileName,
-                                mEncoding,
-                                mFields,
-                                QgsWkbTypes::Point,
-                                mCRS );
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = mEncoding;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::Point, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
   //
   // Create a feature
   //
@@ -176,8 +176,8 @@ void TestQgsVectorFileWriter::createPoint()
   // Write the feature to the filewriter
   // and check for errors
   //
-  QVERIFY( myWriter.addFeature( myFeature ) );
-  mError = myWriter.hasError();
+  QVERIFY( writer->addFeature( myFeature ) );
+  mError = writer->hasError();
   if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
   {
     std::cout << "Driver not found error" << std::endl;
@@ -201,11 +201,10 @@ void TestQgsVectorFileWriter::createLine()
   QString myFileName = QStringLiteral( "/testln.shp" );
   myFileName = QDir::tempPath() + myFileName;
   QVERIFY( QgsVectorFileWriter::deleteShapeFile( myFileName ) );
-  QgsVectorFileWriter myWriter( myFileName,
-                                mEncoding,
-                                mFields,
-                                QgsWkbTypes::LineString,
-                                mCRS );
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = mEncoding;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::LineString, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
   //
   // Create a feature
   //
@@ -220,8 +219,8 @@ void TestQgsVectorFileWriter::createLine()
   // Write the feature to the filewriter
   // and check for errors
   //
-  QVERIFY( myWriter.addFeature( myFeature ) );
-  mError = myWriter.hasError();
+  QVERIFY( writer->addFeature( myFeature ) );
+  mError = writer->hasError();
   if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
   {
     std::cout << "Driver not found error" << std::endl;
@@ -246,11 +245,10 @@ void TestQgsVectorFileWriter::createPolygon()
   QString myFileName = QStringLiteral( "/testply.shp" );
   myFileName = QDir::tempPath() + myFileName;
   QVERIFY( QgsVectorFileWriter::deleteShapeFile( myFileName ) );
-  QgsVectorFileWriter myWriter( myFileName,
-                                mEncoding,
-                                mFields,
-                                QgsWkbTypes::Polygon,
-                                mCRS );
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = mEncoding;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::Polygon, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
   //
   // Create a polygon feature
   //
@@ -270,8 +268,8 @@ void TestQgsVectorFileWriter::createPolygon()
   // Write the feature to the filewriter
   // and check for errors
   //
-  QVERIFY( myWriter.addFeature( myFeature ) );
-  mError = myWriter.hasError();
+  QVERIFY( writer->addFeature( myFeature ) );
+  mError = writer->hasError();
   if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
   {
     std::cout << "Driver not found error" << std::endl;
@@ -294,11 +292,10 @@ void TestQgsVectorFileWriter::polygonGridTest()
   QString myFileName = QStringLiteral( "/testgrid.shp" );
   myFileName = QDir::tempPath() + myFileName;
   QVERIFY( QgsVectorFileWriter::deleteShapeFile( myFileName ) );
-  QgsVectorFileWriter myWriter( myFileName,
-                                mEncoding,
-                                mFields,
-                                QgsWkbTypes::Polygon,
-                                mCRS );
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = mEncoding;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::Polygon, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
   double myInterval = 5.0;
   for ( double i = -180.0; i <= 180.0; i += myInterval )
   {
@@ -327,8 +324,8 @@ void TestQgsVectorFileWriter::polygonGridTest()
       // Write the feature to the filewriter
       // and check for errors
       //
-      QVERIFY( myWriter.addFeature( myFeature ) );
-      mError = myWriter.hasError();
+      QVERIFY( writer->addFeature( myFeature ) );
+      mError = writer->hasError();
       if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
       {
         std::cout << "Driver not found error" << std::endl;
@@ -358,11 +355,10 @@ void TestQgsVectorFileWriter::projectedPlygonGridTest()
   // We are testing projected coordinate
   // system vector writing...
   mCRS = QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3328" ) );
-  QgsVectorFileWriter myWriter( myFileName,
-                                mEncoding,
-                                mFields,
-                                QgsWkbTypes::Polygon,
-                                mCRS );
+
+  QgsVectorFileWriter::SaveVectorOptions saveOptions;
+  saveOptions.fileEncoding = mEncoding;
+  std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( myFileName, mFields, QgsWkbTypes::Polygon, mCRS, QgsCoordinateTransformContext(), saveOptions ) );
   double myInterval = 1000.0; //1km2
   for ( double i = 0.0; i <= 10000.0; i += myInterval ) //10km
   {
@@ -391,8 +387,8 @@ void TestQgsVectorFileWriter::projectedPlygonGridTest()
       // Write the feature to the filewriter
       // and check for errors
       //
-      QVERIFY( myWriter.addFeature( myFeature ) );
-      mError = myWriter.hasError();
+      QVERIFY( writer->addFeature( myFeature ) );
+      mError = writer->hasError();
       if ( mError == QgsVectorFileWriter::ErrDriverNotFound )
       {
         std::cout << "Driver not found error" << std::endl;
@@ -437,11 +433,9 @@ void TestQgsVectorFileWriter::regression1141()
   qDebug( "Creating test dataset: " );
 
   {
-    QgsVectorFileWriter myWriter( fileName,
-                                  encoding,
-                                  fields,
-                                  QgsWkbTypes::Point,
-                                  crs );
+    QgsVectorFileWriter::SaveVectorOptions saveOptions;
+    saveOptions.fileEncoding = encoding;
+    std::unique_ptr< QgsVectorFileWriter > writer( QgsVectorFileWriter::create( fileName, fields, QgsWkbTypes::Point, crs, QgsCoordinateTransformContext(), saveOptions ) );
 
     QgsPointXY myPoint = QgsPointXY( 10.0, 10.0 );
     QgsGeometry mypPointGeometry = QgsGeometry::fromPointXY( myPoint );
@@ -453,8 +447,8 @@ void TestQgsVectorFileWriter::regression1141()
     // Write the feature to the filewriter
     // and check for errors
     //
-    QVERIFY( myWriter.addFeature( myFeature ) );
-    QgsVectorFileWriter::WriterError error = myWriter.hasError();
+    QVERIFY( writer->addFeature( myFeature ) );
+    QgsVectorFileWriter::WriterError error = writer->hasError();
 
     if ( error == QgsVectorFileWriter::ErrDriverNotFound )
     {
@@ -492,9 +486,10 @@ void TestQgsVectorFileWriter::prepareWriteAsVectorFormat()
   options.driverName = "GPKG";
   options.layerName = "test";
   QString newFilename;
-  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormat(
+  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV2(
       &ml,
       fileName,
+      ml.transformContext(),
       options,
       &newFilename ) );
 
@@ -523,9 +518,10 @@ void TestQgsVectorFileWriter::testTextFieldLength()
   options.driverName = "GPKG";
   options.layerName = "test";
   QString newFilename;
-  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormat(
+  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV2(
       &vl,
       fileName,
+      vl.transformContext(),
       options,
       &newFilename ) );
   QCOMPARE( error, QgsVectorFileWriter::WriterError::NoError );
@@ -575,12 +571,12 @@ void TestQgsVectorFileWriter::_testExportToGpx( const QString &geomTypeName,
   options.layerName = inputLayerName;
   options.layerOptions = layerOptions;
   QString outLayerName;
-  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormat(
+  QgsVectorFileWriter::WriterError error( QgsVectorFileWriter::writeAsVectorFormatV2(
       &vl,
       fileName,
+      vl.transformContext(),
       options,
       nullptr, // newFilename
-      nullptr, // errorMessage
       &outLayerName ) );
   QCOMPARE( error, QgsVectorFileWriter::WriterError::NoError );
   QCOMPARE( outLayerName, expectedLayerName );


### PR DESCRIPTION
## Description

When exporting to an OGR dataset, some drivers (AFAIK only KML) enforce one specific CRS. Until now, we left it to the OGR library to do the transformation, however under GDAL3/PROJ6, we want to be in charge of transformation to insure it matches the project/layer context (i.e. user picked transformation).

