### PR TITLE
Fix relation reference constraint when identifying a feature

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -793,9 +793,9 @@ void QgsRelationReferenceWidget::featureIdentified( const QgsFeature &feature )
     }
     mLineEdit->setText( title );
     mForeignKeys.clear();
+    mFeature = feature;
     for ( const QString &fieldName : qgis::as_const( mReferencedFields ) )
       mForeignKeys << mFeature.attribute( fieldName );
-    mFeature = feature;
   }
   else
   {

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -398,17 +398,17 @@ void TestQgsRelationReferenceWidget::testIdentifyOnMap()
   QVERIFY( feature.isValid() );
   QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 11 );
   w.featureIdentified( feature );
-  QCOMPARE( w.mLineEdit->text(), "11" );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "11" ) );
   QCOMPARE( w.mForeignKeys.count(), 1 );
-  QCOMPARE( w.mForeignKeys.at( 0 ), 11 );
+  QCOMPARE( w.mForeignKeys.at( 0 ).toInt(), 11 );
 
   mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 10 ) ).nextFeature( feature );
   QVERIFY( feature.isValid() );
   QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 10 );
   w.featureIdentified( feature );
-  QCOMPARE( w.mLineEdit->text(), "10" );
+  QCOMPARE( w.mLineEdit->text(), QStringLiteral( "10" ) );
   QCOMPARE( w.mForeignKeys.count(), 1 );
-  QCOMPARE( w.mForeignKeys.at( 0 ), 10 );
+  QCOMPARE( w.mForeignKeys.at( 0 ).toInt(), 10 );
 
   mLayer1->rollBack();
 }

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -392,6 +392,24 @@ void TestQgsRelationReferenceWidget::testIdentifyOnMap()
   w.featureIdentified( feature );
   QCOMPARE( w.mComboBox->currentData( Qt::DisplayRole ).toInt(), 10 );
 
+  w.setReadOnlySelector( true );
+
+  mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 11 ) ).nextFeature( feature );
+  QVERIFY( feature.isValid() );
+  QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 11 );
+  w.featureIdentified( feature );
+  QCOMPARE( w.mLineEdit->text(), "11" );
+  QCOMPARE( w.mForeignKeys.count(), 1 );
+  QCOMPARE( w.mForeignKeys.at( 0 ), 11 );
+
+  mLayer2->getFeatures( QStringLiteral( "pk = %1" ).arg( 10 ) ).nextFeature( feature );
+  QVERIFY( feature.isValid() );
+  QCOMPARE( feature.attribute( QStringLiteral( "pk" ) ).toInt(), 10 );
+  w.featureIdentified( feature );
+  QCOMPARE( w.mLineEdit->text(), "10" );
+  QCOMPARE( w.mForeignKeys.count(), 1 );
+  QCOMPARE( w.mForeignKeys.at( 0 ), 10 );
+
   mLayer1->rollBack();
 }
 


### PR DESCRIPTION
## Description

When identifying a feature from relation reference widget, and the selector is read only, the constraint stays invalid after the feature has been identified.

This PR fixes this.