### PR TITLE
Fix issue #28854 Export project to dxf symbol size 

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -1233,8 +1233,6 @@ void QgsSimpleMarkerSymbolLayer::drawMarker( QPainter *p, QgsSymbolRenderContext
 
 bool QgsSimpleMarkerSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScaleFactor, const QString &layerName, QgsSymbolRenderContext &context, QPointF shift ) const
 {
-  Q_UNUSED( mmMapUnitScaleFactor )
-
   //data defined size?
   double size = mSize;
 
@@ -1260,6 +1258,12 @@ bool QgsSimpleMarkerSymbolLayer::writeDxf( QgsDxfExport &e, double mmMapUnitScal
 
     size *= e.mapUnitScaleFactor( e.symbologyScale(), mSizeUnit, e.mapUnits(), context.renderContext().mapToPixel().mapUnitsPerPixel() );
   }
+
+  if ( mSizeUnit == QgsUnitTypes::RenderMillimeters )
+  {
+    size *= mmMapUnitScaleFactor;
+  }
+
   if ( mSizeUnit == QgsUnitTypes::RenderMapUnits )
   {
     e.clipValueToMapUnitScale( size, mSizeMapUnitScale, context.renderContext().scaleFactor() );


### PR DESCRIPTION
## Description

Handle correctly the unit type millimeter when exporting simple marker symbol to DXF.

The strategy is the same as the one used when exporting svg marker symbol, ie simply use the map unit scale factor to scale the marker.

Should fix #28854.

The symbology scale is used again to draw the marker symbol which result in a more coherent size for the output of the symbols in DXF.

For example, for a view like this : 

![qgisview](https://user-images.githubusercontent.com/19537259/73946621-7f1d4200-48f6-11ea-9ab8-2e0faae3d35c.png)

Before the fix the dxf export did not use the symbology scale an gave this :

![dxBeforeFix](https://user-images.githubusercontent.com/19537259/73946667-94926c00-48f6-11ea-8194-de2d7991803a.png)

Now with the fix, if the symbology scale match the one used when viewing the layer in qgis the output look like this : 

![dxfAfterFix](https://user-images.githubusercontent.com/19537259/73946745-b4c22b00-48f6-11ea-92dc-2a71a9ef43fb.png)

Which is what would be expected.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
