### PR TITLE
Show field type icons on attribute table headers

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -679,7 +679,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mDataSourceManagerNonModal->setChecked( mSettings->value( QStringLiteral( "/qgis/dataSourceManagerNonModal" ), false ).toBool() );
   cbxCheckVersion->setChecked( mSettings->value( QStringLiteral( "/qgis/checkVersion" ), true ).toBool() );
   cbxCheckVersion->setVisible( mSettings->value( QStringLiteral( "/qgis/allowVersionCheck" ), true ).toBool() );
-  cbxAttributeTableDocked->setChecked( mSettings->value( QStringLiteral( "/qgis/dockAttributeTable" ), false ).toBool() );
+  cbxAttributeTableDocked->setChecked( mSettings->value( QStringLiteral( "/qgis/dockAttributeTable" ), true ).toBool() );
+  cbxAttributeTableHeaderIcons->setChecked( mSettings->value( QStringLiteral( "/qgis/showAttributeTableHeaderIcons" ), false ).toBool() );
   cbxCompileExpressions->setChecked( mSettings->value( QStringLiteral( "/qgis/compileExpressions" ), true ).toBool() );
 
   mComboCopyFeatureFormat->addItem( tr( "Plain text, no geometry" ), QgsClipboard::AttributesOnly );
@@ -1478,6 +1479,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/dataSourceManagerNonModal" ), mDataSourceManagerNonModal->isChecked() );
   mSettings->setValue( QStringLiteral( "/qgis/checkVersion" ), cbxCheckVersion->isChecked() );
   mSettings->setValue( QStringLiteral( "/qgis/dockAttributeTable" ), cbxAttributeTableDocked->isChecked() );
+  mSettings->setValue( QStringLiteral( "/qgis/showAttributeTableHeaderIcons" ), cbxAttributeTableHeaderIcons->isChecked() );
   mSettings->setEnumValue( QStringLiteral( "/qgis/attributeTableBehavior" ), ( QgsAttributeTableFilterModel::FilterMode )cmbAttrTableBehavior->currentData().toInt() );
   mSettings->setValue( QStringLiteral( "/qgis/attributeTableView" ), mAttrTableViewComboBox->currentData() );
   mSettings->setValue( QStringLiteral( "/qgis/attributeTableRowCache" ), spinBoxAttrTableRowCache->value() );

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -627,7 +627,7 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
       return QgsFieldModel::fieldToolTip( field );
     }
   }
-  else if ( role == Qt::DecorationRole )
+  else if ( role == Qt::DecorationRole && mShowTypeIcons )
   {
     if ( orientation == Qt::Vertical )
     {

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -627,6 +627,22 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
       return QgsFieldModel::fieldToolTip( field );
     }
   }
+  else if ( role == Qt::DecorationRole )
+  {
+    if ( orientation == Qt::Vertical )
+    {
+      return QVariant();
+    }
+    else if ( section >= 0 && section < mFieldCount )
+    {
+      const QIcon icon = layer()->fields().iconForField( mAttributes.at( section ) );
+      return icon;
+    }
+    else
+    {
+      return QVariant();
+    }
+  }
   else
   {
     return QVariant();

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -29,6 +29,7 @@
 #include "qgsattributeeditorcontext.h"
 #include "qgsvectorlayercache.h"
 #include "qgis_gui.h"
+#include "qgssettings.h"
 
 class QgsMapCanvas;
 class QgsMapLayerAction;
@@ -331,6 +332,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
   private:
     QgsVectorLayerCache *mLayerCache = nullptr;
     int mFieldCount = 0;
+    bool mShowTypeIcons = QgsSettings().value( QStringLiteral( "qgis/showAttributeTableHeaderIcons" ) ).toBool();
 
     mutable QgsFeature mFeat;
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1987,6 +1987,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="1" column="0">
+                   <widget class="QCheckBox" name="cbxAttributeTableHeaderIcons">
+                    <property name="text">
+                     <string>Display field type icons on attribute table headers</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>
@@ -5759,6 +5766,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>mPlanimetricMeasurementsComboBox</tabstop>
   <tabstop>mOptionsScrollArea_11</tabstop>
   <tabstop>cbxAttributeTableDocked</tabstop>
+  <tabstop>cbxAttributeTableHeaderIcons</tabstop>
   <tabstop>mComboCopyFeatureFormat</tabstop>
   <tabstop>cmbAttrTableBehavior</tabstop>
   <tabstop>mAttrTableViewComboBox</tabstop>


### PR DESCRIPTION
## Description
I really miss having this info on the attribute table after getting used to other database managers.

![Screenshot_20200206_212933](https://user-images.githubusercontent.com/11358178/73971586-d25bb880-4927-11ea-9ea6-894c48914e75.png)
If it is on purpose not there, in order not to clutter the view, then maybe there could be a settings entry to enable / disable it.
Any other reason not to have this?

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
