### PR TITLE
Change "Ignore shapefile encoding declaration" default from checked to unchecked

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -152,6 +152,11 @@ rendering\label_candidates_limit_lines=0
 # that no limit is present.
 rendering\label_candidates_limit_polygons=0
 
+# When false, QGIS uses information embedded inside Shapefiles to determine the correct encoding to use
+# when opening them (e.g. encoding specified in a cpg file). If true, QGIS will ignore this embedded encoding
+# and use UTF8 encoding by default
+dataProviders\ignoreShapeEncoding=false
+
 [colors]
 # These colors are used in logs.
 default=

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -687,7 +687,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mComboCopyFeatureFormat->addItem( tr( "GeoJSON" ), QgsClipboard::GeoJSON );
   mComboCopyFeatureFormat->setCurrentIndex( mComboCopyFeatureFormat->findData( mSettings->enumValue( QStringLiteral( "/qgis/copyFeatureFormat" ), QgsClipboard::AttributesWithWKT ) ) );
   leNullValue->setText( QgsApplication::nullRepresentation() );
-  cbxIgnoreShapeEncoding->setChecked( mSettings->value( QStringLiteral( "/qgis/ignoreShapeEncoding" ), true ).toBool() );
+  cbxIgnoreShapeEncoding->setChecked( mSettings->value( QStringLiteral( "dataProviders/ignoreShapeEncoding" ), false, QgsSettings::Core ).toBool() );
 
   cmbLegendDoubleClickAction->setCurrentIndex( mSettings->value( QStringLiteral( "/qgis/legendDoubleClickAction" ), 0 ).toInt() );
 
@@ -1486,7 +1486,7 @@ void QgsOptions::saveOptions()
                        cmbScanItemsInBrowser->currentData().toString() );
   mSettings->setValue( QStringLiteral( "/qgis/scanZipInBrowser2" ),
                        cmbScanZipInBrowser->currentData().toString() );
-  mSettings->setValue( QStringLiteral( "/qgis/ignoreShapeEncoding" ), cbxIgnoreShapeEncoding->isChecked() );
+  mSettings->setValue( QStringLiteral( "/dataProviders/ignoreShapeEncoding" ), cbxIgnoreShapeEncoding->isChecked(), QgsSettings::Core );
   mSettings->setValue( QStringLiteral( "/qgis/mainSnappingWidgetMode" ), mSnappingMainDialogComboBox->currentData() );
 
   mSettings->setValue( QStringLiteral( "/qgis/compileExpressions" ), cbxCompileExpressions->isChecked() );

--- a/src/core/providers/ogr/qgsogrprovider.cpp
+++ b/src/core/providers/ogr/qgsogrprovider.cpp
@@ -464,7 +464,7 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &optio
   QgsApplication::registerOgrDrivers();
 
   QgsSettings settings;
-  CPLSetConfigOption( "SHAPE_ENCODING", settings.value( QStringLiteral( "qgis/ignoreShapeEncoding" ), true ).toBool() ? "" : nullptr );
+  CPLSetConfigOption( "SHAPE_ENCODING", settings.value( QStringLiteral( "dataProviders/ignoreShapeEncoding" ), false, QgsSettings::Core ).toBool() ? "" : nullptr );
 
 #ifndef QT_NO_NETWORKPROXY
   setupProxy();
@@ -979,7 +979,7 @@ void QgsOgrProvider::setEncoding( const QString &e )
 {
   QgsSettings settings;
   if ( ( mGDALDriverName == QLatin1String( "ESRI Shapefile" ) &&
-         settings.value( QStringLiteral( "qgis/ignoreShapeEncoding" ), true ).toBool() ) ||
+         settings.value( QStringLiteral( "dataProviders/ignoreShapeEncoding" ), false, QgsSettings::Core ).toBool() ) ||
        ( mOgrLayer && !mOgrLayer->TestCapability( OLCStringsAsUTF8 ) ) )
   {
     QgsVectorDataProvider::setEncoding( e );
@@ -3556,7 +3556,7 @@ bool QgsOgrProviderUtils::createEmptyDataSource( const QString &uri,
   CSLDestroy( papszOptions );
 
   QgsSettings settings;
-  if ( !settings.value( QStringLiteral( "qgis/ignoreShapeEncoding" ), true ).toBool() )
+  if ( !settings.value( QStringLiteral( "dataProviders/ignoreShapeEncoding" ), false, QgsSettings::Core ).toBool() )
   {
     CPLSetConfigOption( "SHAPE_ENCODING", nullptr );
   }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -498,7 +498,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   }
 
   QgsSettings settings;
-  if ( !settings.value( QStringLiteral( "qgis/ignoreShapeEncoding" ), true ).toBool() )
+  if ( !settings.value( QStringLiteral( "dataProviders/ignoreShapeEncoding" ), false, QgsSettings::Core ).toBool() )
   {
     CPLSetConfigOption( "SHAPE_ENCODING", nullptr );
   }

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2032,7 +2032,7 @@
                      <string>Disable OGR on-the-fly conversion from declared encoding to UTF-8</string>
                     </property>
                     <property name="text">
-                     <string>Ignore shapefile encoding declaration</string>
+                     <string>Ignore original encoding when opening Shapefiles</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
...and resolve shapefiles opened in QGIS ignore the cpg/embedded encoding by default.

This is a messy messy situation. The default was changed some years ago to ignore shapefile .cpg encoding BY DEFAULT, because if we don't ignore it, then it becomes impossible to override the encoding on a file-by-file basis (i.e. the setting in layer properties gets disabled and the encoding setting in the data source manager has no effect).

But by ignoring it by default we are ignoring the encoding specified by the files themselves. It basically means that users ALWAYS need to manually select the encoding for shapefiles, because we ignore the logic on OGR's side to select the embedded one automatically. This has led to a lot of user pain -- see #21264 and many posts on mailing lists e.g.

http://osgeo-org.1560.x6.nabble.com/Shapefile-with-file-cpg-codepage-td5275106.html
http://osgeo-org.1560.x6.nabble.com/QGIS-ignore-the-cpg-files-when-loading-shapefiles-td5348021.html

@rouault I spent some time trying to see if we could make a solution which satisfied both requirements -- by defaulting to an "automatic" encoding option which means trust GDAL, but I cannot find a reliable way to change the SHAPE_ENCODING configuration option used by GDAL after the layer has been initially loaded (i.e. if the user selects a specific encoding we need to change SHAPE_ENCODING to "" instead of nullptr for the already opened dataset. I thought calling QgsOgrProvider::reloadProviderData() after changing SHAPE_ENCODING may work for this, but doing so doesn't disable the UTF-8 conversion on GDAL's side...

The other approach I tried was to always disable the GDAL side UTF-8 conversion for shapefiles, but then I can't find a way to still take advantage of GDAL's .cpg/LDID handling logic and retrieve the encoding detected by GDAL (and I don't want to reimplement this logic in QGIS, if that's even possible to do)

Can you think of a nicer way to handle this in general? 