### PR TITLE
Port font marker away from deprecated API

### DIFF
--- a/src/core/symbology/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology/qgsmarkersymbollayer.cpp
@@ -3040,7 +3040,11 @@ void QgsFontMarkerSymbolLayer::startRender( QgsSymbolRenderContext &context )
   mFont.setPixelSize( std::max( 2, static_cast< int >( std::round( sizePixels ) ) ) );
   delete mFontMetrics;
   mFontMetrics = new QFontMetrics( mFont );
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
   mChrWidth = mFontMetrics->width( mString );
+#else
+  mChrWidth = mFontMetrics->horizontalAdvance( mString );
+#endif
   mChrOffset = QPointF( mChrWidth / 2.0, -mFontMetrics->ascent() / 2.0 );
   mOrigSize = mSize; // save in case the size would be data defined
 
@@ -3071,7 +3075,11 @@ QString QgsFontMarkerSymbolLayer::characterToRender( QgsSymbolRenderContext &con
     stringToRender = mDataDefinedProperties.valueAsString( QgsSymbolLayer::PropertyCharacter, context.renderContext().expressionContext(), mString );
     if ( stringToRender != mString )
     {
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
       charWidth = mFontMetrics->width( stringToRender );
+#else
+      charWidth = mFontMetrics->horizontalAdvance( stringToRender );
+#endif
       charOffset = QPointF( charWidth / 2.0, -mFontMetrics->ascent() / 2.0 );
     }
   }


### PR DESCRIPTION
Note: it's highly likely there's a bug here, and we should be
using the (tight)boundingRect of the string here instead of the
width/horizontalAdvance. But doing so changes the rendering position
of characters substantially, as it means that font markers are
properly centered on the actual character itself (otherwise
a character like '.' is not placed over the point itself, but
rather below it! iThat's the current behavior).

We could possibly handle this by only applying the improved
positioning to newly created font marker symbols, but that's
left for a follow-up work...

----
With this commit the final deprecation warning from 5.13 is cleared (finally I can build without warnings again!). That means that after https://github.com/qgis/QGIS/pull/34343 is merged, we've only got to port away from any newly introduced deprecations in 5.14/5.15 and we'll be ready for Qt6 builds (upstream has pledged that if your project builds without deprecation warnings in 5.15, it will build and run in the upcoming Qt6 release without issue).

