### PR TITLE
QgsMapLayerAction: add legend context menu entry for action on selection

### DIFF
--- a/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
+++ b/python/gui/auto_generated/qgsmaplayeractionregistry.sip.in
@@ -76,7 +76,7 @@ True if action can run using the specified layer
 Triggers the action with the specified layer and list of feature.
 %End
 
-    void triggerForFeature( QgsMapLayer *layer, const QgsFeature *feature );
+    void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature );
 %Docstring
 Triggers the action with the specified layer and feature.
 %End

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -291,7 +291,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           {
             if ( target == QgsMapLayerAction::Target::SingleFeature )
             {
-              actionMenu->addAction( action->text(), action, [ = ]() {action->triggerForFeature( vlayer,  QgsFeature( vlayer->selectedFeatures().at( 0 ) ) );} );
+              actionMenu->addAction( action->text(), action, [ = ]() { action->triggerForFeature( vlayer,  vlayer->selectedFeatures().at( 0 ) ); } );
             }
             else if ( target == QgsMapLayerAction::Target::MultipleFeatures )
             {

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -12,9 +12,9 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include <QClipboard>
 
 #include "qgsapplayertreeviewmenuprovider.h"
-
 
 #include "qgisapp.h"
 #include "qgsapplication.h"
@@ -22,6 +22,7 @@
 #include "qgscolorwidgets.h"
 #include "qgscolorschemeregistry.h"
 #include "qgscolorswatchgrid.h"
+#include "qgsgui.h"
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
 #include "qgslayertreemodellegendnode.h"
@@ -42,7 +43,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsxmlutils.h"
 
-#include <QClipboard>
+
 
 QgsAppLayerTreeViewMenuProvider::QgsAppLayerTreeViewMenuProvider( QgsLayerTreeView *view, QgsMapCanvas *canvas )
   : mView( view )
@@ -270,6 +271,34 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           } );
         }
         menu->addAction( a );
+      }
+
+      // actions on the selection
+      if ( vlayer && vlayer->selectedFeatureCount() > 0 )
+      {
+        int selectionCount = vlayer->selectedFeatureCount();
+        QgsMapLayerAction::Target target;
+        if ( selectionCount == 1 )
+          target = QgsMapLayerAction::Target::SingleFeature;
+        else
+          target = QgsMapLayerAction::Target::MultipleFeatures;
+
+        const QList<QgsMapLayerAction *> constRegisteredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( vlayer, target );
+        if ( !constRegisteredActions.isEmpty() )
+        {
+          QMenu *actionMenu = menu->addMenu( tr( "Actions on selection (%1)" ).arg( selectionCount ) );
+          for ( QgsMapLayerAction *action : constRegisteredActions )
+          {
+            if ( target == QgsMapLayerAction::Target::SingleFeature )
+            {
+              actionMenu->addAction( action->text(), action, [ = ]() {action->triggerForFeature( vlayer,  new QgsFeature( vlayer->selectedFeatures().at( 0 ) ) );} );
+            }
+            else if ( target == QgsMapLayerAction::Target::MultipleFeatures )
+            {
+              actionMenu->addAction( action->text(), action, [ = ]() {action->triggerForFeatures( vlayer, vlayer->selectedFeatures() );} );
+            }
+          }
+        }
       }
 
       menu->addSeparator();

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -286,7 +286,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         const QList<QgsMapLayerAction *> constRegisteredActions = QgsGui::mapLayerActionRegistry()->mapLayerActions( vlayer, target );
         if ( !constRegisteredActions.isEmpty() )
         {
-          QMenu *actionMenu = menu->addMenu( tr( "Actions on selection (%1)" ).arg( selectionCount ) );
+          QMenu *actionMenu = menu->addMenu( tr( "Actions on Selection (%1)" ).arg( selectionCount ) );
           for ( QgsMapLayerAction *action : constRegisteredActions )
           {
             if ( target == QgsMapLayerAction::Target::SingleFeature )

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -291,7 +291,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           {
             if ( target == QgsMapLayerAction::Target::SingleFeature )
             {
-              actionMenu->addAction( action->text(), action, [ = ]() {action->triggerForFeature( vlayer,  new QgsFeature( vlayer->selectedFeatures().at( 0 ) ) );} );
+              actionMenu->addAction( action->text(), action, [ = ]() {action->triggerForFeature( vlayer,  QgsFeature( vlayer->selectedFeatures().at( 0 ) ) );} );
             }
             else if ( target == QgsMapLayerAction::Target::MultipleFeatures )
             {

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1479,7 +1479,7 @@ void QgsIdentifyResultsDialog::doMapLayerAction( QTreeWidgetItem *item, QgsMapLa
     return;
 
   int featIdx = featItem->data( 0, Qt::UserRole + 1 ).toInt();
-  action->triggerForFeature( layer, &mFeatures[ featIdx ] );
+  action->triggerForFeature( layer, QgsFeature( mFeatures[ featIdx ] ) );
 }
 
 QTreeWidgetItem *QgsIdentifyResultsDialog::featureItem( QTreeWidgetItem *item )
@@ -2186,7 +2186,7 @@ void QgsIdentifyResultsDialog::formatChanged( int index )
 
 void QgsIdentifyResultsDialogMapLayerAction::execute()
 {
-  mAction->triggerForFeature( mLayer, mFeature );
+  mAction->triggerForFeature( mLayer, QgsFeature( *mFeature ) );
 }
 
 void QgsIdentifyResultsDialog::showHelp()

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1479,7 +1479,7 @@ void QgsIdentifyResultsDialog::doMapLayerAction( QTreeWidgetItem *item, QgsMapLa
     return;
 
   int featIdx = featItem->data( 0, Qt::UserRole + 1 ).toInt();
-  action->triggerForFeature( layer, QgsFeature( mFeatures[ featIdx ] ) );
+  action->triggerForFeature( layer, mFeatures[ featIdx ] );
 }
 
 QTreeWidgetItem *QgsIdentifyResultsDialog::featureItem( QTreeWidgetItem *item )
@@ -2186,7 +2186,7 @@ void QgsIdentifyResultsDialog::formatChanged( int index )
 
 void QgsIdentifyResultsDialogMapLayerAction::execute()
 {
-  mAction->triggerForFeature( mLayer, QgsFeature( *mFeature ) );
+  mAction->triggerForFeature( mLayer, *mFeature );
 }
 
 void QgsIdentifyResultsDialog::showHelp()

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -182,7 +182,7 @@ void QgsMapToolFeatureAction::doActionForFeature( QgsVectorLayer *layer, const Q
     QgsMapLayerAction *mapLayerAction = QgsGui::mapLayerActionRegistry()->defaultActionForLayer( layer );
     if ( mapLayerAction )
     {
-      mapLayerAction->triggerForFeature( layer, &feature );
+      mapLayerAction->triggerForFeature( layer, feature );
     }
   }
 }

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -846,7 +846,7 @@ void QgsAttributeTableModel::executeAction( QUuid action, const QModelIndex &idx
 void QgsAttributeTableModel::executeMapLayerAction( QgsMapLayerAction *action, const QModelIndex &idx ) const
 {
   QgsFeature f = feature( idx );
-  action->triggerForFeature( layer(), &f );
+  action->triggerForFeature( layer(), f );
 }
 
 QgsFeature QgsAttributeTableModel::feature( const QModelIndex &idx ) const

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -449,7 +449,7 @@ void QgsAttributeTableView::actionTriggered()
     QgsMapLayerAction *layerAction = qobject_cast<QgsMapLayerAction *>( object );
     if ( layerAction )
     {
-      layerAction->triggerForFeature( mFilterModel->layer(), &f );
+      layerAction->triggerForFeature( mFilterModel->layer(), QgsFeature( f ) );
     }
   }
 }

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -449,7 +449,7 @@ void QgsAttributeTableView::actionTriggered()
     QgsMapLayerAction *layerAction = qobject_cast<QgsMapLayerAction *>( object );
     if ( layerAction )
     {
-      layerAction->triggerForFeature( mFilterModel->layer(), QgsFeature( f ) );
+      layerAction->triggerForFeature( mFilterModel->layer(), f );
     }
   }
 }

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -93,7 +93,7 @@ void QgsActionMenu::triggerAction()
   if ( data.actionType == MapLayerAction )
   {
     QgsMapLayerAction *mapLayerAction = data.actionData.value<QgsMapLayerAction *>();
-    mapLayerAction->triggerForFeature( data.mapLayer, &mFeature );
+    mapLayerAction->triggerForFeature( data.mapLayer, mFeature );
   }
   else if ( data.actionType == AttributeAction )
   {

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -498,7 +498,7 @@ void QgsIdentifyMenu::triggerMapLayerAction()
       {
         if ( result.mFeature.id() == actData.mFeatureId )
         {
-          actData.mMapLayerAction->triggerForFeature( actData.mLayer, QgsFeature( result.mFeature ) );
+          actData.mMapLayerAction->triggerForFeature( actData.mLayer, result.mFeature );
           return;
         }
       }

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -498,7 +498,7 @@ void QgsIdentifyMenu::triggerMapLayerAction()
       {
         if ( result.mFeature.id() == actData.mFeatureId )
         {
-          actData.mMapLayerAction->triggerForFeature( actData.mLayer, new QgsFeature( result.mFeature ) );
+          actData.mMapLayerAction->triggerForFeature( actData.mLayer, QgsFeature( result.mFeature ) );
           return;
         }
       }

--- a/src/gui/qgsmaplayeractionregistry.cpp
+++ b/src/gui/qgsmaplayeractionregistry.cpp
@@ -92,9 +92,9 @@ void QgsMapLayerAction::triggerForFeatures( QgsMapLayer *layer, const QList<QgsF
   emit triggeredForFeatures( layer, featureList );
 }
 
-void QgsMapLayerAction::triggerForFeature( QgsMapLayer *layer, const QgsFeature *feature )
+void QgsMapLayerAction::triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature )
 {
-  emit triggeredForFeature( layer, *feature );
+  emit triggeredForFeature( layer, feature );
 }
 
 void QgsMapLayerAction::triggerForLayer( QgsMapLayer *layer )

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -89,7 +89,7 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
     void triggerForFeatures( QgsMapLayer *layer, const QList<QgsFeature> &featureList );
 
     //! Triggers the action with the specified layer and feature.
-    void triggerForFeature( QgsMapLayer *layer, const QgsFeature *feature );
+    void triggerForFeature( QgsMapLayer *layer, const QgsFeature &feature );
 
     //! Triggers the action with the specified layer.
     void triggerForLayer( QgsMapLayer *layer );


### PR DESCRIPTION
A new menu entry (Actions on selection) is added to the layer tree context menu
It is shown only when required (layer has selection and actions can be run on the given layer)

![image](https://user-images.githubusercontent.com/127259/74035907-7f334580-49bb-11ea-8d2d-b99eaa10aa89.png)
