### PR TITLE
UI: lower opacity for menu in feature attribute dialog (not in edit mode), Fix #29542

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -258,7 +258,7 @@ void QgsTextEditWrapper::setEnabled( bool enabled )
       mLineEdit->setPalette( mReadOnlyPalette );
       // removing frame + setting transparent background to distinguish the readonly lineEdit from a normal one
       // did not get this working via the Palette:
-      mLineEdit->setStyleSheet( QStringLiteral( "background-color: rgba(255, 255, 255, 75%);" ) );
+      mLineEdit->setStyleSheet( QStringLiteral( "background-color: rgba(255, 255, 255, 50%);" ) );
     }
     mLineEdit->setFrame( enabled );
   }


### PR DESCRIPTION
## Description

Fix #29542

Simple fix ever

When a layer is not in edit mode in the attribute dialog, do a right click on a field, the highlight on the mouseover change the menu item into a white menu.

It's because the text become white over a white background. Decreasing opacity resolve the problem.

Before :

![white_menu](https://user-images.githubusercontent.com/18545440/74054727-d860a080-49de-11ea-974c-acf95bb23b35.png)

After :

![white_less](https://user-images.githubusercontent.com/18545440/74054751-e31b3580-49de-11ea-8056-462e9a6f0c6b.png)
