### PR TITLE
Fix identify menu when an expression is used as display name

### DIFF
--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -25,6 +25,7 @@
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
+#include "qgsexpressioncontextutils.h"
 
 //TODO 4.0 add explicitly qobject parent to constructor
 QgsIdentifyMenu::QgsIdentifyMenu( QgsMapCanvas *canvas )
@@ -282,7 +283,12 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
   if ( !createMenu )
   {
     // case 1
-    QString featureTitle = results[0].mFeature.attribute( layer->displayField() ).toString();
+
+    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+    QgsExpression exp( layer->displayExpression() );
+    exp.prepare( &context );
+    context.setFeature( results[0].mFeature );
+    QString featureTitle = exp.evaluate( &context ).toString();
     if ( featureTitle.isEmpty() )
       featureTitle = QStringLiteral( "%1" ).arg( results[0].mFeature.id() );
     layerAction = new QAction( QStringLiteral( "%1 (%2)" ).arg( layer->name(), featureTitle ), this );
@@ -304,7 +310,11 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
       // case 2b
       else
       {
-        QString featureTitle = results[0].mFeature.attribute( layer->displayField() ).toString();
+        QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+        QgsExpression exp( layer->displayExpression() );
+        exp.prepare( &context );
+        context.setFeature( results[0].mFeature );
+        QString featureTitle = exp.evaluate( &context ).toString();
         if ( featureTitle.isEmpty() )
           featureTitle = QStringLiteral( "%1" ).arg( results[0].mFeature.id() );
         layerMenu = new QMenu( QStringLiteral( "%1 (%2)" ).arg( layer->name(), featureTitle ), this );
@@ -364,7 +374,11 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
     }
 
     // feature title
-    QString featureTitle = result.mFeature.attribute( layer->displayField() ).toString();
+    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+    QgsExpression exp( layer->displayExpression() );
+    exp.prepare( &context );
+    context.setFeature( result.mFeature );
+    QString featureTitle = exp.evaluate( &context ).toString();
     if ( featureTitle.isEmpty() )
       featureTitle = QStringLiteral( "%1" ).arg( result.mFeature.id() );
 

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -279,15 +279,14 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
     }
   }
 
+  QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+  QgsExpression exp( layer->displayExpression() );
+  exp.prepare( &context );
+  context.setFeature( results[0].mFeature );
   // use a menu only if actions will be listed
   if ( !createMenu )
   {
     // case 1
-
-    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
-    QgsExpression exp( layer->displayExpression() );
-    exp.prepare( &context );
-    context.setFeature( results[0].mFeature );
     QString featureTitle = exp.evaluate( &context ).toString();
     if ( featureTitle.isEmpty() )
       featureTitle = QStringLiteral( "%1" ).arg( results[0].mFeature.id() );
@@ -310,10 +309,6 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
       // case 2b
       else
       {
-        QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
-        QgsExpression exp( layer->displayExpression() );
-        exp.prepare( &context );
-        context.setFeature( results[0].mFeature );
         QString featureTitle = exp.evaluate( &context ).toString();
         if ( featureTitle.isEmpty() )
           featureTitle = QStringLiteral( "%1" ).arg( results[0].mFeature.id() );
@@ -374,9 +369,6 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer *layer, const QList<QgsMapT
     }
 
     // feature title
-    QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
-    QgsExpression exp( layer->displayExpression() );
-    exp.prepare( &context );
     context.setFeature( result.mFeature );
     QString featureTitle = exp.evaluate( &context ).toString();
     if ( featureTitle.isEmpty() )


### PR DESCRIPTION
## Description
When an expression is filled in the display field, the identification menu always returns the ID of the clicked feature rather than the result of the expression.

In many projects we use expressions to clearly identify features, it's more readable than the ID. This PR fixes this problem.
