### PR TITLE
Make QgsExifTools QML friendly

### DIFF
--- a/python/analysis/auto_generated/raster/qgsexiftools.sip.in
+++ b/python/analysis/auto_generated/raster/qgsexiftools.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsExifTools
 {
 %Docstring
@@ -19,6 +20,9 @@ Contains utilities for working with EXIF tags in images.
 %TypeHeaderCode
 #include "qgsexiftools.h"
 %End
+  public:
+    static const QMetaObject staticMetaObject;
+
   public:
 
 
@@ -32,6 +36,13 @@ If the image contains an elevation tag then the returned point will contain
 the elevation as a z value.
 
 .. seealso:: :py:func:`geoTagImage`
+%End
+
+    static bool hasGeoTag( const QString &imagePath );
+%Docstring
+Returns ``True`` if the image at ``imagePath`` contains a valid geotag.
+
+.. seealso:: :py:func:`getGeoTag`
 %End
 
     class GeoTagDetails

--- a/src/analysis/raster/qgsexiftools.cpp
+++ b/src/analysis/raster/qgsexiftools.cpp
@@ -100,6 +100,13 @@ QString doubleToExifCoordinate( const double val )
   return QStringLiteral( "%1/1 %2/1 %3/1000" ).arg( degrees ).arg( minutes ).arg( seconds );
 }
 
+bool QgsExifTools::hasGeoTag( const QString &imagePath )
+{
+  bool ok = false;
+  QgsExifTools::getGeoTag( imagePath, ok );
+  return ok;
+}
+
 QgsPoint QgsExifTools::getGeoTag( const QString &imagePath, bool &ok )
 {
   ok = false;

--- a/src/analysis/raster/qgsexiftools.h
+++ b/src/analysis/raster/qgsexiftools.h
@@ -18,6 +18,8 @@
 
 #include "qgis_analysis.h"
 #include "qgspointxy.h"
+
+#include <QObject>
 #include <QString>
 #include <QVariant>
 #include <QVariantMap>
@@ -29,6 +31,8 @@
  */
 class ANALYSIS_EXPORT QgsExifTools
 {
+    Q_GADGET
+
   public:
 
 #if 0
@@ -46,6 +50,13 @@ class ANALYSIS_EXPORT QgsExifTools
      * \see geoTagImage()
      */
     static QgsPoint getGeoTag( const QString &imagePath, bool &ok SIP_OUT );
+
+    /**
+     * Returns TRUE if the image at \a imagePath contains a valid geotag.
+     *
+     * \see getGeoTag()
+     */
+    Q_INVOKABLE static bool hasGeoTag( const QString &imagePath );
 
     /**
      * Extended image geotag details.


### PR DESCRIPTION
## Description

This PR tweaks the useful QgsExifTools to make it QML-friendly, and adds a shortcut hasGeoTag() function that essentially calls getGeoTag(...) (which isn't callable via QML due to the presence of reference parameters).

@3nids , all good?