### PR TITLE
Fix build with txt2tags >= 3.5

### DIFF
--- a/cmake/Txt2Tags.cmake
+++ b/cmake/Txt2Tags.cmake
@@ -46,7 +46,7 @@ MACRO(ADD_TXT2TAGS_FILES _sources)
     ADD_CUSTOM_COMMAND(
       OUTPUT ${_out}
       COMMAND ${TXT2TAGS_EXECUTABLE}
-      ARGS --encoding=utf-8 -o${_out} -t txt ${_in}.tmp
+      ARGS -o${_out} -t txt ${_in}.tmp
       DEPENDS ${_in}
       COMMENT "Building ${_out} from ${_in}"
       )
@@ -54,7 +54,7 @@ MACRO(ADD_TXT2TAGS_FILES _sources)
     ADD_CUSTOM_COMMAND(
       OUTPUT ${_out}.html
       COMMAND ${TXT2TAGS_EXECUTABLE}
-      ARGS --encoding=utf-8 -o${_out}.html -t html ${_in}.tmp
+      ARGS -o${_out}.html -t html ${_in}.tmp
       DEPENDS ${_in}
       COMMENT "Building ${_out}.html from ${_in}"
       )

--- a/doc/INSTALL.t2t
+++ b/doc/INSTALL.t2t
@@ -11,7 +11,7 @@ Building QGIS from source - step by step
 %! PostProc(html):  \(R\)   &reg;
 % Next line will replace tabs with 2 spaces in txt generated outputs
 %! PostProc(txt): '(?i)(\t)' '  '
-%! encoding: iso-8859-1
+%! encoding: utf-8
 %
 % Tex processing
 %
@@ -36,7 +36,7 @@ Building QGIS from source - step by step
 %! PostProc(tex): NEWPAGE  '\\newpage'
 % Give alternating table rows different colors and use a smaller font in tables (\tiny)
 %! PostProc(tex): '\\begin{tabular}' '\\rowcolors{2}{tableShade}{white} \n\\tiny\\begin{tabular}'
-%! encoding: iso-8859-1
+%! encoding: utf-8
 
 %! PostProc(tex): WALLPAPER-IMAGE 'qgis-footer.png'
 % These are comments and will not be generated in any output

--- a/doc/NEWS.t2t
+++ b/doc/NEWS.t2t
@@ -10,7 +10,7 @@ Change history for the QGIS Project
 %! PostProc(html): '(?i)(</pre>)' '\1</div>'
 % Next line will replace tabs with 2 spaces in txt generated outputs
 %! PostProc(txt): '(?i)(\t)' '  '
-%! encoding: iso-8859-1
+%! encoding: utf-8
 %
 % These are comments and will not be generated in any output
 % -------------------

--- a/scripts/release.pl
+++ b/scripts/release.pl
@@ -182,8 +182,8 @@ run( "cp debian/changelog /tmp", "backup changelog failed" );
 unless( $dopoint ) {
 	run( "perl -i -pe 's/qgis-dev-deps/qgis-ltr-deps/;' doc/msvc.t2t", "could not update osgeo4w deps package" ) if $doltr;
 	run( "perl -i -pe 's/qgis-dev-deps/qgis-rel-deps/;' doc/msvc.t2t", "could not update osgeo4w deps package" ) unless $doltr;
-	run( "txt2tags --encoding=utf-8 -odoc/INSTALL.html -t html doc/INSTALL.t2t", "could not update INSTALL.html" );
-	run( "txt2tags --encoding=utf-8 -oINSTALL -t txt doc/INSTALL.t2t", "could not update INSTALL" );
+	run( "txt2tags -odoc/INSTALL.html -t html doc/INSTALL.t2t", "could not update INSTALL.html" );
+	run( "txt2tags -oINSTALL -t txt doc/INSTALL.t2t", "could not update INSTALL" );
 
 	run( "cp -v images/splash/splash-$newmajor.$newminor.png images/splash/splash.png", "splash png switch failed" );
 	run( "convert -resize 164x314 ms-windows/Installer-Files/WelcomeFinishPage-$newmajor.$newminor.png BMP3:ms-windows/Installer-Files/WelcomeFinishPage.bmp", "installer bitmap switch failed" );

--- a/scripts/update-news.pl
+++ b/scripts/update-news.pl
@@ -61,8 +61,8 @@ close $in;
 
 copy($tempfile, "doc/NEWS.t2t");
 
-system "txt2tags --encoding=utf-8 -odoc/NEWS.html -t html doc/NEWS.t2t";
-system "txt2tags --encoding=utf-8 -oNEWS -t txt doc/NEWS.t2t";
+system "txt2tags -odoc/NEWS.html -t html doc/NEWS.t2t";
+system "txt2tags -oNEWS -t txt doc/NEWS.t2t";
 
 =head1 NAME
 


### PR DESCRIPTION
## Description

txt2tags 3.5 dropped the encoding option. It's always UTF-8 now. https://github.com/txt2tags/txt2tags/blob/v3/CHANGELOG.md#35-2020-02-01

cc @rhurlin @sebastic 