### PR TITLE
Fixes empty tracebacks for user Python code

### DIFF
--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -92,10 +92,10 @@ class PYTHON_EXPORT QgsPythonUtils
     virtual bool runString( const QString &command, QString msgOnError = QString(), bool single = true ) = 0;
 
     /**
-     * Runs a Python \a command. No error reporting is not performed.
-     * \returns TRUE if no error occurred
+     * Runs a Python \a command.
+     * \returns empty QString if no error occurred, or Python traceback as a QString on error.
      */
-    virtual bool runStringUnsafe( const QString &command, bool single = true ) = 0;
+    virtual QString runStringUnsafe( const QString &command, bool single = true ) = 0;
 
     /**
      * Evaluates a Python \a command and stores the result in a the \a result string.

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -306,7 +306,7 @@ QString QgsPythonUtilsImpl::runStringUnsafe( const QString &command, bool single
   // (non-unicode strings can be mangled)
   PyObject *obj = PyRun_String( command.toUtf8().constData(), single ? Py_single_input : Py_file_input, mMainDict, mMainDict );
   PyObject *errobj = PyErr_Occurred();
-  if(nullptr != errobj)
+  if ( nullptr != errobj )
   {
     ret = getTraceback();
   }

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -294,30 +294,38 @@ void QgsPythonUtilsImpl::uninstallErrorHook()
   runString( QStringLiteral( "qgis.utils.uninstallErrorHook()" ) );
 }
 
-bool QgsPythonUtilsImpl::runStringUnsafe( const QString &command, bool single )
+QString QgsPythonUtilsImpl::runStringUnsafe( const QString &command, bool single )
 {
   // acquire global interpreter lock to ensure we are in a consistent state
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
+  QString ret;
 
   // TODO: convert special characters from unicode strings u"…" to \uXXXX
   // so that they're not mangled to utf-8
   // (non-unicode strings can be mangled)
   PyObject *obj = PyRun_String( command.toUtf8().constData(), single ? Py_single_input : Py_file_input, mMainDict, mMainDict );
-  bool res = nullptr == PyErr_Occurred();
+  PyObject *errobj = PyErr_Occurred();
+  if(nullptr != errobj)
+  {
+    ret = getTraceback();
+  }
   Py_XDECREF( obj );
 
   // we are done calling python API, release global interpreter lock
   PyGILState_Release( gstate );
 
-  return res;
+  return ret;
 }
 
 bool QgsPythonUtilsImpl::runString( const QString &command, QString msgOnError, bool single )
 {
-  bool res = runStringUnsafe( command, single );
-  if ( res )
+  bool res = true;
+  QString traceback = runStringUnsafe( command, single );
+  if ( traceback.isEmpty() )
     return true;
+  else
+    res = false;
 
   if ( msgOnError.isEmpty() )
   {
@@ -327,7 +335,6 @@ bool QgsPythonUtilsImpl::runString( const QString &command, QString msgOnError, 
 
   // TODO: use python implementation
 
-  QString traceback = getTraceback();
   QString path, version;
   evalString( QStringLiteral( "str(sys.path)" ), path );
   evalString( QStringLiteral( "sys.version" ), version );
@@ -352,10 +359,6 @@ QString QgsPythonUtilsImpl::getTraceback()
 {
 #define TRACEBACK_FETCH_ERROR(what) {errMsg = what; goto done;}
 
-  // acquire global interpreter lock to ensure we are in a consistent state
-  PyGILState_STATE gstate;
-  gstate = PyGILState_Ensure();
-
   QString errMsg;
   QString result;
 
@@ -364,7 +367,7 @@ QString QgsPythonUtilsImpl::getTraceback()
   PyObject *obStringIO = nullptr;
   PyObject *obResult = nullptr;
 
-  PyObject *type, *value, *traceback;
+  PyObject *type = nullptr, *value = nullptr, *traceback = nullptr;
 
   PyErr_Fetch( &type, &value, &traceback );
   PyErr_NormalizeException( &type, &value, &traceback );
@@ -422,9 +425,6 @@ done:
   Py_XDECREF( value );
   Py_XDECREF( traceback );
   Py_XDECREF( type );
-
-  // we are done calling python API, release global interpreter lock
-  PyGILState_Release( gstate );
 
   return result;
 }

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -44,7 +44,7 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     void exitPython() override;
     bool isEnabled() override;
     bool runString( const QString &command, QString msgOnError = QString(), bool single = true ) override;
-    bool runStringUnsafe( const QString &command, bool single = true ) override;
+    QString runStringUnsafe( const QString &command, bool single = true ) override; // returns error traceback on failure, empty QString on success
     bool evalString( const QString &command, QString &result ) override;
     bool getError( QString &errorClassName, QString &errorText ) override;
 


### PR DESCRIPTION
## Summary

Moving python traceback collection to within runStringUnsafe() so other
threads don't clear the global error status before we have a chance to
display it to users.

## Description

This fixes #34370, possibly #31235 (I cannot test on Mac OS) and old, old https://issues.qgis.org/issues/16923 from QGIS 2. As said in #34370 summary: 

> Windows users don't seem to have this problem. I believe that it is caused by the way threading works on Posix systems: in src/python/qgspythonutilsimpl.cpp, the method runString() calls runStringUnsafe(), which acquires then releases the GIL; if runStrtingUnsafe() returns error, runString() calls getTraceback(), which again acquires then releases the GIL, but by that time the error information is lost, the global error objects might have been cleared by some other thread, and all we get is nothingness.

This moves QgsPythonUtilsImpl::getTraceback() call from  QgsPythonUtilsImpl::runString() to  QgsPythonUtilsImpl::runStringUnsafe(), and changes the latter return type to QString so we can catch Python errors there, before releasing the GIL.

I believe this should be backported to older stable releases, since this issue has been reported so long, and it affects Posix users so much.

Fixes #34370
Fixes #31235
Fixes #34229 

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
