### PR TITLE
[edit widgets] Fix text edit right-click menu item background when widget is disabled 

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -258,7 +258,7 @@ void QgsTextEditWrapper::setEnabled( bool enabled )
       mLineEdit->setPalette( mReadOnlyPalette );
       // removing frame + setting transparent background to distinguish the readonly lineEdit from a normal one
       // did not get this working via the Palette:
-      mLineEdit->setStyleSheet( QStringLiteral( "background-color: rgba(255, 255, 255, 75%);" ) );
+      mLineEdit->setStyleSheet( QStringLiteral( "QLineEdit { background-color: rgba(255, 255, 255, 75%); }" ) );
     }
     mLineEdit->setFrame( enabled );
   }


### PR DESCRIPTION
## Description

This PR fixes issue #29542 . Long story short, applying hyper-generic stylesheet strings to widgets is a dangerous thing to do.

This supersedes PR #34359 .