### PR TITLE
WFS: support all GetFeature output formats for all layers

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -579,14 +579,6 @@ namespace QgsWfs
 
       layerElem.appendChild( operationsElement );
 
-      //create OutputFormats element
-      QDomElement outputFormatsElem = doc.createElement( QStringLiteral( "OutputFormats" ) );
-      QDomElement outputFormatElem = doc.createElement( QStringLiteral( "Format" ) );
-      QDomText outputFormatText = doc.createTextNode( QStringLiteral( "text/xml; subtype=gml/3.1.1" ) );
-      outputFormatElem.appendChild( outputFormatText );
-      outputFormatsElem.appendChild( outputFormatElem );
-      layerElem.appendChild( outputFormatsElem );
-
       //create WGS84BoundingBox
       QgsRectangle layerExtent = layer->extent();
       //transform the layers native CRS into WGS84

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -96,9 +96,6 @@ Content-Type: text/xml; charset=utf-8
     <Operation>Update</Operation>
     <Operation>Delete</Operation>
    </Operations>
-   <OutputFormats>
-    <Format>text/xml; subtype=gml/3.1.1</Format>
-   </OutputFormats>
    <ows:WGS84BoundingBox dimensions="2">
     <ows:LowerCorner>8.203459 44.901394</ows:LowerCorner>
     <ows:UpperCorner>8.203547 44.901483</ows:UpperCorner>


### PR DESCRIPTION
In the WFS capabilities response, we currently only advertise gml 3 as output format in the FeatureType section. Afaik we also support gml2 and json. If yes, my suggestion is to leave away the OutputFormat tag on feature type level. Like this, all the output types from the OperationsMetadata section above are considered to be supported by the layer. From the WFS 1.1. spec:

If this optional element is not specified, then all the result formats listed for the GetFeature operation are assumed to be supported.

There are probably some unit tests to be adapted. I'll wait for the travis output and will adapt the expected xml soon.
