### PR TITLE
[Processing] Fix isEnabled check for modeler context menu actions

### DIFF
--- a/python/plugins/processing/modeler/DeleteModelAction.py
+++ b/python/plugins/processing/modeler/DeleteModelAction.py
@@ -23,7 +23,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 import os
 from qgis.core import (QgsApplication,
-                       QgsProcessingModelAlgorithm,
+                       QgsProcessingAlgorithm,
                        QgsProject)
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.PyQt.QtCore import QCoreApplication
@@ -38,7 +38,7 @@ class DeleteModelAction(ContextAction):
         self.name = QCoreApplication.translate('DeleteModelAction', 'Delete Model…')
 
     def isEnabled(self):
-        return isinstance(self.itemData, QgsProcessingModelAlgorithm)
+        return isinstance(self.itemData, QgsProcessingAlgorithm) and self.itemData.provider().id() == "model"
 
     def execute(self):
         model = self.itemData

--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -22,7 +22,7 @@ __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
 from qgis.PyQt.QtCore import QCoreApplication
-from qgis.core import QgsApplication, QgsProcessingModelAlgorithm, QgsMessageLog
+from qgis.core import QgsApplication, QgsProcessingAlgorithm
 from processing.gui.ContextAction import ContextAction
 from processing.modeler.ModelerDialog import ModelerDialog
 from qgis.core import Qgis
@@ -36,7 +36,7 @@ class EditModelAction(ContextAction):
         self.name = QCoreApplication.translate('EditModelAction', 'Edit Model…')
 
     def isEnabled(self):
-        return isinstance(self.itemData, QgsProcessingModelAlgorithm)
+        return isinstance(self.itemData, QgsProcessingAlgorithm) and self.itemData.provider().id() == "model"
 
     def execute(self):
         alg = self.itemData

--- a/python/plugins/processing/modeler/ExportModelAsPythonScriptAction.py
+++ b/python/plugins/processing/modeler/ExportModelAsPythonScriptAction.py
@@ -22,7 +22,7 @@ __date__ = 'February 2019'
 __copyright__ = '(C) 2019, Nyall Dawson'
 
 from qgis.PyQt.QtCore import QCoreApplication
-from qgis.core import QgsProcessingModelAlgorithm, QgsProcessing, QgsApplication
+from qgis.core import QgsProcessingAlgorithm, QgsProcessing, QgsApplication
 from processing.gui.ContextAction import ContextAction
 from processing.script.ScriptEditorDialog import ScriptEditorDialog
 
@@ -34,7 +34,7 @@ class ExportModelAsPythonScriptAction(ContextAction):
         self.name = QCoreApplication.translate('ExportModelAsPythonScriptAction', 'Export Model as Python Algorithm…')
 
     def isEnabled(self):
-        return isinstance(self.itemData, QgsProcessingModelAlgorithm)
+        return isinstance(self.itemData, QgsProcessingAlgorithm) and self.itemData.provider().id() == "model"
 
     def icon(self):
         return QgsApplication.getThemeIcon('/mActionSaveAsPython.svg')


### PR DESCRIPTION
## Description

This aligns the check with [Processing scripts context menu actions](https://github.com/qgis/QGIS/blob/d969e41799fc2176d612a6572d2bf4890ac0edb6/python/plugins/processing/script/EditScriptAction.py#L43-L44) and allows subclasses of QgsProcessingModelAlgorithm to register their own actions.

The PR is suitable for backporting to 3.10.
