### PR TITLE
Fix spatialite crash on field added

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -1024,6 +1024,11 @@ QVariant QgsSpatiaLiteProvider::defaultValue( int fieldId ) const
 
 QString QgsSpatiaLiteProvider::defaultValueClause( int fieldIndex ) const
 {
+  if ( ! mAttributeFields.exists( fieldIndex ) )
+  {
+    return QString();
+  }
+
   if ( mAttributeFields.at( fieldIndex ).name() == mPrimaryKey && mPrimaryKeyAutoIncrement )
   {
     return tr( "Autogenerate" );


### PR DESCRIPTION
Fixes #34375

Add a check for the field index validity, but the issue was really
an undesired side effect of the spaghetti-signal-slot hell.
