### PR TITLE
[backport 3.10] Fix parentheses in QgsExpression::dump()

### DIFF
--- a/src/core/expression/qgsexpressionnodeimpl.cpp
+++ b/src/core/expression/qgsexpressionnodeimpl.cpp
@@ -124,7 +124,10 @@ bool QgsExpressionNodeUnaryOperator::prepareNode( QgsExpression *parent, const Q
 
 QString QgsExpressionNodeUnaryOperator::dump() const
 {
-  return QStringLiteral( "%1 %2" ).arg( UNARY_OPERATOR_TEXT[mOp], mOperand->dump() );
+  if ( dynamic_cast<QgsExpressionNodeBinaryOperator *>( mOperand ) )
+    return QStringLiteral( "%1 ( %2 )" ).arg( UNARY_OPERATOR_TEXT[mOp], mOperand->dump() );
+  else
+    return QStringLiteral( "%1 %2" ).arg( UNARY_OPERATOR_TEXT[mOp], mOperand->dump() );
 }
 
 QSet<QString> QgsExpressionNodeUnaryOperator::referencedColumns() const

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -463,6 +463,25 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
                                           "<Literal>+2</Literal>"
                                           "</PropertyIsEqualTo></Filter>" )
                                         << QStringLiteral( "LITERAL = '+2'" );
+
+  QTest::newRow( "not or list" ) << QStringLiteral( "<ogc:Filter xmlns:ogc=\"http://www.opengis.net/ogc\">"
+                                 "<ogc:Not>"
+                                 " <ogc:Or>"
+                                 "  <ogc:PropertyIsEqualTo>"
+                                 "   <ogc:PropertyName>A</ogc:PropertyName>"
+                                 "   <ogc:Literal>1</ogc:Literal>"
+                                 "  </ogc:PropertyIsEqualTo>"
+                                 "  <ogc:PropertyIsEqualTo>"
+                                 "   <ogc:PropertyName>A</ogc:PropertyName>"
+                                 "   <ogc:Literal>2</ogc:Literal>"
+                                 "  </ogc:PropertyIsEqualTo>"
+                                 "  <ogc:PropertyIsEqualTo>"
+                                 "   <ogc:PropertyName>A</ogc:PropertyName>"
+                                 "   <ogc:Literal>3</ogc:Literal>"
+                                 "  </ogc:PropertyIsEqualTo>"
+                                 " </ogc:Or>"
+                                 "</ogc:Not>"
+                                 "</ogc:Filter>" ) << QStringLiteral( "NOT ( A = 1 OR A = 2 OR A = 3 )" );
 }
 
 void TestQgsOgcUtils::testExpressionFromOgcFilter()


### PR DESCRIPTION
QgsExpression('NOT (1 or 2 or 3)').dump() previously returned 'NOT 1 or 2 or 3'.

This is especially painful since QGIS as WFS client translates 'attribute NOT IN (1, 2, 3)' to an ogc filter of the form 'NOT ( attribute = 1 or attribute = 2 or attribute = 3 )' which would be translated back to a faulty expression on the wfs server.

Backport of #34420 