### PR TITLE
[Bugfix] Read SLD TextSymbolizer PointPlacement for lines

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4620,7 +4620,7 @@ bool QgsVectorLayer::readSldTextSymbolizer( const QDomNode &node, QgsPalLayerSet
       settings.placement = QgsPalLayerSettings::OverPoint;
       if ( geometryType() == QgsWkbTypes::LineGeometry )
       {
-        settings.placement = QgsPalLayerSettings::Line;
+        settings.placement = QgsPalLayerSettings::Horizontal;
       }
 
       QDomElement displacementElem = pointPlacementElem.firstChildElement( QStringLiteral( "Displacement" ) );


### PR DESCRIPTION
## Description
For lines, if labeling palcement is horizontal, the TextSymbolizer will contain PointPlacement instead of LinePlacement.

It completes  #34223