### PR TITLE
When showing original path in the "Select a Data Source" dialog allow the original path text to be selected and copied

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -209,6 +209,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsfieldcalculator.h"
 #include "qgsfieldformatter.h"
 #include "qgsfieldformatterregistry.h"
+#include "qgsfileutils.h"
 #include "qgsformannotation.h"
 #include "qgsgeos.h"
 #include "qgsguiutils.h"
@@ -7702,7 +7703,17 @@ void QgisApp::changeDataSource( QgsMapLayer *layer )
   QgsMapLayerType layerType( layer->type() );
 
   QgsDataSourceSelectDialog dlg( mBrowserModel, true, layerType );
-  dlg.setDescription( tr( "Original source URI: %1" ).arg( layer->publicSource() ) );
+
+  const QVariantMap sourceParts = QgsProviderRegistry::instance()->decodeUri( layer->providerType(), layer->publicSource() );
+  QString source = layer->publicSource();
+  if ( sourceParts.contains( QStringLiteral( "path" ) ) )
+  {
+    const QString path = sourceParts.value( QStringLiteral( "path" ) ).toString();
+    const QString closestPath = QFile::exists( path ) ? path : QgsFileUtils::findClosestExistingPath( path );
+    source.replace( path, QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( closestPath ).toString(),
+                    path ) );
+  }
+  dlg.setDescription( tr( "Original source URI: %1" ).arg( source ) );
 
   const QVariantMap originalSourceParts = QgsProviderRegistry::instance()->decodeUri( layer->providerType(), layer->source() );
 

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -22,9 +22,11 @@
 #include "qgsgui.h"
 #include "qgsguiutils.h"
 #include "qgssettings.h"
+#include "qgsnative.h"
 
 #include <QPushButton>
 #include <QMenu>
+#include <QDesktopServices>
 
 QgsDataSourceSelectDialog::QgsDataSourceSelectDialog(
   QgsBrowserGuiModel *browserModel,
@@ -166,6 +168,16 @@ void QgsDataSourceSelectDialog::setDescription( const QString &description )
       mDescriptionLabel = new QLabel();
       mDescriptionLabel->setWordWrap( true );
       mDescriptionLabel->setMargin( 4 );
+      mDescriptionLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
+      connect( mDescriptionLabel, &QLabel::linkActivated, this, [ = ]( const QString & link )
+      {
+        QUrl url( link );
+        QFileInfo file( url.toLocalFile() );
+        if ( file.exists() && !file.isDir() )
+          QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
+        else
+          QDesktopServices::openUrl( url );
+      } );
       verticalLayout->insertWidget( 1, mDescriptionLabel );
     }
     mDescriptionLabel->setText( description );


### PR DESCRIPTION
... and make the original path a hyperlink to open the corresponding folder

Makes it much easier for users to find the correct fixed paths,
e.g. by allowing them to use OS level find files functionality
