### PR TITLE
GDAL: make sure we are not reading outside the raster

### DIFF
--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -124,11 +124,18 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
     }
   }
 
+  // Check if we need to read the raster as a whole (which is memory inefficient
+  // and not interruptible by the user) by checking if any raster matrix nodes are
+  // in the expression
+  bool requiresMatrix = ! calcNode->findNodes( QgsRasterCalcNode::Type::tMatrix ).isEmpty();
+
 #ifdef HAVE_OPENCL
   // Check for matrix nodes, GPU implementation does not support them
   QList<const QgsRasterCalcNode *> nodeList;
-  if ( QgsOpenClUtils::enabled() && QgsOpenClUtils::available() && calcNode->findNodes( QgsRasterCalcNode::Type::tMatrix ).isEmpty() )
+  if ( QgsOpenClUtils::enabled() && QgsOpenClUtils::available() && ! requiresMatrix )
+  {
     return processCalculationGPU( std::move( calcNode ), feedback );
+  }
 #endif
 
   //open output dataset for writing
@@ -152,10 +159,6 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
   float outputNodataValue = -FLT_MAX;
   GDALSetRasterNoDataValue( outputRasterBand, outputNodataValue );
 
-  // Check if we need to read the raster as a whole (which is memory inefficient
-  // and not interruptible by the user) by checking if any raster matrix nodes are
-  // in the expression
-  bool requiresMatrix = ! calcNode->findNodes( QgsRasterCalcNode::Type::tMatrix ).isEmpty();
 
   // Take the fast route (process one line at a time) if we can
   if ( ! requiresMatrix )
@@ -528,9 +531,13 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculationGPU( std::uni
 
     GDALSetProjection( outputDataset.get(), mOutputCrs.toWkt( QgsCoordinateReferenceSystem::WKT2_2018 ).toLocal8Bit().data() );
 
+
     GDALRasterBandH outputRasterBand = GDALGetRasterBand( outputDataset.get(), 1 );
     if ( !outputRasterBand )
       return BandError;
+
+    float outputNodataValue = -FLT_MAX;
+    GDALSetRasterNoDataValue( outputRasterBand, outputNodataValue );
 
     // Input block (buffer)
     std::unique_ptr<QgsRasterBlock> block;

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -853,6 +853,11 @@ bool QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &extent, int pi
     srcBottom = static_cast<int>( std::floor( -1. * ( mExtent.yMaximum() - rasterExtent.yMinimum() ) / srcYRes ) );
   }
 
+  // srcBottom must be less than raster height or we'll get a raster I/O error,
+  // this may happen because of rounding errors with the floating point operations used above
+  // See: issue GH #34435
+  srcBottom = std::min( mHeight - 1, srcBottom );
+
   QgsDebugMsgLevel( QStringLiteral( "srcTop = %1 srcBottom = %2 srcLeft = %3 srcRight = %4" ).arg( srcTop ).arg( srcBottom ).arg( srcLeft ).arg( srcRight ), 5 );
 
   int srcWidth = srcRight - srcLeft + 1;

--- a/tests/src/python/test_provider_gdal.py
+++ b/tests/src/python/test_provider_gdal.py
@@ -10,9 +10,17 @@ __author__ = 'Nyall Dawson'
 __date__ = '2018-30-10'
 __copyright__ = 'Copyright 2018, Nyall Dawson'
 
-from qgis.core import (QgsProviderRegistry,
-                       QgsDataProvider)
+import os
+
+from qgis.core import (
+    QgsProviderRegistry,
+    QgsDataProvider,
+    QgsRasterLayer,
+    QgsRectangle,
+)
 from qgis.testing import start_app, unittest
+
+from qgis.PyQt.QtGui import qRed
 
 from utilities import unitTestDataPath
 
@@ -22,10 +30,56 @@ TEST_DATA_DIR = unitTestDataPath()
 
 class PyQgsGdalProvider(unittest.TestCase):
 
+    def checkBlockContents(self, block, expected):
+        res = []
+        for r in range(block.height()):
+            res.extend([block.value(r, c) for c in range(block.width())])
+        self.assertEqual(res, expected)
+
     def testCapabilities(self):
         self.assertTrue(QgsProviderRegistry.instance().providerCapabilities("gdal") & QgsDataProvider.File)
         self.assertTrue(QgsProviderRegistry.instance().providerCapabilities("gdal") & QgsDataProvider.Dir)
         self.assertTrue(QgsProviderRegistry.instance().providerCapabilities("gdal") & QgsDataProvider.Net)
+
+    def testRasterBlock(self):
+        """Test raster block with extent"""
+
+        path = os.path.join(unitTestDataPath(), 'landsat_4326.tif')
+        raster_layer = QgsRasterLayer(path, 'test')
+        self.assertTrue(raster_layer.isValid())
+
+        extent = QgsRectangle(17.94284482577178252, 30.23021770271909503, 17.94407867909909626, 30.23154272264058307)
+        block = raster_layer.dataProvider().block(1, extent, 2, 3)
+        self.checkBlockContents(block, [
+            125.0, 125.0,
+            125.0, 125.0,
+            125.0, 124.0,
+        ])
+
+        full_content = [
+            125.0, 125.0, 125.0,
+            125.0, 125.0, 125.0,
+            125.0, 124.0, 125.0,
+            126.0, 127.0, 127.0,
+        ]
+
+        extent = raster_layer.extent()
+        block = raster_layer.dataProvider().block(1, extent, 3, 4)
+        self.checkBlockContents(block, full_content)
+
+        extent = raster_layer.extent()
+        extent.grow(-0.0001)
+        block = raster_layer.dataProvider().block(1, extent, 3, 4)
+        self.checkBlockContents(block, full_content)
+
+        row_height = raster_layer.extent().height() / raster_layer.height()
+
+        for row in range(raster_layer.height()):
+            extent = raster_layer.extent()
+            extent.setYMaximum(extent.yMaximum() - row_height * row)
+            extent.setYMinimum(extent.yMaximum() - row_height)
+            block = raster_layer.dataProvider().block(1, extent, 3, 1)
+            self.checkBlockContents(block, full_content[row * 3:row * 3 + 3])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #34435

Unfortunately I wasn't able to write a test for this
case: it seems to be related to a very rare combination
of floating point (double) rounding issues that I could
only reproduce manually.

But since I was trying to test it and I wrote some
raster block test cases, I thought it would be good
to leave them in the PR instead of throwing them
away.

The changes in the raster calculator are not strictly related 
but they make the GPU and CPU path behave the same as
far as nodata are concerned, as was pointed out in  
#34435, the behavior was different (the CPU path was the 
good one).
