### PR TITLE
fix warning, change Qt version for deprecated Qt3DRender::QBuffer

### DIFF
--- a/src/3d/chunks/qgschunkboundsentity_p.cpp
+++ b/src/3d/chunks/qgschunkboundsentity_p.cpp
@@ -26,7 +26,7 @@
 LineMeshGeometry::LineMeshGeometry( Qt3DCore::QNode *parent )
   : Qt3DRender::QGeometry( parent )
   , mPositionAttribute( new Qt3DRender::QAttribute( this ) )
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   , mVertexBuffer( new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this ) )
 #else
   , mVertexBuffer( new Qt3DRender::QBuffer( this ) )

--- a/src/3d/mesh/qgsmesh3dgeometry_p.cpp
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.cpp
@@ -281,7 +281,7 @@ void QgsMesh3dGeometry::init()
   mTexCoordAttribute = new QAttribute( this );
   mIndexAttribute = new QAttribute( this );
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   mVertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
   mIndexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, this );
 #else

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -28,7 +28,7 @@
 QgsTessellatedPolygonGeometry::QgsTessellatedPolygonGeometry( QNode *parent )
   : Qt3DRender::QGeometry( parent )
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   mVertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
 #else
   mVertexBuffer = new Qt3DRender::QBuffer( this );

--- a/src/3d/symbols/qgsbillboardgeometry.cpp
+++ b/src/3d/symbols/qgsbillboardgeometry.cpp
@@ -20,7 +20,7 @@
 QgsBillboardGeometry::QgsBillboardGeometry( Qt3DCore::QNode *parent )
   : Qt3DRender::QGeometry( parent )
   , mPositionAttribute( new Qt3DRender::QAttribute( this ) )
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   , mVertexBuffer( new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this ) )
 #else
   , mVertexBuffer( new Qt3DRender::QBuffer( this ) )

--- a/src/3d/symbols/qgslinevertexdata_p.cpp
+++ b/src/3d/symbols/qgslinevertexdata_p.cpp
@@ -70,14 +70,14 @@ QByteArray QgsLineVertexData::createIndexBuffer()
 
 Qt3DRender::QGeometry *QgsLineVertexData::createGeometry( Qt3DCore::QNode *parent )
 {
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   Qt3DRender::QBuffer *vertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, parent );
 #else
   Qt3DRender::QBuffer *vertexBuffer = new Qt3DRender::QBuffer( parent );
 #endif
   vertexBuffer->setData( createVertexBuffer() );
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   Qt3DRender::QBuffer *indexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, parent );
 #else
   Qt3DRender::QBuffer *indexBuffer = new Qt3DRender::QBuffer( parent );

--- a/src/3d/symbols/qgspoint3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspoint3dsymbol_p.cpp
@@ -229,7 +229,7 @@ Qt3DRender::QGeometryRenderer *QgsInstancedPoint3DSymbolHandler::renderer( const
   ba.resize( byteCount );
   memcpy( ba.data(), positions.constData(), byteCount );
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   Qt3DRender::QBuffer *instanceBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer );
 #else
   Qt3DRender::QBuffer *instanceBuffer = new Qt3DRender::QBuffer();

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.cpp
@@ -356,7 +356,7 @@ void DemTerrainTileGeometry::init()
   mNormalAttribute = new QAttribute( this );
   mTexCoordAttribute = new QAttribute( this );
   mIndexAttribute = new QAttribute( this );
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   mVertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
   mIndexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, this );
 #else

--- a/src/3d/terrain/quantizedmeshgeometry.cpp
+++ b/src/3d/terrain/quantizedmeshgeometry.cpp
@@ -329,11 +329,15 @@ QuantizedMeshGeometry::QuantizedMeshGeometry( QuantizedMeshTile *t, const Map3D 
     ibptr[i*3+2] = srcptr[i*3];
   }
   */
-
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   m_vertexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::VertexBuffer, this );
-  m_vertexBuffer->setData( vb );
-
   m_indexBuffer = new Qt3DRender::QBuffer( Qt3DRender::QBuffer::IndexBuffer, this );
+#else
+  m_vertexBuffer = new Qt3DRender::QBuffer( this );
+  m_indexBuffer = new Qt3DRender::QBuffer( this );
+#endif
+
+  m_vertexBuffer->setData( vb );
   m_indexBuffer->setData( ib );
 
   m_positionAttribute = new Qt3DRender::QAttribute( this );


### PR DESCRIPTION
In 3D, Qt version is check for deprecated QBuffer constructor. The checked version was 5.13 while this constructor is deprecated since 5.10. That leads to warning when building with version >= 5.10 and <5.13.
