### PR TITLE
Fix Task manager race conditions issues

### DIFF
--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -91,7 +91,9 @@ void QgsTask::cancel()
   if ( mOverallStatus == Complete || mOverallStatus == Terminated )
     return;
 
+  mShouldTerminateMutex.lock();
   mShouldTerminate = true;
+  mShouldTerminateMutex.unlock();
   if ( mStatus == Queued || mStatus == OnHold )
   {
     // immediately terminate unstarted jobs
@@ -109,6 +111,12 @@ void QgsTask::cancel()
   {
     subTask.task->cancel();
   }
+}
+
+bool QgsTask::isCanceled() const
+{
+  QMutexLocker locker( &mShouldTerminateMutex );
+  return mShouldTerminate;
 }
 
 void QgsTask::hold()

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -264,7 +264,7 @@ void QgsTask::setProgress( double progress )
 void QgsTask::completed()
 {
   mStatus = Complete;
-  QMetaObject::invokeMethod( this, &QgsTask::processSubTasksForCompletion, Qt::AutoConnection );
+  QMetaObject::invokeMethod( this, "processSubTasksForCompletion" );
 }
 
 void QgsTask::processSubTasksForCompletion()
@@ -350,7 +350,7 @@ void QgsTask::processSubTasksForHold()
 void QgsTask::terminated()
 {
   mStatus = Terminated;
-  QMetaObject::invokeMethod( this, &QgsTask::processSubTasksForTermination, Qt::AutoConnection );
+  QMetaObject::invokeMethod( this, "processSubTasksForTermination" );
 }
 
 

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -36,7 +36,8 @@ QgsTask::QgsTask( const QString &name, Flags flags )
 QgsTask::~QgsTask()
 {
   Q_ASSERT_X( mStatus != Running, "delete", QStringLiteral( "status was %1" ).arg( mStatus ).toLatin1() );
-  mNotFinishedMutex.tryLock(); // we're not guaranteed to already have the lock in place here
+  // even here we are not sure that task start method has ended
+  mNotFinishedMutex.lock();
   const auto constMSubTasks = mSubTasks;
   for ( const SubTask &subTask : constMSubTasks )
   {

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -58,7 +58,7 @@ qint64 QgsTask::elapsedTime() const
 
 void QgsTask::start()
 {
-  mNotFinishedMutex.lock();
+  QMutexLocker locker( &mNotFinishedMutex );
   mNotStartedMutex.release();
   mStartCount++;
   Q_ASSERT( mStartCount == 1 );
@@ -256,7 +256,6 @@ void QgsTask::completed()
 {
   mStatus = Complete;
   QMetaObject::invokeMethod( this, &QgsTask::processSubTasksForCompletion, Qt::AutoConnection );
-  mNotFinishedMutex.unlock();
 }
 
 void QgsTask::processSubTasksForCompletion()
@@ -343,7 +342,6 @@ void QgsTask::terminated()
 {
   mStatus = Terminated;
   QMetaObject::invokeMethod( this, &QgsTask::processSubTasksForTermination, Qt::AutoConnection );
-  mNotFinishedMutex.unlock();
 }
 
 

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -282,7 +282,7 @@ class CORE_EXPORT QgsTask : public QObject
      * flag, then derived classes' run() methods should periodically check this and
      * terminate in a safe manner.
      */
-    bool isCanceled() const { return mShouldTerminate; }
+    bool isCanceled() const;
 
   protected slots:
 
@@ -322,6 +322,7 @@ class CORE_EXPORT QgsTask : public QObject
     //! Overall progress of this task and all subtasks
     double mTotalProgress = 0.0;
     bool mShouldTerminate = false;
+    mutable QMutex mShouldTerminateMutex;
     int mStartCount = 0;
 
     struct SubTask

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -357,15 +357,18 @@ class CORE_EXPORT QgsTask : public QObject
      */
     void terminated();
 
-    void processSubTasksForCompletion();
-
-    void processSubTasksForTermination();
 
     void processSubTasksForHold();
 
     friend class QgsTaskManager;
     friend class QgsTaskRunnableWrapper;
     friend class TestQgsTaskManager;
+
+  private slots:
+
+    void processSubTasksForCompletion();
+
+    void processSubTasksForTermination();
 
 };
 

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -133,9 +133,6 @@ class CancelableTask : public QgsTask
     ~CancelableTask() override
     {
       qDebug() << "deleting task " << description();
-
-      int i = 1;
-      i++;
     }
 
   protected:

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -1016,7 +1016,7 @@ void TestQgsTaskManager::progressChanged()
   flushEvents();
   QCOMPARE( spy.count(), 3 );
   QCOMPARE( spy.last().at( 0 ).toLongLong(), 1LL );
-  QCOMPARE( spy.last().at( 1 ).toDouble(), 100 );
+  QCOMPARE( spy.last().at( 1 ).toDouble(), 100.0 );
   QCOMPARE( task2->status(), QgsTask::Running );
   task2->emitProgressChanged( 80.0 );
   while ( spy.count() == 3 )

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -44,7 +44,6 @@ class TestTask : public QgsTask
       qDebug() << "deleting task " << description();
     }
 
-    void emitProgressChanged( double progress ) { setProgress( progress ); }
     void emitTaskStopped() {  }
     void emitTaskCompleted() { }
 
@@ -76,22 +75,56 @@ class ProgressReportingTask : public QgsTask
       qDebug() << "deleting task " << description();
     }
 
-    void emitProgressChanged( double progress ) { setProgress( progress ); }
+    void emitProgressChanged( double progress )
+    {
+      QMutexLocker locker( &mProgressMutex );
+      mProgress.append( progress );
+    }
 
     bool finished =  false ;
     bool terminated =  false ;
 
   public slots:
-    void finish() { finished = true; }
-    void terminate() { terminated = true; }
+
+    void finish()
+    {
+      QMutexLocker locker( &mCompletedMutex );
+      finished = true;
+    }
+
+    void terminate()
+    {
+      QMutexLocker locker( &mCompletedMutex );
+      terminated = true;
+    }
 
   protected:
 
     bool run() override
     {
-      while ( !finished && !terminated && !isCanceled() ) {}
+      while ( true )
+      {
+        mCompletedMutex.lock();
+        if ( finished || terminated || isCanceled() )
+        {
+          mCompletedMutex.unlock();
+          return finished;
+        }
+        mCompletedMutex.unlock();
+
+        QMutexLocker locker( &mProgressMutex );
+        while ( !mProgress.isEmpty() )
+        {
+          setProgress( mProgress.takeFirst() );
+        }
+      }
+
       return finished;
     }
+
+    QList<double> mProgress;
+    QMutex mProgressMutex;
+    QMutex mCompletedMutex;
 
 };
 
@@ -240,6 +273,8 @@ void flushEvents()
 
 class WaitTask : public QgsTask
 {
+    Q_OBJECT
+
   public:
 
     WaitTask( const QString &desc = QString() ) : QgsTask( desc )
@@ -275,7 +310,14 @@ class TestQgsTaskManager : public QObject
     void task();
     void taskResult();
     void taskFinished();
-    void subTask();
+    void subTaskSimple();
+    void subTaskGrandChildren();
+    void subTaskProgress();
+    void subTaskCancelParent();
+    void subTaskTerminateSubTask();
+    void subTaskPartialComplete();
+    void subTaskPartialComplete2();
+
     void addTask();
     void taskTerminationBeforeDelete();
     void taskId();
@@ -531,10 +573,8 @@ void TestQgsTaskManager::taskFinished()
   QCOMPARE( resultObtained, false );
 }
 
-void TestQgsTaskManager::subTask()
+void TestQgsTaskManager::subTaskSimple()
 {
-  QgsTaskManager manager;
-
   // parent with one subtask
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_1" ) );
   QPointer<ProgressReportingTask> subTask( new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_1" ) ) );
@@ -544,10 +584,13 @@ void TestQgsTaskManager::subTask()
   // subtask should be deleted with parent
   delete parent;
   QVERIFY( !subTask.data() );
+}
 
+void TestQgsTaskManager::subTaskGrandChildren()
+{
   // parent with grand children
-  parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_2" ) );
-  subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_2" ) );
+  ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_2" ) );
+  QPointer<ProgressReportingTask> subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_2" ) );
   QPointer< ProgressReportingTask> subsubTask( new ProgressReportingTask( QStringLiteral( "sub_task_subsub_task_2" ) ) );
   subTask->addSubTask( subsubTask );
   parent->addSubTask( subTask );
@@ -555,10 +598,19 @@ void TestQgsTaskManager::subTask()
   delete parent;
   QVERIFY( !subTask.data() );
   QVERIFY( !subsubTask.data() );
+}
+
+void TestQgsTaskManager::subTaskProgress()
+{
+  // we need 3 threads to run this test (one for each task)
+  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
+  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+
+  QgsTaskManager manager;
 
   // test parent task progress
-  parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_3" ) );
-  subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_3" ) );
+  ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_3" ) );
+  QPointer<ProgressReportingTask> subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_3" ) );
   QPointer< ProgressReportingTask > subTask2( new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_3a" ) ) );
 
   parent->addSubTask( subTask );
@@ -566,23 +618,33 @@ void TestQgsTaskManager::subTask()
 
   manager.addTask( parent );
   while ( parent->status() != QgsTask::Running
-          && subTask->status() != QgsTask::Running
-          && subTask2->status() != QgsTask::Running )
+          || subTask->status() != QgsTask::Running
+          || subTask2->status() != QgsTask::Running )
   {
     QCoreApplication::processEvents();
   }
   flushEvents();
 
   // test progress calculation
+  flushEvents();
   QSignalSpy spy( parent, &QgsTask::progressChanged );
   parent->emitProgressChanged( 50 );
-  flushEvents();
+  while ( spy.count() == 0 )
+  {
+    QCoreApplication::processEvents();
+  }
+
   QCOMPARE( std::round( parent->progress() ), 17.0 );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( std::round( spy.last().at( 0 ).toDouble() ), 17.0 );
 
   subTask->emitProgressChanged( 100 );
   flushEvents();
+  while ( spy.count() == 1 )
+  {
+    QCoreApplication::processEvents();
+  }
+
   QCOMPARE( std::round( parent->progress() ), 50.0 );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( std::round( spy.last().at( 0 ).toDouble() ), 50.0 );
@@ -598,16 +660,23 @@ void TestQgsTaskManager::subTask()
   QCOMPARE( std::round( spy.last().at( 0 ).toDouble() ), 83.0 );
 
   parent->emitProgressChanged( 100 );
+  while ( spy.count() != 4 )
+  {
+    QCoreApplication::processEvents();
+  }
+
   QCOMPARE( std::round( parent->progress() ), 100.0 );
-  QCOMPARE( spy.count(), 4 );
   QCOMPARE( std::round( spy.last().at( 0 ).toDouble() ), 100.0 );
   parent->terminate();
   subTask->terminate();
+}
 
+void TestQgsTaskManager::subTaskCancelParent()
+{
   // test canceling task with subtasks
-  parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_4" ) );
-  subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_4" ) );
-  subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_4" ) );
+  ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_4" ) );
+  QPointer<ProgressReportingTask> subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_4" ) );
+  QPointer<ProgressReportingTask> subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_4" ) );
   subTask->addSubTask( subsubTask );
   parent->addSubTask( subTask );
 
@@ -617,18 +686,27 @@ void TestQgsTaskManager::subTask()
   QCOMPARE( parent->status(), QgsTask::Terminated );
 
   delete parent;
+}
+
+void TestQgsTaskManager::subTaskTerminateSubTask()
+{
+  // we need 3 threads to run this test (one for each task)
+  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
+  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+
+  QgsTaskManager manager;
 
   // test that if a subtask terminates the parent task is canceled
-  parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_5" ) );
-  subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_5" ) );
-  subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_5" ) );
+  ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_5" ) );
+  QPointer<ProgressReportingTask> subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_5" ) );
+  QPointer<ProgressReportingTask> subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_5" ) );
   subTask->addSubTask( subsubTask );
   parent->addSubTask( subTask );
 
   manager.addTask( parent );
   while ( subsubTask->status() != QgsTask::Running
-          && subTask->status() != QgsTask::Running
-          && parent->status() != QgsTask::Running )
+          || subTask->status() != QgsTask::Running
+          || parent->status() != QgsTask::Running )
   {
     QCoreApplication::processEvents();
   }
@@ -648,17 +726,26 @@ void TestQgsTaskManager::subTask()
   QVERIFY( parentTerminated.count() > 0 );
   QVERIFY( subTerminated.count() > 0 );
   QVERIFY( subsubTerminated.count() > 0 );
+}
+
+void TestQgsTaskManager::subTaskPartialComplete()
+{
+  // we need 3 threads to run this test (one for each task)
+  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
+  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+
+  QgsTaskManager manager;
 
   // test that a task is not marked complete until all subtasks are complete
-  parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_6" ) );
-  subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_6" ) );
-  subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_6" ) );
+  ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_6" ) );
+  QPointer<ProgressReportingTask> subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_6" ) );
+  QPointer<ProgressReportingTask> subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_6" ) );
   subTask->addSubTask( subsubTask );
   parent->addSubTask( subTask );
   manager.addTask( parent );
   while ( subsubTask->status() != QgsTask::Running
-          && subTask->status() != QgsTask::Running
-          && parent->status() != QgsTask::Running )
+          || subTask->status() != QgsTask::Running
+          || parent->status() != QgsTask::Running )
   {
     QCoreApplication::processEvents();
   }
@@ -689,10 +776,20 @@ void TestQgsTaskManager::subTask()
   QVERIFY( subFinished.count() > 0 );
   QVERIFY( subsubFinished.count() > 0 );
 
+}
+
+void TestQgsTaskManager::subTaskPartialComplete2()
+{
+  // we need 3 threads to run this test (one for each task)
+  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
+  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+
+  QgsTaskManager manager;
+
   // another test
-  parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_7" ) );
-  subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_7" ) );
-  subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_7" ) );
+  ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "sub_task_parent_task_7" ) );
+  QPointer<ProgressReportingTask> subTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_task_7" ) );
+  QPointer<ProgressReportingTask> subsubTask = new ProgressReportingTask( QStringLiteral( "sub_task_sub_sub_task_7" ) );
   subTask->addSubTask( subsubTask );
   parent->addSubTask( subTask );
   manager.addTask( parent );
@@ -703,15 +800,12 @@ void TestQgsTaskManager::subTask()
     QCoreApplication::processEvents();
   }
   flushEvents();
-
-  QCOMPARE( ( int )parent->status(), ( int )QgsTask::Running );
-  QCOMPARE( ( int )subsubTask->status(), ( int )QgsTask::Running );
-  QCOMPARE( ( int )subTask->status(), ( int )QgsTask::Running );
   subTask->finish();
   flushEvents();
   QCOMPARE( parent->status(), QgsTask::Running );
   QCOMPARE( subTask->status(), QgsTask::Running );
   QCOMPARE( subsubTask->status(), QgsTask::Running );
+
   subsubTask->finish();
   while ( subsubTask->status() == QgsTask::Running )
   {
@@ -756,9 +850,6 @@ void TestQgsTaskManager::taskId()
 
 void TestQgsTaskManager::waitForFinished()
 {
-  if ( !QgsTest::runFlakyTests() )
-    QSKIP( "This test is disabled on Travis CI environment" );
-
   QgsTaskManager manager;
   QEventLoop loop;
 
@@ -894,6 +985,10 @@ void TestQgsTaskManager::progressChanged()
   QSignalSpy spy2( &manager, &QgsTaskManager::finalTaskProgressChanged );
 
   task->emitProgressChanged( 50.0 );
+  while ( spy.count() == 0 )
+  {
+    QCoreApplication::processEvents();
+  }
 
   QCOMPARE( task->progress(), 50.0 );
   QCOMPARE( spy.count(), 1 );
@@ -903,6 +998,10 @@ void TestQgsTaskManager::progressChanged()
   QCOMPARE( spy2.count(), 0 );
 
   task2->emitProgressChanged( 75.0 );
+  while ( spy.count() == 1 )
+  {
+    QCoreApplication::processEvents();
+  }
   QCOMPARE( task2->progress(), 75.0 );
   QCOMPARE( spy.count(), 2 );
   QCOMPARE( spy.last().at( 0 ).toLongLong(), 2LL );
@@ -915,8 +1014,19 @@ void TestQgsTaskManager::progressChanged()
     QCoreApplication::processEvents();
   }
   flushEvents();
+  QCOMPARE( spy.count(), 3 );
+  QCOMPARE( spy.last().at( 0 ).toLongLong(), 1LL );
+  QCOMPARE( spy.last().at( 1 ).toDouble(), 100 );
   QCOMPARE( task2->status(), QgsTask::Running );
   task2->emitProgressChanged( 80.0 );
+  while ( spy.count() == 3 )
+  {
+    QCoreApplication::processEvents();
+  }
+  QCOMPARE( spy.count(), 4 );
+  QCOMPARE( task2->progress(), 80.0 );
+  QCOMPARE( spy.last().at( 0 ).toLongLong(), 2LL );
+  QCOMPARE( spy.last().at( 1 ).toDouble(), 80.0 );
   //single running task, so finalTaskProgressChanged(double) should be emitted
   QCOMPARE( spy2.count(), 1 );
   QCOMPARE( spy2.last().at( 0 ).toDouble(), 80.0 );
@@ -931,6 +1041,15 @@ void TestQgsTaskManager::progressChanged()
 
   //multiple running tasks, so finalTaskProgressChanged(double) should not be emitted
   task2->emitProgressChanged( 81.0 );
+  while ( spy.count() == 4 )
+  {
+    QCoreApplication::processEvents();
+  }
+  QCOMPARE( spy.count(), 5 );
+  QCOMPARE( task2->progress(), 81.0 );
+  QCOMPARE( spy.last().at( 0 ).toLongLong(), 2LL );
+  QCOMPARE( spy.last().at( 1 ).toDouble(), 81.0 );
+
   QCOMPARE( spy2.count(), 1 );
   QCOMPARE( task2->status(), QgsTask::Running );
   QCOMPARE( task3->status(), QgsTask::Running );
@@ -941,10 +1060,23 @@ void TestQgsTaskManager::progressChanged()
     QCoreApplication::processEvents();
   }
   flushEvents();
+  QCOMPARE( spy.count(), 6 );
+  QCOMPARE( task2->progress(), 100.0 );
+  QCOMPARE( spy.last().at( 0 ).toLongLong(), 2LL );
+  QCOMPARE( spy.last().at( 1 ).toDouble(), 100.0 );
+
   task3->emitProgressChanged( 30.0 );
+  while ( spy.count() == 6 )
+  {
+    QCoreApplication::processEvents();
+  }
+  QCOMPARE( spy.count(), 7 );
+  QCOMPARE( task3->progress(), 30.0 );
+  QCOMPARE( spy.last().at( 0 ).toLongLong(), 3LL );
+  QCOMPARE( spy.last().at( 1 ).toDouble(), 30.0 );
+
   //single running task, so finalTaskProgressChanged(double) should be emitted
   QCOMPARE( spy2.count(), 2 );
-  QCOMPARE( spy2.last().at( 0 ).toDouble(), 30.0 );
   task3->finish();
 }
 
@@ -1145,11 +1277,11 @@ void TestQgsTaskManager::dependencies()
   QgsTaskManager manager;
 
   //test that canceling tasks cancels all tasks which are dependent on them
-  CancelableTask *task = new CancelableTask();
+  QPointer<CancelableTask> task = new CancelableTask();
   task->hold();
-  CancelableTask *childTask = new CancelableTask();
+  QPointer<CancelableTask> childTask = new CancelableTask();
   childTask->hold();
-  CancelableTask *grandChildTask = new CancelableTask();
+  QPointer<CancelableTask> grandChildTask = new CancelableTask();
   grandChildTask->hold();
 
   long taskId = manager.addTask( QgsTaskManager::TaskDefinition( task, QgsTaskList() << childTask ) );
@@ -1187,7 +1319,6 @@ void TestQgsTaskManager::dependencies()
   {
     QCoreApplication::processEvents();
   }
-  flushEvents();
   QCOMPARE( childTask->status(), QgsTask::Running );
   QCOMPARE( task->status(), QgsTask::Queued );
   childTask->cancel(); // Note: CancelableTask signals successful completion when canceled!
@@ -1196,18 +1327,17 @@ void TestQgsTaskManager::dependencies()
   {
     QCoreApplication::processEvents();
   }
-  flushEvents();
   QVERIFY( manager.dependenciesSatisfied( taskId ) );
+  QVERIFY( !childTask.isNull() );
   QCOMPARE( childTask->status(), QgsTask::Complete );
   //wait for task to spin up
   while ( !task->isActive() )
   {
     QCoreApplication::processEvents();
   }
-  flushEvents();
+  QVERIFY( !task.isNull() );
   QCOMPARE( task->status(), QgsTask::Running );
   task->cancel(); // Note: CancelableTask signals successful completion when canceled!
-
 
   // test circular dependency detection
   task = new CancelableTask();
@@ -1269,8 +1399,9 @@ void TestQgsTaskManager::layerDependencies()
 
 void TestQgsTaskManager::managerWithSubTasks()
 {
-  if ( !QgsTest::runFlakyTests() )
-    QSKIP( "This test is disabled on Travis CI environment" );
+  // we need 3 threads to run this test (one for each task)
+  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
+  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
 
   // parent with subtasks
   ProgressReportingTask *parent = new ProgressReportingTask( QStringLiteral( "parent" ) );
@@ -1297,6 +1428,10 @@ void TestQgsTaskManager::managerWithSubTasks()
   //(only parent tasks, which themselves include their subtask progress)
   QCOMPARE( spyProgress.count(), 0 );
   subTask->emitProgressChanged( 50 );
+  while ( spyProgress.count() == 0 )
+  {
+    QCoreApplication::processEvents();
+  }
   QCOMPARE( spyProgress.count(), 1 );
   QCOMPARE( spyProgress.last().at( 0 ).toLongLong(), 1LL );
   // subTask itself is 50% done, so with it's child task it's sitting at overall 25% done
@@ -1306,10 +1441,18 @@ void TestQgsTaskManager::managerWithSubTasks()
   QCOMPARE( spyProgress.last().at( 1 ).toInt(), 13 );
 
   subsubTask->emitProgressChanged( 100 );
+  while ( spyProgress.count() == 1 )
+  {
+    QCoreApplication::processEvents();
+  }
   QCOMPARE( spyProgress.count(), 2 );
   QCOMPARE( spyProgress.last().at( 0 ).toLongLong(), 1LL );
   QCOMPARE( spyProgress.last().at( 1 ).toInt(), 38 );
   parent->emitProgressChanged( 50 );
+  while ( spyProgress.count() == 2 )
+  {
+    QCoreApplication::processEvents();
+  }
   QCOMPARE( spyProgress.count(), 3 );
   QCOMPARE( spyProgress.last().at( 0 ).toLongLong(), 1LL );
   QCOMPARE( spyProgress.last().at( 1 ).toInt(), 63 );
@@ -1323,9 +1466,6 @@ void TestQgsTaskManager::managerWithSubTasks()
     QCoreApplication::processEvents();
   }
   flushEvents();
-  QCOMPARE( statusSpy.count(), 1 );
-  QCOMPARE( statusSpy.last().at( 0 ).toLongLong(), 1LL );
-  QCOMPARE( static_cast< QgsTask::TaskStatus >( statusSpy.last().at( 1 ).toInt() ), QgsTask::Running );
 
   subTask->finish();
   while ( subTask->status() != QgsTask::Complete )
@@ -1333,7 +1473,7 @@ void TestQgsTaskManager::managerWithSubTasks()
     QCoreApplication::processEvents();
   }
   flushEvents();
-  QCOMPARE( statusSpy.count(), 1 );
+  QCOMPARE( statusSpy.count(), 0 );
 
   parent->finish();
   while ( parent->status() != QgsTask::Complete )
@@ -1341,10 +1481,9 @@ void TestQgsTaskManager::managerWithSubTasks()
     QCoreApplication::processEvents();
   }
   flushEvents();
-  QCOMPARE( statusSpy.count(), 2 );
+  QCOMPARE( statusSpy.count(), 1 );
   QCOMPARE( statusSpy.last().at( 0 ).toLongLong(), 1LL );
   QCOMPARE( static_cast< QgsTask::TaskStatus >( statusSpy.last().at( 1 ).toInt() ), QgsTask::Complete );
-
 
   subsubTask->finish();
   subTask->finish();
@@ -1411,11 +1550,14 @@ void TestQgsTaskManager::managerWithSubTasks3()
 
 void TestQgsTaskManager::cancelBeforeStart()
 {
-  // add a lot of tasks to the manager, so that some are queued and can't start immediately
+  QThreadPool::globalInstance()->setMaxThreadCount( 3 );
+  QCOMPARE( QThreadPool::globalInstance()->maxThreadCount(), 3 );
+
+  // add too much tasks to the manager, so that some are queued and can't start immediately
   // then cancel them all!
   QList< QgsTask * > tasks;
   QgsTaskManager manager;
-  for ( int i = 0; i < 30; ++i )
+  for ( int i = 0; i < 10; ++i )
   {
     QgsTask *task = new CancelableTask();
     tasks << task;
@@ -1441,9 +1583,6 @@ void TestQgsTaskManager::cancelBeforeStart()
 
 void TestQgsTaskManager::proxyTask()
 {
-  if ( !QgsTest::runFlakyTests() )
-    QSKIP( "This test is disabled on Travis CI environment" );
-
   QgsProxyProgressTask *proxyTask = new QgsProxyProgressTask( QString() );
 
   // finalize before task gets a chance to start
@@ -1463,9 +1602,6 @@ void TestQgsTaskManager::proxyTask()
 
 void TestQgsTaskManager::proxyTask2()
 {
-  if ( !QgsTest::runFlakyTests() )
-    QSKIP( "This test is disabled on Travis CI environment" );
-
   QgsProxyProgressTask *proxyTask = new QgsProxyProgressTask( QString() );
 
   // finalize before task gets a chance to start
@@ -1489,9 +1625,6 @@ void TestQgsTaskManager::proxyTask2()
 
 void TestQgsTaskManager::scopedProxyTask()
 {
-  if ( !QgsTest::runFlakyTests() )
-    QSKIP( "This test is disabled on Travis CI environment" );
-
   {
     // task finishes before it can start
     QgsScopedProxyProgressTask task{ QString() };

--- a/tests/src/python/test_qgstaskmanager.py
+++ b/tests/src/python/test_qgstaskmanager.py
@@ -79,7 +79,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task', run, 20)
         QgsApplication.taskManager().addTask(task)
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
 
         self.assertEqual(task.returned_values, 20)
         self.assertFalse(task.exception)
@@ -89,7 +89,7 @@ class TestQgsTaskManager(unittest.TestCase):
         bad_task = QgsTask.fromFunction('test task2', run, None)
         QgsApplication.taskManager().addTask(bad_task)
         while bad_task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
 
         self.assertFalse(bad_task.returned_values)
         self.assertTrue(bad_task.exception)
@@ -109,7 +109,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task3', run_with_kwargs, result=5, password=1)
         QgsApplication.taskManager().addTask(task)
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
 
         self.assertEqual(task.returned_values, 5)
         self.assertFalse(task.exception)
@@ -120,11 +120,11 @@ class TestQgsTaskManager(unittest.TestCase):
         bad_task = QgsTask.fromFunction('test task4', cancelable)
         QgsApplication.taskManager().addTask(bad_task)
         while bad_task.status() != QgsTask.Running:
-            pass
+            QCoreApplication.processEvents()
 
         bad_task.cancel()
         while bad_task.status() == QgsTask.Running:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 
@@ -136,7 +136,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task5', progress_function)
         QgsApplication.taskManager().addTask(task)
         while task.status() != QgsTask.Running:
-            pass
+            QCoreApplication.processEvents()
 
         # wait a fraction so that setProgress gets a chance to be called
         sleep(0.001)
@@ -145,7 +145,7 @@ class TestQgsTaskManager(unittest.TestCase):
 
         task.cancel()
         while task.status() == QgsTask.Running:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 
@@ -162,7 +162,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task', run_no_result, on_finished=finished_no_val)
         QgsApplication.taskManager().addTask(task)
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 
@@ -183,7 +183,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task', run_fail, on_finished=finished_fail)
         QgsApplication.taskManager().addTask(task)
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 
@@ -206,7 +206,7 @@ class TestQgsTaskManager(unittest.TestCase):
         QgsApplication.taskManager().addTask(task)
         task.cancel()
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 
@@ -228,7 +228,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task', run_single_val_result, on_finished=finished_single_value_result)
         QgsApplication.taskManager().addTask(task)
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 
@@ -252,7 +252,7 @@ class TestQgsTaskManager(unittest.TestCase):
         task = QgsTask.fromFunction('test task', run_multiple_val_result, on_finished=finished_multiple_value_result)
         QgsApplication.taskManager().addTask(task)
         while task.status() not in [QgsTask.Complete, QgsTask.Terminated]:
-            pass
+            QCoreApplication.processEvents()
         while QgsApplication.taskManager().countActiveTasks() > 0:
             QCoreApplication.processEvents()
 


### PR DESCRIPTION
## Description

This PR fixes differrent race condition issues is QgsTaskManager:

c380b09945  When a task is completed, statusChanged signal is emitted in task thread. As a consequence cleanupAndDeleteTask will be called in the main thread and the task will be deleted (later). It happens sometimes that instructions after statusChanged are executed after the task had been effectively deleted, leading to crash or non emitted signals.

It cause also issue with sub task. Indeed, when a subTask is completed, you have no garantie that instructions after statusChanged are executed before the parent caught the statusChanged signal and delete itself and the subtask.

This commit propose to force  `processSubTasksForCompletion` and `processSubTasksForTermination` execution in main thread (`processSubTasksForHold` if out of the scope because it doesn't delete tasks and is executed in main thread), so all status modification and deletion are made in a determinist order. 

a79431d5ad : remove unlock from `terminated`/`completed` because unlock call from `terminated` crashes the application when called from `cancel` method on not started task. In this case, the task is canceled without being started, so the mutex isn't locked. And the Qt documentation says

> Unlocking a mutex that is not locked results in undefined behavior.

5e4c1ea6a5 : cancel is called from a different thread than the one running the task so mShouldTerminate should be protected with a mutex

956b142239 : we need to be sure that the task is really completly finished (start method has exited) before deleting the task object to avoid crash

0ed9ea93f5 : I fix the tests, slip subTask in several one to ease debug (when it fails on CI for instance) and remove the SKIP tests on CI. I run all tests on linux and Windows, [repeatdly](https://github.com/troopa81/QGIS/commit/3a2382792c) and injecting latency in task manager to try to make it crash. So far, I have no more failing tests. 

