### PR TITLE
Fix invalid escape sequence

### DIFF
--- a/python/core/auto_additions/qgsprocessingutils.py
+++ b/python/core/auto_additions/qgsprocessingutils.py
@@ -7,6 +7,6 @@ QgsProcessingUtils.LayerHint.Vector.__doc__ = "Vector layer type"
 QgsProcessingUtils.Raster = QgsProcessingUtils.LayerHint.Raster
 QgsProcessingUtils.LayerHint.Raster.__doc__ = "Raster layer type"
 QgsProcessingUtils.Mesh = QgsProcessingUtils.LayerHint.Mesh
-QgsProcessingUtils.LayerHint.Mesh.__doc__ = "Mesh layer type  \since QGIS 3.6"
+QgsProcessingUtils.LayerHint.Mesh.__doc__ = "Mesh layer type, since QGIS 3.6"
 QgsProcessingUtils.LayerHint.__doc__ = 'Layer type hints.\n\n.. versionadded:: 3.4\n\n' + '* ``UnknownType``: ' + QgsProcessingUtils.LayerHint.UnknownType.__doc__ + '\n' + '* ``Vector``: ' + QgsProcessingUtils.LayerHint.Vector.__doc__ + '\n' + '* ``Raster``: ' + QgsProcessingUtils.LayerHint.Raster.__doc__ + '\n' + '* ``Mesh``: ' + QgsProcessingUtils.LayerHint.Mesh.__doc__
 # --

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -114,7 +114,7 @@ class CORE_EXPORT QgsProcessingUtils
       UnknownType, //!< Unknown layer type
       Vector, //!< Vector layer type
       Raster, //!< Raster layer type
-      Mesh, //!< Mesh layer type  \since QGIS 3.6
+      Mesh, //!< Mesh layer type, since QGIS 3.6
     };
 
     /**


### PR DESCRIPTION
```
/usr/lib/python3/dist-packages/qgis/core/__init__.py:195

  /usr/lib/python3/dist-packages/qgis/core/__init__.py:195: DeprecationWarning: invalid escape sequence \s

    QgsProcessingUtils.LayerHint.Mesh.__doc__ = "Mesh layer type  \since QGIS 3.6"

/usr/lib/python3/dist-packages/qgis/core/additions/qgsfunction.py:167

  /usr/lib/python3/dist-packages/qgis/core/additions/qgsfunction.py:167: DeprecationWarning: invalid escape sequence \*

```

See https://travis-ci.org/opengisch/QgisModelBaker/jobs/650350792#L1274-L1283