### PR TITLE
Responsive cancelation of raster projector

### DIFF
--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -139,7 +139,7 @@ class ProjectorData
 {
   public:
     //! Initialize reprojector and calculate matrix
-    ProjectorData( const QgsRectangle &extent, int width, int height, QgsRasterInterface *input, const QgsCoordinateTransform &inverseCt, QgsRasterProjector::Precision precision );
+    ProjectorData( const QgsRectangle &extent, int width, int height, QgsRasterInterface *input, const QgsCoordinateTransform &inverseCt, QgsRasterProjector::Precision precision, QgsRasterBlockFeedback *feedback = nullptr );
     ~ProjectorData();
 
     ProjectorData( const ProjectorData &other ) = delete;


### PR DESCRIPTION
In the case of messy transforms (e.g. transforming global coordinates to a localized projection) the raster projection setup code can be very expensive, so add a responsive check to abort early if the
render operation is canceled
