### PR TITLE
Less noisy transform failure errors

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -243,7 +243,7 @@ QgsPointXY QgsCoordinateTransform::transform( const QgsPointXY &point, Transform
   catch ( const QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 
@@ -260,7 +260,7 @@ QgsPointXY QgsCoordinateTransform::transform( const double theX, const double th
   catch ( const QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 }
@@ -287,7 +287,7 @@ QgsRectangle QgsCoordinateTransform::transform( const QgsRectangle &rect, Transf
   catch ( const QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 
@@ -317,7 +317,7 @@ void QgsCoordinateTransform::transformInPlace( double &x, double &y, double &z,
   catch ( const QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 }
@@ -353,7 +353,7 @@ void QgsCoordinateTransform::transformInPlace( float &x, float &y, float &z,
   catch ( QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 }
@@ -432,7 +432,7 @@ void QgsCoordinateTransform::transformInPlace(
   catch ( const QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 }
@@ -494,7 +494,7 @@ void QgsCoordinateTransform::transformInPlace(
   catch ( QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 }
@@ -569,7 +569,7 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
   catch ( const QgsCsException & )
   {
     // rethrow the exception
-    QgsDebugMsg( QStringLiteral( "rethrowing exception" ) );
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
     throw;
   }
 
@@ -758,8 +758,13 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     pj_dalloc( dstdef );
 #endif
 
-    QgsDebugMsg( "Projection failed emitting invalid transform signal: " + msg );
-    QgsDebugMsg( QStringLiteral( "throwing exception" ) );
+    // don't flood console with thousands of duplicate transform error messages
+    if ( msg != mLastError )
+    {
+      QgsDebugMsg( "Projection failed emitting invalid transform signal: " + msg );
+      mLastError = msg;
+    }
+    QgsDebugMsgLevel( QStringLiteral( "rethrowing exception" ), 2 );
 
     throw QgsCsException( msg );
   }

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -577,6 +577,8 @@ class CORE_EXPORT QgsCoordinateTransform
     bool mHasContext = false;
 #endif
 
+    mutable QString mLastError;
+
 #if PROJ_VERSION_MAJOR>=6
     bool setFromCache( const QgsCoordinateReferenceSystem &src,
                        const QgsCoordinateReferenceSystem &dest,


### PR DESCRIPTION
- Don't spew a whole lot of "rethrowing expection" log messages on the
default log level
- Don't output tons of duplicate transform error messages - instead
only output the message if its different to the last error encountered
(avoids flooding the console when transform failures occur during
raster projection, resulting in quasi-hangs)
