### PR TITLE
disable browsing auto pan/scale in attribute table when showing visible features only

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -514,7 +514,7 @@ void QgsDualView::setBrowsingAutoPanScaleAllowed( bool allowed )
   QString disabledHint = tr( "(disabled when attribute table ony shows features visible in the current map canvas extent)" );
 
   mAutoPanButton->setToolTip( tr( "Automatically pan to the current feature" ) + ( allowed ? QString() : QString( ' ' ) + disabledHint ) );
-  mAutoZoomButton->setToolTip( tr( "Automatically zoom to the current feature" ) + ( allowed ? QStringLiteral( "" ) : QStringLiteral( " " ) + disabledHint ) );
+  mAutoZoomButton->setToolTip( tr( "Automatically zoom to the current feature" ) + ( allowed ? QString() : QString( ' ' ) + disabledHint ) );
 }
 
 void QgsDualView::panZoomGroupButtonToggled( QAbstractButton *button, bool checked )

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -513,7 +513,7 @@ void QgsDualView::setBrowsingAutoPanScaleAllowed( bool allowed )
 
   QString disabledHint = tr( "(disabled when attribute table ony shows features visible in the current map canvas extent)" );
 
-  mAutoPanButton->setToolTip( tr( "Automatically pan to the current feature" ) + ( allowed ? QStringLiteral( "" ) : QStringLiteral( " " ) + disabledHint ) );
+  mAutoPanButton->setToolTip( tr( "Automatically pan to the current feature" ) + ( allowed ? QString() : QString( ' ' ) + disabledHint ) );
   mAutoZoomButton->setToolTip( tr( "Automatically zoom to the current feature" ) + ( allowed ? QStringLiteral( "" ) : QStringLiteral( " " ) + disabledHint ) );
 }
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -301,6 +301,21 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
     mMasterModel->loadLayer();
   }
 
+  // disable the browsing auto pan/scale if the list only shows visible items
+  switch ( filterMode )
+  {
+    case QgsAttributeTableFilterModel::ShowVisible:
+      setBrowsingAutoPanScaleAllowed( false );
+      break;
+
+    case QgsAttributeTableFilterModel::ShowAll:
+    case QgsAttributeTableFilterModel::ShowEdited:
+    case QgsAttributeTableFilterModel::ShowFilteredList:
+    case QgsAttributeTableFilterModel::ShowSelected:
+      setBrowsingAutoPanScaleAllowed( true );
+      break;
+  }
+
   //update filter model
   mFilterModel->setFilterMode( filterMode );
   emit filterChanged();
@@ -464,7 +479,7 @@ void QgsDualView::panOrZoomToFeature( const QgsFeatureIds &featureset )
   QgsMapCanvas *canvas = mFilterModel->mapCanvas();
   if ( canvas && view() == AttributeEditor && featureset != mLastFeatureSet )
   {
-    if ( filterMode() != QgsAttributeTableFilterModel::ShowVisible )
+    if ( mBrowsingAutoPanScaleAllowed )
     {
       if ( mAutoPanButton->isChecked() )
         QTimer::singleShot( 0, this, [ = ]()
@@ -484,6 +499,22 @@ void QgsDualView::panOrZoomToFeature( const QgsFeatureIds &featureset )
     } );
     mLastFeatureSet = featureset;
   }
+}
+
+void QgsDualView::setBrowsingAutoPanScaleAllowed( bool allowed )
+{
+  if ( mBrowsingAutoPanScaleAllowed == allowed )
+    return;
+
+  mBrowsingAutoPanScaleAllowed = allowed;
+
+  mAutoPanButton->setEnabled( allowed );
+  mAutoZoomButton->setEnabled( allowed );
+
+  QString disabledHint = tr( "(disabled when attribute table ony shows features visible in the current map canvas extent)" );
+
+  mAutoPanButton->setToolTip( tr( "Automatically pan to the current feature" ) + ( allowed ? QStringLiteral( "" ) : QStringLiteral( " " ) + disabledHint ) );
+  mAutoZoomButton->setToolTip( tr( "Automatically zoom to the current feature" ) + ( allowed ? QStringLiteral( "" ) : QStringLiteral( " " ) + disabledHint ) );
 }
 
 void QgsDualView::panZoomGroupButtonToggled( QAbstractButton *button, bool checked )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -387,6 +387,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void insertRecentlyUsedDisplayExpression( const QString &expression );
     void updateEditSelectionProgress( int progress, int count );
     void panOrZoomToFeature( const QgsFeatureIds &featureset );
+    //! disable/enable the buttons of the browsing toolbar (feature list view)
+    void setBrowsingAutoPanScaleAllowed( bool allowed );
 
     QgsFieldConditionalFormatWidget *mConditionalFormatWidget = nullptr;
     QgsAttributeEditorContext mEditorContext;
@@ -409,6 +411,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     // we will temporarily save it in here and set it on init
     QgsFeature mTempAttributeFormFeature;
     QgsFeatureIds mLastFeatureSet;
+    bool mBrowsingAutoPanScaleAllowed = true;
 
     friend class TestQgsDualView;
     friend class TestQgsAttributeTable;


### PR DESCRIPTION

fixes #34486
