### PR TITLE
fix browsing counter not reset in feature list (attribute table)

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -301,6 +301,7 @@ void QgsDualView::setFilterMode( QgsAttributeTableFilterModel::FilterMode filter
     mMasterModel->loadLayer();
   }
 
+
   // disable the browsing auto pan/scale if the list only shows visible items
   switch ( filterMode )
   {

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -365,7 +365,12 @@ void QgsFeatureListView::selectRow( const QModelIndex &index, bool anchor )
 void QgsFeatureListView::ensureEditSelection( bool inSelection )
 {
   if ( !mModel->rowCount() )
+  {
+    // not sure this is the best place to emit from
+    // this will allow to set the counter to zero in the browsing panel
+    emit currentEditSelectionProgressChanged( 0, 0 );
     return;
+  }
 
   const QModelIndexList selectedIndexes = mCurrentEditSelectionModel->selectedIndexes();
 

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -367,7 +367,7 @@ void QgsFeatureListView::ensureEditSelection( bool inSelection )
   if ( !mModel->rowCount() )
   {
     // not sure this is the best place to emit from
-    // this will allow to set the counter to zero in the browsing panel
+    // this will allow setting the counter to zero in the browsing panel
     emit currentEditSelectionProgressChanged( 0, 0 );
     return;
   }


### PR DESCRIPTION
the counter was not set to 0 when switching to selected or visible only and if there were no features listed

