### PR TITLE
remove assert from a left over (fix crash)

### DIFF
--- a/src/app/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/app/attributeformconfig/qgsattributewidgetedit.cpp
@@ -25,7 +25,6 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
   setupUi( this );
 
   const QgsAttributesFormProperties::DnDTreeItemData itemData = mTreeItem->data( 0, QgsAttributesFormProperties::DnDTreeRole ).value<QgsAttributesFormProperties::DnDTreeItemData>();
-  Q_ASSERT( itemData.type() == QgsAttributesFormProperties::DnDTreeItemData::Container );
 
   // common configs
   mShowLabelCheckBox->setChecked( itemData.showLabel() );


### PR DESCRIPTION
the assert was copied from other class and I was running with RelWithDebugInfo and not Debug.

