### PR TITLE
Typo fix

### DIFF
--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -102,19 +102,19 @@ class CORE_EXPORT QgsWkbPtr
 
     /**
      * \brief size
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     inline int size() const { return mEnd - mStart; } SIP_SKIP
 
     /**
      * \brief remaining
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     inline int remaining() const { return mEnd - mP; } SIP_SKIP
 
     /**
      * \brief writtenSize
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     inline int writtenSize() const { return mP - mStart; } SIP_SKIP
 };
@@ -134,13 +134,13 @@ class CORE_EXPORT QgsConstWkbPtr
 
     /**
      * \brief Verify bounds
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     void verifyBound( int size ) const SIP_SKIP;
 
     /**
      * \brief Read a value
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     template<typename T> void read( T &v ) const SIP_SKIP
     {
@@ -158,7 +158,7 @@ class CORE_EXPORT QgsConstWkbPtr
 
     /**
      * \brief readHeader
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     QgsWkbTypes::Type readHeader() const SIP_SKIP;
 
@@ -180,7 +180,7 @@ class CORE_EXPORT QgsConstWkbPtr
 
     /**
      * \brief remaining
-     * \note note available in Python bindings
+     * \note not available in Python bindings
      */
     inline int remaining() const { return mEnd - mP; } SIP_SKIP
 


### PR DESCRIPTION
## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
