### PR TITLE
[ui] Fix diagram attribute colors missing on non-default theme in the diagram properties dialog

### DIFF
--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -126,7 +126,13 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
   mSizeSpinBox->setClearValue( 5 );
 
   mDiagramAttributesTreeWidget->setItemDelegateForColumn( ColumnAttributeExpression, new EditBlockerDelegate( this ) );
-  mDiagramAttributesTreeWidget->setItemDelegateForColumn( ColumnColor, new EditBlockerDelegate( this ) );
+  mDiagramAttributesTreeWidget->setItemDelegateForColumn( ColumnColor, new QgsColorSwatchDelegate( this ) );
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+  mDiagramAttributesTreeWidget->setColumnWidth( ColumnColor, Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 6.6 );
+#else
+  mDiagramAttributesTreeWidget->setColumnWidth( ColumnColor, Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 6.6 );
+#endif
 
   connect( mFixedSizeRadio, &QRadioButton::toggled, this, &QgsDiagramProperties::scalingTypeChanged );
   connect( mAttributeBasedScalingRadio, &QRadioButton::toggled, this, &QgsDiagramProperties::scalingTypeChanged );
@@ -401,7 +407,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
         newItem->setFlags( newItem->flags() & ~Qt::ItemIsDropEnabled );
         QColor col( *coIt );
         col.setAlpha( 255 );
-        newItem->setBackground( 1, QBrush( col ) );
+        newItem->setData( ColumnColor, Qt::EditRole, col );
         newItem->setText( 2, *labIt );
         newItem->setFlags( newItem->flags() | Qt::ItemIsEditable );
       }
@@ -647,7 +653,7 @@ void QgsDiagramProperties::addAttribute( QTreeWidgetItem *item )
   int green = 1 + ( int )( 255.0 * qrand() / ( RAND_MAX + 1.0 ) );
   int blue = 1 + ( int )( 255.0 * qrand() / ( RAND_MAX + 1.0 ) );
   QColor randomColor( red, green, blue );
-  newItem->setBackground( 1, QBrush( randomColor ) );
+  newItem->setData( ColumnColor, Qt::EditRole, randomColor );
   mDiagramAttributesTreeWidget->addTopLevelItem( newItem );
 }
 
@@ -736,14 +742,7 @@ void QgsDiagramProperties::mDiagramAttributesTreeWidget_itemDoubleClicked( QTree
     }
 
     case ColumnColor:
-    {
-      QColor newColor = QgsColorDialog::getColor( item->background( 1 ).color(), nullptr );
-      if ( newColor.isValid() )
-      {
-        item->setBackground( 1, QBrush( newColor ) );
-      }
       break;
-    }
 
     case ColumnLegendText:
       break;
@@ -813,7 +812,7 @@ void QgsDiagramProperties::apply()
   categoryLabels.reserve( mDiagramAttributesTreeWidget->topLevelItemCount() );
   for ( int i = 0; i < mDiagramAttributesTreeWidget->topLevelItemCount(); ++i )
   {
-    QColor color = mDiagramAttributesTreeWidget->topLevelItem( i )->background( 1 ).color();
+    QColor color = mDiagramAttributesTreeWidget->topLevelItem( i )->data( ColumnColor, Qt::EditRole ).value<QColor>();
     color.setAlphaF( ds.opacity );
     categoryColors.append( color );
     categoryAttributes.append( mDiagramAttributesTreeWidget->topLevelItem( i )->data( 0, RoleAttributeExpression ).toString() );
@@ -1007,7 +1006,7 @@ void QgsDiagramProperties::showAddAttributeExpressionDialog()
     int green = 1 + ( int )( 255.0 * qrand() / ( RAND_MAX + 1.0 ) );
     int blue = 1 + ( int )( 255.0 * qrand() / ( RAND_MAX + 1.0 ) );
     QColor randomColor( red, green, blue );
-    newItem->setBackground( 1, QBrush( randomColor ) );
+    newItem->setData( ColumnColor, Qt::EditRole, randomColor );
     mDiagramAttributesTreeWidget->addTopLevelItem( newItem );
   }
   activateWindow(); // set focus back parent

--- a/src/app/qgsdiagramproperties.h
+++ b/src/app/qgsdiagramproperties.h
@@ -18,11 +18,14 @@
 #ifndef QGSDIAGRAMPROPERTIES_H
 #define QGSDIAGRAMPROPERTIES_H
 
-#include <QDialog>
-#include "qgsdiagramrenderer.h"
 #include "ui_qgsdiagrampropertiesbase.h"
-#include <QStyledItemDelegate>
+
 #include "qgis_app.h"
+#include "qgsdiagramrenderer.h"
+#include "qgscolorschemelist.h"
+
+#include <QDialog>
+#include <QStyledItemDelegate>
 
 class QgsVectorLayer;
 class QgsMapCanvas;
@@ -57,6 +60,13 @@ class APP_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPr
     void updatePlacementWidgets();
     void scalingTypeChanged();
     void showSizeLegendDialog();
+
+  private slots:
+
+    void updateProperty();
+    void showHelp();
+
+    void createAuxiliaryField();
 
   private:
 
@@ -96,13 +106,6 @@ class APP_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPr
     QgsExpressionContext createExpressionContext() const override;
 
     void registerDataDefinedButton( QgsPropertyOverrideButton *button, QgsDiagramLayerSettings::Property key );
-
-  private slots:
-
-    void updateProperty();
-    void showHelp();
-
-    void createAuxiliaryField();
 };
 
 class EditBlockerDelegate: public QStyledItemDelegate


### PR DESCRIPTION
## Description

Hadn't stumbled on a non-default theme issue. Our diagram properties dialog was using setBackground() on a tree view widget to indicate the color for diagram attributes. This is a big no-no as the color is _not_ visible for non-default themes. 

Before vs. fixed:
![image](https://user-images.githubusercontent.com/1728657/74702407-8882a480-523c-11ea-8434-33239c209064.png)

Bonuses:
- the color column is set to be as narrow as possible
- the UI now matches other tree widgets having color columns (color ramp shader widget, raster renderer's unique value UI, etc.)