### PR TITLE
[georeferencer] Fix wrong target CRS using GDAL3/PROJ6 builds

### DIFF
--- a/src/plugins/georeferencer/qgsimagewarper.cpp
+++ b/src/plugins/georeferencer/qgsimagewarper.cpp
@@ -97,7 +97,11 @@ bool QgsImageWarper::createDestinationDataset( const QString &outputName, GDALDa
   if ( crs.isValid() )
   {
     OGRSpatialReference oTargetSRS;
+#if PROJ_VERSION_MAJOR>=6
+    oTargetSRS.importFromWkt( crs.toWkt( QgsCoordinateReferenceSystem::WKT2_2018 ).toLatin1().data() );
+#else
     oTargetSRS.importFromProj4( crs.toProj().toLatin1().data() );
+#endif
 
     char *wkt = nullptr;
     OGRErr err = oTargetSRS.exportToWkt( &wkt );


### PR DESCRIPTION
## Description

Under GDAL3/PROJ6 builds, passing the CRS to GDAL as a Proj4 string results in the wrong projection being picked. The fix is simple, pass the projection as WKT, a superior format to begin with.

