### PR TITLE
Backport fix for wfs capabilities output formats to 3.10

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -579,14 +579,6 @@ namespace QgsWfs
 
       layerElem.appendChild( operationsElement );
 
-      //create OutputFormats element
-      QDomElement outputFormatsElem = doc.createElement( QStringLiteral( "OutputFormats" ) );
-      QDomElement outputFormatElem = doc.createElement( QStringLiteral( "Format" ) );
-      QDomText outputFormatText = doc.createTextNode( QStringLiteral( "text/xml; subtype=gml/3.1.1" ) );
-      outputFormatElem.appendChild( outputFormatText );
-      outputFormatsElem.appendChild( outputFormatElem );
-      layerElem.appendChild( outputFormatsElem );
-
       //create WGS84BoundingBox
       QgsRectangle layerExtent = layer->extent();
       //transform the layers native CRS into WGS84

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -96,9 +96,6 @@ Content-Type: text/xml; charset=utf-8
     <Operation>Update</Operation>
     <Operation>Delete</Operation>
    </Operations>
-   <OutputFormats>
-    <Format>text/xml; subtype=gml/3.1.1</Format>
-   </OutputFormats>
    <ows:WGS84BoundingBox dimensions="2">
     <ows:LowerCorner>8.203459 44.901394</ows:LowerCorner>
     <ows:UpperCorner>8.203547 44.901483</ows:UpperCorner>


### PR DESCRIPTION
This is the backport of the WFS capabilities layer format fix ( 2f50c0acb3f7fd5906febc1fc7da40c851341f79)