### PR TITLE
[Processing] Fix setting band parameter from string

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -105,8 +105,10 @@ def getParameterFromString(s, context=''):
                 if len(params) > 3:
                     params[3] = True if params[3].lower() == 'true' else False
             elif clazz == QgsProcessingParameterBand:
-                if len(params) > 3:
-                    params[3] = True if params[3].lower() == 'true' else False
+                if len(params) > 4:
+                    params[4] = True if params[4].lower() == 'true' else False
+                if len(params) > 5:
+                    params[5] = True if params[5].lower() == 'true' else False
             elif clazz == QgsProcessingParameterVectorLayer:
                 if len(params) > 2:
                     params[2] = [int(p) for p in params[2].split(';')]


### PR DESCRIPTION
## Description

Optional bool variables are in positions 5 and 6 (see the [API](https://qgis.org/api/classQgsProcessingParameterBand.html#a818ede059a45feac1379fb7bca9e84f5)).

Suitable for backport to 3.10.
