### PR TITLE
Fix geometry type for "Convert geometry type" algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/GeometryConvert.py
+++ b/python/plugins/processing/algs/qgis/GeometryConvert.py
@@ -214,7 +214,7 @@ class GeometryConvert(QgisAlgorithm):
             p.setExteriorRing(linestring)
             return [QgsGeometry(p)]
         elif QgsWkbTypes.geometryType(geom.wkbType()) == QgsWkbTypes.LineGeometry:
-            if QgsWkbTypes.isMultiType(geom):
+            if QgsWkbTypes.isMultiType(geom.wkbType()):
                 parts = []
                 for i in range(geom.constGet().numGeometries()):
                     p = QgsPolygon()
@@ -232,7 +232,7 @@ class GeometryConvert(QgisAlgorithm):
                 return [QgsGeometry(p)]
         else:
             #polygon
-            if QgsWkbTypes.isMultiType(geom):
+            if QgsWkbTypes.isMultiType(geom.wkbType()):
                 return geom.asGeometryCollection()
             else:
                 return [geom]


### PR DESCRIPTION
Fixes errors like
```
Traceback (most recent call last):
File "/Applications/QGIS3.10.app/Contents/MacOS/../Resources/python/plugins/processing/algs/qgis/GeometryConvert.py", line 123, in processAlgorithm
for p in self.convertGeometry(f.geometry(), index):
File "/Applications/QGIS3.10.app/Contents/MacOS/../Resources/python/plugins/processing/algs/qgis/GeometryConvert.py", line 149, in convertGeometry
return self.convertToPolygon(geom)
File "/Applications/QGIS3.10.app/Contents/MacOS/../Resources/python/plugins/processing/algs/qgis/GeometryConvert.py", line 217, in convertToPolygon
if QgsWkbTypes.isMultiType(geom):
TypeError: QgsWkbTypes.isMultiType(): argument 1 has unexpected type 'QgsGeometry'

Échec d'exécution au bout de 0.04 secondes
```

