### PR TITLE
Add algorithms for raising warnings and exceptions from models

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -46,6 +46,7 @@ Abstract base class for processing algorithms.
       FlagDisplayNameIsLiteral,
       FlagSupportsInPlaceEdits,
       FlagKnownIssues,
+      FlagCustomException,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -107,6 +107,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmpoleofinaccessibility.cpp
   processing/qgsalgorithmprojectpointcartesian.cpp
   processing/qgsalgorithmpromotetomultipart.cpp
+  processing/qgsalgorithmraiseexception.cpp
   processing/qgsalgorithmrandomextract.cpp
   processing/qgsalgorithmrandompointsextent.cpp
   processing/qgsalgorithmrasterlayeruniquevalues.cpp

--- a/src/analysis/processing/qgsalgorithmraiseexception.cpp
+++ b/src/analysis/processing/qgsalgorithmraiseexception.cpp
@@ -1,0 +1,180 @@
+/***************************************************************************
+                         qgsalgorithmraiseexception.cpp
+                         ---------------------
+    begin                : February 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmraiseexception.h"
+
+///@cond PRIVATE
+
+//
+// QgsRaiseExceptionAlgorithm
+//
+
+QString QgsRaiseExceptionAlgorithm::name() const
+{
+  return QStringLiteral( "raiseexception" );
+}
+
+QgsProcessingAlgorithm::Flags QgsRaiseExceptionAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagHideFromToolbox | FlagCustomException;
+}
+
+QString QgsRaiseExceptionAlgorithm::displayName() const
+{
+  return QObject::tr( "Raise exception" );
+}
+
+QStringList QgsRaiseExceptionAlgorithm::tags() const
+{
+  return QObject::tr( "abort,warn,error,cancel" ).split( ',' );
+}
+
+QString QgsRaiseExceptionAlgorithm::group() const
+{
+  return QObject::tr( "Modeler tools" );
+}
+
+QString QgsRaiseExceptionAlgorithm::groupId() const
+{
+  return QStringLiteral( "modelertools" );
+}
+
+QString QgsRaiseExceptionAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm raises an exception and cancels a model's execution.\n\n"
+                      "The exception message can be customized, and optionally an expression based condition "
+                      "can be specified. If an expression condition is used, then the exception will only "
+                      "be raised if the expression result is true. A false result indicates that no exception "
+                      "will be raised, and the model execution can continue uninterrupted." );
+}
+
+QString QgsRaiseExceptionAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Raises an exception and cancels a model's execution." );
+}
+
+QgsRaiseExceptionAlgorithm *QgsRaiseExceptionAlgorithm::createInstance() const
+{
+  return new QgsRaiseExceptionAlgorithm();
+}
+
+void QgsRaiseExceptionAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "MESSAGE" ), QObject::tr( "Error message" ) ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "CONDITION" ), QObject::tr( "Condition" ), QVariant(), QString(), true ) );
+}
+
+QVariantMap QgsRaiseExceptionAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  const QString expression = parameterAsExpression( parameters, QStringLiteral( "CONDITION" ), context );
+  if ( !expression.isEmpty() )
+  {
+    QgsExpressionContext expContext = createExpressionContext( parameters, context );
+    QgsExpression exp( expression );
+    if ( exp.hasParserError() )
+    {
+      throw QgsProcessingException( QObject::tr( "Error parsing condition expression: %1" ).arg( exp.parserErrorString() ) );
+    }
+    if ( !exp.evaluate( &expContext ).toBool() )
+      return QVariantMap();
+  }
+
+  const QString error = parameterAsString( parameters, QStringLiteral( "MESSAGE" ), context );
+  throw QgsProcessingException( error );
+}
+
+
+//
+// QgsRaiseWarningAlgorithm
+//
+
+QString QgsRaiseWarningAlgorithm::name() const
+{
+  return QStringLiteral( "raisewarning" );
+}
+
+QgsProcessingAlgorithm::Flags QgsRaiseWarningAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagHideFromToolbox;
+}
+
+QString QgsRaiseWarningAlgorithm::displayName() const
+{
+  return QObject::tr( "Raise warning" );
+}
+
+QStringList QgsRaiseWarningAlgorithm::tags() const
+{
+  return QObject::tr( "abort,warn,error,cancel" ).split( ',' );
+}
+
+QString QgsRaiseWarningAlgorithm::group() const
+{
+  return QObject::tr( "Modeler tools" );
+}
+
+QString QgsRaiseWarningAlgorithm::groupId() const
+{
+  return QStringLiteral( "modelertools" );
+}
+
+QString QgsRaiseWarningAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm raises a warning message in the log.\n\n"
+                      "The warning message can be customized, and optionally an expression based condition "
+                      "can be specified. If an expression condition is used, then the warning will only "
+                      "be logged if the expression result is true. A false result indicates that no warning "
+                      "will be logged." );
+}
+
+QString QgsRaiseWarningAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Raises an warning message." );
+}
+
+QgsRaiseWarningAlgorithm *QgsRaiseWarningAlgorithm::createInstance() const
+{
+  return new QgsRaiseWarningAlgorithm();
+}
+
+void QgsRaiseWarningAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "MESSAGE" ), QObject::tr( "Warning message" ) ) );
+  addParameter( new QgsProcessingParameterExpression( QStringLiteral( "CONDITION" ), QObject::tr( "Condition" ), QVariant(), QString(), true ) );
+}
+
+QVariantMap QgsRaiseWarningAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  const QString expression = parameterAsExpression( parameters, QStringLiteral( "CONDITION" ), context );
+  if ( !expression.isEmpty() )
+  {
+    QgsExpressionContext expContext = createExpressionContext( parameters, context );
+    QgsExpression exp( expression );
+    if ( exp.hasParserError() )
+    {
+      throw QgsProcessingException( QObject::tr( "Error parsing condition expression: %1" ).arg( exp.parserErrorString() ) );
+    }
+    if ( !exp.evaluate( &expContext ).toBool() )
+      return QVariantMap();
+  }
+
+  const QString warning = parameterAsString( parameters, QStringLiteral( "MESSAGE" ), context );
+  feedback->reportError( warning );
+  return QVariantMap();
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmraiseexception.h
+++ b/src/analysis/processing/qgsalgorithmraiseexception.h
@@ -1,0 +1,82 @@
+/***************************************************************************
+                         qgsalgorithmraiseexception.h
+                         ---------------------
+    begin                : February 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMRAISEEXCEPTION_H
+#define QGSALGORITHMRAISEEXCEPTION_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
+
+///@cond PRIVATE
+
+/**
+ * Native raise exception algorithm.
+ */
+class QgsRaiseExceptionAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsRaiseExceptionAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsRaiseExceptionAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+};
+
+/**
+ * Native raise warning algorithm.
+ */
+class QgsRaiseWarningAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsRaiseWarningAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsRaiseWarningAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+};
+
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMRAISEEXCEPTION_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -101,6 +101,7 @@
 #include "qgsalgorithmpoleofinaccessibility.h"
 #include "qgsalgorithmprojectpointcartesian.h"
 #include "qgsalgorithmpromotetomultipart.h"
+#include "qgsalgorithmraiseexception.h"
 #include "qgsalgorithmrandomextract.h"
 #include "qgsalgorithmrandompointsextent.h"
 #include "qgsalgorithmrasterlayeruniquevalues.h"
@@ -297,6 +298,8 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsPoleOfInaccessibilityAlgorithm() );
   addAlgorithm( new QgsProjectPointCartesianAlgorithm() );
   addAlgorithm( new QgsPromoteToMultipartAlgorithm() );
+  addAlgorithm( new QgsRaiseExceptionAlgorithm() );
+  addAlgorithm( new QgsRaiseWarningAlgorithm() );
   addAlgorithm( new QgsRandomExtractAlgorithm() );
   addAlgorithm( new QgsRandomPointsExtentAlgorithm() );
   addAlgorithm( new QgsRasterLayerUniqueValuesReportAlgorithm() );

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -316,14 +316,12 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       bool ok = false;
       std::unique_ptr< QgsProcessingAlgorithm > childAlg( child.algorithm()->create( child.configuration() ) );
       QVariantMap results = childAlg->run( childParams, context, &modelFeedback, &ok, child.configuration() );
-      childAlg.reset( nullptr );
       if ( !ok )
       {
-        QString error = QObject::tr( "Error encountered while running %1" ).arg( child.description() );
-        if ( feedback )
-          feedback->reportError( error );
+        const QString error = childAlg->flags() & QgsProcessingAlgorithm::FlagCustomException ? QString() : QObject::tr( "Error encountered while running %1" ).arg( child.description() );
         throw QgsProcessingException( error );
       }
+      childAlg.reset( nullptr );
       childResults.insert( childId, results );
 
       // look through child alg's outputs to determine whether any of these should be copied

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -76,6 +76,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagDisplayNameIsLiteral = 1 << 7, //!< Algorithm's display name is a static literal string, and should not be translated or automatically formatted. For use with algorithms named after commands, e.g. GRASS 'v.in.ogr'.
       FlagSupportsInPlaceEdits = 1 << 8, //!< Algorithm supports in-place editing
       FlagKnownIssues = 1 << 9, //!< Algorithm has known issues
+      FlagCustomException = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -106,6 +106,9 @@ class TestQgsProcessingAlgs: public QObject
     void shapefileEncoding();
     void setLayerEncoding();
 
+    void raiseException();
+    void raiseWarning();
+
   private:
 
     QString mPointLayerPath;
@@ -2122,6 +2125,87 @@ void TestQgsProcessingAlgs::setLayerEncoding()
   QVERIFY( ok );
   QCOMPARE( vl->dataProvider()->encoding(), QStringLiteral( "ISO-8859-1" ) );
 
+}
+
+class TestProcessingFeedback : public QgsProcessingFeedback
+{
+  public:
+
+    void reportError( const QString &error, bool ) override
+    {
+      errors << error;
+    }
+
+    QStringList errors;
+
+};
+
+void TestQgsProcessingAlgs::raiseException()
+{
+  TestProcessingFeedback feedback;
+
+  std::unique_ptr< QgsProcessingAlgorithm > alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:raiseexception" ) ) );
+  QVERIFY( alg != nullptr );
+
+  QVariantMap parameters;
+  parameters.insert( QStringLiteral( "MESSAGE" ), QStringLiteral( "you done screwed up boy" ) );
+
+  bool ok = false;
+  std::unique_ptr< QgsProcessingContext > context = qgis::make_unique< QgsProcessingContext >();
+
+  QVariantMap results;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( !ok );
+
+  QCOMPARE( feedback.errors, QStringList() << QStringLiteral( "you done screwed up boy" ) );
+
+  parameters.insert( QStringLiteral( "CONDITION" ), QStringLiteral( "FALSE" ) );
+  feedback.errors.clear();
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( feedback.errors, QStringList() );
+
+  parameters.insert( QStringLiteral( "CONDITION" ), QStringLiteral( "TRUE" ) );
+  feedback.errors.clear();
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( !ok );
+
+  QCOMPARE( feedback.errors, QStringList() << QStringLiteral( "you done screwed up boy" ) );
+}
+
+void TestQgsProcessingAlgs::raiseWarning()
+{
+  TestProcessingFeedback feedback;
+
+  std::unique_ptr< QgsProcessingAlgorithm > alg( QgsApplication::processingRegistry()->createAlgorithmById( QStringLiteral( "native:raisewarning" ) ) );
+  QVERIFY( alg != nullptr );
+
+  QVariantMap parameters;
+  parameters.insert( QStringLiteral( "MESSAGE" ), QStringLiteral( "you mighta screwed up boy, but i aint so sure" ) );
+
+  bool ok = false;
+  std::unique_ptr< QgsProcessingContext > context = qgis::make_unique< QgsProcessingContext >();
+
+  QVariantMap results;
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( feedback.errors, QStringList() << QStringLiteral( "you mighta screwed up boy, but i aint so sure" ) );
+
+  parameters.insert( QStringLiteral( "CONDITION" ), QStringLiteral( "FALSE" ) );
+  feedback.errors.clear();
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( feedback.errors, QStringList() );
+
+  parameters.insert( QStringLiteral( "CONDITION" ), QStringLiteral( "TRUE" ) );
+  feedback.errors.clear();
+  results = alg->run( parameters, *context, &feedback, &ok );
+  QVERIFY( ok );
+
+  QCOMPARE( feedback.errors, QStringList() << QStringLiteral( "you mighta screwed up boy, but i aint so sure" ) );
 }
 
 QGSTEST_MAIN( TestQgsProcessingAlgs )


### PR DESCRIPTION
These algorithms raise either a custom warning in the processing log, OR raise
an exception which causes the model execution to terminate.

An optional condition expression can be specified to control whether or not
the warning/exception is raised, allowing logic like "if the output layer from
another algorithm contains more then 10 features, then abort the model execution"

Sponsored by Fisel + König
