### PR TITLE
Fix unicode character errors when fetching WKT string from GDAL

### DIFF
--- a/src/core/qgsogrutils.cpp
+++ b/src/core/qgsogrutils.cpp
@@ -736,7 +736,7 @@ QString QgsOgrUtils::OGRSpatialReferenceToWkt( OGRSpatialReferenceH srs )
   OSRExportToWkt( srs, &pszWkt );
 #endif
 
-  const QString res( pszWkt );
+  const QString res = QString::fromLatin1( pszWkt );
   CPLFree( pszWkt );
   return res;
 }


### PR DESCRIPTION
## Description

Without this fix, wkt string passed on by GDAL's OSRExportToWktEx function have unicode character errors. For e.g.:
![image](https://user-images.githubusercontent.com/1728657/74917783-a4cc4000-53fa-11ea-9642-95e046baa3f3.png)
