### PR TITLE
Small rework on QgsFeatureFilterModel

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -225,7 +225,7 @@ QVariant QgsFeatureFilterModel::data( const QModelIndex &index, int role ) const
 void QgsFeatureFilterModel::updateCompleter()
 {
   emit beginUpdate();
-  if( !mGatherer )
+  if ( !mGatherer )
   {
     emit endUpdate();
     return;


### PR DESCRIPTION
Add a check for nullptr on mGatherer in QgsFeatureFilterModel::updateCompleter.

Also avoid relying on signal to slot call order conservation to make sure that gathererThreadFinished (that delete mGatherer)  is called after updateCompleter :
  - gathererThreadFinished is disconnected from finished signal emitted at the end of QgsFieldExpressionValuesGatherer::run
  - gathererThreadFinished is instead called explicitly at the end of updateCompleter
  - when QgsFieldExpressionValuesGatherer::run is stopped manually, rely on the connection to QgsFieldExpressionValuesGatherer::deleteLater to clean mGatherer.

This should fix an observed bug where a crash happened at the begining of updateCompleter because mGatherer was null.

Could fix #34580
