### PR TITLE
Fix atlas filename expression validation

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2665,6 +2665,21 @@ void QgsLayoutDesignerDialog::exportAtlasToRaster()
     QString error;
     printAtlas->setFilenameExpression( QStringLiteral( "'output_'||@atlas_featurenumber" ), error );
   }
+  else
+  {
+    // Validate filename expression
+    QString errorString;
+    if ( ! printAtlas->setFilenameExpression( printAtlas->filenameExpression(), errorString ) )
+    {
+      QMessageBox::warning( nullptr, tr( "Export Atlas" ),
+                            tr( "Output file name expression is not valid. Canceling.\n"
+                                "Evaluation error: %1" ).arg( errorString ),
+                            QMessageBox::Ok,
+                            QMessageBox::Ok );
+      return;
+    }
+  }
+
 
   QString lastUsedDir = defaultExportPath();
 


### PR DESCRIPTION
Make sure expression is validated within the context
of the layer (even when there is no current feature).

Also do not start the export process if the expression
is not valid.

Fixes #33824
