### PR TITLE
Don't try to use a fallback transform when only one operation is possible

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -743,7 +743,9 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
 #if PROJ_VERSION_MAJOR>=6
 
   mFallbackOperationOccurred = false;
-  if ( actualRes != 0 && ( d->mAllowFallbackTransforms || mBallparkTransformsAreAppropriate ) )
+  if ( actualRes != 0
+       && ( d->mAvailableOpCount > 1 || d->mAvailableOpCount == -1 ) // only use fallbacks if more than one operation is possible -- otherwise we've already tried it and it failed
+       && ( d->mAllowFallbackTransforms || mBallparkTransformsAreAppropriate ) )
   {
     // fail #1 -- try with getting proj to auto-pick an appropriate coordinate operation for the points
     if ( PJ *transform = d->threadLocalFallbackProjData() )

--- a/src/core/qgscoordinatetransform_p.h
+++ b/src/core/qgscoordinatetransform_p.h
@@ -103,6 +103,7 @@ class QgsCoordinateTransformPrivate : public QSharedData
     ProjData threadLocalProjData();
 
 #if PROJ_VERSION_MAJOR>=6
+    int mAvailableOpCount = -1;
     ProjData threadLocalFallbackProjData();
 
     // Only meant to be called by QgsCoordinateTransform::removeFromCacheObjectsBelongingToCurrentThread()


### PR DESCRIPTION
Don't try to use a fallback transform when we've already established that only a single transform is possible between a CRS pair. (since we've already tried that transform, it's pointless to re-try
it and expect different results)

Avoids superious "fallback transform used" warnings when only one
operation is possible between a CRS pair
