### PR TITLE
Fix incorrect error about "cannot load dependant fields"

### DIFF
--- a/python/core/auto_generated/qgsfieldmodel.sip.in
+++ b/python/core/auto_generated/qgsfieldmodel.sip.in
@@ -136,6 +136,29 @@ like the field name, alias and type.
 .. versionadded:: 3.0
 %End
 
+    void setFields( const QgsFields &fields );
+%Docstring
+Manually sets the ``fields`` to use for the model.
+
+This method should only be used when the model ISN'T associated with a layer()
+and needs to show the fields from an arbitrary field collection instead. Calling
+setFields() will automatically clear any existing layer().
+
+.. seealso:: :py:func:`fields`
+
+.. versionadded:: 3.14
+%End
+
+    QgsFields fields() const;
+%Docstring
+Returns the fields currently shown in the model.
+
+This will either be fields from the associated layer() or the fields
+manually set by a call to setFields().
+
+.. versionadded:: 3.14
+%End
+
   public slots:
 
     void setLayer( QgsVectorLayer *layer );

--- a/python/gui/auto_generated/qgsfieldcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfieldcombobox.sip.in
@@ -74,6 +74,29 @@ Returns the layer currently associated with the combobox.
 .. seealso:: :py:func:`setLayer`
 %End
 
+    void setFields( const QgsFields &fields );
+%Docstring
+Manually sets the ``fields`` to use for the combo box.
+
+This method should only be used when the combo box ISN'T associated with a layer()
+and needs to show the fields from an arbitrary field collection instead. Calling
+setFields() will automatically clear any existing layer().
+
+.. seealso:: :py:func:`fields`
+
+.. versionadded:: 3.14
+%End
+
+    QgsFields fields() const;
+%Docstring
+Returns the fields currently shown in the combobox.
+
+This will either be fields from the associated layer() or the fields
+manually set by a call to setFields().
+
+.. versionadded:: 3.14
+%End
+
   signals:
     void fieldChanged( const QString &fieldName );
 %Docstring

--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -411,6 +411,10 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       {
         return mLayer->attributeDisplayName( index.row() - fieldOffset );
       }
+      else if ( mFields.size() > index.row() - fieldOffset )
+      {
+        return mFields.field( index.row() - fieldOffset ).displayName();
+      }
       else
         return QVariant();
     }
@@ -489,4 +493,17 @@ QString QgsFieldModel::fieldToolTip( const QgsField &field )
   }
   toolTip += QStringLiteral( "<p>%1</p>" ).arg( typeString );
   return toolTip;
+}
+
+void QgsFieldModel::setFields( const QgsFields &fields )
+{
+  setLayer( nullptr );
+  beginResetModel();
+  mFields = fields;
+  endResetModel();
+}
+
+QgsFields QgsFieldModel::fields() const
+{
+  return mFields;
 }

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -137,6 +137,28 @@ class CORE_EXPORT QgsFieldModel : public QAbstractItemModel
      */
     static QString fieldToolTip( const QgsField &field );
 
+    /**
+     * Manually sets the \a fields to use for the model.
+     *
+     * This method should only be used when the model ISN'T associated with a layer()
+     * and needs to show the fields from an arbitrary field collection instead. Calling
+     * setFields() will automatically clear any existing layer().
+     *
+     * \see fields()
+     * \since QGIS 3.14
+     */
+    void setFields( const QgsFields &fields );
+
+    /**
+     * Returns the fields currently shown in the model.
+     *
+     * This will either be fields from the associated layer() or the fields
+     * manually set by a call to setFields().
+     *
+     * \since QGIS 3.14
+     */
+    QgsFields fields() const;
+
   public slots:
 
     /**

--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -54,6 +54,16 @@ QgsVectorLayer *QgsFieldComboBox::layer() const
   return mFieldProxyModel->sourceFieldModel()->layer();
 }
 
+void QgsFieldComboBox::setFields( const QgsFields &fields )
+{
+  mFieldProxyModel->sourceFieldModel()->setFields( fields );
+}
+
+QgsFields QgsFieldComboBox::fields() const
+{
+  return mFieldProxyModel->sourceFieldModel()->fields();
+}
+
 void QgsFieldComboBox::setField( const QString &fieldName )
 {
   const QString prevField = currentField();

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -25,6 +25,7 @@
 
 class QgsMapLayer;
 class QgsVectorLayer;
+class QgsFields;
 
 /**
  * \ingroup gui
@@ -76,6 +77,28 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
      * \see setLayer()
      */
     QgsVectorLayer *layer() const;
+
+    /**
+     * Manually sets the \a fields to use for the combo box.
+     *
+     * This method should only be used when the combo box ISN'T associated with a layer()
+     * and needs to show the fields from an arbitrary field collection instead. Calling
+     * setFields() will automatically clear any existing layer().
+     *
+     * \see fields()
+     * \since QGIS 3.14
+     */
+    void setFields( const QgsFields &fields );
+
+    /**
+     * Returns the fields currently shown in the combobox.
+     *
+     * This will either be fields from the associated layer() or the fields
+     * manually set by a call to setFields().
+     *
+     * \since QGIS 3.14
+     */
+    QgsFields fields() const;
 
   signals:
     //! Emitted when the currently selected field changes.

--- a/tests/src/python/test_qgsfieldcombobox.py
+++ b/tests/src/python/test_qgsfieldcombobox.py
@@ -12,7 +12,7 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 
 import qgis  # NOQA
 
-from qgis.core import QgsFields, QgsVectorLayer, QgsFieldProxyModel
+from qgis.core import QgsFields, QgsVectorLayer, QgsFieldProxyModel, QgsField, QgsFieldModel
 from qgis.gui import QgsFieldComboBox
 from qgis.PyQt.QtCore import QVariant, Qt
 from qgis.PyQt.QtTest import QSignalSpy
@@ -47,6 +47,13 @@ class TestQgsFieldComboBox(unittest.TestCase):
         w.setField('fldint')
         self.assertEqual(w.currentField(), 'fldint')
 
+        fields = QgsFields()
+        fields.append(QgsField('test1', QVariant.String))
+        fields.append(QgsField('test2', QVariant.String))
+        w.setFields(fields)
+        self.assertIsNone(w.layer())
+        self.assertEqual(w.fields(), fields)
+
     def testFilter(self):
         """ test setting field with filter """
         l = create_layer()
@@ -79,6 +86,16 @@ class TestQgsFieldComboBox(unittest.TestCase):
         w.setField(None)
         self.assertEqual(len(spy), 3)
         self.assertEqual(spy[-1][0], None)
+
+    def testManualFields(self):
+        fields = QgsFields()
+        fields.append(QgsField('test1', QVariant.String))
+        fields.append(QgsField('test2', QVariant.String))
+        w = QgsFieldComboBox()
+        w.setFields(fields)
+        self.assertEqual(w.count(), 2)
+        self.assertEqual(w.itemText(0), 'test1')
+        self.assertEqual(w.itemText(1), 'test2')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -20,7 +20,7 @@ from qgis.core import (QgsField,
                        QgsEditorWidgetSetup,
                        QgsProject,
                        QgsVectorLayerJoinInfo)
-from qgis.PyQt.QtCore import QVariant, Qt
+from qgis.PyQt.QtCore import QVariant, Qt, QModelIndex
 
 from qgis.testing import start_app, unittest
 
@@ -63,6 +63,13 @@ class TestQgsFieldModel(unittest.TestCase):
         self.assertTrue(m.allowEmptyFieldName())
         m.setAllowEmptyFieldName(False)
         self.assertFalse(m.allowEmptyFieldName())
+
+        fields = QgsFields()
+        fields.append(QgsField('test1', QVariant.String))
+        fields.append(QgsField('test2', QVariant.String))
+        m.setFields(fields)
+        self.assertIsNone(m.layer())
+        self.assertEqual(m.fields(), fields)
 
     def testIndexFromName(self):
         l, m = create_model()
@@ -250,6 +257,16 @@ class TestQgsFieldModel(unittest.TestCase):
         self.assertEqual(m.data(m.indexFromName('an expression'), Qt.DisplayRole), 'an expression')
         m.setAllowEmptyFieldName(True)
         self.assertFalse(m.data(m.indexFromName(None), Qt.DisplayRole))
+
+    def testManualFields(self):
+        _, m = create_model()
+        fields = QgsFields()
+        fields.append(QgsField('f1', QVariant.String))
+        fields.append(QgsField('f2', QVariant.String))
+        m.setFields(fields)
+        self.assertEqual(m.rowCount(), 2)
+        self.assertEqual(m.data(m.index(0, 0, QModelIndex()), Qt.DisplayRole), 'f1')
+        self.assertEqual(m.data(m.index(1, 0, QModelIndex()), Qt.DisplayRole), 'f2')
 
     def testEditorWidgetTypeRole(self):
         l, m = create_model()


### PR DESCRIPTION
Add API to QgsFieldModel/QgsFieldComboBox to manually set the field to show in the widget (i.e. when no layer is available), and use this to fix the incorrect error message when the "selected features" option is checked
