### PR TITLE
Add parameters to contour.py to enable creation of polygons

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -37,7 +37,7 @@ from .buildvrt import buildvrt
 from .ClipRasterByExtent import ClipRasterByExtent
 from .ClipRasterByMask import ClipRasterByMask
 from .ColorRelief import ColorRelief
-from .contour import contour
+from .contour import contour, contour_polygon
 from .Datasources2Vrt import Datasources2Vrt
 from .fillnodata import fillnodata
 from .gdalinfo import gdalinfo
@@ -147,6 +147,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             ClipRasterByMask(),
             ColorRelief(),
             contour(),
+            contour_polygon(),
             Datasources2Vrt(),
             fillnodata(),
             gdalinfo(),

--- a/python/plugins/processing/algs/gdal/contour.py
+++ b/python/plugins/processing/algs/gdal/contour.py
@@ -213,12 +213,12 @@ class contour_polygon(contour):
         self.removeParameter(contour.FIELD_NAME)
 
         self.addParameter(QgsProcessingParameterString(self.FIELD_NAME_MIN,
-                                                       self.tr('Attribute name to use for the minimum elevation of contour polygons (if not set, no elevation attribute is attached)'),
+                                                       self.tr('Attribute name for minimum elevation of contour polygon'),
                                                        defaultValue='ELEV_MIN',
                                                        optional=True))
 
         self.addParameter(QgsProcessingParameterString(self.FIELD_NAME_MAX,
-                                                       self.tr('Attribute name to use for the maximum elevation of contour polygons (if not set, no elevation attribute is attached)'),
+                                                       self.tr('Attribute name for maximum elevation of contour polygon'),
                                                        defaultValue='ELEV_MAX',
                                                        optional=True))
 

--- a/python/plugins/processing/algs/gdal/contour.py
+++ b/python/plugins/processing/algs/gdal/contour.py
@@ -81,7 +81,6 @@ class contour(GdalAlgorithm):
         create_3d_param.setFlags(create_3d_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(create_3d_param)
 
-
         ignore_nodata_param = QgsProcessingParameterBoolean(self.IGNORE_NODATA,
                                                             self.tr('Treat all raster values as valid'),
                                                             defaultValue=False)
@@ -194,7 +193,6 @@ class contour(GdalAlgorithm):
         arguments.append(inLayer.source())
         arguments.append(output)
         return arguments
-
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         arguments = self._buildArgsList(parameters, context, feedback, executing)

--- a/python/plugins/processing/algs/gdal/contour.py
+++ b/python/plugins/processing/algs/gdal/contour.py
@@ -203,7 +203,6 @@ class contour_polygon(contour):
 
     FIELD_NAME_MIN = 'FIELD_NAME_MIN'
     FIELD_NAME_MAX = 'FIELD_NAME_MAX'
-    OUTPUT = 'OUTPUT'
 
     def __init__(self):
         super().__init__()
@@ -226,7 +225,7 @@ class contour_polygon(contour):
         # Need to replace the output parameter, as we are producing a different type of output
         self.removeParameter(contour.OUTPUT)
         self.addParameter(QgsProcessingParameterVectorDestination(
-            self.OUTPUT, self.tr('Contours'), QgsProcessing.TypeVectorPolygon))
+            contour.OUTPUT, self.tr('Contours'), QgsProcessing.TypeVectorPolygon))
 
     def name(self):
         return 'contour_polygon'

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -435,6 +435,20 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  '-b 1 -a elev -i 5.0 -snodata 9999.0 -f "ESRI Shapefile" ' +
                  source + ' ' +
                  outdir + '/check.shp'])
+            # with CREATE_POLYGON
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'FIELD_NAME': 'elev',
+                                        'FIELD_NAME_MIN': 'min',
+                                        'FIELD_NAME_MAX': 'max',
+                                        'INTERVAL': 5,
+                                        'CREATE_POLYGON': True,
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['gdal_contour',
+                 '-b 1 -i 5.0 -p -amin min -amax max -f "ESRI Shapefile" ' +
+                 source + ' ' +
+                 outdir + '/check.shp'])
             # with "0" NODATA value
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -404,7 +404,6 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  source + ' ' +
                  outdir + '/check.jpg'])
 
-
     def testContourPolygon(self):
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()
@@ -423,7 +422,6 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                     '-p -amax max -amin min -b 1 -i 5.0 -f "ESRI Shapefile" ' +
                     source + ' ' +
                     outdir + '/check.shp'])
-
 
     def testContour(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsRasterTest.py
@@ -47,7 +47,7 @@ from processing.algs.gdal.GridNearestNeighbor import GridNearestNeighbor
 from processing.algs.gdal.gdal2tiles import gdal2tiles
 from processing.algs.gdal.gdalcalc import gdalcalc
 from processing.algs.gdal.gdaltindex import gdaltindex
-from processing.algs.gdal.contour import contour
+from processing.algs.gdal.contour import contour, contour_polygon
 from processing.algs.gdal.gdalinfo import gdalinfo
 from processing.algs.gdal.hillshade import hillshade
 from processing.algs.gdal.aspect import aspect
@@ -404,6 +404,27 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                  source + ' ' +
                  outdir + '/check.jpg'])
 
+
+    def testContourPolygon(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+        alg = contour_polygon()
+        alg.initAlgorithm()
+        with tempfile.TemporaryDirectory() as outdir:
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'FIELD_NAME_MIN': 'min',
+                                        'FIELD_NAME_MAX': 'max',
+                                        'INTERVAL': 5,
+                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
+                ['gdal_contour',
+                    '-p -amax max -amin min -b 1 -i 5.0 -f "ESRI Shapefile" ' +
+                    source + ' ' +
+                    outdir + '/check.shp'])
+
+
     def testContour(self):
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()
@@ -433,20 +454,6 @@ class TestGdalRasterAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsT
                                         'OUTPUT': outdir + '/check.shp'}, context, feedback),
                 ['gdal_contour',
                  '-b 1 -a elev -i 5.0 -snodata 9999.0 -f "ESRI Shapefile" ' +
-                 source + ' ' +
-                 outdir + '/check.shp'])
-            # with CREATE_POLYGON
-            self.assertEqual(
-                alg.getConsoleCommands({'INPUT': source,
-                                        'BAND': 1,
-                                        'FIELD_NAME': 'elev',
-                                        'FIELD_NAME_MIN': 'min',
-                                        'FIELD_NAME_MAX': 'max',
-                                        'INTERVAL': 5,
-                                        'CREATE_POLYGON': True,
-                                        'OUTPUT': outdir + '/check.shp'}, context, feedback),
-                ['gdal_contour',
-                 '-b 1 -i 5.0 -p -amin min -amax max -f "ESRI Shapefile" ' +
                  source + ' ' +
                  outdir + '/check.shp'])
             # with "0" NODATA value


### PR DESCRIPTION
## Description

`gdal_contour` supports creating polygon contours instead of lines, but QGIS doesn't expose that functionality. This commit adds the necessary bits to expose it. Specifically, it adds 3 new parameters to the plugin:

* `CREATE_POLYGON`: This controls whether polygon mode is enabled, i.e. is `-p` passed to `gdal_contour`. 

* `FIELD_NAME_MIN` and `FIELD_NAME_MAX`: These correspond to the `-amin` and `-amax` parameters of `gdal_contour` and are only added to the output if the polygon mode is enabled.

 I also modified the plugin to avoid setting the `-a` parameter when polygon mode is enabled to ensure that there aren't extraneous errors from `gdal_contour`. 

### Screenshot
![image](https://user-images.githubusercontent.com/56168/75208838-94390400-5731-11ea-8e78-c2328cb48383.png)

