### PR TITLE
[layouts] Fix crash when reading layouts XML after failing to add a layout

### DIFF
--- a/src/core/layout/qgslayoutmanager.cpp
+++ b/src/core/layout/qgslayoutmanager.cpp
@@ -210,11 +210,7 @@ bool QgsLayoutManager::readXml( const QDomElement &element, const QDomDocument &
       continue;
     }
     l->undoStack()->blockCommands( false );
-    if ( addLayout( l.get() ) )
-    {
-      ( void )l.release(); // ownership was transferred successfully
-    }
-    else
+    if ( !addLayout( l.release() ) )
     {
       result = false;
     }
@@ -229,11 +225,7 @@ bool QgsLayoutManager::readXml( const QDomElement &element, const QDomDocument &
       result = false;
       continue;
     }
-    if ( addLayout( r.get() ) )
-    {
-      ( void )r.release(); // ownership was transferred successfully
-    }
-    else
+    if ( !addLayout( r.release() ) )
     {
       result = false;
     }


### PR DESCRIPTION
## Description

This PR fixes a layout crasher filed as #34621 . The crash occurred due to an attempt at double deleting a QgsPrintLayout pointer after failing to add a layout being restored in readXml which shares the same name as another layout already added.

