### PR TITLE
[feature] Relation widget force suppress popup

### DIFF
--- a/python/core/auto_generated/qgsvectorlayertools.sip.in
+++ b/python/core/auto_generated/qgsvectorlayertools.sip.in
@@ -91,6 +91,25 @@ Copy and move features with defined translation.
          - errorMsg: If given, it will contain the error message
 %End
 
+    bool forceSuppressFormPopup() const;
+%Docstring
+Returns force suppress form popup status.
+
+:return: ``True`` if force suppress form popup is set.
+
+.. versionadded:: 3.14
+%End
+
+    void setForceSuppressFormPopup( bool forceSuppressFormPopup );
+%Docstring
+Sets force suppress form popup status to ``forceSuppressFormPopup``.
+
+This flag will override the layer and general settings regarding the automatic
+opening of the attribute form dialog when digitizing is completed.
+
+.. versionadded:: 3.14
+%End
+
 };
 
 /************************************************************************

--- a/src/app/attributeformconfig/qgsattributerelationedit.cpp
+++ b/src/app/attributeformconfig/qgsattributerelationedit.cpp
@@ -36,7 +36,17 @@ void QgsAttributeRelationEdit::setCardinality( const QVariant &auserData )
     coCardinality->setCurrentIndex( idx );
 }
 
+void QgsAttributeRelationEdit::setForceSuppressFormPopup( bool suppressFormOpen )
+{
+  cbForceSuppressFormPopup->setChecked( suppressFormOpen );
+}
+
 QVariant  QgsAttributeRelationEdit::cardinality()
 {
   return coCardinality->currentData();
+}
+
+bool QgsAttributeRelationEdit::forceSuppressFormPopup()
+{
+  return cbForceSuppressFormPopup->isChecked();
 }

--- a/src/app/attributeformconfig/qgsattributerelationedit.h
+++ b/src/app/attributeformconfig/qgsattributerelationedit.h
@@ -42,9 +42,27 @@ class APP_EXPORT QgsAttributeRelationEdit: public QWidget, private Ui::QgsAttrib
     void setCardinality( const QVariant &auserData = QVariant() );
 
     /**
+     * Sets force suppress form popup status to \a forceSuppressFormPopup.
+     *
+     * This flag will override the layer and general settings regarding the automatic
+     * opening of the attribute form dialog when digitizing is completed.
+     *
+     * \since QGIS 3.14
+     */
+    void setForceSuppressFormPopup( bool forceSuppressFormPopup );
+
+    /**
      * Getter for combo cardinality
      */
     QVariant cardinality();
+
+    /**
+     * Returns force suppress form popup status.
+     *
+     * \returns TRUE if force suppress form popup is set.
+     * \since QGIS 3.14
+     */
+    bool forceSuppressFormPopup();
 
     QString mRelationId;
   private:

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -381,6 +381,7 @@ void QgsAttributesFormProperties::loadAttributeRelationEdit()
   }
 
   mAttributeRelationEdit->setCardinality( cfg.mCardinality );
+  mAttributeRelationEdit->setForceSuppressFormPopup( cfg.mForceSuppressFormPopup );
 
   mAttributeRelationEdit->layout()->setMargin( 0 );
   mAttributeTypeFrame->layout()->setMargin( 0 );
@@ -397,6 +398,7 @@ void QgsAttributesFormProperties::storeAttributeRelationEdit()
   RelationConfig cfg;
 
   cfg.mCardinality = mAttributeRelationEdit->cardinality();
+  cfg.mForceSuppressFormPopup = mAttributeRelationEdit->forceSuppressFormPopup();
 
   QTreeWidgetItem *relationContainer = mAvailableWidgetsTree->invisibleRootItem()->child( 1 );
 
@@ -921,6 +923,7 @@ void QgsAttributesFormProperties::apply()
 
     QVariantMap cfg;
     cfg[QStringLiteral( "nm-rel" )] = relCfg.mCardinality.toString();
+    cfg[QStringLiteral( "force-suppress-popup" )] = relCfg.mForceSuppressFormPopup;
 
     editFormConfig.setWidgetConfig( itemData.name(), cfg );
   }

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -188,6 +188,11 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
 
       QVariant mCardinality;
 
+      /**
+       * Force suppress form popup open overriding other options.
+       */
+      bool mForceSuppressFormPopup;
+
       operator QVariant();
     };
 

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -37,6 +37,7 @@ bool QgsGuiVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAttribu
 
   f->setGeometry( defaultGeometry );
   QgsFeatureAction a( tr( "Add feature" ), *f, layer );
+  a.setForceSuppressFormPopup( forceSuppressFormPopup() );
   bool added = a.addFeature( defaultValues );
   if ( !feat )
     delete f;

--- a/src/core/qgstrackedvectorlayertools.cpp
+++ b/src/core/qgstrackedvectorlayertools.cpp
@@ -23,6 +23,8 @@ bool QgsTrackedVectorLayerTools::addFeature( QgsVectorLayer *layer, const QgsAtt
   if ( !feature )
     f = new QgsFeature();
 
+  const_cast<QgsVectorLayerTools *>( mBackend )->setForceSuppressFormPopup( forceSuppressFormPopup() );
+
   if ( mBackend->addFeature( layer, defaultValues, defaultGeometry, f ) )
   {
     mAddedFeatures[layer].insert( f->id() );

--- a/src/core/qgsvectorlayertools.cpp
+++ b/src/core/qgsvectorlayertools.cpp
@@ -106,3 +106,13 @@ bool QgsVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureReq
   }
   return res;
 }
+
+bool QgsVectorLayerTools::forceSuppressFormPopup() const
+{
+  return mForceSuppressFormPopup;
+}
+
+void QgsVectorLayerTools::setForceSuppressFormPopup( bool forceSuppressFormPopup )
+{
+  mForceSuppressFormPopup = forceSuppressFormPopup;
+}

--- a/src/core/qgsvectorlayertools.h
+++ b/src/core/qgsvectorlayertools.h
@@ -113,6 +113,29 @@ class CORE_EXPORT QgsVectorLayerTools : public QObject
      */
     virtual bool copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureRequest &request SIP_INOUT, double dx = 0, double dy = 0, QString *errorMsg SIP_OUT = nullptr, const bool topologicalEditing = false, QgsVectorLayer *topologicalLayer = nullptr ) const;
 
+    /**
+     * Returns force suppress form popup status.
+     *
+     * \returns TRUE if force suppress form popup is set.
+     * \since QGIS 3.14
+     */
+    bool forceSuppressFormPopup() const;
+
+    /**
+     * Sets force suppress form popup status to \a forceSuppressFormPopup.
+     *
+     * This flag will override the layer and general settings regarding the automatic
+     * opening of the attribute form dialog when digitizing is completed.
+     *
+     * \since QGIS 3.14
+     */
+    void setForceSuppressFormPopup( bool forceSuppressFormPopup );
+
+  private:
+
+    bool mForceSuppressFormPopup { false };
+
+
 };
 
 #endif // QGSVECTORLAYERTOOLS_H

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -121,6 +121,11 @@ void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
 
   QgsAttributeEditorContext myContext( QgsAttributeEditorContext( context(), mRelation, QgsAttributeEditorContext::Multiple, QgsAttributeEditorContext::Embed ) );
 
+  if ( config( QStringLiteral( "force-suppress-popup" ), false ).toBool() )
+  {
+    const_cast<QgsVectorLayerTools *>( myContext.vectorLayerTools() )->setForceSuppressFormPopup( true );
+  }
+
   w->setEditorContext( myContext );
 
   mNmRelation = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "nm-rel" ) ).toString() );

--- a/src/ui/attributeformconfig/qgsattributerelationedit.ui
+++ b/src/ui/attributeformconfig/qgsattributerelationedit.ui
@@ -19,21 +19,35 @@
      <property name="title">
       <string>Relation</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Cardinality</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Cardinality</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="coCardinality"/>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QComboBox" name="coCardinality"/>
+       <widget class="QCheckBox" name="cbForceSuppressFormPopup">
+        <property name="statusTip">
+         <string>Do not open a new attribute form after digitizing a new feature, overrides all other options </string>
+        </property>
+        <property name="text">
+         <string>Hide form for new features</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/ui/attributeformconfig/qgsattributerelationedit.ui
+++ b/src/ui/attributeformconfig/qgsattributerelationedit.ui
@@ -37,10 +37,10 @@
       <item>
        <widget class="QCheckBox" name="cbForceSuppressFormPopup">
         <property name="statusTip">
-         <string>Do not open a new attribute form after digitizing a new feature, overrides all other options </string>
+         <string>Do not open a new attribute form after digitizing a new feature, overrides all other options</string>
         </property>
         <property name="text">
-         <string>Hide form for new features</string>
+         <string>Force hide form on add feature</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Adds an option to the relation widget configuration
to suppress form popup open when new features are
added in an embedded form context.

This option overrides the form-level option (that might
still be the desired behavior when the form is used
as a standalone form).

![qgis-feature-hide-form-on-new-features](https://user-images.githubusercontent.com/142164/75249972-9786cb00-57d7-11ea-8100-3426d32831db.png)

Note: the final label is **Force hide form on add feature**
