### PR TITLE
Make "pre-set DPI not equal to painter's DPI" check less stringent

### DIFF
--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -46,7 +46,7 @@ void QgsMapRendererAbstractCustomPainterJob::preparePainter( QPainter *painter, 
   QString errMsg = QStringLiteral( "pre-set DPI not equal to painter's DPI (%1 vs %2)" )
                    .arg( paintDevice->logicalDpiX() )
                    .arg( mSettings.outputDpi() * mSettings.devicePixelRatio() );
-  Q_ASSERT_X( qgsDoubleNear( paintDevice->logicalDpiX(), mSettings.outputDpi() * mSettings.devicePixelRatio() ),
+  Q_ASSERT_X( qgsDoubleNear( paintDevice->logicalDpiX(), mSettings.outputDpi() * mSettings.devicePixelRatio(), 1.0 ),
               "Job::startRender()", errMsg.toLatin1().data() );
 #endif
 }


### PR DESCRIPTION
This assert gets tripped frequently when working with magnified maps, because there's tiny (inconsequential) differences in the dpi value.
