### PR TITLE
Focus on first feature in embedded forms

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -159,6 +159,10 @@ void QgsDualView::init( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, const Qg
 
   // This slows down load of the attribute table heaps and uses loads of memory.
   //mTableView->resizeColumnsToContents();
+
+  if ( mFeatureListModel->rowCount( ) > 0 )
+    mFeatureListView->setEditSelection( QgsFeatureIds() << mFeatureListModel->data( mFeatureListModel->index( 0, 0 ), QgsFeatureListModel::Role::FeatureRole ).value<QgsFeature>().id() );
+
 }
 
 void QgsDualView::columnBoxInit()


### PR DESCRIPTION
When opening a form with embedded children, focus on first feature (if any).
![qgis-embedded-forms-focus-first-feature](https://user-images.githubusercontent.com/142164/75335326-a1690680-5889-11ea-8de1-e4c49c67ada1.gif)
