### PR TITLE
[processing modeler] display "parents" links with dotted stroke

### DIFF
--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -152,6 +152,7 @@ class ModelerScene(QGraphicsScene):
             for depend in alg.dependencies():
                 arrow = ModelerArrowItem(self.algItems[depend], -1,
                                          self.algItems[alg.childId()], -1)
+                arrow.setPenStyle(Qt.DotLine)
                 self.algItems[depend].addArrow(arrow)
                 self.algItems[alg.childId()].addArrow(arrow)
                 arrow.updatePath()


### PR DESCRIPTION
## Description

This makes the "parent" links display as dotted lines in the modeler instead of solid lines, so that they are less visually proeminent.
