### PR TITLE
[Bugfix][Server] WMS GetFeatureInfo provides bounding box when configured

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1424,7 +1424,7 @@ namespace QgsWms
     bool segmentizeWktGeometry = QgsServerProjectUtils::wmsFeatureInfoSegmentizeWktGeometry( *mProject );
     const QSet<QString> &excludedAttributes = layer->excludeAttributesWms();
 
-    bool hasGeometry = addWktGeometry || featureBBox || layerFilterGeom;
+    bool hasGeometry = QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject ) || addWktGeometry || featureBBox || layerFilterGeom;
     fReq.setFlags( ( ( hasGeometry ) ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry ) | QgsFeatureRequest::ExactIntersect );
 
     if ( ! searchRect.isEmpty() )
@@ -1582,7 +1582,8 @@ namespace QgsWms
         }
 
         //append feature bounding box to feature info xml
-        if ( layer->wkbType() != QgsWkbTypes::NoGeometry && hasGeometry )
+        if ( QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject ) &&
+             layer->wkbType() != QgsWkbTypes::NoGeometry && hasGeometry )
         {
           QDomElement bBoxElem = infoDocument.createElement( QStringLiteral( "BoundingBox" ) );
           bBoxElem.setAttribute( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS", outputCrs.authid() );
@@ -2314,8 +2315,11 @@ namespace QgsWms
       expressionContext << QgsExpressionContextUtils::layerScope( layer );
     expressionContext.setFeature( *feat );
 
-    // always add bounding box info if feature contains geometry
-    if ( !geom.isNull() && geom.type() != QgsWkbTypes::UnknownGeometry && geom.type() != QgsWkbTypes::NullGeometry )
+    // always add bounding box info if feature contains geometry and has been
+    // explicitly configured in the project
+    if ( QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( *mProject ) &&
+         !geom.isNull() && geom.type() != QgsWkbTypes::UnknownGeometry &&
+         geom.type() != QgsWkbTypes::NullGeometry )
     {
       QgsRectangle box = feat->geometry().boundingBox();
       if ( transform.isValid() )

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-group_name-notqueryable.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-group_name-notqueryable.txt
@@ -7,6 +7,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-text-xml.txt
@@ -7,6 +7,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-thousands-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-thousands-text-xml.txt
@@ -9,6 +9,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="three èé↓" name="utf8nameè"/>
    <Attribute value="123456" name="long_int"/>
    <Attribute value="123456.8900" name="long_float"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values0-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values0-text-xml.txt
@@ -7,16 +7,19 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="1" name="id"/>
    <Attribute value="one" name="name"/>
    <Attribute value="First Value" name="utf8nameè"/>
+   <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
   </Feature>
   <Feature id="2">
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="Second Value" name="utf8nameè"/>
+   <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
   <Feature id="3">
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="Third èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_line_tolerance_20_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_line_tolerance_20_text_xml.txt
@@ -5,6 +5,7 @@ Content-Type: text/xml; charset=utf-8
  <Layer name="ls2d">
   <Feature id="1">
    <Attribute value="1" name="id"/>
+   <BoundingBox maxy="111325.1429" maxx="111319.4908" miny="-0" CRS="EPSG:3857" minx="0"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_notvisible.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_notvisible.txt
@@ -7,6 +7,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" CRS="EPSG:4326" minx="8.2035"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_0_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_0_text_xml.txt
@@ -6,6 +6,7 @@ Content-Type: text/xml; charset=utf-8
   <Feature id="2">
    <Attribute value="2" name="id"/>
    <Attribute value="" name="location"/>
+   <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_20_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_point_tolerance_20_text_xml.txt
@@ -6,10 +6,12 @@ Content-Type: text/xml; charset=utf-8
   <Feature id="1">
    <Attribute value="1" name="id"/>
    <Attribute value="Id no. 1 value, Id no. 2 value, Id número 3 value" name="location"/>
+   <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
   </Feature>
   <Feature id="2">
    <Attribute value="2" name="id"/>
    <Attribute value="" name="location"/>
+   <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_polygon_tolerance_20_text_xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_polygon_tolerance_20_text_xml.txt
@@ -5,6 +5,7 @@ Content-Type: text/xml; charset=utf-8
  <Layer name="p2d">
   <Feature id="1">
    <Attribute value="1" name="id"/>
+   <BoundingBox maxy="111325.1429" maxx="111319.4908" miny="-0" CRS="EPSG:3857" minx="0"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
Some providers always retrieve geometry even if the NoGeometry flags is used in request. So in WMS GetFeatureInfo the bounding box even if it as not been configured.

The `WITH_GEOMETRY` parameter has been introduced to force getting the geometry. The project can contain a parameter to add wkt geometry in the WMS GetFeatureInfo response: `wmsFeatureInfoAddWktGeometry`

For example:
* if the datasource is an ESRI ShapeFIle, the bounding box is always provided
* if the datasource is an Oracle table or a Psotgis one, the bounding box is only provided when `wmsFeatureInfoAddWktGeometry` and `WITH_GEOMETRY`

To provide something more homogeneous:
* The wkt geometry is only provided if the project has been configured to provide wkt geometry and the request contains WITH_GEOMETRY.
* The bounding box is provided if the project has been configured to provide wkt geometry
* The bounding box is not provided if the project has not been configured to provide wkt geometry
