### PR TITLE
[backport] Fix merge selected features when evaluate defaults

### DIFF
--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -186,6 +186,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
       if ( v.isValid() )
       {
         mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::DisplayRole, v );
+        mTableWidget->item( mTableWidget->rowCount() - 1, j )->setData( Qt::UserRole, v );
         setToManual = true;
       }
     }


### PR DESCRIPTION
Fix merge selected features when evaluate defaults

Fixes #34666

Backport of https://github.com/qgis/QGIS/pull/34686