### PR TITLE
Make containsAdvancedEffects function more accurate

### DIFF
--- a/src/core/qgsmapsettingsutils.cpp
+++ b/src/core/qgsmapsettingsutils.cpp
@@ -31,7 +31,7 @@ const QStringList QgsMapSettingsUtils::containsAdvancedEffects( const QgsMapSett
   const auto constLayers = mapSettings.layers();
   for ( QgsMapLayer *layer : constLayers )
   {
-    if ( layer )
+    if ( layer && layer->isInScaleRange( mapSettings.scale() ) )
     {
       if ( layer->blendMode() != QPainter::CompositionMode_SourceOver )
       {

--- a/tests/src/core/testqgsmapsettingsutils.cpp
+++ b/tests/src/core/testqgsmapsettingsutils.cpp
@@ -19,6 +19,7 @@
 
 #include "qgsmapsettings.h"
 #include "qgsmapsettingsutils.h"
+#include "qgsvectorlayer.h"
 
 #include <QString>
 
@@ -33,6 +34,7 @@ class TestQgsMapSettingsUtils : public QObject
     void cleanup() {} // will be called after each testfunction was executed.
 
     void createWorldFileContent(); //test world file content function
+    void containsAdvancedEffects(); //test contains advanced effects function
 
   private:
 
@@ -64,6 +66,26 @@ void TestQgsMapSettingsUtils::createWorldFileContent()
 
   mMapSettings.setRotation( 145 );
   QCOMPARE( QgsMapSettingsUtils::worldFileContent( mMapSettings ), QString( "-0.81915204428899191\r\n0.57357643635104594\r\n0.57357643635104594\r\n0.81915204428899191\r\n0.5\r\n0.49999999999999994\r\n" ) );
+}
+
+void TestQgsMapSettingsUtils::containsAdvancedEffects()
+{
+  QgsMapSettings mapSettings = mMapSettings;
+
+  std::unique_ptr< QgsVectorLayer > layer( new QgsVectorLayer( QStringLiteral( "Point?field=col1:real" ), QStringLiteral( "layer" ), QStringLiteral( "memory" ) ) );
+  layer->setBlendMode( QPainter::CompositionMode_Multiply );
+
+  QList<QgsMapLayer *> layers;
+  layers << layer.get();
+  mapSettings.setLayers( layers );
+
+  QCOMPARE( QgsMapSettingsUtils::containsAdvancedEffects( mapSettings ).size(), 1 );
+
+  // set the layer scale-based visibility so it falls outside of the map settings scale
+  layer->setScaleBasedVisibility( true );
+  layer->setMaximumScale( 10 );
+
+  QCOMPARE( QgsMapSettingsUtils::containsAdvancedEffects( mapSettings ).size(), 0 );
 }
 
 QGSTEST_MAIN( TestQgsMapSettingsUtils )


### PR DESCRIPTION
## Description

This PR insures the QgsMapSettingsUtils::containsAdvancedEffects function doesn't lie by skipping layers that are not within their visible scale range. This avoids needless "you should rasterize your PDF export" warning messages.