### PR TITLE
Fix planimetric measurements checkbox not restored in options dialog

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1606,7 +1606,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), mShowDatumTransformDialogCheckBox->isChecked(), QgsSettings::App );
 
   //measurement settings
-  mSettings->setValue( QStringLiteral( "/qgis/measure/planimetric" ), mPlanimetricMeasurementsComboBox->isChecked() );
+  mSettings->setValue( QStringLiteral( "measure/planimetric" ), mPlanimetricMeasurementsComboBox->isChecked(), QgsSettings::Core );
 
   QgsUnitTypes::DistanceUnit distanceUnit = static_cast< QgsUnitTypes::DistanceUnit >( mDistanceUnitsComboBox->currentData().toInt() );
   mSettings->setValue( QStringLiteral( "/qgis/measure/displayunits" ), QgsUnitTypes::encodeUnit( distanceUnit ) );


### PR DESCRIPTION
# Description

This fixes a bug where the planimetric checkox in the QGIS options wasn't saved to the correct key, and hence effectless.

It was due to a confusion : `QgsSettings::Core` corresponds to the `/core` section, not to `/qgis`.

The naming inconsistency remains (other measure related settings are grouped under `/qgis/measure/*`, not `/core/measure`). But solving that inconsistency would be backwards incompatible (behaviour could change without the user making any change to the settings).

(original issue : https://github.com/opengisch/QGIS-Issues-SH/issues/12#issuecomment-591450501)

![image](https://user-images.githubusercontent.com/1894106/75427867-8eb50700-5947-11ea-88e3-3931ae86d0d1.png)
