### PR TITLE
Remove debug message

### DIFF
--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -160,8 +160,6 @@ void QgsRequestHandler::setupParameters()
     QString formatString = mFormatString;
     if ( !formatString.isEmpty() )
     {
-      QgsMessageLog::logMessage( QStringLiteral( "formatString is: %1" ).arg( formatString ) );
-
       //remove the image/ in front of the format
       if ( formatString.contains( QLatin1String( "image/png" ), Qt::CaseInsensitive ) || formatString.compare( QLatin1String( "png" ), Qt::CaseInsensitive ) == 0 )
       {


### PR DESCRIPTION
The message ended up as WARNING in QGIS server log files.

I didn't check if and why it ends up as warning (just because it's sent to messageLog?) but I doubt it should end up in the log anyway.