### PR TITLE
Relation-ref widget ask the user to save the parent layer when saving…

### DIFF
--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -204,6 +204,18 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void setMapTool( QgsMapTool *mapTool );
     void unsetMapTool();
 
+    /**
+     * Returns TRUE if the parent (referenced) feature is not yet saved and the
+     * referenced layer is not part of a transaction group.
+     */
+    bool saveReferencedLayerRequired();
+
+    /**
+     * If saveReferencedLayerRequired() is TRUE, ask the user to save the parent layer,
+     * returns TRUE unless the user has chosen to cancel (abort) the operation.
+     */
+    bool checkSaveParentFeature( );
+
     QgsDualView *mDualView = nullptr;
     QPointer<QgsMessageBarItem> mMessageBarItem;
     QgsDualView::ViewMode mViewMode = QgsDualView::AttributeEditor;


### PR DESCRIPTION
… children

When the user clicks on "Save child layer edits" on an embedded
form if the following condition are met:

- the parent feature was added but not saved (feature id is 0)
- the layer is not part of a transaction group

![qgis-embedd-forms-save-prent](https://user-images.githubusercontent.com/142164/75467269-b332d280-598b-11ea-9ef1-6caa76650be7.gif)
