### PR TITLE
Add a vertical spacer at the bottom of mask label tab

### DIFF
--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -2771,6 +2771,19 @@ font-style: italic;</string>
                              </property>
                             </widget>
                            </item>
+                           <item row="7" column="0">
+                            <spacer name="verticalSpacer_2">
+                             <property name="orientation">
+                              <enum>Qt::Vertical</enum>
+                             </property>
+                             <property name="sizeHint" stdset="0">
+                              <size>
+                               <width>20</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                            </spacer>
+                           </item>
                           </layout>
                          </widget>
                         </item>


### PR DESCRIPTION
to avoid this 
![image](https://user-images.githubusercontent.com/7983394/75488023-e0917780-59af-11ea-8a92-d21843a11767.png) 
wonder if the spacer should not be right after the "Draw effects" button...
