### PR TITLE
Align 3D View properties tab rendering with common properties tabs

### DIFF
--- a/src/app/3d/qgsphongmaterialwidget.cpp
+++ b/src/app/3d/qgsphongmaterialwidget.cpp
@@ -33,7 +33,7 @@ QgsPhongMaterialWidget::QgsPhongMaterialWidget( QWidget *parent )
 
 void QgsPhongMaterialWidget::setDiffuseVisible( bool visible )
 {
-  label->setVisible( visible );
+  lblDiffuse->setVisible( visible );
   btnDiffuse->setVisible( visible );
 }
 

--- a/src/app/3d/qgspoint3dsymbolwidget.cpp
+++ b/src/app/3d/qgspoint3dsymbolwidget.cpp
@@ -257,7 +257,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
              << labelBillboardHeight << spinBillboardHeight << labelBillboardSymbol << btnChangeSymbol;
 
   widgetMaterial->setEnabled( true );
-  widgetMaterial->show();
+  materialsGroupBox->show();
   transformationWidget->show();
   QList<QWidget *> activeWidgets;
   switch ( cboShape->currentIndex() )
@@ -287,7 +287,7 @@ void QgsPoint3DSymbolWidget::onShapeChanged()
     case 7:  // billboard
       activeWidgets << labelBillboardHeight << spinBillboardHeight << labelBillboardSymbol << btnChangeSymbol;
       // Always hide material and transformationwidget for billboard
-      widgetMaterial->hide();
+      materialsGroupBox->hide();
       transformationWidget->hide();
       break;
   }

--- a/src/app/3d/qgssymbol3dwidget.cpp
+++ b/src/app/3d/qgssymbol3dwidget.cpp
@@ -42,6 +42,7 @@ QgsSymbol3DWidget::QgsSymbol3DWidget( QWidget *parent ) : QWidget( parent )
   widgetStack->addWidget( widgetPolygon );
 
   QVBoxLayout *layout = new QVBoxLayout( this );
+  layout->setContentsMargins( 0, 0, 0, 0 );
   layout->addWidget( widgetStack );
 
   connect( widgetLine, &QgsLine3DSymbolWidget::changed, this, &QgsSymbol3DWidget::widgetChanged );

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -38,6 +38,7 @@ QgsSingleSymbol3DRendererWidget::QgsSingleSymbol3DRendererWidget( QWidget *paren
   widgetSymbol = new QgsSymbol3DWidget( this );
 
   QVBoxLayout *layout = new QVBoxLayout( this );
+  layout->setContentsMargins( 0, 0, 0, 0 );
   layout->addWidget( widgetSymbol );
 
   connect( widgetSymbol, &QgsSymbol3DWidget::widgetChanged, this, &QgsSingleSymbol3DRendererWidget::widgetChanged );

--- a/src/ui/3d/line3dsymbolwidget.ui
+++ b/src/ui/3d/line3dsymbolwidget.ui
@@ -6,18 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>538</width>
-    <height>547</height>
+    <width>382</width>
+    <height>264</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QFormLayout" name="formLayout">
      <item row="1" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelHeight">
        <property name="text">
         <string>Height</string>
        </property>
@@ -34,7 +37,7 @@
       </widget>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="labelExtrusion">
        <property name="text">
         <string>Extrusion</string>
        </property>
@@ -48,7 +51,7 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="labelClamping">
        <property name="text">
         <string>Altitude clamping</string>
        </property>
@@ -74,7 +77,7 @@
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="labelBinding">
        <property name="text">
         <string>Altitude binding</string>
        </property>
@@ -95,7 +98,7 @@
       </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="labelWidth">
        <property name="text">
         <string>Width</string>
        </property>
@@ -118,14 +121,39 @@
     </widget>
    </item>
    <item>
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QgsCollapsibleGroupBox" name="groupShading">
+     <property name="title">
+      <string>Shading</string>
      </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item row="3" column="0" colspan="2">
+       <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true"/>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -140,6 +168,12 @@
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -154,7 +154,7 @@
        <item row="3" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupTerrainShading">
          <property name="title">
-          <string>Terrain shading</string>
+          <string>Terrain Shading</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -319,7 +319,7 @@
        <item row="2" column="0">
         <widget class="QgsCollapsibleGroupBox" name="groupMeshTerrainShading">
          <property name="title">
-          <string>Mesh terrain settings</string>
+          <string>Mesh Terrain Settings</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="leftMargin">

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -36,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>521</width>
-        <height>685</height>
+        <width>539</width>
+        <height>693</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_4">
@@ -160,6 +160,9 @@
           <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="margin">
+           <number>0</number>
+          </property>
           <item>
            <widget class="QgsPhongMaterialWidget" name="widgetTerrainMaterial" native="true"/>
           </item>
@@ -198,6 +201,9 @@
           <string>Lights</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="margin">
+           <number>0</number>
+          </property>
           <item>
            <widget class="QgsLightsWidget" name="widgetLights" native="true"/>
           </item>

--- a/src/ui/3d/phongmaterialwidget.ui
+++ b/src/ui/3d/phongmaterialwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>334</width>
-    <height>252</height>
+    <width>338</width>
+    <height>138</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="lblDiffuse">
      <property name="text">
       <string>Diffuse</string>
      </property>
@@ -38,7 +38,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="lblAmbient">
      <property name="text">
       <string>Ambient</string>
      </property>
@@ -61,7 +61,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="lblSpecular">
      <property name="text">
       <string>Specular</string>
      </property>
@@ -84,7 +84,7 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
+    <widget class="QLabel" name="lblShininess">
      <property name="text">
       <string>Shininess</string>
      </property>

--- a/src/ui/3d/point3dsymbolwidget.ui
+++ b/src/ui/3d/point3dsymbolwidget.ui
@@ -6,271 +6,33 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
-    <height>942</height>
+    <width>457</width>
+    <height>587</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Shape</string>
+   <property name="margin">
+    <number>0</number>
+   </property>
+   <item row="2" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="transformationWidget">
+     <property name="title">
+      <string>Transformation</string>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="cboShape"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="labelRadius">
-     <property name="text">
-      <string>Radius</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="labelMinorRadius">
-     <property name="text">
-      <string>Minor radius</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinMinorRadius">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>5.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="labelTopRadius">
-     <property name="text">
-      <string>Top radius</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinTopRadius">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="labelBottomRadius">
-     <property name="text">
-      <string>Bottom radius</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinBottomRadius">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="labelSize">
-     <property name="text">
-      <string>Size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinSize">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="labelLength">
-     <property name="text">
-      <string>Length</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinLength">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>10.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="labelModel">
-     <property name="text">
-      <string>Model</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLineEdit" name="lineEditModel"/>
-     </item>
-     <item>
-      <widget class="QToolButton" name="btnModel">
-       <property name="text">
-        <string>…</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="cbOverwriteMaterial">
-       <property name="toolTip">
-        <string>Overwrite model material</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="labelBillboardHeight">
-     <property name="text">
-      <string>Billboard Height</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="labelBillboardSymbol">
-     <property name="text">
-      <string>Billboard symbol</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QgsSymbolButton" name="btnChangeSymbol">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="labelAltClamping">
-     <property name="text">
-      <string>Altitude clamping</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QComboBox" name="cboAltClamping">
-     <item>
-      <property name="text">
-       <string>Absolute</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Relative</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Terrain</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="2">
-    <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true"/>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="2">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0" colspan="2">
-    <widget class="QWidget" name="transformationWidget" native="true">
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>X</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Y</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Z</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Translation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsDoubleSpinBox" name="spinTX">
+      <item row="2" column="1">
+       <widget class="QgsDoubleSpinBox" name="spinSX">
         <property name="minimum">
          <double>-99999.899999999994179</double>
         </property>
         <property name="maximum">
          <double>99999.899999999994179</double>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QgsDoubleSpinBox" name="spinTY">
-        <property name="minimum">
-         <double>-99999.899999999994179</double>
-        </property>
-        <property name="maximum">
-         <double>99999.899999999994179</double>
+        <property name="value">
+         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -284,23 +46,43 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Scale</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsDoubleSpinBox" name="spinSX">
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="spinTX">
         <property name="minimum">
          <double>-99999.899999999994179</double>
         </property>
         <property name="maximum">
          <double>99999.899999999994179</double>
         </property>
-        <property name="value">
-         <double>1.000000000000000</double>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>X</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QgsDoubleSpinBox" name="spinTY">
+        <property name="minimum">
+         <double>-99999.899999999994179</double>
+        </property>
+        <property name="maximum">
+         <double>99999.899999999994179</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QgsDoubleSpinBox" name="spinRX">
+        <property name="decimals">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -317,16 +99,13 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="3">
-       <widget class="QgsDoubleSpinBox" name="spinSZ">
-        <property name="minimum">
-         <double>-99999.899999999994179</double>
+      <item row="3" column="3">
+       <widget class="QgsDoubleSpinBox" name="spinRZ">
+        <property name="decimals">
+         <number>0</number>
         </property>
         <property name="maximum">
-         <double>99999.899999999994179</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
+         <double>360.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -334,16 +113,6 @@
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Rotation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QgsDoubleSpinBox" name="spinRX">
-        <property name="decimals">
-         <number>0</number>
-        </property>
-        <property name="maximum">
-         <double>360.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -357,35 +126,300 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
-       <widget class="QgsDoubleSpinBox" name="spinRZ">
-        <property name="decimals">
-         <number>0</number>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Y</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QgsDoubleSpinBox" name="spinSZ">
+        <property name="minimum">
+         <double>-99999.899999999994179</double>
         </property>
         <property name="maximum">
-         <double>360.000000000000000</double>
+         <double>99999.899999999994179</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Translation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Scale</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Z</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinRadius">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
+   <item row="1" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="materialsGroupBox">
+     <property name="title">
+      <string>Shading</string>
      </property>
-     <property name="value">
-      <double>10.000000000000000</double>
-     </property>
+     <layout class="QGridLayout" name="shadingGroup">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>10</width>
+          <height>10</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="8" column="1">
-    <widget class="QDoubleSpinBox" name="spinBillboardHeight">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
+   <item row="0" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <property name="verticalSpacing">
+      <number>6</number>
      </property>
-    </widget>
+     <item row="1" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QComboBox" name="cboAltClamping">
+       <item>
+        <property name="text">
+         <string>Absolute</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Relative</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Terrain</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLineEdit" name="lineEditModel"/>
+       </item>
+       <item>
+        <widget class="QToolButton" name="btnModel">
+         <property name="text">
+          <string>…</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbOverwriteMaterial">
+         <property name="toolTip">
+          <string>Overwrite model material</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelRadius">
+       <property name="text">
+        <string>Radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelBottomRadius">
+       <property name="text">
+        <string>Bottom radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinSize">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelModel">
+       <property name="text">
+        <string>Model</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinTopRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="spinBillboardHeight">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelBillboardSymbol">
+       <property name="text">
+        <string>Billboard symbol</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinMinorRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>5.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelBillboardHeight">
+       <property name="text">
+        <string>Billboard Height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelSize">
+       <property name="text">
+        <string>Size</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QgsSymbolButton" name="btnChangeSymbol">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelMinorRadius">
+       <property name="text">
+        <string>Minor radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cboShape"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinBottomRadius">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelTopRadius">
+       <property name="text">
+        <string>Top radius</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Shape</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QgsDoubleSpinBox" name="spinLength">
+       <property name="maximum">
+        <double>99999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="labelAltClamping">
+       <property name="text">
+        <string>Altitude clamping</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelLength">
+       <property name="text">
+        <string>Length</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -406,14 +440,27 @@
    <extends>QToolButton</extends>
    <header>qgssymbolbutton.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>cboShape</tabstop>
   <tabstop>spinRadius</tabstop>
   <tabstop>spinMinorRadius</tabstop>
   <tabstop>spinTopRadius</tabstop>
   <tabstop>spinBottomRadius</tabstop>
   <tabstop>spinSize</tabstop>
   <tabstop>spinLength</tabstop>
+  <tabstop>lineEditModel</tabstop>
+  <tabstop>btnModel</tabstop>
+  <tabstop>cbOverwriteMaterial</tabstop>
+  <tabstop>spinBillboardHeight</tabstop>
+  <tabstop>btnChangeSymbol</tabstop>
+  <tabstop>cboAltClamping</tabstop>
   <tabstop>spinTX</tabstop>
   <tabstop>spinTY</tabstop>
   <tabstop>spinTZ</tabstop>

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -6,32 +6,37 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>561</width>
-    <height>697</height>
+    <width>479</width>
+    <height>397</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Culling mode</string>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="1">
+    <widget class="QgsDoubleSpinBox" name="spinHeight">
+     <property name="minimum">
+      <double>-99999.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>99999.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="chkInvertNormals">
      <property name="text">
-      <string>Extrusion</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QCheckBox" name="chkAddBackFaces">
-     <property name="text">
-      <string>Add back faces</string>
+      <string>Invert normals (experimental)</string>
      </property>
     </widget>
    </item>
@@ -52,6 +57,55 @@
        <string>Back</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Extrusion</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsDoubleSpinBox" name="spinExtrusion">
+     <property name="maximum">
+      <double>99999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="groupShading">
+     <property name="title">
+      <string>Shading</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Culling mode</string>
+     </property>
     </widget>
    </item>
    <item row="1" column="2">
@@ -80,7 +134,7 @@
      </item>
     </widget>
    </item>
-   <item row="9" column="0" colspan="3">
+   <item row="8" column="0" colspan="3">
     <widget class="QGroupBox" name="groupEdges">
      <property name="title">
       <string>Edges</string>
@@ -141,6 +195,20 @@
      </layout>
     </widget>
    </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="chkAddBackFaces">
+     <property name="text">
+      <string>Add back faces</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QgsPropertyOverrideButton" name="btnHeightDD">
+     <property name="text">
+      <string>…</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1">
     <widget class="QComboBox" name="cboAltBinding">
      <item>
@@ -155,10 +223,10 @@
      </item>
     </widget>
    </item>
-   <item row="7" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Altitude binding</string>
      </property>
     </widget>
    </item>
@@ -169,20 +237,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QgsPropertyOverrideButton" name="btnHeightDD">
-     <property name="text">
-      <string>…</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinExtrusion">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -190,59 +244,9 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinHeight">
-     <property name="minimum">
-      <double>-99999.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="3">
-    <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Altitude binding</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QCheckBox" name="chkInvertNormals">
-     <property name="text">
-      <string>Invert normals (experimental)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="3">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
-  </customwidget>
   <customwidget>
    <class>QgsPhongMaterialWidget</class>
    <extends>QWidget</extends>
@@ -250,9 +254,25 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButton</class>
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
* using groupbox for items instead of line separator
* reducing the oversized margins

before (from 3.10 but still true in 3.12 for the issues) vs after
![image](https://user-images.githubusercontent.com/7983394/75490240-19335000-59b4-11ea-8657-d3de33bbb378.png)

![image](https://user-images.githubusercontent.com/7983394/75498958-e21b6980-59c8-11ea-9b80-3ea084de121b.png)

![image](https://user-images.githubusercontent.com/7983394/75499046-142ccb80-59c9-11ea-8895-6de56ff86d3f.png)

![image](https://user-images.githubusercontent.com/7983394/75499907-bfd71b00-59cb-11ea-89de-a745f2d4317f.png)

PS: I don't know whether "shading" is the appropriate word...