### PR TITLE
Fix relation reference widget test crashes under debug builds

### DIFF
--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -60,6 +60,8 @@ class TestQgsRelationReferenceWidget : public QObject
     std::unique_ptr<QgsVectorLayer> mLayer1;
     std::unique_ptr<QgsVectorLayer> mLayer2;
     std::unique_ptr<QgsRelation> mRelation;
+    QgsMapCanvas *mMapCanvas = nullptr;
+    QgsAdvancedDigitizingDockWidget *mCadWidget = nullptr;
 };
 
 void TestQgsRelationReferenceWidget::initTestCase()
@@ -67,10 +69,14 @@ void TestQgsRelationReferenceWidget::initTestCase()
   QgsApplication::init();
   QgsApplication::initQgis();
   QgsGui::editorWidgetRegistry()->initEditors();
+  mMapCanvas = new QgsMapCanvas();
+  mCadWidget = new QgsAdvancedDigitizingDockWidget( mMapCanvas );
 }
 
 void TestQgsRelationReferenceWidget::cleanupTestCase()
 {
+  delete mCadWidget;
+  delete mMapCanvas;
   QgsApplication::exitQgis();
 }
 
@@ -342,11 +348,16 @@ void TestQgsRelationReferenceWidget::testChainFilterDeleteForeignKey()
 void TestQgsRelationReferenceWidget::testInvalidRelation()
 {
   QgsVectorLayer vl( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=fk:int" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
-  QgsMapCanvas canvas;
+
   QgsRelationReferenceWidget editor( new QWidget() );
 
   // initWidget with an invalid relation
-  QgsRelationReferenceWidgetWrapper ww( &vl, 10, &editor, &canvas, nullptr, nullptr );
+  QgsRelationReferenceWidgetWrapper ww( &vl, 10, &editor, mMapCanvas, nullptr, nullptr );
+
+  QgsAttributeEditorContext context = ww.context();
+  context.setCadDockWidget( mCadWidget );
+  ww.setContext( context );
+
   ww.initWidget( nullptr );
 }
 


### PR DESCRIPTION
Because of the new assert in QgsMapToolAdvancedDigitizing requiring the cad widget

Not the cleanest fix -- the widget should instead gracefully handle having no cad widget available by disabling the digiting tool instead, but we urgently need the CI infrastructure to stop flagging everything because of this change.
