### PR TITLE
Remove oversized margin of the Container properties frame

### DIFF
--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -446,7 +446,8 @@ void QgsAttributesFormProperties::loadAttributeContainerEdit()
 
   QTreeWidgetItem *currentItem = mFormLayoutTree->selectedItems().at( 0 );
   mAttributeContainerEdit = new QgsAttributeFormContainerEdit( currentItem, this );
-  mAttributeTypeFrame->layout()->setMargin( 0 );
+  mAttributeContainerEdit->layout()->setContentsMargins( 0, 0, 0, 0 );
+  mAttributeTypeFrame->layout()->setContentsMargins( 0, 0, 0, 0 );
   mAttributeTypeFrame->layout()->addWidget( mAttributeContainerEdit );
 }
 


### PR DESCRIPTION
in drag-and-drop mode of attribute forms, harmonizing with fields properties, to look like this

![image](https://user-images.githubusercontent.com/7983394/75257617-8349ca80-57e5-11ea-84d3-ae2494c0c7c3.png)
instead of 
![image](https://user-images.githubusercontent.com/7983394/75500768-37a64500-59ce-11ea-8d14-0ea376bc5cc7.png)

To backport to 3.10 after #34656 