### PR TITLE
[feature] Relation wdgt: add checkbox to hide save child edits button

### DIFF
--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -370,7 +370,7 @@ Determines if the "save child layer edits" button should be shown
 
     bool showSaveChildEditsButton( ) const;
 %Docstring
-Returns ``True`` if the "save child layer edits" button flag should be shown.
+Returns ``True`` if the "save child layer edits" button should be shown.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -361,6 +361,20 @@ Determines if the "unlink feature" button should be shown
 .. versionadded:: 2.18
 %End
 
+    void setShowSaveChildEditsButton( bool showSaveChildEditsButton );
+%Docstring
+Determines if the "save child layer edits" button should be shown
+
+.. versionadded:: 3.14
+%End
+
+    bool showSaveChildEditsButton( ) const;
+%Docstring
+Returns ``True`` if the "save child layer edits" button flag should be shown.
+
+.. versionadded:: 3.14
+%End
+
 
 };
 

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -53,6 +53,20 @@ Determines if the "link feature" button should be shown
 .. versionadded:: 2.18
 %End
 
+    bool showSaveChildEditsButton() const;
+%Docstring
+Determines if the "save child layer edits" button should be shown
+
+.. versionadded:: 3.14
+%End
+
+    void setShowSaveChildEditsButton( bool showSaveChildEditsButton );
+%Docstring
+Determines if the "save child layer edits" button should be shown
+
+.. versionadded:: 3.14
+%End
+
     bool showUnlinkButton() const;
 %Docstring
 Determines if the "unlink feature" button should be shown

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -115,6 +115,21 @@ Determines if the "unlink feature" button should be shown
 .. versionadded:: 2.18
 %End
 
+    void setShowSaveChildEditsButton( bool showChildEdits );
+%Docstring
+Determines if the "Save child layer edits" button should be shown
+
+.. versionadded:: 3.14
+%End
+
+    bool showSaveChildEditsButton() const;
+%Docstring
+Determines if the "Save child layer edits" button should be shown
+
+.. versionadded:: 3.14
+%End
+
+
 };
 
 /************************************************************************

--- a/src/app/attributeformconfig/qgsattributewidgetedit.cpp
+++ b/src/app/attributeformconfig/qgsattributewidgetedit.cpp
@@ -32,6 +32,7 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
   // hide specific configs
   mRelationShowLinkCheckBox->hide();
   mRelationShowUnlinkCheckBox->hide();
+  mRelationShowSaveChildEditsCheckBox->hide();
 
   switch ( itemData.type() )
   {
@@ -39,8 +40,10 @@ QgsAttributeWidgetEdit::QgsAttributeWidgetEdit( QTreeWidgetItem *item, QWidget *
     {
       mRelationShowLinkCheckBox->show();
       mRelationShowUnlinkCheckBox->show();
+      mRelationShowSaveChildEditsCheckBox->show();
       mRelationShowLinkCheckBox->setChecked( itemData.relationEditorConfiguration().showLinkButton );
       mRelationShowUnlinkCheckBox->setChecked( itemData.relationEditorConfiguration().showUnlinkButton );
+      mRelationShowSaveChildEditsCheckBox->setChecked( itemData.relationEditorConfiguration().showSaveChildEditsButton );
     }
     break;
 
@@ -70,6 +73,7 @@ void QgsAttributeWidgetEdit::updateItemData()
       QgsAttributesFormProperties::RelationEditorConfiguration relEdCfg;
       relEdCfg.showLinkButton = mRelationShowLinkCheckBox->isChecked();
       relEdCfg.showUnlinkButton = mRelationShowUnlinkCheckBox->isChecked();
+      relEdCfg.showSaveChildEditsButton = mRelationShowSaveChildEditsCheckBox->isChecked();
       itemData.setRelationEditorConfiguration( relEdCfg );
     }
     break;

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -492,6 +492,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       RelationEditorConfiguration relEdConfig;
       relEdConfig.showLinkButton = relationEditor->showLinkButton();
       relEdConfig.showUnlinkButton = relationEditor->showUnlinkButton();
+      relEdConfig.showSaveChildEditsButton = relationEditor->showSaveChildEditsButton( );
       itemData.setRelationEditorConfiguration( relEdConfig );
       newWidget = tree->addItem( parent, itemData );
       break;
@@ -720,6 +721,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
       QgsAttributeEditorRelation *relDef = new QgsAttributeEditorRelation( relation, parent );
       relDef->setShowLinkButton( itemData.relationEditorConfiguration().showLinkButton );
       relDef->setShowUnlinkButton( itemData.relationEditorConfiguration().showUnlinkButton );
+      relDef->setShowSaveChildEditsButton( itemData.relationEditorConfiguration().showSaveChildEditsButton );
       widgetDef = relDef;
       break;
     }
@@ -1192,8 +1194,11 @@ void DnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int column )
       showLinkButton->setChecked( itemData.relationEditorConfiguration().showLinkButton );
       QCheckBox *showUnlinkButton = new QCheckBox( tr( "Show unlink button" ) );
       showUnlinkButton->setChecked( itemData.relationEditorConfiguration().showUnlinkButton );
+      QCheckBox *showSaveChildEditsButton = new QCheckBox( tr( "Show save child layer edits button" ) );
+      showSaveChildEditsButton->setChecked( itemData.relationEditorConfiguration().showSaveChildEditsButton );
       layout->addRow( showLinkButton );
       layout->addRow( showUnlinkButton );
+      layout->addRow( showSaveChildEditsButton );
 
       QDialogButtonBox *buttonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel );
 
@@ -1207,6 +1212,7 @@ void DnDTree::onItemDoubleClicked( QTreeWidgetItem *item, int column )
         QgsAttributesFormProperties::RelationEditorConfiguration relEdCfg;
         relEdCfg.showLinkButton = showLinkButton->isChecked();
         relEdCfg.showUnlinkButton = showUnlinkButton->isChecked();
+        relEdCfg.showSaveChildEditsButton = showSaveChildEditsButton->isChecked();
         itemData.setShowLabel( showLabelCheckbox->isChecked() );
         itemData.setRelationEditorConfiguration( relEdCfg );
 

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -70,6 +70,7 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
     {
       bool showLinkButton = true;
       bool showUnlinkButton = true;
+      bool showSaveChildEditsButton = true;
     };
 
     struct QmlElementEditorConfiguration

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -135,6 +135,7 @@ void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem ) const
   elem.setAttribute( QStringLiteral( "relation" ), mRelation.id() );
   elem.setAttribute( QStringLiteral( "showLinkButton" ), mShowLinkButton );
   elem.setAttribute( QStringLiteral( "showUnlinkButton" ), mShowUnlinkButton );
+  elem.setAttribute( QStringLiteral( "showSaveChildEditsButton" ), mShowSaveChildEditsButton );
 }
 
 QString QgsAttributeEditorRelation::typeIdentifier() const
@@ -160,6 +161,16 @@ bool QgsAttributeEditorRelation::showUnlinkButton() const
 void QgsAttributeEditorRelation::setShowUnlinkButton( bool showUnlinkButton )
 {
   mShowUnlinkButton = showUnlinkButton;
+}
+
+void QgsAttributeEditorRelation::setShowSaveChildEditsButton( bool showSaveChildEdits )
+{
+  mShowSaveChildEditsButton = showSaveChildEdits;
+}
+
+bool QgsAttributeEditorRelation::showSaveChildEditsButton() const
+{
+  return mShowSaveChildEditsButton;
 }
 
 QgsAttributeEditorElement *QgsAttributeEditorQmlElement::clone( QgsAttributeEditorElement *parent ) const

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -419,6 +419,20 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
      */
     void setShowUnlinkButton( bool showUnlinkButton );
 
+    /**
+     * Determines if the "save child layer edits" button should be shown
+     *
+     * \since QGIS 3.14
+     */
+    void setShowSaveChildEditsButton( bool showSaveChildEditsButton );
+
+    /**
+     * Returns TRUE if the "save child layer edits" button flag should be shown.
+     *
+     * \since QGIS 3.14
+     */
+    bool showSaveChildEditsButton( ) const;
+
 
   private:
     void saveConfiguration( QDomElement &elem ) const override;
@@ -427,6 +441,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     QgsRelation mRelation;
     bool mShowLinkButton = true;
     bool mShowUnlinkButton = true;
+    bool mShowSaveChildEditsButton = true;
 };
 
 /**

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -427,7 +427,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     void setShowSaveChildEditsButton( bool showSaveChildEditsButton );
 
     /**
-     * Returns TRUE if the "save child layer edits" button flag should be shown.
+     * Returns TRUE if the "save child layer edits" button should be shown.
      *
      * \since QGIS 3.14
      */

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -582,6 +582,7 @@ QgsAttributeEditorElement *QgsEditFormConfig::attributeEditorElementFromDomEleme
     QgsAttributeEditorRelation *relElement = new QgsAttributeEditorRelation( elem.attribute( QStringLiteral( "relation" ), QStringLiteral( "[None]" ) ), parent );
     relElement->setShowLinkButton( elem.attribute( QStringLiteral( "showLinkButton" ), QStringLiteral( "1" ) ).toInt() );
     relElement->setShowUnlinkButton( elem.attribute( QStringLiteral( "showUnlinkButton" ), QStringLiteral( "1" ) ).toInt() );
+    relElement->setShowSaveChildEditsButton( elem.attribute( QStringLiteral( "showSaveChildEditsButton" ), QStringLiteral( "1" ) ).toInt() );
     newElement = relElement;
   }
   else if ( elem.tagName() == QLatin1String( "attributeEditorQmlElement" ) )

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -89,6 +89,13 @@ void QgsRelationWidgetWrapper::setShowUnlinkButton( bool showUnlinkButton )
     mWidget->setShowUnlinkButton( showUnlinkButton );
 }
 
+
+void QgsRelationWidgetWrapper::setShowSaveChildEditsButton( bool showSaveChildEditsButton )
+{
+  if ( mWidget )
+    mWidget->setShowSaveChildEditsButton( showSaveChildEditsButton );
+}
+
 bool QgsRelationWidgetWrapper::showLabel() const
 {
   if ( mWidget )
@@ -124,6 +131,11 @@ void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
   if ( config( QStringLiteral( "force-suppress-popup" ), false ).toBool() )
   {
     const_cast<QgsVectorLayerTools *>( myContext.vectorLayerTools() )->setForceSuppressFormPopup( true );
+  }
+
+  if ( config( QStringLiteral( "hide-save-child-edits" ), false ).toBool() )
+  {
+    w->setShowSaveChildEditsButton( false );
   }
 
   w->setEditorContext( myContext );
@@ -163,4 +175,9 @@ void QgsRelationWidgetWrapper::setShowLinkButton( bool showLinkButton )
 {
   if ( mWidget )
     mWidget->setShowLinkButton( showLinkButton );
+}
+
+bool QgsRelationWidgetWrapper::showSaveChildEditsButton() const
+{
+  return mWidget && mWidget->showSaveChildEditsButton();
 }

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -67,6 +67,20 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     void setShowLinkButton( bool showLinkButton );
 
     /**
+     * Determines if the "save child layer edits" button should be shown
+     *
+     * \since QGIS 3.14
+     */
+    bool showSaveChildEditsButton() const;
+
+    /**
+     * Determines if the "save child layer edits" button should be shown
+     *
+     * \since QGIS 3.14
+     */
+    void setShowSaveChildEditsButton( bool showSaveChildEditsButton );
+
+    /**
      * Determines if the "unlink feature" button should be shown
      *
      * \since QGIS 2.18

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1861,6 +1861,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
       // below directly alter the widget and check for it.
       rww->setShowLinkButton( relDef->showLinkButton() );
       rww->setShowUnlinkButton( relDef->showUnlinkButton() );
+      rww->setShowSaveChildEditsButton( relDef->showSaveChildEditsButton() );
 
       mWidgets.append( rww );
       mFormWidgets.append( formWidget );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -892,6 +892,16 @@ bool QgsRelationEditorWidget::showUnlinkButton() const
   return mUnlinkFeatureButton->isVisible();
 }
 
+void QgsRelationEditorWidget::setShowSaveChildEditsButton( bool showChildEdits )
+{
+  mSaveEditsButton->setVisible( showChildEdits );
+}
+
+bool QgsRelationEditorWidget::showSaveChildEditsButton() const
+{
+  return mSaveEditsButton->isVisible();
+}
+
 void QgsRelationEditorWidget::setShowUnlinkButton( bool showUnlinkButton )
 {
   mUnlinkFeatureButton->setVisible( showUnlinkButton );

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -176,6 +176,21 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
      */
     void setShowUnlinkButton( bool showUnlinkButton );
 
+    /**
+     * Determines if the "Save child layer edits" button should be shown
+     *
+     * \since QGIS 3.14
+     */
+    void setShowSaveChildEditsButton( bool showChildEdits );
+
+    /**
+     * Determines if the "Save child layer edits" button should be shown
+     *
+     * \since QGIS 3.14
+     */
+    bool showSaveChildEditsButton() const;
+
+
   private slots:
     void setViewMode( int mode ) {setViewMode( static_cast<QgsDualView::ViewMode>( mode ) );}
     void updateButtons();

--- a/src/ui/attributeformconfig/qgsattributewidgeteditgroupbox.ui
+++ b/src/ui/attributeformconfig/qgsattributewidgeteditgroupbox.ui
@@ -17,13 +17,6 @@
    <string>Widget display</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QCheckBox" name="mShowLabelCheckBox">
-     <property name="text">
-      <string>Show label</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QCheckBox" name="mRelationShowLinkCheckBox">
      <property name="text">
@@ -31,10 +24,24 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="mShowLabelCheckBox">
+     <property name="text">
+      <string>Show label</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QCheckBox" name="mRelationShowUnlinkCheckBox">
      <property name="text">
       <string>Show unlink button</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="mRelationShowSaveChildEditsCheckBox">
+     <property name="text">
+      <string>Show save child layer edits button</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This is very useful for embedded forms.

Funded by: **ARPA Piemonte**

![qgis-feature-hide-save-child-layer-edits-button-highlight](https://user-images.githubusercontent.com/142164/75524592-82e04800-5a0e-11ea-9333-461a0d02a1c0.png)
