### PR TITLE
[Backport 3.10] Fix planimetric measurements checkbox not restored in options dialog

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1594,7 +1594,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), mShowDatumTransformDialogCheckBox->isChecked(), QgsSettings::App );
 
   //measurement settings
-  mSettings->setValue( QStringLiteral( "/qgis/measure/planimetric" ), mPlanimetricMeasurementsComboBox->isChecked() );
+  mSettings->setValue( QStringLiteral( "measure/planimetric" ), mPlanimetricMeasurementsComboBox->isChecked(), QgsSettings::Core );
 
   QgsUnitTypes::DistanceUnit distanceUnit = static_cast< QgsUnitTypes::DistanceUnit >( mDistanceUnitsComboBox->currentData().toInt() );
   mSettings->setValue( QStringLiteral( "/qgis/measure/displayunits" ), QgsUnitTypes::encodeUnit( distanceUnit ) );


### PR DESCRIPTION
manual backport of #34726

note : backport instructions of qgis-bot didn't work :
```
$ cherry-pick 03436dcbd6899d61bcc371254d4e83cfeed534d2
error: commit 03436dcbd6899d61bcc371254d4e83cfeed534d2 is a merge but no -m option was given.
```
I used the actual commit instead
```
git cherry-pick c68a50f0c343d1371a0934f6081b8e19cdeae9ff
```
(not sure it matters...)