### PR TITLE
[BUG][Mesh] Fix streamlines/traces issue when CRS transform fails

### DIFF
--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -259,7 +259,8 @@ void QgsMeshStreamField::updateSize( const QgsRenderContext &renderContext )
   catch ( QgsCsException &cse )
   {
     Q_UNUSED( cse );
-    layerExtent = mLayerExtent;
+    //if the transform fail, the whole map is considered
+    layerExtent = mMapExtent;
   }
 
   QgsRectangle interestZoneExtent;
@@ -298,8 +299,16 @@ void QgsMeshStreamField::updateSize( const QgsRenderContext &renderContext )
   if ( fieldHeightInDeviceCoordinate % mFieldResolution > 0 )
     fieldHeight++;
 
-  mFieldSize.setWidth( fieldWidth );
-  mFieldSize.setHeight( fieldHeight );
+  if ( fieldWidth == 0 || fieldHeight == 0 )
+  {
+    mFieldSize = QSize();
+  }
+  else
+  {
+    mFieldSize.setWidth( fieldWidth );
+    mFieldSize.setHeight( fieldHeight );
+  }
+
 
   double mapUnitPerFieldPixel;
   if ( interestZoneExtent.width() > 0 )

--- a/src/core/mesh/qgsmeshtracerenderer.cpp
+++ b/src/core/mesh/qgsmeshtracerenderer.cpp
@@ -259,7 +259,7 @@ void QgsMeshStreamField::updateSize( const QgsRenderContext &renderContext )
   catch ( QgsCsException &cse )
   {
     Q_UNUSED( cse );
-    //if the transform fail, the whole map is considered
+    //if the transform fails, consider the whole map
     layerExtent = mMapExtent;
   }
 


### PR DESCRIPTION
When CRS transform fails,  trace/streamlines renderers can have issue, QGIS crash or streamlines not rendered.
This PR fix this issue.
