### PR TITLE
Fix crash when opening raster layer properties

### DIFF
--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -86,6 +86,7 @@ Shiva Reddy Koti
 Stefanie Tellex
 Steven Mizuno
 Tamas Szekeres
+Tim Tisler
 Tom Russo
 Tyler Mitchell
 Vita Cizek

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -956,8 +956,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     const int horizontalDpi = qApp->desktop()->screen()->logicalDpiX();
 #else
-    QScreen *screen = QGuiApplication::screenAt( mapToGlobal( QPoint( width() / 2, 0 ) ) );
-    const int horizontalDpi = screen->logicalDotsPerInchX();
+    const int horizontalDpi = logicalDpiX();
 #endif
 
 

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
@@ -50,8 +50,7 @@ void QgsHtmlWidgetWrapper::initWidget( QWidget *editor )
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   const int horizontalDpi = qApp->desktop()->screen()->logicalDpiX();
 #else
-  QScreen *screen = QGuiApplication::screenAt( mWidget->mapToGlobal( QPoint( mWidget->width() / 2, 0 ) ) );
-  const int horizontalDpi = screen->logicalDotsPerInchX();
+  const int horizontalDpi = mWidget->logicalDpiX();
 #endif
 
   mWidget->setZoomFactor( horizontalDpi / 96.0 );

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -445,8 +445,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   const int horizontalDpi = qApp->desktop()->screen()->logicalDpiX();
 #else
-  QScreen *screen = QGuiApplication::screenAt( mapToGlobal( QPoint( width() / 2, 0 ) ) );
-  const int horizontalDpi = screen->logicalDotsPerInchX();
+  const int horizontalDpi = logicalDpiX();
 #endif
 
   // Adjust zoom: text is ok, but HTML seems rather big at least on Linux/KDE


### PR DESCRIPTION
This bug was exposed on my particular screen setup (see #34772).  The raster layer properties was trying to get the screen at an x,y position where there was no screen.

When QgsRasterLayerProperties constructor was trying to calculate the DPI of the screen the widget was on, but since hasn't been displayed yet, it diesn't have a logical location on the screen. 

`QScreen *screen = QGuiApplication::screenAt( mapToGlobal( QPoint( width() / 2, 0 ) ) );`

i.e. mapToGlobal(...) was returning the same value that was sent in, which isn't a valif position on my screen, hence *screen was null, and the next usage caused a NULL pointer access crash. 

Since QT5, the QPaintDevice class contains a logicalDpiX().  QWidget is a QPaintDevice, so we can simply use that method to get the logical DPI.

NOTE:  I don't have a high DPI display, so I can't verify changes on those devices.

This change should be backported to any version(s) updated with  3aaeb81 

Fixes #34772 
