### PR TITLE
Fix Python3 'TypeError' when loading Oracle metadata in DB Manager

### DIFF
--- a/python/plugins/db_manager/db_plugins/oracle/info_model.py
+++ b/python/plugins/db_manager/db_plugins/oracle/info_model.py
@@ -142,7 +142,7 @@ class ORTableInfo(TableInfo):
                     "DBManagerPlugin", "Rows (estimation):"),
                  self.table.estimatedRowCount)
             )
-        if self.table.rowCount or self.table.rowCount >= 0:
+        if self.table.rowCount is not None and self.table.rowCount >= 0:
             # Add a real count of rows
             tbl.append(
                 (QApplication.translate("DBManagerPlugin", "Rows (counted):"),
@@ -624,7 +624,7 @@ class ORVectorTableInfo(ORTableInfo, VectorTableInfo):
         if self.table.extent and len(self.table.extent) == 4:
             extent_str = (u"{:.9f}, {:.9f} - {:.9f}, "
                           u"{:.9f}".format(*self.table.extent))
-        elif self.table.rowCount > 0 or self.table.estimatedRowCount > 0:
+        elif (self.table.rowCount is not None and self.table.rowCount > 0) or (self.table.estimatedRowCount is not None and self.table.estimatedRowCount > 0):
             # Can't calculate an extent on empty layer
             extent_str = QApplication.translate(
                 "DBManagerPlugin",


### PR DESCRIPTION
Error is related to python 2 to 3 migration.
See https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons

Adding proper check for NoneType before checking if variable is 'greater than' solves it.

Fixes #34774 