### PR TITLE
[Bugfix] Prevent crash when deleting invalid pointer

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -339,8 +339,11 @@ void QgsFeatureFilterModel::updateCompleter()
 
 void QgsFeatureFilterModel::gathererThreadFinished()
 {
-  delete mGatherer;
-  mGatherer = nullptr;
+  if ( mGatherer )
+  {
+    delete mGatherer;
+    mGatherer = nullptr;
+  }
   emit isLoadingChanged();
 }
 


### PR DESCRIPTION
## Description

This is a quick fix to a segfault that Travis encountered during the Qgs relationreferencewidget test for one of my build..
