### PR TITLE
Avoid confirmation dialog from Refactor fields when not appropriate

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -187,6 +187,9 @@ Copies the current log contents to the clipboard.
 Switches the dialog to the parameters page.
 %End
 
+    virtual void reject();
+
+
   protected:
 
     virtual void closeEvent( QCloseEvent *e );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -654,6 +654,15 @@ void QgsProcessingAlgorithmDialogBase::setInfo( const QString &message, bool isE
   processEvents();
 }
 
+void QgsProcessingAlgorithmDialogBase::reject()
+{
+  if ( !mAlgorithmTask )
+  {
+    setAttribute( Qt::WA_DeleteOnClose );
+  }
+  QDialog::reject();
+}
+
 //
 // QgsProcessingAlgorithmProgressDialog
 //

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -234,6 +234,8 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      */
     void showParameters();
 
+    void reject() override;
+
   protected:
 
     void closeEvent( QCloseEvent *e ) override;


### PR DESCRIPTION
A confirmation dialog from Refactor fields keeps showing after rejecting the algorithm dialog.

![1st_case](https://user-images.githubusercontent.com/652785/75619902-da3a0180-5b4f-11ea-9c08-767058cc6d48.gif)

**Suggested solution**: destroy widgets from a Processing dialog as soon as it is rejected.

**Steps to reproduce:** 

1. Open QGIS.
2. Load 2 layers.
3. Open the Refactor Fields dialog.
4. Press the Escape key.
5. Remove the layer that is currently selected in the Layers Panel.
6. You get the confirmation dialog from Refactor fields.

**Another case:**

1. Open QGIS.
2. Open the Refactor Fields dialog.
3. Press the Escape key.
4. Load  layer to QGIS and then remove it.
5. Once more, load a layer (it might be the same as in 4).
6. You get the confirmation dialog from Refactor fields.


These 2 are quite feasible scenarios.

It can be even more confusing when you have more layers in the project and run the algorithm several times: the connections may accumulate, showing several confirmation dialogs, consecutively.


--------------------------------
@arnaud-morvan, does it make sense for you?