### PR TITLE
Use a different key sequence for close editing line. Fixes #34793

### DIFF
--- a/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
+++ b/python/gui/auto_generated/qgsmaptooldigitizefeature.sip.in
@@ -32,8 +32,6 @@ QgsMapToolDigitizeFeature is a map tool to digitize a feature geometry
 :param mode: type of geometry to capture (point/line/polygon), QgsMapToolCapture.CaptureNone to autodetect geometry
 %End
 
-    virtual void keyPressEvent( QKeyEvent *e );
-
     virtual void cadCanvasReleaseEvent( QgsMapMouseEvent *e );
 
 

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -92,46 +92,6 @@ void QgsMapToolDigitizeFeature::setCheckGeometryType( bool checkGeometryType )
   mCheckGeometryType = checkGeometryType;
 }
 
-void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
-{
-  if ( e && e->key() == Qt::Key_C && e->modifiers() == Qt::ShiftModifier )
-  {
-    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );
-    if ( !vlayer )
-      //if no given layer take the current from canvas
-      vlayer = currentVectorLayer();
-
-    if ( !vlayer )
-    {
-      notifyNotVectorLayer();
-      return;
-    }
-
-    QgsVectorDataProvider *provider = vlayer->dataProvider();
-
-    if ( !( provider->capabilities() & QgsVectorDataProvider::AddFeatures ) )
-    {
-      emit messageEmitted( tr( "The data provider for this layer does not support the addition of features." ), Qgis::Warning );
-      return;
-    }
-
-    if ( !vlayer->isEditable() )
-    {
-      notifyNotEditableLayer();
-      return;
-    }
-
-    if ( ( mode() == CaptureLine && vlayer->geometryType() == QgsWkbTypes::LineGeometry && mCheckGeometryType ) || ( mode() == CapturePolygon && vlayer->geometryType() == QgsWkbTypes::PolygonGeometry && mCheckGeometryType ) )
-    {
-      closePolygon();
-      QgsMapMouseEvent e2( mCanvas, QEvent::MouseButtonRelease, QPoint( ), Qt::RightButton );
-      cadCanvasReleaseEvent( &e2 );
-    }
-  }
-  else
-    QgsMapToolCapture::keyPressEvent( e );
-}
-
 void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -131,6 +131,7 @@ void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
   else
     QgsMapToolCapture::keyPressEvent( e );
 }
+
 void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );
@@ -313,7 +314,7 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         return;
       }
 
-      if ( mode() == CapturePolygon )
+      if ( mode() == CapturePolygon || e->modifiers() == Qt::ShiftModifier )
       {
         closePolygon();
       }

--- a/src/gui/qgsmaptooldigitizefeature.cpp
+++ b/src/gui/qgsmaptooldigitizefeature.cpp
@@ -94,7 +94,7 @@ void QgsMapToolDigitizeFeature::setCheckGeometryType( bool checkGeometryType )
 
 void QgsMapToolDigitizeFeature::keyPressEvent( QKeyEvent *e )
 {
-  if ( e && e->key() == Qt::Key_C )
+  if ( e && e->key() == Qt::Key_C && e->modifiers() == Qt::ShiftModifier )
   {
     QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mLayer );
     if ( !vlayer )

--- a/src/gui/qgsmaptooldigitizefeature.h
+++ b/src/gui/qgsmaptooldigitizefeature.h
@@ -42,7 +42,6 @@ class GUI_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCapture
      */
     QgsMapToolDigitizeFeature( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget, CaptureMode mode = QgsMapToolCapture::CaptureNone );
 
-    void keyPressEvent( QKeyEvent *e ) override;
     void cadCanvasReleaseEvent( QgsMapMouseEvent *e ) override;
 
     /**

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -499,7 +499,7 @@ void TestQgsMapToolAddFeatureLine::testCloseLine()
   utils.mouseClick( 1, 1, Qt::LeftButton );
   utils.mouseClick( 5, 1, Qt::LeftButton );
   utils.mouseClick( 5, 5, Qt::LeftButton );
-  utils.keyClick( Qt::Key_C );
+  utils.keyClick( Qt::Key_C, Qt::ShiftModifier );
   QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
   QString wkt = "LineString (1 1, 5 1, 5 5, 1 1)";

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -69,7 +69,6 @@ class TestQgsMapToolAddFeatureLine : public QObject
     void testZMSnapping();
     void testTopologicalEditingZ();
     void testCloseLine();
-    void testCloseLineShiftRigthClick();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -492,23 +491,6 @@ void TestQgsMapToolAddFeatureLine::testTopologicalEditingZ()
 }
 
 void TestQgsMapToolAddFeatureLine::testCloseLine()
-{
-  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
-
-  mCanvas->setCurrentLayer( mLayerCloseLine );
-  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
-  utils.mouseClick( 1, 1, Qt::LeftButton );
-  utils.mouseClick( 5, 1, Qt::LeftButton );
-  utils.mouseClick( 5, 5, Qt::LeftButton );
-  utils.keyClick( Qt::Key_C, Qt::ShiftModifier );
-  QgsFeatureId newFid = utils.newFeatureId( oldFids );
-
-  QString wkt = "LineString (1 1, 5 1, 5 5, 1 1)";
-  QCOMPARE( mLayerCloseLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
-
-  mLayerCloseLine->undoStack()->undo();
-}
-void TestQgsMapToolAddFeatureLine::testCloseLineShiftRigthClick()
 {
   TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
 

--- a/tests/src/app/testqgsmaptooladdfeatureline.cpp
+++ b/tests/src/app/testqgsmaptooladdfeatureline.cpp
@@ -69,6 +69,7 @@ class TestQgsMapToolAddFeatureLine : public QObject
     void testZMSnapping();
     void testTopologicalEditingZ();
     void testCloseLine();
+    void testCloseLineShiftRigthClick();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -500,6 +501,23 @@ void TestQgsMapToolAddFeatureLine::testCloseLine()
   utils.mouseClick( 5, 1, Qt::LeftButton );
   utils.mouseClick( 5, 5, Qt::LeftButton );
   utils.keyClick( Qt::Key_C, Qt::ShiftModifier );
+  QgsFeatureId newFid = utils.newFeatureId( oldFids );
+
+  QString wkt = "LineString (1 1, 5 1, 5 5, 1 1)";
+  QCOMPARE( mLayerCloseLine->getFeature( newFid ).geometry(), QgsGeometry::fromWkt( wkt ) );
+
+  mLayerCloseLine->undoStack()->undo();
+}
+void TestQgsMapToolAddFeatureLine::testCloseLineShiftRigthClick()
+{
+  TestQgsMapToolAdvancedDigitizingUtils utils( mCaptureTool );
+
+  mCanvas->setCurrentLayer( mLayerCloseLine );
+  QSet<QgsFeatureId> oldFids = utils.existingFeatureIds();
+  utils.mouseClick( 1, 1, Qt::LeftButton );
+  utils.mouseClick( 5, 1, Qt::LeftButton );
+  utils.mouseClick( 5, 5, Qt::LeftButton );
+  utils.mouseClick( 5, 5, Qt::RightButton, Qt::ShiftModifier );
   QgsFeatureId newFid = utils.newFeatureId( oldFids );
 
   QString wkt = "LineString (1 1, 5 1, 5 5, 1 1)";

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -97,12 +97,12 @@ class TestQgsMapToolAdvancedDigitizingUtils
       mouseRelease( mapX, mapY, button, stateKey, snap );
     }
 
-    void keyClick( int key )
+    void keyClick( int key, modifier = Qt::KeyboardModifiers() )
     {
-      QKeyEvent e1( QEvent::KeyPress, key, Qt::KeyboardModifiers() );
+      QKeyEvent e1( QEvent::KeyPress, key, modifier );
       mMapTool->keyPressEvent( &e1 );
 
-      QKeyEvent e2( QEvent::KeyRelease, key, Qt::KeyboardModifiers() );
+      QKeyEvent e2( QEvent::KeyRelease, key, modifier );
       mMapTool->keyReleaseEvent( &e2 );
     }
 

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -97,12 +97,12 @@ class TestQgsMapToolAdvancedDigitizingUtils
       mouseRelease( mapX, mapY, button, stateKey, snap );
     }
 
-    void keyClick( int key, modifier = Qt::KeyboardModifiers() )
+    void keyClick( int key, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers() )
     {
-      QKeyEvent e1( QEvent::KeyPress, key, modifier );
+      QKeyEvent e1( QEvent::KeyPress, key, stateKey );
       mMapTool->keyPressEvent( &e1 );
 
-      QKeyEvent e2( QEvent::KeyRelease, key, modifier );
+      QKeyEvent e2( QEvent::KeyRelease, key, stateKey );
       mMapTool->keyReleaseEvent( &e2 );
     }
 
@@ -183,12 +183,12 @@ class TestQgsMapToolUtils
       mouseRelease( mapX, mapY, button, stateKey, snap );
     }
 
-    void keyClick( int key )
+    void keyClick( int key, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers() )
     {
-      QKeyEvent e1( QEvent::KeyPress, key, Qt::KeyboardModifiers() );
+      QKeyEvent e1( QEvent::KeyPress, key, stateKey );
       mMapTool->keyPressEvent( &e1 );
 
-      QKeyEvent e2( QEvent::KeyRelease, key, Qt::KeyboardModifiers() );
+      QKeyEvent e2( QEvent::KeyRelease, key, stateKey );
       mMapTool->keyReleaseEvent( &e2 );
     }
 


### PR DESCRIPTION
## Description

You can not close an editing line by pressing 'C' key when advanced digtizing tool is enabled, since 'C' is always used for 'Construction' mode.

This PR adds the Shift modifier key. So you have to press Shift+C. Obviously C is for [C]lose.

cc @SrNetoChan @pigreco @uclaros 
