### PR TITLE
Added a fix for the missing WMS category layers

### DIFF
--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -98,7 +98,7 @@ QVector<QgsDataItem *> QgsWMSConnectionItem::createChildren()
       QString pathName = layerProperty.name.isEmpty() ? QString::number( layerProperty.orderId ) : layerProperty.name;
       QgsDataItem *layer = nullptr;
 
-      if ( layerProperty.name.isEmpty() )
+      if ( layerProperty.name.isEmpty() || !layerProperty.layer.isEmpty() )
         layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
       else
         layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, uri, layerProperty );
@@ -285,7 +285,7 @@ QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QStri
 
     QgsDataItem *layer = nullptr;
 
-    if ( layerProperty.name.isEmpty() )
+    if ( layerProperty.name.isEmpty() || !layerProperty.layer.isEmpty() )
       layer = new QgsWMSLayerCollectionItem( this, layerProperty.title, mPath + '/' + pathName, capabilitiesProperty, dataSourceUri, layerProperty );
     else
       layer = new QgsWMSLayerItem( this, layerProperty.title, mPath + '/' + pathName, mCapabilitiesProperty, dataSourceUri, layerProperty );


### PR DESCRIPTION
Provides a fix for https://github.com/qgis/QGIS/issues/34692 and https://github.com/qgis/QGIS/issues/34798, these issues occurred because of the new way of displaying wms collection layers and layers on the browser was not torelant with non-conforming wms services as the old approach was, this PR adds a fix for that.

The new way of these layers separates collection layers and data layers, this enable simple refresh of the wms layers compared to the old way of treating the collection layers and data layers as one.

I'm currently working on a fix in a different PR to enable adding to the layers panel the new collection layers.