### PR TITLE
[ui] Add missing label mask panel title

### DIFF
--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -2570,6 +2570,13 @@ font-style: italic;</string>
                       </property>
                       <item>
                        <layout class="QGridLayout" name="gridLayout_361">
+                        <item row="0" column="0" colspan="3">
+                         <widget class="QLabel" name="label_99">
+                          <property name="text">
+                           <string>Mask</string>
+                          </property>
+                         </widget>
+                        </item>
                         <item row="1" column="1">
                          <widget class="QgsPropertyOverrideButton" name="mEnableMaskDDBtn">
                           <property name="text">


### PR DESCRIPTION
## Description

Small UI harmonization fix, add a title label to the label mask properties panel. 

Problem being fixed here:
![image](https://user-images.githubusercontent.com/1728657/75646115-1fa71d80-5c7b-11ea-9905-0e621451cfeb.png)
