### PR TITLE
Warn that layers will be lost when overwriting container vector file

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -19,6 +19,7 @@
 #include "qgsvectorlayersaveasdialog.h"
 #include "qgsprojectionselectiondialog.h"
 #include "qgsvectordataprovider.h"
+#include "qgsogrdataitems.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgseditorwidgetfactory.h"
 #include "qgseditorwidgetregistry.h"
@@ -292,7 +293,23 @@ void QgsVectorLayerSaveAsDialog::accept()
         if ( ret == QMessageBox::Cancel )
           return;
         if ( msgBox.clickedButton() == overwriteFileButton )
+        {
+          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+          QStringList layerList = QStringList();
+          for ( const auto layer : subLayers )
+          {
+            layerList.append( layer->name() );
+          }
+          if ( layerList.length() > 1 && QMessageBox::warning( this,
+               tr( "Overwrite file" ),
+               tr( "This file contains %1 layers that will be discarded!\n"
+                   "The following layers will be permanently lost:\n"
+                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
+               QMessageBox::Ok | QMessageBox::Cancel,
+               QMessageBox::Cancel ) == QMessageBox::Cancel )
+            return;
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        }
         else if ( msgBox.clickedButton() == overwriteLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
       }
@@ -322,7 +339,23 @@ void QgsVectorLayerSaveAsDialog::accept()
         if ( ret == QMessageBox::Cancel )
           return;
         if ( msgBox.clickedButton() == overwriteFileButton )
+        {
+          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+          QStringList layerList = QStringList();
+          for ( const auto layer : subLayers )
+          {
+            layerList.append( layer->name() );
+          }
+          if ( layerList.length() > 1 && QMessageBox::warning( this,
+               tr( "Overwrite file" ),
+               tr( "This file contains %1 layers that will be discarded!\n"
+                   "The following layers will be permanently lost:\n"
+                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
+               QMessageBox::Ok | QMessageBox::Cancel,
+               QMessageBox::Cancel ) == QMessageBox::Cancel )
+            return;
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        }
         else if ( msgBox.clickedButton() == overwriteLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
         else if ( msgBox.clickedButton() == appendToLayerButton )
@@ -342,7 +375,23 @@ void QgsVectorLayerSaveAsDialog::accept()
         if ( ret == QMessageBox::Cancel )
           return;
         if ( msgBox.clickedButton() == overwriteFileButton )
+        {
+          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+          QStringList layerList = QStringList();
+          for ( const auto layer : subLayers )
+          {
+            layerList.append( layer->name() );
+          }
+          if ( layerList.length() > 1 && QMessageBox::warning( this,
+               tr( "Overwrite file" ),
+               tr( "This file contains %1 layers that will be discarded!\n"
+                   "The following layers will be permanently lost:\n"
+                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
+               QMessageBox::Ok | QMessageBox::Cancel,
+               QMessageBox::Cancel ) == QMessageBox::Cancel )
+            return;
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        }
         else if ( msgBox.clickedButton() == appendToLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
       }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -278,13 +278,11 @@ void QgsVectorLayerSaveAsDialog::accept()
     QMessageBox msgBox;
     msgBox.setIcon( QMessageBox::Question );
     msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-    msgBox.setText( tr( "The layer already exists. What do you want to do?" ) );
     QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
     QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
     QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
     msgBox.setStandardButtons( QMessageBox::Cancel );
     msgBox.setDefaultButton( QMessageBox::Cancel );
-    int ret = msgBox.exec();
     overwriteFileButton->hide();
     overwriteLayerButton->hide();
     appendToLayerButton->hide();
@@ -294,39 +292,41 @@ void QgsVectorLayerSaveAsDialog::accept()
            ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
            ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
       {
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or overwrite the layer?" ) );
         overwriteFileButton->setVisible( true );
         overwriteLayerButton->setVisible( true );
       }
       else if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) )
       {
+        msgBox.setText( tr( "The file already exists. Do you want to overwrite it?" ) );
         overwriteFileButton->setVisible( true );
       }
       else if ( ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
                 ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
       {
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
         appendToLayerButton->setVisible( true );
         overwriteFileButton->setVisible( true );
         overwriteLayerButton->setVisible( true );
       }
       else
       {
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or append features to the layer?" ) );
         appendToLayerButton->setVisible( true );
         overwriteFileButton->setVisible( true );
       }
 
-//      int ret = msgBox.exec();
+      int ret = msgBox.exec();
       if ( ret == QMessageBox::Cancel )
         return;
       if ( msgBox.clickedButton() == overwriteFileButton )
-      {
         mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-      }
       else if ( msgBox.clickedButton() == overwriteLayerButton )
         mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
       else if ( msgBox.clickedButton() == appendToLayerButton )
         mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
     }
-    else
+    else // !layerExists
     {
       if ( ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
       {
@@ -334,7 +334,7 @@ void QgsVectorLayerSaveAsDialog::accept()
       }
       else
       {
-        // should not reach here, file does not exist and cannot add new layer
+        // should not reach here, layer does not exist and cannot add new layer
         if ( QMessageBox::question( this,
                                     tr( "Save Vector Layer As" ),
                                     tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
@@ -358,166 +358,27 @@ void QgsVectorLayerSaveAsDialog::accept()
       }
     }
   }
-
-//    if ( layerExists )
-//    {
-//      if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) &&
-//           ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
-//           ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
-//      {
-//        QMessageBox msgBox;
-//        msgBox.setIcon( QMessageBox::Question );
-//        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-//        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or overwrite the layer?" ) );
-//        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
-//        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
-//        msgBox.setStandardButtons( QMessageBox::Cancel );
-//        msgBox.setDefaultButton( QMessageBox::Cancel );
-//        int ret = msgBox.exec();
-//        if ( ret == QMessageBox::Cancel )
-//          return;
-//        if ( msgBox.clickedButton() == overwriteFileButton )
-//        {
-//          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-//          QStringList layerList = QStringList();
-//          for ( const auto layer : subLayers )
-//          {
-//            layerList.append( layer->name() );
-//          }
-//          layerList.sort();
-//          if ( layerList.length() > 1 && QMessageBox::warning( this,
-//               tr( "Overwrite file" ),
-//               tr( "This file contains %1 layers that will be discarded!\n"
-//                   "The following layers will be permanently lost:\n"
-//                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
-//               QMessageBox::Ok | QMessageBox::Cancel,
-//               QMessageBox::Cancel ) == QMessageBox::Cancel )
-//            return;
-//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-//        }
-//        else if ( msgBox.clickedButton() == overwriteLayerButton )
-//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
-//      }
-//      else if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) )
-//      {
-//        if ( QMessageBox::question( this,
-//                                    tr( "Save Vector Layer As" ),
-//                                    tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
-//        {
-//          return;
-//        }
-//        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-//      }
-//      else if ( ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
-//                ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
-//      {
-//        QMessageBox msgBox;
-//        msgBox.setIcon( QMessageBox::Question );
-//        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-//        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
-//        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
-//        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
-//        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
-//        msgBox.setStandardButtons( QMessageBox::Cancel );
-//        msgBox.setDefaultButton( QMessageBox::Cancel );
-//        int ret = msgBox.exec();
-//        if ( ret == QMessageBox::Cancel )
-//          return;
-//        if ( msgBox.clickedButton() == overwriteFileButton )
-//        {
-//          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-//          QStringList layerList = QStringList();
-//          for ( const auto layer : subLayers )
-//          {
-//            layerList.append( layer->name() );
-//          }
-//          layerList.sort();
-//          if ( layerList.length() > 1 && QMessageBox::warning( this,
-//               tr( "Overwrite file" ),
-//               tr( "This file contains %1 layers that will be discarded!\n"
-//                   "The following layers will be permanently lost:\n"
-//                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
-//               QMessageBox::Ok | QMessageBox::Cancel,
-//               QMessageBox::Cancel ) == QMessageBox::Cancel )
-//            return;
-//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-//        }
-//        else if ( msgBox.clickedButton() == overwriteLayerButton )
-//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
-//        else if ( msgBox.clickedButton() == appendToLayerButton )
-//          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
-//      }
-//      else
-//      {
-//        QMessageBox msgBox;
-//        msgBox.setIcon( QMessageBox::Question );
-//        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-//        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or append features to the layer?" ) );
-//        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
-//        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
-//        msgBox.setStandardButtons( QMessageBox::Cancel );
-//        msgBox.setDefaultButton( QMessageBox::Cancel );
-//        int ret = msgBox.exec();
-//        if ( ret == QMessageBox::Cancel )
-//          return;
-//        if ( msgBox.clickedButton() == overwriteFileButton )
-//        {
-//          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-//          QStringList layerList = QStringList();
-//          for ( const auto layer : subLayers )
-//          {
-//            layerList.append( layer->name() );
-//          }
-//          layerList.sort();
-//          if ( layerList.length() > 1 && QMessageBox::warning( this,
-//               tr( "Overwrite file" ),
-//               tr( "This file contains %1 layers that will be discarded!\n"
-//                   "The following layers will be permanently lost:\n"
-//                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
-//               QMessageBox::Ok | QMessageBox::Cancel,
-//               QMessageBox::Cancel ) == QMessageBox::Cancel )
-//            return;
-//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-//        }
-//        else if ( msgBox.clickedButton() == appendToLayerButton )
-//          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
-//      }
-
-//      if ( mActionOnExistingFile == QgsVectorFileWriter::AppendToLayerNoNewFields )
-//      {
-//        if ( QgsVectorFileWriter::areThereNewFieldsToCreate( filename(),
-//             layername(),
-//             mLayer,
-//             selectedAttributes() ) )
-//        {
-//          if ( QMessageBox::question( this,
-//                                      tr( "Save Vector Layer As" ),
-//                                      tr( "The existing layer has different fields. Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
-//          {
-//            mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerAddFields;
-//          }
-//        }
-//      }
-
-//    }
-//    else
-//    {
-//      if ( ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
-//      {
-//        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
-//      }
-//      else
-//      {
-//        if ( QMessageBox::question( this,
-//                                    tr( "Save Vector Layer As" ),
-//                                    tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
-//        {
-//          return;
-//        }
-//        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-//      }
-//    }
-//  }
+  else if ( mActionOnExistingFile == QgsVectorFileWriter::CreateOrOverwriteFile )
+  {
+    const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+    QStringList layerList = QStringList();
+    for ( const auto layer : subLayers )
+    {
+      layerList.append( layer->name() );
+    }
+    if ( layerList.length() > 1 )
+    {
+      layerList.sort( Qt::CaseInsensitive );
+      QMessageBox msgBox;
+      msgBox.setIcon( QMessageBox::Warning );
+      msgBox.setWindowTitle( tr( "Overwrite file" ) );
+      msgBox.setText( tr( "This file contains %1 layers that will be lost!\n" ).arg( QString::number( layerList.length() ) ) );
+      msgBox.setDetailedText( tr( "The following layers will be permanently lost:\n\n%1" ).arg( layerList.join( "\n" ) ) );
+      msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Cancel );
+      if ( msgBox.exec() == QMessageBox::Cancel )
+        return;
+    }
+  }
 
   QgsSettings settings;
   settings.setValue( QStringLiteral( "UI/lastVectorFileFilterDir" ), QFileInfo( filename() ).absolutePath() );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -283,16 +283,13 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Question );
         msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or overwrite the layer?" ) );
-        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite it?" ) );
         QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
         msgBox.setStandardButtons( QMessageBox::Cancel );
         msgBox.setDefaultButton( QMessageBox::Cancel );
         int ret = msgBox.exec();
         if ( ret == QMessageBox::Cancel )
           return;
-        if ( msgBox.clickedButton() == overwriteFileButton )
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
         else if ( msgBox.clickedButton() == overwriteLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
       }
@@ -312,8 +309,7 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Question );
         msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
-        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite it or append features to it?" ) );
         QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
         QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
         msgBox.setStandardButtons( QMessageBox::Cancel );
@@ -321,8 +317,6 @@ void QgsVectorLayerSaveAsDialog::accept()
         int ret = msgBox.exec();
         if ( ret == QMessageBox::Cancel )
           return;
-        if ( msgBox.clickedButton() == overwriteFileButton )
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
         else if ( msgBox.clickedButton() == overwriteLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
         else if ( msgBox.clickedButton() == appendToLayerButton )
@@ -333,16 +327,13 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Question );
         msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or append features to the layer?" ) );
-        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+        msgBox.setText( tr( "The layer already exists. Do you want to append features to it?" ) );
         QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
         msgBox.setStandardButtons( QMessageBox::Cancel );
         msgBox.setDefaultButton( QMessageBox::Cancel );
         int ret = msgBox.exec();
         if ( ret == QMessageBox::Cancel )
           return;
-        if ( msgBox.clickedButton() == overwriteFileButton )
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
         else if ( msgBox.clickedButton() == appendToLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
       }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -352,7 +352,7 @@ void QgsVectorLayerSaveAsDialog::accept()
     {
       if ( QMessageBox::question( this,
                                   tr( "Save Vector Layer As" ),
-                                  tr( "The existing layer has different fields. Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
+                                  tr( "The existing layer has additional fields. Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
       {
         mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerAddFields;
       }
@@ -361,17 +361,18 @@ void QgsVectorLayerSaveAsDialog::accept()
   else if ( mActionOnExistingFile == QgsVectorFileWriter::CreateOrOverwriteFile )
   {
     const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-    QStringList layerList = QStringList();
-    for ( const auto layer : subLayers )
+    QStringList layerList;
+    for ( const QgsOgrDbLayerInfo *layer : subLayers )
     {
       layerList.append( layer->name() );
     }
+    qDeleteAll( subLayers );
     if ( layerList.length() > 1 )
     {
       layerList.sort( Qt::CaseInsensitive );
       QMessageBox msgBox;
       msgBox.setIcon( QMessageBox::Warning );
-      msgBox.setWindowTitle( tr( "Overwrite file" ) );
+      msgBox.setWindowTitle( tr( "Overwrite File" ) );
       msgBox.setText( tr( "This file contains %1 layers that will be lost!\n" ).arg( QString::number( layerList.length() ) ) );
       msgBox.setDetailedText( tr( "The following layers will be permanently lost:\n\n%1" ).arg( layerList.join( "\n" ) ) );
       msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Cancel );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -275,146 +275,56 @@ void QgsVectorLayerSaveAsDialog::accept()
       QgsVectorFileWriter::editionCapabilities( filename() );
     bool layerExists = QgsVectorFileWriter::targetLayerExists( filename(),
                        layername() );
+    QMessageBox msgBox;
+    msgBox.setIcon( QMessageBox::Question );
+    msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
+    msgBox.setText( tr( "The layer already exists. What do you want to do?" ) );
+    QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+    QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
+    QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
+    msgBox.setStandardButtons( QMessageBox::Cancel );
+    msgBox.setDefaultButton( QMessageBox::Cancel );
+    int ret = msgBox.exec();
+    overwriteFileButton->hide();
+    overwriteLayerButton->hide();
+    appendToLayerButton->hide();
     if ( layerExists )
     {
       if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) &&
            ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
            ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
       {
-        QMessageBox msgBox;
-        msgBox.setIcon( QMessageBox::Question );
-        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or overwrite the layer?" ) );
-        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
-        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
-        msgBox.setStandardButtons( QMessageBox::Cancel );
-        msgBox.setDefaultButton( QMessageBox::Cancel );
-        int ret = msgBox.exec();
-        if ( ret == QMessageBox::Cancel )
-          return;
-        if ( msgBox.clickedButton() == overwriteFileButton )
-        {
-          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-          QStringList layerList = QStringList();
-          for ( const auto layer : subLayers )
-          {
-            layerList.append( layer->name() );
-          }
-          layerList.sort();
-          if ( layerList.length() > 1 && QMessageBox::warning( this,
-               tr( "Overwrite file" ),
-               tr( "This file contains %1 layers that will be discarded!\n"
-                   "The following layers will be permanently lost:\n"
-                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
-               QMessageBox::Ok | QMessageBox::Cancel,
-               QMessageBox::Cancel ) == QMessageBox::Cancel )
-            return;
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-        }
-        else if ( msgBox.clickedButton() == overwriteLayerButton )
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+        overwriteFileButton->setVisible( true );
+        overwriteLayerButton->setVisible( true );
       }
       else if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) )
       {
-        if ( QMessageBox::question( this,
-                                    tr( "Save Vector Layer As" ),
-                                    tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
-        {
-          return;
-        }
-        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        overwriteFileButton->setVisible( true );
       }
       else if ( ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
                 ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
       {
-        QMessageBox msgBox;
-        msgBox.setIcon( QMessageBox::Question );
-        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
-        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
-        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
-        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
-        msgBox.setStandardButtons( QMessageBox::Cancel );
-        msgBox.setDefaultButton( QMessageBox::Cancel );
-        int ret = msgBox.exec();
-        if ( ret == QMessageBox::Cancel )
-          return;
-        if ( msgBox.clickedButton() == overwriteFileButton )
-        {
-          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-          QStringList layerList = QStringList();
-          for ( const auto layer : subLayers )
-          {
-            layerList.append( layer->name() );
-          }
-          layerList.sort();
-          if ( layerList.length() > 1 && QMessageBox::warning( this,
-               tr( "Overwrite file" ),
-               tr( "This file contains %1 layers that will be discarded!\n"
-                   "The following layers will be permanently lost:\n"
-                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
-               QMessageBox::Ok | QMessageBox::Cancel,
-               QMessageBox::Cancel ) == QMessageBox::Cancel )
-            return;
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-        }
-        else if ( msgBox.clickedButton() == overwriteLayerButton )
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
-        else if ( msgBox.clickedButton() == appendToLayerButton )
-          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
+        appendToLayerButton->setVisible( true );
+        overwriteFileButton->setVisible( true );
+        overwriteLayerButton->setVisible( true );
       }
       else
       {
-        QMessageBox msgBox;
-        msgBox.setIcon( QMessageBox::Question );
-        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or append features to the layer?" ) );
-        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
-        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
-        msgBox.setStandardButtons( QMessageBox::Cancel );
-        msgBox.setDefaultButton( QMessageBox::Cancel );
-        int ret = msgBox.exec();
-        if ( ret == QMessageBox::Cancel )
-          return;
-        if ( msgBox.clickedButton() == overwriteFileButton )
-        {
-          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
-          QStringList layerList = QStringList();
-          for ( const auto layer : subLayers )
-          {
-            layerList.append( layer->name() );
-          }
-          layerList.sort();
-          if ( layerList.length() > 1 && QMessageBox::warning( this,
-               tr( "Overwrite file" ),
-               tr( "This file contains %1 layers that will be discarded!\n"
-                   "The following layers will be permanently lost:\n"
-                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
-               QMessageBox::Ok | QMessageBox::Cancel,
-               QMessageBox::Cancel ) == QMessageBox::Cancel )
-            return;
-          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
-        }
-        else if ( msgBox.clickedButton() == appendToLayerButton )
-          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
+        appendToLayerButton->setVisible( true );
+        overwriteFileButton->setVisible( true );
       }
 
-      if ( mActionOnExistingFile == QgsVectorFileWriter::AppendToLayerNoNewFields )
+//      int ret = msgBox.exec();
+      if ( ret == QMessageBox::Cancel )
+        return;
+      if ( msgBox.clickedButton() == overwriteFileButton )
       {
-        if ( QgsVectorFileWriter::areThereNewFieldsToCreate( filename(),
-             layername(),
-             mLayer,
-             selectedAttributes() ) )
-        {
-          if ( QMessageBox::question( this,
-                                      tr( "Save Vector Layer As" ),
-                                      tr( "The existing layer has different fields. Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
-          {
-            mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerAddFields;
-          }
-        }
+        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
       }
-
+      else if ( msgBox.clickedButton() == overwriteLayerButton )
+        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+      else if ( msgBox.clickedButton() == appendToLayerButton )
+        mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
     }
     else
     {
@@ -424,6 +334,7 @@ void QgsVectorLayerSaveAsDialog::accept()
       }
       else
       {
+        // should not reach here, file does not exist and cannot add new layer
         if ( QMessageBox::question( this,
                                     tr( "Save Vector Layer As" ),
                                     tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
@@ -434,6 +345,179 @@ void QgsVectorLayerSaveAsDialog::accept()
       }
     }
   }
+
+  if ( mActionOnExistingFile == QgsVectorFileWriter::AppendToLayerNoNewFields )
+  {
+    if ( QgsVectorFileWriter::areThereNewFieldsToCreate( filename(), layername(), mLayer, selectedAttributes() ) )
+    {
+      if ( QMessageBox::question( this,
+                                  tr( "Save Vector Layer As" ),
+                                  tr( "The existing layer has different fields. Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
+      {
+        mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerAddFields;
+      }
+    }
+  }
+
+//    if ( layerExists )
+//    {
+//      if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) &&
+//           ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
+//           ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
+//      {
+//        QMessageBox msgBox;
+//        msgBox.setIcon( QMessageBox::Question );
+//        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
+//        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or overwrite the layer?" ) );
+//        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+//        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
+//        msgBox.setStandardButtons( QMessageBox::Cancel );
+//        msgBox.setDefaultButton( QMessageBox::Cancel );
+//        int ret = msgBox.exec();
+//        if ( ret == QMessageBox::Cancel )
+//          return;
+//        if ( msgBox.clickedButton() == overwriteFileButton )
+//        {
+//          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+//          QStringList layerList = QStringList();
+//          for ( const auto layer : subLayers )
+//          {
+//            layerList.append( layer->name() );
+//          }
+//          layerList.sort();
+//          if ( layerList.length() > 1 && QMessageBox::warning( this,
+//               tr( "Overwrite file" ),
+//               tr( "This file contains %1 layers that will be discarded!\n"
+//                   "The following layers will be permanently lost:\n"
+//                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
+//               QMessageBox::Ok | QMessageBox::Cancel,
+//               QMessageBox::Cancel ) == QMessageBox::Cancel )
+//            return;
+//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+//        }
+//        else if ( msgBox.clickedButton() == overwriteLayerButton )
+//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+//      }
+//      else if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) )
+//      {
+//        if ( QMessageBox::question( this,
+//                                    tr( "Save Vector Layer As" ),
+//                                    tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
+//        {
+//          return;
+//        }
+//        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+//      }
+//      else if ( ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
+//                ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
+//      {
+//        QMessageBox msgBox;
+//        msgBox.setIcon( QMessageBox::Question );
+//        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
+//        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
+//        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+//        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
+//        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
+//        msgBox.setStandardButtons( QMessageBox::Cancel );
+//        msgBox.setDefaultButton( QMessageBox::Cancel );
+//        int ret = msgBox.exec();
+//        if ( ret == QMessageBox::Cancel )
+//          return;
+//        if ( msgBox.clickedButton() == overwriteFileButton )
+//        {
+//          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+//          QStringList layerList = QStringList();
+//          for ( const auto layer : subLayers )
+//          {
+//            layerList.append( layer->name() );
+//          }
+//          layerList.sort();
+//          if ( layerList.length() > 1 && QMessageBox::warning( this,
+//               tr( "Overwrite file" ),
+//               tr( "This file contains %1 layers that will be discarded!\n"
+//                   "The following layers will be permanently lost:\n"
+//                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
+//               QMessageBox::Ok | QMessageBox::Cancel,
+//               QMessageBox::Cancel ) == QMessageBox::Cancel )
+//            return;
+//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+//        }
+//        else if ( msgBox.clickedButton() == overwriteLayerButton )
+//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+//        else if ( msgBox.clickedButton() == appendToLayerButton )
+//          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
+//      }
+//      else
+//      {
+//        QMessageBox msgBox;
+//        msgBox.setIcon( QMessageBox::Question );
+//        msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
+//        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or append features to the layer?" ) );
+//        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
+//        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
+//        msgBox.setStandardButtons( QMessageBox::Cancel );
+//        msgBox.setDefaultButton( QMessageBox::Cancel );
+//        int ret = msgBox.exec();
+//        if ( ret == QMessageBox::Cancel )
+//          return;
+//        if ( msgBox.clickedButton() == overwriteFileButton )
+//        {
+//          const QList<QgsOgrDbLayerInfo *> subLayers = QgsOgrLayerItem::subLayers( filename(), format() );
+//          QStringList layerList = QStringList();
+//          for ( const auto layer : subLayers )
+//          {
+//            layerList.append( layer->name() );
+//          }
+//          layerList.sort();
+//          if ( layerList.length() > 1 && QMessageBox::warning( this,
+//               tr( "Overwrite file" ),
+//               tr( "This file contains %1 layers that will be discarded!\n"
+//                   "The following layers will be permanently lost:\n"
+//                   "\n%2" ).arg( QString::number( layerList.length() ), layerList.join( ", " ) ),
+//               QMessageBox::Ok | QMessageBox::Cancel,
+//               QMessageBox::Cancel ) == QMessageBox::Cancel )
+//            return;
+//          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+//        }
+//        else if ( msgBox.clickedButton() == appendToLayerButton )
+//          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
+//      }
+
+//      if ( mActionOnExistingFile == QgsVectorFileWriter::AppendToLayerNoNewFields )
+//      {
+//        if ( QgsVectorFileWriter::areThereNewFieldsToCreate( filename(),
+//             layername(),
+//             mLayer,
+//             selectedAttributes() ) )
+//        {
+//          if ( QMessageBox::question( this,
+//                                      tr( "Save Vector Layer As" ),
+//                                      tr( "The existing layer has different fields. Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
+//          {
+//            mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerAddFields;
+//          }
+//        }
+//      }
+
+//    }
+//    else
+//    {
+//      if ( ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
+//      {
+//        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+//      }
+//      else
+//      {
+//        if ( QMessageBox::question( this,
+//                                    tr( "Save Vector Layer As" ),
+//                                    tr( "The file already exists. Do you want to overwrite it?" ) ) == QMessageBox::NoButton )
+//        {
+//          return;
+//        }
+//        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+//      }
+//    }
+//  }
 
   QgsSettings settings;
   settings.setValue( QStringLiteral( "UI/lastVectorFileFilterDir" ), QFileInfo( filename() ).absolutePath() );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -283,13 +283,16 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Question );
         msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite it?" ) );
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or overwrite the layer?" ) );
+        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
         QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
         msgBox.setStandardButtons( QMessageBox::Cancel );
         msgBox.setDefaultButton( QMessageBox::Cancel );
         int ret = msgBox.exec();
         if ( ret == QMessageBox::Cancel )
           return;
+        if ( msgBox.clickedButton() == overwriteFileButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
         else if ( msgBox.clickedButton() == overwriteLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
       }
@@ -309,7 +312,8 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Question );
         msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to overwrite it or append features to it?" ) );
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
+        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
         QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite Layer" ), QMessageBox::ActionRole );
         QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
         msgBox.setStandardButtons( QMessageBox::Cancel );
@@ -317,6 +321,8 @@ void QgsVectorLayerSaveAsDialog::accept()
         int ret = msgBox.exec();
         if ( ret == QMessageBox::Cancel )
           return;
+        if ( msgBox.clickedButton() == overwriteFileButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
         else if ( msgBox.clickedButton() == overwriteLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
         else if ( msgBox.clickedButton() == appendToLayerButton )
@@ -327,13 +333,16 @@ void QgsVectorLayerSaveAsDialog::accept()
         QMessageBox msgBox;
         msgBox.setIcon( QMessageBox::Question );
         msgBox.setWindowTitle( tr( "Save Vector Layer As" ) );
-        msgBox.setText( tr( "The layer already exists. Do you want to append features to it?" ) );
+        msgBox.setText( tr( "The layer already exists. Do you want to overwrite the whole file or append features to the layer?" ) );
+        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite File" ), QMessageBox::ActionRole );
         QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to Layer" ), QMessageBox::ActionRole );
         msgBox.setStandardButtons( QMessageBox::Cancel );
         msgBox.setDefaultButton( QMessageBox::Cancel );
         int ret = msgBox.exec();
         if ( ret == QMessageBox::Cancel )
           return;
+        if ( msgBox.clickedButton() == overwriteFileButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
         else if ( msgBox.clickedButton() == appendToLayerButton )
           mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
       }

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -300,6 +300,7 @@ void QgsVectorLayerSaveAsDialog::accept()
           {
             layerList.append( layer->name() );
           }
+          layerList.sort();
           if ( layerList.length() > 1 && QMessageBox::warning( this,
                tr( "Overwrite file" ),
                tr( "This file contains %1 layers that will be discarded!\n"
@@ -346,6 +347,7 @@ void QgsVectorLayerSaveAsDialog::accept()
           {
             layerList.append( layer->name() );
           }
+          layerList.sort();
           if ( layerList.length() > 1 && QMessageBox::warning( this,
                tr( "Overwrite file" ),
                tr( "This file contains %1 layers that will be discarded!\n"
@@ -382,6 +384,7 @@ void QgsVectorLayerSaveAsDialog::accept()
           {
             layerList.append( layer->name() );
           }
+          layerList.sort();
           if ( layerList.length() > 1 && QMessageBox::warning( this,
                tr( "Overwrite file" ),
                tr( "This file contains %1 layers that will be discarded!\n"


### PR DESCRIPTION
## Description
Removed the dangerous option to delete the whole container file (geopackage, spatialite etc) when it contains a layer with the same name as the one the user is trying to save.

Fixes  #32823
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
