### PR TITLE
Fix crash in relation reference test

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -353,6 +353,8 @@ void QgsFeatureFilterModel::updateCompleter()
 
 void QgsFeatureFilterModel::gathererThreadFinished()
 {
+  // It's possible that gatherer run method is not completely over, so we wait
+  mGatherer->wait();
   delete mGatherer;
   mGatherer = nullptr;
   emit isLoadingChanged();


### PR DESCRIPTION
## Description

Fix flaky test in relation reference widget test. 

QgsFeatureFilterModel needs to wait for the `mGatherer` to be complety finished. Even if the `collectedValues` signal emitting is the last instruction, there is no garantie `run` is over when we delete it (I can reproduce the issue every time by adding a sleep just after the signal emitting).
