### PR TITLE
Add missing attributes at QgsAttributeEditorContext creation. 

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9268,6 +9268,9 @@ void QgisApp::modifyAttributesOfSelectedFeatures()
   QgsFeature f;
   QgsAttributeEditorContext context;
   context.setAllowCustomUi( false );
+  context.setVectorLayerTools( mVectorLayerTools );
+  context.setCadDockWidget(mAdvancedDigitizingDockWidget);
+  context.setMapCanvas(mMapCanvas);
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( vl, &f, false, this, true, context );
   dialog->setMode( QgsAttributeEditorContext::MultiEditMode );
@@ -9567,6 +9570,7 @@ void QgisApp::selectByForm()
   QgsAttributeEditorContext context;
   context.setDistanceArea( myDa );
   context.setVectorLayerTools( mVectorLayerTools );
+  context.setCadDockWidget(mAdvancedDigitizingDockWidget);
   context.setMapCanvas( mMapCanvas );
 
   QgsSelectByFormDialog *dlg = new QgsSelectByFormDialog( vlayer, context, this );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9269,8 +9269,8 @@ void QgisApp::modifyAttributesOfSelectedFeatures()
   QgsAttributeEditorContext context;
   context.setAllowCustomUi( false );
   context.setVectorLayerTools( mVectorLayerTools );
-  context.setCadDockWidget(mAdvancedDigitizingDockWidget);
-  context.setMapCanvas(mMapCanvas);
+  context.setCadDockWidget( mAdvancedDigitizingDockWidget );
+  context.setMapCanvas( mMapCanvas );
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( vl, &f, false, this, true, context );
   dialog->setMode( QgsAttributeEditorContext::MultiEditMode );
@@ -9570,7 +9570,7 @@ void QgisApp::selectByForm()
   QgsAttributeEditorContext context;
   context.setDistanceArea( myDa );
   context.setVectorLayerTools( mVectorLayerTools );
-  context.setCadDockWidget(mAdvancedDigitizingDockWidget);
+  context.setCadDockWidget( mAdvancedDigitizingDockWidget );
   context.setMapCanvas( mMapCanvas );
 
   QgsSelectByFormDialog *dlg = new QgsSelectByFormDialog( vlayer, context, this );


### PR DESCRIPTION
Should fix some asserts and crashs. I came across this bug when using multiple edit tool in the digitizing tool bar. An assert was raise in QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing line 28 because the  advancedDigitizingDockWidget pointer was null. The mapCanvas and vectorlayertools were also missing.
