### PR TITLE
QtDBus linked to other Qt frameowrks, needs bundling

### DIFF
--- a/mac/cmake/1qt.cmake.in
+++ b/mac/cmake/1qt.cmake.in
@@ -16,8 +16,8 @@ SET (QT_FWVER "5")
 # build list of Qt frameworks to bundle
 
 # core list, includes dependencies and used by extra plugins
-SET (QTLISTQG QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtConcurrent QtPrintSupport QtSerialPort QtPositioning QtTest QtSql QtMacExtras)
-SET (PYQTLIST Qt QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtPrintSupport QtPositioning QtSerialPort QtTest QtSql QtMacExtras)
+SET (QTLISTQG QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtConcurrent QtPrintSupport QtSerialPort QtPositioning QtTest QtSql QtMacExtras QtDBus)
+SET (PYQTLIST Qt QtCore QtGui QtWidgets QtNetwork QtXml QtSvg QtPrintSupport QtPositioning QtSerialPort QtTest QtSql QtMacExtras QtDBus)
 
 # QtQuickWidgets appears to be implied direct dep, it needs Quick and Qml,
 # whether or not WITH_QUICK specified


### PR DESCRIPTION
## Description

QtDBus is missing from Mac bundling.