### PR TITLE
[feature] Get current parent form values in child forms

### DIFF
--- a/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressioncontextutils.sip.in
@@ -33,11 +33,20 @@ For instance, QGIS version numbers and variables specified through QGIS options.
 
     static QgsExpressionContextScope *formScope( const QgsFeature &formFeature = QgsFeature( ), const QString &formMode = QString() ) /Factory/;
 %Docstring
-Creates a new scope which contains functions and variables from the current attribute form/table ``feature``.
+Creates a new scope which contains functions and variables from the current attribute form/table ``formFeature``.
 The variables and values in this scope will reflect the current state of the form/row being edited.
 The ``formMode`` (SingleEditMode etc.) is passed as text
 
 .. versionadded:: 3.2
+%End
+
+    static QgsExpressionContextScope *parentFormScope( const QgsFeature &formFeature = QgsFeature( ), const QString &formMode = QString() ) /Factory/;
+%Docstring
+Creates a new scope which contains functions and variables from the current parent attribute form/table ``formFeature``.
+The variables and values in this scope will reflect the current state of the parent form/row being edited.
+The ``formMode`` (SingleEditMode etc.) is passed as text
+
+.. versionadded:: 3.14
 %End
 
     static void setGlobalVariable( const QString &name, const QVariant &value );

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -64,7 +64,7 @@ Utility to convert a list or a string representation of an (hstore style: {1,2..
 .. versionadded:: 3.2
 %End
 
-    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature() );
+    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature(), const QgsFeature &parentFormFeature = QgsFeature() );
 %Docstring
 Create a cache for a value relation field.
 This can be used to keep the value map in the local memory
@@ -112,9 +112,45 @@ Returns a list of variables required by the form context ``expression``
 .. versionadded:: 3.2
 %End
 
-    static bool expressionIsUsable( const QString &expression, const QgsFeature &feature );
+    static bool expressionRequiresParentFormScope( const QString &expression );
 %Docstring
-Check whether the ``feature`` has all values required by the ``expression``
+Check if the ``expression`` requires a parent form scope (i.e. if it uses fields
+or geometry of the parent form's currently edited feature).
+
+:param expression: The widget's filter expression
+
+:return: ``True`` if the expression requires a parent form scope
+
+.. versionadded:: 3.14
+%End
+
+    static QSet<QString> expressionParentFormAttributes( const QString &expression );
+%Docstring
+Returns a list of attributes required by the parent form's form context ``expression``
+
+:param expression: Form filter expression
+
+:return: list of parent attributes required by the expression
+
+.. versionadded:: 3.14
+%End
+
+    static QSet<QString> expressionParentFormVariables( const QString &expression );
+%Docstring
+Returns a list of variables required by the parent form's form context ``expression``
+
+:param expression: Form filter expression
+
+:return: list of parent variables required by the expression
+
+.. versionadded:: 3.14
+%End
+
+
+    static bool expressionIsUsable( const QString &expression, const QgsFeature &feature, const QgsFeature &parentFeature = QgsFeature() );
+%Docstring
+Check whether the ``feature`` has all values required by the ``expression``,
+optionally checks for ``parentFeature``
 
 :return: ``True`` if the expression can be used
 

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -72,6 +72,7 @@ if doing multiple lookups in a loop.
 
 :param config: The widget configuration
 :param formFeature: The feature currently being edited with current attribute values
+:param parentFormFeature: For embedded forms only, the feature currently being edited in the parent form with current attribute values
 
 :return: A kvp list of values for the widget
 

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -69,6 +69,7 @@ Returns the selected features in the attribute table in table sorted order.
 .. versionadded:: 3.4
 %End
 
+
   protected:
 
     virtual void mousePressEvent( QMouseEvent *event );

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -234,6 +234,16 @@ Cancel the progress dialog (if any)
 .. versionadded:: 3.0
 %End
 
+    void parentFormValueChanged( const QString &attribute, const QVariant &value );
+%Docstring
+Called in embedded forms when an ``attribute`` ``value`` in the parent form has changed.
+
+Notify the form widgets that something has changed in case they
+have filter expression that depend on the parent form scope.
+
+.. versionadded:: 3.14
+%End
+
   signals:
 
     void displayExpressionChanged( const QString &expression );

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -304,6 +304,19 @@ to reflect the new values.
 Will call the value() method to determine the emitted value
 %End
 
+    virtual void parentFormValueChanged( const QString &attribute, const QVariant &value );
+%Docstring
+Is called in embedded form widgets when an ``attribute`` ``value`` in
+the parent form has changed.
+
+The default implementations does nothing.
+Subclasses should reimplement this method to notify the form widgets
+that something has changed in case they have filter expressions that
+depend on the parent form scope.
+
+.. versionadded:: 3.14
+%End
+
   protected:
 
     virtual void updateConstraintWidgetStatus();

--- a/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationwidgetwrapper.sip.in
@@ -88,6 +88,21 @@ The relation for which this wrapper is created.
 .. versionadded:: 3.0
 %End
 
+    void widgetValueChanged( const QString &attribute, const QVariant &newValue, bool attributeChanged );
+%Docstring
+Will be called when a value in the current edited form or table row
+changes
+
+Forward the signal to the embedded form
+
+:param attribute: The name of the attribute that changed.
+:param newValue: The new value of the attribute.
+:param attributeChanged: If ``True``, it corresponds to an actual change of the feature attribute
+
+.. versionadded:: 3.14
+%End
+
+
   protected:
     virtual QWidget *createWidget( QWidget *parent );
 

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -237,6 +237,24 @@ Set current ``feature`` for the currently edited form or table row
 .. versionadded:: 3.2
 %End
 
+    QgsFeature parentFormFeature() const;
+%Docstring
+Returns the feature of the currently edited parent form in its actual state
+
+.. seealso:: :py:func:`setParentFormFeature`
+
+.. versionadded:: 3.14
+%End
+
+    void setParentFormFeature( const QgsFeature &feature );
+%Docstring
+Sets the ``feature`` of the currently edited parent form
+
+.. seealso:: :py:func:`parentFormFeature`
+
+.. versionadded:: 3.14
+%End
+
     Mode attributeFormMode() const;
 %Docstring
 Returns current attributeFormMode

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -280,6 +280,18 @@ Resets the search/filter form values.
 reload current feature
 %End
 
+    void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
+%Docstring
+Is called in embedded forms when an ``attribute`` value in the parent form
+has changed to ``newValue``.
+
+Notify the form widgets that something has changed in case they
+have filter expressions that depend on the parent form scope.
+
+.. versionadded:: 3.14
+%End
+
+
 };
 
 

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -63,7 +63,10 @@ inserting and deleting entries on the intermediate table as required.
 :param nmrelation: Optional reference from the referencing table to a 3rd N:M table
 %End
 
-    void setFeature( const QgsFeature &feature );
+    void setFeature( const QgsFeature &feature, bool update = true );
+%Docstring
+Sets the ``feature`` being edited and updates the UI unless ``update`` is set to ``False``
+%End
 
     void setEditorContext( const QgsAttributeEditorContext &context );
 
@@ -129,6 +132,21 @@ Determines if the "Save child layer edits" button should be shown
 .. versionadded:: 3.14
 %End
 
+    QgsFeature feature() const;
+%Docstring
+Returns the widget's current feature
+
+.. versionadded:: 3.14
+%End
+
+  public slots:
+
+    void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
+%Docstring
+Called when an ``attribute`` value in the parent widget has changed to ``newValue``
+
+.. versionadded:: 3.14
+%End
 
 };
 

--- a/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsrelationeditorwidget.sip.in
@@ -51,6 +51,9 @@ Gets the view mode for the dual view
 %End
 
     void setRelationFeature( const QgsRelation &relation, const QgsFeature &feature );
+%Docstring
+Sets the ``relation`` and the ``feature``
+%End
 
     void setRelations( const QgsRelation &relation, const QgsRelation &nmrelation );
 %Docstring
@@ -69,6 +72,9 @@ Sets the ``feature`` being edited and updates the UI unless ``update`` is set to
 %End
 
     void setEditorContext( const QgsAttributeEditorContext &context );
+%Docstring
+Sets the editor ``context``
+%End
 
     QgsIFeatureSelectionManager *featureSelectionManager();
 %Docstring

--- a/resources/function_help/json/current_parent_value
+++ b/resources/function_help/json/current_parent_value
@@ -1,0 +1,7 @@
+{
+  "name": "current_parent_value",
+  "type": "function",
+  "description": "Only usable in an embedded form context, this function returns the current, unsaved value of a field in the parent form currently being edited. This will differ from the parent feature's actual attribute values for features which are currently being edited or have not yet been added to a parent layer. When used in a value-relation widget filter expression, this function should be wrapped into a 'coalesce()' that can retrieve the actual parent feature from the layer when the form is not used in an embedded context.",
+  "arguments": [ {"arg":"field_name","description":"a field name in the current parent form"}],
+  "examples": [ { "expression":"current_parent_value( 'FIELD_NAME' )","returns":"The current value of a field 'FIELD_NAME' in the parent form."} ]
+}

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -826,6 +826,22 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts()->insert( QStringLiteral( "current_geometry" ), QCoreApplication::translate( "current_geometry", "Represents the geometry of the feature currently being edited in the form or the table row. Can be used in a form/row context to filter the related features." ) );
   sVariableHelpTexts()->insert( QStringLiteral( "current_feature" ), QCoreApplication::translate( "current_feature", "Represents the feature currently being edited in the form or the table row. Can be used in a form/row context to filter the related features." ) );
 
+  //parent form context variable
+  sVariableHelpTexts()->insert( QStringLiteral( "current_parent_geometry" ), QCoreApplication::translate( "current_parent_geometry",
+                                "Only usable in an embedded form context, "
+                                "represents the geometry of the feature currently being edited in the parent form.\n"
+                                "Can be used in a form/row context to filter the related features using a value "
+                                "from the feature currently edited in the parent form, to make sure that the filter "
+                                "still works with standalone forms it is recommended to wrap this variable in a "
+                                "'coalesce()'." ) );
+  sVariableHelpTexts()->insert( QStringLiteral( "current_parent_feature" ), QCoreApplication::translate( "current_parent_feature",
+                                "Only usable in an embedded form context, "
+                                "represents the feature currently being edited in the parent form.\n"
+                                "Can be used in a form/row context to filter the related features using a value "
+                                "from the feature currently edited in the parent form, to make sure that the filter "
+                                "still works with standalone forms it is recommended to wrap this variable in a "
+                                "'coalesce()'." ) );
+
   //form variable
   sVariableHelpTexts()->insert( QStringLiteral( "form_mode" ), QCoreApplication::translate( "form_mode", "What the form is used for, like AddFeatureMode, SingleEditMode, MultiEditMode, SearchMode, AggregateSearchMode or IdentifyMode as string." ) );
 }

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -134,6 +134,31 @@ class GetCurrentFormFieldValue : public QgsScopedExpressionFunction
 
 };
 
+class GetCurrentParentFormFieldValue : public QgsScopedExpressionFunction
+{
+  public:
+    GetCurrentParentFormFieldValue( )
+      : QgsScopedExpressionFunction( QStringLiteral( "current_parent_value" ), QgsExpressionFunction::ParameterList() << QStringLiteral( "field_name" ), QStringLiteral( "Form" ) )
+    {}
+
+    QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
+    {
+      QString fieldName( values.at( 0 ).toString() );
+      const QgsFeature feat( context->variable( QStringLiteral( "current_parent_feature" ) ).value<QgsFeature>() );
+      if ( fieldName.isEmpty() || ! feat.isValid( ) )
+      {
+        return QVariant();
+      }
+      return feat.attribute( fieldName ) ;
+    }
+
+    QgsScopedExpressionFunction *clone() const override
+    {
+      return new GetCurrentParentFormFieldValue( );
+    }
+
+};
+
 
 class GetProcessingParameterValue : public QgsScopedExpressionFunction
 {
@@ -169,6 +194,17 @@ QgsExpressionContextScope *QgsExpressionContextUtils::formScope( const QgsFeatur
   scope->setVariable( QStringLiteral( "current_geometry" ), formFeature.geometry( ), true );
   scope->setVariable( QStringLiteral( "current_feature" ), formFeature, true );
   scope->setVariable( QStringLiteral( "form_mode" ), formMode, true );
+  return scope;
+}
+
+
+QgsExpressionContextScope *QgsExpressionContextUtils::parentFormScope( const QgsFeature &parentFormFeature, const QString &parentFormMode )
+{
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Parent Form" ) );
+  scope->addFunction( QStringLiteral( "current_parent_value" ), new GetCurrentParentFormFieldValue( ) );
+  scope->setVariable( QStringLiteral( "current_parent_geometry" ), parentFormFeature.geometry( ), true );
+  scope->setVariable( QStringLiteral( "current_parent_feature" ), parentFormFeature, true );
+  scope->setVariable( QStringLiteral( "parent_form_mode" ), parentFormMode, true );
   return scope;
 }
 
@@ -766,6 +802,7 @@ void QgsExpressionContextUtils::registerContextFunctions()
   QgsExpression::registerFunction( new GetLayerVisibility( QList<QgsMapLayer *>(), 0.0 ) );
   QgsExpression::registerFunction( new GetProcessingParameterValue( QVariantMap() ) );
   QgsExpression::registerFunction( new GetCurrentFormFieldValue( ) );
+  QgsExpression::registerFunction( new GetCurrentParentFormFieldValue( ) );
 }
 
 bool QgsScopedExpressionFunction::usesGeometry( const QgsExpressionNodeFunction *node ) const

--- a/src/core/expression/qgsexpressioncontextutils.h
+++ b/src/core/expression/qgsexpressioncontextutils.h
@@ -54,12 +54,20 @@ class CORE_EXPORT QgsExpressionContextUtils
     static QgsExpressionContextScope *globalScope() SIP_FACTORY;
 
     /**
-     * Creates a new scope which contains functions and variables from the current attribute form/table \a feature.
+     * Creates a new scope which contains functions and variables from the current attribute form/table \a formFeature.
      * The variables and values in this scope will reflect the current state of the form/row being edited.
      * The \a formMode (SingleEditMode etc.) is passed as text
      * \since QGIS 3.2
      */
     static QgsExpressionContextScope *formScope( const QgsFeature &formFeature = QgsFeature( ), const QString &formMode = QString() ) SIP_FACTORY;
+
+    /**
+     * Creates a new scope which contains functions and variables from the current parent attribute form/table \a formFeature.
+     * The variables and values in this scope will reflect the current state of the parent form/row being edited.
+     * The \a formMode (SingleEditMode etc.) is passed as text
+     * \since QGIS 3.14
+     */
+    static QgsExpressionContextScope *parentFormScope( const QgsFeature &formFeature = QgsFeature( ), const QString &formMode = QString() ) SIP_FACTORY;
 
     /**
      * Sets a global context variable. This variable will be contained within scopes retrieved via

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -81,7 +81,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
      *
      * \since QGIS 3.0
      */
-    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature() );
+    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature(), const QgsFeature &parentFormFeature = QgsFeature() );
 
     /**
      * Check if the \a expression requires a form scope (i.e. if it uses fields
@@ -112,12 +112,42 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     static QSet<QString> expressionFormVariables( const QString &expression );
 
     /**
-     * Check whether the \a feature has all values required by the \a expression
+     * Check if the \a expression requires a parent form scope (i.e. if it uses fields
+     * or geometry of the parent form's currently edited feature).
+     *
+     * \param expression The widget's filter expression
+     * \return TRUE if the expression requires a parent form scope
+     * \since QGIS 3.14
+     */
+    static bool expressionRequiresParentFormScope( const QString &expression );
+
+    /**
+     * Returns a list of attributes required by the parent form's form context \a expression
+     *
+     * \param expression Form filter expression
+     * \return list of parent attributes required by the expression
+     * \since QGIS 3.14
+     */
+    static QSet<QString> expressionParentFormAttributes( const QString &expression );
+
+    /**
+     * Returns a list of variables required by the parent form's form context \a expression
+     *
+     * \param expression Form filter expression
+     * \return list of parent variables required by the expression
+     * \since QGIS 3.14
+     */
+    static QSet<QString> expressionParentFormVariables( const QString &expression );
+
+
+    /**
+     * Check whether the \a feature has all values required by the \a expression,
+     * optionally checks for \a parentFeature
      *
      * \return TRUE if the expression can be used
      * \since QGIS 3.2
      */
-    static bool expressionIsUsable( const QString &expression, const QgsFeature &feature );
+    static bool expressionIsUsable( const QString &expression, const QgsFeature &feature, const QgsFeature &parentFeature = QgsFeature() );
 
     /**
      * Returns the (possibly NULL) layer from the widget's \a config and \a project

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -77,6 +77,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
      * if doing multiple lookups in a loop.
      * \param config The widget configuration
      * \param formFeature The feature currently being edited with current attribute values
+     * \param parentFormFeature For embedded forms only, the feature currently being edited in the parent form with current attribute values
      * \return A kvp list of values for the widget
      *
      * \since QGIS 3.0

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -88,6 +88,7 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
      */
     QList<QgsFeatureId> selectedFeaturesIds() const;
 
+
   protected:
 
     /**

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -687,6 +687,14 @@ void QgsDualView::cancelProgress()
     mProgressDlg->cancel();
 }
 
+void QgsDualView::parentFormValueChanged( const QString &attribute, const QVariant &newValue )
+{
+  if ( mAttributeForm )
+  {
+    mAttributeForm->parentFormValueChanged( attribute, newValue );
+  }
+}
+
 void QgsDualView::hideEvent( QHideEvent *event )
 {
   Q_UNUSED( event )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -259,6 +259,16 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     void cancelProgress( );
 
+    /**
+     * Called in embedded forms when an \a attribute \a value in the parent form has changed.
+     *
+     * Notify the form widgets that something has changed in case they
+     * have filter expression that depend on the parent form scope.
+     *
+     * \since QGIS 3.14
+     */
+    void parentFormValueChanged( const QString &attribute, const QVariant &value );
+
   signals:
 
     /**

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -96,6 +96,12 @@ void QgsEditorWidgetWrapper::emitValueChanged()
   emit valuesChanged( value(), additionalFieldValues() );
 }
 
+void QgsEditorWidgetWrapper::parentFormValueChanged( const QString &attribute, const QVariant &value )
+{
+  Q_UNUSED( attribute )
+  Q_UNUSED( value )
+}
+
 void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
 {
   if ( !mConstraintResultVisible )

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -306,6 +306,19 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     void emitValueChanged();
 
+    /**
+     * Is called in embedded form widgets when an \a attribute \a value in
+     * the parent form has changed.
+     *
+     * The default implementations does nothing.
+     * Subclasses should reimplement this method to notify the form widgets
+     * that something has changed in case they have filter expressions that
+     * depend on the parent form scope.
+     *
+     * \since QGIS 3.14
+     */
+    virtual void parentFormValueChanged( const QString &attribute, const QVariant &value );
+
   protected:
 
     /**

--- a/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgshtmlwidgetwrapper.cpp
@@ -82,9 +82,13 @@ void QgsHtmlWidgetWrapper::setHtmlContext( )
   if ( !mWidget )
     return;
 
-  QgsAttributeEditorContext attributecontext = context();
+  const QgsAttributeEditorContext attributecontext = context();
   QgsExpressionContext expressionContext = layer()->createExpressionContext();
   expressionContext << QgsExpressionContextUtils::formScope( mFeature, attributecontext.attributeFormModeString() );
+  if ( attributecontext.parentFormFeature().isValid() )
+  {
+    expressionContext << QgsExpressionContextUtils::parentFormScope( attributecontext.parentFormFeature() );
+  }
   expressionContext.setFeature( mFeature );
 
   HtmlExpression *htmlExpression = new HtmlExpression();

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -30,6 +30,10 @@ QgsRelationWidgetWrapper::QgsRelationWidgetWrapper( QgsVectorLayer *vl, const Qg
 
 QWidget *QgsRelationWidgetWrapper::createWidget( QWidget *parent )
 {
+  QgsAttributeForm *form = qobject_cast<QgsAttributeForm *>( parent );
+  if ( form )
+    connect( form, &QgsAttributeForm::widgetValueChanged, this, &QgsRelationWidgetWrapper::widgetValueChanged );
+
   return new QgsRelationEditorWidget( parent );
 }
 
@@ -76,6 +80,23 @@ void QgsRelationWidgetWrapper::aboutToSave()
 QgsRelation QgsRelationWidgetWrapper::relation() const
 {
   return mRelation;
+}
+
+void QgsRelationWidgetWrapper::widgetValueChanged( const QString &attribute, const QVariant &newValue, bool attributeChanged )
+{
+  if ( mWidget && attributeChanged )
+  {
+    QgsFeature feature { mWidget->feature() };
+    if ( feature.attribute( attribute ) != newValue )
+    {
+      feature.setAttribute( attribute, newValue );
+      QgsAttributeEditorContext newContext { context() };
+      newContext.setParentFormFeature( feature );
+      mWidget->setEditorContext( newContext );
+      mWidget->setFeature( feature, false );
+      mWidget->parentFormValueChanged( attribute, newValue );
+    }
+  }
 }
 
 bool QgsRelationWidgetWrapper::showUnlinkButton() const

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -101,6 +101,20 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
      */
     QgsRelation relation() const;
 
+    /**
+     * Will be called when a value in the current edited form or table row
+     * changes
+     *
+     * Forward the signal to the embedded form
+     *
+     * \param attribute The name of the attribute that changed.
+     * \param newValue     The new value of the attribute.
+     * \param attributeChanged If TRUE, it corresponds to an actual change of the feature attribute
+     * \since QGIS 3.14
+     */
+    void widgetValueChanged( const QString &attribute, const QVariant &newValue, bool attributeChanged );
+
+
   protected:
     QWidget *createWidget( QWidget *parent ) override;
     void initWidget( QWidget *editor ) override;

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -111,11 +111,14 @@ void QgsValueRelationConfigDlg::editExpression()
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( vl ) );
   context << QgsExpressionContextUtils::formScope( );
+  context << QgsExpressionContextUtils::parentFormScope( );
 
-  context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) );
+  context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) << QStringLiteral( "current_parent_value" ) );
   context.setHighlightedVariables( QStringList() << QStringLiteral( "current_geometry" )
                                    << QStringLiteral( "current_feature" )
-                                   << QStringLiteral( "form_mode" ) );
+                                   << QStringLiteral( "form_mode" )
+                                   << QStringLiteral( "current_parent_geometry" )
+                                   << QStringLiteral( "current_parent_feature" ) );
 
   QgsExpressionBuilderDialog dlg( vl, mFilterExpression->toPlainText(), this, QStringLiteral( "generic" ), context );
   dlg.setWindowTitle( tr( "Edit Filter Expression" ) );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -298,14 +298,17 @@ void QgsValueRelationWidgetWrapper::setFeature( const QgsFeature &feature )
   // and signals unblocked (we want this to propagate to the feature itself)
   if ( formFeature().isValid()
        && ! formFeature().attribute( fieldIdx() ).isValid()
-       && ! mCache.empty()
+       && ! mCache.isEmpty()
        && ! config( QStringLiteral( "AllowNull" ) ).toBool( ) )
   {
     // This is deferred because at the time the feature is set in one widget it is not
     // set in the next, which is typically the "down" in a drill-down
     QTimer::singleShot( 0, this, [ this ]
     {
-      updateValues( mCache.at( 0 ).key );
+      if ( ! mCache.isEmpty() )
+      {
+        updateValues( mCache.at( 0 ).key );
+      }
     } );
   }
 }
@@ -334,9 +337,17 @@ QVariant::Type QgsValueRelationWidgetWrapper::fkType() const
 void QgsValueRelationWidgetWrapper::populate( )
 {
   // Initialize, note that signals are blocked, to avoid double signals on new features
-  if ( QgsValueRelationFieldFormatter::expressionRequiresFormScope( mExpression ) )
+  if ( QgsValueRelationFieldFormatter::expressionRequiresFormScope( mExpression ) ||
+       QgsValueRelationFieldFormatter::expressionRequiresParentFormScope( mExpression ) )
   {
-    mCache = QgsValueRelationFieldFormatter::createCache( config( ), formFeature() );
+    if ( context().parentFormFeature().isValid() )
+    {
+      mCache = QgsValueRelationFieldFormatter::createCache( config( ), formFeature(), context().parentFormFeature() );
+    }
+    else
+    {
+      mCache = QgsValueRelationFieldFormatter::createCache( config( ), formFeature() );
+    }
   }
   else if ( mCache.empty() )
   {
@@ -355,6 +366,7 @@ void QgsValueRelationWidgetWrapper::populate( )
     {
       whileBlocking( mComboBox )->addItem( element.value, element.key );
     }
+
   }
   else if ( mTableWidget )
   {
@@ -384,6 +396,7 @@ void QgsValueRelationWidgetWrapper::populate( )
       whileBlocking( mTableWidget )->setItem( row, column, item );
       column++;
     }
+
   }
   else if ( mLineEdit )
   {
@@ -450,6 +463,28 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
   }
   else
     QgsEditorWidgetWrapper::setEnabled( enabled );
+}
+
+void QgsValueRelationWidgetWrapper::parentFormValueChanged( const QString &attribute, const QVariant &value )
+{
+
+  // Update the parent feature in the context ( which means to replace the whole context :/ )
+  QgsAttributeEditorContext ctx { context() };
+  QgsFeature feature { context().parentFormFeature() };
+  feature.setAttribute( attribute, value );
+  ctx.setParentFormFeature( feature );
+  setContext( ctx );
+
+  // Check if the change might affect the filter expression and the cache needs updates
+  if ( QgsValueRelationFieldFormatter::expressionRequiresParentFormScope( mExpression )
+       && ( config( QStringLiteral( "Value" ) ).toString() == attribute ||
+            config( QStringLiteral( "Key" ) ).toString() == attribute ||
+            ! QgsValueRelationFieldFormatter::expressionParentFormVariables( mExpression ).isEmpty() ||
+            QgsValueRelationFieldFormatter::expressionParentFormAttributes( mExpression ).contains( attribute ) ) )
+  {
+    populate();
+  }
+
 }
 
 void QgsValueRelationWidgetWrapper::emitValueChangedInternal( const QString &value )

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -73,6 +73,10 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
     void setEnabled( bool enabled ) override;
 
+  public slots:
+
+    void parentFormValueChanged( const QString &attribute, const QVariant &value ) override;
+
   protected:
     QWidget *createWidget( QWidget *parent ) override;
     void initWidget( QWidget *editor ) override;

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -243,6 +243,20 @@ class GUI_EXPORT QgsAttributeEditorContext
     void setFormFeature( const QgsFeature &feature ) { mFormFeature = feature ; }
 
     /**
+     * Returns the feature of the currently edited parent form in its actual state
+     * \see setParentFormFeature()
+     * \since QGIS 3.14
+     */
+    QgsFeature parentFormFeature() const { return mParentFormFeature; }
+
+    /**
+     * Sets the \a feature of the currently edited parent form
+     * \see parentFormFeature()
+     * \since QGIS 3.14
+     */
+    void setParentFormFeature( const QgsFeature &feature ) { mParentFormFeature = feature ; }
+
+    /**
      * Returns current attributeFormMode
      * \since QGIS 3.4
      */
@@ -288,6 +302,8 @@ class GUI_EXPORT QgsAttributeEditorContext
     RelationMode mRelationMode = Undefined;
     //! Store the values of the currently edited form or table row
     QgsFeature mFormFeature;
+    //! Store the values of the currently edited parent form or table row
+    QgsFeature mParentFormFeature;
     FormMode mFormMode = Embed;
     bool mAllowCustomUi = true;
     Mode mAttributeFormMode = SingleEditMode;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1225,6 +1225,18 @@ void QgsAttributeForm::refreshFeature()
   setFeature( mFeature );
 }
 
+void QgsAttributeForm::parentFormValueChanged( const QString &attribute, const QVariant &newValue )
+{
+  for ( QgsWidgetWrapper *ww : qgis::as_const( mWidgets ) )
+  {
+    QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
+    if ( eww )
+    {
+      eww->parentFormValueChanged( attribute, newValue );
+    }
+  }
+}
+
 void QgsAttributeForm::synchronizeEnabledState()
 {
   bool isEditable = ( mFeature.isValid()

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -293,6 +293,18 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      */
     void refreshFeature();
 
+    /**
+     * Is called in embedded forms when an \a attribute value in the parent form
+     * has changed to \a newValue.
+     *
+     * Notify the form widgets that something has changed in case they
+     * have filter expressions that depend on the parent form scope.
+     *
+     * \since QGIS 3.14
+     */
+    void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
+
+
   private slots:
     void onAttributeChanged( const QVariant &value, const QVariantList &additionalFieldValues );
     void onAttributeAdded( int idx );

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -261,7 +261,6 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
 
     QgsFeatureFilterModel *mModel = nullptr;
     QCompleter *mCompleter = nullptr;
-    QString mDisplayExpression;
     QgsFilterLineEdit *mLineEdit;
     bool mPopupRequested = false;
     bool mIsCurrentlyEdited = false;

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -111,6 +111,9 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     //! Gets the view mode for the dual view
     QgsDualView::ViewMode viewMode() {return mViewMode;}
 
+    /**
+     * Sets the \a relation and the \a feature
+     */
     void setRelationFeature( const QgsRelation &relation, const QgsFeature &feature );
 
     /**
@@ -129,6 +132,9 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
      */
     void setFeature( const QgsFeature &feature, bool update = true );
 
+    /**
+     * Sets the editor \a context
+     */
     void setEditorContext( const QgsAttributeEditorContext &context );
 
     /**
@@ -193,7 +199,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
      */
     bool showSaveChildEditsButton() const;
 
-    /*
+    /**
      * Returns the widget's current feature
      *
      * \since QGIS 3.14

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -124,7 +124,10 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
      */
     void setRelations( const QgsRelation &relation, const QgsRelation &nmrelation );
 
-    void setFeature( const QgsFeature &feature );
+    /**
+     * Sets the \a feature being edited and updates the UI unless \a update is set to FALSE
+     */
+    void setFeature( const QgsFeature &feature, bool update = true );
 
     void setEditorContext( const QgsAttributeEditorContext &context );
 
@@ -190,6 +193,21 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
      */
     bool showSaveChildEditsButton() const;
 
+    /*
+     * Returns the widget's current feature
+     *
+     * \since QGIS 3.14
+     */
+    QgsFeature feature() const;
+
+  public slots:
+
+    /**
+     * Called when an \a attribute value in the parent widget has changed to \a newValue
+     *
+     * \since QGIS 3.14
+     */
+    void parentFormValueChanged( const QString &attribute, const QVariant &newValue );
 
   private slots:
     void setViewMode( int mode ) {setViewMode( static_cast<QgsDualView::ViewMode>( mode ) );}

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -176,8 +176,13 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  QCOMPARE( w_municipality.mCache.size(), 2 );
-  QCOMPARE( w_municipality.mComboBox->count(), 2 );
+  QCOMPARE( w_municipality.mCache.size(), 0 );
+  QCOMPARE( w_municipality.mComboBox->count(), 0 );
+
+  // Set a feature
+  w_municipality.setFeature( vl2.getFeature( 1 ) );
+  QCOMPARE( w_municipality.mCache.size(), 1 );
+  QCOMPARE( w_municipality.mComboBox->count(), 1 );
 
   // check that valueChanged signal is correctly triggered
   QSignalSpy spy( &w_municipality, &QgsEditorWidgetWrapper::valuesChanged );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -170,14 +170,14 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   cfg_municipality.insert( QStringLiteral( "NofColumns" ), 1 );
   cfg_municipality.insert( QStringLiteral( "AllowNull" ), false );
   cfg_municipality.insert( QStringLiteral( "OrderByValue" ), true );
-  cfg_municipality.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "\"province\" =  current_value('fk_province')" ) );
+  cfg_municipality.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "\"province\" = current_value('fk_province')" ) );
   cfg_municipality.insert( QStringLiteral( "UseCompleter" ), false );
   w_municipality.setConfig( cfg_municipality );
   w_municipality.widget();
   w_municipality.setEnabled( true );
 
-  QCOMPARE( w_municipality.mCache.size(), 0 );
-  QCOMPARE( w_municipality.mComboBox->count(), 0 );
+  QCOMPARE( w_municipality.mCache.size(), 2 );
+  QCOMPARE( w_municipality.mComboBox->count(), 2 );
 
   // Set a feature
   w_municipality.setFeature( vl2.getFeature( 1 ) );

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -175,6 +175,24 @@ class TestQgsValueRelationFieldFormatter(unittest.TestCase):
 
         QgsProject.instance().removeMapLayer(layer.id())
 
+    def test_expressionRequiresParentFormScope(self):
+
+        res = list(QgsValueRelationFieldFormatter.expressionFormAttributes("current_value('ONE') AND current_parent_value('TWO')"))
+        res = sorted(res)
+        self.assertEqual(res, ['ONE'])
+
+        res = list(QgsValueRelationFieldFormatter.expressionParentFormAttributes("current_value('ONE') AND current_parent_value('TWO')"))
+        res = sorted(res)
+        self.assertEqual(res, ['TWO'])
+
+        res = list(QgsValueRelationFieldFormatter.expressionParentFormVariables("@current_parent_geometry"))
+        self.assertEqual(res, ['current_parent_geometry'])
+
+        self.assertFalse(QgsValueRelationFieldFormatter.expressionRequiresParentFormScope(""))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresParentFormScope("current_parent_value('TWO')"))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresParentFormScope("current_parent_value ( 'TWO' )"))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresParentFormScope("@current_parent_geometry"))
+
 
 class TestQgsRelationReferenceFieldFormatter(unittest.TestCase):
 


### PR DESCRIPTION
## Description

This PR introduces the possibility to use current values from the "parent" form in filter expressions (for  now only in value-relation widgets, to be used in drill-down filters).

A new "parentForm" scope was added as well as a new set of functions and variables to access the parent from from within an embedded child form. The new functions and variables were modeled on the existing "current_value", "current_feature" etc..

The new functions and variables are also available when the parent form was opened from a new (unsaved, unbuffered) feature, making it easier to create drill-down filters based on the parent's values when adding children from an unsaved parent form.

## Example

![qgis-parent-form-value](https://user-images.githubusercontent.com/142164/75692656-28f9af80-5ca6-11ea-8dd6-9a4bf454f5b7.gif)

## New functions and variables


![qgis-feature-current_parent_value](https://user-images.githubusercontent.com/142164/75693398-2ba8d480-5ca7-11ea-8be0-9643f8841c89.png)
![qgis-feature-current_parent_geometry](https://user-images.githubusercontent.com/142164/75693402-2cda0180-5ca7-11ea-9d65-f0c00e26180e.png)
![qgis-feature-current_parent_feature](https://user-images.githubusercontent.com/142164/75693404-2d729800-5ca7-11ea-889d-5aa73bc131ce.png)


Funded by: **ARPA Piemonte**