### PR TITLE
Select-deselect layers in check geometries plugin

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -106,10 +106,7 @@ QgsGeometryCheckerResultTab::QgsGeometryCheckerResultTab( QgisInterface *iface, 
   ui.tableWidgetErrors->horizontalHeader()->setSortIndicator( 0, Qt::AscendingOrder );
   ui.tableWidgetErrors->resizeColumnToContents( 0 );
   ui.tableWidgetErrors->resizeColumnToContents( 1 );
-  ui.tableWidgetErrors->horizontalHeader()->setSectionResizeMode( 2, QHeaderView::Stretch );
-  ui.tableWidgetErrors->horizontalHeader()->setSectionResizeMode( 3, QHeaderView::Stretch );
-  ui.tableWidgetErrors->horizontalHeader()->setSectionResizeMode( 4, QHeaderView::Stretch );
-  ui.tableWidgetErrors->horizontalHeader()->setSectionResizeMode( 5, QHeaderView::Stretch );
+  ui.tableWidgetErrors->horizontalHeader()->setStretchLastSection( true );
   // Not sure why, but this is needed...
   ui.tableWidgetErrors->setSortingEnabled( true );
   ui.tableWidgetErrors->setSortingEnabled( false );

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -69,6 +69,8 @@ QgsGeometryCheckerSetupTab::QgsGeometryCheckerSetupTab( QgisInterface *iface, QD
   connect( ui.listWidgetInputLayers, &QListWidget::itemChanged, this, &QgsGeometryCheckerSetupTab::validateInput );
   connect( QgsProject::instance(), &QgsProject::layersAdded, this, &QgsGeometryCheckerSetupTab::updateLayers );
   connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersRemoved ), this, &QgsGeometryCheckerSetupTab::updateLayers );
+  connect( ui.pushButtonSelectAllLayers, &QAbstractButton::clicked, this, &QgsGeometryCheckerSetupTab::selectAllLayers );
+  connect( ui.pushButtonDeselectAllLayers, &QAbstractButton::clicked, this, &QgsGeometryCheckerSetupTab::deselectAllLayers );
   connect( ui.radioButtonOutputNew, &QAbstractButton::toggled, ui.frameOutput, &QWidget::setEnabled );
   connect( ui.buttonGroupOutput, static_cast<void ( QButtonGroup::* )( int )>( &QButtonGroup::buttonClicked ), this, &QgsGeometryCheckerSetupTab::validateInput );
   connect( ui.pushButtonOutputDirectory, &QAbstractButton::clicked, this, &QgsGeometryCheckerSetupTab::selectOutputDirectory );
@@ -133,16 +135,8 @@ void QgsGeometryCheckerSetupTab::updateLayers()
     item->setData( LayerIdRole, layer->id() );
     if ( supportedGeometryType )
     {
-      if ( mCheckerDialog->isVisible() )
-      {
-        // If dialog is visible, only set item to checked if it previously was
-        item->setCheckState( prevCheckedLayers.contains( layer->id() ) ? Qt::Checked : Qt::Unchecked );
-      }
-      else
-      {
-        // Otherwise, set item to checked
-        item->setCheckState( Qt::Checked );
-      }
+      // Only set item to checked if it previously was
+      item->setCheckState( prevCheckedLayers.contains( layer->id() ) ? Qt::Checked : Qt::Unchecked );
     }
     else
     {
@@ -152,6 +146,30 @@ void QgsGeometryCheckerSetupTab::updateLayers()
     ui.listWidgetInputLayers->addItem( item );
   }
   validateInput();
+}
+
+void QgsGeometryCheckerSetupTab::selectAllLayers()
+{
+  for ( int row = 0, nRows = ui.listWidgetInputLayers->count(); row < nRows; ++row )
+  {
+    QListWidgetItem *item = ui.listWidgetInputLayers->item( row );
+    if ( item->flags().testFlag( Qt::ItemIsEnabled ) )
+    {
+      item->setCheckState( Qt::Checked );
+    }
+  }
+}
+
+void QgsGeometryCheckerSetupTab::deselectAllLayers()
+{
+  for ( int row = 0, nRows = ui.listWidgetInputLayers->count(); row < nRows; ++row )
+  {
+    QListWidgetItem *item = ui.listWidgetInputLayers->item( row );
+    if ( item->flags().testFlag( Qt::ItemIsEnabled ) )
+    {
+      item->setCheckState( Qt::Unchecked );
+    }
+  }
 }
 
 QList<QgsVectorLayer *> QgsGeometryCheckerSetupTab::getSelectedLayers()

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
@@ -57,6 +57,8 @@ class QgsGeometryCheckerSetupTab : public QWidget
   private slots:
     void runChecks();
     void updateLayers();
+    void selectAllLayers();
+    void deselectAllLayers();
     void validateInput();
     void selectOutputDirectory();
     void showCancelFeedback();

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.ui
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.ui
@@ -90,14 +90,52 @@
               <number>2</number>
              </property>
              <item>
-              <widget class="QListWidget" name="listWidgetInputLayers"/>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkBoxInputSelectedOnly">
-               <property name="text">
-                <string>Only selected features</string>
+              <widget class="QListWidget" name="listWidgetInputLayers">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>150</height>
+                </size>
                </property>
               </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QCheckBox" name="checkBoxInputSelectedOnly">
+                 <property name="text">
+                  <string>Only selected features</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pushButtonSelectAllLayers">
+                 <property name="text">
+                  <string>Select All</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pushButtonDeselectAllLayers">
+                 <property name="text">
+                  <string>Deselect All</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>


### PR DESCRIPTION
## Description
Added buttons to select-deselect all layers in check geometries core plugin.
Since now selecting all layers is always just one click away, I changed the default status of new layers to unchecked instead of checked.
Also now the dialog does not forget which layers where checked every time a layer is added to or removed from the project.

![select_all](https://user-images.githubusercontent.com/11358178/75721192-9cb8ae00-5ce0-11ea-870e-e339c29bd2c2.gif)

I also tried more time than I would like to admit to fit the layers list in a `QSplitter` in order to make it user resizable but QtDesigner had a different opinion, so I just enlarged it a bit. The QSplitter would be great though since scrolling past the end of the layer list scrolls the whole dialog and throws the cursor out of the list...


Fixes #33380
Fixes #28473
Fixes #22783
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
