### PR TITLE
Port most of the remaining ModelerScene code to c++ 

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
@@ -32,7 +32,7 @@ should be set to a QgsProcessingAlgorithm algorithm ID.
 
     QgsProcessingModelChildAlgorithm( const QgsProcessingModelChildAlgorithm &other );
 
-    virtual QgsProcessingModelChildAlgorithm *clone() /Factory/;
+    virtual QgsProcessingModelChildAlgorithm *clone() const /Factory/;
 
 
     QString childId() const;

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
@@ -251,6 +251,7 @@ The ``friendlyChildNames`` argument gives a map of child id to a friendly algori
 
 
 
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
@@ -86,7 +86,7 @@ in the graphical modeler.
 .. seealso:: :py:func:`linksCollapsed`
 %End
 
-    virtual QgsProcessingModelComponent *clone() = 0 /Factory/;
+    virtual QgsProcessingModelComponent *clone() const = 0 /Factory/;
 %Docstring
 Clones the component.
 

--- a/python/core/auto_generated/processing/models/qgsprocessingmodeloutput.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodeloutput.sip.in
@@ -28,7 +28,7 @@ Represents a final output created by the model.
 Constructor for QgsProcessingModelOutput with the specified ``name`` and ``description``.
 %End
 
-    virtual QgsProcessingModelOutput *clone() /Factory/;
+    virtual QgsProcessingModelOutput *clone() const /Factory/;
 
 
     QString name() const;

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelparameter.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelparameter.sip.in
@@ -30,7 +30,7 @@ Constructor for QgsProcessingModelParameter. The parameter name should match one
 parameters from the parent model.
 %End
 
-    virtual QgsProcessingModelParameter *clone() /Factory/;
+    virtual QgsProcessingModelParameter *clone() const /Factory/;
 
 
     QString parameterName() const;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -3344,6 +3344,8 @@ Returns the type name for the parameter class.
 
     virtual QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonQgsProcessingAlgorithmSubclass ) const;
 
+    virtual QStringList dependsOnOtherParameters() const;
+
 
     virtual QVariantMap toVariantMap() const;
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -88,6 +88,12 @@ Emitted when a change in the model requires a full rebuild of the scene.
 Emitted whenever a component of the model is changed.
 %End
 
+  protected:
+
+    virtual QgsModelComponentGraphicItem *createParameterGraphicItem( QgsProcessingModelParameter *param ) const /Factory/;
+    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelChildAlgorithm *child ) const  /Factory/;
+    virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelOutput *output ) const /Factory/;
+
 };
 
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -76,6 +76,11 @@ Returns the current combination of flags set for the scene.
     virtual void mousePressEvent( QGraphicsSceneMouseEvent *event );
 
 
+    void createItems( QgsProcessingModelAlgorithm *model, QgsProcessingContext &context );
+%Docstring
+Populates the scene by creating items representing the specified ``model``.
+%End
+
   signals:
 
     void rebuildRequired();
@@ -90,9 +95,20 @@ Emitted whenever a component of the model is changed.
 
   protected:
 
-    virtual QgsModelComponentGraphicItem *createParameterGraphicItem( QgsProcessingModelParameter *param ) const /Factory/;
-    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelChildAlgorithm *child ) const  /Factory/;
-    virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelOutput *output ) const /Factory/;
+    virtual QgsModelComponentGraphicItem *createParameterGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelParameter *param ) const /Factory/;
+%Docstring
+Creates a new graphic item for a model parameter.
+%End
+
+    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelChildAlgorithm *child ) const  /Factory/;
+%Docstring
+Creates a new graphic item for a model child algorithm.
+%End
+
+    virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelOutput *output ) const /Factory/;
+%Docstring
+Creates a new graphic item for a model output.
+%End
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -73,6 +73,21 @@ Returns the current combination of flags set for the scene.
 .. seealso:: :py:func:`setFlag`
 %End
 
+    virtual void mousePressEvent( QGraphicsSceneMouseEvent *event );
+
+
+  signals:
+
+    void rebuildRequired();
+%Docstring
+Emitted when a change in the model requires a full rebuild of the scene.
+%End
+
+    void componentChanged();
+%Docstring
+Emitted whenever a component of the model is changed.
+%End
+
 };
 
 

--- a/python/plugins/processing/modeler/AddModelFromFileAction.py
+++ b/python/plugins/processing/modeler/AddModelFromFileAction.py
@@ -29,7 +29,6 @@ from qgis.PyQt.QtCore import QFileInfo, QCoreApplication
 from qgis.core import QgsApplication, QgsSettings, QgsProcessingModelAlgorithm
 
 from processing.gui.ToolboxAction import ToolboxAction
-from processing.modeler.exceptions import WrongModelException
 from processing.modeler.ModelerUtils import ModelerUtils
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]

--- a/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
@@ -23,15 +23,11 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 import os
 
-from qgis.PyQt.QtXml import QDomDocument
-
 from qgis.core import (Qgis,
                        QgsApplication,
                        QgsProcessingProvider,
                        QgsMessageLog,
-                       QgsProcessingModelAlgorithm,
-                       QgsProcessingUtils,
-                       QgsXmlUtils)
+                       QgsProcessingModelAlgorithm)
 
 from processing.core.ProcessingConfig import ProcessingConfig, Setting
 
@@ -45,7 +41,6 @@ from processing.modeler.DeleteModelAction import DeleteModelAction
 from processing.modeler.EditModelAction import EditModelAction
 from processing.modeler.ExportModelAsPythonScriptAction import ExportModelAsPythonScriptAction
 from processing.modeler.OpenModelFromFileAction import OpenModelFromFileAction
-from processing.modeler.exceptions import WrongModelException
 from processing.modeler.ModelerUtils import ModelerUtils
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
@@ -120,17 +115,14 @@ class ModelerAlgorithmProvider(QgsProcessingProvider):
         for path, subdirs, files in os.walk(folder):
             for descriptionFile in files:
                 if descriptionFile.endswith('model3'):
-                    try:
-                        fullpath = os.path.join(path, descriptionFile)
+                    fullpath = os.path.join(path, descriptionFile)
 
-                        alg = QgsProcessingModelAlgorithm()
-                        if alg.fromFile(fullpath):
-                            if alg.name():
-                                alg.setSourceFilePath(fullpath)
-                                self.algs.append(alg)
-                        else:
-                            QgsMessageLog.logMessage(self.tr('Could not load model {0}', 'ModelerAlgorithmProvider').format(descriptionFile),
-                                                     self.tr('Processing'), Qgis.Critical)
-                    except WrongModelException as e:
-                        QgsMessageLog.logMessage(self.tr('Could not load model {0}\n{1}', 'ModelerAlgorithmProvider').format(descriptionFile, str(e)),
+                    alg = QgsProcessingModelAlgorithm()
+                    if alg.fromFile(fullpath):
+                        if alg.name():
+                            alg.setSourceFilePath(fullpath)
+                            self.algs.append(alg)
+                    else:
+                        QgsMessageLog.logMessage(self.tr('Could not load model {0}', 'ModelerAlgorithmProvider').format(descriptionFile),
                                                  self.tr('Processing'), Qgis.Critical)
+

--- a/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
@@ -125,4 +125,3 @@ class ModelerAlgorithmProvider(QgsProcessingProvider):
                     else:
                         QgsMessageLog.logMessage(self.tr('Could not load model {0}', 'ModelerAlgorithmProvider').format(descriptionFile),
                                                  self.tr('Processing'), Qgis.Critical)
-

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -23,7 +23,6 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 import codecs
 import sys
-import operator
 import os
 import warnings
 
@@ -73,7 +72,6 @@ from qgis.core import (Qgis,
                        QgsProject,
                        QgsSettings,
                        QgsMessageLog,
-                       QgsProcessingUtils,
                        QgsProcessingModelAlgorithm,
                        QgsProcessingModelParameter,
                        QgsProcessingParameterType,
@@ -789,7 +787,9 @@ class ModelerDialog(BASE, WIDGET):
 
         if not controls:
             self.scene.setFlag(QgsModelGraphicsScene.FlagHideControls)
-        self.scene.paintModel(self.model)
+
+        context = createContext()
+        self.scene.createItems(self.model, context)
         self.view.setScene(self.scene)
 
         self.scene.rebuildRequired.connect(self.repaintModel)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -329,8 +329,10 @@ class ModelerDialog(BASE, WIDGET):
         self.restoreState(settings.value("/Processing/stateModeler", QByteArray()))
         self.restoreGeometry(settings.value("/Processing/geometryModeler", QByteArray()))
 
-        self.scene = ModelerScene(self, dialog=self)
+        self.scene = ModelerScene(self)
         self.scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE, self.CANVAS_SIZE))
+        self.scene.rebuildRequired.connect(self.repaintModel)
+        self.scene.componentChanged.connect(self.componentChanged)
 
         self.view.setScene(self.scene)
         self.view.setAcceptDrops(True)
@@ -781,7 +783,7 @@ class ModelerDialog(BASE, WIDGET):
                                          'See the log for more information.'))
 
     def repaintModel(self, controls=True):
-        self.scene = ModelerScene(self, dialog=self)
+        self.scene = ModelerScene(self)
         self.scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE,
                                        self.CANVAS_SIZE))
 
@@ -789,6 +791,12 @@ class ModelerDialog(BASE, WIDGET):
             self.scene.setFlag(QgsModelGraphicsScene.FlagHideControls)
         self.scene.paintModel(self.model)
         self.view.setScene(self.scene)
+
+        self.scene.rebuildRequired.connect(self.repaintModel)
+        self.scene.componentChanged.connect(self.componentChanged)
+
+    def componentChanged(self):
+        self.hasChanged = True
 
     def addInput(self):
         item = self.inputsTree.currentItem()

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -87,6 +87,7 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
             self.model().addModelParameter(new_param, self.component())
             self.setLabel(new_param.description())
             self.requestModelRepaint.emit()
+            self.changed.emit()
 
 
 class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
@@ -109,6 +110,7 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
             alg.setChildId(self.component().childId())
             self.updateAlgorithm(alg)
             self.requestModelRepaint.emit()
+            self.changed.emit()
 
     def updateAlgorithm(self, alg):
         existing_child = self.model().childAlgorithm(alg.childId())
@@ -145,3 +147,4 @@ class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):
             model_output.setDefaultValue(dlg.param.defaultValue())
             model_output.setMandatory(not (dlg.param.flags() & QgsProcessingParameterDefinition.FlagOptional))
             self.model().updateDestinationParameters()
+            self.changed.emit()

--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -83,20 +83,8 @@ class ModelerScene(QgsModelGraphicsScene):
 
         # Input dependency arrows
         for input_name in list(model.parameterComponents().keys()):
-            idx = 0
             parameter_def = model.parameterDefinition(input_name)
-            parent_names = []
-            if hasattr(parameter_def, 'parentLayerParameterName') and parameter_def.parentLayerParameterName():
-                parent_names.append(parameter_def.parentLayerParameterName())
-            if hasattr(parameter_def, 'parentLayoutParameterName') and parameter_def.parentLayoutParameterName():
-                parent_names.append(parameter_def.parentLayoutParameterName())
-            if hasattr(parameter_def, 'parentParameterName') and parameter_def.parentParameterName():
-                parent_names.append(parameter_def.parentParameterName())
-            if hasattr(parameter_def, 'sourceCrsParameterName') and parameter_def.sourceCrsParameterName():
-                parent_names.append(parameter_def.sourceCrsParameterName())
-            if hasattr(parameter_def, 'destinationCrsParameterName') and parameter_def.destinationCrsParameterName():
-                parent_names.append(parameter_def.destinationCrsParameterName())
-            for parent_name in parent_names:
+            for parent_name in parameter_def.dependsOnOtherParameters():
                 if input_name in self.paramItems and parent_name in self.paramItems:
                     input_item = self.paramItems[input_name]
                     parent_item = self.paramItems[parent_name]

--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -21,140 +21,30 @@ __author__ = 'Victor Olaya'
 __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
-from qgis.PyQt.QtCore import QPointF, Qt
-from qgis.core import (QgsProcessingParameterDefinition,
-                       QgsProcessingModelChildParameterSource,
-                       QgsExpression)
-from qgis.gui import (
-    QgsModelGraphicsScene,
-    QgsModelArrowItem
-)
+from qgis.gui import QgsModelGraphicsScene
 from processing.modeler.ModelerGraphicItem import (
     ModelerInputGraphicItem,
     ModelerOutputGraphicItem,
     ModelerChildAlgorithmGraphicItem
 )
-from processing.tools.dataobjects import createContext
 
 
 class ModelerScene(QgsModelGraphicsScene):
+    """
+    IMPORTANT! This is intentionally a MINIMAL class, only containing code which HAS TO BE HERE
+    because it contains Python code for compatibility with deprecated methods ONLY.
+
+    Don't add anything here -- edit the c++ base class instead!
+    """
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.paramItems = {}
-        self.algItems = {}
-        self.outputItems = {}
 
-    def getItemsFromParamValue(self, value, child_id, context):
-        items = []
-        if isinstance(value, list):
-            for v in value:
-                items.extend(self.getItemsFromParamValue(v, child_id, context))
-        elif isinstance(value, QgsProcessingModelChildParameterSource):
-            if value.source() == QgsProcessingModelChildParameterSource.ModelParameter:
-                items.append((self.paramItems[value.parameterName()], None, 0))
-            elif value.source() == QgsProcessingModelChildParameterSource.ChildOutput:
-                outputs = self.model.childAlgorithm(value.outputChildId()).algorithm().outputDefinitions()
-                for i, out in enumerate(outputs):
-                    if out.name() == value.outputName():
-                        break
-                if value.outputChildId() in self.algItems:
-                    items.append((self.algItems[value.outputChildId()], Qt.BottomEdge, i))
-            elif value.source() == QgsProcessingModelChildParameterSource.Expression:
-                variables = self.model.variablesForChildAlgorithm(child_id, context)
-                exp = QgsExpression(value.expression())
-                for v in exp.referencedVariables():
-                    if v in variables:
-                        items.extend(self.getItemsFromParamValue(variables[v].source, child_id, context))
-        return items
+    def createParameterGraphicItem(self, model, param):
+        return ModelerInputGraphicItem(param.clone(), model)
 
-    def paintModel(self, model):
-        self.model = model
-        context = createContext()
-        # Inputs
-        for inp in list(model.parameterComponents().values()):
-            item = ModelerInputGraphicItem(inp.clone(), model)
-            self.addItem(item)
-            item.setPos(inp.position().x(), inp.position().y())
-            self.paramItems[inp.parameterName()] = item
+    def createChildAlgGraphicItem(self, model, child):
+        return ModelerChildAlgorithmGraphicItem(child.clone(), model)
 
-            item.requestModelRepaint.connect(self.rebuildRequired)
-            item.changed.connect(self.componentChanged)
-
-        # Input dependency arrows
-        for input_name in list(model.parameterComponents().keys()):
-            parameter_def = model.parameterDefinition(input_name)
-            for parent_name in parameter_def.dependsOnOtherParameters():
-                if input_name in self.paramItems and parent_name in self.paramItems:
-                    input_item = self.paramItems[input_name]
-                    parent_item = self.paramItems[parent_name]
-                    arrow = QgsModelArrowItem(parent_item, input_item)
-                    arrow.setPenStyle(Qt.DotLine)
-                    self.addItem(arrow)
-
-        # We add the algs
-        for alg in list(model.childAlgorithms().values()):
-            item = ModelerChildAlgorithmGraphicItem(alg.clone(), model)
-            self.addItem(item)
-            item.setPos(alg.position().x(), alg.position().y())
-            self.algItems[alg.childId()] = item
-
-            item.requestModelRepaint.connect(self.rebuildRequired)
-            item.changed.connect(self.componentChanged)
-
-        # And then the arrows
-
-        for alg in list(model.childAlgorithms().values()):
-            idx = 0
-            for parameter in alg.algorithm().parameterDefinitions():
-                if not parameter.isDestination() and not parameter.flags() & QgsProcessingParameterDefinition.FlagHidden:
-                    if parameter.name() in alg.parameterSources():
-                        sources = alg.parameterSources()[parameter.name()]
-                    else:
-                        sources = []
-                    for source in sources:
-                        sourceItems = self.getItemsFromParamValue(source, alg.childId(), context)
-                        for sourceItem, sourceEdge, sourceIdx in sourceItems:
-                            if sourceEdge is None:
-                                arrow = QgsModelArrowItem(sourceItem, self.algItems[alg.childId()], Qt.TopEdge, idx)
-                            else:
-                                arrow = QgsModelArrowItem(sourceItem, sourceEdge, sourceIdx, self.algItems[alg.childId()], Qt.TopEdge, idx)
-                            self.addItem(arrow)
-                        idx += 1
-            for depend in alg.dependencies():
-                arrow = QgsModelArrowItem(self.algItems[depend], self.algItems[alg.childId()])
-                self.addItem(arrow)
-
-        # And finally the outputs
-        for alg in list(model.childAlgorithms().values()):
-            outputs = alg.modelOutputs()
-            outputItems = {}
-
-            for key, out in outputs.items():
-                if out is not None:
-                    item = ModelerOutputGraphicItem(out.clone(), model)
-                    item.requestModelRepaint.connect(self.rebuildRequired)
-                    item.changed.connect(self.componentChanged)
-
-                    self.addItem(item)
-                    pos = out.position()
-
-                    # find the actual index of the linked output from the child algorithm it comes from
-                    source_child_alg_outputs = alg.algorithm().outputDefinitions()
-                    idx = -1
-                    for i, child_alg_output in enumerate(source_child_alg_outputs):
-                        if child_alg_output.name() == out.childOutputName():
-                            idx = i
-                            break
-
-                    if pos is None:
-                        pos = (alg.position() + QPointF(alg.size().width(), 0)
-                               + self.algItems[alg.childId()].linkPoint(Qt.BottomEdge, idx))
-                    item.setPos(pos)
-                    outputItems[key] = item
-
-                    arrow = QgsModelArrowItem(self.algItems[alg.childId()], Qt.BottomEdge, idx, item)
-                    self.addItem(arrow)
-                else:
-                    outputItems[key] = None
-            self.outputItems[alg.childId()] = outputItems
+    def createOutputGraphicItem(self, model, output):
+        return ModelerOutputGraphicItem(output.clone(), model)

--- a/python/plugins/processing/modeler/exceptions.py
+++ b/python/plugins/processing/modeler/exceptions.py
@@ -18,9 +18,5 @@
 """
 
 
-class WrongModelException(Exception):
-    pass
-
-
 class UndefinedParameterException(Exception):
     pass

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -52,7 +52,7 @@ QgsProcessingModelChildAlgorithm &QgsProcessingModelChildAlgorithm::operator=( c
   return *this;
 }
 
-QgsProcessingModelChildAlgorithm *QgsProcessingModelChildAlgorithm::clone()
+QgsProcessingModelChildAlgorithm *QgsProcessingModelChildAlgorithm::clone() const
 {
   return new QgsProcessingModelChildAlgorithm( *this );
 }

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     QgsProcessingModelChildAlgorithm( const QgsProcessingModelChildAlgorithm &other );
     QgsProcessingModelChildAlgorithm &operator=( const QgsProcessingModelChildAlgorithm &other );
 
-    QgsProcessingModelChildAlgorithm *clone() override SIP_FACTORY;
+    QgsProcessingModelChildAlgorithm *clone() const override SIP_FACTORY;
 
     /**
      * Returns the child algorithm's unique ID string, used the identify

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.h
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.h
@@ -232,6 +232,8 @@ class CORE_EXPORT QgsProcessingModelChildParameterSource
 
 };
 
+Q_DECLARE_METATYPE( QgsProcessingModelChildParameterSource );
+
 #ifndef SIP_RUN
 //! List of child parameter sources
 typedef QList< QgsProcessingModelChildParameterSource > QgsProcessingModelChildParameterSources;

--- a/src/core/processing/models/qgsprocessingmodelcomponent.h
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.h
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsProcessingModelComponent
      *
      * Ownership is transferred to the caller.
      */
-    virtual QgsProcessingModelComponent *clone() = 0 SIP_FACTORY;
+    virtual QgsProcessingModelComponent *clone() const = 0 SIP_FACTORY;
 
   protected:
 

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -24,7 +24,7 @@ QgsProcessingModelOutput::QgsProcessingModelOutput( const QString &name, const Q
   , mName( name )
 {}
 
-QgsProcessingModelOutput *QgsProcessingModelOutput::clone()
+QgsProcessingModelOutput *QgsProcessingModelOutput::clone() const
 {
   return new QgsProcessingModelOutput( *this );
 }

--- a/src/core/processing/models/qgsprocessingmodeloutput.h
+++ b/src/core/processing/models/qgsprocessingmodeloutput.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
      */
     QgsProcessingModelOutput( const QString &name = QString(), const QString &description = QString() );
 
-    QgsProcessingModelOutput *clone() override SIP_FACTORY;
+    QgsProcessingModelOutput *clone() const override SIP_FACTORY;
 
     /**
      * Returns the model output name.

--- a/src/core/processing/models/qgsprocessingmodelparameter.cpp
+++ b/src/core/processing/models/qgsprocessingmodelparameter.cpp
@@ -25,7 +25,7 @@ QgsProcessingModelParameter::QgsProcessingModelParameter( const QString &paramet
 
 }
 
-QgsProcessingModelParameter *QgsProcessingModelParameter::clone()
+QgsProcessingModelParameter *QgsProcessingModelParameter::clone() const
 {
   return new QgsProcessingModelParameter( *this );
 }

--- a/src/core/processing/models/qgsprocessingmodelparameter.h
+++ b/src/core/processing/models/qgsprocessingmodelparameter.h
@@ -40,7 +40,7 @@ class CORE_EXPORT QgsProcessingModelParameter : public QgsProcessingModelCompone
      */
     QgsProcessingModelParameter( const QString &parameterName = QString() );
 
-    QgsProcessingModelParameter *clone() override SIP_FACTORY;
+    QgsProcessingModelParameter *clone() const override SIP_FACTORY;
 
     /**
      * Returns the associated parameter name. The parameter name should match one of the

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -6130,6 +6130,16 @@ QString QgsProcessingParameterCoordinateOperation::asPythonString( QgsProcessing
   return QString();
 }
 
+QStringList QgsProcessingParameterCoordinateOperation::dependsOnOtherParameters() const
+{
+  QStringList res;
+  if ( !mSourceParameterName.isEmpty() )
+    res << mSourceParameterName;
+  if ( !mDestParameterName.isEmpty() )
+    res << mDestParameterName;
+  return res;
+}
+
 QVariantMap QgsProcessingParameterCoordinateOperation::toVariantMap() const
 {
   QVariantMap map = QgsProcessingParameterDefinition::toVariantMap();

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -3122,6 +3122,7 @@ class CORE_EXPORT QgsProcessingParameterCoordinateOperation : public QgsProcessi
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
     QString asScriptCode() const override;
     QString asPythonString( QgsProcessing::PythonOutputType outputType = QgsProcessing::PythonQgsProcessingAlgorithmSubclass ) const override;
+    QStringList dependsOnOtherParameters() const override;
 
     QVariantMap toVariantMap() const override;
     bool fromVariantMap( const QVariantMap &map ) override;

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -14,13 +14,14 @@
  ***************************************************************************/
 
 #include "qgsmodelgraphicsscene.h"
+#include <QGraphicsSceneMouseEvent>
 
 ///@cond NOT_STABLE
 
 QgsModelGraphicsScene::QgsModelGraphicsScene( QObject *parent )
   : QGraphicsScene( parent )
 {
-
+  setItemIndexMethod( QGraphicsScene::NoIndex );
 }
 
 void QgsModelGraphicsScene::setFlag( QgsModelGraphicsScene::Flag flag, bool on )
@@ -29,6 +30,13 @@ void QgsModelGraphicsScene::setFlag( QgsModelGraphicsScene::Flag flag, bool on )
     mFlags |= flag;
   else
     mFlags &= ~flag;
+}
+
+void QgsModelGraphicsScene::mousePressEvent( QGraphicsSceneMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+    return;
+  QGraphicsScene::mousePressEvent( event );
 }
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -14,6 +14,10 @@
  ***************************************************************************/
 
 #include "qgsmodelgraphicsscene.h"
+#include "qgsprocessingmodelchildparametersource.h"
+#include "qgsprocessingmodelalgorithm.h"
+#include "qgsmodelcomponentgraphicitem.h"
+#include "qgsmodelarrowitem.h"
 #include <QGraphicsSceneMouseEvent>
 
 ///@cond NOT_STABLE
@@ -37,6 +41,192 @@ void QgsModelGraphicsScene::mousePressEvent( QGraphicsSceneMouseEvent *event )
   if ( event->button() != Qt::LeftButton )
     return;
   QGraphicsScene::mousePressEvent( event );
+}
+
+QgsModelComponentGraphicItem *QgsModelGraphicsScene::createParameterGraphicItem( QgsProcessingModelParameter *param ) const
+{
+  return new QgsModelParameterGraphicItem( param, mModel, nullptr );
+}
+
+QgsModelComponentGraphicItem *QgsModelGraphicsScene::createChildAlgGraphicItem( QgsProcessingModelChildAlgorithm *child ) const
+{
+  return new QgsModelChildAlgorithmGraphicItem( child, mModel, nullptr );
+}
+
+QgsModelComponentGraphicItem *QgsModelGraphicsScene::createOutputGraphicItem( QgsProcessingModelOutput *output ) const
+{
+  return new QgsModelOutputGraphicItem( output, mModel, nullptr );
+}
+
+void QgsModelGraphicsScene::createItems( QgsProcessingContext &context )
+{
+  const QMap<QString, QgsProcessingModelParameter> params = mModel->parameterComponents();
+  for ( auto it = params.constBegin(); it != params.constEnd(); ++it )
+  {
+    QgsModelComponentGraphicItem *item = createParameterGraphicItem( it.value().clone() );
+    addItem( item );
+    item->setPos( it.value().position().x(), it.value().position().y() );
+    mParameterItems.insert( it.value().parameterName(), item );
+    connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
+    connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+  }
+
+  const QMap<QString, QgsProcessingModelChildAlgorithm> childAlgs = mModel->childAlgorithms();
+  for ( auto it = childAlgs.constBegin(); it != childAlgs.constEnd(); ++it )
+  {
+    QgsModelComponentGraphicItem *item = createChildAlgGraphicItem( it.value().clone() );
+    addItem( item );
+    item->setPos( it.value().position().x(), it.value().position().y() );
+    mChildAlgorithmItems.insert( it.value().childId(), item );
+    connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
+    connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+  }
+
+  for ( auto it = childAlgs.constBegin(); it != childAlgs.constEnd(); ++it )
+  {
+    int idx = 0;
+    const QgsProcessingParameterDefinitions parameters = it.value().algorithm()->parameterDefinitions();
+    for ( const QgsProcessingParameterDefinition *parameter : parameters )
+    {
+      if ( !parameter->isDestination() && !( parameter->flags() & QgsProcessingParameterDefinition::FlagHidden ) )
+      {
+        QList< QgsProcessingModelChildParameterSource > sources;
+        if ( it.value().parameterSources().contains( parameter->name() ) )
+          sources = it.value().parameterSources()[parameter->name()];
+        for ( const QgsProcessingModelChildParameterSource &source : sources )
+        {
+          const QList< LinkSource > sourceItems = linkSourcesForParameterValue( QVariant::fromValue( source ), it.value().childId(), context );
+          for ( const LinkSource &link : sourceItems )
+          {
+            QgsModelArrowItem *arrow = nullptr;
+            if ( link.linkIndex == -1 )
+              arrow = new QgsModelArrowItem( link.item, mChildAlgorithmItems.value( it.value().childId() ), Qt::TopEdge, idx );
+            else
+              arrow = new QgsModelArrowItem( link.item, link.edge, link.linkIndex, mChildAlgorithmItems.value( it.value().childId() ), Qt::TopEdge, idx );
+            addItem( arrow );
+          }
+          idx += 1;
+        }
+      }
+    }
+    const QStringList dependencies = it.value().dependencies();
+    for ( const QString &depend : dependencies )
+    {
+      addItem( new QgsModelArrowItem( mChildAlgorithmItems.value( depend ), mChildAlgorithmItems.value( it.value().childId() ) ) );
+    }
+  }
+
+  for ( auto it = childAlgs.constBegin(); it != childAlgs.constEnd(); ++it )
+  {
+    const QMap<QString, QgsProcessingModelOutput> outputs = it.value().modelOutputs();
+    QMap< QString, QgsModelComponentGraphicItem * > outputItems;
+
+    for ( auto outputIt = outputs.constBegin(); outputIt != outputs.constEnd(); ++outputIt )
+    {
+      QgsModelComponentGraphicItem *item = createOutputGraphicItem( outputIt.value().clone() );
+      addItem( item );
+      connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
+      connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+
+      QPointF pos = outputIt.value().position();
+
+      // find the actual index of the linked output from the child algorithm it comes from
+      const QgsProcessingOutputDefinitions sourceChildAlgOutputs = it.value().algorithm()->outputDefinitions();
+      int idx = -1;
+      int i = 0;
+      for ( const QgsProcessingOutputDefinition *childAlgOutput : sourceChildAlgOutputs )
+      {
+        if ( childAlgOutput->name() == outputIt.value().childOutputName() )
+        {
+          idx = i;
+          break;
+        }
+        i++;
+      }
+
+#if 0
+    if pos is None:
+      pos = ( alg.position() + QPointF( alg.size().width(), 0 )
+              + self.algItems[alg.childId()].linkPoint( Qt.BottomEdge, idx ) )
+#endif
+              item->setPos( pos );
+      outputItems.insert( outputIt.key(), item );
+      addItem( new QgsModelArrowItem( mChildAlgorithmItems[it.value().childId()], Qt::BottomEdge, idx, item ) );
+    }
+    mOutputItems.insert( it.value().childId(), outputItems );
+  }
+}
+
+QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForParameterValue( const QVariant &value, const QString &childId, QgsProcessingContext &context ) const
+{
+  QList<QgsModelGraphicsScene::LinkSource> res;
+  if ( value.type() == QVariant::List )
+  {
+    const QVariantList list = value.toList();
+    for ( const QVariant &v : list )
+      res.append( linkSourcesForParameterValue( v, childId, context ) );
+  }
+  else if ( value.type() == QVariant::StringList )
+  {
+    const QStringList list = value.toStringList();
+    for ( const QString &v : list )
+      res.append( linkSourcesForParameterValue( v, childId, context ) );
+  }
+  else if ( value.canConvert< QgsProcessingModelChildParameterSource >() )
+  {
+    const QgsProcessingModelChildParameterSource source = value.value< QgsProcessingModelChildParameterSource >();
+    switch ( source.source() )
+    {
+      case QgsProcessingModelChildParameterSource::ModelParameter:
+      {
+        LinkSource l;
+        l.item = mParameterItems.value( source.parameterName() );
+        res.append( l );
+        break;
+      }
+      case QgsProcessingModelChildParameterSource::ChildOutput:
+      {
+        const QgsProcessingOutputDefinitions outputs = mModel->childAlgorithm( source.outputChildId() ).algorithm()->outputDefinitions();
+        int i = 0;
+        for ( const QgsProcessingOutputDefinition *output : outputs )
+        {
+          if ( output->name() == source.outputName() )
+            break;
+          i++;
+        }
+        if ( mChildAlgorithmItems.contains( source.outputChildId() ) )
+        {
+          LinkSource l;
+          l.item = mChildAlgorithmItems.value( source.outputChildId() );
+          l.edge = Qt::BottomEdge;
+          l.linkIndex = i;
+          res.append( l );
+        }
+
+        break;
+      }
+
+      case QgsProcessingModelChildParameterSource::Expression:
+      {
+        const QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> variables = mModel->variablesForChildAlgorithm( childId, context );
+        QgsExpression exp( source.expression() );
+        const QSet<QString> vars = exp.referencedVariables();
+        for ( const QString &v : vars )
+        {
+          if ( variables.contains( v ) )
+          {
+            res.append( linkSourcesForParameterValue( QVariant::fromValue( variables.value( v ).source ), childId, context ) );
+          }
+        }
+        break;
+      }
+
+      case QgsProcessingModelChildParameterSource::StaticValue:
+      case QgsProcessingModelChildParameterSource::ExpressionText:
+        break;
+    }
+  }
+  return res;
 }
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -18,8 +18,14 @@
 
 #include "qgis.h"
 #include "qgis_gui.h"
+#include "qgsprocessingcontext.h"
 #include <QGraphicsScene>
 
+class QgsProcessingModelAlgorithm;
+class QgsModelComponentGraphicItem;
+class QgsProcessingModelParameter;
+class QgsProcessingModelChildAlgorithm;
+class QgsProcessingModelOutput;
 
 ///@cond NOT_STABLE
 
@@ -90,9 +96,32 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     void componentChanged();
 
+  protected:
+
+    virtual QgsModelComponentGraphicItem *createParameterGraphicItem( QgsProcessingModelParameter *param ) const SIP_FACTORY;
+    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelChildAlgorithm *child ) const  SIP_FACTORY;
+    virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelOutput *output ) const SIP_FACTORY;
+
   private:
 
+    void createItems( QgsProcessingContext &context );
+
+    struct LinkSource
+    {
+      QgsModelComponentGraphicItem *item = nullptr;
+      Qt::Edge edge = Qt::LeftEdge;
+      int linkIndex = -1;
+    };
+    QList< LinkSource > linkSourcesForParameterValue( const QVariant &value, const QString &childId, QgsProcessingContext &context ) const;
+
+
     Flags mFlags = nullptr;
+
+    QgsProcessingModelAlgorithm *mModel = nullptr;
+
+    QMap< QString, QgsModelComponentGraphicItem * > mParameterItems;
+    QMap< QString, QgsModelComponentGraphicItem * > mChildAlgorithmItems;
+    QMap< QString, QMap< QString, QgsModelComponentGraphicItem * > > mOutputItems;
 
 };
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -84,6 +84,11 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
 
     void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
 
+    /**
+     * Populates the scene by creating items representing the specified \a model.
+     */
+    void createItems( QgsProcessingModelAlgorithm *model, QgsProcessingContext &context );
+
   signals:
 
     /**
@@ -98,13 +103,22 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
 
   protected:
 
-    virtual QgsModelComponentGraphicItem *createParameterGraphicItem( QgsProcessingModelParameter *param ) const SIP_FACTORY;
-    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelChildAlgorithm *child ) const  SIP_FACTORY;
-    virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelOutput *output ) const SIP_FACTORY;
+    /**
+     * Creates a new graphic item for a model parameter.
+     */
+    virtual QgsModelComponentGraphicItem *createParameterGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelParameter *param ) const SIP_FACTORY;
+
+    /**
+     * Creates a new graphic item for a model child algorithm.
+     */
+    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelChildAlgorithm *child ) const  SIP_FACTORY;
+
+    /**
+     * Creates a new graphic item for a model output.
+     */
+    virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelOutput *output ) const SIP_FACTORY;
 
   private:
-
-    void createItems( QgsProcessingContext &context );
 
     struct LinkSource
     {
@@ -112,12 +126,9 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
       Qt::Edge edge = Qt::LeftEdge;
       int linkIndex = -1;
     };
-    QList< LinkSource > linkSourcesForParameterValue( const QVariant &value, const QString &childId, QgsProcessingContext &context ) const;
-
+    QList< LinkSource > linkSourcesForParameterValue( QgsProcessingModelAlgorithm *model, const QVariant &value, const QString &childId, QgsProcessingContext &context ) const;
 
     Flags mFlags = nullptr;
-
-    QgsProcessingModelAlgorithm *mModel = nullptr;
 
     QMap< QString, QgsModelComponentGraphicItem * > mParameterItems;
     QMap< QString, QgsModelComponentGraphicItem * > mChildAlgorithmItems;

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -76,6 +76,20 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     QgsModelGraphicsScene::Flags flags() const { return mFlags; }
 
+    void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
+
+  signals:
+
+    /**
+     * Emitted when a change in the model requires a full rebuild of the scene.
+     */
+    void rebuildRequired();
+
+    /**
+     * Emitted whenever a component of the model is changed.
+     */
+    void componentChanged();
+
   private:
 
     Flags mFlags = nullptr;


### PR DESCRIPTION
The final bit of the recent Python -> c++ conversion and cleanup for model designer. Now the Python ModelerScene class is a minimal shell implementing the bare necessity required for compatibility with the older deprecated Processing Python API. 