### PR TITLE
 Fix QgsCoordinateReferenceSystem documentation rendering

### DIFF
--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -15,6 +15,7 @@
 
 
 
+
 class QgsCoordinateReferenceSystem
 {
 %Docstring
@@ -30,6 +31,7 @@ Most commonly one comes across two types of coordinate systems:
 
 1. **Geographic coordinate systems** - based on a geodetic datum, normally with coordinates being
 latitude/longitude in degrees. The most common one is World Geodetic System 84 (WGS84).
+
 2. **Projected coordinate systems** - based on a geodetic datum with coordinates projected to a plane,
 typically using meters or feet as units. Common projected coordinate systems are Universal
 Transverse Mercator or Albers Equal Area.
@@ -79,15 +81,24 @@ QGIS adds support for "USER" authority that refers to IDs used internally in QGI
 is best avoided or used with caution as the IDs are not permanent and they refer to different CRS
 on different machines or user profiles.
 
-See authid() and createFromOgcWmsCrs() methods.
+
+.. seealso:: :py:func:`authid`
+
+.. seealso:: :py:func:`createFromOgcWmsCrs`
 
 2. **PROJ string.** This is a string consisting of a series of key/value pairs in the following
 format: `+param1=value1 +param2=value2 [...]`. This is the format natively used by the
 underlying proj library. For example, the definition of WGS84 looks like this:
 
-+proj=longlat +datum=WGS84 +no_defs
+.. code-block::
 
-See toProj() and createFromProj() methods.
+        +proj=longlat +datum=WGS84 +no_defs
+
+
+
+.. seealso:: :py:func:`toProj`
+
+.. seealso:: :py:func:`createFromProj`
 
 3. **Well-known text (WKT).** Defined by Open Geospatial Consortium (OGC), this is another common
 format to define CRS. For WGS84 the OGC WKT definition is the following:
@@ -100,7 +111,10 @@ PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],
 UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],
 AUTHORITY["EPSG","4326"]]
 
-See toWkt() and createFromWkt() methods.
+
+.. seealso:: :py:func:`toWkt`
+
+.. seealso:: :py:func:`createFromWkt`
 
 CRS Database and Custom CRS
 ===========================
@@ -188,6 +202,7 @@ Constructs an invalid CRS object
 Constructs a CRS object from a string definition using createFromString()
 
 It supports the following formats:
+
 - "EPSG:<code>" - handled with createFromOgcWms()
 - "POSTGIS:<srid>" - handled with createFromSrid()
 - "INTERNAL:<srsid>" - handled with createFromSrsId()
@@ -204,7 +219,9 @@ If no prefix is specified, WKT definition is assumed.
 
  explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) /Deprecated/;
 %Docstring
-Constructor a CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
+Constructor
+
+A CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
 
 .. note::
 
@@ -418,10 +435,8 @@ database.
 We try to match the Proj string to internal QGIS CRS ID using the following logic:
 
 - ask the Proj library to identify the CRS to a standard registered CRS (e.g. EPSG codes)
-- if no match is found, compare the CRS to all user CRSes, using the Proj library
-to determine CRS equivalence (hence making the match parameter order insensitive)
-- if none of the above match, use the Proj string to create the CRS and do not
-associated an internal CRS ID to it.
+- if no match is found, compare the CRS to all user CRSes, using the Proj library to determine CRS equivalence (hence making the match parameter order insensitive)
+- if none of the above match, use the Proj string to create the CRS and do not associated an internal CRS ID to it.
 
 :param projString: A Proj format string
 
@@ -433,7 +448,7 @@ associated an internal CRS ID to it.
 
 .. note::
 
-   this method uses an internal cache. Call invalidateCache() to clear the cache.
+   This method uses an internal cache. Call invalidateCache() to clear the cache.
 
 .. seealso:: :py:func:`fromProj`
 
@@ -455,10 +470,8 @@ database.
 We try to match the Proj string to internal QGIS CRS ID using the following logic:
 
 - ask the Proj library to identify the CRS to a standard registered CRS (e.g. EPSG codes)
-- if no match is found, compare the CRS to all user CRSes, using the Proj library
-to determine CRS equivalence (hence making the match parameter order insensitive)
-- if none of the above match, use the Proj string to create the CRS and do not
-associated an internal CRS ID to it.
+- if no match is found, compare the CRS to all user CRSes, using the Proj library to determine CRS equivalence (hence making the match parameter order insensitive)
+- if none of the above match, use the Proj string to create the CRS and do not associated an internal CRS ID to it.
 
 :param projString: A Proj format string
 
@@ -470,7 +483,7 @@ associated an internal CRS ID to it.
 
 .. note::
 
-   this method uses an internal cache. Call invalidateCache() to clear the cache.
+   This method uses an internal cache. Call invalidateCache() to clear the cache.
 
 .. seealso:: :py:func:`fromProj`
 

--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -233,7 +233,7 @@ A CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
 :param type: One of the types described in CrsType
 
 .. deprecated::
-   We encourage you to use EPSG codes or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
+   QGIS 3.10 We encourage you to use EPSG codes or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
 %End
 
     QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &srs );
@@ -289,7 +289,7 @@ Creates a CRS from a proj style formatted string.
 .. seealso:: :py:func:`createFromProj`
 
 .. deprecated::
-   Use fromProj() instead.
+   QGIS 3.10 Use fromProj() instead.
 %End
 
     static QgsCoordinateReferenceSystem fromProj( const QString &proj );
@@ -342,7 +342,7 @@ Sets this CRS by lookup of the given ID in the CRS database.
 :return: ``True`` on success else ``False``
 
 .. deprecated::
-   We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
+   QGIS 3.10 We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
 %End
 
 
@@ -373,7 +373,7 @@ Sets this CRS by lookup of the given PostGIS SRID in the CRS database.
 :return: ``True`` on success else ``False``
 
 .. deprecated::
-   Use alternative methods for SRS construction instead -- this method was specifically created for use by the postgres provider alone, and using it elsewhere will lead to subtle bugs.
+   QGIS 3.10 Use alternative methods for SRS construction instead -- this method was specifically created for use by the postgres provider alone, and using it elsewhere will lead to subtle bugs.
 %End
 
     bool createFromWkt( const QString &wkt );
@@ -453,7 +453,7 @@ We try to match the Proj string to internal QGIS CRS ID using the following logi
 .. seealso:: :py:func:`fromProj`
 
 .. deprecated::
-   Use createFromProj() instead
+   QGIS 3.10 Use createFromProj() instead
 %End
 
     bool createFromProj( const QString &projString );
@@ -548,7 +548,7 @@ This is required for proper shapefile CRS import when using gdal>= 1.9.
    For more details refer to OGRSpatialReference.morphFromESRI() .
 
 .. deprecated::
-   Not used on builds based on Proj version 6 or later
+   QGIS 3.10 Not used on builds based on Proj version 6 or later
 %End
 
     bool isValid() const;
@@ -586,7 +586,7 @@ pieces of information about CRS.
 :return: long the SrsId of the matched CRS, zero if no match was found
 
 .. deprecated::
-   Not used in Proj >= 6 based builds
+   QGIS 3.10 Not used in Proj >= 6 based builds
 %End
 
     bool operator==( const QgsCoordinateReferenceSystem &srs ) const;
@@ -751,7 +751,7 @@ overridden with these.
 .. seealso:: :py:func:`toWkt`
 
 .. deprecated::
-   use toProj() instead.
+   QGIS 3.10 Use toProj() instead.
 %End
 
     QString toProj() const;
@@ -860,7 +860,7 @@ Returns a list of recently used projections
 :return: list of srsid for recently used projections
 
 .. deprecated::
-   use recentCoordinateReferenceSystems() instead.
+   QGIS 3.10 Use recentCoordinateReferenceSystems() instead.
 %End
 
     static QList< QgsCoordinateReferenceSystem > recentCoordinateReferenceSystems();

--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -392,7 +392,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
         if crsid != 4326:  # reproject to EPSG:4326
             src = QgsCoordinateReferenceSystem(crsid)
-            dest = QgsCoordinateReferenceSystem(4326)
+            dest = QgsCoordinateReferenceSystem("EPSG:4326")
             xform = QgsCoordinateTransform(src, dest, QgsProject.instance())
             minxy = xform.transform(QgsPointXY(extent.xMinimum(),
                                                extent.yMinimum()))
@@ -562,7 +562,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         if record.bbox is not None:
             points = bbox_to_polygon(record.bbox)
             if points is not None:
-                src = QgsCoordinateReferenceSystem(4326)
+                src = QgsCoordinateReferenceSystem("EPSG:4326")
                 dst = self.map.mapSettings().destinationCrs()
                 geom = QgsGeometry.fromWkt(points)
                 if src.postgisSrid() != dst.postgisSrid():

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -209,7 +209,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         srcCrs = self.inLayer.crs()
         if not srcCrs.isValid():
-            srcCrs = QgsCoordinateReferenceSystem(4326)
+            srcCrs = QgsCoordinateReferenceSystem("EPSG:4326")
         self.widgetSourceSrid.setCrs(srcCrs)
         self.widgetTargetSrid.setCrs(srcCrs)
 

--- a/python/plugins/processing/tests/CheckValidityAlgorithm.py
+++ b/python/plugins/processing/tests/CheckValidityAlgorithm.py
@@ -62,7 +62,7 @@ class TestQgsProcessingCheckValidity(unittest.TestCase):
         wkb_type = getattr(QgsWkbTypes, layer_wkb_name)
         fields.append(QgsField('int_f', QVariant.Int))
         layer = QgsMemoryProviderUtils.createMemoryLayer(
-            '%s_layer' % layer_wkb_name, fields, wkb_type, QgsCoordinateReferenceSystem(4326))
+            '%s_layer' % layer_wkb_name, fields, wkb_type, QgsCoordinateReferenceSystem("EPSG:4326"))
         self.assertTrue(layer.isValid())
         self.assertEqual(layer.wkbType(), wkb_type)
         return layer

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -265,7 +265,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * and proj strings are a lossy format.
      * \param id The ID valid for the chosen CRS ID type
      * \param type One of the types described in CrsType
-     * \deprecated We encourage you to use EPSG codes or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
+     * \deprecated QGIS 3.10 We encourage you to use EPSG codes or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
      */
     Q_DECL_DEPRECATED explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId ) SIP_DEPRECATED;
 
@@ -313,7 +313,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Creates a CRS from a proj style formatted string.
      * \returns matching CRS, or an invalid CRS if string could not be matched
      * \see createFromProj()
-     * \deprecated Use fromProj() instead.
+     * \deprecated QGIS 3.10 Use fromProj() instead.
     */
     Q_DECL_DEPRECATED static QgsCoordinateReferenceSystem fromProj4( const QString &proj4 ) SIP_DEPRECATED;
 
@@ -352,7 +352,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     /**
      * Sets this CRS by lookup of the given ID in the CRS database.
      * \returns TRUE on success else FALSE
-     * \deprecated We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
+     * \deprecated QGIS 3.10 We encourage you to use EPSG code or WKT to describe CRSes in your code wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile, and Proj strings are a lossy format.
      */
     Q_DECL_DEPRECATED bool createFromId( long id, CrsType type = PostgisCrsId ) SIP_DEPRECATED;
 
@@ -377,7 +377,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \param srid The PostGIS SRID for the desired spatial reference system.
      * \returns TRUE on success else FALSE
      *
-     * \deprecated Use alternative methods for SRS construction instead -- this method was specifically created for use by the postgres provider alone, and using it elsewhere will lead to subtle bugs.
+     * \deprecated QGIS 3.10 Use alternative methods for SRS construction instead -- this method was specifically created for use by the postgres provider alone, and using it elsewhere will lead to subtle bugs.
      */
     Q_DECL_DEPRECATED bool createFromSrid( long srid ) SIP_DEPRECATED;
 
@@ -430,7 +430,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \note Some members may be left blank if no match can be found in CRS database.
      * \note This method uses an internal cache. Call invalidateCache() to clear the cache.
      * \see fromProj()
-     * \deprecated Use createFromProj() instead
+     * \deprecated QGIS 3.10 Use createFromProj() instead
      */
     Q_DECL_DEPRECATED bool createFromProj4( const QString &projString ) SIP_DEPRECATED;
 
@@ -500,7 +500,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \note This function sets CPL config option GDAL_FIX_ESRI_WKT to a proper value,
      * unless it has been set by the user through the commandline or an environment variable.
      * For more details refer to OGRSpatialReference::morphFromESRI() .
-     * \deprecated Not used on builds based on Proj version 6 or later
+     * \deprecated QGIS 3.10 Not used on builds based on Proj version 6 or later
      */
     Q_DECL_DEPRECATED static void setupESRIWktFix() SIP_DEPRECATED;
 
@@ -528,7 +528,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *  pieces of information about CRS.
      *  \note The ellipsoid and projection acronyms must be set as well as the proj string!
      *  \returns long the SrsId of the matched CRS, zero if no match was found
-     * \deprecated Not used in Proj >= 6 based builds
+     * \deprecated QGIS 3.10 Not used in Proj >= 6 based builds
      */
     Q_DECL_DEPRECATED long findMatchingProj() SIP_DEPRECATED;
 
@@ -691,7 +691,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \warning Not all CRS definitions can be represented by Proj strings. An empty
      * string will be returned if the CRS could not be represented by a Proj string.
      * \see toWkt()
-     * \deprecated use toProj() instead.
+     * \deprecated QGIS 3.10 Use toProj() instead.
      */
     Q_DECL_DEPRECATED QString toProj4() const SIP_DEPRECATED;
 
@@ -799,7 +799,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     /**
      * Returns a list of recently used projections
      * \returns list of srsid for recently used projections
-     * \deprecated use recentCoordinateReferenceSystems() instead.
+     * \deprecated QGIS 3.10 Use recentCoordinateReferenceSystems() instead.
      */
     Q_DECL_DEPRECATED static QStringList recentProjections() SIP_DEPRECATED;
 

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -77,6 +77,7 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  *
  * 1. **Geographic coordinate systems** - based on a geodetic datum, normally with coordinates being
  *    latitude/longitude in degrees. The most common one is World Geodetic System 84 (WGS84).
+ *
  * 2. **Projected coordinate systems** - based on a geodetic datum with coordinates projected to a plane,
  *    typically using meters or feet as units. Common projected coordinate systems are Universal
  *    Transverse Mercator or Albers Equal Area.
@@ -126,15 +127,19 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  *    is best avoided or used with caution as the IDs are not permanent and they refer to different CRS
  *    on different machines or user profiles.
  *
- *    See authid() and createFromOgcWmsCrs() methods.
+ *    \see authid()
+ *    \see createFromOgcWmsCrs()
  *
  * 2. **PROJ string.** This is a string consisting of a series of key/value pairs in the following
  *    format: `+param1=value1 +param2=value2 [...]`. This is the format natively used by the
  *    underlying proj library. For example, the definition of WGS84 looks like this:
  *
- *        +proj=longlat +datum=WGS84 +no_defs
+ *    \code
+ *    +proj=longlat +datum=WGS84 +no_defs
+ *    \endcode
  *
- *    See toProj() and createFromProj() methods.
+ *    \see toProj()
+ *    \see createFromProj()
  *
  * 3. **Well-known text (WKT).** Defined by Open Geospatial Consortium (OGC), this is another common
  *    format to define CRS. For WGS84 the OGC WKT definition is the following:
@@ -147,7 +152,8 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  *               UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],
  *               AUTHORITY["EPSG","4326"]]
  *
- *    See toWkt() and createFromWkt() methods.
+ *    \see toWkt()
+ *    \see createFromWkt()
  *
  * CRS Database and Custom CRS
  * ===========================
@@ -199,6 +205,7 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem & ) SIP_SK
  *
  * \see QgsCoordinateTransform
  */
+
 class CORE_EXPORT QgsCoordinateReferenceSystem
 {
     Q_GADGET
@@ -234,6 +241,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * Constructs a CRS object from a string definition using createFromString()
      *
      * It supports the following formats:
+     *
      * - "EPSG:<code>" - handled with createFromOgcWms()
      * - "POSTGIS:<srid>" - handled with createFromSrid()
      * - "INTERNAL:<srsid>" - handled with createFromSrsId()
@@ -249,7 +257,9 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     // TODO QGIS 4: remove type and always use EPSG code
 
     /**
-     * Constructor a CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
+     * Constructor
+     *
+     * A CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
      * \note We encourage you to use EPSG code or WKT to describe CRSes in your code
      * wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile,
      * and proj strings are a lossy format.
@@ -412,15 +422,13 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * We try to match the Proj string to internal QGIS CRS ID using the following logic:
      *
      * - ask the Proj library to identify the CRS to a standard registered CRS (e.g. EPSG codes)
-     * - if no match is found, compare the CRS to all user CRSes, using the Proj library
-     * to determine CRS equivalence (hence making the match parameter order insensitive)
-     * - if none of the above match, use the Proj string to create the CRS and do not
-     * associated an internal CRS ID to it.
+     * - if no match is found, compare the CRS to all user CRSes, using the Proj library to determine CRS equivalence (hence making the match parameter order insensitive)
+     * - if none of the above match, use the Proj string to create the CRS and do not associated an internal CRS ID to it.
      *
      * \param projString A Proj format string
      * \returns TRUE on success else FALSE
      * \note Some members may be left blank if no match can be found in CRS database.
-     * \note this method uses an internal cache. Call invalidateCache() to clear the cache.
+     * \note This method uses an internal cache. Call invalidateCache() to clear the cache.
      * \see fromProj()
      * \deprecated Use createFromProj() instead
      */
@@ -439,15 +447,13 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * We try to match the Proj string to internal QGIS CRS ID using the following logic:
      *
      * - ask the Proj library to identify the CRS to a standard registered CRS (e.g. EPSG codes)
-     * - if no match is found, compare the CRS to all user CRSes, using the Proj library
-     * to determine CRS equivalence (hence making the match parameter order insensitive)
-     * - if none of the above match, use the Proj string to create the CRS and do not
-     * associated an internal CRS ID to it.
+     * - if no match is found, compare the CRS to all user CRSes, using the Proj library to determine CRS equivalence (hence making the match parameter order insensitive)
+     * - if none of the above match, use the Proj string to create the CRS and do not associated an internal CRS ID to it.
      *
      * \param projString A Proj format string
      * \returns TRUE on success else FALSE
      * \note Some members may be left blank if no match can be found in CRS database.
-     * \note this method uses an internal cache. Call invalidateCache() to clear the cache.
+     * \note This method uses an internal cache. Call invalidateCache() to clear the cache.
      * \see fromProj()
      * \since QGIS 3.10.3
      */


### PR DESCRIPTION
with better list display, highlight related methods, add deprecation version
https://qgis.org/pyqgis/master/core/QgsCoordinateReferenceSystem.html
question: does this class create an **invalid** CRS object, as stated in the doc?
ps: there is obviously an issue with rendering of list items that expand on more than one line or paragraph (making the doc indistinct and hard to read/understand)