### PR TITLE
Comments in Processing Models

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
@@ -35,6 +35,16 @@ should be set to a QgsProcessingAlgorithm algorithm ID.
     virtual QgsProcessingModelChildAlgorithm *clone() const /Factory/;
 
 
+    void copyNonDefinitionPropertiesFromModel( QgsProcessingModelAlgorithm *model );
+%Docstring
+Copies all non-specific definition properties from the the matching component from a ``model``.
+
+This includes properties like the size and position of the component, but not properties
+like the specific algorithm or input details.
+
+.. versionadded:: 3.14
+%End
+
     QString childId() const;
 %Docstring
 Returns the child algorithm's unique ID string, used the identify

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
@@ -275,6 +275,9 @@ The ``currentIndent`` and ``indentSize`` are used to set the base line indent an
 The ``friendlyChildNames`` argument gives a map of child id to a friendly algorithm name, to be used in the code to identify that algorithm instead of the raw child id.
 %End
 
+    virtual QgsProcessingModelComment *comment();
+    virtual void setComment( const QgsProcessingModelComment &comment );
+
 };
 
 

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelcomment.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelcomment.sip.in
@@ -1,0 +1,56 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/processing/models/qgsprocessingmodelcomment.h               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsProcessingModelComment : QgsProcessingModelComponent
+{
+%Docstring
+Represents a comment in a model.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingmodelcomment.h"
+%End
+  public:
+
+    QgsProcessingModelComment( const QString &description = QString() );
+%Docstring
+Constructor for QgsProcessingModelComment with the specified ``description``.
+%End
+
+    virtual QgsProcessingModelComment *clone() const /Factory/;
+
+
+    QVariant toVariant() const;
+%Docstring
+Saves this comment to a QVariant.
+
+.. seealso:: :py:func:`loadVariant`
+%End
+
+    bool loadVariant( const QVariantMap &map );
+%Docstring
+Loads this comment from a QVariantMap.
+
+.. seealso:: :py:func:`toVariant`
+%End
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/processing/models/qgsprocessingmodelcomment.h               *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsProcessingModelComponent
 {
 %Docstring
@@ -84,6 +85,21 @@ Sets whether the link points for the specified ``edge`` for this component shoul
 in the graphical modeler.
 
 .. seealso:: :py:func:`linksCollapsed`
+%End
+
+
+    virtual QgsProcessingModelComment *comment();
+%Docstring
+Returns the comment attached to this component (may be ``None``)
+
+.. seealso:: :py:func:`setComment`
+%End
+
+    virtual void setComment( const QgsProcessingModelComment &comment );
+%Docstring
+Sets the ``comment`` attached to this component.
+
+.. seealso:: :py:func:`comment`
 %End
 
     virtual QgsProcessingModelComponent *clone() const = 0 /Factory/;

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
@@ -136,6 +136,16 @@ Restores the component properties from a QVariantMap.
 .. seealso:: :py:func:`saveCommonProperties`
 %End
 
+    void copyNonDefinitionProperties( const QgsProcessingModelComponent &other );
+%Docstring
+Copies all non-specific definition properties from the ``other`` component definition.
+
+This includes properties like the size and position of the component, but not properties
+like the specific algorithm or input details.
+
+.. versionadded:: 3.14
+%End
+
 };
 
 

--- a/python/core/auto_generated/processing/models/qgsprocessingmodeloutput.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodeloutput.sip.in
@@ -127,6 +127,9 @@ Loads this output from a QVariantMap.
 .. seealso:: :py:func:`toVariant`
 %End
 
+    virtual QgsProcessingModelComment *comment();
+    virtual void setComment( const QgsProcessingModelComment &comment );
+
 };
 
 

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelparameter.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelparameter.sip.in
@@ -63,6 +63,9 @@ Loads this parameter from a QVariantMap.
 .. seealso:: :py:func:`toVariant`
 %End
 
+    virtual QgsProcessingModelComment *comment();
+    virtual void setComment( const QgsProcessingModelComment &comment );
+
 };
 
 

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -415,6 +415,7 @@
 %Include auto_generated/processing/models/qgsprocessingmodelalgorithm.sip
 %Include auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip
 %Include auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip
+%Include auto_generated/processing/models/qgsprocessingmodelcomment.sip
 %Include auto_generated/processing/models/qgsprocessingmodelcomponent.sip
 %Include auto_generated/processing/models/qgsprocessingmodeloutput.sip
 %Include auto_generated/processing/models/qgsprocessingmodelparameter.sip

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -34,6 +34,13 @@ Base class for graphic items representing model components in the model designer
       Hover,
     };
 
+    enum Flag
+    {
+      FlagMultilineText,
+    };
+    typedef QFlags<QgsModelComponentGraphicItem::Flag> Flags;
+
+
     QgsModelComponentGraphicItem( QgsProcessingModelComponent *component /Transfer/,
                                   QgsProcessingModelAlgorithm *model,
                                   QGraphicsItem *parent /TransferThis/ );
@@ -47,6 +54,11 @@ Ownership of ``component`` is transferred to the item.
 %End
 
     ~QgsModelComponentGraphicItem();
+
+    virtual Flags flags() const;
+%Docstring
+Returns item flags.
+%End
 
     QgsProcessingModelComponent *component();
 %Docstring
@@ -238,6 +250,8 @@ Updates the position stored in the model for the associated comment
 %End
 
 };
+QFlags<QgsModelComponentGraphicItem::Flag> operator|(QgsModelComponentGraphicItem::Flag f1, QFlags<QgsModelComponentGraphicItem::Flag> f2);
+
 
 class QgsModelParameterGraphicItem : QgsModelComponentGraphicItem
 {
@@ -433,6 +447,7 @@ Ownership of ``output`` is transferred to the item.
     ~QgsModelCommentGraphicItem();
     virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
 
+    virtual Flags flags() const;
 
   protected:
 

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -147,6 +147,13 @@ Returns the best link point to use for a link originating at a specified ``other
          - edge: item edge for calculated best link point
 %End
 
+    virtual void editComment();
+%Docstring
+Called when the comment attached to the item should be edited.
+
+The default implementation does nothing.
+%End
+
   signals:
 
 
@@ -210,6 +217,11 @@ Returns the stroke color for the item for the specified ``state``.
 Returns the label text color for the item for the specified ``state``.
 %End
 
+    virtual Qt::PenStyle strokeStyle( State state ) const;
+%Docstring
+Returns the stroke style to use while rendering the outline of the item.
+%End
+
     virtual QPicture iconPicture() const;
 %Docstring
 Returns a QPicture version of the item's icon, if available.
@@ -218,6 +230,11 @@ Returns a QPicture version of the item's icon, if available.
     virtual QPixmap iconPixmap() const;
 %Docstring
 Returns a QPixmap version of the item's icon, if available.
+%End
+
+    virtual void updateStoredComponentPosition( const QPointF &pos ) = 0;
+%Docstring
+Updates the position stored in the model for the associated comment
 %End
 
 };
@@ -263,6 +280,8 @@ Ownership of ``parameter`` is transferred to the item.
     virtual QColor textColor( State state ) const;
 
     virtual QPicture iconPicture() const;
+
+    virtual void updateStoredComponentPosition( const QPointF &pos );
 
 
   protected slots:
@@ -320,6 +339,8 @@ Ownership of ``child`` is transferred to the item.
 
     virtual QString linkPointText( Qt::Edge edge, int index ) const;
 
+    virtual void updateStoredComponentPosition( const QPointF &pos );
+
 
   protected slots:
 
@@ -368,11 +389,69 @@ Ownership of ``output`` is transferred to the item.
 
     virtual QPicture iconPicture() const;
 
+    virtual void updateStoredComponentPosition( const QPointF &pos );
+
 
   protected slots:
 
     virtual void deleteComponent();
 
+
+};
+
+
+
+class QgsModelCommentGraphicItem : QgsModelComponentGraphicItem
+{
+%Docstring
+A graphic item representing a model comment in the model designer.
+
+.. warning::
+
+   Not stable API
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsmodelcomponentgraphicitem.h"
+%End
+  public:
+
+    QgsModelCommentGraphicItem( QgsProcessingModelComment *comment /Transfer/,
+                                QgsModelComponentGraphicItem *parentItem,
+                                QgsProcessingModelAlgorithm *model,
+                                QGraphicsItem *parent /TransferThis/ );
+%Docstring
+Constructor for QgsModelCommentGraphicItem for the specified ``comment``, with the specified ``parent`` item.
+
+The ``model`` argument specifies the associated processing model. Ownership of ``model`` is not transferred, and
+it must exist for the lifetime of this object.
+
+Ownership of ``output`` is transferred to the item.
+%End
+    ~QgsModelCommentGraphicItem();
+    virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
+
+
+  protected:
+
+    virtual QColor fillColor( State state ) const;
+
+    virtual QColor strokeColor( State state ) const;
+
+    virtual QColor textColor( State state ) const;
+
+    virtual Qt::PenStyle strokeStyle( State state ) const;
+
+    virtual void updateStoredComponentPosition( const QPointF &pos );
+
+
+  protected slots:
+
+    virtual void deleteComponent();
+
+    virtual void editComponent();
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -110,6 +110,13 @@ Creates a new graphic item for a model child algorithm.
 Creates a new graphic item for a model output.
 %End
 
+    virtual QgsModelComponentGraphicItem *createCommentGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelComment *comment,
+        QgsModelComponentGraphicItem *parentItem ) const /Factory/;
+%Docstring
+Creates a new graphic item for a model comment.
+%End
+
+
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
@@ -142,6 +142,29 @@ Returns a new instance of a parameter definition, using the current settings def
 The ``name`` parameter specifies the name for the newly created parameter.
 %End
 
+    void setComments( const QString &comments );
+%Docstring
+Sets the comments for the parameter.
+
+.. seealso:: :py:func:`comments`
+
+.. versionadded:: 3.14
+%End
+
+    QString comments() const;
+%Docstring
+Returns the comments for the parameter.
+
+.. seealso:: :py:func:`setComments`
+
+.. versionadded:: 3.14
+%End
+
+    void switchToCommentTab();
+%Docstring
+Switches the dialog to the comments tab.
+%End
+
   public slots:
     virtual void accept();
 

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -831,10 +831,12 @@ class ModelerDialog(BASE, WIDGET):
 
     def addInputOfType(self, paramType, pos=None):
         new_param = None
+        comment = None
         if ModelerParameterDefinitionDialog.use_legacy_dialog(paramType=paramType):
             dlg = ModelerParameterDefinitionDialog(self.model, paramType)
             if dlg.exec_():
                 new_param = dlg.param
+                comment = dlg.comments()
         else:
             # yay, use new API!
             context = createContext()
@@ -846,6 +848,7 @@ class ModelerDialog(BASE, WIDGET):
             if dlg.exec_():
                 new_param = dlg.createParameter()
                 self.autogenerate_parameter_name(new_param)
+                comment = dlg.comments()
 
         if new_param is not None:
             if pos is None:
@@ -855,6 +858,12 @@ class ModelerDialog(BASE, WIDGET):
             component = QgsProcessingModelParameter(new_param.name())
             component.setDescription(new_param.name())
             component.setPosition(pos)
+
+            component.comment().setDescription(comment)
+            component.comment().setPosition(component.position() + QPointF(
+                component.size().width(),
+                -1.5 * component.size().height()))
+
             self.model.addModelParameter(new_param, component)
             self.repaintModel()
             # self.view.ensureVisible(self.scene.getLastParameterItem())
@@ -902,6 +911,10 @@ class ModelerDialog(BASE, WIDGET):
                 alg.setPosition(self.getPositionForAlgorithmItem())
             else:
                 alg.setPosition(pos)
+
+            alg.comment().setPosition(alg.position() + QPointF(
+                alg.size().width(),
+                -1.5 * alg.size().height()))
 
             output_offset_x = alg.size().width()
             output_offset_y = 1.5 * alg.size().height()

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -140,11 +140,15 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         alg.setLinksCollapsed(Qt.TopEdge, existing_child.linksCollapsed(Qt.TopEdge))
         alg.setLinksCollapsed(Qt.BottomEdge, existing_child.linksCollapsed(Qt.BottomEdge))
         alg.comment().setPosition(existing_child.comment().position())
+        alg.comment().setSize(existing_child.comment().size())
         for i, out in enumerate(alg.modelOutputs().keys()):
-            alg.modelOutput(out).setPosition(alg.modelOutput(out).position()
+            alg.modelOutput(out).setPosition(existing_child.modelOutput(out).position()
                                              or alg.position() + QPointF(
                 self.component().size().width(),
                 (i + 1.5) * self.component().size().height()))
+            alg.modelOutput(out).comment().setDescription(existing_child.modelOutput(out).comment().description())
+            alg.modelOutput(out).comment().setSize(existing_child.modelOutput(out).comment().size())
+            alg.modelOutput(out).comment().setPosition(existing_child.modelOutput(out).comment().position())
         self.model().setChildAlgorithm(alg)
 
 

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -29,8 +29,7 @@ from qgis.gui import (
     QgsProcessingParameterWidgetContext,
     QgsModelParameterGraphicItem,
     QgsModelChildAlgorithmGraphicItem,
-    QgsModelOutputGraphicItem,
-    QgsModelCommentGraphicItem
+    QgsModelOutputGraphicItem
 )
 from processing.modeler.ModelerParameterDefinitionDialog import ModelerParameterDefinitionDialog
 from processing.modeler.ModelerParametersDialog import ModelerParametersDialog
@@ -129,7 +128,8 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         if dlg.exec_():
             alg = dlg.createAlgorithm()
             alg.setChildId(self.component().childId())
-            self.updateAlgorithm(alg)
+            alg.copyNonDefinitionPropertiesFromModel(self.model())
+            self.model().setChildAlgorithm(alg)
             self.requestModelRepaint.emit()
             self.changed.emit()
 
@@ -138,27 +138,6 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
 
     def editComment(self):
         self.edit(edit_comment=True)
-
-    def updateAlgorithm(self, alg):
-        existing_child = self.model().childAlgorithm(alg.childId())
-        alg.setPosition(existing_child.position())
-        alg.setLinksCollapsed(Qt.TopEdge, existing_child.linksCollapsed(Qt.TopEdge))
-        alg.setLinksCollapsed(Qt.BottomEdge, existing_child.linksCollapsed(Qt.BottomEdge))
-        alg.comment().setPosition(existing_child.comment().position()
-                                  or alg.position() + QPointF(
-            self.component().size().width(),
-            -1.5 * self.component().size().height())
-        )
-        alg.comment().setSize(existing_child.comment().size())
-        for i, out in enumerate(alg.modelOutputs().keys()):
-            alg.modelOutput(out).setPosition(existing_child.modelOutput(out).position()
-                                             or alg.position() + QPointF(
-                self.component().size().width(),
-                (i + 1.5) * self.component().size().height()))
-            alg.modelOutput(out).comment().setDescription(existing_child.modelOutput(out).comment().description())
-            alg.modelOutput(out).comment().setSize(existing_child.modelOutput(out).comment().size())
-            alg.modelOutput(out).comment().setPosition(existing_child.modelOutput(out).comment().position())
-        self.model().setChildAlgorithm(alg)
 
 
 class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -144,15 +144,15 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         alg.setPosition(existing_child.position())
         alg.setLinksCollapsed(Qt.TopEdge, existing_child.linksCollapsed(Qt.TopEdge))
         alg.setLinksCollapsed(Qt.BottomEdge, existing_child.linksCollapsed(Qt.BottomEdge))
-        alg.comment().setPosition(existing_child.comment().position() or
-                                  alg.position() + QPointF(
+        alg.comment().setPosition(existing_child.comment().position()
+                                  or alg.position() + QPointF(
             self.component().size().width(),
             -1.5 * self.component().size().height())
         )
         alg.comment().setSize(existing_child.comment().size())
         for i, out in enumerate(alg.modelOutputs().keys()):
-            alg.modelOutput(out).setPosition(existing_child.modelOutput(out).position() or
-                                             alg.position() + QPointF(
+            alg.modelOutput(out).setPosition(existing_child.modelOutput(out).position()
+                                             or alg.position() + QPointF(
                 self.component().size().width(),
                 (i + 1.5) * self.component().size().height()))
             alg.modelOutput(out).comment().setDescription(existing_child.modelOutput(out).comment().description())
@@ -196,18 +196,3 @@ class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):
 
     def editComment(self):
         self.edit(edit_comment=True)
-
-
-class ModelerCommentGraphicItem(QgsModelCommentGraphicItem):
-    """
-    IMPORTANT! This is intentionally a MINIMAL class, only containing code which HAS TO BE HERE
-    because it contains Python code for compatibility with deprecated methods ONLY.
-
-    Don't add anything here -- edit the c++ base class instead!
-    """
-
-    def __init__(self, model, element, parent_component):
-        super().__init__(element, parent_component, model, None)
-
-    def editComponent(self):
-        pass

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -83,8 +83,13 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
                                                          widgetContext=widget_context,
                                                          definition=existing_param,
                                                          algorithm=self.model())
+            dlg.setComments(comment)
+            if edit_comment:
+                dlg.switchToCommentTab()
+
             if dlg.exec_():
                 new_param = dlg.createParameter(existing_param.name())
+                comment = dlg.comments()
 
         if new_param is not None:
             self.model().removeModelParameter(self.component().parameterName())
@@ -139,11 +144,15 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         alg.setPosition(existing_child.position())
         alg.setLinksCollapsed(Qt.TopEdge, existing_child.linksCollapsed(Qt.TopEdge))
         alg.setLinksCollapsed(Qt.BottomEdge, existing_child.linksCollapsed(Qt.BottomEdge))
-        alg.comment().setPosition(existing_child.comment().position())
+        alg.comment().setPosition(existing_child.comment().position() or
+                                  alg.position() + QPointF(
+            self.component().size().width(),
+            -1.5 * self.component().size().height())
+        )
         alg.comment().setSize(existing_child.comment().size())
         for i, out in enumerate(alg.modelOutputs().keys()):
-            alg.modelOutput(out).setPosition(existing_child.modelOutput(out).position()
-                                             or alg.position() + QPointF(
+            alg.modelOutput(out).setPosition(existing_child.modelOutput(out).position() or
+                                             alg.position() + QPointF(
                 self.component().size().width(),
                 (i + 1.5) * self.component().size().height()))
             alg.modelOutput(out).comment().setDescription(existing_child.modelOutput(out).comment().description())

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -21,7 +21,6 @@ __author__ = 'Victor Olaya'
 __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
-from qgis.PyQt.QtCore import Qt, QPointF
 from qgis.core import (QgsProcessingParameterDefinition,
                        QgsProject)
 from qgis.gui import (

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -129,6 +129,8 @@ class ModelerParameterDefinitionDialog(QDialog):
 
     def switchToCommentTab(self):
         self.tab.setCurrentIndex(1)
+        self.commentEdit.setFocus()
+        self.commentEdit.selectAll()
 
     def setupUi(self):
         type_metadata = QgsApplication.processingRegistry().parameterType(self.param.type() if self.param else self.paramType)

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -33,7 +33,10 @@ from qgis.PyQt.QtWidgets import (QDialog,
                                  QComboBox,
                                  QCheckBox,
                                  QDialogButtonBox,
-                                 QMessageBox)
+                                 QMessageBox,
+                                 QTabWidget,
+                                 QWidget,
+                                 QTextEdit)
 
 from qgis.gui import QgsExpressionLineEdit, QgsProjectionSelectionWidget
 from qgis.core import (QgsApplication,
@@ -124,13 +127,20 @@ class ModelerParameterDefinitionDialog(QDialog):
         settings.setValue("/Processing/modelParametersDefinitionDialogGeometry", self.saveGeometry())
         super(ModelerParameterDefinitionDialog, self).closeEvent(event)
 
+    def switchToCommentTab(self):
+        self.tab.setCurrentIndex(1)
+
     def setupUi(self):
         type_metadata = QgsApplication.processingRegistry().parameterType(self.param.type() if self.param else self.paramType)
         self.setWindowTitle(self.tr('{} Parameter Definition').format(type_metadata.name()))
+
+        self.mainLayout = QVBoxLayout()
+        self.tab = QTabWidget()
+        self.mainLayout.addWidget(self.tab)
+
         self.setMinimumWidth(300)
 
-        self.verticalLayout = QVBoxLayout(self)
-        self.verticalLayout.setMargin(20)
+        self.verticalLayout = QVBoxLayout()
 
         self.label = QLabel(self.tr('Parameter name'))
         self.verticalLayout.addWidget(self.label)
@@ -214,8 +224,8 @@ class ModelerParameterDefinitionDialog(QDialog):
             if self.param is not None:
                 self.shapetypeCombo.setCurrentIndex(self.shapetypeCombo.findData(self.param.dataTypes()[0]))
             self.verticalLayout.addWidget(self.shapetypeCombo)
-        elif (self.paramType == parameters.PARAMETER_MULTIPLE or
-              isinstance(self.param, QgsProcessingParameterMultipleLayers)):
+        elif (self.paramType == parameters.PARAMETER_MULTIPLE
+              or isinstance(self.param, QgsProcessingParameterMultipleLayers)):
             self.verticalLayout.addWidget(QLabel(self.tr('Data type')))
             self.datatypeCombo = QComboBox()
             self.datatypeCombo.addItem(self.tr('Any Map Layer'), QgsProcessing.TypeMapLayer)
@@ -229,11 +239,11 @@ class ModelerParameterDefinitionDialog(QDialog):
             if self.param is not None:
                 self.datatypeCombo.setCurrentIndex(self.datatypeCombo.findData(self.param.layerType()))
             self.verticalLayout.addWidget(self.datatypeCombo)
-        elif (self.paramType in (parameters.PARAMETER_NUMBER, parameters.PARAMETER_DISTANCE, parameters.PARAMETER_SCALE) or
-              isinstance(self.param, (QgsProcessingParameterNumber, QgsProcessingParameterDistance, QgsProcessingParameterScale))):
+        elif (self.paramType in (parameters.PARAMETER_NUMBER, parameters.PARAMETER_DISTANCE, parameters.PARAMETER_SCALE)
+              or isinstance(self.param, (QgsProcessingParameterNumber, QgsProcessingParameterDistance, QgsProcessingParameterScale))):
 
-            if (self.paramType == parameters.PARAMETER_DISTANCE or
-                    isinstance(self.param, QgsProcessingParameterDistance)):
+            if (self.paramType == parameters.PARAMETER_DISTANCE
+                    or isinstance(self.param, QgsProcessingParameterDistance)):
                 self.verticalLayout.addWidget(QLabel(self.tr('Linked input')))
                 self.parentCombo = QComboBox()
                 self.parentCombo.addItem('', '')
@@ -281,8 +291,8 @@ class ModelerParameterDefinitionDialog(QDialog):
                 if default:
                     self.defaultTextBox.setText(str(default))
             self.verticalLayout.addWidget(self.defaultTextBox)
-        elif (self.paramType == parameters.PARAMETER_EXPRESSION or
-              isinstance(self.param, QgsProcessingParameterExpression)):
+        elif (self.paramType == parameters.PARAMETER_EXPRESSION
+              or isinstance(self.param, QgsProcessingParameterExpression)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.defaultEdit = QgsExpressionLineEdit()
             if self.param is not None:
@@ -302,15 +312,15 @@ class ModelerParameterDefinitionDialog(QDialog):
                             self.parentCombo.setCurrentIndex(idx)
                     idx += 1
             self.verticalLayout.addWidget(self.parentCombo)
-        elif (self.paramType == parameters.PARAMETER_POINT or
-              isinstance(self.param, QgsProcessingParameterPoint)):
+        elif (self.paramType == parameters.PARAMETER_POINT
+              or isinstance(self.param, QgsProcessingParameterPoint)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.defaultTextBox = QLineEdit()
             if self.param is not None:
                 self.defaultTextBox.setText(self.param.defaultValue())
             self.verticalLayout.addWidget(self.defaultTextBox)
-        elif (self.paramType == parameters.PARAMETER_CRS or
-              isinstance(self.param, QgsProcessingParameterCrs)):
+        elif (self.paramType == parameters.PARAMETER_CRS
+              or isinstance(self.param, QgsProcessingParameterCrs)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.selector = QgsProjectionSelectionWidget()
             if self.param is not None:
@@ -367,18 +377,37 @@ class ModelerParameterDefinitionDialog(QDialog):
             self.advancedCheck.setEnabled(False)
             self.advancedCheck.setChecked(False)
 
+        self.verticalLayout.addStretch()
+
+        w = QWidget()
+        w.setLayout(self.verticalLayout)
+        self.tab.addTab(w, self.tr('Properties'))
+
+        self.commentLayout = QVBoxLayout()
+        self.commentEdit = QTextEdit()
+        self.commentEdit.setAcceptRichText(False)
+        self.commentLayout.addWidget(self.commentEdit)
+        w2 = QWidget()
+        w2.setLayout(self.commentLayout)
+        self.tab.addTab(w2, self.tr('Comments'))
+
         self.buttonBox = QDialogButtonBox(self)
         self.buttonBox.setOrientation(Qt.Horizontal)
-        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel |
-                                          QDialogButtonBox.Ok)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel
+                                          | QDialogButtonBox.Ok)
         self.buttonBox.setObjectName('buttonBox')
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
 
-        self.verticalLayout.addStretch()
-        self.verticalLayout.addWidget(self.buttonBox)
+        self.mainLayout.addWidget(self.buttonBox)
 
-        self.setLayout(self.verticalLayout)
+        self.setLayout(self.mainLayout)
+
+    def setComments(self, text):
+        self.commentEdit.setPlainText(text)
+
+    def comments(self):
+        return self.commentEdit.toPlainText()
 
     def accept(self):
         description = self.nameTextBox.text()
@@ -397,8 +426,8 @@ class ModelerParameterDefinitionDialog(QDialog):
                 i += 1
         else:
             name = self.param.name()
-        if (self.paramType == parameters.PARAMETER_TABLE_FIELD or
-                isinstance(self.param, QgsProcessingParameterField)):
+        if (self.paramType == parameters.PARAMETER_TABLE_FIELD
+                or isinstance(self.param, QgsProcessingParameterField)):
             if self.parentCombo.currentIndex() < 0:
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
                                     self.tr('Wrong or missing parameter values'))
@@ -411,39 +440,39 @@ class ModelerParameterDefinitionDialog(QDialog):
             self.param = QgsProcessingParameterField(name, description, defaultValue=default,
                                                      parentLayerParameterName=parent, type=datatype,
                                                      allowMultiple=self.multipleCheck.isChecked())
-        elif (self.paramType == parameters.PARAMETER_BAND or
-              isinstance(self.param, QgsProcessingParameterBand)):
+        elif (self.paramType == parameters.PARAMETER_BAND
+              or isinstance(self.param, QgsProcessingParameterBand)):
             if self.parentCombo.currentIndex() < 0:
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
                                     self.tr('Wrong or missing parameter values'))
                 return
             parent = self.parentCombo.currentData()
             self.param = QgsProcessingParameterBand(name, description, None, parent)
-        elif (self.paramType == parameters.PARAMETER_MAP_LAYER or
-              isinstance(self.param, QgsProcessingParameterMapLayer)):
+        elif (self.paramType == parameters.PARAMETER_MAP_LAYER
+              or isinstance(self.param, QgsProcessingParameterMapLayer)):
             self.param = QgsProcessingParameterMapLayer(
                 name, description)
-        elif (self.paramType == parameters.PARAMETER_RASTER or
-              isinstance(self.param, QgsProcessingParameterRasterLayer)):
+        elif (self.paramType == parameters.PARAMETER_RASTER
+              or isinstance(self.param, QgsProcessingParameterRasterLayer)):
             self.param = QgsProcessingParameterRasterLayer(
                 name, description)
-        elif (self.paramType == parameters.PARAMETER_TABLE or
-              isinstance(self.param, QgsProcessingParameterVectorLayer)):
+        elif (self.paramType == parameters.PARAMETER_TABLE
+              or isinstance(self.param, QgsProcessingParameterVectorLayer)):
             self.param = QgsProcessingParameterVectorLayer(
                 name, description,
                 [self.shapetypeCombo.currentData()])
-        elif (self.paramType == parameters.PARAMETER_VECTOR or
-              isinstance(self.param, QgsProcessingParameterFeatureSource)):
+        elif (self.paramType == parameters.PARAMETER_VECTOR
+              or isinstance(self.param, QgsProcessingParameterFeatureSource)):
             self.param = QgsProcessingParameterFeatureSource(
                 name, description,
                 [self.shapetypeCombo.currentData()])
-        elif (self.paramType == parameters.PARAMETER_MULTIPLE or
-              isinstance(self.param, QgsProcessingParameterMultipleLayers)):
+        elif (self.paramType == parameters.PARAMETER_MULTIPLE
+              or isinstance(self.param, QgsProcessingParameterMultipleLayers)):
             self.param = QgsProcessingParameterMultipleLayers(
                 name, description,
                 self.datatypeCombo.currentData())
-        elif (self.paramType == parameters.PARAMETER_DISTANCE or
-              isinstance(self.param, QgsProcessingParameterDistance)):
+        elif (self.paramType == parameters.PARAMETER_DISTANCE
+              or isinstance(self.param, QgsProcessingParameterDistance)):
             self.param = QgsProcessingParameterDistance(name, description,
                                                         self.defaultTextBox.text())
             try:
@@ -465,12 +494,12 @@ class ModelerParameterDefinitionDialog(QDialog):
             parent = self.parentCombo.currentData()
             if parent:
                 self.param.setParentParameterName(parent)
-        elif (self.paramType == parameters.PARAMETER_SCALE or
-              isinstance(self.param, QgsProcessingParameterScale)):
+        elif (self.paramType == parameters.PARAMETER_SCALE
+              or isinstance(self.param, QgsProcessingParameterScale)):
             self.param = QgsProcessingParameterScale(name, description,
                                                      self.defaultTextBox.text())
-        elif (self.paramType == parameters.PARAMETER_NUMBER or
-              isinstance(self.param, QgsProcessingParameterNumber)):
+        elif (self.paramType == parameters.PARAMETER_NUMBER
+              or isinstance(self.param, QgsProcessingParameterNumber)):
 
             type = self.type_combo.currentData()
             self.param = QgsProcessingParameterNumber(name, description, type,
@@ -486,27 +515,27 @@ class ModelerParameterDefinitionDialog(QDialog):
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
                                     self.tr('Wrong or missing parameter values'))
                 return
-        elif (self.paramType == parameters.PARAMETER_EXPRESSION or
-              isinstance(self.param, QgsProcessingParameterExpression)):
+        elif (self.paramType == parameters.PARAMETER_EXPRESSION
+              or isinstance(self.param, QgsProcessingParameterExpression)):
             parent = self.parentCombo.currentData()
             self.param = QgsProcessingParameterExpression(name, description,
                                                           str(self.defaultEdit.expression()),
                                                           parent)
-        elif (self.paramType == parameters.PARAMETER_EXTENT or
-              isinstance(self.param, QgsProcessingParameterExtent)):
+        elif (self.paramType == parameters.PARAMETER_EXTENT
+              or isinstance(self.param, QgsProcessingParameterExtent)):
             self.param = QgsProcessingParameterExtent(name, description)
-        elif (self.paramType == parameters.PARAMETER_POINT or
-              isinstance(self.param, QgsProcessingParameterPoint)):
+        elif (self.paramType == parameters.PARAMETER_POINT
+              or isinstance(self.param, QgsProcessingParameterPoint)):
             self.param = QgsProcessingParameterPoint(name, description,
                                                      str(self.defaultTextBox.text()))
-        elif (self.paramType == parameters.PARAMETER_CRS or
-              isinstance(self.param, QgsProcessingParameterCrs)):
+        elif (self.paramType == parameters.PARAMETER_CRS
+              or isinstance(self.param, QgsProcessingParameterCrs)):
             self.param = QgsProcessingParameterCrs(name, description, self.selector.crs().authid())
-        elif (self.paramType == parameters.PARAMETER_ENUM or
-                isinstance(self.param, QgsProcessingParameterEnum)):
+        elif (self.paramType == parameters.PARAMETER_ENUM
+                or isinstance(self.param, QgsProcessingParameterEnum)):
             self.param = QgsProcessingParameterEnum(name, description, self.widget.options(), self.widget.allowMultiple(), self.widget.defaultOptions())
-        elif (self.paramType == parameters.PARAMETER_MATRIX or
-                isinstance(self.param, QgsProcessingParameterMatrix)):
+        elif (self.paramType == parameters.PARAMETER_MATRIX
+                or isinstance(self.param, QgsProcessingParameterMatrix)):
             self.param = QgsProcessingParameterMatrix(name, description, hasFixedNumberRows=self.widget.fixedRows(), headers=self.widget.headers(), defaultValue=self.widget.value())
 
         # Destination parameter

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -29,7 +29,7 @@ from qgis.PyQt.QtCore import (Qt,
                               QByteArray)
 from qgis.PyQt.QtWidgets import (QDialog, QDialogButtonBox, QLabel, QLineEdit,
                                  QFrame, QPushButton, QSizePolicy, QVBoxLayout,
-                                 QHBoxLayout, QWidget)
+                                 QHBoxLayout, QWidget, QTabWidget, QTextEdit)
 
 from qgis.core import (Qgis,
                        QgsProject,
@@ -102,6 +102,9 @@ class ModelerParametersDialog(QDialog):
         settings.setValue("/Processing/modelParametersDialogGeometry", self.saveGeometry())
         super(ModelerParametersDialog, self).closeEvent(event)
 
+    def switchToCommentTab(self):
+        self.tab.setCurrentIndex(1)
+
     def setupUi(self):
         self.checkBoxes = {}
         self.showAdvanced = False
@@ -111,6 +114,11 @@ class ModelerParametersDialog(QDialog):
         self.algorithmItem = None
 
         self.resize(650, 450)
+
+        self.mainLayout = QVBoxLayout()
+        self.tab = QTabWidget()
+        self.mainLayout.addWidget(self.tab)
+
         self.buttonBox = QDialogButtonBox()
         self.buttonBox.setOrientation(Qt.Horizontal)
         self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel | QDialogButtonBox.Ok | QDialogButtonBox.Help)
@@ -118,7 +126,6 @@ class ModelerParametersDialog(QDialog):
                            QSizePolicy.Expanding)
         self.verticalLayout = QVBoxLayout()
         self.verticalLayout.setSpacing(5)
-        self.verticalLayout.setMargin(20)
 
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
@@ -229,12 +236,32 @@ class ModelerParametersDialog(QDialog):
         self.scrollArea.setWidgetResizable(True)
 
         self.verticalLayout2.addWidget(self.scrollArea)
-        self.verticalLayout2.addWidget(self.buttonBox)
-        self.setLayout(self.verticalLayout2)
         self.buttonBox.accepted.connect(self.okPressed)
         self.buttonBox.rejected.connect(self.cancelPressed)
         self.buttonBox.helpRequested.connect(self.openHelp)
+
+        w = QWidget()
+        w.setLayout(self.verticalLayout2)
+        self.tab.addTab(w, self.tr('Properties'))
+
+        self.commentLayout = QVBoxLayout()
+        self.commentEdit = QTextEdit()
+        self.commentEdit.setAcceptRichText(False)
+        self.commentLayout.addWidget(self.commentEdit)
+        w2 = QWidget()
+        w2.setLayout(self.commentLayout)
+        self.tab.addTab(w2, self.tr('Comments'))
+
+        self.mainLayout.addWidget(self.buttonBox)
+        self.setLayout(self.mainLayout)
+
         QMetaObject.connectSlotsByName(self)
+
+    def setComments(self, text):
+        self.commentEdit.setPlainText(text)
+
+    def comments(self):
+        return self.commentEdit.toPlainText()
 
     def getAvailableDependencies(self):  # spellok
         if self.childId is None:
@@ -378,9 +405,9 @@ class ModelerParametersDialog(QDialog):
                     [isinstance(subval, QgsProcessingModelChildParameterSource) for subval in val])):
                 val = [QgsProcessingModelChildParameterSource.fromStaticValue(val)]
             for subval in val:
-                if (isinstance(subval, QgsProcessingModelChildParameterSource) and
-                    subval.source() == QgsProcessingModelChildParameterSource.StaticValue and
-                        not param.checkValueIsAcceptable(subval.staticValue())) \
+                if (isinstance(subval, QgsProcessingModelChildParameterSource)
+                    and subval.source() == QgsProcessingModelChildParameterSource.StaticValue
+                        and not param.checkValueIsAcceptable(subval.staticValue())) \
                         or (subval is None and not param.flags() & QgsProcessingParameterDefinition.FlagOptional):
                     self.bar.pushMessage(self.tr("Error"), self.tr("Wrong or missing value for parameter '{}'").format(
                         param.description()),
@@ -419,6 +446,7 @@ class ModelerParametersDialog(QDialog):
         #except:
         #    pass
 
+        alg.comment().setDescription(self.comments())
         return alg
 
     def okPressed(self):

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -104,6 +104,8 @@ class ModelerParametersDialog(QDialog):
 
     def switchToCommentTab(self):
         self.tab.setCurrentIndex(1)
+        self.commentEdit.setFocus()
+        self.commentEdit.selectAll()
 
     def setupUi(self):
         self.checkBoxes = {}

--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -25,8 +25,7 @@ from qgis.gui import QgsModelGraphicsScene
 from processing.modeler.ModelerGraphicItem import (
     ModelerInputGraphicItem,
     ModelerOutputGraphicItem,
-    ModelerChildAlgorithmGraphicItem,
-    ModelerCommentGraphicItem
+    ModelerChildAlgorithmGraphicItem
 )
 
 
@@ -49,6 +48,3 @@ class ModelerScene(QgsModelGraphicsScene):
 
     def createOutputGraphicItem(self, model, output):
         return ModelerOutputGraphicItem(output.clone(), model)
-
-    #def createCommentGraphicItem(self, model, comment, parent):
-    #    return ModelerCommentGraphicItem(model, comment.clone(), parent)

--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -25,7 +25,8 @@ from qgis.gui import QgsModelGraphicsScene
 from processing.modeler.ModelerGraphicItem import (
     ModelerInputGraphicItem,
     ModelerOutputGraphicItem,
-    ModelerChildAlgorithmGraphicItem
+    ModelerChildAlgorithmGraphicItem,
+    ModelerCommentGraphicItem
 )
 
 
@@ -48,3 +49,6 @@ class ModelerScene(QgsModelGraphicsScene):
 
     def createOutputGraphicItem(self, model, output):
         return ModelerOutputGraphicItem(output.clone(), model)
+
+    #def createCommentGraphicItem(self, model, comment, parent):
+    #    return ModelerCommentGraphicItem(model, comment.clone(), parent)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -152,6 +152,7 @@ SET(QGIS_CORE_SRCS
   processing/models/qgsprocessingmodelalgorithm.cpp
   processing/models/qgsprocessingmodelchildalgorithm.cpp
   processing/models/qgsprocessingmodelchildparametersource.cpp
+  processing/models/qgsprocessingmodelcomment.cpp
   processing/models/qgsprocessingmodelcomponent.cpp
   processing/models/qgsprocessingmodelparameter.cpp
   processing/models/qgsprocessingmodeloutput.cpp
@@ -1169,6 +1170,7 @@ SET(QGIS_CORE_HDRS
   processing/models/qgsprocessingmodelalgorithm.h
   processing/models/qgsprocessingmodelchildalgorithm.h
   processing/models/qgsprocessingmodelchildparametersource.h
+  processing/models/qgsprocessingmodelcomment.h
   processing/models/qgsprocessingmodelcomponent.h
   processing/models/qgsprocessingmodeloutput.h
   processing/models/qgsprocessingmodelparameter.h

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -465,6 +465,11 @@ QStringList QgsProcessingModelAlgorithm::asPythonCode( const QgsProcessing::Pyth
             friendlyOutputNames.insert( defClone->name(), friendlyName );
             defClone->setName( friendlyName );
           }
+          else
+          {
+            if ( !mParameterComponents.value( defClone->name() ).comment()->description().isEmpty() )
+              lines << indent + indent + QStringLiteral( "# %1" ).arg( mParameterComponents.value( defClone->name() ).comment()->description() );
+          }
 
           if ( defClone->flags() & QgsProcessingParameterDefinition::FlagAdvanced )
           {

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -35,6 +35,7 @@ QgsProcessingModelChildAlgorithm::QgsProcessingModelChildAlgorithm( const QgsPro
   , mModelOutputs( other.mModelOutputs )
   , mActive( other.mActive )
   , mDependencies( other.mDependencies )
+  , mComment( other.mComment )
 {
   setAlgorithmId( other.algorithmId() );
 }
@@ -49,6 +50,7 @@ QgsProcessingModelChildAlgorithm &QgsProcessingModelChildAlgorithm::operator=( c
   mModelOutputs = other.mModelOutputs;
   mActive = other.mActive;
   mDependencies = other.mDependencies;
+  mComment = other.mComment;
   return *this;
 }
 
@@ -89,6 +91,7 @@ QVariant QgsProcessingModelChildAlgorithm::toVariant() const
   map.insert( QStringLiteral( "alg_config" ), mConfiguration );
   map.insert( QStringLiteral( "active" ), mActive );
   map.insert( QStringLiteral( "dependencies" ), mDependencies );
+  map.insert( QStringLiteral( "comment" ), mComment.toVariant() );
 
   saveCommonProperties( map );
 
@@ -126,6 +129,7 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   setAlgorithmId( map.value( QStringLiteral( "alg_id" ) ).toString() );
   mActive = map.value( QStringLiteral( "active" ) ).toBool();
   mDependencies = map.value( QStringLiteral( "dependencies" ) ).toStringList();
+  mComment.loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
 
   restoreCommonProperties( map );
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -59,6 +59,32 @@ QgsProcessingModelChildAlgorithm *QgsProcessingModelChildAlgorithm::clone() cons
   return new QgsProcessingModelChildAlgorithm( *this );
 }
 
+void QgsProcessingModelChildAlgorithm::copyNonDefinitionPropertiesFromModel( QgsProcessingModelAlgorithm *model )
+{
+  const QgsProcessingModelChildAlgorithm existingChild = model->childAlgorithm( mId );
+  copyNonDefinitionProperties( existingChild );
+
+  int i = 0;
+  for ( auto it = mModelOutputs.begin(); it != mModelOutputs.end(); ++it )
+  {
+    if ( !existingChild.modelOutputs().value( it.key() ).position().isNull() )
+      it.value().setPosition( existingChild.modelOutputs().value( it.key() ).position() );
+    else
+      it.value().setPosition( position() + QPointF( size().width(), ( i + 1.5 ) * size().height() ) );
+
+    if ( QgsProcessingModelComment *comment = it.value().comment() )
+    {
+      if ( const QgsProcessingModelComment *existingComment = existingChild.modelOutputs().value( it.key() ).comment() )
+      {
+        comment->setDescription( existingComment->description() );
+        comment->setSize( existingComment->size() );
+        comment->setPosition( existingComment->position() );
+      }
+    }
+    i++;
+  }
+}
+
 const QgsProcessingAlgorithm *QgsProcessingModelChildAlgorithm::algorithm() const
 {
   return mAlgorithm.get();

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -177,6 +177,9 @@ QStringList QgsProcessingModelChildAlgorithm::asPythonCode( const QgsProcessing:
 
   if ( !description().isEmpty() )
     lines << baseIndent + QStringLiteral( "# %1" ).arg( description() );
+  if ( !mComment.description().isEmpty() )
+    lines << baseIndent + QStringLiteral( "# %1" ).arg( mComment.description() );
+
   QStringList paramParts;
   for ( auto paramIt = mParams.constBegin(); paramIt != mParams.constEnd(); ++paramIt )
   {

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -117,7 +117,6 @@ QVariant QgsProcessingModelChildAlgorithm::toVariant() const
   map.insert( QStringLiteral( "alg_config" ), mConfiguration );
   map.insert( QStringLiteral( "active" ), mActive );
   map.insert( QStringLiteral( "dependencies" ), mDependencies );
-  map.insert( QStringLiteral( "comment" ), mComment.toVariant() );
 
   saveCommonProperties( map );
 
@@ -155,7 +154,6 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   setAlgorithmId( map.value( QStringLiteral( "alg_id" ) ).toString() );
   mActive = map.value( QStringLiteral( "active" ) ).toBool();
   mDependencies = map.value( QStringLiteral( "dependencies" ) ).toStringList();
-  mComment.loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
 
   restoreCommonProperties( map );
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -23,6 +23,7 @@
 #include "qgsprocessingmodelcomponent.h"
 #include "qgsprocessingmodelchildparametersource.h"
 #include "qgsprocessingmodeloutput.h"
+#include "qgsprocessingmodelcomment.h"
 #include <memory>
 
 class QgsProcessingModelAlgorithm;
@@ -261,6 +262,10 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     QStringList asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsStringMap &extraParameters, int currentIndent, int indentSize,
                               const QMap<QString, QString> &friendlyChildNames, const QMap<QString, QString> &friendlyOutputNames ) const;
 
+    SIP_SKIP const QgsProcessingModelComment *comment() const override { return &mComment; }
+    QgsProcessingModelComment *comment() override { return &mComment; }
+    void setComment( const QgsProcessingModelComment &comment ) override { mComment = comment; }
+
   private:
 
     QString mId;
@@ -280,6 +285,8 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
 
     //! List of child algorithms from the parent model on which this algorithm is dependent
     QStringList mDependencies;
+
+    QgsProcessingModelComment mComment;
 
     friend class TestQgsProcessing;
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -52,6 +52,16 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     QgsProcessingModelChildAlgorithm *clone() const override SIP_FACTORY;
 
     /**
+     * Copies all non-specific definition properties from the the matching component from a \a model.
+     *
+     * This includes properties like the size and position of the component, but not properties
+     * like the specific algorithm or input details.
+     *
+     * \since QGIS 3.14
+     */
+    void copyNonDefinitionPropertiesFromModel( QgsProcessingModelAlgorithm *model );
+
+    /**
      * Returns the child algorithm's unique ID string, used the identify
      * this child algorithm within its parent model.
      * \see setChildId()

--- a/src/core/processing/models/qgsprocessingmodelcomment.cpp
+++ b/src/core/processing/models/qgsprocessingmodelcomment.cpp
@@ -1,8 +1,8 @@
 /***************************************************************************
-                         qgsprocessingmodelparameter.cpp
-                         ------------------------------
-    begin                : June 2017
-    copyright            : (C) 2017 by Nyall Dawson
+                         qgsprocessingmodelcomment.cpp
+                         --------------------------
+    begin                : February 2020
+    copyright            : (C) 2020 by Nyall Dawson
     email                : nyall dot dawson at gmail dot com
  ***************************************************************************/
 
@@ -15,36 +15,33 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsprocessingmodelparameter.h"
+#include "qgsprocessingmodelcomment.h"
 
 ///@cond NOT_STABLE
 
-QgsProcessingModelParameter::QgsProcessingModelParameter( const QString &parameterName )
-  : mParameterName( parameterName )
+QgsProcessingModelComment::QgsProcessingModelComment( const QString &description )
+  : QgsProcessingModelComponent( description )
 {
-
+  setSize( QSizeF( 100, 60 ) );
 }
 
-QgsProcessingModelParameter *QgsProcessingModelParameter::clone() const
+QgsProcessingModelComment *QgsProcessingModelComment::clone() const
 {
-  return new QgsProcessingModelParameter( *this );
+  return new QgsProcessingModelComment( *this );
 }
 
-QVariant QgsProcessingModelParameter::toVariant() const
+QVariant QgsProcessingModelComment::toVariant() const
 {
   QVariantMap map;
-  map.insert( QStringLiteral( "name" ), mParameterName );
-  map.insert( QStringLiteral( "comment" ), mComment.toVariant() );
   saveCommonProperties( map );
   return map;
 }
 
-bool QgsProcessingModelParameter::loadVariant( const QVariantMap &map )
+bool QgsProcessingModelComment::loadVariant( const QVariantMap &map )
 {
-  mParameterName = map.value( QStringLiteral( "name" ) ).toString();
-  mComment.loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
   restoreCommonProperties( map );
   return true;
 }
+
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelcomment.h
+++ b/src/core/processing/models/qgsprocessingmodelcomment.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+                         qgsprocessingmodelcomment.h
+                         --------------------------
+    begin                : February 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGMODELCOMMENT_H
+#define QGSPROCESSINGMODELCOMMENT_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsprocessingmodelcomponent.h"
+#include "qgsprocessingparameters.h"
+
+///@cond NOT_STABLE
+
+/**
+ * Represents a comment in a model.
+ * \ingroup core
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsProcessingModelComment : public QgsProcessingModelComponent
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingModelComment with the specified \a description.
+     */
+    QgsProcessingModelComment( const QString &description = QString() );
+
+    QgsProcessingModelComment *clone() const override SIP_FACTORY;
+
+    /**
+     * Saves this comment to a QVariant.
+     * \see loadVariant()
+     */
+    QVariant toVariant() const;
+
+    /**
+     * Loads this comment from a QVariantMap.
+     * \see toVariant()
+     */
+    bool loadVariant( const QVariantMap &map );
+};
+
+///@endcond
+
+#endif // QGSPROCESSINGMODELCOMMENT_H

--- a/src/core/processing/models/qgsprocessingmodelcomponent.cpp
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsprocessingmodelcomponent.h"
+#include "qgsprocessingmodelcomment.h"
 
 ///@cond NOT_STABLE
 
@@ -115,6 +116,21 @@ void QgsProcessingModelComponent::restoreCommonProperties( const QVariantMap &ma
   mSize.setHeight( map.value( QStringLiteral( "component_height" ), QString::number( DEFAULT_COMPONENT_HEIGHT ) ).toDouble() );
   mTopEdgeLinksCollapsed = map.value( QStringLiteral( "parameters_collapsed" ) ).toBool();
   mBottomEdgeLinksCollapsed = map.value( QStringLiteral( "outputs_collapsed" ) ).toBool();
+}
+
+void QgsProcessingModelComponent::copyNonDefinitionProperties( const QgsProcessingModelComponent &other )
+{
+  setPosition( other.position() );
+  setLinksCollapsed( Qt::TopEdge, other.linksCollapsed( Qt::TopEdge ) );
+  setLinksCollapsed( Qt::BottomEdge, other.linksCollapsed( Qt::BottomEdge ) );
+  if ( comment() && other.comment() )
+  {
+    if ( !other.comment()->position().isNull() )
+      comment()->setPosition( other.comment()->position() );
+    else
+      comment()->setPosition( other.position() + QPointF( size().width(), -1.5 * size().height() ) );
+    comment()->setSize( other.comment()->size() );
+  }
 }
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelcomponent.cpp
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.cpp
@@ -103,6 +103,8 @@ void QgsProcessingModelComponent::saveCommonProperties( QVariantMap &map ) const
   map.insert( QStringLiteral( "component_height" ), mSize.height() );
   map.insert( QStringLiteral( "parameters_collapsed" ), mTopEdgeLinksCollapsed );
   map.insert( QStringLiteral( "outputs_collapsed" ), mBottomEdgeLinksCollapsed );
+  if ( comment() )
+    map.insert( QStringLiteral( "comment" ), comment()->toVariant() );
 }
 
 void QgsProcessingModelComponent::restoreCommonProperties( const QVariantMap &map )
@@ -116,11 +118,14 @@ void QgsProcessingModelComponent::restoreCommonProperties( const QVariantMap &ma
   mSize.setHeight( map.value( QStringLiteral( "component_height" ), QString::number( DEFAULT_COMPONENT_HEIGHT ) ).toDouble() );
   mTopEdgeLinksCollapsed = map.value( QStringLiteral( "parameters_collapsed" ) ).toBool();
   mBottomEdgeLinksCollapsed = map.value( QStringLiteral( "outputs_collapsed" ) ).toBool();
+  if ( comment() )
+    comment()->loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
 }
 
 void QgsProcessingModelComponent::copyNonDefinitionProperties( const QgsProcessingModelComponent &other )
 {
   setPosition( other.position() );
+  setSize( other.size() );
   setLinksCollapsed( Qt::TopEdge, other.linksCollapsed( Qt::TopEdge ) );
   setLinksCollapsed( Qt::BottomEdge, other.linksCollapsed( Qt::BottomEdge ) );
   if ( comment() && other.comment() )

--- a/src/core/processing/models/qgsprocessingmodelcomponent.cpp
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.cpp
@@ -88,6 +88,11 @@ void QgsProcessingModelComponent::setLinksCollapsed( Qt::Edge edge, bool collaps
   }
 }
 
+void QgsProcessingModelComponent::setComment( const QgsProcessingModelComment & )
+{
+
+}
+
 void QgsProcessingModelComponent::saveCommonProperties( QVariantMap &map ) const
 {
   map.insert( QStringLiteral( "component_pos_x" ), mPosition.x() );

--- a/src/core/processing/models/qgsprocessingmodelcomponent.h
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.h
@@ -23,6 +23,8 @@
 #include <QPointF>
 #include <QSizeF>
 
+class QgsProcessingModelComment;
+
 ///@cond NOT_STABLE
 
 /**
@@ -86,6 +88,24 @@ class CORE_EXPORT QgsProcessingModelComponent
      * \see linksCollapsed()
      */
     void setLinksCollapsed( Qt::Edge edge, bool collapsed );
+
+    /**
+     * Returns the comment attached to this component (may be NULLPTR)
+     * \see setComment()
+     */
+    SIP_SKIP virtual const QgsProcessingModelComment *comment() const { return nullptr; }
+
+    /**
+     * Returns the comment attached to this component (may be NULLPTR)
+     * \see setComment()
+     */
+    virtual QgsProcessingModelComment *comment() { return nullptr; }
+
+    /**
+     * Sets the \a comment attached to this component.
+     * \see comment()
+     */
+    virtual void setComment( const QgsProcessingModelComment &comment );
 
     /**
      * Clones the component.

--- a/src/core/processing/models/qgsprocessingmodelcomponent.h
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.h
@@ -137,6 +137,16 @@ class CORE_EXPORT QgsProcessingModelComponent
      */
     void restoreCommonProperties( const QVariantMap &map );
 
+    /**
+     * Copies all non-specific definition properties from the \a other component definition.
+     *
+     * This includes properties like the size and position of the component, but not properties
+     * like the specific algorithm or input details.
+     *
+     * \since QGIS 3.14
+     */
+    void copyNonDefinitionProperties( const QgsProcessingModelComponent &other );
+
   private:
 
     static constexpr double DEFAULT_COMPONENT_WIDTH = 200;

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -48,6 +48,7 @@ QVariant QgsProcessingModelOutput::toVariant() const
   map.insert( QStringLiteral( "child_id" ), mChildId );
   map.insert( QStringLiteral( "output_name" ), mOutputName );
   map.insert( QStringLiteral( "mandatory" ), mMandatory );
+  map.insert( QStringLiteral( "comment" ), mComment.toVariant() );
   saveCommonProperties( map );
   return map;
 }
@@ -79,6 +80,7 @@ bool QgsProcessingModelOutput::loadVariant( const QVariantMap &map )
   mChildId = map.value( QStringLiteral( "child_id" ) ).toString();
   mOutputName = map.value( QStringLiteral( "output_name" ) ).toString();
   mMandatory = map.value( QStringLiteral( "mandatory" ), false ).toBool();
+  mComment.loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
   restoreCommonProperties( map );
   return true;
 }

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -48,7 +48,6 @@ QVariant QgsProcessingModelOutput::toVariant() const
   map.insert( QStringLiteral( "child_id" ), mChildId );
   map.insert( QStringLiteral( "output_name" ), mOutputName );
   map.insert( QStringLiteral( "mandatory" ), mMandatory );
-  map.insert( QStringLiteral( "comment" ), mComment.toVariant() );
   saveCommonProperties( map );
   return map;
 }
@@ -80,7 +79,6 @@ bool QgsProcessingModelOutput::loadVariant( const QVariantMap &map )
   mChildId = map.value( QStringLiteral( "child_id" ) ).toString();
   mOutputName = map.value( QStringLiteral( "output_name" ) ).toString();
   mMandatory = map.value( QStringLiteral( "mandatory" ), false ).toBool();
-  mComment.loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
   restoreCommonProperties( map );
   return true;
 }

--- a/src/core/processing/models/qgsprocessingmodeloutput.h
+++ b/src/core/processing/models/qgsprocessingmodeloutput.h
@@ -22,6 +22,7 @@
 #include "qgis.h"
 #include "qgsprocessingmodelcomponent.h"
 #include "qgsprocessingparameters.h"
+#include "qgsprocessingmodelcomment.h"
 
 ///@cond NOT_STABLE
 
@@ -121,6 +122,10 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
      */
     bool loadVariant( const QVariantMap &map );
 
+    SIP_SKIP const QgsProcessingModelComment *comment() const override { return &mComment; }
+    QgsProcessingModelComment *comment() override { return &mComment; }
+    void setComment( const QgsProcessingModelComment &comment ) override { mComment = comment; }
+
   private:
 
     QString mName;
@@ -128,6 +133,9 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
     QString mChildId;
     QString mOutputName;
     bool mMandatory = false;
+
+    QgsProcessingModelComment mComment;
+
 };
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelparameter.cpp
+++ b/src/core/processing/models/qgsprocessingmodelparameter.cpp
@@ -34,7 +34,6 @@ QVariant QgsProcessingModelParameter::toVariant() const
 {
   QVariantMap map;
   map.insert( QStringLiteral( "name" ), mParameterName );
-  map.insert( QStringLiteral( "comment" ), mComment.toVariant() );
   saveCommonProperties( map );
   return map;
 }
@@ -42,7 +41,6 @@ QVariant QgsProcessingModelParameter::toVariant() const
 bool QgsProcessingModelParameter::loadVariant( const QVariantMap &map )
 {
   mParameterName = map.value( QStringLiteral( "name" ) ).toString();
-  mComment.loadVariant( map.value( QStringLiteral( "comment" ) ).toMap() );
   restoreCommonProperties( map );
   return true;
 }

--- a/src/core/processing/models/qgsprocessingmodelparameter.h
+++ b/src/core/processing/models/qgsprocessingmodelparameter.h
@@ -21,6 +21,7 @@
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsprocessingmodelcomponent.h"
+#include "qgsprocessingmodelcomment.h"
 
 ///@cond NOT_STABLE
 
@@ -68,9 +69,15 @@ class CORE_EXPORT QgsProcessingModelParameter : public QgsProcessingModelCompone
      */
     bool loadVariant( const QVariantMap &map );
 
+    SIP_SKIP const QgsProcessingModelComment *comment() const override { return &mComment; }
+    QgsProcessingModelComment *comment() override { return &mComment; }
+    void setComment( const QgsProcessingModelComment &comment ) override { mComment = comment; }
+
   private:
 
     QString mParameterName;
+
+    QgsProcessingModelComment mComment;
 
 };
 

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -20,6 +20,7 @@
 #include "qgsrectangle.h"
 #include "qgsproperty.h"
 #include "qgssymbollayerutils.h"
+#include "qgsprocessingparameters.h"
 
 QgsUnitTypes::DistanceUnit QgsXmlUtils::readMapUnits( const QDomElement &element )
 {
@@ -213,7 +214,15 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
         element.setAttribute( QStringLiteral( "value" ), geom.asWkt() );
         break;
       }
-      FALLTHROUGH
+      else if ( value.canConvert< QgsProcessingOutputLayerDefinition >() )
+      {
+        QDomElement valueElement = writeVariant( value.value< QgsProcessingOutputLayerDefinition >().toVariant(), doc );
+        element.appendChild( valueElement );
+        element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingOutputLayerDefinition" ) );
+        break;
+      }
+      Q_ASSERT_X( false, "QgsXmlUtils::writeVariant", QStringLiteral( "unsupported user variant type %1" ).arg( QMetaType::typeName( value.userType() ) ).toLocal8Bit() );
+      break;
     }
 
     default:
@@ -337,6 +346,18 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
   else if ( type == QLatin1String( "QgsGeometry" ) )
   {
     return QgsGeometry::fromWkt( element.attribute( "value" ) );
+  }
+  else if ( type == QLatin1String( "QgsProcessingOutputLayerDefinition" ) )
+  {
+    QgsProcessingOutputLayerDefinition res;
+    const QDomNodeList values = element.childNodes();
+    if ( values.isEmpty() )
+      return QVariant();
+
+    if ( res.loadVariant( QgsXmlUtils::readVariant( values.at( 0 ).toElement() ).toMap() ) )
+      return res;
+
+    return QVariant();
   }
   else
   {

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -54,6 +54,13 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
       Hover, //!< Cursor is hovering over an deselected item
     };
 
+    //! Available flags
+    enum Flag
+    {
+      FlagMultilineText = 1 << 0, //!< Show multiline text in label
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
     /**
      * Constructor for QgsModelComponentGraphicItem for the specified \a component, with the specified \a parent item.
      *
@@ -67,6 +74,11 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
                                   QGraphicsItem *parent SIP_TRANSFERTHIS );
 
     ~QgsModelComponentGraphicItem() override;
+
+    /**
+     * Returns item flags.
+     */
+    virtual Flags flags() const;
 
     /**
      * Returns the model component associated with this item.
@@ -278,6 +290,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     bool mIsHovering = false;
 
 };
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsModelComponentGraphicItem::Flags )
 
 /**
  * \ingroup gui
@@ -442,7 +455,7 @@ class GUI_EXPORT QgsModelCommentGraphicItem : public QgsModelComponentGraphicIte
                                 QGraphicsItem *parent SIP_TRANSFERTHIS );
     ~QgsModelCommentGraphicItem() override;
     void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
-
+    Flags flags() const override;
   protected:
 
     QColor fillColor( State state ) const override;

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -26,6 +26,8 @@ class QgsModelComponentGraphicItem;
 class QgsProcessingModelParameter;
 class QgsProcessingModelChildAlgorithm;
 class QgsProcessingModelOutput;
+class QgsProcessingModelComponent;
+class QgsProcessingModelComment;
 
 ///@cond NOT_STABLE
 
@@ -118,6 +120,13 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     virtual QgsModelComponentGraphicItem *createOutputGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelOutput *output ) const SIP_FACTORY;
 
+    /**
+     * Creates a new graphic item for a model comment.
+     */
+    virtual QgsModelComponentGraphicItem *createCommentGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelComment *comment,
+        QgsModelComponentGraphicItem *parentItem ) const SIP_FACTORY;
+
+
   private:
 
     struct LinkSource
@@ -127,6 +136,8 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
       int linkIndex = -1;
     };
     QList< LinkSource > linkSourcesForParameterValue( QgsProcessingModelAlgorithm *model, const QVariant &value, const QString &childId, QgsProcessingContext &context ) const;
+
+    void addCommentItemForComponent( QgsProcessingModelAlgorithm *model, const QgsProcessingModelComponent &component, QgsModelComponentGraphicItem *parentItem );
 
     Flags mFlags = nullptr;
 

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
@@ -29,6 +29,8 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QMessageBox>
+#include <QTabWidget>
+#include <QTextEdit>
 
 QgsProcessingAbstractParameterDefinitionWidget::QgsProcessingAbstractParameterDefinitionWidget( QgsProcessingContext &,
     const QgsProcessingParameterWidgetContext &,
@@ -130,11 +132,28 @@ QgsProcessingParameterDefinitionDialog::QgsProcessingParameterDefinitionDialog( 
   : QDialog( parent )
 {
   QVBoxLayout *vLayout = new QVBoxLayout();
+  mTabWidget = new QTabWidget();
+  vLayout->addWidget( mTabWidget );
+
+  QVBoxLayout *vLayout2 = new QVBoxLayout();
   mWidget = new QgsProcessingParameterDefinitionWidget( type, context, widgetContext, definition, algorithm );
-  vLayout->addWidget( mWidget );
+  vLayout2->addWidget( mWidget );
+  QWidget *w = new QWidget();
+  w->setLayout( vLayout2 );
+  mTabWidget->addTab( w, tr( "Properties" ) );
+
+  QVBoxLayout *commentLayout = new QVBoxLayout();
+  mCommentEdit = new QTextEdit();
+  mCommentEdit->setAcceptRichText( false );
+  commentLayout->addWidget( mCommentEdit );
+  QWidget *w2 = new QWidget();
+  w2->setLayout( commentLayout );
+  mTabWidget->addTab( w2, tr( "Comments" ) );
+
   QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok );
   connect( bbox, &QDialogButtonBox::accepted, this, &QgsProcessingParameterDefinitionDialog::accept );
   connect( bbox, &QDialogButtonBox::rejected, this, &QgsProcessingParameterDefinitionDialog::reject );
+
   vLayout->addWidget( bbox );
   setLayout( vLayout );
   setWindowTitle( definition ? tr( "%1 Parameter Definition" ).arg( definition->description() )
@@ -147,6 +166,23 @@ QgsProcessingParameterDefinitionDialog::QgsProcessingParameterDefinitionDialog( 
 QgsProcessingParameterDefinition *QgsProcessingParameterDefinitionDialog::createParameter( const QString &name ) const
 {
   return mWidget->createParameter( name );
+}
+
+void QgsProcessingParameterDefinitionDialog::setComments( const QString &comments )
+{
+  mCommentEdit->setPlainText( comments );
+}
+
+QString QgsProcessingParameterDefinitionDialog::comments() const
+{
+  return mCommentEdit->toPlainText();
+}
+
+void QgsProcessingParameterDefinitionDialog::switchToCommentTab()
+{
+  mTabWidget->setCurrentIndex( 1 );
+  mCommentEdit->setFocus();
+  mCommentEdit->selectAll();
 }
 
 void QgsProcessingParameterDefinitionDialog::accept()

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
@@ -29,6 +29,8 @@
 class QgsProcessingParameterWidgetContext;
 class QLineEdit;
 class QCheckBox;
+class QTabWidget;
+class QTextEdit;
 
 /**
  * Abstract base class for widgets which allow users to specify the properties of a
@@ -167,11 +169,32 @@ class GUI_EXPORT QgsProcessingParameterDefinitionDialog: public QDialog
      */
     QgsProcessingParameterDefinition *createParameter( const QString &name = QString() ) const SIP_FACTORY;
 
+    /**
+     * Sets the comments for the parameter.
+     * \see comments()
+     * \since QGIS 3.14
+     */
+    void setComments( const QString &comments );
+
+    /**
+     * Returns the comments for the parameter.
+     * \see setComments()
+     * \since QGIS 3.14
+     */
+    QString comments() const;
+
+    /**
+     * Switches the dialog to the comments tab.
+     */
+    void switchToCommentTab();
+
   public slots:
     void accept() override;
 
   private:
 
+    QTabWidget *mTabWidget = nullptr;
+    QTextEdit *mCommentEdit = nullptr;
     QgsProcessingParameterDefinitionWidget *mWidget = nullptr;
 
 };

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -15,6 +15,7 @@ from qgis.core import (QgsXmlUtils,
                        QgsProperty,
                        QgsGeometry,
                        QgsCoordinateReferenceSystem,
+                       QgsProcessingOutputLayerDefinition,
                        NULL)
 
 from qgis.PyQt.QtCore import QDateTime, QDate, QTime
@@ -240,6 +241,20 @@ class TestQgsXmlUtils(unittest.TestCase):
         elem = QgsXmlUtils.writeVariant(QTime(), doc)
         c = QgsXmlUtils.readVariant(elem)
         self.assertEqual(c, NULL)
+
+    def test_output_layer_definition(self):
+        """
+        Test that QgsProcessingOutputLayerDefinition values are correctly loaded and written
+        """
+        doc = QDomDocument("properties")
+
+        definition = QgsProcessingOutputLayerDefinition(QgsProperty.fromValue('my sink'))
+        definition.createOptions = {'opt': 1, 'opt2': 2}
+
+        elem = QgsXmlUtils.writeVariant(definition, doc)
+        c = QgsXmlUtils.readVariant(elem)
+        self.assertEqual(c.sink.staticValue(), 'my sink')
+        self.assertEqual(c.createOptions, {'opt': 1, 'opt2': 2})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
(includes https://github.com/qgis/QGIS/pull/34852)

This allows users to create comments attached to model components (inputs, algorithms or outputs). Comments are shown linked to the associated component, and can be freely moved around the model.

(will be more user-friendly when model components can also be resized :laughing: )

![Peek 2020-03-04 16-27](https://user-images.githubusercontent.com/1829991/75851342-26799000-5e35-11ea-8895-a310f01b3823.gif)

 Funded by Fisel + König