### PR TITLE
[plugin manager] allow to install stable or experimental

### DIFF
--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -220,14 +220,19 @@ class QgsPluginInstaller(QObject):
                 "installed": plugin["installed"] and "true" or "false",
                 "available": plugin["available"] and "true" or "false",
                 "status": plugin["status"],
+                "status_exp": plugin["status_exp"],
                 "error": plugin["error"],
                 "error_details": plugin["error_details"],
                 "experimental": plugin["experimental"] and "true" or "false",
                 "deprecated": plugin["deprecated"] and "true" or "false",
                 "trusted": plugin["trusted"] and "true" or "false",
                 "version_available": plugin["version_available"],
+                "version_available_stable": plugin["version_available_stable"] or "",
+                "version_available_experimental": plugin["version_available_experimental"] or "",
                 "zip_repository": plugin["zip_repository"],
                 "download_url": plugin["download_url"],
+                "download_url_stable": plugin["download_url_stable"],
+                "download_url_experimental": plugin["download_url_experimental"],
                 "filename": plugin["filename"],
                 "downloads": plugin["downloads"],
                 "average_vote": plugin["average_vote"],
@@ -282,19 +287,20 @@ class QgsPluginInstaller(QObject):
             self.installPlugin(key, quiet=True)
 
     # ----------------------------------------- #
-    def installPlugin(self, key, quiet=False):
+    def installPlugin(self, key, quiet=False, stable=True):
         """ Install given plugin """
         error = False
+        status_key = 'status' if stable else 'status_exp'
         infoString = ('', '')
         plugin = plugins.all()[key]
-        previousStatus = plugin["status"]
+        previousStatus = plugin[status_key]
         if not plugin:
             return
-        if plugin["status"] == "newer" and not plugin["error"]:  # ask for confirmation if user downgrades an usable plugin
+        if plugin[status_key] == "newer" and not plugin["error"]:  # ask for confirmation if user downgrades an usable plugin
             if QMessageBox.warning(iface.mainWindow(), self.tr("QGIS Python Plugin Installer"), self.tr("Are you sure you want to downgrade the plugin to the latest available version? The installed one is newer!"), QMessageBox.Yes, QMessageBox.No) == QMessageBox.No:
                 return
 
-        dlg = QgsPluginInstallerInstallingDialog(iface.mainWindow(), plugin)
+        dlg = QgsPluginInstallerInstallingDialog(iface.mainWindow(), plugin, stable=stable)
         dlg.exec_()
 
         if dlg.result():

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -40,7 +40,7 @@ from .unzip import unzip
 class QgsPluginInstallerInstallingDialog(QDialog, Ui_QgsPluginInstallerInstallingDialogBase):
     # ----------------------------------------- #
 
-    def __init__(self, parent, plugin):
+    def __init__(self, parent, plugin, stable=True):
         QDialog.__init__(self, parent)
         self.setupUi(self)
         self.plugin = plugin
@@ -50,7 +50,7 @@ class QgsPluginInstallerInstallingDialog(QDialog, Ui_QgsPluginInstallerInstallin
         self.labelName.setText(plugin["name"])
         self.buttonBox.clicked.connect(self.abort)
 
-        self.url = QUrl(plugin["download_url"])
+        self.url = QUrl(plugin["download_url_stable"] if stable else plugin["download_url_experimental"])
         self.redirectionCounter = 0
 
         fileName = plugin["filename"]

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -127,6 +127,9 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! Install selected plugin
     void buttonInstall_clicked();
 
+    //! Install selected plugin
+    void buttonInstallExperimental_clicked();
+
     //! Uninstall selected plugin
     void buttonUninstall_clicked();
 

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.cpp
@@ -66,10 +66,11 @@ bool QgsPluginSortFilterProxyModel::filterByStatus( QModelIndex &index ) const
   }
 
   QString status = sourceModel()->data( index, PLUGIN_STATUS_ROLE ).toString();
+  QString statusexp = sourceModel()->data( index, PLUGIN_STATUSEXP_ROLE ).toString();
   if ( status.endsWith( 'Z' ) ) status.chop( 1 );
   if ( ! mAcceptedStatuses.isEmpty()
        && ! mAcceptedStatuses.contains( QStringLiteral( "invalid" ) )
-       && ! mAcceptedStatuses.contains( status ) )
+       && !( mAcceptedStatuses.contains( status ) || mAcceptedStatuses.contains( statusexp ) ) )
   {
     // Don't accept if the status doesn't match
     return false;

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.h
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.h
@@ -30,6 +30,7 @@ const int PLUGIN_STATUS_ROLE = Qt::UserRole + 6;       // for filtering and sort
 const int PLUGIN_DOWNLOADS_ROLE = Qt::UserRole + 7;    // for sorting
 const int PLUGIN_VOTE_ROLE = Qt::UserRole + 8;         // for sorting
 const int PLUGIN_ISDEPRECATED_ROLE = Qt::UserRole + 9; // for styling
+const int PLUGIN_STATUSEXP_ROLE = Qt::UserRole + 10;       // for filtering and sorting
 const int SPACER_ROLE = Qt::UserRole + 20;  // for sorting
 
 

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -504,6 +504,32 @@
                    </property>
                   </widget>
                  </item>
+                 <item>
+                  <widget class="QPushButton" name="buttonInstallExperimental">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>160</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Install, reinstall or upgrade the experimental version of selected plugin</string>
+                   </property>
+                   <property name="styleSheet">
+                    <string notr="true">background-color: #EEEEBB</string>
+                   </property>
+                   <property name="text">
+                    <string>Reinstall Experimental</string>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../../images/images.qrc">
+                     <normaloff>:/images/themes/default/pluginExperimental.png</normaloff>:/images/themes/default/pluginExperimental.png</iconset>
+                   </property>
+                  </widget>
+                 </item>
                 </layout>
                </item>
               </layout>


### PR DESCRIPTION
## Description

This PR improves the plugin manager to offer the possibility for users to choose between the stable or the experimental version.

This allows to push pre-releases to the repository for power-users to test, while still allowing them to switch back easily to stable versions, without having to untick the global `enable experimental` option.

For users who didn't check the `enable experimental` option, this PR makes no difference.

For users who checked the `enable experimental` options, there are now two install/upgrade/downgrade buttons when there's both a stable and an experimental release.

Below are some before/after screenshots for a typical plugin (from [this dummy repository](https://raw.githubusercontent.com/olivierdalang/debug-qgis-plugin-repository/master/plugins.xml)).

I still need to test behaviour a bit more (hence draft pull request), but would be interested in collecting feedback for both for UX and code already.

Cheers !

### Plugin not yet installed

Before PR
![e_before_not_installed](https://user-images.githubusercontent.com/1894106/75906876-ac9ed200-5e47-11ea-9b7c-7800837cedc9.PNG)

After PR
![e_after_not_installed](https://user-images.githubusercontent.com/1894106/75906889-b1fc1c80-5e47-11ea-954a-bdb16939b0c6.PNG)


### Experimental version installed

Before PR
![e_before_experimental_installed](https://user-images.githubusercontent.com/1894106/75906894-b294b300-5e47-11ea-9acc-121b32144d85.PNG)

After PR
![e_after_experimental_installed](https://user-images.githubusercontent.com/1894106/75906887-b1638600-5e47-11ea-98c6-06fb664ab177.PNG)

### Stable version installed

Before PR : not possible (unless you uncheck show experimental versions)

After PR
![e_after_stable_installed](https://user-images.githubusercontent.com/1894106/75906892-b1fc1c80-5e47-11ea-86b5-b15995c24362.PNG)



<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
