### PR TITLE
[MESH][3D] fix active faces not supported

### DIFF
--- a/src/3d/mesh/qgsmesh3dgeometry_p.cpp
+++ b/src/3d/mesh/qgsmesh3dgeometry_p.cpp
@@ -144,7 +144,7 @@ static QByteArray createDatasetIndexData( const QgsTriangularMesh &mesh, const Q
   for ( int i = 0; i < trianglesCount; ++i )
   {
     int nativeFaceIndex = mesh.trianglesToNativeFaces()[i];
-    const bool isActive = mActiveFaceFlagValues.active( nativeFaceIndex );
+    const bool isActive = mActiveFaceFlagValues.active().isEmpty() || mActiveFaceFlagValues.active( nativeFaceIndex );
     if ( !isActive )
       continue;
     const QgsMeshFace &face = mesh.triangles().at( i );
@@ -425,12 +425,15 @@ int QgsMeshDataset3dGeometry::extractDataset( QVector<double> &verticalMagnitude
 
   //count active faces
   int activeTriangularCount = 0;
-  for ( int i = 0; i < triangularMesh.triangles().count(); ++i )
-  {
-    int nativeIndex = triangularMesh.trianglesToNativeFaces()[i];
-    if ( activeFaceFlagValues.active( nativeIndex ) )
-      activeTriangularCount++;
-  }
+  if ( activeFaceFlagValues.active().isEmpty() )
+    activeTriangularCount = triangularMesh.triangles().count();
+  else
+    for ( int i = 0; i < triangularMesh.triangles().count(); ++i )
+    {
+      int nativeIndex = triangularMesh.trianglesToNativeFaces()[i];
+      if ( activeFaceFlagValues.active( nativeIndex ) )
+        activeTriangularCount++;
+    }
 
   //extract the scalar dataset used to render color shading
   QgsMeshDataBlock scalarActiveFaceFlagValues =

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -262,8 +262,6 @@ QVector<double> QgsMeshLayerUtils::calculateMagnitudeOnVertices( const QgsMeshLa
   if ( vals.isValid() )
   {
     ret = QgsMeshLayerUtils::calculateMagnitudes( vals );
-    QgsMeshDataBlock scalarActiveFaceFlagValues =
-      meshLayer->dataProvider()->areFacesActive( index, 0, nativeMesh->faces.count() );
 
     if ( !scalarDataOnVertices )
     {


### PR DESCRIPTION
When active face flag values are not supported, the array of those flag are empty. The 3D dataset scalar rendering didn't take account of that case.
This PR fixes this issue