### PR TITLE
Remember parameter values between model designer runs

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -443,6 +443,32 @@ These variables are added to the model's expression context scope, allowing for 
 .. versionadded:: 3.8
 %End
 
+    QVariantMap designerParameterValues() const;
+%Docstring
+Returns the parameter values to use as default values when running this model through the
+designer dialog.
+
+This usually corresponds to the last set of parameter values used when the model was
+run through the designer.
+
+.. seealso:: :py:func:`setDesignerParameterValues`
+
+.. versionadded:: 3.14
+%End
+
+    void setDesignerParameterValues( const QVariantMap &values );
+%Docstring
+Sets the parameter ``values`` to use as default values when running this model through the
+designer dialog.
+
+This usually corresponds to the last set of parameter values used when the model was
+run through the designer.
+
+.. seealso:: :py:func:`designerParameterValues`
+
+.. versionadded:: 3.14
+%End
+
   protected:
 
     virtual QgsProcessingAlgorithm *createInstance() const /Factory/;

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -31,29 +31,31 @@ Model designer dialog base class
 
     QgsModelDesignerDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = 0 );
 
+    virtual void closeEvent( QCloseEvent *event );
+
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;
     virtual QgsProcessingModelAlgorithm *model() = 0;
     virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
+    virtual void exportAsScriptAlgorithm() = 0;
+    virtual void saveModel( bool saveAs = false ) = 0;
 
     QToolBar *toolbar();
     QAction *actionOpen();
-    QAction *actionSave();
-    QAction *actionSaveAs();
     QAction *actionSaveInProject();
     QAction *actionEditHelp();
     QAction *actionRun();
-    QAction *actionExportImage();
     QLineEdit *textName();
     QLineEdit *textGroup();
-    QTreeWidget *inputsTree();
-
     QgsMessageBar *messageBar();
     QGraphicsView *view();
 
     void updateVariablesGui();
+
+    void setDirty( bool dirty );
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -44,9 +44,15 @@ Model designer dialog base class
     QAction *actionEditHelp();
     QAction *actionRun();
     QAction *actionExportImage();
+    QLineEdit *textName();
+    QLineEdit *textGroup();
+    QScrollArea *inputsScrollArea();
+    QgsProcessingToolboxTreeView *algorithmsTree();
 
     QgsMessageBar *messageBar();
     QGraphicsView *view();
+
+    void updateVariablesGui();
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsModelDesignerDialog : QMainWindow
 {
 %Docstring
@@ -26,11 +27,26 @@ Model designer dialog base class
 %End
   public:
 
-    QgsModelDesignerDialog( QWidget *parent = 0, Qt::WindowFlags flags = 0 );
+    QgsModelDesignerDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = 0 );
 
   protected:
 
+    virtual void repaintModel( bool showControls = true ) = 0;
+    virtual QgsProcessingModelAlgorithm *model() = 0;
+    virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
+    virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
+
     QToolBar *toolbar();
+    QAction *actionOpen();
+    QAction *actionSave();
+    QAction *actionSaveAs();
+    QAction *actionSaveInProject();
+    QAction *actionEditHelp();
+    QAction *actionRun();
+    QAction *actionExportImage();
+
+    QgsMessageBar *messageBar();
+    QGraphicsView *view();
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsModelDesignerDialog : QMainWindow
 {
 %Docstring
@@ -47,7 +49,6 @@ Model designer dialog base class
     QLineEdit *textName();
     QLineEdit *textGroup();
     QTreeWidget *inputsTree();
-    QgsProcessingToolboxTreeView *algorithmsTree();
 
     QgsMessageBar *messageBar();
     QGraphicsView *view();

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -46,7 +46,7 @@ Model designer dialog base class
     QAction *actionExportImage();
     QLineEdit *textName();
     QLineEdit *textGroup();
-    QScrollArea *inputsScrollArea();
+    QTreeWidget *inputsTree();
     QgsProcessingToolboxTreeView *algorithmsTree();
 
     QgsMessageBar *messageBar();

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -1,0 +1,44 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/processing/models/qgsmodeldesignerdialog.h                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsModelDesignerDialog : QMainWindow
+{
+%Docstring
+Model designer dialog base class
+
+.. warning::
+
+   Not stable API
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsmodeldesignerdialog.h"
+%End
+  public:
+
+    QgsModelDesignerDialog( QWidget *parent = 0, Qt::WindowFlags flags = 0 );
+
+  protected:
+
+    QToolBar *toolbar();
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/processing/models/qgsmodeldesignerdialog.h                   *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -36,6 +36,7 @@ QGraphicsScene subclass representing the model designer.
     enum Flag
     {
       FlagHideControls,
+      FlagHideComments,
     };
     typedef QFlags<QgsModelGraphicsScene::Flag> Flags;
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -1,0 +1,70 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/processing/models/qgsmodelgraphicsview.h                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsModelGraphicsView : QGraphicsView
+{
+%Docstring
+QGraphicsView subclass representing the model designer.
+
+.. warning::
+
+   Not stable API
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsmodelgraphicsview.h"
+%End
+  public:
+
+    QgsModelGraphicsView( QWidget *parent = 0 );
+%Docstring
+Constructor for QgsModelGraphicsView, with the specified ``parent`` widget.
+%End
+
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+    virtual void dropEvent( QDropEvent *event );
+
+    virtual void dragMoveEvent( QDragMoveEvent *event );
+
+    virtual void wheelEvent( QWheelEvent *event );
+
+    virtual void enterEvent( QEvent *event );
+
+    virtual void mousePressEvent( QMouseEvent *event );
+
+    virtual void mouseMoveEvent( QMouseEvent *event );
+
+
+  signals:
+
+    void algorithmDropped( const QString &algorithmId, const QPointF &pos );
+%Docstring
+Emitted when an algorithm is dropped onto the view.
+%End
+
+    void inputDropped( const QString &inputId, const QPointF &pos );
+%Docstring
+Emitted when an input parameter is dropped onto the view.
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/processing/models/qgsmodelgraphicsview.h                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
@@ -405,6 +405,7 @@ level group containing recently used algorithms.
 Returns the underlying source Processing toolbox model.
 %End
 
+
     void setFilters( QgsProcessingToolboxProxyModel::Filters filters );
 %Docstring
 Set ``filters`` that affect how toolbox content is filtered.

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -314,6 +314,7 @@
 %Include auto_generated/processing/models/qgsmodeldesignerdialog.sip
 %Include auto_generated/processing/models/qgsmodelgraphicitem.sip
 %Include auto_generated/processing/models/qgsmodelgraphicsscene.sip
+%Include auto_generated/processing/models/qgsmodelgraphicsview.sip
 %Include auto_generated/raster/qgscolorrampshaderwidget.sip
 %Include auto_generated/raster/qgshillshaderendererwidget.sip
 %Include auto_generated/raster/qgsmultibandcolorrendererwidget.sip

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -311,6 +311,7 @@
 %Include auto_generated/processing/qgsprocessingwidgetwrapper.sip
 %Include auto_generated/processing/models/qgsmodelarrowitem.sip
 %Include auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip
+%Include auto_generated/processing/models/qgsmodeldesignerdialog.sip
 %Include auto_generated/processing/models/qgsmodelgraphicitem.sip
 %Include auto_generated/processing/models/qgsmodelgraphicsscene.sip
 %Include auto_generated/raster/qgscolorrampshaderwidget.sip

--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -122,7 +122,7 @@ class ProcessingModelItem(QgsDataItem):
         ProcessingDropHandler.runAlg(self.path())
 
     def editModel(self):
-        dlg = ModelerDialog()
+        dlg = ModelerDialog.create()
         dlg.loadModel(self.path())
         dlg.show()
 
@@ -332,7 +332,7 @@ class ProcessingPlugin:
         self.toolboxAction.setChecked(visible)
 
     def openModeler(self):
-        dlg = ModelerDialog()
+        dlg = ModelerDialog.create()
         dlg.update_model.connect(self.updateModel)
         dlg.show()
 

--- a/python/plugins/processing/modeler/CreateNewModelAction.py
+++ b/python/plugins/processing/modeler/CreateNewModelAction.py
@@ -26,6 +26,7 @@ import os
 from qgis.PyQt.QtCore import QCoreApplication
 
 from qgis.core import QgsApplication
+from qgis.utils import iface
 
 from processing.gui.ToolboxAction import ToolboxAction
 from processing.modeler.ModelerDialog import ModelerDialog
@@ -43,7 +44,7 @@ class CreateNewModelAction(ToolboxAction):
         return QgsApplication.getThemeIcon("/processingModel.svg")
 
     def execute(self):
-        dlg = ModelerDialog()
+        dlg = ModelerDialog.create()
         dlg.update_model.connect(self.updateModel)
         dlg.show()
 

--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -44,7 +44,7 @@ class EditModelAction(ContextAction):
         if not ok:
             iface.messageBar().pushMessage(QCoreApplication.translate('EditModelAction', 'Cannot edit model: {}').format(msg), level=Qgis.Warning)
         else:
-            dlg = ModelerDialog(alg)
+            dlg = ModelerDialog.create(alg)
             dlg.update_model.connect(self.updateModel)
             dlg.show()
 

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -49,8 +49,7 @@ from qgis.core import (Qgis,
                        QgsProcessingModelParameter,
                        QgsProcessingParameterType,
                        )
-from qgis.gui import (QgsProcessingToolboxProxyModel,
-                      QgsProcessingParameterDefinitionDialog,
+from qgis.gui import (QgsProcessingParameterDefinitionDialog,
                       QgsProcessingParameterWidgetContext,
                       QgsModelGraphicsScene,
                       QgsModelDesignerDialog)
@@ -66,22 +65,6 @@ from processing.tools.dataobjects import createContext
 from qgis.utils import iface
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
-
-
-class ModelerToolboxModel(QgsProcessingToolboxProxyModel):
-
-    def __init__(self, parent=None, registry=None, recentLog=None):
-        super().__init__(parent, registry, recentLog)
-
-    def flags(self, index):
-        f = super().flags(index)
-        source_index = self.mapToSource(index)
-        if self.toolboxModel().isAlgorithm(source_index):
-            f = f | Qt.ItemIsDragEnabled
-        return f
-
-    def supportedDragActions(self):
-        return Qt.CopyAction
 
 
 class ModelerDialog(QgsModelDesignerDialog):
@@ -136,9 +119,6 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.view().setScene(self.scene)
         self.view().ensureVisible(0, 0, 10, 10)
         self.view().scale(QgsApplication.desktop().logicalDpiX() / 96, QgsApplication.desktop().logicalDpiX() / 96)
-
-        self.algorithms_model = ModelerToolboxModel(self, QgsApplication.processingRegistry())
-        self.algorithmsTree().setToolboxProxyModel(self.algorithms_model)
 
         # Connect signals and slots
         self.inputsTree().doubleClicked.connect(self._addInput)
@@ -473,8 +453,8 @@ class ModelerDialog(QgsModelDesignerDialog):
             maxX = max([alg.position().x() for alg in list(self.model().childAlgorithms().values())])
             maxY = max([alg.position().y() for alg in list(self.model().childAlgorithms().values())])
             newX = min(MARGIN + BOX_WIDTH + maxX, self.CANVAS_SIZE - BOX_WIDTH)
-            newY = min(MARGIN + BOX_HEIGHT + maxY, self.CANVAS_SIZE -
-                       BOX_HEIGHT)
+            newY = min(MARGIN + BOX_HEIGHT + maxY, self.CANVAS_SIZE
+                       - BOX_HEIGHT)
         else:
             newX = MARGIN + BOX_WIDTH / 2
             newY = MARGIN * 2 + BOX_HEIGHT + BOX_HEIGHT / 2

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -543,7 +543,11 @@ class ModelerDialog(BASE, WIDGET):
             return
 
         dlg = AlgorithmDialog(self.model.create(), parent=iface.mainWindow())
+        dlg.setParameters(self.model.designerParameterValues())
         dlg.exec_()
+
+        if dlg.wasExecuted():
+            self.model.setDesignerParameterValues(dlg.getParameterValues())
 
     def save(self):
         self.saveModel(False)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -87,7 +87,8 @@ from qgis.gui import (QgsMessageBar,
                       QgsProcessingParameterDefinitionDialog,
                       QgsVariableEditorWidget,
                       QgsProcessingParameterWidgetContext,
-                      QgsModelGraphicsScene)
+                      QgsModelGraphicsScene,
+                      QgsModelDesignerDialog)
 from processing.gui.HelpEditionDialog import HelpEditionDialog
 from processing.gui.AlgorithmDialog import AlgorithmDialog
 from processing.modeler.ModelerParameterDefinitionDialog import ModelerParameterDefinitionDialog
@@ -102,10 +103,6 @@ from qgis.utils import iface
 
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    WIDGET, BASE = uic.loadUiType(
-        os.path.join(pluginPath, 'ui', 'DlgModeler.ui'))
 
 
 class ModelerToolboxModel(QgsProcessingToolboxProxyModel):
@@ -124,7 +121,7 @@ class ModelerToolboxModel(QgsProcessingToolboxProxyModel):
         return Qt.CopyAction
 
 
-class ModelerDialog(BASE, WIDGET):
+class ModelerDialog(QgsModelDesignerDialog):
     ALG_ITEM = 'ALG_ITEM'
     PROVIDER_ITEM = 'PROVIDER_ITEM'
     GROUP_ITEM = 'GROUP_ITEM'
@@ -140,8 +137,6 @@ class ModelerDialog(BASE, WIDGET):
     def __init__(self, model=None):
         super().__init__(None)
         self.setAttribute(Qt.WA_DeleteOnClose)
-
-        self.setupUi(self)
 
         self._variables_scope = None
 
@@ -273,7 +268,7 @@ class ModelerDialog(BASE, WIDGET):
             pass
 
         if iface is not None:
-            self.mToolbar.setIconSize(iface.iconSize())
+            self.toolbar().setIconSize(iface.iconSize())
             self.setStyleSheet(iface.mainWindow().styleSheet())
 
         self.toolbutton_export_to_script = QToolButton()
@@ -281,37 +276,8 @@ class ModelerDialog(BASE, WIDGET):
         self.export_to_script_algorithm_action = QAction(QCoreApplication.translate('ModelerDialog', 'Export as Script Algorithm…'))
         self.toolbutton_export_to_script.addActions([self.export_to_script_algorithm_action])
         self.toolbutton_export_to_script.setDefaultAction(self.export_to_script_algorithm_action)
-        self.mToolbar.insertWidget(self.mActionExportImage, self.toolbutton_export_to_script)
+        self.toolbar().insertWidget(self.mActionExportImage, self.toolbutton_export_to_script)
         self.export_to_script_algorithm_action.triggered.connect(self.export_as_script_algorithm)
-
-        self.mActionOpen.setIcon(
-            QgsApplication.getThemeIcon('/mActionFileOpen.svg'))
-        self.mActionSave.setIcon(
-            QgsApplication.getThemeIcon('/mActionFileSave.svg'))
-        self.mActionSaveAs.setIcon(
-            QgsApplication.getThemeIcon('/mActionFileSaveAs.svg'))
-        self.mActionSaveInProject.setIcon(
-            QgsApplication.getThemeIcon('/mAddToProject.svg'))
-        self.mActionZoomActual.setIcon(
-            QgsApplication.getThemeIcon('/mActionZoomActual.svg'))
-        self.mActionZoomIn.setIcon(
-            QgsApplication.getThemeIcon('/mActionZoomIn.svg'))
-        self.mActionZoomOut.setIcon(
-            QgsApplication.getThemeIcon('/mActionZoomOut.svg'))
-        self.mActionExportImage.setIcon(
-            QgsApplication.getThemeIcon('/mActionSaveMapAsImage.svg'))
-        self.mActionZoomToItems.setIcon(
-            QgsApplication.getThemeIcon('/mActionZoomFullExtent.svg'))
-        self.mActionExportPdf.setIcon(
-            QgsApplication.getThemeIcon('/mActionSaveAsPDF.svg'))
-        self.mActionExportSvg.setIcon(
-            QgsApplication.getThemeIcon('/mActionSaveAsSVG.svg'))
-        self.toolbutton_export_to_script.setIcon(
-            QgsApplication.getThemeIcon('/mActionSaveAsPython.svg'))
-        self.mActionEditHelp.setIcon(
-            QgsApplication.getThemeIcon('/mActionEditHelpContent.svg'))
-        self.mActionRun.setIcon(
-            QgsApplication.getThemeIcon('/mActionStart.svg'))
 
         self.addDockWidget(Qt.LeftDockWidgetArea, self.propertiesDock)
         self.addDockWidget(Qt.LeftDockWidgetArea, self.inputsDock)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -132,7 +132,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         if len(self.model().childAlgorithms()) == 0:
             self.messageBar().pushMessage("", self.tr(
                 "Model doesn't contain any algorithm and/or parameter and can't be executed"), level=Qgis.Warning,
-                                          duration=5)
+                duration=5)
             return
 
         dlg = AlgorithmDialog(self.model().create(), parent=self)
@@ -205,7 +205,7 @@ class ModelerDialog(QgsModelDesignerDialog):
             if saveAs:
                 self.messageBar().pushMessage("", self.tr("Model was correctly saved to <a href=\"{}\">{}</a>").format(
                     QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success,
-                                              duration=5)
+                    duration=5)
             else:
                 self.messageBar().pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
 
@@ -377,8 +377,8 @@ class ModelerDialog(QgsModelDesignerDialog):
             maxX = max([alg.position().x() for alg in list(self.model().childAlgorithms().values())])
             maxY = max([alg.position().y() for alg in list(self.model().childAlgorithms().values())])
             newX = min(MARGIN + BOX_WIDTH + maxX, self.CANVAS_SIZE - BOX_WIDTH)
-            newY = min(MARGIN + BOX_HEIGHT + maxY, self.CANVAS_SIZE -
-                       BOX_HEIGHT)
+            newY = min(MARGIN + BOX_HEIGHT + maxY, self.CANVAS_SIZE
+                       - BOX_HEIGHT)
         else:
             newX = MARGIN + BOX_WIDTH / 2
             newY = MARGIN * 2 + BOX_HEIGHT + BOX_HEIGHT / 2

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -462,6 +462,7 @@ class ModelerDialog(BASE, WIDGET):
         ctrlEquals = QShortcut(QKeySequence("Ctrl+="), self)
         ctrlEquals.activated.connect(self.zoomIn)
 
+        self.mActionClose.triggered.connect(self.close)
         self.mActionOpen.triggered.connect(self.openModel)
         self.mActionSave.triggered.connect(self.save)
         self.mActionSaveAs.triggered.connect(self.saveAs)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -38,10 +38,10 @@ from qgis.core import (Qgis,
                        QgsApplication,
                        QgsProcessing,
                        QgsProject,
-                       QgsSettings,
                        QgsMessageLog,
                        QgsProcessingModelAlgorithm,
                        QgsProcessingModelParameter,
+                       QgsSettings
                        )
 from qgis.gui import (QgsProcessingParameterDefinitionDialog,
                       QgsProcessingParameterWidgetContext,
@@ -102,9 +102,6 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.actionEditHelp().triggered.connect(self.editHelp)
         self.actionRun().triggered.connect(self.runModel)
 
-        #        self.mActionShowComments.toggled.connect(self.showComments)
-        # self.mActionShowComments.setChecked(settings.value("/Processing/stateModeler", self.saveState())))
-
         if model is not None:
             self._model = model.create()
             self._model.setSourceFilePath(model.sourceFilePath())
@@ -135,7 +132,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         if len(self.model().childAlgorithms()) == 0:
             self.messageBar().pushMessage("", self.tr(
                 "Model doesn't contain any algorithm and/or parameter and can't be executed"), level=Qgis.Warning,
-                duration=5)
+                                          duration=5)
             return
 
         dlg = AlgorithmDialog(self.model().create(), parent=self)
@@ -208,7 +205,7 @@ class ModelerDialog(QgsModelDesignerDialog):
             if saveAs:
                 self.messageBar().pushMessage("", self.tr("Model was correctly saved to <a href=\"{}\">{}</a>").format(
                     QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success,
-                    duration=5)
+                                              duration=5)
             else:
                 self.messageBar().pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
 
@@ -250,6 +247,10 @@ class ModelerDialog(QgsModelDesignerDialog):
 
         if not showControls:
             self.scene.setFlag(QgsModelGraphicsScene.FlagHideControls)
+
+        showComments = QgsSettings().value("/Processing/Modeler/ShowComments", True, bool)
+        if not showComments:
+            self.scene.setFlag(QgsModelGraphicsScene.FlagHideComments)
 
         context = createContext()
         self.scene.createItems(self.model(), context)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -21,12 +21,9 @@ __author__ = 'Victor Olaya'
 __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
-import codecs
 import sys
 import os
-import warnings
 
-from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (
     Qt,
     QCoreApplication,
@@ -35,22 +32,14 @@ from qgis.PyQt.QtCore import (
     QMimeData,
     QPoint,
     QPointF,
-    QByteArray,
-    QSize,
-    QSizeF,
     pyqtSignal,
-    QDataStream,
-    QIODevice,
-    QUrl,
-    QTimer)
-from qgis.PyQt.QtWidgets import (QGraphicsView,
-                                 QTreeWidget,
+    QUrl)
+from qgis.PyQt.QtWidgets import (QTreeWidget,
                                  QMessageBox,
                                  QFileDialog,
                                  QTreeWidgetItem,
                                  QSizePolicy,
                                  QMainWindow,
-                                 QShortcut,
                                  QLabel,
                                  QDockWidget,
                                  QWidget,
@@ -60,12 +49,7 @@ from qgis.PyQt.QtWidgets import (QGraphicsView,
                                  QLineEdit,
                                  QToolButton,
                                  QAction)
-from qgis.PyQt.QtGui import (QIcon,
-                             QImage,
-                             QPainter,
-                             QKeySequence)
-from qgis.PyQt.QtSvg import QSvgGenerator
-from qgis.PyQt.QtPrintSupport import QPrinter
+from qgis.PyQt.QtGui import QIcon
 from qgis.core import (Qgis,
                        QgsApplication,
                        QgsProcessing,
@@ -78,8 +62,7 @@ from qgis.core import (Qgis,
                        QgsExpressionContextScope,
                        QgsExpressionContext
                        )
-from qgis.gui import (QgsMessageBar,
-                      QgsDockWidget,
+from qgis.gui import (QgsDockWidget,
                       QgsScrollArea,
                       QgsFilterLineEdit,
                       QgsProcessingToolboxTreeView,
@@ -100,7 +83,6 @@ from processing.script.ScriptEditorDialog import ScriptEditorDialog
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.tools.dataobjects import createContext
 from qgis.utils import iface
-
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
 
@@ -134,11 +116,24 @@ class ModelerDialog(QgsModelDesignerDialog):
 
     update_model = pyqtSignal()
 
-    def __init__(self, model=None):
-        super().__init__(None)
-        self.setAttribute(Qt.WA_DeleteOnClose)
+    dlgs = []
 
+    @staticmethod
+    def create(model=None):
+        """
+        Workaround crappy sip handling of QMainWindow. It doesn't know that we are using the deleteonclose
+        flag, so happily just deletes dialogs as soon as they go out of scope. The only workaround possible
+        while we still have to drag around this Python code is to store a reference to the sip wrapper so that
+        sip doesn't get confused. The underlying object will still be deleted by the deleteonclose flag though!
+        """
+        dlg = ModelerDialog(model)
+        ModelerDialog.dlgs.append(dlg)
+        return dlg
+
+    def __init__(self, model=None, parent=None):
+        super().__init__(parent)
         self._variables_scope = None
+        self._model = None
 
         # LOTS of bug reports when we include the dock creation in the UI file
         # see e.g. #16428, #19068
@@ -258,10 +253,6 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.tabifyDockWidget(self.propertiesDock, self.variables_dock)
         self.variables_editor.scopeChanged.connect(self.variables_changed)
 
-        self.bar = QgsMessageBar()
-        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
-        self.centralWidget().layout().insertWidget(0, self.bar)
-
         try:
             self.setDockOptions(self.dockOptions() | QMainWindow.GroupedDragging)
         except:
@@ -273,10 +264,11 @@ class ModelerDialog(QgsModelDesignerDialog):
 
         self.toolbutton_export_to_script = QToolButton()
         self.toolbutton_export_to_script.setPopupMode(QToolButton.InstantPopup)
-        self.export_to_script_algorithm_action = QAction(QCoreApplication.translate('ModelerDialog', 'Export as Script Algorithm…'))
+        self.export_to_script_algorithm_action = QAction(
+            QCoreApplication.translate('ModelerDialog', 'Export as Script Algorithm…'))
         self.toolbutton_export_to_script.addActions([self.export_to_script_algorithm_action])
         self.toolbutton_export_to_script.setDefaultAction(self.export_to_script_algorithm_action)
-        self.toolbar().insertWidget(self.mActionExportImage, self.toolbutton_export_to_script)
+        self.toolbar().insertWidget(self.actionExportImage(), self.toolbutton_export_to_script)
         self.export_to_script_algorithm_action.triggered.connect(self.export_as_script_algorithm)
 
         self.addDockWidget(Qt.LeftDockWidgetArea, self.propertiesDock)
@@ -285,111 +277,14 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.tabifyDockWidget(self.inputsDock, self.algorithmsDock)
         self.inputsDock.raise_()
 
-        self.setWindowFlags(Qt.WindowMinimizeButtonHint |
-                            Qt.WindowMaximizeButtonHint |
-                            Qt.WindowCloseButtonHint)
-
-        settings = QgsSettings()
-        self.restoreState(settings.value("/Processing/stateModeler", QByteArray()))
-        self.restoreGeometry(settings.value("/Processing/geometryModeler", QByteArray()))
-
         self.scene = ModelerScene(self)
         self.scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE, self.CANVAS_SIZE))
         self.scene.rebuildRequired.connect(self.repaintModel)
         self.scene.componentChanged.connect(self.componentChanged)
 
-        self.view.setScene(self.scene)
-        self.view.setAcceptDrops(True)
-        self.view.ensureVisible(0, 0, 10, 10)
-        self.view.scale(QgsApplication.desktop().logicalDpiX() / 96, QgsApplication.desktop().logicalDpiX() / 96)
-
-        def _dragEnterEvent(event):
-            if event.mimeData().hasText() or event.mimeData().hasFormat('application/x-vnd.qgis.qgis.algorithmid'):
-                event.acceptProposedAction()
-            else:
-                event.ignore()
-
-        def _dropEvent(event):
-            def alg_dropped(algorithm_id, pos):
-                alg = QgsApplication.processingRegistry().createAlgorithmById(algorithm_id)
-                if alg is not None:
-                    self._addAlgorithm(alg, pos)
-                else:
-                    assert False, algorithm_id
-
-            def input_dropped(id, pos):
-                if id in [param.id() for param in QgsApplication.instance().processingRegistry().parameterTypes()]:
-                    self.addInputOfType(itemId, pos)
-
-            if event.mimeData().hasFormat('application/x-vnd.qgis.qgis.algorithmid'):
-                data = event.mimeData().data('application/x-vnd.qgis.qgis.algorithmid')
-                stream = QDataStream(data, QIODevice.ReadOnly)
-                algorithm_id = stream.readQString()
-                QTimer.singleShot(0, lambda id=algorithm_id, pos=self.view.mapToScene(event.pos()): alg_dropped(id, pos))
-                event.accept()
-            elif event.mimeData().hasText():
-                itemId = event.mimeData().text()
-                QTimer.singleShot(0, lambda id=itemId, pos=self.view.mapToScene(event.pos()): input_dropped(id, pos))
-                event.accept()
-            else:
-                event.ignore()
-
-        def _dragMoveEvent(event):
-            if event.mimeData().hasText() or event.mimeData().hasFormat('application/x-vnd.qgis.qgis.algorithmid'):
-                event.accept()
-            else:
-                event.ignore()
-
-        def _wheelEvent(event):
-            self.view.setTransformationAnchor(QGraphicsView.AnchorUnderMouse)
-
-            settings = QgsSettings()
-            factor = settings.value('/qgis/zoom_favor', 2.0)
-
-            # "Normal" mouse has an angle delta of 120, precision mouses provide data
-            # faster, in smaller steps
-            factor = 1.0 + (factor - 1.0) / 120.0 * abs(event.angleDelta().y())
-
-            if (event.modifiers() == Qt.ControlModifier):
-                factor = 1.0 + (factor - 1.0) / 20.0
-
-            if event.angleDelta().y() < 0:
-                factor = 1 / factor
-
-            self.view.scale(factor, factor)
-
-        def _enterEvent(e):
-            QGraphicsView.enterEvent(self.view, e)
-            self.view.viewport().setCursor(Qt.ArrowCursor)
-
-        def _mouseReleaseEvent(e):
-            QGraphicsView.mouseReleaseEvent(self.view, e)
-            self.view.viewport().setCursor(Qt.ArrowCursor)
-
-        def _mousePressEvent(e):
-            if e.button() == Qt.MidButton:
-                self.previousMousePos = e.pos()
-            else:
-                QGraphicsView.mousePressEvent(self.view, e)
-
-        def _mouseMoveEvent(e):
-            if e.buttons() == Qt.MidButton:
-                offset = self.previousMousePos - e.pos()
-                self.previousMousePos = e.pos()
-
-                self.view.verticalScrollBar().setValue(self.view.verticalScrollBar().value() + offset.y())
-                self.view.horizontalScrollBar().setValue(self.view.horizontalScrollBar().value() + offset.x())
-            else:
-                QGraphicsView.mouseMoveEvent(self.view, e)
-
-        self.view.setDragMode(QGraphicsView.ScrollHandDrag)
-        self.view.dragEnterEvent = _dragEnterEvent
-        self.view.dropEvent = _dropEvent
-        self.view.dragMoveEvent = _dragMoveEvent
-        self.view.wheelEvent = _wheelEvent
-        self.view.enterEvent = _enterEvent
-        self.view.mousePressEvent = _mousePressEvent
-        self.view.mouseMoveEvent = _mouseMoveEvent
+        self.view().setScene(self.scene)
+        self.view().ensureVisible(0, 0, 10, 10)
+        self.view().scale(QgsApplication.desktop().logicalDpiX() / 96, QgsApplication.desktop().logicalDpiX() / 96)
 
         def _mimeDataInput(items):
             mimeData = QMimeData()
@@ -420,54 +315,40 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.textGroup.setPlaceholderText(self.tr('Enter group name here'))
 
         # Connect signals and slots
-        self.inputsTree.doubleClicked.connect(self.addInput)
+        self.inputsTree.doubleClicked.connect(self._addInput)
         self.searchBox.textChanged.connect(self.algorithmTree.setFilterString)
-        self.algorithmTree.doubleClicked.connect(self.addAlgorithm)
+        self.algorithmTree.doubleClicked.connect(self._addAlgorithm)
 
-        # Ctrl+= should also trigger a zoom in action
-        ctrlEquals = QShortcut(QKeySequence("Ctrl+="), self)
-        ctrlEquals.activated.connect(self.zoomIn)
+        self.actionOpen().triggered.connect(self.openModel)
+        self.actionSave().triggered.connect(self.save)
+        self.actionSaveAs().triggered.connect(self.saveAs)
+        self.actionSaveInProject().triggered.connect(self.saveInProject)
+        self.actionEditHelp().triggered.connect(self.editHelp)
+        self.actionRun().triggered.connect(self.runModel)
 
-        self.mActionClose.triggered.connect(self.close)
-        self.mActionOpen.triggered.connect(self.openModel)
-        self.mActionSave.triggered.connect(self.save)
-        self.mActionSaveAs.triggered.connect(self.saveAs)
-        self.mActionSaveInProject.triggered.connect(self.saveInProject)
-        self.mActionZoomIn.triggered.connect(self.zoomIn)
-        self.mActionZoomOut.triggered.connect(self.zoomOut)
-        self.mActionZoomActual.triggered.connect(self.zoomActual)
-        self.mActionZoomToItems.triggered.connect(self.zoomToItems)
-        self.mActionExportImage.triggered.connect(self.exportAsImage)
-        self.mActionExportPdf.triggered.connect(self.exportAsPdf)
-        self.mActionExportSvg.triggered.connect(self.exportAsSvg)
-        #self.mActionExportPython.triggered.connect(self.exportAsPython)
-        self.mActionEditHelp.triggered.connect(self.editHelp)
-        self.mActionRun.triggered.connect(self.runModel)
+        #        self.mActionShowComments.toggled.connect(self.showComments)
+        # self.mActionShowComments.setChecked(settings.value("/Processing/stateModeler", self.saveState())))
 
         if model is not None:
-            self.model = model.create()
-            self.model.setSourceFilePath(model.sourceFilePath())
-            self.textGroup.setText(self.model.group())
-            self.textName.setText(self.model.displayName())
+            self._model = model.create()
+            self._model.setSourceFilePath(model.sourceFilePath())
+            self.textGroup.setText(self._model.group())
+            self.textName.setText(self._model.displayName())
             self.repaintModel()
 
         else:
-            self.model = QgsProcessingModelAlgorithm()
-            self.model.setProvider(QgsApplication.processingRegistry().providerById('model'))
+            self._model = QgsProcessingModelAlgorithm()
+            self._model.setProvider(QgsApplication.processingRegistry().providerById('model'))
         self.update_variables_gui()
 
         self.fillInputsTree()
 
-        self.view.centerOn(0, 0)
+        self.view().centerOn(0, 0)
         self.help = None
 
         self.hasChanged = False
 
     def closeEvent(self, evt):
-        settings = QgsSettings()
-        settings.setValue("/Processing/stateModeler", self.saveState())
-        settings.setValue("/Processing/geometryModeler", self.saveGeometry())
-
         if self.hasChanged:
             ret = QMessageBox.question(
                 self, self.tr('Save Model?'),
@@ -484,17 +365,20 @@ class ModelerDialog(QgsModelDesignerDialog):
         else:
             evt.accept()
 
+    def model(self):
+        return self._model
+
     def editHelp(self):
-        alg = self.model
+        alg = self.model()
         dlg = HelpEditionDialog(alg)
         dlg.exec_()
         if dlg.descriptions:
-            self.model.setHelpContent(dlg.descriptions)
+            self.model().setHelpContent(dlg.descriptions)
             self.hasChanged = True
 
     def update_variables_gui(self):
         variables_scope = QgsExpressionContextScope(self.tr('Model Variables'))
-        for k, v in self.model.variables().items():
+        for k, v in self.model().variables().items():
             variables_scope.setVariable(k, v)
         variables_context = QgsExpressionContext()
         variables_context.appendScope(variables_scope)
@@ -502,19 +386,21 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.variables_editor.setEditableScopeIndex(0)
 
     def variables_changed(self):
-        self.model.setVariables(self.variables_editor.variablesInActiveScope())
+        self.model().setVariables(self.variables_editor.variablesInActiveScope())
 
     def runModel(self):
-        if len(self.model.childAlgorithms()) == 0:
-            self.bar.pushMessage("", self.tr("Model doesn't contain any algorithm and/or parameter and can't be executed"), level=Qgis.Warning, duration=5)
+        if len(self.model().childAlgorithms()) == 0:
+            self.messageBar().pushMessage("", self.tr(
+                "Model doesn't contain any algorithm and/or parameter and can't be executed"), level=Qgis.Warning,
+                duration=5)
             return
 
-        dlg = AlgorithmDialog(self.model.create(), parent=iface.mainWindow())
-        dlg.setParameters(self.model.designerParameterValues())
+        dlg = AlgorithmDialog(self.model().create(), parent=self)
+        dlg.setParameters(self.model().designerParameterValues())
         dlg.exec_()
 
         if dlg.wasExecuted():
-            self.model.setDesignerParameterValues(dlg.getParameterValues())
+            self.model().setDesignerParameterValues(dlg.getParameterValues())
 
     def save(self):
         self.saveModel(False)
@@ -526,153 +412,19 @@ class ModelerDialog(QgsModelDesignerDialog):
         if not self.can_save():
             return
 
-        self.model.setName(str(self.textName.text()))
-        self.model.setGroup(str(self.textGroup.text()))
-        self.model.setSourceFilePath(None)
+        self.model().setName(str(self.textName.text()))
+        self.model().setGroup(str(self.textGroup.text()))
+        self.model().setSourceFilePath(None)
 
         project_provider = QgsApplication.processingRegistry().providerById(PROJECT_PROVIDER_ID)
-        project_provider.add_model(self.model)
+        project_provider.add_model(self.model())
 
         self.update_model.emit()
-        self.bar.pushMessage("", self.tr("Model was saved inside current project"), level=Qgis.Success, duration=5)
+        self.messageBar().pushMessage("", self.tr("Model was saved inside current project"), level=Qgis.Success,
+                                      duration=5)
 
         self.hasChanged = False
         QgsProject.instance().setDirty(True)
-
-    def zoomIn(self):
-        self.view.setTransformationAnchor(QGraphicsView.NoAnchor)
-        point = self.view.mapToScene(QPoint(self.view.viewport().width() / 2, self.view.viewport().height() / 2))
-
-        settings = QgsSettings()
-        factor = settings.value('/qgis/zoom_favor', 2.0)
-
-        self.view.scale(factor, factor)
-        self.view.centerOn(point)
-        self.repaintModel()
-
-    def zoomOut(self):
-        self.view.setTransformationAnchor(QGraphicsView.NoAnchor)
-        point = self.view.mapToScene(QPoint(self.view.viewport().width() / 2, self.view.viewport().height() / 2))
-
-        settings = QgsSettings()
-        factor = settings.value('/qgis/zoom_favor', 2.0)
-        factor = 1 / factor
-
-        self.view.scale(factor, factor)
-        self.view.centerOn(point)
-        self.repaintModel()
-
-    def zoomActual(self):
-        point = self.view.mapToScene(QPoint(self.view.viewport().width() / 2, self.view.viewport().height() / 2))
-        self.view.resetTransform()
-        self.view.scale(QgsApplication.desktop().logicalDpiX() / 96, QgsApplication.desktop().logicalDpiX() / 96)
-        self.view.centerOn(point)
-
-    def zoomToItems(self):
-        totalRect = self.scene.itemsBoundingRect()
-        totalRect.adjust(-10, -10, 10, 10)
-        self.view.fitInView(totalRect, Qt.KeepAspectRatio)
-
-    def exportAsImage(self):
-        self.repaintModel(controls=False)
-        filename, fileFilter = QFileDialog.getSaveFileName(self,
-                                                           self.tr('Save Model As Image'), '',
-                                                           self.tr('PNG files (*.png *.PNG)'))
-        if not filename:
-            return
-
-        if not filename.lower().endswith('.png'):
-            filename += '.png'
-
-        totalRect = self.scene.itemsBoundingRect()
-        totalRect.adjust(-10, -10, 10, 10)
-        imgRect = QRectF(0, 0, totalRect.width(), totalRect.height())
-
-        img = QImage(totalRect.width(), totalRect.height(),
-                     QImage.Format_ARGB32_Premultiplied)
-        img.fill(Qt.white)
-        painter = QPainter()
-        painter.setRenderHint(QPainter.Antialiasing)
-        painter.begin(img)
-        self.scene.render(painter, imgRect, totalRect)
-        painter.end()
-
-        img.save(filename)
-
-        self.bar.pushMessage("", self.tr("Successfully exported model as image to <a href=\"{}\">{}</a>").format(QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success, duration=5)
-        self.repaintModel(controls=True)
-
-    def exportAsPdf(self):
-        self.repaintModel(controls=False)
-        filename, fileFilter = QFileDialog.getSaveFileName(self,
-                                                           self.tr('Save Model As PDF'), '',
-                                                           self.tr('PDF files (*.pdf *.PDF)'))
-        if not filename:
-            return
-
-        if not filename.lower().endswith('.pdf'):
-            filename += '.pdf'
-
-        totalRect = self.scene.itemsBoundingRect()
-        totalRect.adjust(-10, -10, 10, 10)
-        printerRect = QRectF(0, 0, totalRect.width(), totalRect.height())
-
-        printer = QPrinter()
-        printer.setOutputFormat(QPrinter.PdfFormat)
-        printer.setOutputFileName(filename)
-        printer.setPaperSize(QSizeF(printerRect.width(), printerRect.height()), QPrinter.DevicePixel)
-        printer.setFullPage(True)
-
-        painter = QPainter(printer)
-        self.scene.render(painter, printerRect, totalRect)
-        painter.end()
-
-        self.bar.pushMessage("", self.tr("Successfully exported model as PDF to <a href=\"{}\">{}</a>").format(QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success, duration=5)
-        self.repaintModel(controls=True)
-
-    def exportAsSvg(self):
-        self.repaintModel(controls=False)
-        filename, fileFilter = QFileDialog.getSaveFileName(self,
-                                                           self.tr('Save Model As SVG'), '',
-                                                           self.tr('SVG files (*.svg *.SVG)'))
-        if not filename:
-            return
-
-        if not filename.lower().endswith('.svg'):
-            filename += '.svg'
-
-        totalRect = self.scene.itemsBoundingRect()
-        totalRect.adjust(-10, -10, 10, 10)
-        svgRect = QRectF(0, 0, totalRect.width(), totalRect.height())
-
-        svg = QSvgGenerator()
-        svg.setFileName(filename)
-        svg.setSize(QSize(totalRect.width(), totalRect.height()))
-        svg.setViewBox(svgRect)
-        svg.setTitle(self.model.displayName())
-
-        painter = QPainter(svg)
-        self.scene.render(painter, svgRect, totalRect)
-        painter.end()
-
-        self.bar.pushMessage("", self.tr("Successfully exported model as SVG to <a href=\"{}\">{}</a>").format(QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success, duration=5)
-        self.repaintModel(controls=True)
-
-    def exportAsPython(self):
-        filename, filter = QFileDialog.getSaveFileName(self,
-                                                       self.tr('Save Model As Python Script'), '',
-                                                       self.tr('Processing scripts (*.py *.PY)'))
-        if not filename:
-            return
-
-        if not filename.lower().endswith('.py'):
-            filename += '.py'
-
-        text = self.model.asPythonCode()
-        with codecs.open(filename, 'w', encoding='utf-8') as fout:
-            fout.write(text)
-
-        self.bar.pushMessage("", self.tr("Successfully exported model as python script to <a href=\"{}\">{}</a>").format(QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success, duration=5)
 
     def can_save(self):
         """
@@ -680,7 +432,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         :return: bool
         """
         if str(self.textName.text()).strip() == '':
-            self.bar.pushWarning(
+            self.messageBar().pushWarning(
                 "", self.tr('Please a enter model name before saving')
             )
             return False
@@ -690,10 +442,10 @@ class ModelerDialog(QgsModelDesignerDialog):
     def saveModel(self, saveAs):
         if not self.can_save():
             return
-        self.model.setName(str(self.textName.text()))
-        self.model.setGroup(str(self.textGroup.text()))
-        if self.model.sourceFilePath() and not saveAs:
-            filename = self.model.sourceFilePath()
+        self.model().setName(str(self.textName.text()))
+        self.model().setGroup(str(self.textGroup.text()))
+        if self.model().sourceFilePath() and not saveAs:
+            filename = self.model().sourceFilePath()
         else:
             filename, filter = QFileDialog.getSaveFileName(self,
                                                            self.tr('Save Model'),
@@ -702,23 +454,26 @@ class ModelerDialog(QgsModelDesignerDialog):
             if filename:
                 if not filename.endswith('.model3'):
                     filename += '.model3'
-                self.model.setSourceFilePath(filename)
+                self.model().setSourceFilePath(filename)
         if filename:
-            if not self.model.toFile(filename):
+            if not self.model().toFile(filename):
                 if saveAs:
                     QMessageBox.warning(self, self.tr('I/O error'),
                                         self.tr('Unable to save edits. Reason:\n {0}').format(str(sys.exc_info()[1])))
                 else:
-                    QMessageBox.warning(self, self.tr("Can't save model"), QCoreApplication.translate('QgsPluginInstallerInstallingDialog', (
-                        "This model can't be saved in its original location (probably you do not "
-                        "have permission to do it). Please, use the 'Save as…' option."))
-                    )
+                    QMessageBox.warning(self, self.tr("Can't save model"),
+                                        QCoreApplication.translate('QgsPluginInstallerInstallingDialog', (
+                                            "This model can't be saved in its original location (probably you do not "
+                                            "have permission to do it). Please, use the 'Save as…' option."))
+                                        )
                 return
             self.update_model.emit()
             if saveAs:
-                self.bar.pushMessage("", self.tr("Model was correctly saved to <a href=\"{}\">{}</a>").format(QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success, duration=5)
+                self.messageBar().pushMessage("", self.tr("Model was correctly saved to <a href=\"{}\">{}</a>").format(
+                    QUrl.fromLocalFile(filename).toString(), QDir.toNativeSeparators(filename)), level=Qgis.Success,
+                    duration=5)
             else:
-                self.bar.pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
+                self.messageBar().pushMessage("", self.tr("Model was correctly saved"), level=Qgis.Success, duration=5)
 
             self.hasChanged = False
 
@@ -733,15 +488,15 @@ class ModelerDialog(QgsModelDesignerDialog):
     def loadModel(self, filename):
         alg = QgsProcessingModelAlgorithm()
         if alg.fromFile(filename):
-            self.model = alg
-            self.model.setProvider(QgsApplication.processingRegistry().providerById('model'))
+            self._model = alg
+            self._model.setProvider(QgsApplication.processingRegistry().providerById('model'))
             self.textGroup.setText(alg.group())
             self.textName.setText(alg.name())
             self.repaintModel()
 
             self.update_variables_gui()
 
-            self.view.centerOn(0, 0)
+            self.view().centerOn(0, 0)
             self.hasChanged = False
         else:
             QgsMessageLog.logMessage(self.tr('Could not load model {0}').format(filename),
@@ -751,17 +506,17 @@ class ModelerDialog(QgsModelDesignerDialog):
                                  self.tr('The selected model could not be loaded.\n'
                                          'See the log for more information.'))
 
-    def repaintModel(self, controls=True):
+    def repaintModel(self, showControls=True):
         self.scene = ModelerScene(self)
         self.scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE,
                                        self.CANVAS_SIZE))
 
-        if not controls:
+        if not showControls:
             self.scene.setFlag(QgsModelGraphicsScene.FlagHideControls)
 
         context = createContext()
-        self.scene.createItems(self.model, context)
-        self.view.setScene(self.scene)
+        self.scene.createItems(self.model(), context)
+        self.view().setScene(self.scene)
 
         self.scene.rebuildRequired.connect(self.repaintModel)
         self.scene.componentChanged.connect(self.componentChanged)
@@ -769,10 +524,10 @@ class ModelerDialog(QgsModelDesignerDialog):
     def componentChanged(self):
         self.hasChanged = True
 
-    def addInput(self):
+    def _addInput(self):
         item = self.inputsTree.currentItem()
         param = item.data(0, Qt.UserRole)
-        self.addInputOfType(param)
+        self.addInput(param)
 
     def create_widget_context(self):
         """
@@ -782,7 +537,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         widget_context.setProject(QgsProject.instance())
         if iface is not None:
             widget_context.setMapCanvas(iface.mapCanvas())
-        widget_context.setModel(self.model)
+        widget_context.setModel(self.model())
         return widget_context
 
     def autogenerate_parameter_name(self, parameter):
@@ -795,16 +550,19 @@ class ModelerDialog(QgsModelDesignerDialog):
         safeName = ''.join(c for c in parameter.description() if c in validChars)
         name = safeName.lower()
         i = 2
-        while self.model.parameterDefinition(name):
+        while self.model().parameterDefinition(name):
             name = safeName.lower() + str(i)
             i += 1
         parameter.setName(safeName)
 
-    def addInputOfType(self, paramType, pos=None):
+    def addInput(self, paramType, pos=None):
+        if paramType not in [param.id() for param in QgsApplication.instance().processingRegistry().parameterTypes()]:
+            return
+
         new_param = None
         comment = None
         if ModelerParameterDefinitionDialog.use_legacy_dialog(paramType=paramType):
-            dlg = ModelerParameterDefinitionDialog(self.model, paramType)
+            dlg = ModelerParameterDefinitionDialog(self.model(), paramType)
             if dlg.exec_():
                 new_param = dlg.param
                 comment = dlg.comments()
@@ -815,7 +573,7 @@ class ModelerDialog(QgsModelDesignerDialog):
             dlg = QgsProcessingParameterDefinitionDialog(type=paramType,
                                                          context=context,
                                                          widgetContext=widget_context,
-                                                         algorithm=self.model)
+                                                         algorithm=self.model())
             if dlg.exec_():
                 new_param = dlg.createParameter()
                 self.autogenerate_parameter_name(new_param)
@@ -835,17 +593,17 @@ class ModelerDialog(QgsModelDesignerDialog):
                 component.size().width(),
                 -1.5 * component.size().height()))
 
-            self.model.addModelParameter(new_param, component)
+            self.model().addModelParameter(new_param, component)
             self.repaintModel()
-            # self.view.ensureVisible(self.scene.getLastParameterItem())
+            # self.view().ensureVisible(self.scene.getLastParameterItem())
             self.hasChanged = True
 
     def getPositionForParameterItem(self):
         MARGIN = 20
         BOX_WIDTH = 200
         BOX_HEIGHT = 80
-        if len(self.model.parameterComponents()) > 0:
-            maxX = max([i.position().x() for i in list(self.model.parameterComponents().values())])
+        if len(self.model().parameterComponents()) > 0:
+            maxX = max([i.position().x() for i in list(self.model().parameterComponents().values())])
             newX = min(MARGIN + BOX_WIDTH + maxX, self.CANVAS_SIZE - BOX_WIDTH)
         else:
             newX = MARGIN + BOX_WIDTH / 2
@@ -868,14 +626,15 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.inputsTree.addTopLevelItem(parametersItem)
         parametersItem.setExpanded(True)
 
-    def addAlgorithm(self):
-        algorithm = self.algorithmTree.selectedAlgorithm()
-        if algorithm is not None:
-            alg = QgsApplication.processingRegistry().createAlgorithmById(algorithm.id())
-            self._addAlgorithm(alg)
+    def _addAlgorithm(self):
+        self.addAlgorithm(self.algorithmTree.selectedAlgorithm())
 
-    def _addAlgorithm(self, alg, pos=None):
-        dlg = ModelerParametersDialog(alg, self.model)
+    def addAlgorithm(self, alg_id, pos=None):
+        alg = QgsApplication.processingRegistry().createAlgorithmById(alg_id)
+        if not alg:
+            return
+
+        dlg = ModelerParametersDialog(alg, self.model())
         if dlg.exec_():
             alg = dlg.createAlgorithm()
             if pos is None:
@@ -893,7 +652,7 @@ class ModelerDialog(QgsModelDesignerDialog):
                 alg.modelOutput(out).setPosition(alg.position() + QPointF(output_offset_x, output_offset_y))
                 output_offset_y += 1.5 * alg.modelOutput(out).size().height()
 
-            self.model.addChildAlgorithm(alg)
+            self.model().addChildAlgorithm(alg)
             self.repaintModel()
             self.hasChanged = True
 
@@ -901,12 +660,12 @@ class ModelerDialog(QgsModelDesignerDialog):
         MARGIN = 20
         BOX_WIDTH = 200
         BOX_HEIGHT = 80
-        if self.model.childAlgorithms():
-            maxX = max([alg.position().x() for alg in list(self.model.childAlgorithms().values())])
-            maxY = max([alg.position().y() for alg in list(self.model.childAlgorithms().values())])
+        if self.model().childAlgorithms():
+            maxX = max([alg.position().x() for alg in list(self.model().childAlgorithms().values())])
+            maxY = max([alg.position().y() for alg in list(self.model().childAlgorithms().values())])
             newX = min(MARGIN + BOX_WIDTH + maxX, self.CANVAS_SIZE - BOX_WIDTH)
-            newY = min(MARGIN + BOX_HEIGHT + maxY, self.CANVAS_SIZE -
-                       BOX_HEIGHT)
+            newY = min(MARGIN + BOX_HEIGHT + maxY, self.CANVAS_SIZE
+                       - BOX_HEIGHT)
         else:
             newX = MARGIN + BOX_WIDTH / 2
             newY = MARGIN * 2 + BOX_HEIGHT + BOX_HEIGHT / 2
@@ -915,5 +674,5 @@ class ModelerDialog(QgsModelDesignerDialog):
     def export_as_script_algorithm(self):
         dlg = ScriptEditorDialog(None)
 
-        dlg.editor.setText('\n'.join(self.model.asPythonCode(QgsProcessing.PythonQgsProcessingAlgorithmSubclass, 4)))
+        dlg.editor.setText('\n'.join(self.model().asPythonCode(QgsProcessing.PythonQgsProcessingAlgorithmSubclass, 4)))
         dlg.show()

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -29,18 +29,13 @@ from qgis.PyQt.QtCore import (
     QCoreApplication,
     QDir,
     QRectF,
-    QMimeData,
     QPoint,
     QPointF,
     pyqtSignal,
     QUrl)
-from qgis.PyQt.QtWidgets import (QTreeWidget,
-                                 QMessageBox,
+from qgis.PyQt.QtWidgets import (QMessageBox,
                                  QFileDialog,
                                  QTreeWidgetItem,
-                                 QDockWidget,
-                                 QWidget,
-                                 QVBoxLayout,
                                  QToolButton,
                                  QAction)
 from qgis.PyQt.QtGui import QIcon
@@ -53,13 +48,9 @@ from qgis.core import (Qgis,
                        QgsProcessingModelAlgorithm,
                        QgsProcessingModelParameter,
                        QgsProcessingParameterType,
-                       QgsExpressionContextScope,
-                       QgsExpressionContext
                        )
-from qgis.gui import (QgsDockWidget,
-                      QgsProcessingToolboxProxyModel,
+from qgis.gui import (QgsProcessingToolboxProxyModel,
                       QgsProcessingParameterDefinitionDialog,
-                      QgsVariableEditorWidget,
                       QgsProcessingParameterWidgetContext,
                       QgsModelGraphicsScene,
                       QgsModelDesignerDialog)
@@ -124,16 +115,6 @@ class ModelerDialog(QgsModelDesignerDialog):
         super().__init__(parent)
         self._model = None
 
-        self.scrollAreaWidgetContents_2 = QWidget()
-        self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents_2)
-        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
-        self.verticalLayout.setSpacing(0)
-        self.inputsTree = QTreeWidget(self.scrollAreaWidgetContents_2)
-        self.inputsTree.setAlternatingRowColors(True)
-        self.inputsTree.header().setVisible(False)
-        self.verticalLayout.addWidget(self.inputsTree)
-        self.inputsScrollArea().setWidget(self.scrollAreaWidgetContents_2)
-
         if iface is not None:
             self.toolbar().setIconSize(iface.iconSize())
             self.setStyleSheet(iface.mainWindow().styleSheet())
@@ -156,22 +137,11 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.view().ensureVisible(0, 0, 10, 10)
         self.view().scale(QgsApplication.desktop().logicalDpiX() / 96, QgsApplication.desktop().logicalDpiX() / 96)
 
-        def _mimeDataInput(items):
-            mimeData = QMimeData()
-            text = items[0].data(0, Qt.UserRole)
-            mimeData.setText(text)
-            return mimeData
-
-        self.inputsTree.mimeData = _mimeDataInput
-
-        self.inputsTree.setDragDropMode(QTreeWidget.DragOnly)
-        self.inputsTree.setDropIndicatorShown(True)
-
         self.algorithms_model = ModelerToolboxModel(self, QgsApplication.processingRegistry())
         self.algorithmsTree().setToolboxProxyModel(self.algorithms_model)
 
         # Connect signals and slots
-        self.inputsTree.doubleClicked.connect(self._addInput)
+        self.inputsTree().doubleClicked.connect(self._addInput)
 
         self.actionOpen().triggered.connect(self.openModel)
         self.actionSave().triggered.connect(self.save)
@@ -367,7 +337,7 @@ class ModelerDialog(QgsModelDesignerDialog):
         self.hasChanged = True
 
     def _addInput(self):
-        item = self.inputsTree.currentItem()
+        item = self.inputsTree().currentItem()
         param = item.data(0, Qt.UserRole)
         self.addInput(param)
 
@@ -465,7 +435,7 @@ class ModelerDialog(QgsModelDesignerDialog):
                 paramItem.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled)
                 paramItem.setToolTip(0, param.description())
                 parametersItem.addChild(paramItem)
-        self.inputsTree.addTopLevelItem(parametersItem)
+        self.inputsTree().addTopLevelItem(parametersItem)
         parametersItem.setExpanded(True)
 
     def addAlgorithm(self, alg_id, pos=None):

--- a/python/plugins/processing/modeler/OpenModelFromFileAction.py
+++ b/python/plugins/processing/modeler/OpenModelFromFileAction.py
@@ -26,7 +26,7 @@ from qgis.PyQt.QtWidgets import QFileDialog
 from qgis.PyQt.QtCore import QFileInfo, QCoreApplication
 
 from qgis.core import QgsApplication, QgsSettings
-
+from qgis.utils import iface
 from processing.gui.ToolboxAction import ToolboxAction
 from processing.modeler.ModelerDialog import ModelerDialog
 
@@ -52,6 +52,6 @@ class OpenModelFromFileAction(ToolboxAction):
             settings.setValue('Processing/lastModelsDir',
                               QFileInfo(filename).absoluteDir().absolutePath())
 
-            dlg = ModelerDialog()
+            dlg = ModelerDialog.create()
             dlg.loadModel(filename)
             dlg.show()

--- a/python/plugins/processing/ui/DlgModeler.ui
+++ b/python/plugins/processing/ui/DlgModeler.ui
@@ -35,6 +35,53 @@
     </item>
    </layout>
   </widget>
+  <widget class="QMenuBar" name="mMenu">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>891</width>
+     <height>24</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menu_Model">
+    <property name="title">
+     <string>&amp;Model</string>
+    </property>
+    <widget class="QMenu" name="menuExport">
+     <property name="title">
+      <string>Export</string>
+     </property>
+     <addaction name="mActionExportImage"/>
+     <addaction name="mActionExportPdf"/>
+     <addaction name="mActionExportSvg"/>
+     <addaction name="separator"/>
+     <addaction name="mActionExportPython"/>
+    </widget>
+    <addaction name="mActionRun"/>
+    <addaction name="separator"/>
+    <addaction name="mActionOpen"/>
+    <addaction name="mActionSave"/>
+    <addaction name="mActionSaveAs"/>
+    <addaction name="mActionSaveInProject"/>
+    <addaction name="mActionEditHelp"/>
+    <addaction name="separator"/>
+    <addaction name="menuExport"/>
+    <addaction name="separator"/>
+    <addaction name="mActionClose"/>
+   </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="mActionZoomIn"/>
+    <addaction name="mActionZoomOut"/>
+    <addaction name="mActionZoomActual"/>
+    <addaction name="mActionZoomToItems"/>
+   </widget>
+   <addaction name="menu_Model"/>
+   <addaction name="menu_View"/>
+  </widget>
   <widget class="QToolBar" name="mToolbar">
    <property name="windowTitle">
     <string>Navigation</string>
@@ -65,7 +112,7 @@
   </widget>
   <action name="mActionOpen">
    <property name="text">
-    <string>Open model…</string>
+    <string>Open Model…</string>
    </property>
    <property name="toolTip">
     <string>Open model (Ctrl+O)</string>
@@ -76,7 +123,7 @@
   </action>
   <action name="mActionSave">
    <property name="text">
-    <string>Save model</string>
+    <string>Save Model</string>
    </property>
    <property name="toolTip">
     <string>Save model (Ctrl+S)</string>
@@ -87,7 +134,7 @@
   </action>
   <action name="mActionSaveAs">
    <property name="text">
-    <string>Save model as…</string>
+    <string>Save Model as…</string>
    </property>
    <property name="toolTip">
     <string>Save model as (Ctrl+S)</string>
@@ -109,7 +156,7 @@
   </action>
   <action name="mActionZoomIn">
    <property name="text">
-    <string>Zoom in</string>
+    <string>Zoom In</string>
    </property>
    <property name="toolTip">
     <string>Zoom in</string>
@@ -120,7 +167,7 @@
   </action>
   <action name="mActionZoomOut">
    <property name="text">
-    <string>Zoom out</string>
+    <string>Zoom Out</string>
    </property>
    <property name="toolTip">
     <string>Zoom out</string>
@@ -131,7 +178,7 @@
   </action>
   <action name="mActionExportImage">
    <property name="text">
-    <string>Export as image…</string>
+    <string>Export as Image…</string>
    </property>
    <property name="toolTip">
     <string>Export as image</string>
@@ -139,7 +186,7 @@
   </action>
   <action name="mActionZoomToItems">
    <property name="text">
-    <string>Zoom full</string>
+    <string>Zoom Full</string>
    </property>
    <property name="toolTip">
     <string>Zoom full</string>
@@ -174,7 +221,7 @@
   </action>
   <action name="mActionEditHelp">
    <property name="text">
-    <string>Edit model help…</string>
+    <string>Edit Model Help…</string>
    </property>
    <property name="toolTip">
     <string>Edit model help</string>
@@ -182,7 +229,7 @@
   </action>
   <action name="mActionRun">
    <property name="text">
-    <string>Run model…</string>
+    <string>Run Model…</string>
    </property>
    <property name="toolTip">
     <string>Run model (F5)</string>
@@ -193,10 +240,15 @@
   </action>
   <action name="mActionSaveInProject">
    <property name="text">
-    <string>Save model in project</string>
+    <string>Save Model in Project</string>
    </property>
    <property name="toolTip">
     <string>Save model in project</string>
+   </property>
+  </action>
+  <action name="mActionClose">
+   <property name="text">
+    <string>Close</string>
    </property>
   </action>
  </widget>

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1162,6 +1162,8 @@ QVariant QgsProcessingModelAlgorithm::toVariant() const
 
   map.insert( QStringLiteral( "modelVariables" ), mVariables );
 
+  map.insert( QStringLiteral( "designerParameterValues" ), mDesignerParameterValues );
+
   return map;
 }
 
@@ -1175,6 +1177,7 @@ bool QgsProcessingModelAlgorithm::loadVariant( const QVariant &model )
   mHelpContent = map.value( QStringLiteral( "help" ) ).toMap();
 
   mVariables = map.value( QStringLiteral( "modelVariables" ) ).toMap();
+  mDesignerParameterValues = map.value( QStringLiteral( "designerParameterValues" ) ).toMap();
 
   mChildAlgorithms.clear();
   QVariantMap childMap = map.value( QStringLiteral( "children" ) ).toMap();

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -398,6 +398,32 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
      */
     void setVariables( const QVariantMap &variables );
 
+    /**
+     * Returns the parameter values to use as default values when running this model through the
+     * designer dialog.
+     *
+     * This usually corresponds to the last set of parameter values used when the model was
+     * run through the designer.
+     *
+     * \see setDesignerParameterValues()
+     *
+     * \since QGIS 3.14
+     */
+    QVariantMap designerParameterValues() const { return mDesignerParameterValues; }
+
+    /**
+     * Sets the parameter \a values to use as default values when running this model through the
+     * designer dialog.
+     *
+     * This usually corresponds to the last set of parameter values used when the model was
+     * run through the designer.
+     *
+     * \see designerParameterValues()
+     *
+     * \since QGIS 3.14
+     */
+    void setDesignerParameterValues( const QVariantMap &values ) { mDesignerParameterValues = values; }
+
   protected:
 
     QgsProcessingAlgorithm *createInstance() const override SIP_FACTORY;
@@ -423,6 +449,8 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QVariantMap mResults;
 
     QVariantMap mVariables;
+
+    QVariantMap mDesignerParameterValues;
 
     void dependsOnChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;
     void dependentChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -256,6 +256,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelarrowitem.cpp
   processing/models/qgsmodelcomponentgraphicitem.cpp
   processing/models/qgsmodeldesignerdialog.cpp
+  processing/models/qgsmodeldesignerinputstreewidget.cpp
   processing/models/qgsmodelgraphicitem.cpp
   processing/models/qgsmodelgraphicsscene.cpp
   processing/models/qgsmodelgraphicsview.cpp
@@ -889,6 +890,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelarrowitem.h
   processing/models/qgsmodelcomponentgraphicitem.h
   processing/models/qgsmodeldesignerdialog.h
+  processing/models/qgsmodeldesignerinputstreewidget.h
   processing/models/qgsmodelgraphicitem.h
   processing/models/qgsmodelgraphicsscene.h
   processing/models/qgsmodelgraphicsview.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -255,6 +255,7 @@ SET(QGIS_GUI_SRCS
 
   processing/models/qgsmodelarrowitem.cpp
   processing/models/qgsmodelcomponentgraphicitem.cpp
+  processing/models/qgsmodeldesignerdialog.cpp
   processing/models/qgsmodelgraphicitem.cpp
   processing/models/qgsmodelgraphicsscene.cpp
 
@@ -886,6 +887,7 @@ SET(QGIS_GUI_HDRS
 
   processing/models/qgsmodelarrowitem.h
   processing/models/qgsmodelcomponentgraphicitem.h
+  processing/models/qgsmodeldesignerdialog.h
   processing/models/qgsmodelgraphicitem.h
   processing/models/qgsmodelgraphicsscene.h
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -258,6 +258,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodeldesignerdialog.cpp
   processing/models/qgsmodelgraphicitem.cpp
   processing/models/qgsmodelgraphicsscene.cpp
+  processing/models/qgsmodelgraphicsview.cpp
 
   providers/gdal/qgsgdalsourceselect.cpp
   providers/gdal/qgsgdalguiprovider.cpp
@@ -890,6 +891,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodeldesignerdialog.h
   processing/models/qgsmodelgraphicitem.h
   processing/models/qgsmodelgraphicsscene.h
+  processing/models/qgsmodelgraphicsview.h
 
   providers/gdal/qgsgdalguiprovider.h
   providers/gdal/qgsgdalsourceselect.h

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -33,6 +33,30 @@
 ///@cond NOT_STABLE
 
 
+QgsModelerToolboxModel::QgsModelerToolboxModel( QObject *parent )
+  : QgsProcessingToolboxProxyModel( parent )
+{
+
+}
+
+Qt::ItemFlags QgsModelerToolboxModel::flags( const QModelIndex &index ) const
+{
+  Qt::ItemFlags f = QgsProcessingToolboxProxyModel::flags( index );
+  const QModelIndex sourceIndex = mapToSource( index );
+  if ( toolboxModel()->isAlgorithm( sourceIndex ) )
+  {
+    f = f | Qt::ItemIsDragEnabled;
+  }
+  return f;
+}
+
+Qt::DropActions QgsModelerToolboxModel::supportedDragActions() const
+{
+  return Qt::CopyAction;
+}
+
+
+
 QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags flags )
   : QMainWindow( parent, flags )
 {
@@ -88,6 +112,9 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mAlgorithmsTree->setFilters( filters );
   mAlgorithmsTree->setDragDropMode( QTreeWidget::DragOnly );
   mAlgorithmsTree->setDropIndicatorShown( true );
+
+  mAlgorithmsModel = new QgsModelerToolboxModel( this );
+  mAlgorithmsTree->setToolboxProxyModel( mAlgorithmsModel );
 
   connect( mView, &QgsModelGraphicsView::algorithmDropped, this, [ = ]( const QString & algorithmId, const QPointF & pos )
   {

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -14,6 +14,21 @@
  ***************************************************************************/
 
 #include "qgsmodeldesignerdialog.h"
+#include "qgssettings.h"
+#include "qgsapplication.h"
+#include "qgsfileutils.h"
+#include "qgsmessagebar.h"
+#include "qgsprocessingmodelalgorithm.h"
+#include "qgsprocessingregistry.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsgui.h"
+
+#include <QShortcut>
+#include <QDesktopWidget>
+#include <QKeySequence>
+#include <QFileDialog>
+#include <QPrinter>
+#include <QSvgGenerator>
 
 ///@cond NOT_STABLE
 
@@ -21,6 +36,181 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   : QMainWindow( parent, flags )
 {
   setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  setAttribute( Qt::WA_DeleteOnClose );
+  setWindowFlags( Qt::WindowMinimizeButtonHint |
+                  Qt::WindowMaximizeButtonHint |
+                  Qt::WindowCloseButtonHint );
+  mMessageBar = new QgsMessageBar();
+  mMessageBar->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::Fixed );
+  mainLayout->insertWidget( 0, mMessageBar );
+
+  mView->setAcceptDrops( true );
+
+  connect( mActionClose, &QAction::triggered, this, &QWidget::close );
+  connect( mActionZoomIn, &QAction::triggered, this, &QgsModelDesignerDialog::zoomIn );
+  connect( mActionZoomOut, &QAction::triggered, this, &QgsModelDesignerDialog::zoomOut );
+  connect( mActionZoomActual, &QAction::triggered, this, &QgsModelDesignerDialog::zoomActual );
+  connect( mActionZoomToItems, &QAction::triggered, this, &QgsModelDesignerDialog::zoomFull );
+  connect( mActionExportImage, &QAction::triggered, this, &QgsModelDesignerDialog::exportToImage );
+  connect( mActionExportPdf, &QAction::triggered, this, &QgsModelDesignerDialog::exportToPdf );
+  connect( mActionExportSvg, &QAction::triggered, this, &QgsModelDesignerDialog::exportToSvg );
+  connect( mActionExportPython, &QAction::triggered, this, &QgsModelDesignerDialog::exportAsPython );
+
+  connect( mView, &QgsModelGraphicsView::algorithmDropped, this, [ = ]( const QString & algorithmId, const QPointF & pos )
+  {
+    addAlgorithm( algorithmId, pos );
+  } );
+  connect( mView, &QgsModelGraphicsView::inputDropped, this, &QgsModelDesignerDialog::addInput );
+
+// Ctrl+= should also trigger a zoom in action
+  QShortcut *ctrlEquals = new QShortcut( QKeySequence( QStringLiteral( "Ctrl+=" ) ), this );
+  connect( ctrlEquals, &QShortcut::activated, this, &QgsModelDesignerDialog::zoomIn );
+}
+
+void QgsModelDesignerDialog::zoomIn()
+{
+  mView->setTransformationAnchor( QGraphicsView::NoAnchor );
+  QPointF point = mView->mapToScene( QPoint( mView->viewport()->width() / 2.0, mView->viewport()->height() / 2 ) );
+  QgsSettings settings;
+  const double factor = settings.value( QStringLiteral( "/qgis/zoom_favor" ), 2.0 ).toDouble();
+  mView->scale( factor, factor );
+  mView->centerOn( point );
+  repaintModel();
+}
+
+void QgsModelDesignerDialog::zoomOut()
+{
+  mView->setTransformationAnchor( QGraphicsView::NoAnchor );
+  QPointF point = mView->mapToScene( QPoint( mView->viewport()->width() / 2.0, mView->viewport()->height() / 2 ) );
+  QgsSettings settings;
+  const double factor = 1.0 / settings.value( QStringLiteral( "/qgis/zoom_favor" ), 2.0 ).toDouble();
+  mView->scale( factor, factor );
+  mView->centerOn( point );
+  repaintModel();
+}
+
+void QgsModelDesignerDialog::zoomActual()
+{
+  QPointF point = mView->mapToScene( QPoint( mView->viewport()->width() / 2.0, mView->viewport()->height() / 2 ) );
+  mView->resetTransform();
+  mView->scale( QgsApplication::desktop()->logicalDpiX() / 96, QgsApplication::desktop()->logicalDpiX() / 96 );
+  mView->centerOn( point );
+}
+
+void QgsModelDesignerDialog::zoomFull()
+{
+  QRectF totalRect = mView->scene()->itemsBoundingRect();
+  totalRect.adjust( -10, -10, 10, 10 );
+  mView->fitInView( totalRect, Qt::KeepAspectRatio );
+}
+
+void QgsModelDesignerDialog::exportToImage()
+{
+  QString filename = QFileDialog::getSaveFileName( this, tr( "Save Model as Image" ), tr( "PNG files (*.png *.PNG)" ) );
+  if ( filename.isEmpty() )
+    return;
+
+  filename = QgsFileUtils::ensureFileNameHasExtension( filename, QStringList() << QStringLiteral( "png" ) );
+
+  repaintModel( false );
+
+  QRectF totalRect = mView->scene()->itemsBoundingRect();
+  totalRect.adjust( -10, -10, 10, 10 );
+  const QRectF imageRect = QRectF( 0, 0, totalRect.width(), totalRect.height() );
+
+  QImage img( totalRect.width(), totalRect.height(),
+              QImage::Format_ARGB32_Premultiplied );
+  img.fill( Qt::white );
+  QPainter painter;
+  painter.setRenderHint( QPainter::Antialiasing );
+  painter.begin( &img );
+  mView->scene()->render( &painter, imageRect, totalRect );
+  painter.end();
+
+  img.save( filename );
+
+  mMessageBar->pushMessage( QString(), tr( "Successfully exported model as image to <a href=\"{}\">{}</a>" ).arg( QUrl::fromLocalFile( filename ).toString(), QDir::toNativeSeparators( filename ) ), Qgis::Success, 5 );
+  repaintModel( true );
+}
+
+void QgsModelDesignerDialog::exportToPdf()
+{
+  QString filename = QFileDialog::getSaveFileName( this, tr( "Save Model as PDF" ), tr( "PDF files (*.pdf *.PDF)" ) );
+  if ( filename.isEmpty() )
+    return;
+
+  filename = QgsFileUtils::ensureFileNameHasExtension( filename, QStringList() << QStringLiteral( "pdf" ) );
+
+  repaintModel( false );
+
+  QRectF totalRect = mView->scene()->itemsBoundingRect();
+  totalRect.adjust( -10, -10, 10, 10 );
+  const QRectF printerRect = QRectF( 0, 0, totalRect.width(), totalRect.height() );
+
+  QPrinter printer;
+  printer.setOutputFormat( QPrinter::PdfFormat );
+  printer.setOutputFileName( filename );
+  printer.setPaperSize( QSizeF( printerRect.width(), printerRect.height() ), QPrinter::DevicePixel );
+  printer.setFullPage( true );
+
+  QPainter painter( &printer );
+  mView->scene()->render( &painter, printerRect, totalRect );
+  painter.end();
+
+  mMessageBar->pushMessage( QString(), tr( "Successfully exported model as PDF to <a href=\"{}\">{}</a>" ).arg( QUrl::fromLocalFile( filename ).toString(), QDir::toNativeSeparators( filename ) ), Qgis::Success, 5 );
+  repaintModel( true );
+}
+
+void QgsModelDesignerDialog::exportToSvg()
+{
+  QString filename = QFileDialog::getSaveFileName( this, tr( "Save Model as SVG" ), tr( "SVG files (*.svg *.SVG)" ) );
+  if ( filename.isEmpty() )
+    return;
+
+  filename = QgsFileUtils::ensureFileNameHasExtension( filename, QStringList() << QStringLiteral( "svg" ) );
+
+  repaintModel( false );
+
+  QRectF totalRect = mView->scene()->itemsBoundingRect();
+  totalRect.adjust( -10, -10, 10, 10 );
+  const QRectF svgRect = QRectF( 0, 0, totalRect.width(), totalRect.height() );
+
+  QSvgGenerator svg;
+  svg.setFileName( filename );
+  svg.setSize( QSize( totalRect.width(), totalRect.height() ) );
+  svg.setViewBox( svgRect );
+  svg.setTitle( model()->displayName() );
+
+  QPainter painter( &svg );
+  mView->scene()->render( &painter, svgRect, totalRect );
+  painter.end();
+
+  mMessageBar->pushMessage( QString(), tr( "Successfully exported model as SVG to <a href=\"{}\">{}</a>" ).arg( QUrl::fromLocalFile( filename ).toString(), QDir::toNativeSeparators( filename ) ), Qgis::Success, 5 );
+  repaintModel( true );
+}
+
+void QgsModelDesignerDialog::exportAsPython()
+{
+  QString filename = QFileDialog::getSaveFileName( this, tr( "Save Model as Python Script" ), tr( "Processing scripts (*.py *.PY)" ) );
+  if ( filename.isEmpty() )
+    return;
+
+  filename = QgsFileUtils::ensureFileNameHasExtension( filename, QStringList() << QStringLiteral( "py" ) );
+
+  const QString text = model()->asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, 4 ).join( '\n' );
+
+  QFile outFile( filename );
+  if ( !outFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+  {
+    return;
+  }
+  QTextStream fout( &outFile );
+  fout << text;
+  outFile.close();
+
+  mMessageBar->pushMessage( QString(), tr( "Successfully exported model as Python script to <a href=\"{}\">{}</a>" ).arg( QUrl::fromLocalFile( filename ).toString(), QDir::toNativeSeparators( filename ) ), Qgis::Success, 5 );
 }
 
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -32,6 +32,7 @@
 
 ///@cond NOT_STABLE
 
+
 QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags flags )
   : QMainWindow( parent, flags )
 {
@@ -53,6 +54,11 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mAlgorithmSearchEdit->setShowSearchIcon( true );
   mAlgorithmSearchEdit->setPlaceholderText( tr( "Search…" ) );
   connect( mAlgorithmSearchEdit, &QgsFilterLineEdit::textChanged, mAlgorithmsTree, &QgsProcessingToolboxTreeView::setFilterString );
+
+  mInputsTreeWidget->header()->setVisible( false );
+  mInputsTreeWidget->setAlternatingRowColors( true );
+  mInputsTreeWidget->setDragDropMode( QTreeWidget::DragOnly );
+  mInputsTreeWidget->setDropIndicatorShown( true );
 
   mNameEdit->setPlaceholderText( tr( "Enter model name here" ) );
   mGroupEdit->setPlaceholderText( tr( "Enter group name here" ) );
@@ -271,3 +277,4 @@ void QgsModelDesignerDialog::exportAsPython()
 
 
 ///@endcond
+

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -1,0 +1,27 @@
+/***************************************************************************
+                             qgsmodeldesignerdialog.cpp
+                             ------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodeldesignerdialog.h"
+
+///@cond NOT_STABLE
+
+QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags flags )
+  : QMainWindow( parent, flags )
+{
+  setupUi( this );
+}
+
+
+///@endcond

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -161,6 +161,9 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   toolbuttonExportToScript->setDefaultAction( mActionExportAsScriptAlgorithm );
   mToolbar->insertWidget( mActionExportImage, toolbuttonExportToScript );
   connect( mActionExportAsScriptAlgorithm, &QAction::triggered, this, &QgsModelDesignerDialog::exportAsScriptAlgorithm );
+
+  mActionShowComments->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/ShowComments" ), true ).toBool() );
+  connect( mActionShowComments, &QAction::toggled, this, &QgsModelDesignerDialog::toggleComments );
 }
 
 void QgsModelDesignerDialog::closeEvent( QCloseEvent *event )
@@ -219,7 +222,6 @@ void QgsModelDesignerDialog::zoomIn()
   const double factor = settings.value( QStringLiteral( "/qgis/zoom_favor" ), 2.0 ).toDouble();
   mView->scale( factor, factor );
   mView->centerOn( point );
-  repaintModel();
 }
 
 void QgsModelDesignerDialog::zoomOut()
@@ -230,7 +232,6 @@ void QgsModelDesignerDialog::zoomOut()
   const double factor = 1.0 / settings.value( QStringLiteral( "/qgis/zoom_favor" ), 2.0 ).toDouble();
   mView->scale( factor, factor );
   mView->centerOn( point );
-  repaintModel();
 }
 
 void QgsModelDesignerDialog::zoomActual()
@@ -353,6 +354,13 @@ void QgsModelDesignerDialog::exportAsPython()
   outFile.close();
 
   mMessageBar->pushMessage( QString(), tr( "Successfully exported model as Python script to <a href=\"{}\">{}</a>" ).arg( QUrl::fromLocalFile( filename ).toString(), QDir::toNativeSeparators( filename ) ), Qgis::Success, 5 );
+}
+
+void QgsModelDesignerDialog::toggleComments( bool show )
+{
+  QgsSettings().setValue( QStringLiteral( "/Processing/Modeler/ShowComments" ), show );
+
+  repaintModel( true );
 }
 
 void QgsModelDesignerDialog::fillInputsTree()

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -52,29 +52,30 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
 
     QgsModelDesignerDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = nullptr );
 
+    void closeEvent( QCloseEvent *event ) override;
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;
     virtual QgsProcessingModelAlgorithm *model() = 0;
     virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
+    virtual void exportAsScriptAlgorithm() = 0;
+    virtual void saveModel( bool saveAs = false ) = 0;
 
     QToolBar *toolbar() { return mToolbar; }
     QAction *actionOpen() { return mActionOpen; }
-    QAction *actionSave() { return mActionSave; }
-    QAction *actionSaveAs() { return mActionSaveAs; }
     QAction *actionSaveInProject() { return mActionSaveInProject; }
     QAction *actionEditHelp() { return mActionEditHelp; }
     QAction *actionRun() { return mActionRun; }
-    QAction *actionExportImage() { return mActionExportImage; }
     QLineEdit *textName() { return mNameEdit; }
     QLineEdit *textGroup() { return mGroupEdit; }
-    QTreeWidget *inputsTree() { return mInputsTreeWidget; }
-
     QgsMessageBar *messageBar() { return mMessageBar; }
     QGraphicsView *view() { return mView; }
 
     void updateVariablesGui();
+
+    void setDirty( bool dirty );
 
   private slots:
 
@@ -91,6 +92,10 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
 
     QgsMessageBar *mMessageBar = nullptr;
     QgsModelerToolboxModel *mAlgorithmsModel = nullptr;
+
+    bool mHasChanged = false;
+
+    void fillInputsTree();
 
 };
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+                             qgsmodeldesignerdialog.h
+                             ------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELDESIGNERDIALOG_H
+#define QGSMODELDESIGNERDIALOG_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "ui_qgsmodeldesignerdialogbase.h"
+
+///@cond NOT_STABLE
+
+/**
+ * \ingroup gui
+ * \brief Model designer dialog base class
+ * \warning Not stable API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsModelDesignerDialogBase
+{
+  public:
+
+    QgsModelDesignerDialog( QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr );
+
+  protected:
+
+    QToolBar *toolbar() { return mToolbar; }
+
+};
+
+///@endcond
+
+#endif // QGSMODELDESIGNERDIALOG_H

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -87,6 +87,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void exportToPdf();
     void exportToSvg();
     void exportAsPython();
+    void toggleComments( bool show );
 
   private:
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QAction *actionExportImage() { return mActionExportImage; }
     QLineEdit *textName() { return mNameEdit; }
     QLineEdit *textGroup() { return mGroupEdit; }
-    QScrollArea *inputsScrollArea() { return mInputsScrollArea; }
+    QTreeWidget *inputsTree() { return mInputsTreeWidget; }
     QgsProcessingToolboxTreeView *algorithmsTree() { return mAlgorithmsTree; }
 
     QgsMessageBar *messageBar() { return mMessageBar; }

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -20,6 +20,9 @@
 #include "qgis_gui.h"
 #include "ui_qgsmodeldesignerdialogbase.h"
 
+class QgsMessageBar;
+class QgsProcessingModelAlgorithm;
+
 ///@cond NOT_STABLE
 
 /**
@@ -32,11 +35,41 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
 {
   public:
 
-    QgsModelDesignerDialog( QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr );
+    QgsModelDesignerDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = nullptr );
 
   protected:
 
+    virtual void repaintModel( bool showControls = true ) = 0;
+    virtual QgsProcessingModelAlgorithm *model() = 0;
+    virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
+    virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
+
     QToolBar *toolbar() { return mToolbar; }
+    QAction *actionOpen() { return mActionOpen; }
+    QAction *actionSave() { return mActionSave; }
+    QAction *actionSaveAs() { return mActionSaveAs; }
+    QAction *actionSaveInProject() { return mActionSaveInProject; }
+    QAction *actionEditHelp() { return mActionEditHelp; }
+    QAction *actionRun() { return mActionRun; }
+    QAction *actionExportImage() { return mActionExportImage; }
+
+    QgsMessageBar *messageBar() { return mMessageBar; }
+    QGraphicsView *view() { return mView; }
+
+  private slots:
+
+    void zoomIn();
+    void zoomOut();
+    void zoomActual();
+    void zoomFull();
+    void exportToImage();
+    void exportToPdf();
+    void exportToSvg();
+    void exportAsPython();
+
+  private:
+
+    QgsMessageBar *mMessageBar = nullptr;
 
 };
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -52,9 +52,15 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QAction *actionEditHelp() { return mActionEditHelp; }
     QAction *actionRun() { return mActionRun; }
     QAction *actionExportImage() { return mActionExportImage; }
+    QLineEdit *textName() { return mNameEdit; }
+    QLineEdit *textGroup() { return mGroupEdit; }
+    QScrollArea *inputsScrollArea() { return mInputsScrollArea; }
+    QgsProcessingToolboxTreeView *algorithmsTree() { return mAlgorithmsTree; }
 
     QgsMessageBar *messageBar() { return mMessageBar; }
     QGraphicsView *view() { return mView; }
+
+    void updateVariablesGui();
 
   private slots:
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -20,10 +20,25 @@
 #include "qgis_gui.h"
 #include "ui_qgsmodeldesignerdialogbase.h"
 
+#include "qgsprocessingtoolboxmodel.h"
+
 class QgsMessageBar;
 class QgsProcessingModelAlgorithm;
 
 ///@cond NOT_STABLE
+
+#ifndef SIP_RUN
+
+class GUI_EXPORT QgsModelerToolboxModel : public QgsProcessingToolboxProxyModel
+{
+  public:
+    explicit QgsModelerToolboxModel( QObject *parent = nullptr );
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    Qt::DropActions supportedDragActions() const override;
+
+};
+
+#endif
 
 /**
  * \ingroup gui
@@ -55,7 +70,6 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QLineEdit *textName() { return mNameEdit; }
     QLineEdit *textGroup() { return mGroupEdit; }
     QTreeWidget *inputsTree() { return mInputsTreeWidget; }
-    QgsProcessingToolboxTreeView *algorithmsTree() { return mAlgorithmsTree; }
 
     QgsMessageBar *messageBar() { return mMessageBar; }
     QGraphicsView *view() { return mView; }
@@ -76,6 +90,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
   private:
 
     QgsMessageBar *mMessageBar = nullptr;
+    QgsModelerToolboxModel *mAlgorithmsModel = nullptr;
 
 };
 

--- a/src/gui/processing/models/qgsmodeldesignerinputstreewidget.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerinputstreewidget.cpp
@@ -1,0 +1,40 @@
+/***************************************************************************
+                             qgsmodeldesignerinputstreewidget.cpp
+                             ------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodeldesignerinputstreewidget.h"
+
+#include <QMimeData>
+
+///@cond NOT_STABLE
+
+QgsModelDesignerInputsTreeWidget::QgsModelDesignerInputsTreeWidget( QWidget *parent )
+  : QTreeWidget( parent )
+{
+
+}
+
+QMimeData *QgsModelDesignerInputsTreeWidget::mimeData( const QList<QTreeWidgetItem *> items ) const
+{
+  if ( items.empty() )
+    return nullptr;
+
+  std::unique_ptr< QMimeData > res = qgis::make_unique< QMimeData >();
+  const QString text = items.value( 0 )->data( 0, Qt::UserRole ).toString();
+  res->setText( text );
+  return res.release();
+}
+
+///@endcond
+

--- a/src/gui/processing/models/qgsmodeldesignerinputstreewidget.h
+++ b/src/gui/processing/models/qgsmodeldesignerinputstreewidget.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+                             qgsmodeldesignerinputstreewidget.h
+                             ------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELDESIGNERINPUTSTREEWIDGET_H
+#define QGSMODELDESIGNERINPUTSTREEWIDGET_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include <QTreeWidget>
+
+class QMimeData;
+
+#define SIP_NO_FILE
+
+///@cond NOT_STABLE
+
+/**
+ * \ingroup gui
+ * \brief QTreeWidget subclass for use in the model designer as an input list.
+ * \warning Not stable API
+ * \since QGIS 3.14
+ */
+class QgsModelDesignerInputsTreeWidget : public QTreeWidget
+{
+  public:
+
+    /**
+     * Constructor for QgsModelDesignerInputsTreeWidget with the specified \a parent widget.
+     */
+    explicit QgsModelDesignerInputsTreeWidget( QWidget *parent = nullptr );
+
+    QMimeData *mimeData( const QList<QTreeWidgetItem *> items ) const override;
+};
+
+///@endcond
+
+#endif // QGSMODELDESIGNERINPUTSTREEWIDGET_H

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -257,7 +257,7 @@ QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForPa
 
 void QgsModelGraphicsScene::addCommentItemForComponent( QgsProcessingModelAlgorithm *model, const QgsProcessingModelComponent &component, QgsModelComponentGraphicItem *parentItem )
 {
-  if ( !component.comment() || component.comment()->description().isEmpty() )
+  if ( mFlags & FlagHideComments || !component.comment() || component.comment()->description().isEmpty() )
     return;
 
   QgsModelComponentGraphicItem *commentItem = createCommentGraphicItem( model, component.comment()->clone(), parentItem );

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -54,6 +54,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     enum Flag
     {
       FlagHideControls = 1 << 1,  //!< If set, item interactive controls will be hidden
+      FlagHideComments = 1 << 2, //!< If set, comments will be hidden
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -94,7 +94,7 @@ void QgsModelGraphicsView::wheelEvent( QWheelEvent *event )
 
   //calculate zoom scale factor
   bool zoomIn = event->angleDelta().y() > 0;
-  double scaleFactor = ( zoomIn ? 1 / zoomFactor : zoomFactor );
+  double scaleFactor = ( !zoomIn ? 1 / zoomFactor : zoomFactor );
 
   scale( scaleFactor, scaleFactor );
 }

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+                             qgsmodelgraphicsview.cpp
+                             ----------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelgraphicsview.h"
+#include "qgssettings.h"
+
+#include <QDragEnterEvent>
+#include <QScrollBar>
+
+///@cond NOT_STABLE
+
+QgsModelGraphicsView::QgsModelGraphicsView( QWidget *parent )
+  : QGraphicsView( parent )
+{
+  setAcceptDrops( true );
+  setDragMode( QGraphicsView::ScrollHandDrag );
+}
+
+void QgsModelGraphicsView::dragEnterEvent( QDragEnterEvent *event )
+{
+  if ( event->mimeData()->hasText() || event->mimeData()->hasFormat( QStringLiteral( "application/x-vnd.qgis.qgis.algorithmid" ) ) )
+    event->acceptProposedAction();
+  else
+    event->ignore();
+}
+
+void QgsModelGraphicsView::dropEvent( QDropEvent *event )
+{
+  const QPointF dropPoint = mapToScene( event->pos() );
+  if ( event->mimeData()->hasFormat( QStringLiteral( "application/x-vnd.qgis.qgis.algorithmid" ) ) )
+  {
+    QByteArray data = event->mimeData()->data( QStringLiteral( "application/x-vnd.qgis.qgis.algorithmid" ) );
+    QDataStream stream( &data, QIODevice::ReadOnly );
+    QString algorithmId;
+    stream >> algorithmId;
+
+    QTimer::singleShot( 0, this, [this, dropPoint, algorithmId ]
+    {
+      emit algorithmDropped( algorithmId, dropPoint );
+    } );
+    event->accept();
+  }
+  else if ( event->mimeData()->hasText() )
+  {
+    const QString itemId = event->mimeData()->text();
+    QTimer::singleShot( 0, this, [this, dropPoint, itemId ]
+    {
+      emit inputDropped( itemId, dropPoint );
+    } );
+    event->accept();
+  }
+  else
+  {
+    event->ignore();
+  }
+}
+
+void QgsModelGraphicsView::dragMoveEvent( QDragMoveEvent *event )
+{
+  if ( event->mimeData()->hasText() || event->mimeData()->hasFormat( QStringLiteral( "application/x-vnd.qgis.qgis.algorithmid" ) ) )
+    event->acceptProposedAction();
+  else
+    event->ignore();
+}
+
+void QgsModelGraphicsView::wheelEvent( QWheelEvent *event )
+{
+  setTransformationAnchor( QGraphicsView::AnchorUnderMouse );
+
+  //get mouse wheel zoom behavior settings
+  QgsSettings settings;
+  double zoomFactor = settings.value( QStringLiteral( "qgis/zoom_factor" ), 2 ).toDouble();
+
+  // "Normal" mouse have an angle delta of 120, precision mouses provide data faster, in smaller steps
+  zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 120.0 * std::fabs( event->angleDelta().y() );
+
+  if ( event->modifiers() & Qt::ControlModifier )
+  {
+    //holding ctrl while wheel zooming results in a finer zoom
+    zoomFactor = 1.0 + ( zoomFactor - 1.0 ) / 20.0;
+  }
+
+  //calculate zoom scale factor
+  bool zoomIn = event->angleDelta().y() > 0;
+  double scaleFactor = ( zoomIn ? 1 / zoomFactor : zoomFactor );
+
+  scale( scaleFactor, scaleFactor );
+}
+
+void QgsModelGraphicsView::enterEvent( QEvent *event )
+{
+  QGraphicsView::enterEvent( event );
+  viewport()->setCursor( Qt::ArrowCursor );
+}
+
+void QgsModelGraphicsView::mousePressEvent( QMouseEvent *event )
+{
+  if ( event->button() == Qt::MidButton )
+    mPreviousMousePos = event->pos();
+  else
+    QGraphicsView::mousePressEvent( event );
+}
+
+void QgsModelGraphicsView::mouseMoveEvent( QMouseEvent *event )
+{
+  if ( event->buttons() == Qt::MidButton )
+  {
+    const QPoint offset = mPreviousMousePos - event->pos();
+    mPreviousMousePos = event->pos();
+
+    verticalScrollBar()->setValue( verticalScrollBar()->value() + offset.y() );
+    horizontalScrollBar()->setValue( horizontalScrollBar()->value() + offset.x() );
+  }
+  else
+  {
+    QGraphicsView::mouseMoveEvent( event );
+  }
+}
+
+
+///@endcond
+
+

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+                             qgsmodelgraphicsview.h
+                             -----------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELGRAPHICVIEW_H
+#define QGSMODELGRAPHICVIEW_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "qgsprocessingcontext.h"
+#include <QGraphicsView>
+
+///@cond NOT_STABLE
+
+/**
+ * \ingroup gui
+ * \brief QGraphicsView subclass representing the model designer.
+ * \warning Not stable API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelGraphicsView, with the specified \a parent widget.
+     */
+    QgsModelGraphicsView( QWidget *parent = nullptr );
+
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
+    void dragMoveEvent( QDragMoveEvent *event ) override;
+    void wheelEvent( QWheelEvent *event ) override;
+    void enterEvent( QEvent *event ) override;
+    void mousePressEvent( QMouseEvent *event ) override;
+    void mouseMoveEvent( QMouseEvent *event ) override;
+
+  signals:
+
+    /**
+     * Emitted when an algorithm is dropped onto the view.
+     */
+    void algorithmDropped( const QString &algorithmId, const QPointF &pos );
+
+    /**
+     * Emitted when an input parameter is dropped onto the view.
+     */
+    void inputDropped( const QString &inputId, const QPointF &pos );
+
+  private:
+    QPoint mPreviousMousePos;
+
+};
+
+///@endcond
+
+#endif // QGSMODELGRAPHICVIEW_H

--- a/src/gui/processing/qgsprocessingtoolboxmodel.cpp
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.cpp
@@ -666,6 +666,11 @@ QgsProcessingToolboxModel *QgsProcessingToolboxProxyModel::toolboxModel()
   return mModel;
 }
 
+const QgsProcessingToolboxModel *QgsProcessingToolboxProxyModel::toolboxModel() const
+{
+  return mModel;
+}
+
 void QgsProcessingToolboxProxyModel::setFilters( QgsProcessingToolboxProxyModel::Filters filters )
 {
   mFilters = filters;

--- a/src/gui/processing/qgsprocessingtoolboxmodel.h
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.h
@@ -451,6 +451,12 @@ class GUI_EXPORT QgsProcessingToolboxProxyModel: public QSortFilterProxyModel
     QgsProcessingToolboxModel *toolboxModel();
 
     /**
+     * Returns the underlying source Processing toolbox model.
+     * \note Not available in Python bindings
+     */
+    const QgsProcessingToolboxModel *toolboxModel() const SIP_SKIP;
+
+    /**
      * Set \a filters that affect how toolbox content is filtered.
      * \see filters()
      */

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>DlgModeler</class>
- <widget class="QMainWindow" name="DlgModeler">
+ <class>QgsModelDesignerDialogBase</class>
+ <widget class="QMainWindow" name="QgsModelDesignerDialogBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -78,6 +78,8 @@
     <addaction name="mActionZoomOut"/>
     <addaction name="mActionZoomActual"/>
     <addaction name="mActionZoomToItems"/>
+    <addaction name="separator"/>
+    <addaction name="mActionShowComments"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="menu_View"/>
@@ -111,6 +113,10 @@
    <addaction name="mActionRun"/>
   </widget>
   <action name="mActionOpen">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+   </property>
    <property name="text">
     <string>Open Model…</string>
    </property>
@@ -122,6 +128,10 @@
    </property>
   </action>
   <action name="mActionSave">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+   </property>
    <property name="text">
     <string>Save Model</string>
    </property>
@@ -133,6 +143,10 @@
    </property>
   </action>
   <action name="mActionSaveAs">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileSaveAs.svg</normaloff>:/images/themes/default/mActionFileSaveAs.svg</iconset>
+   </property>
    <property name="text">
     <string>Save Model as…</string>
    </property>
@@ -144,6 +158,10 @@
    </property>
   </action>
   <action name="mActionZoomActual">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomActual.svg</normaloff>:/images/themes/default/mActionZoomActual.svg</iconset>
+   </property>
    <property name="text">
     <string>Zoom to &amp;100%</string>
    </property>
@@ -155,6 +173,10 @@
    </property>
   </action>
   <action name="mActionZoomIn">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomIn.svg</normaloff>:/images/themes/default/mActionZoomIn.svg</iconset>
+   </property>
    <property name="text">
     <string>Zoom In</string>
    </property>
@@ -166,6 +188,10 @@
    </property>
   </action>
   <action name="mActionZoomOut">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomOut.svg</normaloff>:/images/themes/default/mActionZoomOut.svg</iconset>
+   </property>
    <property name="text">
     <string>Zoom Out</string>
    </property>
@@ -177,6 +203,10 @@
    </property>
   </action>
   <action name="mActionExportImage">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveMapAsImage.svg</normaloff>:/images/themes/default/mActionSaveMapAsImage.svg</iconset>
+   </property>
    <property name="text">
     <string>Export as Image…</string>
    </property>
@@ -185,6 +215,10 @@
    </property>
   </action>
   <action name="mActionZoomToItems">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomFullExtent.svg</normaloff>:/images/themes/default/mActionZoomFullExtent.svg</iconset>
+   </property>
    <property name="text">
     <string>Zoom Full</string>
    </property>
@@ -196,6 +230,10 @@
    </property>
   </action>
   <action name="mActionExportPdf">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveAsPDF.svg</normaloff>:/images/themes/default/mActionSaveAsPDF.svg</iconset>
+   </property>
    <property name="text">
     <string>Export as PDF…</string>
    </property>
@@ -204,6 +242,10 @@
    </property>
   </action>
   <action name="mActionExportSvg">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveAsSVG.svg</normaloff>:/images/themes/default/mActionSaveAsSVG.svg</iconset>
+   </property>
    <property name="text">
     <string>Export as SVG…</string>
    </property>
@@ -212,6 +254,10 @@
    </property>
   </action>
   <action name="mActionExportPython">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveAsPython.svg</normaloff>:/images/themes/default/mActionSaveAsPython.svg</iconset>
+   </property>
    <property name="text">
     <string>Export as Python Script…</string>
    </property>
@@ -220,6 +266,10 @@
    </property>
   </action>
   <action name="mActionEditHelp">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditHelpContent.svg</normaloff>:/images/themes/default/mActionEditHelpContent.svg</iconset>
+   </property>
    <property name="text">
     <string>Edit Model Help…</string>
    </property>
@@ -228,6 +278,10 @@
    </property>
   </action>
   <action name="mActionRun">
+   <property name="icon">
+    <iconset resource="../../plugins/georeferencer/georeferencer.qrc">
+     <normaloff>:/icons/default/mActionStartGeoref.png</normaloff>:/icons/default/mActionStartGeoref.png</iconset>
+   </property>
    <property name="text">
     <string>Run Model…</string>
    </property>
@@ -239,6 +293,10 @@
    </property>
   </action>
   <action name="mActionSaveInProject">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mAddToProject.svg</normaloff>:/images/themes/default/mAddToProject.svg</iconset>
+   </property>
    <property name="text">
     <string>Save Model in Project</string>
    </property>
@@ -251,7 +309,20 @@
     <string>Close</string>
    </property>
   </action>
+  <action name="mActionShowComments">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Comments</string>
+   </property>
+  </action>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../plugins/georeferencer/georeferencer.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -579,6 +579,15 @@
     <string>Show Comments</string>
    </property>
   </action>
+  <action name="mActionExportAsScriptAlgorithm">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveAsPython.svg</normaloff>:/images/themes/default/mActionSaveAsPython.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Export as Script Algorithm…</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -14,7 +14,7 @@
    <string>Graphical Modeler</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_1">
+   <layout class="QVBoxLayout" name="mainLayout">
     <property name="spacing">
      <number>3</number>
     </property>
@@ -31,7 +31,7 @@
      <number>2</number>
     </property>
     <item>
-     <widget class="QGraphicsView" name="view"/>
+     <widget class="QgsModelGraphicsView" name="mView"/>
     </item>
    </layout>
   </widget>
@@ -279,8 +279,8 @@
   </action>
   <action name="mActionRun">
    <property name="icon">
-    <iconset resource="../../plugins/georeferencer/georeferencer.qrc">
-     <normaloff>:/icons/default/mActionStartGeoref.png</normaloff>:/icons/default/mActionStartGeoref.png</iconset>
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionStart.svg</normaloff>:/images/themes/default/mActionStart.svg</iconset>
    </property>
    <property name="text">
     <string>Run Model…</string>
@@ -318,9 +318,15 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsModelGraphicsView</class>
+   <extends>QGraphicsView</extends>
+   <header>qgsmodelgraphicsview.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../../images/images.qrc"/>
-  <include location="../../plugins/georeferencer/georeferencer.qrc"/>
   <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -243,6 +243,29 @@
           <height>70</height>
          </rect>
         </property>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QgsModelDesignerInputsTreeWidget" name="mInputsTreeWidget">
+           <column>
+            <property name="text">
+             <string notr="true">1</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </widget>
      </item>
@@ -590,6 +613,11 @@
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsModelDesignerInputsTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>qgsmodeldesignerinputstreewidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>891</width>
+    <width>786</width>
     <height>596</height>
    </rect>
   </property>
@@ -40,7 +40,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>891</width>
+     <width>786</width>
      <height>24</height>
     </rect>
    </property>
@@ -111,6 +111,245 @@
    <addaction name="mActionEditHelp"/>
    <addaction name="separator"/>
    <addaction name="mActionRun"/>
+  </widget>
+  <widget class="QgsDockWidget" name="mPropertiesDock">
+   <property name="windowTitle">
+    <string>Model Properties</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsScrollArea" name="scrollArea">
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>256</width>
+          <height>128</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="mNameEdit">
+           <property name="toolTip">
+            <string>Enter model name here</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Group</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="mGroupEdit">
+           <property name="toolTip">
+            <string>Enter group name here</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QgsDockWidget" name="mInputsDock">
+   <property name="windowTitle">
+    <string>Inputs</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_2">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsScrollArea" name="mInputsScrollArea">
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents_2">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>256</width>
+          <height>70</height>
+         </rect>
+        </property>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QgsDockWidget" name="mAlgorithmsDock">
+   <property name="windowTitle">
+    <string>Algorithms</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_3">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsScrollArea" name="scrollArea_2">
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents_3">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>256</width>
+          <height>231</height>
+         </rect>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QgsFilterLineEdit" name="mAlgorithmSearchEdit">
+           <property name="toolTip">
+            <string>Enter algorithm name to filter list</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsProcessingToolboxTreeView" name="mAlgorithmsTree">
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QgsDockWidget" name="mVariablesDock">
+   <property name="windowTitle">
+    <string>Variables</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_4">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QgsVariableEditorWidget" name="mVariablesEditor" native="true"/>
+     </item>
+    </layout>
+   </widget>
   </widget>
   <action name="mActionOpen">
    <property name="icon">
@@ -323,6 +562,34 @@
    <class>QgsModelGraphicsView</class>
    <extends>QGraphicsView</extends>
    <header>qgsmodelgraphicsview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsProcessingToolboxTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgsprocessingtoolboxtreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsVariableEditorWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsvariableeditorwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDockWidget</class>
+   <extends>QDockWidget</extends>
+   <header>qgsdockwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -7841,6 +7841,12 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( alg.shortDescription(), QStringLiteral( "short" ) );
   QCOMPARE( alg.helpUrl(), QStringLiteral( "url" ) );
 
+  QVariantMap lastParams;
+  lastParams.insert( QStringLiteral( "a" ), 2 );
+  lastParams.insert( QStringLiteral( "b" ), 4 );
+  alg.setDesignerParameterValues( lastParams );
+  QCOMPARE( alg.designerParameterValues(), lastParams );
+
   // child algorithms
   QMap<QString, QgsProcessingModelChildAlgorithm> algs;
   QgsProcessingModelChildAlgorithm a1;
@@ -8185,6 +8191,7 @@ void TestQgsProcessing::modelerAlgorithm()
   alg5pc1.setPosition( QPointF( 11, 12 ) );
   alg5pc1.setSize( QSizeF( 21, 22 ) );
   alg5.addModelParameter( new QgsProcessingParameterBoolean( QStringLiteral( "my_param" ) ), alg5pc1 );
+  alg5.setDesignerParameterValues( lastParams );
 
   QDomDocument doc = QDomDocument( "model" );
   QDomElement elem = QgsXmlUtils::writeVariant( alg5.toVariant(), doc );
@@ -8196,6 +8203,7 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( alg6.group(), QStringLiteral( "testGroup" ) );
   QCOMPARE( alg6.helpContent(), alg5.helpContent() );
   QCOMPARE( alg6.variables(), variables );
+  QCOMPARE( alg6.designerParameterValues(), lastParams );
   QgsProcessingModelChildAlgorithm alg6c1 = alg6.childAlgorithm( "cx1" );
   QCOMPARE( alg6c1.childId(), QStringLiteral( "cx1" ) );
   QCOMPARE( alg6c1.algorithmId(), QStringLiteral( "buffer" ) );


### PR DESCRIPTION
When designing a model, users typically will need to run the model many times as they tweak its structure.

This change causes the parameters used when running the model from the designer to be remembered and saved into the model, so that each time you run the model from the designer you don't have to re-set all the input parameter values to the desired test ones.

Makes iterative model design SO much easier!

Sponsored by Alta Ehf

Also includes a partial port of the model designer dialog from Python to c++, because c++ >> Python.