### PR TITLE
Disable flaky tests on Travis

### DIFF
--- a/.ci/travis/linux/scripts/test_blacklist.txt
+++ b/.ci/travis/linux/scripts/test_blacklist.txt
@@ -4,6 +4,13 @@ PyQgsPalLabelingServer
 qgis_composerutils
 PyQgsAppStartup
 
+# flaky 
+PyQgsPostgresRasterProvider
+
+# intermittent crashes
+PyQgsExpressionBuilderWidget
+PyQgsRulebasedRenderer
+
 # code layout tests are run on separate build
 qgis_spelling
 qgis_sipify


### PR DESCRIPTION
Travis is seriously annoying these days, so disable the culprits:

PyQgsPostgresRasterProvider: intermittently returns different results
PyQgsExpressionBuilderWidget: intermittent crash on end
PyQgsRulebasedRenderer: intermittent crash on end
