### PR TITLE
Fixes the activation of the shape map tools when digitizing is finished

### DIFF
--- a/src/app/qgsmaptooladdcircle.cpp
+++ b/src/app/qgsmaptooladdcircle.cpp
@@ -139,3 +139,13 @@ void QgsMapToolAddCircle::clean()
   if ( vLayer )
     mLayerType = vLayer->geometryType();
 }
+
+void QgsMapToolAddCircle::release( QgsMapMouseEvent *e )
+{
+  deactivate();
+  if ( mParentTool )
+  {
+    mParentTool->canvasReleaseEvent( e );
+  }
+  activate();
+}

--- a/src/app/qgsmaptooladdcircle.h
+++ b/src/app/qgsmaptooladdcircle.h
@@ -46,6 +46,9 @@ class APP_EXPORT QgsMapToolAddCircle: public QgsMapToolCapture
   protected:
     explicit QgsMapToolAddCircle( QgsMapCanvas *canvas ) = delete; //forbidden
 
+    //! Convenient method to release (activate/deactivate) tools
+    void release( QgsMapMouseEvent *e );
+
     /**
      * The parent map tool, e.g. the add feature tool.
      *  Completed circle will be added to this tool by calling its addCurve() method.

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -242,3 +242,13 @@ void QgsMapToolAddCircularString::removeCenterPointRubberBand()
   delete mCenterPointRubberBand;
   mCenterPointRubberBand = nullptr;
 }
+
+void QgsMapToolAddCircularString::release( QgsMapMouseEvent *e )
+{
+  deactivate();
+  if ( mParentTool )
+  {
+    mParentTool->canvasReleaseEvent( e );
+  }
+  activate();
+}

--- a/src/app/qgsmaptooladdcircularstring.h
+++ b/src/app/qgsmaptooladdcircularstring.h
@@ -41,6 +41,9 @@ class APP_EXPORT QgsMapToolAddCircularString: public QgsMapToolCapture
 
   protected:
 
+    //! Convenient method to release (activate/deactivate) tools
+    void release( QgsMapMouseEvent *e );
+
     /**
      * The parent map tool, e.g. the add feature tool.
      *  Completed circular strings will be added to this tool by calling its addCurve() method.

--- a/src/app/qgsmaptooladdellipse.cpp
+++ b/src/app/qgsmaptooladdellipse.cpp
@@ -139,3 +139,13 @@ void QgsMapToolAddEllipse::clean()
   if ( vLayer )
     mLayerType = vLayer->geometryType();
 }
+
+void QgsMapToolAddEllipse::release( QgsMapMouseEvent *e )
+{
+  deactivate();
+  if ( mParentTool )
+  {
+    mParentTool->canvasReleaseEvent( e );
+  }
+  activate();
+}

--- a/src/app/qgsmaptooladdellipse.h
+++ b/src/app/qgsmaptooladdellipse.h
@@ -42,6 +42,9 @@ class APP_EXPORT QgsMapToolAddEllipse: public QgsMapToolCapture
   protected:
     explicit QgsMapToolAddEllipse( QgsMapCanvas *canvas ) = delete; //forbidden
 
+    //! Convenient method to release (activate/deactivate) tools
+    void release( QgsMapMouseEvent *e );
+
     /**
      * The parent map tool, e.g. the add feature tool.
      *  Completed ellipse will be added to this tool by calling its toLineString() method.

--- a/src/app/qgsmaptooladdrectangle.cpp
+++ b/src/app/qgsmaptooladdrectangle.cpp
@@ -139,3 +139,13 @@ void QgsMapToolAddRectangle::clean()
   if ( vLayer )
     mLayerType = vLayer->geometryType();
 }
+
+void QgsMapToolAddRectangle::release( QgsMapMouseEvent *e )
+{
+  deactivate();
+  if ( mParentTool )
+  {
+    mParentTool->canvasReleaseEvent( e );
+  }
+  activate();
+}

--- a/src/app/qgsmaptooladdrectangle.h
+++ b/src/app/qgsmaptooladdrectangle.h
@@ -43,6 +43,9 @@ class APP_EXPORT QgsMapToolAddRectangle: public QgsMapToolCapture
   protected:
     explicit QgsMapToolAddRectangle( QgsMapCanvas *canvas ) = delete; //forbidden
 
+    //! Convenient method to release (activate/deactivate) tools
+    void release( QgsMapMouseEvent *e );
+
     /**
      * The parent map tool, e.g. the add feature tool.
      *  Completed regular shape will be added to this tool by calling its addCurve() method.

--- a/src/app/qgsmaptooladdregularpolygon.cpp
+++ b/src/app/qgsmaptooladdregularpolygon.cpp
@@ -163,3 +163,13 @@ void QgsMapToolAddRegularPolygon::clean()
   if ( vLayer )
     mLayerType = vLayer->geometryType();
 }
+
+void QgsMapToolAddRegularPolygon::release( QgsMapMouseEvent *e )
+{
+  deactivate();
+  if ( mParentTool )
+  {
+    mParentTool->canvasReleaseEvent( e );
+  }
+  activate();
+}

--- a/src/app/qgsmaptooladdregularpolygon.h
+++ b/src/app/qgsmaptooladdregularpolygon.h
@@ -51,6 +51,9 @@ class APP_EXPORT QgsMapToolAddRegularPolygon: public QgsMapToolCapture
     //! delete the spin box to enter the number of sides, if it exists
     void deleteNumberSidesSpinBox();
 
+    //! Convenient method to release (activate/deactivate) tools
+    void release( QgsMapMouseEvent *e );
+
     /**
      * The parent map tool, e.g. the add feature tool.
      *  Completed regular polygon will be added to this tool by calling its addCurve() method.

--- a/src/app/qgsmaptoolcircle2points.cpp
+++ b/src/app/qgsmaptoolcircle2points.cpp
@@ -61,6 +61,7 @@ void QgsMapToolCircle2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolcircle2points.cpp
+++ b/src/app/qgsmaptoolcircle2points.cpp
@@ -56,12 +56,7 @@ void QgsMapToolCircle2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcircle2tangentspoint.cpp
+++ b/src/app/qgsmaptoolcircle2tangentspoint.cpp
@@ -83,6 +83,7 @@ void QgsMapToolCircle2TangentsPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
         QgisApp::instance()->messageBar()->pushMessage( tr( "Error" ), tr( "Segments are parallels" ),
             Qgis::Critical, QgisApp::instance()->messageTimeout() );
         deactivate();
+        activate();
       }
       else
         createRadiusSpinBox();
@@ -107,6 +108,7 @@ void QgsMapToolCircle2TangentsPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolcircle2tangentspoint.cpp
+++ b/src/app/qgsmaptoolcircle2tangentspoint.cpp
@@ -101,14 +101,9 @@ void QgsMapToolCircle2TangentsPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
     qDeleteAll( mRubberBands );
     mRubberBands.clear();
 
-    deactivate();
     deleteRadiusSpinBox();
     mCenters.clear();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcircle3points.cpp
+++ b/src/app/qgsmaptoolcircle3points.cpp
@@ -53,12 +53,7 @@ void QgsMapToolCircle3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcircle3points.cpp
+++ b/src/app/qgsmaptoolcircle3points.cpp
@@ -58,6 +58,7 @@ void QgsMapToolCircle3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolcircle3tangents.cpp
+++ b/src/app/qgsmaptoolcircle3tangents.cpp
@@ -76,12 +76,7 @@ void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         mTempRubberBand = nullptr;
       }
     }
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcircle3tangents.cpp
+++ b/src/app/qgsmaptoolcircle3tangents.cpp
@@ -81,6 +81,7 @@ void QgsMapToolCircle3Tangents::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolcirclecenterpoint.cpp
+++ b/src/app/qgsmaptoolcirclecenterpoint.cpp
@@ -57,12 +57,7 @@ void QgsMapToolCircleCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcirclecenterpoint.cpp
+++ b/src/app/qgsmaptoolcirclecenterpoint.cpp
@@ -62,6 +62,7 @@ void QgsMapToolCircleCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -82,12 +82,7 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -87,6 +87,7 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -95,12 +95,7 @@ void QgsMapToolCircularStringRadius::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
   {
     if ( !( mPoints.size() % 2 ) )
       mPoints.removeLast();
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -100,6 +100,7 @@ void QgsMapToolCircularStringRadius::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolellipsecenter2points.cpp
+++ b/src/app/qgsmaptoolellipsecenter2points.cpp
@@ -56,12 +56,7 @@ void QgsMapToolEllipseCenter2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolellipsecenter2points.cpp
+++ b/src/app/qgsmaptoolellipsecenter2points.cpp
@@ -61,6 +61,7 @@ void QgsMapToolEllipseCenter2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e 
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolellipsecenterpoint.cpp
+++ b/src/app/qgsmaptoolellipsecenterpoint.cpp
@@ -54,12 +54,7 @@ void QgsMapToolEllipseCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolellipsecenterpoint.cpp
+++ b/src/app/qgsmaptoolellipsecenterpoint.cpp
@@ -59,6 +59,7 @@ void QgsMapToolEllipseCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolellipseextent.cpp
+++ b/src/app/qgsmaptoolellipseextent.cpp
@@ -61,6 +61,7 @@ void QgsMapToolEllipseExtent::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolellipseextent.cpp
+++ b/src/app/qgsmaptoolellipseextent.cpp
@@ -56,12 +56,7 @@ void QgsMapToolEllipseExtent::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolellipsefoci.cpp
+++ b/src/app/qgsmaptoolellipsefoci.cpp
@@ -55,12 +55,7 @@ void QgsMapToolEllipseFoci::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolellipsefoci.cpp
+++ b/src/app/qgsmaptoolellipsefoci.cpp
@@ -60,6 +60,7 @@ void QgsMapToolEllipseFoci::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolrectangle3points.cpp
+++ b/src/app/qgsmaptoolrectangle3points.cpp
@@ -66,12 +66,7 @@ void QgsMapToolRectangle3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    deactivate( );
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolrectangle3points.cpp
+++ b/src/app/qgsmaptoolrectangle3points.cpp
@@ -71,6 +71,7 @@ void QgsMapToolRectangle3Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolrectanglecenter.cpp
+++ b/src/app/qgsmaptoolrectanglecenter.cpp
@@ -65,6 +65,7 @@ void QgsMapToolRectangleCenter::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolrectanglecenter.cpp
+++ b/src/app/qgsmaptoolrectanglecenter.cpp
@@ -60,12 +60,7 @@ void QgsMapToolRectangleCenter::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolrectangleextent.cpp
+++ b/src/app/qgsmaptoolrectangleextent.cpp
@@ -58,12 +58,7 @@ void QgsMapToolRectangleExtent::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolrectangleextent.cpp
+++ b/src/app/qgsmaptoolrectangleextent.cpp
@@ -63,6 +63,7 @@ void QgsMapToolRectangleExtent::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolregularpolygon2points.cpp
+++ b/src/app/qgsmaptoolregularpolygon2points.cpp
@@ -65,12 +65,7 @@ void QgsMapToolRegularPolygon2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolregularpolygon2points.cpp
+++ b/src/app/qgsmaptoolregularpolygon2points.cpp
@@ -70,6 +70,7 @@ void QgsMapToolRegularPolygon2Points::cadCanvasReleaseEvent( QgsMapMouseEvent *e
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolregularpolygoncentercorner.cpp
+++ b/src/app/qgsmaptoolregularpolygoncentercorner.cpp
@@ -68,6 +68,7 @@ void QgsMapToolRegularPolygonCenterCorner::cadCanvasReleaseEvent( QgsMapMouseEve
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolregularpolygoncentercorner.cpp
+++ b/src/app/qgsmaptoolregularpolygoncentercorner.cpp
@@ -63,12 +63,7 @@ void QgsMapToolRegularPolygonCenterCorner::cadCanvasReleaseEvent( QgsMapMouseEve
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 

--- a/src/app/qgsmaptoolregularpolygoncenterpoint.cpp
+++ b/src/app/qgsmaptoolregularpolygoncenterpoint.cpp
@@ -70,6 +70,7 @@ void QgsMapToolRegularPolygonCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEven
     {
       mParentTool->canvasReleaseEvent( e );
     }
+    activate();
   }
 }
 

--- a/src/app/qgsmaptoolregularpolygoncenterpoint.cpp
+++ b/src/app/qgsmaptoolregularpolygoncenterpoint.cpp
@@ -65,12 +65,7 @@ void QgsMapToolRegularPolygonCenterPoint::cadCanvasReleaseEvent( QgsMapMouseEven
   {
     mPoints.append( point );
 
-    deactivate();
-    if ( mParentTool )
-    {
-      mParentTool->canvasReleaseEvent( e );
-    }
-    activate();
+    release( e );
   }
 }
 


### PR DESCRIPTION
## Description
The digitizing logic for these tools is to deactivate them when digitizing is complete (right-click). However, the tool remains active, but the icon is not pushed in, and the Advanced Digitizing Tool is not active. To fix it, activate the tool again.
