### PR TITLE
Fix landing page test for OGC API Features certification

### DIFF
--- a/src/server/qgsserverogcapi.cpp
+++ b/src/server/qgsserverogcapi.cpp
@@ -33,7 +33,7 @@ QMap<QgsServerOgcApi::ContentType, QStringList> QgsServerOgcApi::sContentTypeMim
     QStringLiteral( "application/geojson" )
   };
   map[QgsServerOgcApi::ContentType::HTML] = QStringList { QStringLiteral( "text/html" ) };
-  map[QgsServerOgcApi::ContentType::OPENAPI3] = QStringList { QStringLiteral( "application/openapi+json;version=3.0" ) };
+  map[QgsServerOgcApi::ContentType::OPENAPI3] = QStringList { QStringLiteral( "application/vnd.oai.openapi+json;version=3.0" ) };
   map[QgsServerOgcApi::ContentType::XML] = QStringList { QStringLiteral( "application/xml" ) };
   return map;
 }();

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -301,7 +301,7 @@ void QgsWfs3LandingPageHandler::handleRequest( const QgsServerApiContext &contex
   } );
   data["links"].push_back(
   {
-    { "href", href( context, "/api" )},
+    { "href", href( context, "/api.json" )},
     { "rel", QgsServerOgcApi::relToString( QgsServerOgcApi::Rel::service_desc ) },
     { "type", QgsServerOgcApi::mimeType( QgsServerOgcApi::ContentType::OPENAPI3 ) },
     { "title", "API description" },

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -169,7 +169,7 @@ json QgsWfs3APIHandler::schema( const QgsServerApiContext &context ) const
                 {
                   "content", {
                     {
-                      "application/openapi+json;version=3.0", {
+                      "application/vnd.oai.openapi+json;version=3.0", {
                         {
                           "schema",  {
                             { "type", "object" }

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -1,4 +1,4 @@
-Content-Type: application/openapi+json;version=3.0
+Content-Type: application/vnd.oai.openapi+json;version=3.0
 
 {
   "components": {

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -563,7 +563,7 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
         "responses": {
           "200": {
             "content": {
-              "application/openapi+json;version=3.0": {
+              "application/vnd.oai.openapi+json;version=3.0": {
                 "schema": {
                   "type": "object"
                 }

--- a/tests/testdata/qgis_server/api/test_wfs3_landing_page.html
+++ b/tests/testdata/qgis_server/api/test_wfs3_landing_page.html
@@ -28,7 +28,7 @@
 
     <link rel="conformance" href="http://server.qgis.org/wfs3/conformance" title="Conformance classes" type="application/json">
 
-    <link rel="service-desc" href="http://server.qgis.org/wfs3/api" title="API description" type="application/openapi+json;version=3.0">
+    <link rel="service-desc" href="http://server.qgis.org/wfs3/api.json" title="API description" type="application/vnd.oai.openapi+json;version=3.0">
 
 
 
@@ -83,7 +83,7 @@
     
         
         
-        <li><a rel="service-desc" href="http://server.qgis.org/wfs3/api">API description</a></li>
+        <li><a rel="service-desc" href="http://server.qgis.org/wfs3/api.json">API description</a></li>
         
         
     

--- a/tests/testdata/qgis_server/api/test_wfs3_landing_page.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_landing_page.json
@@ -27,10 +27,10 @@ Content-Type: application/json
       "type": "application/json"
     },
     {
-      "href": "http://server.qgis.org/wfs3/api",
+      "href": "http://server.qgis.org/wfs3/api.json",
       "rel": "service-desc",
       "title": "API description",
-      "type": "application/openapi+json;version=3.0"
+      "type": "application/vnd.oai.openapi+json;version=3.0"
     }
   ],
   "timeStamp": "2019-07-05T12:27:07Z"


### PR DESCRIPTION
## Description

The first two commits fix the `openapiDocumentRetrieval` test for OGC API Features certification.

The third one is not necessary to pass the corresponding test, but the current `service-desc` url links to a HTML page whereas the type is explicitly stated as json (which seems wrong).