### PR TITLE
[processing][needs-docs] Adjust status of controls executing an algorithm dialog 

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -75,6 +75,11 @@ Returns the main widget for the dialog, usually a panel for configuring algorith
 Switches the dialog to the log page.
 %End
 
+    void showParameters();
+%Docstring
+Switches the dialog to the parameters page.
+%End
+
     bool wasExecuted() const;
 %Docstring
 Returns ``True`` if an algorithm was executed in the dialog.
@@ -197,6 +202,11 @@ Returns the dialog's run button.
 Returns the dialog's cancel button.
 %End
 
+    QPushButton *changeParametersButton();
+%Docstring
+Returns the dialog's change parameters button.
+%End
+
     QDialogButtonBox *buttonBox();
 %Docstring
 Returns the dialog's button box.
@@ -221,6 +231,12 @@ Sets whether the algorithm was executed through the dialog.
 .. seealso:: :py:func:`setResults`
 %End
 
+    void setExecutedAnyResult( bool executedAnyResult );
+%Docstring
+Sets whether the algorithm was executed through the dialog (no matter the result).
+%End
+
+
     void setResults( const QVariantMap &results );
 %Docstring
 Sets the algorithm results.
@@ -238,6 +254,17 @@ Displays an info ``message`` in the dialog's log.
     void resetGui();
 %Docstring
 Resets the dialog's gui, ready for another algorithm execution.
+%End
+
+    void updateRunButtonVisibility();
+%Docstring
+Sets visibility for mutually exclusive buttons Run and Change Parameters.
+%End
+
+    void blockControlsWhileRunning();
+%Docstring
+Blocks run and changeParameters buttons and parameters tab while the
+algorithm is running.
 %End
 
     QgsMessageBar *messageBar();

--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -256,6 +256,12 @@ Displays an info ``message`` in the dialog's log.
 Resets the dialog's gui, ready for another algorithm execution.
 %End
 
+    virtual void resetAdditionalGui();
+%Docstring
+For subclasses to register their own GUI controls to be reset, ready
+for another algorithm execution.
+%End
+
     void updateRunButtonVisibility();
 %Docstring
 Sets visibility for mutually exclusive buttons Run and Change Parameters.
@@ -265,6 +271,12 @@ Sets visibility for mutually exclusive buttons Run and Change Parameters.
 %Docstring
 Blocks run and changeParameters buttons and parameters tab while the
 algorithm is running.
+%End
+
+    virtual void blockAdditionalControlsWhileRunning();
+%Docstring
+For subclasses to register their own GUI controls to be blocked while
+the algorithm is running.
 %End
 
     QgsMessageBar *messageBar();

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -90,6 +90,8 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.buttonBox().button(QDialogButtonBox.Close).setText(QCoreApplication.translate("AlgorithmDialog", "Cancel"))
             self.setWindowTitle(self.windowTitle() + ' | ' + self.active_layer.name())
 
+        self.updateRunButtonVisibility()
+
     def getParametersPanel(self, alg, parent):
         return ParametersPanel(parent, alg, self.in_place)
 
@@ -189,7 +191,9 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 QMessageBox.warning(
                     self, self.tr('Unable to execute algorithm'), msg)
                 return
-            self.runButton().setEnabled(False)
+
+            self.blockControlsWhileRunning()
+            self.setExecutedAnyResult(True)
             self.cancelButton().setEnabled(False)
             buttons = self.mainWidget().iterateButtons
             self.iterateParam = None

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -101,6 +101,14 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         dlg.show()
         dlg.exec_()
 
+    def resetAdditionalGui(self):
+        if not self.in_place:
+            self.runAsBatchButton.setEnabled(True)
+
+    def blockAdditionalControlsWhileRunning(self):
+        if not self.in_place:
+            self.runAsBatchButton.setEnabled(False)
+
     def setParameters(self, parameters):
         self.mainWidget().setParameters(parameters)
 

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -77,6 +77,8 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         self.btnRunSingle.clicked.connect(self.runAsSingle)
         self.buttonBox().addButton(self.btnRunSingle, QDialogButtonBox.ResetRole)  # reset role to ensure left alignment
 
+        self.updateRunButtonVisibility()
+
     def runAsSingle(self):
         self.close()
 
@@ -106,7 +108,8 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
 
         with OverrideCursor(Qt.WaitCursor):
 
-            self.mainWidget().setEnabled(False)
+            self.blockControlsWhileRunning()
+            self.setExecutedAnyResult(True)
             self.cancelButton().setEnabled(True)
 
             # Make sure the Log tab is visible before executing the algorithm
@@ -178,7 +181,6 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.loadHTMLResults(results['results'], count)
 
         self.createSummaryTable(algorithm_results, errors)
-        self.mainWidget().setEnabled(True)
         self.resetGui()
 
     def loadHTMLResults(self, results, num):

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -87,6 +87,12 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         dlg.show()
         dlg.exec_()
 
+    def resetAdditionalGui(self):
+        self.btnRunSingle.setEnabled(True)
+
+    def blockAdditionalControlsWhileRunning(self):
+        self.btnRunSingle.setEnabled(False)
+
     def runAlgorithm(self):
         alg_parameters = []
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -581,7 +581,10 @@ void QgsProcessingAlgorithmDialogBase::resetGui()
   mButtonRun->setEnabled( true );
   mButtonChangeParameters->setEnabled( true );
   mButtonClose->setEnabled( true );
-  mTabWidget->setTabEnabled( 0, true ); // Enable Parameters tab
+  if ( mMainWidget )
+  {
+    mMainWidget->setEnabled( true );
+  }
   updateRunButtonVisibility();
   resetAdditionalGui();
 }
@@ -591,7 +594,7 @@ void QgsProcessingAlgorithmDialogBase::updateRunButtonVisibility()
   // Activate run button if current tab is Parameters
   bool runButtonVisible = mTabWidget->currentIndex() == 0;
   mButtonRun->setVisible( runButtonVisible );
-  mButtonChangeParameters->setVisible( !runButtonVisible && mExecutedAnyResult );
+  mButtonChangeParameters->setVisible( !runButtonVisible && mExecutedAnyResult && mButtonChangeParameters->isEnabled() );
 }
 
 void QgsProcessingAlgorithmDialogBase::resetAdditionalGui()
@@ -603,7 +606,10 @@ void QgsProcessingAlgorithmDialogBase::blockControlsWhileRunning()
 {
   mButtonRun->setEnabled( false );
   mButtonChangeParameters->setEnabled( false );
-  mTabWidget->setTabEnabled( 0, false ); // Disable Parameters tab
+  if ( mMainWidget )
+  {
+    mMainWidget->setEnabled( false );
+  }
   blockAdditionalControlsWhileRunning();
 }
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -583,6 +583,7 @@ void QgsProcessingAlgorithmDialogBase::resetGui()
   mButtonClose->setEnabled( true );
   mTabWidget->setTabEnabled( 0, true ); // Enable Parameters tab
   updateRunButtonVisibility();
+  resetAdditionalGui();
 }
 
 void QgsProcessingAlgorithmDialogBase::updateRunButtonVisibility()
@@ -593,11 +594,22 @@ void QgsProcessingAlgorithmDialogBase::updateRunButtonVisibility()
   mButtonChangeParameters->setVisible( !runButtonVisible && mExecutedAnyResult );
 }
 
+void QgsProcessingAlgorithmDialogBase::resetAdditionalGui()
+{
+
+}
+
 void QgsProcessingAlgorithmDialogBase::blockControlsWhileRunning()
 {
   mButtonRun->setEnabled( false );
   mButtonChangeParameters->setEnabled( false );
   mTabWidget->setTabEnabled( 0, false ); // Disable Parameters tab
+  blockAdditionalControlsWhileRunning();
+}
+
+void QgsProcessingAlgorithmDialogBase::blockAdditionalControlsWhileRunning()
+{
+
 }
 
 QgsMessageBar *QgsProcessingAlgorithmDialogBase::messageBar()

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -134,6 +134,11 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     void showLog();
 
     /**
+     * Switches the dialog to the parameters page.
+     */
+    void showParameters();
+
+    /**
      * Returns TRUE if an algorithm was executed in the dialog.
      * \see results()
      * \see setExecuted()
@@ -245,6 +250,11 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     QPushButton *cancelButton();
 
     /**
+     * Returns the dialog's change parameters button.
+     */
+    QPushButton *changeParametersButton();
+
+    /**
      * Returns the dialog's button box.
      */
     QDialogButtonBox *buttonBox();
@@ -267,6 +277,12 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     void setExecuted( bool executed );
 
     /**
+     * Sets whether the algorithm was executed through the dialog (no matter the result).
+     */
+    void setExecutedAnyResult( bool executedAnyResult );
+
+
+    /**
      * Sets the algorithm results.
      * \see results()
      * \see setExecuted()
@@ -282,6 +298,17 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * Resets the dialog's gui, ready for another algorithm execution.
      */
     void resetGui();
+
+    /**
+     * Sets visibility for mutually exclusive buttons Run and Change Parameters.
+     */
+    void updateRunButtonVisibility();
+
+    /**
+     * Blocks run and changeParameters buttons and parameters tab while the
+     * algorithm is running.
+     */
+    void blockControlsWhileRunning();
 
     /**
      * Returns the dialog's message bar.
@@ -324,6 +351,7 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     void toggleCollapsed();
 
     void splitterChanged( int pos, int index );
+    void mTabWidget_currentChanged( int index );
     void linkClicked( const QUrl &url );
     void algExecuted( bool successful, const QVariantMap &results );
     void taskTriggered( QgsTask *task );
@@ -333,11 +361,13 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
 
     QPushButton *mButtonRun = nullptr;
     QPushButton *mButtonClose = nullptr;
+    QPushButton *mButtonChangeParameters = nullptr;
     QByteArray mSplitterState;
     QToolButton *mButtonCollapse = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 
     bool mExecuted = false;
+    bool mExecutedAnyResult = false;
     QVariantMap mResults;
     QWidget *mMainWidget = nullptr;
     std::unique_ptr< QgsProcessingAlgorithm > mAlgorithm;

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -300,6 +300,12 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
     void resetGui();
 
     /**
+     * For subclasses to register their own GUI controls to be reset, ready
+     * for another algorithm execution.
+     */
+    virtual void resetAdditionalGui();
+
+    /**
      * Sets visibility for mutually exclusive buttons Run and Change Parameters.
      */
     void updateRunButtonVisibility();
@@ -309,6 +315,12 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * algorithm is running.
      */
     void blockControlsWhileRunning();
+
+    /**
+     * For subclasses to register their own GUI controls to be blocked while
+     * the algorithm is running.
+     */
+    virtual void blockAdditionalControlsWhileRunning();
 
     /**
      * Returns the dialog's message bar.


### PR DESCRIPTION
## Description

Currently, after you run a Processing algorithm, the `Log` tab is visible and the `Run` button is enabled, so you can run the algorithm again with a single click. From a user perspective, it shouldn't be the case. If you want to run the algorithm again, you should at least have a look at the `Parameters` tab once more.

This PR adds the following changes to such behaviour:

  + `Run` button is not shown anymore in the `Log` tab, therefore, you can only run algorithms from the `Parameters` tab.
  + While running an algorithm, the `Parameters` panel is now disabled, as well as `Run as Batch Process...` and `Run as Single Process...` buttons.
  + When an algorithm execution finishes (either successfully or not), a new button `Change Parameters` is shown in the `Log` tab.
  + There is now consistency among algorithm dialogs: Before this PR, `Batch Algorithm Dialog` was the only dialog blocking parameter widgets.

These changes were applied to the `Algorithm Dialog` and `Batch Algorithm Dialog`, and work on `Edit in place` dialogs as well. This PR also takes into account cancelling an algorithm execution or obtaining failures in the execution.

(More details and preliminary discussion in issue https://github.com/qgis/QGIS/issues/34484)

## Screencasts

### Algorithm dialog

![pr_algorithm_dialog_v3](https://user-images.githubusercontent.com/652785/76163646-f4f31400-6115-11ea-9b69-1af3517a4ee7.gif)

### Batch algorithm dialog

![pr_batch_algorithm_dialog_v3](https://user-images.githubusercontent.com/652785/76163648-f8869b00-6115-11ea-84b2-8f1b104df33d.gif)

### Cancelling algorithm execution

![pr_cancelling_algorithm_dialog_v3](https://user-images.githubusercontent.com/652785/76163650-fc1a2200-6115-11ea-82f0-3eb452b4966a.gif)


----------------------------
Fix #34484 
Since this PR implies updating QGIS docs, I could give a hand adjusting the corresponding section.