### PR TITLE
Vertically align widgets in expression builder dialog

### DIFF
--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -147,6 +147,9 @@
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
                    <property name="rightMargin">
                     <number>0</number>
                    </property>
@@ -316,6 +319,9 @@
                     <number>2</number>
                    </property>
                    <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
                     <number>0</number>
                    </property>
                    <property name="rightMargin">
@@ -602,6 +608,18 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_2">
                <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="leftMargin">
+                <number>9</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
                 <number>0</number>
                </property>
                <item>


### PR DESCRIPTION
to get this ![image](https://user-images.githubusercontent.com/7983394/76160280-0b569b00-6129-11ea-882d-ead4fc85124e.png) and no more (from 3.10 but still true)
![image](https://user-images.githubusercontent.com/7983394/76160373-178f2800-612a-11ea-8ddc-a5f46aa41b70.png)

Backport welcome. Thanks

