### PR TITLE
Fix inconsistancies in the expression builder help panel

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -633,7 +633,7 @@ void QgsExpressionBuilderWidget::loadRecent( const QString &collection )
   int i = 0;
   for ( const QString &expression : expressions )
   {
-    QString help = formatRecentExpressionHelp(expression, expression);
+    QString help = formatRecentExpressionHelp( expression, expression );
     registerItem( name, expression, expression, help, QgsExpressionItem::ExpressionNode, false, i );
     i++;
   }
@@ -940,11 +940,11 @@ void QgsExpressionBuilderWidget::registerItemForAllGroups( const QStringList &gr
 QString QgsExpressionBuilderWidget::formatRelationHelp( const QgsRelation &relation ) const
 {
   QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-    .arg( QCoreApplication::translate( "relation_help", "relation %1" ).arg( relation.name() ),
-      tr( "Inserts the relation ID for the relation named '%1'." ).arg( relation.name() ) );
+                 .arg( QCoreApplication::translate( "relation_help", "relation %1" ).arg( relation.name() ),
+                       tr( "Inserts the relation ID for the relation named '%1'." ).arg( relation.name() ) );
 
   text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-    .arg( tr( "Current value" ), relation.id() );
+          .arg( tr( "Current value" ), relation.id() );
 
   return text;
 }
@@ -952,11 +952,11 @@ QString QgsExpressionBuilderWidget::formatRelationHelp( const QgsRelation &relat
 QString QgsExpressionBuilderWidget::formatLayerHelp( const QgsMapLayer *layer ) const
 {
   QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-    .arg( QCoreApplication::translate( "layer_help", "map layer %1" ).arg( layer->name() ),
-      tr( "Inserts the layer ID for the layer named '%1'." ).arg( layer->name() ) );
+                 .arg( QCoreApplication::translate( "layer_help", "map layer %1" ).arg( layer->name() ),
+                       tr( "Inserts the layer ID for the layer named '%1'." ).arg( layer->name() ) );
 
   text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-    .arg( tr( "Current value" ), layer->id() );
+          .arg( tr( "Current value" ), layer->id() );
 
   return text;
 }
@@ -964,11 +964,11 @@ QString QgsExpressionBuilderWidget::formatLayerHelp( const QgsMapLayer *layer ) 
 QString QgsExpressionBuilderWidget::formatRecentExpressionHelp( const QString &label, const QString &expression ) const
 {
   QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-    .arg( QCoreApplication::translate( "recent_expression_help", "expression %1" ).arg( label),
-      QCoreApplication::translate( "recent_expression_help", "Recently used expression." ) );
+                 .arg( QCoreApplication::translate( "recent_expression_help", "expression %1" ).arg( label ),
+                       QCoreApplication::translate( "recent_expression_help", "Recently used expression." ) );
 
   text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-    .arg( tr( "Expression" ), expression );
+          .arg( tr( "Expression" ), expression );
 
   return text;
 }
@@ -976,10 +976,10 @@ QString QgsExpressionBuilderWidget::formatRecentExpressionHelp( const QString &l
 QString QgsExpressionBuilderWidget::formatUserExpressionHelp( const QString &label, const QString &expression, const QString &description ) const
 {
   QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-    .arg( QCoreApplication::translate( "user_expression_help", "expression %1" ).arg( label ), description );
+                 .arg( QCoreApplication::translate( "user_expression_help", "expression %1" ).arg( label ), description );
 
   text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-    .arg( tr( "Expression" ), expression );
+          .arg( tr( "Expression" ), expression );
 
   return text;
 }
@@ -987,16 +987,16 @@ QString QgsExpressionBuilderWidget::formatUserExpressionHelp( const QString &lab
 QString QgsExpressionBuilderWidget::formatVariableHelp( const QString &variable, const QString &description, bool showValue, const QVariant &value ) const
 {
   QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-    .arg( QCoreApplication::translate( "variable_help", "variable %1" ).arg( variable ), description );
+                 .arg( QCoreApplication::translate( "variable_help", "variable %1" ).arg( variable ), description );
 
   if ( showValue )
   {
     QString valueString = !value.isValid()
-      ? QCoreApplication::translate( "variable_help", "not set" )
-      : QStringLiteral( "<pre>%1</pre>" ).arg( QgsExpression::formatPreviewString( value ) );
+                          ? QCoreApplication::translate( "variable_help", "not set" )
+                          : QStringLiteral( "<pre>%1</pre>" ).arg( QgsExpression::formatPreviewString( value ) );
 
     text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><p>%2</p></div>" )
-      .arg( tr( "Current value" ), valueString);
+            .arg( tr( "Current value" ), valueString );
   }
 
   return text;

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -482,6 +482,21 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QString formatLayerHelp( const QgsMapLayer *layer ) const;
 
     /**
+     * Returns a HTML formatted string for use as a \a recent \a expression item help.
+     */
+    QString formatRecentExpressionHelp( const QString &label, const QString &expression ) const;
+
+    /**
+     * Returns a HTML formatted string for use as a \a user \a expression item help.
+     */
+    QString formatUserExpressionHelp( const QString &label, const QString &expression, const QString &description ) const;
+
+    /**
+     * Returns a HTML formatted string for use as a \a variable item help.
+     */
+    QString formatVariableHelp( const QString &variable, const QString &description, bool showValue, const QVariant &value ) const;
+
+    /**
      * Will be set to TRUE if the current expression text reported an eval error
      * with the context.
      *


### PR DESCRIPTION
Fix the HTML help for the following groups of expressions:
- Map layers
- Relation
- User expressions
- Variables
- Recent expressions
To match the styling of the docs of the rest expressions (headers, descriptions etc)

Fixes #34919

## Description

The help text in the expression builder had quite different and dull design for some groups, compared to the rest of the functions. When fixing #34919 I decided to make all the groups of expressions to appear consistent, therefore this PR.

| Current 3.12  | New |
| ------------- | ------------- |
| Map Layers |
| ![layers_old](https://user-images.githubusercontent.com/2820439/76173878-1b638e80-61ac-11ea-9c26-bd4e6419d879.png)  | ![layers_new](https://user-images.githubusercontent.com/2820439/76173877-1acaf800-61ac-11ea-8474-dc09bbcb584d.png) |
| Recent |
| ![recent_expr_old](https://user-images.githubusercontent.com/2820439/76173929-88772400-61ac-11ea-8c4e-448f6ebffeb1.png) | ![recent_expr_new](https://user-images.githubusercontent.com/2820439/76173879-1bfc2500-61ac-11ea-8a2d-68384cb09583.png) |
| User Expressions |
| ![user_expr_old](https://user-images.githubusercontent.com/2820439/76173931-8b721480-61ac-11ea-8ef4-d00427f1058b.png) | ![user_expr_new](https://user-images.githubusercontent.com/2820439/76173930-8b721480-61ac-11ea-913d-9a651e6ea0b6.png) |
| Variables |
| ![variables_old](https://user-images.githubusercontent.com/2820439/76173963-bfe5d080-61ac-11ea-96e0-751ec3799693.png) | ![variables_new](https://user-images.githubusercontent.com/2820439/76173962-bf4d3a00-61ac-11ea-8533-d38413233bed.png) |

I am new to C++ and QGIS codebase in general, so any feedback is more appreciated. I wish I can contribute more in the future at least with such simple usability tasks in the beginning.

### Need help
There are a few more things I am planning to do in this or another PR.

1) Where the custom python functions are being added in the expressions list? As far as I tracked it, somehow `QgsExpression::Functions()` magically loads them, but I didn't manage to find the exact place where it happens. Any help is appreciated.

This is related to the following issue with the main title in the help box:

| Normal  | Custom python |
| ------------- | ------------- |
| function <FUNCTION_NAME>| <FUNCTION_NAME> function |
| ![function_normal](https://user-images.githubusercontent.com/2820439/76174094-d8a2b600-61ad-11ea-80ab-875589a3dba4.png) | ![function_custom](https://user-images.githubusercontent.com/2820439/76174114-f53eee00-61ad-11ea-9616-4b8eff469362.png) |

Also I want to see if I can unify the styling with the rest of the functions a little bit more.

2) I don't remember if "row_number" was showing in bold on the top like in all the screenshots above in the previous versions? Should I remove it, I find it ugly?
EDIT: found out it's a feature, it was always there, but I had it overlooked. Ignore this question.

3) I've copied `QgsExpression::formatVariableHelp` to `QgsExpressionBuilderWidget::formatVariableHelp` because I added one additional argument. I know this is a breaking change, but there is noone using `QgsExpression::formatVariableHelp`. What is a good practice here, should I deprecate the old one? Or overload the original method? For me it makes more sense to have all the `format*Help` methods in the same place, no matter where, even though making the changes in `QgsExpression` makes the build time considerably longer and I don't see anyone else using these methods, other than `QgsExpressionBuilderWidget`.
https://github.com/qgis/QGIS/compare/master...suricactus:expression_builder_help?expand=1#diff-ef5e399165e2bf915c7922be4402d0b9L909-R911




