### PR TITLE
Add undo/redo support to model designer

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -87,6 +87,8 @@ Sets the ``font`` used to render text in the item.
 
     virtual void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event );
 
+    virtual void mouseReleaseEvent( QGraphicsSceneMouseEvent *event );
+
     virtual void hoverEnterEvent( QGraphicsSceneHoverEvent *event );
 
     virtual void hoverMoveEvent( QGraphicsSceneHoverEvent *event );
@@ -172,6 +174,15 @@ The default implementation does nothing.
     void requestModelRepaint();
 %Docstring
 Emitted by the item to request a repaint of the parent model scene.
+%End
+
+    void aboutToChange( const QString &text, int id = 0 );
+%Docstring
+Emitted when the definition of the associated component is about to be changed
+by the item.
+
+The ``text`` argument gives the translated text describing the change about to occur, and the
+optional ``id`` can be used to group the associated undo commands.
 %End
 
     void changed();

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -85,6 +85,13 @@ Loads a model into the designer from the specified file ``path``.
 Checks if the model can current be saved, and returns ``True`` if it can.
 %End
 
+    bool checkForUnsavedChanges();
+%Docstring
+Checks if there are unsaved changes in the model, and if so, prompts the user to save them.
+
+Returns ``False`` if the cancel option was selected
+%End
+
 };
 
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -45,10 +45,26 @@ Starts an undo command. This should be called before any changes are made to the
 Ends the current undo command. This should be called after changes are made to the model.
 %End
 
+    QgsProcessingModelAlgorithm *model();
+%Docstring
+Returns the model shown in the dialog.
+%End
+
+    void setModel( QgsProcessingModelAlgorithm *model /Transfer/ );
+%Docstring
+Sets the ``model`` shown in the dialog.
+
+Ownership of ``model`` is transferred to the dialog.
+%End
+
+    void loadModel( const QString &path );
+%Docstring
+Loads a model into the designer from the specified file ``path``.
+%End
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;
-    virtual QgsProcessingModelAlgorithm *model() = 0;
     virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
     virtual void exportAsScriptAlgorithm() = 0;
@@ -59,14 +75,15 @@ Ends the current undo command. This should be called after changes are made to t
     QAction *actionSaveInProject();
     QAction *actionEditHelp();
     QAction *actionRun();
-    QLineEdit *textName();
-    QLineEdit *textGroup();
     QgsMessageBar *messageBar();
     QGraphicsView *view();
 
-    void updateVariablesGui();
-
     void setDirty( bool dirty );
+
+    bool validateSave();
+%Docstring
+Checks if the model can current be saved, and returns ``True`` if it can.
+%End
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -30,9 +30,20 @@ Model designer dialog base class
   public:
 
     QgsModelDesignerDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = 0 );
+    ~QgsModelDesignerDialog();
 
     virtual void closeEvent( QCloseEvent *event );
 
+
+    void beginUndoCommand( const QString &text, int id = 0 );
+%Docstring
+Starts an undo command. This should be called before any changes are made to the model.
+%End
+
+    void endUndoCommand();
+%Docstring
+Ends the current undo command. This should be called after changes are made to the model.
+%End
 
   protected:
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -89,6 +89,14 @@ Populates the scene by creating items representing the specified ``model``.
 Emitted when a change in the model requires a full rebuild of the scene.
 %End
 
+    void componentAboutToChange( const QString &text, int id = 0 );
+%Docstring
+Emitted whenever a component of the model is about to be changed.
+
+The ``text`` argument gives the translated text describing the change about to occur, and the
+optional ``id`` can be used to group the associated undo commands.
+%End
+
     void componentChanged();
 %Docstring
 Emitted whenever a component of the model is changed.

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -38,8 +38,6 @@ from qgis.core import (Qgis,
                        QgsApplication,
                        QgsProcessing,
                        QgsProject,
-                       QgsMessageLog,
-                       QgsProcessingModelAlgorithm,
                        QgsProcessingModelParameter,
                        QgsSettings
                        )
@@ -185,6 +183,9 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.setDirty(False)
 
     def openModel(self):
+        if not self.checkForUnsavedChanges():
+            return
+
         filename, selected_filter = QFileDialog.getOpenFileName(self,
                                                                 self.tr('Open Model'),
                                                                 ModelerUtils.modelsFolders()[0],

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -90,6 +90,7 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
                 comment = dlg.comments()
 
         if new_param is not None:
+            self.aboutToChange.emit(self.tr('Edit {}').format(new_param.description()))
             self.model().removeModelParameter(self.component().parameterName())
             self.component().setParameterName(new_param.name())
             self.component().setDescription(new_param.name())
@@ -128,6 +129,7 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
             alg = dlg.createAlgorithm()
             alg.setChildId(self.component().childId())
             alg.copyNonDefinitionPropertiesFromModel(self.model())
+            self.aboutToChange.emit(self.tr('Edit {}').format(alg.description()))
             self.model().setChildAlgorithm(alg)
             self.requestModelRepaint.emit()
             self.changed.emit()
@@ -165,6 +167,7 @@ class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):
             model_output.setDefaultValue(dlg.param.defaultValue())
             model_output.setMandatory(not (dlg.param.flags() & QgsProcessingParameterDefinition.FlagOptional))
             model_output.comment().setDescription(dlg.comments())
+            self.aboutToChange.emit(self.tr('Edit {}').format(model_output.description()))
             self.model().updateDestinationParameters()
             self.requestModelRepaint.emit()
             self.changed.emit()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -282,6 +282,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelgraphicitem.cpp
   processing/models/qgsmodelgraphicsscene.cpp
   processing/models/qgsmodelgraphicsview.cpp
+  processing/models/qgsmodelundocommand.cpp
 
   providers/gdal/qgsgdalsourceselect.cpp
   providers/gdal/qgsgdalguiprovider.cpp
@@ -942,6 +943,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelgraphicitem.h
   processing/models/qgsmodelgraphicsscene.h
   processing/models/qgsmodelgraphicsview.h
+  processing/models/qgsmodelundocommand.h
 
   providers/gdal/qgsgdalguiprovider.h
   providers/gdal/qgsgdalsourceselect.h

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -108,6 +108,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     void setFont( const QFont &font );
 
     void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
+    void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverLeaveEvent( QGraphicsSceneHoverEvent *event ) override;
@@ -187,6 +188,15 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      * Emitted by the item to request a repaint of the parent model scene.
      */
     void requestModelRepaint();
+
+    /**
+     * Emitted when the definition of the associated component is about to be changed
+     * by the item.
+     *
+     * The \a text argument gives the translated text describing the change about to occur, and the
+     * optional \a id can be used to group the associated undo commands.
+     */
+    void aboutToChange( const QString &text, int id = 0 );
 
     /**
      * Emitted when the definition of the associated component is changed
@@ -288,6 +298,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     QFont mFont;
 
     bool mIsHovering = false;
+    bool mIsMoving = false;
 
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsModelComponentGraphicItem::Flags )

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -239,31 +239,10 @@ QgsModelDesignerDialog::~QgsModelDesignerDialog()
 
 void QgsModelDesignerDialog::closeEvent( QCloseEvent *event )
 {
-  if ( isDirty() )
-  {
-    QMessageBox::StandardButton ret = QMessageBox::question( this, tr( "Save Model?" ),
-                                      tr( "There are unsaved changes in this model. Do you want to keep those?" ),
-                                      QMessageBox::Save | QMessageBox::Cancel | QMessageBox::Discard, QMessageBox::Cancel );
-    switch ( ret )
-    {
-      case QMessageBox::Save:
-        saveModel( false );
-        event->accept();
-        break;
-
-      case QMessageBox::Discard:
-        event->accept();
-        break;
-
-      default:
-        event->ignore();
-        break;
-    }
-  }
-  else
-  {
+  if ( checkForUnsavedChanges() )
     event->accept();
-  }
+  else
+    event->ignore();
 }
 
 void QgsModelDesignerDialog::beginUndoCommand( const QString &text, int id )
@@ -357,6 +336,32 @@ bool QgsModelDesignerDialog::validateSave()
   }
 
   return true;
+}
+
+bool QgsModelDesignerDialog::checkForUnsavedChanges()
+{
+  if ( isDirty() )
+  {
+    QMessageBox::StandardButton ret = QMessageBox::question( this, tr( "Save Model?" ),
+                                      tr( "There are unsaved changes in this model. Do you want to keep those?" ),
+                                      QMessageBox::Save | QMessageBox::Cancel | QMessageBox::Discard, QMessageBox::Cancel );
+    switch ( ret )
+    {
+      case QMessageBox::Save:
+        saveModel( false );
+        return true;
+
+      case QMessageBox::Discard:
+        return true;
+
+      default:
+        return false;
+    }
+  }
+  else
+  {
+    return true;
+  }
 }
 
 void QgsModelDesignerDialog::zoomIn()
@@ -522,7 +527,7 @@ void QgsModelDesignerDialog::updateWindowTitle()
 
 bool QgsModelDesignerDialog::isDirty() const
 {
-  return mHasChanged && mUndoStack->index() == -1;
+  return mHasChanged && mUndoStack->index() != -1;
 }
 
 void QgsModelDesignerDialog::fillInputsTree()

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -67,10 +67,26 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
      */
     void endUndoCommand();
 
+    /**
+     * Returns the model shown in the dialog.
+     */
+    QgsProcessingModelAlgorithm *model();
+
+    /**
+     * Sets the \a model shown in the dialog.
+     *
+     * Ownership of \a model is transferred to the dialog.
+     */
+    void setModel( QgsProcessingModelAlgorithm *model SIP_TRANSFER );
+
+    /**
+     * Loads a model into the designer from the specified file \a path.
+     */
+    void loadModel( const QString &path );
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;
-    virtual QgsProcessingModelAlgorithm *model() = 0;
     virtual void addAlgorithm( const QString &algorithmId, const QPointF &pos ) = 0;
     virtual void addInput( const QString &inputId, const QPointF &pos ) = 0;
     virtual void exportAsScriptAlgorithm() = 0;
@@ -81,17 +97,17 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QAction *actionSaveInProject() { return mActionSaveInProject; }
     QAction *actionEditHelp() { return mActionEditHelp; }
     QAction *actionRun() { return mActionRun; }
-    QLineEdit *textName() { return mNameEdit; }
-    QLineEdit *textGroup() { return mGroupEdit; }
     QgsMessageBar *messageBar() { return mMessageBar; }
     QGraphicsView *view() { return mView; }
 
-    void updateVariablesGui();
-
     void setDirty( bool dirty );
 
-  private slots:
+    /**
+     * Checks if the model can current be saved, and returns TRUE if it can.
+     */
+    bool validateSave();
 
+  private slots:
     void zoomIn();
     void zoomOut();
     void zoomActual();
@@ -101,8 +117,16 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void exportToSvg();
     void exportAsPython();
     void toggleComments( bool show );
-
+    void updateWindowTitle();
   private:
+
+    enum UndoCommand
+    {
+      NameChanged = 1,
+      GroupChanged
+    };
+
+    std::unique_ptr< QgsProcessingModelAlgorithm > mModel;
 
     QgsMessageBar *mMessageBar = nullptr;
     QgsModelerToolboxModel *mAlgorithmsModel = nullptr;
@@ -119,8 +143,12 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     int mBlockUndoCommands = 0;
     int mIgnoreUndoStackChanges = 0;
 
-    void fillInputsTree();
+    QString mTitle;
 
+    bool isDirty() const;
+
+    void fillInputsTree();
+    void updateVariablesGui();
 };
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -107,6 +107,13 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
      */
     bool validateSave();
 
+    /**
+     * Checks if there are unsaved changes in the model, and if so, prompts the user to save them.
+     *
+     * Returns FALSE if the cancel option was selected
+     */
+    bool checkForUnsavedChanges();
+
   private slots:
     void zoomIn();
     void zoomOut();

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -24,6 +24,8 @@
 
 class QgsMessageBar;
 class QgsProcessingModelAlgorithm;
+class QgsModelUndoCommand;
+class QUndoView;
 
 ///@cond NOT_STABLE
 
@@ -51,8 +53,19 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
   public:
 
     QgsModelDesignerDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = nullptr );
+    ~QgsModelDesignerDialog() override;
 
     void closeEvent( QCloseEvent *event ) override;
+
+    /**
+     * Starts an undo command. This should be called before any changes are made to the model.
+     */
+    void beginUndoCommand( const QString &text, int id = 0 );
+
+    /**
+     * Ends the current undo command. This should be called after changes are made to the model.
+     */
+    void endUndoCommand();
 
   protected:
 
@@ -95,6 +108,16 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QgsModelerToolboxModel *mAlgorithmsModel = nullptr;
 
     bool mHasChanged = false;
+    QUndoStack *mUndoStack = nullptr;
+    std::unique_ptr< QgsModelUndoCommand > mActiveCommand;
+
+    QAction *mUndoAction = nullptr;
+    QAction *mRedoAction = nullptr;
+    QUndoView *mUndoView = nullptr;
+    QgsDockWidget *mUndoDock = nullptr;
+
+    int mBlockUndoCommands = 0;
+    int mIgnoreUndoStackChanges = 0;
 
     void fillInputsTree();
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -75,6 +75,7 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
     mParameterItems.insert( it.value().parameterName(), item );
     connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
     connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+    connect( item, &QgsModelComponentGraphicItem::aboutToChange, this, &QgsModelGraphicsScene::componentAboutToChange );
 
     addCommentItemForComponent( model, it.value(), item );
   }
@@ -105,6 +106,7 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
     mChildAlgorithmItems.insert( it.value().childId(), item );
     connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
     connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+    connect( item, &QgsModelComponentGraphicItem::aboutToChange, this, &QgsModelGraphicsScene::componentAboutToChange );
 
     addCommentItemForComponent( model, it.value(), item );
   }
@@ -156,6 +158,7 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       addItem( item );
       connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
       connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+      connect( item, &QgsModelComponentGraphicItem::aboutToChange, this, &QgsModelGraphicsScene::componentAboutToChange );
 
       addCommentItemForComponent( model, outputIt.value(), item );
 
@@ -265,6 +268,7 @@ void QgsModelGraphicsScene::addCommentItemForComponent( QgsProcessingModelAlgori
   addItem( commentItem );
   connect( commentItem, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
   connect( commentItem, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
+  connect( commentItem, &QgsModelComponentGraphicItem::aboutToChange, this, &QgsModelGraphicsScene::componentAboutToChange );
 
   std::unique_ptr< QgsModelArrowItem > arrow = qgis::make_unique< QgsModelArrowItem >( parentItem, commentItem );
   arrow->setPenStyle( Qt::DotLine );

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -100,6 +100,14 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     void rebuildRequired();
 
     /**
+     * Emitted whenever a component of the model is about to be changed.
+     *
+    * The \a text argument gives the translated text describing the change about to occur, and the
+    * optional \a id can be used to group the associated undo commands.
+     */
+    void componentAboutToChange( const QString &text, int id = 0 );
+
+    /**
      * Emitted whenever a component of the model is changed.
      */
     void componentChanged();

--- a/src/gui/processing/models/qgsmodelundocommand.cpp
+++ b/src/gui/processing/models/qgsmodelundocommand.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+                             qgsmodelundocommand.cpp
+                             ----------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelundocommand.h"
+#include "qgsprocessingmodelalgorithm.h"
+///@cond NOT_STABLE
+
+
+QgsModelUndoCommand::QgsModelUndoCommand( QgsProcessingModelAlgorithm *model, const QString &text, int id, QUndoCommand *parent )
+  : QUndoCommand( text, parent )
+  , mModel( model )
+  , mId( id )
+{
+  mBeforeState = model->toVariant();
+}
+
+void QgsModelUndoCommand::saveAfterState()
+{
+  mAfterState = mModel->toVariant();
+}
+
+int QgsModelUndoCommand::id() const
+{
+  return mId;
+}
+
+void QgsModelUndoCommand::undo()
+{
+  QUndoCommand::undo();
+  mModel->loadVariant( mBeforeState );
+}
+
+void QgsModelUndoCommand::redo()
+{
+  if ( mFirstRun )
+  {
+    mFirstRun = false;
+    return;
+  }
+  QUndoCommand::redo();
+  mModel->loadVariant( mAfterState );
+}
+
+bool QgsModelUndoCommand::mergeWith( const QUndoCommand *other )
+{
+  if ( other->id() == 0 || other->id() != mId )
+    return false;
+
+  if ( const QgsModelUndoCommand *c = dynamic_cast<const QgsModelUndoCommand *>( other ) )
+  {
+    mAfterState = c->mAfterState;
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+///@endcond

--- a/src/gui/processing/models/qgsmodelundocommand.cpp
+++ b/src/gui/processing/models/qgsmodelundocommand.cpp
@@ -39,7 +39,13 @@ int QgsModelUndoCommand::id() const
 void QgsModelUndoCommand::undo()
 {
   QUndoCommand::undo();
+
+  // some settings must live "outside" the undo stack
+  const QVariantMap params = mModel->designerParameterValues();
+
   mModel->loadVariant( mBeforeState );
+
+  mModel->setDesignerParameterValues( params );
 }
 
 void QgsModelUndoCommand::redo()
@@ -50,7 +56,13 @@ void QgsModelUndoCommand::redo()
     return;
   }
   QUndoCommand::redo();
+
+  // some settings must live "outside" the undo stack
+  const QVariantMap params = mModel->designerParameterValues();
+
   mModel->loadVariant( mAfterState );
+
+  mModel->setDesignerParameterValues( params );
 }
 
 bool QgsModelUndoCommand::mergeWith( const QUndoCommand *other )

--- a/src/gui/processing/models/qgsmodelundocommand.h
+++ b/src/gui/processing/models/qgsmodelundocommand.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+                             qgsmodelundocommand.h
+                             ----------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELUNDOCOMMAND_H
+#define QGSMODELUNDOCOMMAND_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include <QUndoCommand>
+
+class QgsProcessingModelAlgorithm;
+
+///@cond NOT_STABLE
+
+
+/**
+ * \ingroup gui
+ * \brief A undo command for the model designer.
+ * \warning Not stable API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelUndoCommand : public QUndoCommand
+{
+  public:
+    QgsModelUndoCommand( QgsProcessingModelAlgorithm *model, const QString &text, int id = 0, QUndoCommand *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Saves the "after" state of the model. Should be called after making the actual associated change within the model.
+     */
+    void saveAfterState();
+
+    int id() const override;
+    void undo() override;
+    void redo() override;
+    bool mergeWith( const QUndoCommand *other ) override;
+
+  private:
+
+    //! Flag to prevent the first redo() if the command is pushed to the undo stack
+    bool mFirstRun = true;
+
+    QgsProcessingModelAlgorithm *mModel = nullptr;
+    QVariant mBeforeState;
+    QVariant mAfterState;
+    int mId = 0;
+};
+
+///@endcond
+
+#endif // QGSMODELUNDOCOMMAND_H

--- a/src/gui/processing/models/qgsmodelundocommand.h
+++ b/src/gui/processing/models/qgsmodelundocommand.h
@@ -22,8 +22,9 @@
 
 class QgsProcessingModelAlgorithm;
 
-///@cond NOT_STABLE
+#define SIP_NO_FILE
 
+///@cond NOT_STABLE
 
 /**
  * \ingroup gui

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -81,7 +81,13 @@
     <addaction name="separator"/>
     <addaction name="mActionShowComments"/>
    </widget>
+   <widget class="QMenu" name="mMenuEdit">
+    <property name="title">
+     <string>&amp;Edit</string>
+    </property>
+   </widget>
    <addaction name="menu_Model"/>
+   <addaction name="mMenuEdit"/>
    <addaction name="menu_View"/>
   </widget>
   <widget class="QToolBar" name="mToolbar">
@@ -150,7 +156,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>128</height>
+          <height>97</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout">
@@ -240,7 +246,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>70</height>
+          <height>153</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -310,7 +316,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>231</height>
+          <height>180</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -15,6 +15,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/gui/layout
   ${CMAKE_SOURCE_DIR}/src/gui/symbology
   ${CMAKE_SOURCE_DIR}/src/gui/processing
+  ${CMAKE_SOURCE_DIR}/src/gui/processing/models
   ${CMAKE_SOURCE_DIR}/src/gui/raster
   ${CMAKE_SOURCE_DIR}/src/gui/tableeditor
   ${CMAKE_SOURCE_DIR}/src/core

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -318,6 +318,15 @@ void TestProcessingGui::testModelUndo()
   QCOMPARE( model.childAlgorithm( QStringLiteral( "alg1" ) ).description(), QStringLiteral( "alg1" ) );
   command.redo();
   QCOMPARE( model.childAlgorithm( QStringLiteral( "alg1" ) ).description(), QStringLiteral( "new desc" ) );
+
+  // the last used parameter values setting should not be affected by undo stack changes
+  QVariantMap params;
+  params.insert( QStringLiteral( "a" ), 1 );
+  model.setDesignerParameterValues( params );
+  command.undo();
+  QCOMPARE( model.designerParameterValues(), params );
+  command.redo();
+  QCOMPARE( model.designerParameterValues(), params );
 }
 
 void TestProcessingGui::testSetGetConfig()


### PR DESCRIPTION
Makes QGIS more forgiving for users!

Refs NRCan Contract#3000707093

Works just like you'd expect:

![Peek 2020-03-09 11-54](https://user-images.githubusercontent.com/1829991/76176510-c8fe8e00-61fc-11ea-90e1-91cbeadcbd4f.gif)

Note that we save the whole model definition in the undo stack, not just the affect component changes. This was a lesson I learnt after the composer redesign -- it's just safest to save and restore the WHOLE document then try to deal with interconnected changes.

