### PR TITLE
[MESH] avoid reloading triangular mesh when transforms are invalid

### DIFF
--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -119,9 +119,10 @@ bool QgsTriangularMesh::update( QgsMesh *nativeMesh, const QgsCoordinateTransfor
   if ( mTriangularMesh.vertices.size() >= nativeMesh->vertices.size() &&
        mTriangularMesh.faces.size() >= nativeMesh->faces.size() &&
        mTriangularMesh.edges.size() == nativeMesh->edges.size() &&
-       mCoordinateTransform.sourceCrs() == transform.sourceCrs() &&
-       mCoordinateTransform.destinationCrs() == transform.destinationCrs() &&
-       mCoordinateTransform.isValid() == transform.isValid() )
+       ( ( !mCoordinateTransform.isValid() && !transform.isValid() ) ||
+         ( mCoordinateTransform.sourceCrs() == transform.sourceCrs() &&
+           mCoordinateTransform.destinationCrs() == transform.destinationCrs() &&
+           mCoordinateTransform.isValid() == transform.isValid() ) ) )
     return false;
 
   // CLEAN-UP


### PR DESCRIPTION
When checking if the triangular mesh need to be updated, if the both old and new transform are invalid, the triangular mesh is updated, whereas there is no need (if transform is invalid the triangular mesh keep the coordinates of the layer).
This PR permits to avoid that situation.