### PR TITLE
Fix Multi-Edit dialog is never deleted when launched from the main window

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9281,6 +9281,7 @@ void QgisApp::modifyAttributesOfSelectedFeatures()
 
   QgsAttributeDialog *dialog = new QgsAttributeDialog( vl, &f, false, this, true, context );
   dialog->setMode( QgsAttributeEditorContext::MultiEditMode );
+  dialog->setAttribute( Qt::WA_DeleteOnClose );
   dialog->exec();
 }
 


### PR DESCRIPTION
This results in a leak, plus a gradual slow down in QGIS performance
over time if many multi-edit operations have been performed in a session
(because there's a lot of resultant widgets hanging around and listening
to selection changes + iterating through the selected features as a result)
