### PR TITLE
[temporal] Don't connect the temporal indicator for layers missing temporal properties

### DIFF
--- a/src/app/qgslayertreeviewtemporalindicator.cpp
+++ b/src/app/qgslayertreeviewtemporalindicator.cpp
@@ -30,7 +30,7 @@ QgsLayerTreeViewTemporalIndicatorProvider::QgsLayerTreeViewTemporalIndicatorProv
 
 void QgsLayerTreeViewTemporalIndicatorProvider::connectSignals( QgsMapLayer *layer )
 {
-  if ( !( qobject_cast<QgsVectorLayer *>( layer ) || qobject_cast<QgsRasterLayer *>( layer ) ) )
+  if ( !( qobject_cast<QgsVectorLayer *>( layer ) || qobject_cast<QgsRasterLayer *>( layer ) ) || !layer->temporalProperties() )
     return;
 
   connect( layer->temporalProperties(), &QgsMapLayerTemporalProperties::changed, this, [ this, layer ]( ) { this->onLayerChanged( layer ); } );


### PR DESCRIPTION
## Description

This takes care of a bunch of Qt errors when loading projects that have been popping up after merging the temporal layer indicator.