### PR TITLE
Add multi-selection handling to model designer, interactive resizing

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -239,6 +239,11 @@ Emitted when item requests that all connected arrows are repainted.
 Emitted when item requires that all connected arrow paths are recalculated.
 %End
 
+    void sizePositionChanged();
+%Docstring
+Emitted when the item's size or position changes.
+%End
+
   protected slots:
 
     virtual void editComponent();

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -99,9 +99,22 @@ Moves the component by the specified ``dx`` and ``dy``.
    Call this method, not QGraphicsItem.moveBy!
 %End
 
-    virtual void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event );
+    void previewItemMove( qreal dx, qreal dy );
+%Docstring
+Shows a preview of moving the item from its stored position by ``dx``, ``dy``.
+%End
 
-    virtual void mouseReleaseEvent( QGraphicsSceneMouseEvent *event );
+    void setItemRect( QRectF rect );
+%Docstring
+Sets a new scene ``rect`` for the item.
+%End
+
+    void previewItemRectChange( QRectF rect );
+%Docstring
+Shows a preview of setting a new ``rect`` for the item.
+%End
+
+    virtual void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event );
 
     virtual void hoverEnterEvent( QGraphicsSceneHoverEvent *event );
 
@@ -116,7 +129,7 @@ Moves the component by the specified ``dx`` and ``dy``.
     virtual void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0 );
 
 
-    QRectF itemRect() const;
+    QRectF itemRect( bool storedRect = false ) const;
 %Docstring
 Returns the rectangle representing the body of the item.
 %End
@@ -269,9 +282,9 @@ Returns a QPicture version of the item's icon, if available.
 Returns a QPixmap version of the item's icon, if available.
 %End
 
-    virtual void updateStoredComponentPosition( const QPointF &pos ) = 0;
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) = 0;
 %Docstring
-Updates the position stored in the model for the associated comment
+Updates the position and size stored in the model for the associated comment
 %End
 
 };
@@ -320,7 +333,7 @@ Ownership of ``parameter`` is transferred to the item.
 
     virtual QPicture iconPicture() const;
 
-    virtual void updateStoredComponentPosition( const QPointF &pos );
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size );
 
 
   protected slots:
@@ -378,7 +391,7 @@ Ownership of ``child`` is transferred to the item.
 
     virtual QString linkPointText( Qt::Edge edge, int index ) const;
 
-    virtual void updateStoredComponentPosition( const QPointF &pos );
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size );
 
 
   protected slots:
@@ -428,7 +441,7 @@ Ownership of ``output`` is transferred to the item.
 
     virtual QPicture iconPicture() const;
 
-    virtual void updateStoredComponentPosition( const QPointF &pos );
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size );
 
 
   protected slots:
@@ -484,7 +497,7 @@ Ownership of ``output`` is transferred to the item.
 
     virtual Qt::PenStyle strokeStyle( State state ) const;
 
-    virtual void updateStoredComponentPosition( const QPointF &pos );
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size );
 
 
   protected slots:

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -90,6 +90,15 @@ Sets the ``font`` used to render text in the item.
 .. seealso:: :py:func:`font`
 %End
 
+    void moveComponentBy( qreal dx, qreal dy );
+%Docstring
+Moves the component by the specified ``dx`` and ``dy``.
+
+.. warning::
+
+   Call this method, not QGraphicsItem.moveBy!
+%End
+
     virtual void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event );
 
     virtual void mouseReleaseEvent( QGraphicsSceneMouseEvent *event );

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -194,6 +194,18 @@ Called when the comment attached to the item should be edited.
 The default implementation does nothing.
 %End
 
+    virtual bool canDeleteComponent();
+%Docstring
+Returns ``True`` if the component can be deleted.
+%End
+
+    virtual void deleteComponent();
+%Docstring
+Called when the component should be deleted.
+
+The default implementation does nothing.
+%End
+
   signals:
 
 
@@ -232,13 +244,6 @@ Emitted when item requires that all connected arrow paths are recalculated.
     virtual void editComponent();
 %Docstring
 Called when the component should be edited.
-
-The default implementation does nothing.
-%End
-
-    virtual void deleteComponent();
-%Docstring
-Called when the component should be deleted.
 
 The default implementation does nothing.
 %End
@@ -326,6 +331,8 @@ Ownership of ``parameter`` is transferred to the item.
 
     virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
 
+    virtual bool canDeleteComponent();
+
 
   protected:
 
@@ -376,6 +383,8 @@ it must exist for the lifetime of this object.
 Ownership of ``child`` is transferred to the item.
 %End
     virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
+
+    virtual bool canDeleteComponent();
 
 
   protected:
@@ -435,6 +444,9 @@ it must exist for the lifetime of this object.
 Ownership of ``output`` is transferred to the item.
 %End
 
+    virtual bool canDeleteComponent();
+
+
   protected:
 
     virtual QColor fillColor( State state ) const;
@@ -488,6 +500,8 @@ Ownership of ``output`` is transferred to the item.
 %End
     ~QgsModelCommentGraphicItem();
     virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
+
+    virtual bool canDeleteComponent();
 
   protected:
 

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -36,7 +36,6 @@ Base class for graphic items representing model components in the model designer
 
     enum Flag
     {
-      FlagMultilineText,
     };
     typedef QFlags<QgsModelComponentGraphicItem::Flag> Flags;
 
@@ -287,6 +286,11 @@ Returns a QPixmap version of the item's icon, if available.
 Updates the position and size stored in the model for the associated comment
 %End
 
+    void updateButtonPositions();
+%Docstring
+Updates the item's button positions, based on the current item rect.
+%End
+
 };
 QFlags<QgsModelComponentGraphicItem::Flag> operator|(QgsModelComponentGraphicItem::Flag f1, QFlags<QgsModelComponentGraphicItem::Flag> f2);
 
@@ -484,8 +488,6 @@ Ownership of ``output`` is transferred to the item.
 %End
     ~QgsModelCommentGraphicItem();
     virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
-
-    virtual Flags flags() const;
 
   protected:
 

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -71,6 +71,11 @@ Returns the model component associated with this item.
 Returns the model associated with this item.
 %End
 
+    QgsModelGraphicsView *view();
+%Docstring
+Returns the associated view.
+%End
+
     QFont font() const;
 %Docstring
 Returns the font used to render text in the item.

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -62,6 +62,11 @@ Ownership of ``model`` is transferred to the dialog.
 Loads a model into the designer from the specified file ``path``.
 %End
 
+    void setModelScene( QgsModelGraphicsScene *scene /Transfer/ );
+%Docstring
+Sets the related ``scene``.
+%End
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicitem.sip.in
@@ -48,6 +48,7 @@ for the button. The button will be rendered at the specified ``position`` and ``
     virtual void mousePressEvent( QGraphicsSceneMouseEvent *event );
 
 
+
     void setPosition( const QPointF &position );
 %Docstring
 Sets the button's ``position``.

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicitem.sip.in
@@ -48,6 +48,11 @@ for the button. The button will be rendered at the specified ``position`` and ``
     virtual void mousePressEvent( QGraphicsSceneMouseEvent *event );
 
 
+    void setPosition( const QPointF &position );
+%Docstring
+Sets the button's ``position``.
+%End
+
     QgsModelGraphicsView *view();
 %Docstring
 Returns the associated model view.

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicitem.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsModelDesignerFlatButtonGraphicItem : QGraphicsObject
 {
 %Docstring
@@ -46,6 +47,11 @@ for the button. The button will be rendered at the specified ``position`` and ``
 
     virtual void mousePressEvent( QGraphicsSceneMouseEvent *event );
 
+
+    QgsModelGraphicsView *view();
+%Docstring
+Returns the associated model view.
+%End
 
   signals:
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -31,6 +31,7 @@ QGraphicsScene subclass representing the model designer.
     {
       ArrowLink,
       ModelComponent,
+      RubberBand,
     };
 
     enum Flag

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -83,6 +83,29 @@ Returns the current combination of flags set for the scene.
 Populates the scene by creating items representing the specified ``model``.
 %End
 
+    QList<QgsModelComponentGraphicItem *> selectedComponentItems();
+%Docstring
+Returns list of selected component items.
+%End
+
+    QgsModelComponentGraphicItem *componentItemAt( QPointF position ) const;
+%Docstring
+Returns the topmost component item at a specified ``position``.
+%End
+
+    void deselectAll();
+%Docstring
+Clears any selected items in the scene.
+
+Call this method rather than QGraphicsScene.clearSelection, as the latter does
+not correctly emit signals to allow the scene's model to update.
+%End
+
+    void setSelectedItem( QgsModelComponentGraphicItem *item );
+%Docstring
+Clears any selected items and sets ``item`` as the current selection.
+%End
+
   signals:
 
     void rebuildRequired();
@@ -101,6 +124,12 @@ optional ``id`` can be used to group the associated undo commands.
     void componentChanged();
 %Docstring
 Emitted whenever a component of the model is changed.
+%End
+
+    void selectedItemChanged( QgsModelComponentGraphicItem *selected );
+%Docstring
+Emitted whenever the selected item changes.
+If ``None``, no item is selected.
 %End
 
   protected:

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -32,6 +32,7 @@ QGraphicsScene subclass representing the model designer.
       ArrowLink,
       ModelComponent,
       RubberBand,
+      ZSnapIndicator,
     };
 
     enum Flag

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -31,8 +31,10 @@ QGraphicsScene subclass representing the model designer.
     {
       ArrowLink,
       ModelComponent,
+      MouseHandles,
       RubberBand,
       ZSnapIndicator,
+
     };
 
     enum Flag

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -70,6 +70,16 @@ Returns the scene associated with the tool.
 
 
 
+    void startMacroCommand( const QString &text );
+%Docstring
+Starts a macro command, containing a group of interactions in the view.
+%End
+
+    void endMacroCommand();
+%Docstring
+Ends a macro command, containing a group of interactions in the view.
+%End
+
   signals:
 
     void algorithmDropped( const QString &algorithmId, const QPointF &pos );
@@ -93,6 +103,16 @@ item and should have its properties displayed in any designer windows.
 %Docstring
 Emitted in the destructor when the view is about to be deleted,
 but is still in a perfectly valid state.
+%End
+
+    void macroCommandStarted( const QString &text );
+%Docstring
+Emitted when a macro command containing a group of interactions is started in the view.
+%End
+
+    void macroCommandEnded();
+%Docstring
+Emitted when a macro command containing a group of interactions in the view has ended.
 %End
 
 };

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -54,30 +54,15 @@ Constructor for QgsModelGraphicsView, with the specified ``parent`` widget.
     virtual void keyReleaseEvent( QKeyEvent *event );
 
 
-    QgsModelViewTool *tool();
+    QgsModelGraphicsScene *modelScene() const;
 %Docstring
-Returns the currently active tool for the view.
+Returns the scene associated with the tool.
 
-.. seealso:: :py:func:`setTool`
+.. seealso:: :py:func:`view`
 %End
 
-    void setTool( QgsModelViewTool *tool );
-%Docstring
-Sets the ``tool`` currently being used in the view.
 
-.. seealso:: :py:func:`unsetTool`
 
-.. seealso:: :py:func:`tool`
-%End
-
-    void unsetTool( QgsModelViewTool *tool );
-%Docstring
-Unsets the current view tool, if it matches the specified ``tool``.
-
-This is called from destructor of view tools to make sure
-that the tool won't be used any more.
-You don't have to call it manually, QgsModelViewTool takes care of it.
-%End
 
   signals:
 
@@ -91,12 +76,6 @@ Emitted when an algorithm is dropped onto the view.
 Emitted when an input parameter is dropped onto the view.
 %End
 
-    void toolSet( QgsModelViewTool *tool );
-%Docstring
-Emitted when the current ``tool`` is changed.
-
-.. seealso:: :py:func:`setTool`
-%End
 
     void itemFocused( QgsModelComponentGraphicItem *item );
 %Docstring

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -54,12 +54,18 @@ Constructor for QgsModelGraphicsView, with the specified ``parent`` widget.
     virtual void keyReleaseEvent( QKeyEvent *event );
 
 
+    void setModelScene( QgsModelGraphicsScene *scene );
+%Docstring
+Sets the related ``scene``.
+%End
+
     QgsModelGraphicsScene *modelScene() const;
 %Docstring
 Returns the scene associated with the tool.
 
 .. seealso:: :py:func:`view`
 %End
+
 
 
 
@@ -90,6 +96,26 @@ but is still in a perfectly valid state.
 %End
 
 };
+
+
+class QgsModelViewSnapMarker : QGraphicsRectItem
+{
+%Docstring
+A simple graphics item rendered as an 'x'.
+%End
+
+%TypeHeaderCode
+#include "qgsmodelgraphicsview.h"
+%End
+  public:
+
+    QgsModelViewSnapMarker();
+
+    virtual void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0 );
+
+
+};
+
 
 
 /************************************************************************

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsModelGraphicsView : QGraphicsView
 {
 %Docstring
@@ -30,6 +31,7 @@ QGraphicsView subclass representing the model designer.
 %Docstring
 Constructor for QgsModelGraphicsView, with the specified ``parent`` widget.
 %End
+    ~QgsModelGraphicsView();
 
     virtual void dragEnterEvent( QDragEnterEvent *event );
 
@@ -39,12 +41,43 @@ Constructor for QgsModelGraphicsView, with the specified ``parent`` widget.
 
     virtual void wheelEvent( QWheelEvent *event );
 
-    virtual void enterEvent( QEvent *event );
-
     virtual void mousePressEvent( QMouseEvent *event );
+
+    virtual void mouseReleaseEvent( QMouseEvent *event );
 
     virtual void mouseMoveEvent( QMouseEvent *event );
 
+    virtual void mouseDoubleClickEvent( QMouseEvent *event );
+
+    virtual void keyPressEvent( QKeyEvent *event );
+
+    virtual void keyReleaseEvent( QKeyEvent *event );
+
+
+    QgsModelViewTool *tool();
+%Docstring
+Returns the currently active tool for the view.
+
+.. seealso:: :py:func:`setTool`
+%End
+
+    void setTool( QgsModelViewTool *tool );
+%Docstring
+Sets the ``tool`` currently being used in the view.
+
+.. seealso:: :py:func:`unsetTool`
+
+.. seealso:: :py:func:`tool`
+%End
+
+    void unsetTool( QgsModelViewTool *tool );
+%Docstring
+Unsets the current view tool, if it matches the specified ``tool``.
+
+This is called from destructor of view tools to make sure
+that the tool won't be used any more.
+You don't have to call it manually, QgsModelViewTool takes care of it.
+%End
 
   signals:
 
@@ -56,6 +89,25 @@ Emitted when an algorithm is dropped onto the view.
     void inputDropped( const QString &inputId, const QPointF &pos );
 %Docstring
 Emitted when an input parameter is dropped onto the view.
+%End
+
+    void toolSet( QgsModelViewTool *tool );
+%Docstring
+Emitted when the current ``tool`` is changed.
+
+.. seealso:: :py:func:`setTool`
+%End
+
+    void itemFocused( QgsModelComponentGraphicItem *item );
+%Docstring
+Emitted when an ``item`` is "focused" in the view, i.e. it becomes the active
+item and should have its properties displayed in any designer windows.
+%End
+
+    void willBeDeleted();
+%Docstring
+Emitted in the destructor when the view is about to be deleted,
+but is still in a perfectly valid state.
 %End
 
 };

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -85,13 +85,10 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.toolbar().setIconSize(iface.iconSize())
             self.setStyleSheet(iface.mainWindow().styleSheet())
 
-        self.scene = ModelerScene(self)
-        self.scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE, self.CANVAS_SIZE))
-        self.scene.rebuildRequired.connect(self.repaintModel)
-        self.scene.componentAboutToChange.connect(self.componentAboutToChange)
-        self.scene.componentChanged.connect(self.componentChanged)
+        scene = ModelerScene(self)
+        scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE, self.CANVAS_SIZE))
+        self.setModelScene(scene)
 
-        self.view().setScene(self.scene)
         self.view().ensureVisible(0, 0, 10, 10)
         self.view().scale(QgsApplication.desktop().logicalDpiX() / 96, QgsApplication.desktop().logicalDpiX() / 96)
 
@@ -194,24 +191,20 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.loadModel(filename)
 
     def repaintModel(self, showControls=True):
-        self.scene = ModelerScene(self)
-        self.scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE,
-                                       self.CANVAS_SIZE))
+        scene = ModelerScene(self)
+        scene.setSceneRect(QRectF(0, 0, self.CANVAS_SIZE,
+                                  self.CANVAS_SIZE))
 
         if not showControls:
-            self.scene.setFlag(QgsModelGraphicsScene.FlagHideControls)
+            scene.setFlag(QgsModelGraphicsScene.FlagHideControls)
 
         showComments = QgsSettings().value("/Processing/Modeler/ShowComments", True, bool)
         if not showComments:
             self.scene.setFlag(QgsModelGraphicsScene.FlagHideComments)
 
         context = createContext()
-        self.scene.createItems(self.model(), context)
-        self.view().setScene(self.scene)
-
-        self.scene.rebuildRequired.connect(self.repaintModel)
-        self.scene.componentAboutToChange.connect(self.componentAboutToChange)
-        self.scene.componentChanged.connect(self.componentChanged)
+        scene.createItems(self.model(), context)
+        self.setModelScene(scene)
 
     def componentAboutToChange(self, description, id):
         self.beginUndoCommand(description, id)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -206,12 +206,6 @@ class ModelerDialog(QgsModelDesignerDialog):
         scene.createItems(self.model(), context)
         self.setModelScene(scene)
 
-    def componentAboutToChange(self, description, id):
-        self.beginUndoCommand(description, id)
-
-    def componentChanged(self):
-        self.endUndoCommand()
-
     def create_widget_context(self):
         """
         Returns a new widget context for use in the model editor

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -282,6 +282,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelgraphicitem.cpp
   processing/models/qgsmodelgraphicsscene.cpp
   processing/models/qgsmodelgraphicsview.cpp
+  processing/models/qgsmodelsnapper.cpp
   processing/models/qgsmodelundocommand.cpp
   processing/models/qgsmodelviewmouseevent.cpp
   processing/models/qgsmodelviewrubberband.cpp
@@ -951,6 +952,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelgraphicitem.h
   processing/models/qgsmodelgraphicsscene.h
   processing/models/qgsmodelgraphicsview.h
+  processing/models/qgsmodelsnapper.h
   processing/models/qgsmodelundocommand.h
   processing/models/qgsmodelviewmouseevent.h
   processing/models/qgsmodelviewrubberband.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -283,6 +283,14 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelgraphicsscene.cpp
   processing/models/qgsmodelgraphicsview.cpp
   processing/models/qgsmodelundocommand.cpp
+  processing/models/qgsmodelviewmouseevent.cpp
+  processing/models/qgsmodelviewrubberband.cpp
+  processing/models/qgsmodelviewtool.cpp
+  processing/models/qgsmodelviewtoolselect.cpp
+  processing/models/qgsmodelviewtooltemporarykeypan.cpp
+  processing/models/qgsmodelviewtooltemporarykeyzoom.cpp
+  processing/models/qgsmodelviewtooltemporarymousepan.cpp
+  processing/models/qgsmodelviewtoolzoom.cpp
 
   providers/gdal/qgsgdalsourceselect.cpp
   providers/gdal/qgsgdalguiprovider.cpp
@@ -944,6 +952,14 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelgraphicsscene.h
   processing/models/qgsmodelgraphicsview.h
   processing/models/qgsmodelundocommand.h
+  processing/models/qgsmodelviewmouseevent.h
+  processing/models/qgsmodelviewrubberband.h
+  processing/models/qgsmodelviewtool.h
+  processing/models/qgsmodelviewtoolselect.h
+  processing/models/qgsmodelviewtooltemporarykeypan.h
+  processing/models/qgsmodelviewtooltemporarykeyzoom.h
+  processing/models/qgsmodelviewtooltemporarymousepan.h
+  processing/models/qgsmodelviewtoolzoom.h
 
   providers/gdal/qgsgdalguiprovider.h
   providers/gdal/qgsgdalsourceselect.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -394,6 +394,7 @@ SET(QGIS_GUI_SRCS
   qgsgeometryrubberband.cpp
   qgsgradientcolorrampdialog.cpp
   qgsgradientstopeditor.cpp
+  qgsgraphicsviewmousehandles.cpp
   qgsgroupwmsdatadialog.cpp
   qgsgui.cpp
   qgsguiutils.cpp
@@ -608,6 +609,7 @@ SET(QGIS_GUI_HDRS
   qgsgeometryrubberband.h
   qgsgradientcolorrampdialog.h
   qgsgradientstopeditor.h
+  qgsgraphicsviewmousehandles.h
   qgsgroupwmsdatadialog.h
   qgsgui.h
   qgsguiutils.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -285,6 +285,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelsnapper.cpp
   processing/models/qgsmodelundocommand.cpp
   processing/models/qgsmodelviewmouseevent.cpp
+  processing/models/qgsmodelviewmousehandles.cpp
   processing/models/qgsmodelviewrubberband.cpp
   processing/models/qgsmodelviewtool.cpp
   processing/models/qgsmodelviewtoolselect.cpp
@@ -957,6 +958,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelsnapper.h
   processing/models/qgsmodelundocommand.h
   processing/models/qgsmodelviewmouseevent.h
+  processing/models/qgsmodelviewmousehandles.h
   processing/models/qgsmodelviewrubberband.h
   processing/models/qgsmodelviewtool.h
   processing/models/qgsmodelviewtoolselect.h

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -43,9 +43,6 @@ QgsLayoutMouseHandles::QgsLayoutMouseHandles( QgsLayout *layout, QgsLayoutView *
   //listen for selection changes, and update handles accordingly
   connect( mLayout, &QGraphicsScene::selectionChanged, this, &QgsLayoutMouseHandles::selectionChanged );
 
-  //accept hover events, required for changing cursor to resize cursors
-  setAcceptHoverEvents( true );
-
   mHorizontalSnapLine = mView->createSnapLine();
   mHorizontalSnapLine->hide();
   layout->addItem( mHorizontalSnapLine );
@@ -58,76 +55,6 @@ void QgsLayoutMouseHandles::paint( QPainter *painter, const QStyleOptionGraphics
 {
   paintInternal( painter, mLayout->renderContext().isPreviewRender(),
                  mLayout->renderContext().boundingBoxesVisible(), option, widget );
-}
-
-void QgsLayoutMouseHandles::drawSelectedItemBounds( QPainter *painter )
-{
-  //draw dotted border around selected items to give visual feedback which items are selected
-  const QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-  if ( selectedItems.isEmpty() )
-  {
-    return;
-  }
-
-  //use difference mode so that they are visible regardless of item colors
-  painter->save();
-  painter->setCompositionMode( QPainter::CompositionMode_Difference );
-
-  // use a grey dashed pen - in difference mode this should always be visible
-  QPen selectedItemPen = QPen( QColor( 144, 144, 144, 255 ) );
-  selectedItemPen.setStyle( Qt::DashLine );
-  selectedItemPen.setWidth( 0 );
-  painter->setPen( selectedItemPen );
-  painter->setBrush( Qt::NoBrush );
-
-  QList< QgsLayoutItem * > itemsToDraw;
-  collectItems( selectedItems, itemsToDraw );
-
-  for ( QgsLayoutItem *item : qgis::as_const( itemsToDraw ) )
-  {
-    //get bounds of selected item
-    QPolygonF itemBounds;
-    if ( isDragging() && !item->isLocked() )
-    {
-      //if currently dragging, draw selected item bounds relative to current mouse position
-      //first, get bounds of current item in scene coordinates
-      QPolygonF itemSceneBounds = item->mapToScene( item->rectWithFrame() );
-      //now, translate it by the current movement amount
-      //IMPORTANT - this is done in scene coordinates, since we don't want any rotation/non-translation transforms to affect the movement
-      itemSceneBounds.translate( transform().dx(), transform().dy() );
-      //finally, remap it to the mouse handle item's coordinate system so it's ready for drawing
-      itemBounds = mapFromScene( itemSceneBounds );
-    }
-    else if ( isResizing() && !item->isLocked() )
-    {
-      //if currently resizing, calculate relative resize of this item
-      if ( selectedItems.size() > 1 )
-      {
-        //get item bounds in mouse handle item's coordinate system
-        QRectF itemRect = mapRectFromItem( item, item->rectWithFrame() );
-        //now, resize it relative to the current resized dimensions of the mouse handles
-        QgsLayoutUtils::relativeResizeRect( itemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
-        itemBounds = QPolygonF( itemRect );
-      }
-      else
-      {
-        //single item selected
-        itemBounds = rect();
-      }
-    }
-    else
-    {
-      //not resizing or moving, so just map from scene bounds
-      itemBounds = mapRectFromItem( item, item->rectWithFrame() );
-    }
-
-    // drawPolygon causes issues on windows - corners of path may be missing resulting in triangles being drawn
-    // instead of rectangles! (Same cause as #13343)
-    QPainterPath path;
-    path.addPolygon( itemBounds );
-    painter->drawPath( path );
-  }
-  painter->restore();
 }
 
 void QgsLayoutMouseHandles::selectionChanged()
@@ -160,107 +87,6 @@ void QgsLayoutMouseHandles::selectionChanged()
   updateHandles();
 }
 
-void QgsLayoutMouseHandles::selectedItemSizeChanged()
-{
-  if ( !isDragging() && !isResizing() )
-  {
-    //only required for non-mouse initiated size changes
-    updateHandles();
-  }
-}
-
-void QgsLayoutMouseHandles::selectedItemRotationChanged()
-{
-  if ( !isDragging() && !isResizing() )
-  {
-    //only required for non-mouse initiated rotation changes
-    updateHandles();
-  }
-}
-
-void QgsLayoutMouseHandles::updateHandles()
-{
-  //recalculate size and position of handle item
-
-  //first check to see if any items are selected
-  QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-  if ( !selectedItems.isEmpty() )
-  {
-    //one or more items are selected, get bounds of all selected items
-
-    //update rotation of handle object
-    double rotation;
-    if ( selectionRotation( rotation ) )
-    {
-      //all items share a common rotation value, so we rotate the mouse handles to match
-      setRotation( rotation );
-    }
-    else
-    {
-      //items have varying rotation values - we can't rotate the mouse handles to match
-      setRotation( 0 );
-    }
-
-    //get bounds of all selected items
-    QRectF newHandleBounds = selectionBounds();
-
-    //update size and position of handle object
-    setRect( 0, 0, newHandleBounds.width(), newHandleBounds.height() );
-    setPos( mapToScene( newHandleBounds.topLeft() ) );
-
-    show();
-  }
-  else
-  {
-    //no items selected, hide handles
-    hide();
-  }
-  //force redraw
-  update();
-}
-
-QRectF QgsLayoutMouseHandles::selectionBounds() const
-{
-  //calculate bounds of all currently selected items in mouse handle coordinate system
-  const QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-  auto itemIter = selectedItems.constBegin();
-
-  //start with handle bounds of first selected item
-  QRectF bounds = mapFromItem( ( *itemIter ), ( *itemIter )->rectWithFrame() ).boundingRect();
-
-  //iterate through remaining items, expanding the bounds as required
-  for ( ++itemIter; itemIter != selectedItems.constEnd(); ++itemIter )
-  {
-    bounds = bounds.united( mapFromItem( ( *itemIter ), ( *itemIter )->rectWithFrame() ).boundingRect() );
-  }
-
-  return bounds;
-}
-
-bool QgsLayoutMouseHandles::selectionRotation( double &rotation ) const
-{
-  //check if all selected items have same rotation
-  QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-  auto itemIter = selectedItems.constBegin();
-
-  //start with rotation of first selected item
-  double firstItemRotation = ( *itemIter )->rotation();
-
-  //iterate through remaining items, checking if they have same rotation
-  for ( ++itemIter; itemIter != selectedItems.constEnd(); ++itemIter )
-  {
-    if ( !qgsDoubleNear( ( *itemIter )->rotation(), firstItemRotation ) )
-    {
-      //item has a different rotation, so return false
-      return false;
-    }
-  }
-
-  //all items have the same rotation, so set the rotation variable and return true
-  rotation = firstItemRotation;
-  return true;
-}
-
 void QgsLayoutMouseHandles::setViewportCursor( Qt::CursorShape cursor )
 {
   //workaround qt bug #3732 by setting cursor for QGraphicsView viewport,
@@ -283,170 +109,51 @@ QList<QGraphicsItem *> QgsLayoutMouseHandles::sceneItemsAtPoint( QPointF scenePo
   return items;
 }
 
-void QgsLayoutMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *event )
+QList<QGraphicsItem *> QgsLayoutMouseHandles::selectedSceneItems( bool includeLockedItems ) const
 {
-  if ( isDragging() )
-  {
-    //currently dragging a selection
-    //if shift depressed, constrain movement to horizontal/vertical
-    //if control depressed, ignore snapping
-    dragMouseMove( event->lastScenePos(), event->modifiers() & Qt::ShiftModifier, event->modifiers() & Qt::ControlModifier );
-  }
-  else if ( isResizing() )
-  {
-    //currently resizing a selection
-    //lock aspect ratio if shift depressed
-    //resize from center if alt depressed
-    resizeMouseMove( event->lastScenePos(), event->modifiers() & Qt::ShiftModifier, event->modifiers() & Qt::AltModifier );
-  }
-
-  mLastMouseEventPos = event->lastScenePos();
+  QList<QGraphicsItem *> res;
+  const QList<QgsLayoutItem *> layoutItems = mLayout->selectedLayoutItems( includeLockedItems );
+  res.reserve( layoutItems.size() );
+  for ( QgsLayoutItem *item : layoutItems )
+    res << item;
+  return res;
 }
 
-void QgsLayoutMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
+bool QgsLayoutMouseHandles::itemIsLocked( QGraphicsItem *item )
 {
-  QPointF mouseMoveStopPoint = event->lastScenePos();
-  double diffX = mouseMoveStopPoint.x() - mMouseMoveStartPos.x();
-  double diffY = mouseMoveStopPoint.y() - mMouseMoveStartPos.y();
-
-  //it was only a click
-  if ( std::fabs( diffX ) < std::numeric_limits<double>::min() && std::fabs( diffY ) < std::numeric_limits<double>::min() )
-  {
-    mIsDragging = false;
-    mIsResizing = false;
-    update();
-    hideAlignItems();
-    return;
-  }
-
-  if ( mCurrentMouseMoveAction == QgsLayoutMouseHandles::MoveItem )
-  {
-    //move selected items
-    mLayout->undoStack()->beginMacro( tr( "Move Items" ) );
-
-    QPointF mEndHandleMovePos = scenePos();
-
-    double deltaX = mEndHandleMovePos.x() - mBeginHandlePos.x();
-    double deltaY = mEndHandleMovePos.y() - mBeginHandlePos.y();
-
-    //move all selected items
-    const QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-    for ( QgsLayoutItem *item : selectedItems )
-    {
-      if ( item->isLocked() || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 || item->isGroupMember() )
-      {
-        //don't move locked items, or grouped items (group takes care of that)
-        continue;
-      }
-
-      std::unique_ptr< QgsAbstractLayoutUndoCommand > command( item->createCommand( QString(), 0 ) );
-      command->saveBeforeState();
-
-      item->attemptMoveBy( deltaX, deltaY );
-
-      command->saveAfterState();
-      mLayout->undoStack()->push( command.release() );
-    }
-    mLayout->undoStack()->endMacro();
-  }
-  else if ( mCurrentMouseMoveAction != QgsLayoutMouseHandles::NoAction )
-  {
-    //resize selected items
-    mLayout->undoStack()->beginMacro( tr( "Resize Items" ) );
-
-    //resize all selected items
-    const QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-    for ( QgsLayoutItem *item : selectedItems )
-    {
-      if ( item->isLocked() || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 )
-      {
-        //don't resize locked items or deselectable items (e.g., items which make up an item group)
-        continue;
-      }
-
-      std::unique_ptr< QgsAbstractLayoutUndoCommand > command( item->createCommand( QString(), 0 ) );
-      command->saveBeforeState();
-
-      QRectF itemRect;
-      if ( selectedItems.size() == 1 )
-      {
-        //only a single item is selected, so set its size to the final resized mouse handle size
-        itemRect = mResizeRect;
-      }
-      else
-      {
-        //multiple items selected, so each needs to be scaled relatively to the final size of the mouse handles
-        itemRect = mapRectFromItem( item, item->rectWithFrame() );
-        QgsLayoutUtils::relativeResizeRect( itemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
-      }
-
-      itemRect = itemRect.normalized();
-      QPointF newPos = mapToScene( itemRect.topLeft() );
-
-      QgsLayoutSize itemSize = mLayout->convertFromLayoutUnits( itemRect.size(), item->sizeWithUnits().units() );
-      item->attemptResize( itemSize, true );
-
-      // translate new position to current item units
-      QgsLayoutPoint itemPos = mLayout->convertFromLayoutUnits( newPos, item->positionWithUnits().units() );
-      item->attemptMove( itemPos, false, true );
-
-      command->saveAfterState();
-      mLayout->undoStack()->push( command.release() );
-    }
-    mLayout->undoStack()->endMacro();
-  }
-
-  hideAlignItems();
-  if ( mIsDragging )
-  {
-    mIsDragging = false;
-  }
-  if ( mIsResizing )
-  {
-    mIsResizing = false;
-  }
-
-  //reset default action
-  mCurrentMouseMoveAction = QgsLayoutMouseHandles::MoveItem;
-  setViewportCursor( Qt::ArrowCursor );
-  //redraw handles
-  resetTransform();
-  updateHandles();
-  //reset status bar message
-  resetStatusBar();
-}
-
-void QgsLayoutMouseHandles::resetStatusBar()
-{
-  if ( !mView )
-    return;
-
-  const QList<QgsLayoutItem *> selectedItems = mLayout->selectedLayoutItems( false );
-  int selectedCount = selectedItems.size();
-  if ( selectedCount > 1 )
-  {
-    //set status bar message to count of selected items
-    mView->pushStatusMessage( tr( "%1 items selected" ).arg( selectedCount ) );
-  }
-  else if ( selectedCount == 1 )
-  {
-    //set status bar message to count of selected items
-    mView->pushStatusMessage( tr( "1 item selected" ) );
-  }
+  if ( QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item ) )
+    return layoutItem->isLocked();
   else
-  {
-    //clear status bar message
-    mView->pushStatusMessage( QString() );
-  }
+    return false;
+}
+
+bool QgsLayoutMouseHandles::itemIsGroupMember( QGraphicsItem *item )
+{
+  if ( QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item ) )
+    return layoutItem->isGroupMember();
+  else
+    return false;
+}
+
+QRectF QgsLayoutMouseHandles::itemRect( QGraphicsItem *item ) const
+{
+  if ( QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item ) )
+    return layoutItem->rectWithFrame();
+  else
+    return QRectF();
 }
 
 QPointF QgsLayoutMouseHandles::snapPoint( QPointF originalPoint, QgsLayoutMouseHandles::SnapGuideMode mode, bool snapHorizontal, bool snapVertical )
 {
   bool snapped = false;
 
-  const QList< QgsLayoutItem * > selectedItems = mLayout->selectedLayoutItems();
-  QList< QgsLayoutItem * > itemsToExclude;
-  collectItems( selectedItems, itemsToExclude );
+  const QList< QGraphicsItem * > selectedItems = selectedSceneItems();
+  QList< QGraphicsItem * > itemsToExclude;
+  expandItemList( selectedItems, itemsToExclude );
+
+  QList< QgsLayoutItem * > layoutItemsToExclude;
+  for ( QGraphicsItem *item : itemsToExclude )
+    layoutItemsToExclude << dynamic_cast< QgsLayoutItem * >( item );
 
   //depending on the mode, we either snap just the single point, or all the bounds of the selection
   QPointF snappedPoint;
@@ -454,15 +161,38 @@ QPointF QgsLayoutMouseHandles::snapPoint( QPointF originalPoint, QgsLayoutMouseH
   {
     case Item:
       snappedPoint = mLayout->snapper().snapRect( rect().translated( originalPoint ), mView->transform().m11(), snapped, snapHorizontal ? mHorizontalSnapLine : nullptr,
-                     snapVertical ? mVerticalSnapLine : nullptr, &itemsToExclude ).topLeft();
+                     snapVertical ? mVerticalSnapLine : nullptr, &layoutItemsToExclude ).topLeft();
       break;
     case Point:
       snappedPoint = mLayout->snapper().snapPoint( originalPoint, mView->transform().m11(), snapped, snapHorizontal ? mHorizontalSnapLine : nullptr,
-                     snapVertical ? mVerticalSnapLine : nullptr, &itemsToExclude );
+                     snapVertical ? mVerticalSnapLine : nullptr, &layoutItemsToExclude );
       break;
   }
 
   return snapped ? snappedPoint : originalPoint;
+}
+
+void QgsLayoutMouseHandles::createItemCommand( QGraphicsItem *item )
+{
+  mItemCommand.reset( dynamic_cast< QgsLayoutItem * >( item )->createCommand( QString(), 0 ) );
+  mItemCommand->saveBeforeState();
+}
+
+void QgsLayoutMouseHandles::endItemCommand( QGraphicsItem * )
+{
+  mItemCommand->saveAfterState();
+  mLayout->undoStack()->push( mItemCommand.release() );
+}
+
+void QgsLayoutMouseHandles::startMacroCommand( const QString &text )
+{
+  mLayout->undoStack()->beginMacro( text );
+
+}
+
+void QgsLayoutMouseHandles::endMacroCommand()
+{
+  mLayout->undoStack()->endMacro();
 }
 
 void QgsLayoutMouseHandles::hideAlignItems()
@@ -471,14 +201,17 @@ void QgsLayoutMouseHandles::hideAlignItems()
   mVerticalSnapLine->hide();
 }
 
-void QgsLayoutMouseHandles::collectItems( const QList<QgsLayoutItem *> &items, QList<QgsLayoutItem *> &collected )
+void QgsLayoutMouseHandles::expandItemList( const QList<QGraphicsItem *> &items, QList<QGraphicsItem *> &collected ) const
 {
-  for ( QgsLayoutItem *item : items )
+  for ( QGraphicsItem *item : items )
   {
     if ( item->type() == QgsLayoutItemRegistry::LayoutGroup )
     {
       // if a group is selected, we don't draw the bounds of the group - instead we draw the bounds of the grouped items
-      collected.append( static_cast< QgsLayoutItemGroup * >( item )->items() );
+      const QList<QgsLayoutItem *> groupItems = static_cast< QgsLayoutItemGroup * >( item )->items();
+      collected.reserve( collected.size() + groupItems.size() );
+      for ( QgsLayoutItem *groupItem : groupItems )
+        collected.append( groupItem );
     }
     else
     {
@@ -487,364 +220,24 @@ void QgsLayoutMouseHandles::collectItems( const QList<QgsLayoutItem *> &items, Q
   }
 }
 
-void QgsLayoutMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *event )
+void QgsLayoutMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double deltaY )
 {
-  //save current cursor position
-  mMouseMoveStartPos = event->lastScenePos();
-  mLastMouseEventPos = event->lastScenePos();
-  //save current item geometry
-  mBeginMouseEventPos = event->lastScenePos();
-  mBeginHandlePos = scenePos();
-  mBeginHandleWidth = rect().width();
-  mBeginHandleHeight = rect().height();
-  //type of mouse move action
-  mCurrentMouseMoveAction = mouseActionForPosition( event->pos() );
-
-  hideAlignItems();
-
-  if ( mCurrentMouseMoveAction == QgsLayoutMouseHandles::MoveItem )
-  {
-    //moving items
-    mIsDragging = true;
-  }
-  else if ( mCurrentMouseMoveAction != QgsLayoutMouseHandles::SelectItem &&
-            mCurrentMouseMoveAction != QgsLayoutMouseHandles::NoAction )
-  {
-    //resizing items
-    mIsResizing = true;
-    mResizeRect = QRectF( 0, 0, mBeginHandleWidth, mBeginHandleHeight );
-    mResizeMoveX = 0;
-    mResizeMoveY = 0;
-    mCursorOffset = calcCursorEdgeOffset( mMouseMoveStartPos );
-
-  }
-
+  dynamic_cast< QgsLayoutItem * >( item )->attemptMoveBy( deltaX, deltaY );
 }
 
-void QgsLayoutMouseHandles::dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap )
+void QgsLayoutMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
-  if ( !mLayout )
-  {
+  QgsLayoutItem *layoutItem = dynamic_cast< QgsLayoutItem * >( item );
+  layoutItem->attemptSetSceneRect( rect, true );
+}
+
+void QgsLayoutMouseHandles::showStatusMessage( const QString &message )
+{
+  if ( !mView )
     return;
-  }
 
-  //calculate total amount of mouse movement since drag began
-  double moveX = currentPosition.x() - mBeginMouseEventPos.x();
-  double moveY = currentPosition.y() - mBeginMouseEventPos.y();
-
-  //find target position before snapping (in scene coordinates)
-  QPointF upperLeftPoint( mBeginHandlePos.x() + moveX, mBeginHandlePos.y() + moveY );
-
-  QPointF snappedLeftPoint;
-
-  //no snapping for rotated items for now
-  if ( !preventSnap && qgsDoubleNear( rotation(), 0.0 ) )
-  {
-    //snap to grid and guides
-    snappedLeftPoint = snapPoint( upperLeftPoint, QgsLayoutMouseHandles::Item );
-
-  }
-  else
-  {
-    //no snapping
-    snappedLeftPoint = upperLeftPoint;
-    hideAlignItems();
-  }
-
-  //calculate total shift for item from beginning of drag operation to current position
-  double moveRectX = snappedLeftPoint.x() - mBeginHandlePos.x();
-  double moveRectY = snappedLeftPoint.y() - mBeginHandlePos.y();
-
-  if ( lockMovement )
-  {
-    //constrained (shift) moving should lock to horizontal/vertical movement
-    //reset the smaller of the x/y movements
-    if ( std::fabs( moveRectX ) <= std::fabs( moveRectY ) )
-    {
-      moveRectX = 0;
-    }
-    else
-    {
-      moveRectY = 0;
-    }
-  }
-
-  //shift handle item to new position
-  QTransform moveTransform;
-  moveTransform.translate( moveRectX, moveRectY );
-  setTransform( moveTransform );
-
-  //show current displacement of selection in status bar
-  mView->pushStatusMessage( tr( "dx: %1 mm dy: %2 mm" ).arg( moveRectX ).arg( moveRectY ) );
+  mView->pushStatusMessage( message );
 }
 
-void QgsLayoutMouseHandles::resizeMouseMove( QPointF currentPosition, bool lockRatio, bool fromCenter )
-{
-
-  if ( !mLayout )
-  {
-    return;
-  }
-
-  double mx = 0.0, my = 0.0, rx = 0.0, ry = 0.0;
-
-  QPointF beginMousePos;
-  QPointF finalPosition;
-  if ( qgsDoubleNear( rotation(), 0.0 ) )
-  {
-    //snapping only occurs if handles are not rotated for now
-
-    bool snapVertical = mCurrentMouseMoveAction == ResizeLeft ||
-                        mCurrentMouseMoveAction == ResizeRight ||
-                        mCurrentMouseMoveAction == ResizeLeftUp ||
-                        mCurrentMouseMoveAction == ResizeRightUp ||
-                        mCurrentMouseMoveAction == ResizeLeftDown ||
-                        mCurrentMouseMoveAction == ResizeRightDown;
-
-    bool snapHorizontal = mCurrentMouseMoveAction == ResizeUp ||
-                          mCurrentMouseMoveAction == ResizeDown ||
-                          mCurrentMouseMoveAction == ResizeLeftUp ||
-                          mCurrentMouseMoveAction == ResizeRightUp ||
-                          mCurrentMouseMoveAction == ResizeLeftDown ||
-                          mCurrentMouseMoveAction == ResizeRightDown;
-
-    //subtract cursor edge offset from begin mouse event and current cursor position, so that snapping occurs to edge of mouse handles
-    //rather then cursor position
-    beginMousePos = mapFromScene( QPointF( mBeginMouseEventPos.x() - mCursorOffset.width(), mBeginMouseEventPos.y() - mCursorOffset.height() ) );
-    QPointF snappedPosition = snapPoint( QPointF( currentPosition.x() - mCursorOffset.width(), currentPosition.y() - mCursorOffset.height() ), QgsLayoutMouseHandles::Point, snapHorizontal, snapVertical );
-    finalPosition = mapFromScene( snappedPosition );
-  }
-  else
-  {
-    //no snapping for rotated items for now
-    beginMousePos = mapFromScene( mBeginMouseEventPos );
-    finalPosition = mapFromScene( currentPosition );
-  }
-
-  double diffX = finalPosition.x() - beginMousePos.x();
-  double diffY = finalPosition.y() - beginMousePos.y();
-
-  double ratio = 0;
-  if ( lockRatio && !qgsDoubleNear( mBeginHandleHeight, 0.0 ) )
-  {
-    ratio = mBeginHandleWidth / mBeginHandleHeight;
-  }
-
-  switch ( mCurrentMouseMoveAction )
-  {
-    //vertical resize
-    case QgsLayoutMouseHandles::ResizeUp:
-    {
-      if ( ratio )
-      {
-        diffX = ( ( mBeginHandleHeight - diffY ) * ratio ) - mBeginHandleWidth;
-        mx = -diffX / 2;
-        my = diffY;
-        rx = diffX;
-        ry = -diffY;
-      }
-      else
-      {
-        mx = 0;
-        my = diffY;
-        rx = 0;
-        ry = -diffY;
-      }
-      break;
-    }
-
-    case QgsLayoutMouseHandles::ResizeDown:
-    {
-      if ( ratio )
-      {
-        diffX = ( ( mBeginHandleHeight + diffY ) * ratio ) - mBeginHandleWidth;
-        mx = -diffX / 2;
-        my = 0;
-        rx = diffX;
-        ry = diffY;
-      }
-      else
-      {
-        mx = 0;
-        my = 0;
-        rx = 0;
-        ry = diffY;
-      }
-      break;
-    }
-
-    //horizontal resize
-    case QgsLayoutMouseHandles::ResizeLeft:
-    {
-      if ( ratio )
-      {
-        diffY = ( ( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
-        mx = diffX;
-        my = -diffY / 2;
-        rx = -diffX;
-        ry = diffY;
-      }
-      else
-      {
-        mx = diffX, my = 0;
-        rx = -diffX;
-        ry = 0;
-      }
-      break;
-    }
-
-    case QgsLayoutMouseHandles::ResizeRight:
-    {
-      if ( ratio )
-      {
-        diffY = ( ( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
-        mx = 0;
-        my = -diffY / 2;
-        rx = diffX;
-        ry = diffY;
-      }
-      else
-      {
-        mx = 0;
-        my = 0;
-        rx = diffX, ry = 0;
-      }
-      break;
-    }
-
-    //diagonal resize
-    case QgsLayoutMouseHandles::ResizeLeftUp:
-    {
-      if ( ratio )
-      {
-        //ratio locked resize
-        if ( ( mBeginHandleWidth - diffX ) / ( mBeginHandleHeight - diffY ) > ratio )
-        {
-          diffX = mBeginHandleWidth - ( ( mBeginHandleHeight - diffY ) * ratio );
-        }
-        else
-        {
-          diffY = mBeginHandleHeight - ( ( mBeginHandleWidth - diffX ) / ratio );
-        }
-      }
-      mx = diffX, my = diffY;
-      rx = -diffX;
-      ry = -diffY;
-      break;
-    }
-
-    case QgsLayoutMouseHandles::ResizeRightDown:
-    {
-      if ( ratio )
-      {
-        //ratio locked resize
-        if ( ( mBeginHandleWidth + diffX ) / ( mBeginHandleHeight + diffY ) > ratio )
-        {
-          diffX = ( ( mBeginHandleHeight + diffY ) * ratio ) - mBeginHandleWidth;
-        }
-        else
-        {
-          diffY = ( ( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
-        }
-      }
-      mx = 0;
-      my = 0;
-      rx = diffX, ry = diffY;
-      break;
-    }
-
-    case QgsLayoutMouseHandles::ResizeRightUp:
-    {
-      if ( ratio )
-      {
-        //ratio locked resize
-        if ( ( mBeginHandleWidth + diffX ) / ( mBeginHandleHeight - diffY ) > ratio )
-        {
-          diffX = ( ( mBeginHandleHeight - diffY ) * ratio ) - mBeginHandleWidth;
-        }
-        else
-        {
-          diffY = mBeginHandleHeight - ( ( mBeginHandleWidth + diffX ) / ratio );
-        }
-      }
-      mx = 0;
-      my = diffY, rx = diffX, ry = -diffY;
-      break;
-    }
-
-    case QgsLayoutMouseHandles::ResizeLeftDown:
-    {
-      if ( ratio )
-      {
-        //ratio locked resize
-        if ( ( mBeginHandleWidth - diffX ) / ( mBeginHandleHeight + diffY ) > ratio )
-        {
-          diffX = mBeginHandleWidth - ( ( mBeginHandleHeight + diffY ) * ratio );
-        }
-        else
-        {
-          diffY = ( ( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
-        }
-      }
-      mx = diffX, my = 0;
-      rx = -diffX;
-      ry = diffY;
-      break;
-    }
-
-    case QgsLayoutMouseHandles::MoveItem:
-    case QgsLayoutMouseHandles::SelectItem:
-    case QgsLayoutMouseHandles::NoAction:
-      break;
-  }
-
-  //resizing from center of objects?
-  if ( fromCenter )
-  {
-    my = -ry;
-    mx = -rx;
-    ry = 2 * ry;
-    rx = 2 * rx;
-  }
-
-  //update selection handle rectangle
-
-  //make sure selection handle size rectangle is normalized (ie, left coord < right coord)
-  mResizeMoveX = mBeginHandleWidth + rx > 0 ? mx : mx + mBeginHandleWidth + rx;
-  mResizeMoveY = mBeginHandleHeight + ry > 0 ? my : my + mBeginHandleHeight + ry;
-
-  //calculate movement in scene coordinates
-  QLineF translateLine = QLineF( 0, 0, mResizeMoveX, mResizeMoveY );
-  translateLine.setAngle( translateLine.angle() - rotation() );
-  QPointF sceneTranslate = translateLine.p2();
-
-  //move selection handles
-  QTransform itemTransform;
-  itemTransform.translate( sceneTranslate.x(), sceneTranslate.y() );
-  setTransform( itemTransform );
-
-  //handle non-normalised resizes - e.g., dragging the left handle so far to the right that it's past the right handle
-  if ( mBeginHandleWidth + rx >= 0 && mBeginHandleHeight + ry >= 0 )
-  {
-    mResizeRect = QRectF( 0, 0, mBeginHandleWidth + rx, mBeginHandleHeight + ry );
-  }
-  else if ( mBeginHandleHeight + ry >= 0 )
-  {
-    mResizeRect = QRectF( QPointF( -( mBeginHandleWidth + rx ), 0 ), QPointF( 0, mBeginHandleHeight + ry ) );
-  }
-  else if ( mBeginHandleWidth + rx >= 0 )
-  {
-    mResizeRect = QRectF( QPointF( 0, -( mBeginHandleHeight + ry ) ), QPointF( mBeginHandleWidth + rx, 0 ) );
-  }
-  else
-  {
-    mResizeRect = QRectF( QPointF( -( mBeginHandleWidth + rx ), -( mBeginHandleHeight + ry ) ), QPointF( 0, 0 ) );
-  }
-
-  setRect( 0, 0, std::fabs( mBeginHandleWidth + rx ), std::fabs( mBeginHandleHeight + ry ) );
-
-  //show current size of selection in status bar
-  mView->pushStatusMessage( tr( "width: %1 mm height: %2 mm" ).arg( rect().width() ).arg( rect().height() ) );
-}
 
 ///@endcond PRIVATE

--- a/src/gui/layout/qgslayoutmousehandles.cpp
+++ b/src/gui/layout/qgslayoutmousehandles.cpp
@@ -54,7 +54,7 @@ QgsLayoutMouseHandles::QgsLayoutMouseHandles( QgsLayout *layout, QgsLayoutView *
 void QgsLayoutMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )
 {
   paintInternal( painter, mLayout->renderContext().isPreviewRender(),
-                 mLayout->renderContext().boundingBoxesVisible(), option, widget );
+                 mLayout->renderContext().boundingBoxesVisible(), true, option, widget );
 }
 
 void QgsLayoutMouseHandles::selectionChanged()

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -20,8 +20,7 @@
 // We don't want to expose this in the public API
 #define SIP_NO_FILE
 
-#include <QGraphicsRectItem>
-#include <QObject>
+#include "qgsgraphicsviewmousehandles.h"
 #include <QPointer>
 #include <memory>
 
@@ -45,45 +44,10 @@ class QInputEvent;
  *
  * \since QGIS 3.0
 */
-class GUI_EXPORT QgsLayoutMouseHandles: public QObject, public QGraphicsRectItem
+class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
 {
     Q_OBJECT
   public:
-
-    //! Describes the action (move or resize in different direction) to be done during mouse move
-    enum MouseAction
-    {
-      MoveItem,
-      ResizeUp,
-      ResizeDown,
-      ResizeLeft,
-      ResizeRight,
-      ResizeLeftUp,
-      ResizeRightUp,
-      ResizeLeftDown,
-      ResizeRightDown,
-      SelectItem,
-      NoAction
-    };
-
-    enum ItemPositionMode
-    {
-      UpperLeft,
-      UpperMiddle,
-      UpperRight,
-      MiddleLeft,
-      Middle,
-      MiddleRight,
-      LowerLeft,
-      LowerMiddle,
-      LowerRight
-    };
-
-    enum SnapGuideMode
-    {
-      Item,
-      Point
-    };
 
     QgsLayoutMouseHandles( QgsLayout *layout, QgsLayoutView *view );
 
@@ -101,25 +65,15 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QObject, public QGraphicsRectItem
 
     void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr ) override;
 
-    //! Finds out which mouse move action to choose depending on the scene cursor position
-    QgsLayoutMouseHandles::MouseAction mouseActionForScenePos( QPointF sceneCoordPos );
-
-    //! Returns TRUE is user is currently dragging the handles
-    bool isDragging() const { return mIsDragging; }
-
-    //! Returns TRUE is user is currently resizing with the handles
-    bool isResizing() const { return mIsResizing; }
-
-    bool shouldBlockEvent( QInputEvent *event ) const;
-
   protected:
 
     void mouseMoveEvent( QGraphicsSceneMouseEvent *event ) override;
     void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
     void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
-    void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
-    void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;
-    void hoverLeaveEvent( QGraphicsSceneHoverEvent *event ) override;
+
+    void drawSelectedItemBounds( QPainter *painter ) override;
+    void setViewportCursor( Qt::CursorShape cursor ) override;
+    QList<QGraphicsItem *> sceneItemsAtPoint( QPointF scenePoint ) override;
 
   public slots:
 
@@ -137,33 +91,9 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QObject, public QGraphicsRectItem
     QgsLayout *mLayout = nullptr;
     QPointer< QgsLayoutView > mView;
 
-    MouseAction mCurrentMouseMoveAction = NoAction;
-    //! Start point of the last mouse move action (in scene coordinates)
-    QPointF mMouseMoveStartPos;
-    //! Position of the last mouse move event (in scene coordinates)
-    QPointF mLastMouseEventPos;
-    //! Position of the mouse at beginning of move/resize (in scene coordinates)
-    QPointF mBeginMouseEventPos;
-    //! Position of layout handles at beginning of move/resize (in scene coordinates)
-    QPointF mBeginHandlePos;
-    //! Width and height of layout handles at beginning of resize
-    double mBeginHandleWidth = 0;
-    double mBeginHandleHeight = 0;
-
-    QRectF mResizeRect;
-    double mResizeMoveX = 0;
-    double mResizeMoveY = 0;
-
-    //! True if user is currently dragging items
-    bool mIsDragging = false;
-    //! True is user is currently resizing items
-    bool mIsResizing = false;
-
     //! Align snap lines
     QGraphicsLineItem *mHorizontalSnapLine = nullptr;
     QGraphicsLineItem *mVerticalSnapLine = nullptr;
-
-    QSizeF mCursorOffset;
 
     //! Returns the mouse handle bounds of current selection
     QRectF selectionBounds() const;
@@ -173,33 +103,12 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QObject, public QGraphicsRectItem
 
     //! Redraws or hides the handles based on the current selection
     void updateHandles();
-    //! Draws the handles
-    void drawHandles( QPainter *painter, double rectHandlerSize );
-    //! Draw outlines for selected items
-    void drawSelectedItemBounds( QPainter *painter );
-
-    /**
-     * Returns the current (zoom level dependent) tolerance to decide if mouse position is close enough to the
-    item border for resizing*/
-    double rectHandlerBorderTolerance();
-
-    //! Finds out the appropriate cursor for the current mouse position in the widget (e.g. move in the middle, resize at border)
-    Qt::CursorShape cursorForPosition( QPointF itemCoordPos );
-
-    //! Finds out which mouse move action to choose depending on the cursor position inside the widget
-    MouseAction mouseActionForPosition( QPointF itemCoordPos );
 
     //! Handles dragging of items during mouse move
     void dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap );
 
-    //! Calculates the distance of the mouse cursor from thed edge of the mouse handles
-    QSizeF calcCursorEdgeOffset( QPointF cursorPos );
-
     //! Handles resizing of items during mouse move
     void resizeMouseMove( QPointF currentPosition, bool lockAspect, bool fromCenter );
-
-    //sets the mouse cursor for the QGraphicsView attached to the composition (workaround qt bug #3732)
-    void setViewportCursor( Qt::CursorShape cursor );
 
     //resets the layout designer status bar to the default message
     void resetStatusBar();

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -31,6 +31,7 @@ class QGraphicsView;
 class QgsLayoutView;
 class QgsLayoutItem;
 class QInputEvent;
+class QgsAbstractLayoutUndoCommand;
 
 ///@cond PRIVATE
 
@@ -67,21 +68,26 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
 
   protected:
 
-    void mouseMoveEvent( QGraphicsSceneMouseEvent *event ) override;
-    void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
-    void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
-
-    void drawSelectedItemBounds( QPainter *painter ) override;
     void setViewportCursor( Qt::CursorShape cursor ) override;
     QList<QGraphicsItem *> sceneItemsAtPoint( QPointF scenePoint ) override;
-
+    QList<QGraphicsItem *> selectedSceneItems( bool includeLockedItems = true ) const override;
+    bool itemIsLocked( QGraphicsItem *item ) override;
+    bool itemIsGroupMember( QGraphicsItem *item ) override;
+    QRectF itemRect( QGraphicsItem *item ) const override;
+    void expandItemList( const QList< QGraphicsItem * > &items, QList< QGraphicsItem * > &collected ) const override;
+    void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
+    void setItemRect( QGraphicsItem *item, QRectF rect ) override;
+    void showStatusMessage( const QString &message ) override;
+    void hideAlignItems() override;
+    QPointF snapPoint( QPointF originalPoint, SnapGuideMode mode, bool snapHorizontal = true, bool snapVertical = true ) override;
+    void createItemCommand( QGraphicsItem *item ) override;
+    void endItemCommand( QGraphicsItem *item ) override;
+    void startMacroCommand( const QString &text ) override;
+    void endMacroCommand() override;
   public slots:
 
     //! Sets up listeners to sizeChanged signal for all selected items
     void selectionChanged();
-
-    //! Redraws handles when selected item size changes
-    void selectedItemSizeChanged();
 
     //! Redraws handles when selected item rotation changes
     void selectedItemRotationChanged();
@@ -95,32 +101,7 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     QGraphicsLineItem *mHorizontalSnapLine = nullptr;
     QGraphicsLineItem *mVerticalSnapLine = nullptr;
 
-    //! Returns the mouse handle bounds of current selection
-    QRectF selectionBounds() const;
-
-    //! Returns TRUE if all selected items have same rotation, and if so, updates passed rotation variable
-    bool selectionRotation( double &rotation ) const;
-
-    //! Redraws or hides the handles based on the current selection
-    void updateHandles();
-
-    //! Handles dragging of items during mouse move
-    void dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap );
-
-    //! Handles resizing of items during mouse move
-    void resizeMouseMove( QPointF currentPosition, bool lockAspect, bool fromCenter );
-
-    //resets the layout designer status bar to the default message
-    void resetStatusBar();
-
-    //! Snaps an item or point (depending on mode) originating at originalPoint to the grid or align rulers
-    QPointF snapPoint( QPointF originalPoint, SnapGuideMode mode, bool snapHorizontal = true, bool snapVertical = true );
-
-    void hideAlignItems();
-
-    //! Collects all items from a list of \a items, exploring for any group members and adding them too
-    void collectItems( const QList< QgsLayoutItem * > &items, QList< QgsLayoutItem * > &collected );
-
+    std::unique_ptr< QgsAbstractLayoutUndoCommand > mItemCommand;
 };
 
 ///@endcond PRIVATE

--- a/src/gui/processing/models/qgsmodelarrowitem.cpp
+++ b/src/gui/processing/models/qgsmodelarrowitem.cpp
@@ -37,7 +37,7 @@ QgsModelArrowItem::QgsModelArrowItem( QgsModelComponentGraphicItem *startItem, Q
   setFlag( QGraphicsItem::ItemIsSelectable, false );
   mColor = QApplication::palette().color( QPalette::WindowText );
   mColor.setAlpha( 150 );
-  setPen( QPen( mColor, 4, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin ) );
+  setPen( QPen( mColor, 8, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin ) );
   setZValue( QgsModelGraphicsScene::ArrowLink );
   updatePath();
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -54,9 +54,7 @@ QgsModelComponentGraphicItem::QgsModelComponentGraphicItem( QgsProcessingModelCo
   QPainter painter( &editPicture );
   svg.render( &painter );
   painter.end();
-  mEditButton = new QgsModelDesignerFlatButtonGraphicItem( this, editPicture,
-      QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0,
-               itemSize().height() / 2.0 - mButtonSize.height() / 2.0 ) );
+  mEditButton = new QgsModelDesignerFlatButtonGraphicItem( this, editPicture, QPointF( 0, 0 ) );
   connect( mEditButton, &QgsModelDesignerFlatButtonGraphicItem::clicked, this, &QgsModelComponentGraphicItem::editComponent );
 
   QSvgRenderer svg2( QgsApplication::iconPath( QStringLiteral( "mActionDeleteModelComponent.svg" ) ) );
@@ -64,10 +62,10 @@ QgsModelComponentGraphicItem::QgsModelComponentGraphicItem( QgsProcessingModelCo
   painter.begin( &deletePicture );
   svg2.render( &painter );
   painter.end();
-  mDeleteButton = new QgsModelDesignerFlatButtonGraphicItem( this, deletePicture,
-      QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0,
-               mButtonSize.height() / 2.0 - itemSize().height() / 2.0 ) );
+  mDeleteButton = new QgsModelDesignerFlatButtonGraphicItem( this, deletePicture, QPointF( 0, 0 ) );
   connect( mDeleteButton, &QgsModelDesignerFlatButtonGraphicItem::clicked, this, &QgsModelComponentGraphicItem::deleteComponent );
+
+  updateButtonPositions();
 }
 
 QgsModelComponentGraphicItem::Flags QgsModelComponentGraphicItem::flags() const
@@ -228,19 +226,16 @@ QVariant QgsModelComponentGraphicItem::itemChange( QGraphicsItem::GraphicsItemCh
         // ideally would be in constructor, but cannot call virtual methods from that...
         if ( linkPointCount( Qt::TopEdge ) )
         {
-          QPointF pt = linkPoint( Qt::TopEdge, -1 );
-          pt = QPointF( 0, pt.y() );
-          mExpandTopButton = new QgsModelDesignerFoldButtonGraphicItem( this, mComponent->linksCollapsed( Qt::TopEdge ), pt );
+          mExpandTopButton = new QgsModelDesignerFoldButtonGraphicItem( this, mComponent->linksCollapsed( Qt::TopEdge ), QPointF( 0, 0 ) );
           connect( mExpandTopButton, &QgsModelDesignerFoldButtonGraphicItem::folded, this, [ = ]( bool folded ) { fold( Qt::TopEdge, folded ); } );
         }
         if ( linkPointCount( Qt::BottomEdge ) )
         {
-          QPointF pt = linkPoint( Qt::BottomEdge, -1 );
-          pt = QPointF( 0, pt.y() );
-          mExpandBottomButton = new QgsModelDesignerFoldButtonGraphicItem( this, mComponent->linksCollapsed( Qt::BottomEdge ), pt );
+          mExpandBottomButton = new QgsModelDesignerFoldButtonGraphicItem( this, mComponent->linksCollapsed( Qt::BottomEdge ), QPointF( 0, 0 ) );
           connect( mExpandBottomButton, &QgsModelDesignerFoldButtonGraphicItem::folded, this, [ = ]( bool folded ) { fold( Qt::BottomEdge, folded ); } );
         }
         mInitialized = true;
+        updateButtonPositions();
       }
       break;
     }
@@ -409,10 +404,10 @@ QPixmap QgsModelComponentGraphicItem::iconPixmap() const
 
 void QgsModelComponentGraphicItem::updateButtonPositions()
 {
-  mEditButton->setPosition( QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0,
-                                     itemSize().height() / 2.0 - mButtonSize.height() / 2.0 ) );
-  mDeleteButton->setPosition( QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0,
-                                       mButtonSize.height() / 2.0 - itemSize().height() / 2.0 ) );
+  mEditButton->setPosition( QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0 - 2,
+                                     itemSize().height() / 2.0 - mButtonSize.height() / 2.0  - 2 ) );
+  mDeleteButton->setPosition( QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0  - 2,
+                                       mButtonSize.height() / 2.0 - itemSize().height() / 2.0 + 2 ) );
 
   if ( mExpandTopButton )
   {

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -118,6 +118,7 @@ void QgsModelComponentGraphicItem::moveComponentBy( qreal dx, qreal dy )
   updateStoredComponentPosition( pos(), mComponent->size() );
   emit changed();
 
+  emit sizePositionChanged();
   emit updateArrowPaths();
 }
 
@@ -141,6 +142,7 @@ void QgsModelComponentGraphicItem::setItemRect( QRectF )
 
   emit changed();
 
+  emit sizePositionChanged();
   emit updateArrowPaths();
 }
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -112,7 +112,7 @@ void QgsModelComponentGraphicItem::setFont( const QFont &font )
 
 void QgsModelComponentGraphicItem::moveComponentBy( qreal dx, qreal dy )
 {
-  moveBy( dx, dy );
+  setPos( mComponent->position().x() + dx, mComponent->position().y() + dy );
   mComponent->setPosition( pos() );
 
   emit aboutToChange( tr( "Move %1" ).arg( mComponent->description() ) );
@@ -122,20 +122,16 @@ void QgsModelComponentGraphicItem::moveComponentBy( qreal dx, qreal dy )
   emit updateArrowPaths();
 }
 
+void QgsModelComponentGraphicItem::previewItemMove( qreal dx, qreal dy )
+{
+  setPos( mComponent->position().x() + dx, mComponent->position().y() + dy );
+  emit updateArrowPaths();
+}
+
 void QgsModelComponentGraphicItem::mouseDoubleClickEvent( QGraphicsSceneMouseEvent * )
 {
   if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
     editComponent();
-}
-
-void QgsModelComponentGraphicItem::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
-{
-  if ( mIsMoving && event->button() == Qt::LeftButton )
-  {
-    // released the move drag button, so we've finalised the move operation
-    emit changed();
-    mIsMoving = false;
-  }
 }
 
 void QgsModelComponentGraphicItem::hoverEnterEvent( QGraphicsSceneHoverEvent *event )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -24,6 +24,7 @@
 #include "qgsprocessingmodelalgorithm.h"
 #include "qgsmodelgraphicsview.h"
 #include "qgsmodelviewtool.h"
+#include "qgsmodelviewmouseevent.h"
 
 #include <QSvgRenderer>
 #include <QPicture>
@@ -155,6 +156,38 @@ void QgsModelComponentGraphicItem::previewItemRectChange( QRectF rect )
   emit updateArrowPaths();
 }
 
+void QgsModelComponentGraphicItem::modelHoverEnterEvent( QgsModelViewMouseEvent *event )
+{
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
+    updateToolTip( mapFromScene( event->modelPoint() ) );
+}
+
+void QgsModelComponentGraphicItem::modelHoverMoveEvent( QgsModelViewMouseEvent *event )
+{
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
+    updateToolTip( mapFromScene( event->modelPoint() ) );
+}
+
+void QgsModelComponentGraphicItem::modelHoverLeaveEvent( QgsModelViewMouseEvent * )
+{
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
+  {
+    setToolTip( QString() );
+    if ( mIsHovering )
+    {
+      mIsHovering = false;
+      update();
+      emit repaintArrows();
+    }
+  }
+}
+
+void QgsModelComponentGraphicItem::modelDoubleClickEvent( QgsModelViewMouseEvent * )
+{
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
+    editComponent();
+}
+
 void QgsModelComponentGraphicItem::mouseDoubleClickEvent( QGraphicsSceneMouseEvent * )
 {
   if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
@@ -175,16 +208,7 @@ void QgsModelComponentGraphicItem::hoverMoveEvent( QGraphicsSceneHoverEvent *eve
 
 void QgsModelComponentGraphicItem::hoverLeaveEvent( QGraphicsSceneHoverEvent * )
 {
-  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
-  {
-    setToolTip( QString() );
-    if ( mIsHovering )
-    {
-      mIsHovering = false;
-      update();
-      emit repaintArrows();
-    }
-  }
+  modelHoverLeaveEvent( nullptr );
 }
 
 QVariant QgsModelComponentGraphicItem::itemChange( QGraphicsItem::GraphicsItemChange change, const QVariant &value )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -111,6 +111,13 @@ void QgsModelComponentGraphicItem::setFont( const QFont &font )
   update();
 }
 
+void QgsModelComponentGraphicItem::moveComponentBy( qreal dx, qreal dy )
+{
+  mIsMoving = true;
+  moveBy( dx, dy );
+  mIsMoving = false;
+}
+
 void QgsModelComponentGraphicItem::mouseDoubleClickEvent( QGraphicsSceneMouseEvent * )
 {
   if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -22,6 +22,9 @@
 #include "qgsapplication.h"
 #include "qgsmodelgraphicitem.h"
 #include "qgsprocessingmodelalgorithm.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsmodelviewtool.h"
+
 #include <QSvgRenderer>
 #include <QPicture>
 #include <QPainter>
@@ -89,6 +92,11 @@ QgsProcessingModelAlgorithm *QgsModelComponentGraphicItem::model()
   return mModel;
 }
 
+QgsModelGraphicsView *QgsModelComponentGraphicItem::view()
+{
+  return qobject_cast< QgsModelGraphicsView * >( scene()->views().first() );
+}
+
 QFont QgsModelComponentGraphicItem::font() const
 {
   return mFont;
@@ -102,7 +110,8 @@ void QgsModelComponentGraphicItem::setFont( const QFont &font )
 
 void QgsModelComponentGraphicItem::mouseDoubleClickEvent( QGraphicsSceneMouseEvent * )
 {
-  editComponent();
+  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+    editComponent();
 }
 
 void QgsModelComponentGraphicItem::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
@@ -117,22 +126,27 @@ void QgsModelComponentGraphicItem::mouseReleaseEvent( QGraphicsSceneMouseEvent *
 
 void QgsModelComponentGraphicItem::hoverEnterEvent( QGraphicsSceneHoverEvent *event )
 {
-  updateToolTip( event->pos() );
+  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+    updateToolTip( event->pos() );
 }
 
 void QgsModelComponentGraphicItem::hoverMoveEvent( QGraphicsSceneHoverEvent *event )
 {
-  updateToolTip( event->pos() );
+  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+    updateToolTip( event->pos() );
 }
 
 void QgsModelComponentGraphicItem::hoverLeaveEvent( QGraphicsSceneHoverEvent * )
 {
-  setToolTip( QString() );
-  if ( mIsHovering )
+  if ( view()->tool() && view()->tool()->allowItemInteraction() )
   {
-    mIsHovering = false;
-    update();
-    emit repaintArrows();
+    setToolTip( QString() );
+    if ( mIsHovering )
+    {
+      mIsHovering = false;
+      update();
+      emit repaintArrows();
+    }
   }
 }
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -94,6 +94,9 @@ QgsProcessingModelAlgorithm *QgsModelComponentGraphicItem::model()
 
 QgsModelGraphicsView *QgsModelComponentGraphicItem::view()
 {
+  if ( scene()->views().isEmpty() )
+    return nullptr;
+
   return qobject_cast< QgsModelGraphicsView * >( scene()->views().first() );
 }
 
@@ -110,7 +113,7 @@ void QgsModelComponentGraphicItem::setFont( const QFont &font )
 
 void QgsModelComponentGraphicItem::mouseDoubleClickEvent( QGraphicsSceneMouseEvent * )
 {
-  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
     editComponent();
 }
 
@@ -126,19 +129,19 @@ void QgsModelComponentGraphicItem::mouseReleaseEvent( QGraphicsSceneMouseEvent *
 
 void QgsModelComponentGraphicItem::hoverEnterEvent( QGraphicsSceneHoverEvent *event )
 {
-  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
     updateToolTip( event->pos() );
 }
 
 void QgsModelComponentGraphicItem::hoverMoveEvent( QGraphicsSceneHoverEvent *event )
 {
-  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
     updateToolTip( event->pos() );
 }
 
 void QgsModelComponentGraphicItem::hoverLeaveEvent( QGraphicsSceneHoverEvent * )
 {
-  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+  if ( view() && view()->tool() && view()->tool()->allowItemInteraction() )
   {
     setToolTip( QString() );
     if ( mIsHovering )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -137,6 +137,9 @@ void QgsModelComponentGraphicItem::setItemRect( QRectF )
 
   emit aboutToChange( tr( "Resize %1" ).arg( mComponent->description() ) );
   updateStoredComponentPosition( pos(), mComponent->size() );
+
+  updateButtonPositions();
+
   emit changed();
 
   emit updateArrowPaths();
@@ -148,6 +151,7 @@ void QgsModelComponentGraphicItem::previewItemRectChange( QRectF rect )
   prepareGeometryChange();
   mTempSize = rect.size();
 
+  updateButtonPositions();
   emit updateArrowPaths();
 }
 
@@ -260,7 +264,7 @@ void QgsModelComponentGraphicItem::paint( QPainter *painter, const QStyleOptionG
   double h = fm.ascent();
   QPointF pt( -componentSize.width() / 2 + 25, componentSize.height() / 2.0 - h + 1 );
 
-  if ( flags() & FlagMultilineText )
+  if ( iconPicture().isNull() && iconPixmap().isNull() )
   {
     QRectF labelRect = QRectF( rect.left() + 4, rect.top() + 4, rect.width() - 8 - mButtonSize.width(), rect.height() - 8 );
     text = label();
@@ -268,8 +272,9 @@ void QgsModelComponentGraphicItem::paint( QPainter *painter, const QStyleOptionG
   }
   else
   {
-    text = truncatedTextForItem( label() );
-    painter->drawText( pt, text );
+    QRectF labelRect = QRectF( rect.left() + 25, rect.top() + 4, rect.width() - 8 - mButtonSize.width(), rect.height() - 8 );
+    text = label();
+    painter->drawText( labelRect, Qt::TextWordWrap | Qt::AlignVCenter, text );
   }
 
   painter->setPen( QPen( QApplication::palette().color( QPalette::WindowText ) ) );
@@ -376,6 +381,25 @@ QPicture QgsModelComponentGraphicItem::iconPicture() const
 QPixmap QgsModelComponentGraphicItem::iconPixmap() const
 {
   return QPixmap();
+}
+
+void QgsModelComponentGraphicItem::updateButtonPositions()
+{
+  mEditButton->setPosition( QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0,
+                                     itemSize().height() / 2.0 - mButtonSize.height() / 2.0 ) );
+  mDeleteButton->setPosition( QPointF( itemSize().width() / 2.0 - mButtonSize.width() / 2.0,
+                                       mButtonSize.height() / 2.0 - itemSize().height() / 2.0 ) );
+
+  if ( mExpandTopButton )
+  {
+    QPointF pt = linkPoint( Qt::TopEdge, -1 );
+    mExpandTopButton->setPosition( QPointF( 0, pt.y() ) );
+  }
+  if ( mExpandBottomButton )
+  {
+    QPointF pt = linkPoint( Qt::BottomEdge, -1 );
+    mExpandBottomButton->setPosition( QPointF( 0, pt.y() ) );
+  }
 }
 
 QSizeF QgsModelComponentGraphicItem::itemSize() const
@@ -984,11 +1008,6 @@ void QgsModelCommentGraphicItem::contextMenuEvent( QGraphicsSceneContextMenuEven
   QAction *editAction = popupmenu->addAction( QObject::tr( "Edit…" ) );
   connect( editAction, &QAction::triggered, this, &QgsModelCommentGraphicItem::editComponent );
   popupmenu->exec( event->screenPos() );
-}
-
-QgsModelCommentGraphicItem::Flags QgsModelCommentGraphicItem::flags() const
-{
-  return FlagMultilineText;
 }
 
 QgsModelCommentGraphicItem::~QgsModelCommentGraphicItem() = default;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -121,7 +121,6 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     void moveComponentBy( qreal dx, qreal dy );
 
     void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
-    void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverLeaveEvent( QGraphicsSceneHoverEvent *event ) override;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -153,7 +153,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     virtual void modelHoverLeaveEvent( QgsModelViewMouseEvent *event );
 
     /**
-     * Handles a model double click \a event.
+     * Handles a model double-click \a event.
      */
     virtual void modelDoubleClickEvent( QgsModelViewMouseEvent *event );
 #endif

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -125,6 +125,16 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void previewItemMove( qreal dx, qreal dy );
 
+    /**
+     * Sets a new scene \a rect for the item.
+     */
+    void setItemRect( QRectF rect );
+
+    /**
+     * Shows a preview of setting a new \a rect for the item.
+     */
+    void previewItemRectChange( QRectF rect );
+
     void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;
@@ -136,7 +146,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     /**
      * Returns the rectangle representing the body of the item.
      */
-    QRectF itemRect() const;
+    QRectF itemRect( bool storedRect = false ) const;
 
     /**
      * Returns the item's label text.
@@ -286,11 +296,13 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     virtual QPixmap iconPixmap() const;
 
     /**
-     * Updates the position stored in the model for the associated comment
+     * Updates the position and size stored in the model for the associated comment
      */
-    virtual void updateStoredComponentPosition( const QPointF &pos ) = 0;
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) = 0;
 
   private:
+
+    QSizeF itemSize() const;
 
     void updateToolTip( const QPointF &pos );
 
@@ -316,6 +328,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
 
     bool mIsHovering = false;
     bool mIsMoving = false;
+    QSizeF mTempSize;
 
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsModelComponentGraphicItem::Flags )
@@ -352,7 +365,7 @@ class GUI_EXPORT QgsModelParameterGraphicItem : public QgsModelComponentGraphicI
     QColor strokeColor( State state ) const override;
     QColor textColor( State state ) const override;
     QPicture iconPicture() const override;
-    void updateStoredComponentPosition( const QPointF &pos ) override;
+    void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) override;
 
   protected slots:
 
@@ -398,7 +411,7 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
 
     int linkPointCount( Qt::Edge edge ) const override;
     QString linkPointText( Qt::Edge edge, int index ) const override;
-    void updateStoredComponentPosition( const QPointF &pos ) override;
+    void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) override;
 
   protected slots:
 
@@ -444,7 +457,7 @@ class GUI_EXPORT QgsModelOutputGraphicItem : public QgsModelComponentGraphicItem
     QColor strokeColor( State state ) const override;
     QColor textColor( State state ) const override;
     QPicture iconPicture() const override;
-    void updateStoredComponentPosition( const QPointF &pos ) override;
+    void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) override;
 
   protected slots:
 
@@ -490,7 +503,7 @@ class GUI_EXPORT QgsModelCommentGraphicItem : public QgsModelComponentGraphicIte
     QColor strokeColor( State state ) const override;
     QColor textColor( State state ) const override;
     Qt::PenStyle strokeStyle( State state ) const override;
-    void updateStoredComponentPosition( const QPointF &pos ) override;
+    void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) override;
 
   protected slots:
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -120,6 +120,11 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void moveComponentBy( qreal dx, qreal dy );
 
+    /**
+     * Shows a preview of moving the item from its stored position by \a dx, \a dy.
+     */
+    void previewItemMove( qreal dx, qreal dy );
+
     void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -32,6 +32,7 @@ class QgsProcessingModelAlgorithm;
 class QgsModelDesignerFlatButtonGraphicItem;
 class QgsModelDesignerFoldButtonGraphicItem;
 class QgsModelGraphicsView;
+class QgsModelViewMouseEvent;
 
 ///@cond NOT_STABLE
 
@@ -134,6 +135,28 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void previewItemRectChange( QRectF rect );
 
+#ifndef SIP_RUN
+
+    /**
+     * Handles a model hover enter \a event.
+     */
+    virtual void modelHoverEnterEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Handles a model hover move \a event.
+     */
+    virtual void modelHoverMoveEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Handles a model hover leave \a event.
+     */
+    virtual void modelHoverLeaveEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Handles a model double click \a event.
+     */
+    virtual void modelDoubleClickEvent( QgsModelViewMouseEvent *event );
+#endif
     void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -275,6 +275,11 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void updateArrowPaths();
 
+    /**
+     * Emitted when the item's size or position changes.
+     */
+    void sizePositionChanged();
+
   protected slots:
 
     /**

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -113,6 +113,13 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void setFont( const QFont &font );
 
+    /**
+     * Moves the component by the specified \a dx and \a dy.
+     *
+     * \warning Call this method, not QGraphicsItem::moveBy!
+     */
+    void moveComponentBy( qreal dx, qreal dy );
+
     void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
     void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -229,6 +229,18 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     virtual void editComment() {}
 
+    /**
+     * Returns TRUE if the component can be deleted.
+     */
+    virtual bool canDeleteComponent() { return false; }
+
+    /**
+     * Called when the component should be deleted.
+     *
+     * The default implementation does nothing.
+     */
+    virtual void deleteComponent() {}
+
   signals:
 
     // TODO - rework this, should be triggered externally when the model actually changes!
@@ -271,13 +283,6 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      * The default implementation does nothing.
      */
     virtual void editComponent() {}
-
-    /**
-     * Called when the component should be deleted.
-     *
-     * The default implementation does nothing.
-     */
-    virtual void deleteComponent() {}
 
   protected:
 
@@ -385,6 +390,7 @@ class GUI_EXPORT QgsModelParameterGraphicItem : public QgsModelComponentGraphicI
                                   QGraphicsItem *parent SIP_TRANSFERTHIS );
 
     void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
+    bool canDeleteComponent() override;
 
   protected:
 
@@ -427,6 +433,7 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
                                        QgsProcessingModelAlgorithm *model,
                                        QGraphicsItem *parent SIP_TRANSFERTHIS );
     void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
+    bool canDeleteComponent() override;
 
   protected:
 
@@ -478,6 +485,8 @@ class GUI_EXPORT QgsModelOutputGraphicItem : public QgsModelComponentGraphicItem
                                QgsProcessingModelAlgorithm *model,
                                QGraphicsItem *parent SIP_TRANSFERTHIS );
 
+    bool canDeleteComponent() override;
+
   protected:
 
     QColor fillColor( State state ) const override;
@@ -523,6 +532,7 @@ class GUI_EXPORT QgsModelCommentGraphicItem : public QgsModelComponentGraphicIte
                                 QGraphicsItem *parent SIP_TRANSFERTHIS );
     ~QgsModelCommentGraphicItem() override;
     void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
+    bool canDeleteComponent() override;
   protected:
 
     QColor fillColor( State state ) const override;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -58,7 +58,6 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     //! Available flags
     enum Flag
     {
-      FlagMultilineText = 1 << 0, //!< Show multiline text in label
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 
@@ -300,6 +299,11 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) = 0;
 
+    /**
+     * Updates the item's button positions, based on the current item rect.
+     */
+    void updateButtonPositions();
+
   private:
 
     QSizeF itemSize() const;
@@ -496,7 +500,6 @@ class GUI_EXPORT QgsModelCommentGraphicItem : public QgsModelComponentGraphicIte
                                 QGraphicsItem *parent SIP_TRANSFERTHIS );
     ~QgsModelCommentGraphicItem() override;
     void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
-    Flags flags() const override;
   protected:
 
     QColor fillColor( State state ) const override;

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -31,6 +31,7 @@ class QgsProcessingModelComment;
 class QgsProcessingModelAlgorithm;
 class QgsModelDesignerFlatButtonGraphicItem;
 class QgsModelDesignerFoldButtonGraphicItem;
+class QgsModelGraphicsView;
 
 ///@cond NOT_STABLE
 
@@ -94,6 +95,11 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      * Returns the model associated with this item.
      */
     QgsProcessingModelAlgorithm *model();
+
+    /**
+     * Returns the associated view.
+     */
+    QgsModelGraphicsView *view();
 
     /**
      * Returns the font used to render text in the item.

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -321,6 +321,8 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
 
   mView->setModelScene( mScene );
 
+  mSelectTool->setScene( mScene );
+
   connect( mScene, &QgsModelGraphicsScene::rebuildRequired, this, [ = ] { repaintModel(); } );
   connect( mScene, &QgsModelGraphicsScene::componentChanged, this, [ = ] { setDirty(); } );
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -271,7 +271,9 @@ void QgsModelDesignerDialog::endUndoCommand()
     return;
 
   mActiveCommand->saveAfterState();
+  mIgnoreUndoStackChanges++;
   mUndoStack->push( mActiveCommand.release() );
+  mIgnoreUndoStackChanges--;
   setDirty( true );
 }
 
@@ -291,7 +293,10 @@ void QgsModelDesignerDialog::setModel( QgsProcessingModelAlgorithm *model )
 
   mView->centerOn( 0, 0 );
   setDirty( false );
+
+  mIgnoreUndoStackChanges++;
   mUndoStack->clear();
+  mIgnoreUndoStackChanges--;
 
   updateWindowTitle();
 }

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -244,6 +244,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
 QgsModelDesignerDialog::~QgsModelDesignerDialog()
 {
   mIgnoreUndoStackChanges++;
+  delete mSelectTool; // delete mouse handles before everything else
 }
 
 void QgsModelDesignerDialog::closeEvent( QCloseEvent *event )

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -25,6 +25,7 @@
 #include "qgsprocessingparametertype.h"
 #include "qgsmodelundocommand.h"
 #include "qgsmodelviewtoolselect.h"
+#include "qgsmodelgraphicsscene.h"
 
 #include <QShortcut>
 #include <QDesktopWidget>
@@ -309,6 +310,22 @@ void QgsModelDesignerDialog::loadModel( const QString &path )
     QMessageBox::critical( this, tr( "Open Model" ), tr( "The selected model could not be loaded.\n"
                            "See the log for more information." ) );
   }
+}
+
+void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
+{
+  QgsModelGraphicsScene *oldScene = mScene;
+
+  mScene = scene;
+  mScene->setParent( this );
+
+  mView->setModelScene( mScene );
+
+  connect( mScene, &QgsModelGraphicsScene::rebuildRequired, this, [ = ] { repaintModel(); } );
+  connect( mScene, &QgsModelGraphicsScene::componentChanged, this, [ = ] { setDirty(); } );
+
+  if ( oldScene )
+    oldScene->deleteLater();
 }
 
 void QgsModelDesignerDialog::updateVariablesGui()

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -240,11 +240,15 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
 
   connect( mView, &QgsModelGraphicsView::macroCommandStarted, this, [ = ]( const QString & text )
   {
+    mIgnoreUndoStackChanges++;
     mUndoStack->beginMacro( text );
+    mIgnoreUndoStackChanges--;
   } );
   connect( mView, &QgsModelGraphicsView::macroCommandEnded, this, [ = ]
   {
+    mIgnoreUndoStackChanges++;
     mUndoStack->endMacro();
+    mIgnoreUndoStackChanges--;
   } );
 
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -238,6 +238,16 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mView->setTool( mSelectTool );
   mView->setFocus();
 
+  connect( mView, &QgsModelGraphicsView::macroCommandStarted, this, [ = ]( const QString & text )
+  {
+    mUndoStack->beginMacro( text );
+  } );
+  connect( mView, &QgsModelGraphicsView::macroCommandEnded, this, [ = ]
+  {
+    mUndoStack->endMacro();
+  } );
+
+
   updateWindowTitle();
 }
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -324,7 +324,8 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
   mSelectTool->setScene( mScene );
 
   connect( mScene, &QgsModelGraphicsScene::rebuildRequired, this, [ = ] { repaintModel(); } );
-  connect( mScene, &QgsModelGraphicsScene::componentChanged, this, [ = ] { setDirty(); } );
+  connect( mScene, &QgsModelGraphicsScene::componentAboutToChange, this, [ = ]( const QString & description, int id ) { beginUndoCommand( description, id ); } );
+  connect( mScene, &QgsModelGraphicsScene::componentChanged, this, [ = ] { endUndoCommand(); } );
 
   if ( oldScene )
     oldScene->deleteLater();

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsgui.h"
 #include "qgsprocessingparametertype.h"
 #include "qgsmodelundocommand.h"
+#include "qgsmodelviewtoolselect.h"
 
 #include <QShortcut>
 #include <QDesktopWidget>
@@ -228,6 +229,13 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
 
   mActionShowComments->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/ShowComments" ), true ).toBool() );
   connect( mActionShowComments, &QAction::toggled, this, &QgsModelDesignerDialog::toggleComments );
+
+  mSelectTool = new QgsModelViewToolSelect( mView );
+#if 0
+  mSelectTool->setAction( mActionSelectMoveItem );
+#endif
+  mView->setTool( mSelectTool );
+  mView->setFocus();
 
   updateWindowTitle();
 }

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -85,6 +85,11 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
      */
     void loadModel( const QString &path );
 
+    /**
+     * Sets the related \a scene.
+     */
+    void setModelScene( QgsModelGraphicsScene *scene SIP_TRANSFER );
+
   protected:
 
     virtual void repaintModel( bool showControls = true ) = 0;
@@ -139,6 +144,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QgsMessageBar *mMessageBar = nullptr;
     QgsModelerToolboxModel *mAlgorithmsModel = nullptr;
     QgsModelViewToolSelect *mSelectTool = nullptr;
+    QgsModelGraphicsScene *mScene = nullptr;
 
     bool mHasChanged = false;
     QUndoStack *mUndoStack = nullptr;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -131,6 +131,8 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void exportAsPython();
     void toggleComments( bool show );
     void updateWindowTitle();
+    void deleteSelected();
+
   private:
 
     enum UndoCommand
@@ -159,6 +161,8 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     int mIgnoreUndoStackChanges = 0;
 
     QString mTitle;
+
+    int mBlockRepaints = 0;
 
     bool isDirty() const;
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -26,6 +26,7 @@ class QgsMessageBar;
 class QgsProcessingModelAlgorithm;
 class QgsModelUndoCommand;
 class QUndoView;
+class QgsModelViewToolSelect;
 
 ///@cond NOT_STABLE
 
@@ -137,6 +138,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
 
     QgsMessageBar *mMessageBar = nullptr;
     QgsModelerToolboxModel *mAlgorithmsModel = nullptr;
+    QgsModelViewToolSelect *mSelectTool = nullptr;
 
     bool mHasChanged = false;
     QUndoStack *mUndoStack = nullptr;

--- a/src/gui/processing/models/qgsmodelgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicitem.cpp
@@ -18,6 +18,7 @@
 #include "qgsmodelgraphicsscene.h"
 #include "qgsmodelgraphicsview.h"
 #include "qgsmodelviewtool.h"
+#include "qgsmodelviewmouseevent.h"
 #include <QPainter>
 #include <QSvgRenderer>
 
@@ -89,6 +90,31 @@ void QgsModelDesignerFlatButtonGraphicItem::mousePressEvent( QGraphicsSceneMouse
     emit clicked();
 }
 
+void QgsModelDesignerFlatButtonGraphicItem::modelHoverEnterEvent( QgsModelViewMouseEvent * )
+{
+  if ( view()->tool() && !view()->tool()->allowItemInteraction() )
+    mHoverState = false;
+  else
+    mHoverState = true;
+  update();
+}
+
+void QgsModelDesignerFlatButtonGraphicItem::modelHoverLeaveEvent( QgsModelViewMouseEvent * )
+{
+  mHoverState = false;
+  update();
+}
+
+void QgsModelDesignerFlatButtonGraphicItem::modelPressEvent( QgsModelViewMouseEvent *event )
+{
+  if ( view()->tool() && view()->tool()->allowItemInteraction() && event->button() == Qt::LeftButton )
+  {
+    QMetaObject::invokeMethod( this, &QgsModelDesignerFlatButtonGraphicItem::clicked, Qt::QueuedConnection );
+    mHoverState = false;
+    update();
+  }
+}
+
 void QgsModelDesignerFlatButtonGraphicItem::setPosition( const QPointF &position )
 {
   mPosition = position;
@@ -134,6 +160,14 @@ void QgsModelDesignerFoldButtonGraphicItem::mousePressEvent( QGraphicsSceneMouse
   setPicture( mFolded ? mPlusPicture : mMinusPicture );
   emit folded( mFolded );
   QgsModelDesignerFlatButtonGraphicItem::mousePressEvent( event );
+}
+
+void QgsModelDesignerFoldButtonGraphicItem::modelPressEvent( QgsModelViewMouseEvent *event )
+{
+  mFolded = !mFolded;
+  setPicture( mFolded ? mPlusPicture : mMinusPicture );
+  emit folded( mFolded );
+  QgsModelDesignerFlatButtonGraphicItem::modelPressEvent( event );
 }
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodelgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicitem.cpp
@@ -89,6 +89,13 @@ void QgsModelDesignerFlatButtonGraphicItem::mousePressEvent( QGraphicsSceneMouse
     emit clicked();
 }
 
+void QgsModelDesignerFlatButtonGraphicItem::setPosition( const QPointF &position )
+{
+  mPosition = position;
+  prepareGeometryChange();
+  update();
+}
+
 QgsModelGraphicsView *QgsModelDesignerFlatButtonGraphicItem::view()
 {
   return qobject_cast< QgsModelGraphicsView * >( scene()->views().first() );

--- a/src/gui/processing/models/qgsmodelgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicitem.cpp
@@ -109,7 +109,7 @@ void QgsModelDesignerFlatButtonGraphicItem::modelPressEvent( QgsModelViewMouseEv
 {
   if ( view()->tool() && view()->tool()->allowItemInteraction() && event->button() == Qt::LeftButton )
   {
-    QMetaObject::invokeMethod( this, &QgsModelDesignerFlatButtonGraphicItem::clicked, Qt::QueuedConnection );
+    QMetaObject::invokeMethod( this, "clicked", Qt::QueuedConnection );
     mHoverState = false;
     update();
   }

--- a/src/gui/processing/models/qgsmodelgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicitem.cpp
@@ -16,6 +16,8 @@
 #include "qgsmodelgraphicitem.h"
 #include "qgsapplication.h"
 #include "qgsmodelgraphicsscene.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsmodelviewtool.h"
 #include <QPainter>
 #include <QSvgRenderer>
 
@@ -68,7 +70,10 @@ QRectF QgsModelDesignerFlatButtonGraphicItem::boundingRect() const
 
 void QgsModelDesignerFlatButtonGraphicItem::hoverEnterEvent( QGraphicsSceneHoverEvent * )
 {
-  mHoverState = true;
+  if ( view()->tool() && !view()->tool()->allowItemInteraction() )
+    mHoverState = false;
+  else
+    mHoverState = true;
   update();
 }
 
@@ -80,7 +85,13 @@ void QgsModelDesignerFlatButtonGraphicItem::hoverLeaveEvent( QGraphicsSceneHover
 
 void QgsModelDesignerFlatButtonGraphicItem::mousePressEvent( QGraphicsSceneMouseEvent * )
 {
-  emit clicked();
+  if ( view()->tool() && view()->tool()->allowItemInteraction() )
+    emit clicked();
+}
+
+QgsModelGraphicsView *QgsModelDesignerFlatButtonGraphicItem::view()
+{
+  return qobject_cast< QgsModelGraphicsView * >( scene()->views().first() );
 }
 
 void QgsModelDesignerFlatButtonGraphicItem::setPicture( const QPicture &picture )

--- a/src/gui/processing/models/qgsmodelgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelgraphicitem.h
@@ -53,6 +53,11 @@ class GUI_EXPORT QgsModelDesignerFlatButtonGraphicItem : public QGraphicsObject
     void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
 
     /**
+     * Sets the button's \a position.
+     */
+    void setPosition( const QPointF &position );
+
+    /**
      * Returns the associated model view.
      */
     QgsModelGraphicsView *view();

--- a/src/gui/processing/models/qgsmodelgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelgraphicitem.h
@@ -22,6 +22,7 @@
 #include <QPicture>
 
 class QgsModelGraphicsView;
+class QgsModelViewMouseEvent;
 
 ///@cond NOT_STABLE
 
@@ -51,6 +52,24 @@ class GUI_EXPORT QgsModelDesignerFlatButtonGraphicItem : public QGraphicsObject
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverLeaveEvent( QGraphicsSceneHoverEvent *event ) override;
     void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
+
+#ifndef SIP_RUN
+
+    /**
+     * Handles a model hover enter \a event.
+     */
+    virtual void modelHoverEnterEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Handles a model hover leave \a event.
+     */
+    virtual void modelHoverLeaveEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Handles a model mouse press \a event.
+     */
+    virtual void modelPressEvent( QgsModelViewMouseEvent *event );
+#endif
 
     /**
      * Sets the button's \a position.
@@ -108,6 +127,9 @@ class GUI_EXPORT QgsModelDesignerFoldButtonGraphicItem : public QgsModelDesigner
                                            const QSizeF &size = QSizeF( 11, 11 ) );
 
     void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
+#ifndef SIP_RUN
+    void modelPressEvent( QgsModelViewMouseEvent *event ) override;
+#endif
 
   signals:
 

--- a/src/gui/processing/models/qgsmodelgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelgraphicitem.h
@@ -21,6 +21,8 @@
 #include <QGraphicsObject>
 #include <QPicture>
 
+class QgsModelGraphicsView;
+
 ///@cond NOT_STABLE
 
 
@@ -49,6 +51,11 @@ class GUI_EXPORT QgsModelDesignerFlatButtonGraphicItem : public QGraphicsObject
     void hoverEnterEvent( QGraphicsSceneHoverEvent *event ) override;
     void hoverLeaveEvent( QGraphicsSceneHoverEvent *event ) override;
     void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
+
+    /**
+     * Returns the associated model view.
+     */
+    QgsModelGraphicsView *view();
 
   signals:
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -115,6 +115,9 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
   for ( auto it = childAlgs.constBegin(); it != childAlgs.constEnd(); ++it )
   {
     int idx = 0;
+    if ( !it.value().algorithm() )
+      continue;
+
     const QgsProcessingParameterDefinitions parameters = it.value().algorithm()->parameterDefinitions();
     for ( const QgsProcessingParameterDefinition *parameter : parameters )
     {
@@ -163,19 +166,21 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       addCommentItemForComponent( model, outputIt.value(), item );
 
       QPointF pos = outputIt.value().position();
-
-      // find the actual index of the linked output from the child algorithm it comes from
-      const QgsProcessingOutputDefinitions sourceChildAlgOutputs = it.value().algorithm()->outputDefinitions();
       int idx = -1;
       int i = 0;
-      for ( const QgsProcessingOutputDefinition *childAlgOutput : sourceChildAlgOutputs )
+      // find the actual index of the linked output from the child algorithm it comes from
+      if ( it.value().algorithm() )
       {
-        if ( childAlgOutput->name() == outputIt.value().childOutputName() )
+        const QgsProcessingOutputDefinitions sourceChildAlgOutputs = it.value().algorithm()->outputDefinitions();
+        for ( const QgsProcessingOutputDefinition *childAlgOutput : sourceChildAlgOutputs )
         {
-          idx = i;
-          break;
+          if ( childAlgOutput->name() == outputIt.value().childOutputName() )
+          {
+            idx = i;
+            break;
+          }
+          i++;
         }
-        i++;
       }
 
       item->setPos( pos );
@@ -272,6 +277,9 @@ QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForPa
       }
       case QgsProcessingModelChildParameterSource::ChildOutput:
       {
+        if ( !model->childAlgorithm( source.outputChildId() ).algorithm() )
+          break;
+
         const QgsProcessingOutputDefinitions outputs = model->childAlgorithm( source.outputChildId() ).algorithm()->outputDefinitions();
         int i = 0;
         for ( const QgsProcessingOutputDefinition *output : outputs )

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -49,6 +49,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
       ArrowLink = 0, //!< An arrow linking model items
       ModelComponent = 1, //!< Model components (e.g. algorithms, inputs and outputs)
       RubberBand = 100, //!< Rubber band item
+      ZSnapIndicator = 101, //!< Z-value for snapping indicator
     };
 
     //! Flags for controlling how the scene is rendered and scene behavior

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -93,6 +93,29 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     void createItems( QgsProcessingModelAlgorithm *model, QgsProcessingContext &context );
 
+    /**
+     * Returns list of selected component items.
+     */
+    QList<QgsModelComponentGraphicItem *> selectedComponentItems();
+
+    /**
+     * Returns the topmost component item at a specified \a position.
+     */
+    QgsModelComponentGraphicItem *componentItemAt( QPointF position ) const;
+
+    /**
+     * Clears any selected items in the scene.
+     *
+     * Call this method rather than QGraphicsScene::clearSelection, as the latter does
+     * not correctly emit signals to allow the scene's model to update.
+    */
+    void deselectAll();
+
+    /**
+     * Clears any selected items and sets \a item as the current selection.
+    */
+    void setSelectedItem( QgsModelComponentGraphicItem *item );
+
   signals:
 
     /**
@@ -112,6 +135,12 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      * Emitted whenever a component of the model is changed.
      */
     void componentChanged();
+
+    /**
+     * Emitted whenever the selected item changes.
+     * If NULLPTR, no item is selected.
+     */
+    void selectedItemChanged( QgsModelComponentGraphicItem *selected );
 
   protected:
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -48,8 +48,10 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     {
       ArrowLink = 0, //!< An arrow linking model items
       ModelComponent = 1, //!< Model components (e.g. algorithms, inputs and outputs)
+      MouseHandles = 99, //!< Mouse handles
       RubberBand = 100, //!< Rubber band item
       ZSnapIndicator = 101, //!< Z-value for snapping indicator
+
     };
 
     //! Flags for controlling how the scene is rendered and scene behavior

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -48,6 +48,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     {
       ArrowLink = 0, //!< An arrow linking model items
       ModelComponent = 1, //!< Model components (e.g. algorithms, inputs and outputs)
+      RubberBand = 100, //!< Rubber band item
     };
 
     //! Flags for controlling how the scene is rendered and scene behavior

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -341,25 +341,17 @@ void QgsModelGraphicsView::keyPressEvent( QKeyEvent *event )
   {
     QgsModelGraphicsScene *s = modelScene();
     const QList<QgsModelComponentGraphicItem *> itemList = s->selectedComponentItems();
-
-    QPointF delta = deltaForKeyEvent( event );
-
-#if 0
-    l->undoStack()->beginMacro( tr( "Move Item" ) );
-#endif
-    for ( QgsModelComponentGraphicItem *item : itemList )
+    if ( !itemList.empty() )
     {
-#if 0
-      l->undoStack()->beginCommand( item, tr( "Move Item" ), QgsLayoutItem::UndoIncrementalMove );
-#endif
-      item->moveBy( delta.x(), delta.y() );
-#if 0
-      l->undoStack()->endCommand();
-#endif
+      QPointF delta = deltaForKeyEvent( event );
+
+      itemList.at( 0 )->aboutToChange( tr( "Move Items" ) );
+      for ( QgsModelComponentGraphicItem *item : itemList )
+      {
+        item->moveComponentBy( delta.x(), delta.y() );
+      }
+      itemList.at( 0 )->changed();
     }
-#if 0
-    l->undoStack()->endMacro();
-#endif
     event->accept();
   }
 }

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -21,6 +21,7 @@
 #include "qgsmodelviewtooltemporarymousepan.h"
 #include "qgsmodelviewtooltemporarykeyzoom.h"
 #include "qgsmodelcomponentgraphicitem.h"
+#include "qgsmodelgraphicsscene.h"
 
 #include <QDragEnterEvent>
 #include <QScrollBar>
@@ -98,10 +99,8 @@ void QgsModelGraphicsView::dragMoveEvent( QDragMoveEvent *event )
 
 void QgsModelGraphicsView::wheelEvent( QWheelEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !scene() )
     return;
-#endif
 
   if ( mTool )
   {
@@ -168,10 +167,8 @@ void QgsModelGraphicsView::scaleSafe( double scale )
 
 void QgsModelGraphicsView::mousePressEvent( QMouseEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !modelScene() )
     return;
-#endif
 
   if ( mTool )
   {
@@ -197,10 +194,8 @@ void QgsModelGraphicsView::mousePressEvent( QMouseEvent *event )
 
 void QgsModelGraphicsView::mouseReleaseEvent( QMouseEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !modelScene() )
     return;
-#endif
 
   if ( mTool )
   {
@@ -215,10 +210,8 @@ void QgsModelGraphicsView::mouseReleaseEvent( QMouseEvent *event )
 
 void QgsModelGraphicsView::mouseMoveEvent( QMouseEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !modelScene() )
     return;
-#endif
 
   mMouseCurrentXY = event->pos();
 
@@ -260,10 +253,9 @@ void QgsModelGraphicsView::mouseMoveEvent( QMouseEvent *event )
 
 void QgsModelGraphicsView::mouseDoubleClickEvent( QMouseEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !modelScene() )
     return;
-#endif
+
   if ( mTool )
   {
     std::unique_ptr<QgsModelViewMouseEvent> me( new QgsModelViewMouseEvent( this, event, mTool->flags() & QgsModelViewTool::FlagSnaps ) );
@@ -277,10 +269,8 @@ void QgsModelGraphicsView::mouseDoubleClickEvent( QMouseEvent *event )
 
 void QgsModelGraphicsView::keyPressEvent( QKeyEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !modelScene() )
     return;
-#endif
 
   if ( mTool )
   {
@@ -330,10 +320,8 @@ void QgsModelGraphicsView::keyPressEvent( QKeyEvent *event )
 
 void QgsModelGraphicsView::keyReleaseEvent( QKeyEvent *event )
 {
-#if 0
-  if ( !currentLayout() )
+  if ( !modelScene() )
     return;
-#endif
 
   if ( mTool )
   {
@@ -342,6 +330,11 @@ void QgsModelGraphicsView::keyReleaseEvent( QKeyEvent *event )
 
   if ( !mTool || !event->isAccepted() )
     QGraphicsView::keyReleaseEvent( event );
+}
+
+QgsModelGraphicsScene *QgsModelGraphicsView::modelScene() const
+{
+  return qobject_cast< QgsModelGraphicsScene * >( QgsModelGraphicsView::scene() );
 }
 
 QgsModelViewTool *QgsModelGraphicsView::tool()

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -15,17 +15,38 @@
 
 #include "qgsmodelgraphicsview.h"
 #include "qgssettings.h"
+#include "qgsmodelviewtool.h"
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelviewtooltemporarykeypan.h"
+#include "qgsmodelviewtooltemporarymousepan.h"
+#include "qgsmodelviewtooltemporarykeyzoom.h"
+#include "qgsmodelcomponentgraphicitem.h"
 
 #include <QDragEnterEvent>
 #include <QScrollBar>
 
 ///@cond NOT_STABLE
 
+#define MIN_VIEW_SCALE 0.05
+#define MAX_VIEW_SCALE 1000.0
+
 QgsModelGraphicsView::QgsModelGraphicsView( QWidget *parent )
   : QGraphicsView( parent )
 {
+  setResizeAnchor( QGraphicsView::AnchorViewCenter );
+  setMouseTracking( true );
+  viewport()->setMouseTracking( true );
   setAcceptDrops( true );
-  setDragMode( QGraphicsView::ScrollHandDrag );
+
+  mSpacePanTool = new QgsModelViewToolTemporaryKeyPan( this );
+  mMidMouseButtonPanTool = new QgsModelViewToolTemporaryMousePan( this );
+  mSpaceZoomTool = new QgsModelViewToolTemporaryKeyZoom( this );
+
+}
+
+QgsModelGraphicsView::~QgsModelGraphicsView()
+{
+  emit willBeDeleted();
 }
 
 void QgsModelGraphicsView::dragEnterEvent( QDragEnterEvent *event )
@@ -77,8 +98,25 @@ void QgsModelGraphicsView::dragMoveEvent( QDragMoveEvent *event )
 
 void QgsModelGraphicsView::wheelEvent( QWheelEvent *event )
 {
-  setTransformationAnchor( QGraphicsView::AnchorUnderMouse );
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
 
+  if ( mTool )
+  {
+    mTool->wheelEvent( event );
+  }
+
+  if ( !mTool || !event->isAccepted() )
+  {
+    event->accept();
+    wheelZoom( event );
+  }
+}
+
+void QgsModelGraphicsView::wheelZoom( QWheelEvent *event )
+{
   //get mouse wheel zoom behavior settings
   QgsSettings settings;
   double zoomFactor = settings.value( QStringLiteral( "qgis/zoom_factor" ), 2 ).toDouble();
@@ -94,38 +132,249 @@ void QgsModelGraphicsView::wheelEvent( QWheelEvent *event )
 
   //calculate zoom scale factor
   bool zoomIn = event->angleDelta().y() > 0;
-  double scaleFactor = ( !zoomIn ? 1 / zoomFactor : zoomFactor );
+  double scaleFactor = ( zoomIn ? 1 / zoomFactor : zoomFactor );
 
-  scale( scaleFactor, scaleFactor );
+  //get current visible part of scene
+  QRect viewportRect( 0, 0, viewport()->width(), viewport()->height() );
+  QgsRectangle visibleRect = QgsRectangle( mapToScene( viewportRect ).boundingRect() );
+
+  //transform the mouse pos to scene coordinates
+  QPointF scenePoint = mapToScene( event->pos() );
+
+  //adjust view center
+  QgsPointXY oldCenter( visibleRect.center() );
+  QgsPointXY newCenter( scenePoint.x() + ( ( oldCenter.x() - scenePoint.x() ) * scaleFactor ),
+                        scenePoint.y() + ( ( oldCenter.y() - scenePoint.y() ) * scaleFactor ) );
+  centerOn( newCenter.x(), newCenter.y() );
+
+  //zoom layout
+  if ( zoomIn )
+  {
+    scaleSafe( zoomFactor );
+  }
+  else
+  {
+    scaleSafe( 1 / zoomFactor );
+  }
 }
 
-void QgsModelGraphicsView::enterEvent( QEvent *event )
+void QgsModelGraphicsView::scaleSafe( double scale )
 {
-  QGraphicsView::enterEvent( event );
-  viewport()->setCursor( Qt::ArrowCursor );
+  double currentScale = transform().m11();
+  scale *= currentScale;
+  scale = qBound( MIN_VIEW_SCALE, scale, MAX_VIEW_SCALE );
+  setTransform( QTransform::fromScale( scale, scale ) );
 }
 
 void QgsModelGraphicsView::mousePressEvent( QMouseEvent *event )
 {
-  if ( event->button() == Qt::MidButton )
-    mPreviousMousePos = event->pos();
-  else
-    QGraphicsView::mousePressEvent( event );
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
+
+  if ( mTool )
+  {
+    std::unique_ptr<QgsModelViewMouseEvent> me( new QgsModelViewMouseEvent( this, event, mTool->flags() & QgsModelViewTool::FlagSnaps ) );
+    mTool->modelPressEvent( me.get() );
+    event->setAccepted( me->isAccepted() );
+  }
+
+  if ( !mTool || !event->isAccepted() )
+  {
+    if ( event->button() == Qt::MidButton )
+    {
+      // Pan layout with middle mouse button
+      setTool( mMidMouseButtonPanTool );
+      event->accept();
+    }
+    else
+    {
+      QGraphicsView::mousePressEvent( event );
+    }
+  }
+}
+
+void QgsModelGraphicsView::mouseReleaseEvent( QMouseEvent *event )
+{
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
+
+  if ( mTool )
+  {
+    std::unique_ptr<QgsModelViewMouseEvent> me( new QgsModelViewMouseEvent( this, event, mTool->flags() & QgsModelViewTool::FlagSnaps ) );
+    mTool->modelReleaseEvent( me.get() );
+    event->setAccepted( me->isAccepted() );
+  }
+
+  if ( !mTool || !event->isAccepted() )
+    QGraphicsView::mouseReleaseEvent( event );
 }
 
 void QgsModelGraphicsView::mouseMoveEvent( QMouseEvent *event )
 {
-  if ( event->buttons() == Qt::MidButton )
-  {
-    const QPoint offset = mPreviousMousePos - event->pos();
-    mPreviousMousePos = event->pos();
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
 
-    verticalScrollBar()->setValue( verticalScrollBar()->value() + offset.y() );
-    horizontalScrollBar()->setValue( horizontalScrollBar()->value() + offset.x() );
-  }
-  else
+  mMouseCurrentXY = event->pos();
+
+  QPointF cursorPos = mapToScene( mMouseCurrentXY );
+  if ( mTool )
   {
+    std::unique_ptr<QgsModelViewMouseEvent> me( new QgsModelViewMouseEvent( this, event, false ) );
+#if 0
+    if ( mTool->flags() & QgsModelViewTool::FlagSnaps )
+    {
+
+      me->snapPoint( mHorizontalSnapLine, mVerticalSnapLine, mTool->ignoredSnapItems() );
+    }
+    if ( mTool->flags() & QgsModelViewTool::FlagSnaps )
+    {
+      //draw snapping point indicator
+      if ( me->isSnapped() )
+      {
+        cursorPos = me->snappedPoint();
+        if ( mSnapMarker )
+        {
+          mSnapMarker->setPos( me->snappedPoint() );
+          mSnapMarker->setVisible( true );
+        }
+      }
+      else if ( mSnapMarker )
+      {
+        mSnapMarker->setVisible( false );
+      }
+    }
+#endif
+    mTool->modelMoveEvent( me.get() );
+    event->setAccepted( me->isAccepted() );
+  }
+
+  if ( !mTool || !event->isAccepted() )
     QGraphicsView::mouseMoveEvent( event );
+}
+
+void QgsModelGraphicsView::mouseDoubleClickEvent( QMouseEvent *event )
+{
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
+  if ( mTool )
+  {
+    std::unique_ptr<QgsModelViewMouseEvent> me( new QgsModelViewMouseEvent( this, event, mTool->flags() & QgsModelViewTool::FlagSnaps ) );
+    mTool->modelDoubleClickEvent( me.get() );
+    event->setAccepted( me->isAccepted() );
+  }
+
+  if ( !mTool || !event->isAccepted() )
+    QGraphicsView::mouseDoubleClickEvent( event );
+}
+
+void QgsModelGraphicsView::keyPressEvent( QKeyEvent *event )
+{
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
+
+  if ( mTool )
+  {
+    mTool->keyPressEvent( event );
+  }
+
+  if ( mTool && event->isAccepted() )
+    return;
+
+  if ( event->key() == Qt::Key_Space && ! event->isAutoRepeat() )
+  {
+    if ( !( event->modifiers() & Qt::ControlModifier ) )
+    {
+      // Pan layout with space bar
+      setTool( mSpacePanTool );
+    }
+    else
+    {
+      //ctrl+space pressed, so switch to temporary keyboard based zoom tool
+      setTool( mSpaceZoomTool );
+    }
+    event->accept();
+  }
+#if 0
+  else if ( event->key() == Qt::Key_Left
+            || event->key() == Qt::Key_Right
+            || event->key() == Qt::Key_Up
+            || event->key() == Qt::Key_Down )
+  {
+    QgsLayout *l = currentLayout();
+    const QList<QgsLayoutItem *> layoutItemList = l->selectedLayoutItems();
+
+    QPointF delta = deltaForKeyEvent( event );
+
+    l->undoStack()->beginMacro( tr( "Move Item" ) );
+    for ( QgsLayoutItem *item : layoutItemList )
+    {
+      l->undoStack()->beginCommand( item, tr( "Move Item" ), QgsLayoutItem::UndoIncrementalMove );
+      item->attemptMoveBy( delta.x(), delta.y() );
+      l->undoStack()->endCommand();
+    }
+    l->undoStack()->endMacro();
+    event->accept();
+  }
+#endif
+}
+
+void QgsModelGraphicsView::keyReleaseEvent( QKeyEvent *event )
+{
+#if 0
+  if ( !currentLayout() )
+    return;
+#endif
+
+  if ( mTool )
+  {
+    mTool->keyReleaseEvent( event );
+  }
+
+  if ( !mTool || !event->isAccepted() )
+    QGraphicsView::keyReleaseEvent( event );
+}
+
+QgsModelViewTool *QgsModelGraphicsView::tool()
+{
+  return mTool;
+}
+
+void QgsModelGraphicsView::setTool( QgsModelViewTool *tool )
+{
+  if ( !tool )
+    return;
+
+  if ( mTool )
+  {
+    mTool->deactivate();
+    disconnect( mTool, &QgsModelViewTool::itemFocused, this, &QgsModelGraphicsView::itemFocused );
+  }
+
+  // activate new tool before setting it - gives tools a chance
+  // to respond to whatever the current tool is
+  tool->activate();
+  mTool = tool;
+  connect( mTool, &QgsModelViewTool::itemFocused, this, &QgsModelGraphicsView::itemFocused );
+  emit toolSet( mTool );
+}
+
+void QgsModelGraphicsView::unsetTool( QgsModelViewTool *tool )
+{
+  if ( mTool && mTool == tool )
+  {
+    mTool->deactivate();
+    emit toolSet( nullptr );
+    setCursor( Qt::ArrowCursor );
   }
 }
 

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -425,6 +425,16 @@ QgsModelSnapper *QgsModelGraphicsView::snapper()
   return &mSnapper;
 }
 
+void QgsModelGraphicsView::startMacroCommand( const QString &text )
+{
+  emit macroCommandStarted( text );
+}
+
+void QgsModelGraphicsView::endMacroCommand()
+{
+  emit macroCommandEnded();
+}
+
 
 QgsModelViewSnapMarker::QgsModelViewSnapMarker()
   : QGraphicsRectItem( QRectF( 0, 0, 0, 0 ) )

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -100,6 +100,16 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      */
     QgsModelSnapper *snapper() SIP_SKIP;
 
+    /**
+     * Starts a macro command, containing a group of interactions in the view.
+     */
+    void startMacroCommand( const QString &text );
+
+    /**
+     * Ends a macro command, containing a group of interactions in the view.
+     */
+    void endMacroCommand();
+
   signals:
 
     /**
@@ -129,6 +139,16 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      * but is still in a perfectly valid state.
      */
     void willBeDeleted();
+
+    /**
+     * Emitted when a macro command containing a group of interactions is started in the view.
+     */
+    void macroCommandStarted( const QString &text );
+
+    /**
+     * Emitted when a macro command containing a group of interactions in the view has ended.
+     */
+    void macroCommandEnded();
 
   private:
 

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -128,6 +128,12 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      */
     void scaleSafe( double scale );
 
+    /**
+     * Returns the delta (in model coordinates) by which to move items
+     * for the given key \a event.
+     */
+    QPointF deltaForKeyEvent( QKeyEvent *event );
+
     QPointer< QgsModelViewTool > mTool;
 
     QgsModelViewToolTemporaryKeyPan *mSpacePanTool = nullptr;

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -19,7 +19,9 @@
 #include "qgis.h"
 #include "qgis_gui.h"
 #include "qgsprocessingcontext.h"
+#include "qgsmodelsnapper.h"
 #include <QGraphicsView>
+#include <QGraphicsRectItem>
 
 class QgsModelViewTool;
 class QgsModelViewToolTemporaryKeyPan;
@@ -27,6 +29,7 @@ class QgsModelViewToolTemporaryKeyZoom;
 class QgsModelViewToolTemporaryMousePan;
 class QgsModelComponentGraphicItem;
 class QgsModelGraphicsScene;
+class QgsModelViewSnapMarker;
 
 ///@cond NOT_STABLE
 
@@ -60,6 +63,11 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
     void keyReleaseEvent( QKeyEvent *event ) override;
 
     /**
+     * Sets the related \a scene.
+     */
+    void setModelScene( QgsModelGraphicsScene *scene );
+
+    /**
      * Returns the scene associated with the tool.
      * \see view()
      */
@@ -86,6 +94,11 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      * You don't have to call it manually, QgsModelViewTool takes care of it.
      */
     void unsetTool( QgsModelViewTool *tool ) SIP_SKIP;
+
+    /**
+     * Returns the view's coordinate snapper.
+     */
+    QgsModelSnapper *snapper() SIP_SKIP;
 
   signals:
 
@@ -142,7 +155,29 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
 
     QPoint mMouseCurrentXY;
 
+    QgsModelSnapper mSnapper;
+    QgsModelViewSnapMarker *mSnapMarker = nullptr;
 };
+
+
+/**
+ * \ingroup gui
+ * A simple graphics item rendered as an 'x'.
+ */
+class GUI_EXPORT QgsModelViewSnapMarker : public QGraphicsRectItem
+{
+  public:
+
+    QgsModelViewSnapMarker();
+
+    void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr ) override;
+
+  private:
+
+    int mSize = 0;
+
+};
+
 
 ///@endcond
 

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -26,6 +26,7 @@ class QgsModelViewToolTemporaryKeyPan;
 class QgsModelViewToolTemporaryKeyZoom;
 class QgsModelViewToolTemporaryMousePan;
 class QgsModelComponentGraphicItem;
+class QgsModelGraphicsScene;
 
 ///@cond NOT_STABLE
 
@@ -59,17 +60,23 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
     void keyReleaseEvent( QKeyEvent *event ) override;
 
     /**
+     * Returns the scene associated with the tool.
+     * \see view()
+     */
+    QgsModelGraphicsScene *modelScene() const;
+
+    /**
      * Returns the currently active tool for the view.
      * \see setTool()
      */
-    QgsModelViewTool *tool();
+    QgsModelViewTool *tool() SIP_SKIP;
 
     /**
      * Sets the \a tool currently being used in the view.
      * \see unsetTool()
      * \see tool()
      */
-    void setTool( QgsModelViewTool *tool );
+    void setTool( QgsModelViewTool *tool ) SIP_SKIP;
 
     /**
      * Unsets the current view tool, if it matches the specified \a tool.
@@ -78,7 +85,7 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      * that the tool won't be used any more.
      * You don't have to call it manually, QgsModelViewTool takes care of it.
      */
-    void unsetTool( QgsModelViewTool *tool );
+    void unsetTool( QgsModelViewTool *tool ) SIP_SKIP;
 
   signals:
 
@@ -96,7 +103,7 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      * Emitted when the current \a tool is changed.
      * \see setTool()
      */
-    void toolSet( QgsModelViewTool *tool );
+    void toolSet( QgsModelViewTool *tool ) SIP_SKIP;
 
     /**
      * Emitted when an \a item is "focused" in the view, i.e. it becomes the active

--- a/src/gui/processing/models/qgsmodelsnapper.cpp
+++ b/src/gui/processing/models/qgsmodelsnapper.cpp
@@ -1,0 +1,153 @@
+/***************************************************************************
+                             qgsmodelsnapper.cpp
+                             --------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelsnapper.h"
+#include "qgssettings.h"
+
+QgsModelSnapper::QgsModelSnapper()
+{
+  QgsSettings s;
+  mTolerance = s.value( QStringLiteral( "LayoutDesigner/defaultSnapTolerancePixels" ), 5, QgsSettings::Gui ).toInt();
+}
+
+void QgsModelSnapper::setSnapTolerance( const int snapTolerance )
+{
+  mTolerance = snapTolerance;
+}
+
+void QgsModelSnapper::setSnapToGrid( bool enabled )
+{
+  mSnapToGrid = enabled;
+}
+
+QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &snapped ) const
+{
+  snapped = false;
+
+  bool snappedXToGrid = false;
+  bool snappedYToGrid = false;
+  QPointF res = snapPointToGrid( point, scaleFactor, snappedXToGrid, snappedYToGrid );
+  if ( snappedXToGrid )
+  {
+    snapped = true;
+    point.setX( res.x() );
+  }
+  if ( snappedYToGrid )
+  {
+    snapped = true;
+    point.setY( res.y() );
+  }
+
+  return point;
+}
+
+QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &snapped ) const
+{
+  snapped = false;
+  QRectF snappedRect = rect;
+
+  QList< double > xCoords;
+  xCoords << rect.left() << rect.center().x() << rect.right();
+  QList< double > yCoords;
+  yCoords << rect.top() << rect.center().y() << rect.bottom();
+
+  bool snappedXToGrid = false;
+  bool snappedYToGrid = false;
+  QList< QPointF > points;
+  points << rect.topLeft() << rect.topRight() << rect.bottomLeft() << rect.bottomRight();
+  QPointF res = snapPointsToGrid( points, scaleFactor, snappedXToGrid, snappedYToGrid );
+  if ( snappedXToGrid )
+  {
+    snapped = true;
+    snappedRect.translate( res.x(), 0 );
+  }
+  if ( snappedYToGrid )
+  {
+    snapped = true;
+    snappedRect.translate( 0, res.y() );
+  }
+
+  return snappedRect;
+}
+
+QPointF QgsModelSnapper::snapPointToGrid( QPointF point, double scaleFactor, bool &snappedX, bool &snappedY ) const
+{
+  QPointF delta = snapPointsToGrid( QList< QPointF >() << point, scaleFactor, snappedX, snappedY );
+  return point + delta;
+}
+
+QPointF QgsModelSnapper::snapPointsToGrid( const QList<QPointF> &points, double scaleFactor, bool &snappedX, bool &snappedY ) const
+{
+  snappedX = false;
+  snappedY = false;
+  if ( !mSnapToGrid )
+  {
+    return QPointF( 0, 0 );
+  }
+#if 0
+  const QgsLayoutGridSettings &grid = mLayout->gridSettings();
+  if ( grid.resolution().length() <= 0 )
+    return QPointF( 0, 0 );
+#endif
+
+  double deltaX = 0;
+  double deltaY = 0;
+  double smallestDiffX = std::numeric_limits<double>::max();
+  double smallestDiffY = std::numeric_limits<double>::max();
+  for ( QPointF point : points )
+  {
+    //snap x coordinate
+    double gridRes = 10; //mLayout->convertToLayoutUnits( grid.resolution() );
+    int xRatio = static_cast< int >( ( point.x() ) / gridRes + 0.5 ); //NOLINT
+    int yRatio = static_cast< int >( ( point.y() ) / gridRes + 0.5 ); //NOLINT
+
+    double xSnapped = xRatio * gridRes;
+    double ySnapped = yRatio * gridRes;
+
+    double currentDiffX = std::abs( xSnapped - point.x() );
+    if ( currentDiffX < smallestDiffX )
+    {
+      smallestDiffX = currentDiffX;
+      deltaX = xSnapped - point.x();
+    }
+
+    double currentDiffY = std::abs( ySnapped - point.y() );
+    if ( currentDiffY < smallestDiffY )
+    {
+      smallestDiffY = currentDiffY;
+      deltaY = ySnapped - point.y();
+    }
+  }
+
+  //convert snap tolerance from pixels to layout units
+  double alignThreshold = mTolerance / scaleFactor;
+
+  QPointF delta( 0, 0 );
+  if ( smallestDiffX <= alignThreshold )
+  {
+    //snap distance is inside of tolerance
+    snappedX = true;
+    delta.setX( deltaX );
+  }
+  if ( smallestDiffY <= alignThreshold )
+  {
+    //snap distance is inside of tolerance
+    snappedY = true;
+    delta.setY( deltaY );
+  }
+
+  return delta;
+}

--- a/src/gui/processing/models/qgsmodelsnapper.h
+++ b/src/gui/processing/models/qgsmodelsnapper.h
@@ -1,0 +1,146 @@
+/***************************************************************************
+                             qgsmodelsnapper.h
+                             -------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSMODELSNAPPER_H
+#define QGSMODELSNAPPER_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include <QPen>
+
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * \class QgsModelSnapper
+ * \brief Manages snapping grids and preset snap lines in a layout, and handles
+ * snapping points to the nearest grid coordinate/snap line when possible.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelSnapper
+{
+
+  public:
+
+    /**
+     * Constructor for QgsModelSnapper, attached to the specified \a layout.
+     */
+    QgsModelSnapper();
+
+    /**
+     * Sets the snap \a tolerance (in pixels) to use when snapping.
+     * \see snapTolerance()
+     */
+    void setSnapTolerance( int snapTolerance );
+
+    /**
+     * Returns the snap tolerance (in pixels) to use when snapping.
+     * \see setSnapTolerance()
+     */
+    int snapTolerance() const { return mTolerance; }
+
+    /**
+     * Returns TRUE if snapping to grid is enabled.
+     * \see setSnapToGrid()
+     */
+    bool snapToGrid() const { return mSnapToGrid; }
+
+    /**
+     * Sets whether snapping to grid is \a enabled.
+     * \see snapToGrid()
+     */
+    void setSnapToGrid( bool enabled );
+
+    /**
+     * Snaps a layout coordinate \a point. If \a point was snapped, \a snapped will be set to TRUE.
+     *
+     * The \a scaleFactor argument should be set to the transformation from
+     * scalar transform from layout coordinates to pixels, i.e. the
+     * graphics view transform().m11() value.
+     *
+     * This method considers snapping to the grid, snap lines, etc.
+     *
+     * If the \a horizontalSnapLine and \a verticalSnapLine arguments are specified, then the snapper
+     * will automatically display and position these lines to indicate snapping positions to item bounds.
+     *
+     * A list of items to ignore during the snapping can be specified via the \a ignoreItems list.
+
+     * \see snapRect()
+     */
+    QPointF snapPoint( QPointF point, double scaleFactor, bool &snapped SIP_OUT ) const;
+
+    /**
+     * Snaps a layout coordinate \a rect. If \a rect was snapped, \a snapped will be set to TRUE.
+     *
+     * Snapping occurs by moving the rectangle alone. The rectangle will not be resized
+     * as a result of the snap operation.
+     *
+     * The \a scaleFactor argument should be set to the transformation from
+     * scalar transform from layout coordinates to pixels, i.e. the
+     * graphics view transform().m11() value.
+     *
+     * This method considers snapping to the grid, snap lines, etc.
+     *
+     * If the \a horizontalSnapLine and \a verticalSnapLine arguments are specified, then the snapper
+     * will automatically display and position these lines to indicate snapping positions to item bounds.
+     *
+     * A list of items to ignore during the snapping can be specified via the \a ignoreItems list.
+     *
+     * \see snapPoint()
+     */
+    QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT ) const;
+
+    /**
+     * Snaps a layout coordinate \a point to the grid. If \a point
+     * was snapped horizontally, \a snappedX will be set to TRUE. If \a point
+     * was snapped vertically, \a snappedY will be set to TRUE.
+     *
+     * The \a scaleFactor argument should be set to the transformation from
+     * scalar transform from layout coordinates to pixels, i.e. the
+     * graphics view transform().m11() value.
+     *
+     * If snapToGrid() is disabled, this method will return the point
+     * unchanged.
+     *
+     * \see snapPointsToGrid()
+     */
+    QPointF snapPointToGrid( QPointF point, double scaleFactor, bool &snappedX SIP_OUT, bool &snappedY SIP_OUT ) const;
+
+    /**
+     * Snaps a set of \a points to the grid. If the points
+     * were snapped, \a snapped will be set to TRUE.
+     *
+     * The \a scaleFactor argument should be set to the transformation from
+     * scalar transform from layout coordinates to pixels, i.e. the
+     * graphics view transform().m11() value.
+     *
+     * If snapToGrid() is disabled, this method will not attempt to snap the points.
+     *
+     * The returned value is the smallest delta which the points need to be shifted by in order to align
+     * one of the points to the grid.
+     *
+     * \see snapPointToGrid()
+     */
+    QPointF snapPointsToGrid( const QList< QPointF > &points, double scaleFactor, bool &snappedX SIP_OUT, bool &snappedY SIP_OUT ) const;
+
+  private:
+
+    int mTolerance = 5;
+    bool mSnapToGrid = false;
+
+};
+
+#endif //QGSMODELSNAPPER_H

--- a/src/gui/processing/models/qgsmodelviewmouseevent.cpp
+++ b/src/gui/processing/models/qgsmodelviewmouseevent.cpp
@@ -1,0 +1,29 @@
+/***************************************************************************
+                             qgsmodelviewmouseevent.cpp
+                             ---------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelgraphicsview.h"
+
+QgsModelViewMouseEvent::QgsModelViewMouseEvent( QgsModelGraphicsView *view, QMouseEvent *event, bool snaps )
+  : QMouseEvent( event->type(), event->pos(), event->button(), event->buttons(), event->modifiers() )
+  , mView( view )
+{
+  mModelPoint = mView->mapToScene( x(), y() );
+}
+
+QPointF QgsModelViewMouseEvent::modelPoint() const
+{
+  return mModelPoint;
+}

--- a/src/gui/processing/models/qgsmodelviewmouseevent.cpp
+++ b/src/gui/processing/models/qgsmodelviewmouseevent.cpp
@@ -15,12 +15,30 @@
 
 #include "qgsmodelviewmouseevent.h"
 #include "qgsmodelgraphicsview.h"
+#include "qgsmodelsnapper.h"
 
-QgsModelViewMouseEvent::QgsModelViewMouseEvent( QgsModelGraphicsView *view, QMouseEvent *event, bool snaps )
+QgsModelViewMouseEvent::QgsModelViewMouseEvent( QgsModelGraphicsView *view, QMouseEvent *event, bool snap )
   : QMouseEvent( event->type(), event->pos(), event->button(), event->buttons(), event->modifiers() )
   , mView( view )
 {
   mModelPoint = mView->mapToScene( x(), y() );
+
+  if ( snap && mView->snapper() )
+  {
+    mSnappedPoint = mView->snapper()->snapPoint( mModelPoint, mView->transform().m11(), mSnapped );
+  }
+  else
+  {
+    mSnappedPoint = mModelPoint;
+  }
+}
+
+void QgsModelViewMouseEvent::snapPoint()
+{
+  if ( mView->snapper() )
+  {
+    mSnappedPoint = mView->snapper()->snapPoint( mModelPoint, mView->transform().m11(), mSnapped );
+  }
 }
 
 QPointF QgsModelViewMouseEvent::modelPoint() const

--- a/src/gui/processing/models/qgsmodelviewmouseevent.h
+++ b/src/gui/processing/models/qgsmodelviewmouseevent.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+                             qgsmodelviewmouseevent.h
+                             -------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWMOUSEEVENT_H
+#define QGSMODELVIEWMOUSEEVENT_H
+
+#include <QMouseEvent>
+
+#include "qgis_gui.h"
+
+#define SIP_NO_FILE
+
+class QgsModelGraphicsView;
+
+/**
+ * \ingroup gui
+ * A QgsModelViewMouseEvent is the result of a user interaction with the mouse on a QgsModelGraphicsView.
+ *
+ * It is sent whenever the user moves, clicks, releases or double clicks the mouse.
+ * In addition to the coordinates in pixel space it also knows the coordinates the model space.
+ *
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewMouseEvent : public QMouseEvent
+{
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewMouseEvent. Should only be required to be called from the QgsModelGraphicsView.
+     * \param view The view in which the event occurred.
+     * \param event The original mouse event
+     */
+    QgsModelViewMouseEvent( QgsModelGraphicsView *view, QMouseEvent *event, bool snaps );
+
+    /**
+     * Returns the event point location in model coordinates.
+     */
+    QPointF modelPoint() const;
+
+  private:
+
+    //! The view in which the event was triggered.
+    QgsModelGraphicsView *mView = nullptr;
+
+    QPointF mModelPoint;
+
+};
+
+#endif // QGSMODELVIEWMOUSEEVENT_H

--- a/src/gui/processing/models/qgsmodelviewmouseevent.h
+++ b/src/gui/processing/models/qgsmodelviewmouseevent.h
@@ -46,9 +46,28 @@ class GUI_EXPORT QgsModelViewMouseEvent : public QMouseEvent
     QgsModelViewMouseEvent( QgsModelGraphicsView *view, QMouseEvent *event, bool snaps );
 
     /**
+     * Manually triggers a snap for the mouse event position using the model's snapper.
+     */
+    void snapPoint();
+
+    /**
      * Returns the event point location in model coordinates.
      */
     QPointF modelPoint() const;
+
+    /**
+     * Returns the snapped event point location in model coordinates. The snapped point will consider
+     * all possible snapping methods, such as snapping to grid.
+     * \see isSnapped()
+     */
+    QPointF snappedPoint() const { return mSnappedPoint; }
+
+    /**
+     * Returns TRUE if point was snapped, e.g. to grid.
+     * \see snappedPoint()
+     */
+    bool isSnapped() const { return mSnapped; }
+
 
   private:
 
@@ -56,7 +75,8 @@ class GUI_EXPORT QgsModelViewMouseEvent : public QMouseEvent
     QgsModelGraphicsView *mView = nullptr;
 
     QPointF mModelPoint;
-
+    bool mSnapped = false;
+    QPointF mSnappedPoint;
 };
 
 #endif // QGSMODELVIEWMOUSEEVENT_H

--- a/src/gui/processing/models/qgsmodelviewmouseevent.h
+++ b/src/gui/processing/models/qgsmodelviewmouseevent.h
@@ -42,6 +42,7 @@ class GUI_EXPORT QgsModelViewMouseEvent : public QMouseEvent
      * Constructor for QgsModelViewMouseEvent. Should only be required to be called from the QgsModelGraphicsView.
      * \param view The view in which the event occurred.
      * \param event The original mouse event
+     * \param snaps set to TRUE if the event should be snapped
      */
     QgsModelViewMouseEvent( QgsModelGraphicsView *view, QMouseEvent *event, bool snaps );
 

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -47,7 +47,7 @@ QgsModelGraphicsScene *QgsModelViewMouseHandles::modelScene() const
 void QgsModelViewMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )
 {
   paintInternal( painter, !( modelScene()->flags() & QgsModelGraphicsScene::FlagHideControls ),
-                 !( modelScene()->flags() & QgsModelGraphicsScene::FlagHideControls ), option, widget );
+                 false, false, option, widget );
 }
 
 void QgsModelViewMouseHandles::selectionChanged()
@@ -121,6 +121,14 @@ void QgsModelViewMouseHandles::moveItem( QGraphicsItem *item, double deltaX, dou
   if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
   {
     componentItem->moveComponentBy( deltaX, deltaY );
+  }
+}
+
+void QgsModelViewMouseHandles::previewItemMove( QGraphicsItem *item, double deltaX, double deltaY )
+{
+  if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
+  {
+    componentItem->previewItemMove( deltaX, deltaY );
   }
 }
 

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -47,37 +47,11 @@ QgsModelGraphicsScene *QgsModelViewMouseHandles::modelScene() const
 void QgsModelViewMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )
 {
   paintInternal( painter, !( modelScene()->flags() & QgsModelGraphicsScene::FlagHideControls ),
-                 false, false, option, widget );
+                 true, false, option, widget );
 }
 
 void QgsModelViewMouseHandles::selectionChanged()
 {
-#if 0
-  //listen out for selected items' size and rotation changed signals
-  const QList<QGraphicsItem *> itemList = layout()->items();
-  for ( QGraphicsItem *graphicsItem : itemList )
-  {
-    QgsLayoutItem *item = dynamic_cast<QgsLayoutItem *>( graphicsItem );
-    if ( !item )
-      continue;
-
-    if ( item->isSelected() )
-    {
-      connect( item, &QgsLayoutItem::sizePositionChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
-      connect( item, &QgsLayoutItem::rotationChanged, this, &QgsModelViewMouseHandles::selectedItemRotationChanged );
-      connect( item, &QgsLayoutItem::frameChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
-      connect( item, &QgsLayoutItem::lockChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
-    }
-    else
-    {
-      disconnect( item, &QgsLayoutItem::sizePositionChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
-      disconnect( item, &QgsLayoutItem::rotationChanged, this, &QgsModelViewMouseHandles::selectedItemRotationChanged );
-      disconnect( item, &QgsLayoutItem::frameChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
-      disconnect( item, &QgsLayoutItem::lockChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
-    }
-  }
-
-#endif
   resetStatusBar();
   updateHandles();
 }
@@ -116,6 +90,14 @@ QRectF QgsModelViewMouseHandles::itemRect( QGraphicsItem *item ) const
     return QRectF();
 }
 
+QRectF QgsModelViewMouseHandles::storedItemRect( QGraphicsItem *item ) const
+{
+  if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
+    return componentItem->itemRect( true );
+  else
+    return QRectF();
+}
+
 void QgsModelViewMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double deltaY )
 {
   if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
@@ -136,7 +118,15 @@ void QgsModelViewMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
   if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
   {
+    componentItem->setItemRect( rect );
+  }
+}
 
+void QgsModelViewMouseHandles::previewSetItemRect( QGraphicsItem *item, QRectF rect )
+{
+  if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
+  {
+    componentItem->previewItemRectChange( rect );
   }
 }
 

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -53,6 +53,24 @@ void QgsModelViewMouseHandles::paint( QPainter *painter, const QStyleOptionGraph
 
 void QgsModelViewMouseHandles::selectionChanged()
 {
+  //listen out for selected items' size and rotation changed signals
+  const QList<QGraphicsItem *> itemList = mView->items();
+  for ( QGraphicsItem *graphicsItem : itemList )
+  {
+    QgsModelComponentGraphicItem *item = dynamic_cast<QgsModelComponentGraphicItem *>( graphicsItem );
+    if ( !item )
+      continue;
+
+    if ( item->isSelected() )
+    {
+      connect( item, &QgsModelComponentGraphicItem::sizePositionChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+    }
+    else
+    {
+      disconnect( item, &QgsModelComponentGraphicItem::sizePositionChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+    }
+  }
+
   resetStatusBar();
   updateHandles();
 }

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -140,5 +140,15 @@ void QgsModelViewMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
   }
 }
 
+void QgsModelViewMouseHandles::startMacroCommand( const QString &text )
+{
+  mView->startMacroCommand( text );
+}
+
+void QgsModelViewMouseHandles::endMacroCommand()
+{
+  mView->endMacroCommand();
+}
+
 
 ///@endcond PRIVATE

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -37,6 +37,7 @@ QgsModelViewMouseHandles::QgsModelViewMouseHandles( QgsModelGraphicsView *view )
 {
   //listen for selection changes, and update handles accordingly
   connect( modelScene(), &QGraphicsScene::selectionChanged, this, &QgsModelViewMouseHandles::selectionChanged );
+  setHandleSize( 5 );
 }
 
 QgsModelGraphicsScene *QgsModelViewMouseHandles::modelScene() const

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -1,0 +1,136 @@
+/***************************************************************************
+                             qgsmodelviewmousehandles.cpp
+                             ------------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall.dawson@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewmousehandles.h"
+#include "qgis.h"
+#include "qgslogger.h"
+#include "qgsproject.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsmodelgraphicsscene.h"
+#include "qgsmodelcomponentgraphicitem.h"
+#include "qgsmodelviewtool.h"
+#include <QGraphicsSceneHoverEvent>
+#include <QPainter>
+#include <QWidget>
+#include <limits>
+
+///@cond PRIVATE
+
+
+QgsModelViewMouseHandles::QgsModelViewMouseHandles( QgsModelGraphicsView *view )
+  : QgsGraphicsViewMouseHandles( view )
+  , mView( view )
+{
+  //listen for selection changes, and update handles accordingly
+  connect( modelScene(), &QGraphicsScene::selectionChanged, this, &QgsModelViewMouseHandles::selectionChanged );
+}
+
+QgsModelGraphicsScene *QgsModelViewMouseHandles::modelScene() const
+{
+  return qobject_cast< QgsModelGraphicsScene * >( mView->scene() );
+}
+
+void QgsModelViewMouseHandles::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget )
+{
+  paintInternal( painter, !( modelScene()->flags() & QgsModelGraphicsScene::FlagHideControls ),
+                 !( modelScene()->flags() & QgsModelGraphicsScene::FlagHideControls ), option, widget );
+}
+
+void QgsModelViewMouseHandles::selectionChanged()
+{
+#if 0
+  //listen out for selected items' size and rotation changed signals
+  const QList<QGraphicsItem *> itemList = layout()->items();
+  for ( QGraphicsItem *graphicsItem : itemList )
+  {
+    QgsLayoutItem *item = dynamic_cast<QgsLayoutItem *>( graphicsItem );
+    if ( !item )
+      continue;
+
+    if ( item->isSelected() )
+    {
+      connect( item, &QgsLayoutItem::sizePositionChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+      connect( item, &QgsLayoutItem::rotationChanged, this, &QgsModelViewMouseHandles::selectedItemRotationChanged );
+      connect( item, &QgsLayoutItem::frameChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+      connect( item, &QgsLayoutItem::lockChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+    }
+    else
+    {
+      disconnect( item, &QgsLayoutItem::sizePositionChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+      disconnect( item, &QgsLayoutItem::rotationChanged, this, &QgsModelViewMouseHandles::selectedItemRotationChanged );
+      disconnect( item, &QgsLayoutItem::frameChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+      disconnect( item, &QgsLayoutItem::lockChanged, this, &QgsModelViewMouseHandles::selectedItemSizeChanged );
+    }
+  }
+
+#endif
+  resetStatusBar();
+  updateHandles();
+}
+
+void QgsModelViewMouseHandles::setViewportCursor( Qt::CursorShape cursor )
+{
+  //workaround qt bug #3732 by setting cursor for QGraphicsView viewport,
+  //rather then setting it directly here
+
+  if ( qobject_cast< QgsModelViewTool *>( mView->tool() ) )
+  {
+    mView->viewport()->setCursor( cursor );
+  }
+}
+
+QList<QGraphicsItem *> QgsModelViewMouseHandles::sceneItemsAtPoint( QPointF scenePoint )
+{
+  return modelScene()->items( scenePoint );
+}
+
+QList<QGraphicsItem *> QgsModelViewMouseHandles::selectedSceneItems( bool ) const
+{
+  QList<QGraphicsItem *> res;
+  const QList<QgsModelComponentGraphicItem *> componentItems = modelScene()->selectedComponentItems();
+  res.reserve( componentItems.size() );
+  for ( QgsModelComponentGraphicItem *item : componentItems )
+    res << item;
+  return res;
+}
+
+QRectF QgsModelViewMouseHandles::itemRect( QGraphicsItem *item ) const
+{
+  if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
+    return componentItem->itemRect();
+  else
+    return QRectF();
+}
+
+void QgsModelViewMouseHandles::moveItem( QGraphicsItem *item, double deltaX, double deltaY )
+{
+  if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
+  {
+    componentItem->moveComponentBy( deltaX, deltaY );
+  }
+}
+
+void QgsModelViewMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
+{
+  if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
+  {
+
+  }
+}
+
+
+///@endcond PRIVATE

--- a/src/gui/processing/models/qgsmodelviewmousehandles.h
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.h
@@ -1,8 +1,8 @@
 /***************************************************************************
-                             qgslayoutmousehandles.h
+                             qgsmodelviewmousehandles.h
                              -----------------------
-    begin                : September 2017
-    copyright            : (C) 2017 by Nyall Dawson
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
     email                : nyall.dawson@gmail.com
  ***************************************************************************/
 
@@ -14,10 +14,9 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QGSLAYOUTMOUSEHANDLES_H
-#define QGSLAYOUTMOUSEHANDLES_H
+#ifndef QGSMODELVIEWMOUSEHANDLES_H
+#define QGSMODELVIEWMOUSEHANDLES_H
 
-// We don't want to expose this in the public API
 #define SIP_NO_FILE
 
 #include "qgsgraphicsviewmousehandles.h"
@@ -26,43 +25,30 @@
 
 #include "qgis_gui.h"
 
-class QgsLayout;
-class QGraphicsView;
-class QgsLayoutView;
-class QgsLayoutItem;
+class QgsModelGraphicsView;
+class QgsModelGraphicsScene;
 class QInputEvent;
-class QgsAbstractLayoutUndoCommand;
+
+class QgsLayoutItem;
 
 ///@cond PRIVATE
 
 /**
  * \ingroup gui
- * Handles drawing of selection outlines and mouse handles in a QgsLayoutView
+ * Handles drawing of selection outlines and mouse handles in a QgsModelGraphicsView
  *
  * Also is responsible for mouse interactions such as resizing and moving selected items.
  *
  * \note not available in Python bindings
  *
- * \since QGIS 3.0
+ * \since QGIS 3.14
 */
-class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
+class GUI_EXPORT QgsModelViewMouseHandles: public QgsGraphicsViewMouseHandles
 {
     Q_OBJECT
   public:
 
-    QgsLayoutMouseHandles( QgsLayout *layout, QgsLayoutView *view );
-
-    /**
-     * Sets the \a layout for the handles.
-     * \see layout()
-     */
-    void setLayout( QgsLayout *layout ) { mLayout = layout; }
-
-    /**
-     * Returns the layout for the handles.
-     * \see setLayout()
-     */
-    QgsLayout *layout() { return mLayout; }
+    QgsModelViewMouseHandles( QgsModelGraphicsView *view );
 
     void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr ) override;
 
@@ -71,36 +57,21 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QgsGraphicsViewMouseHandles
     void setViewportCursor( Qt::CursorShape cursor ) override;
     QList<QGraphicsItem *> sceneItemsAtPoint( QPointF scenePoint ) override;
     QList<QGraphicsItem *> selectedSceneItems( bool includeLockedItems = true ) const override;
-    bool itemIsLocked( QGraphicsItem *item ) override;
-    bool itemIsGroupMember( QGraphicsItem *item ) override;
     QRectF itemRect( QGraphicsItem *item ) const override;
-    void expandItemList( const QList< QGraphicsItem * > &items, QList< QGraphicsItem * > &collected ) const override;
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
-    void showStatusMessage( const QString &message ) override;
-    void hideAlignItems() override;
-    QPointF snapPoint( QPointF originalPoint, SnapGuideMode mode, bool snapHorizontal = true, bool snapVertical = true ) override;
-    void createItemCommand( QGraphicsItem *item ) override;
-    void endItemCommand( QGraphicsItem *item ) override;
-    void startMacroCommand( const QString &text ) override;
-    void endMacroCommand() override;
+
   public slots:
 
     //! Sets up listeners to sizeChanged signal for all selected items
     void selectionChanged();
 
   private:
+    QgsModelGraphicsScene *modelScene() const;
 
-    QgsLayout *mLayout = nullptr;
-    QPointer< QgsLayoutView > mView;
-
-    //! Align snap lines
-    QGraphicsLineItem *mHorizontalSnapLine = nullptr;
-    QGraphicsLineItem *mVerticalSnapLine = nullptr;
-
-    std::unique_ptr< QgsAbstractLayoutUndoCommand > mItemCommand;
+    QPointer< QgsModelGraphicsView > mView;
 };
 
 ///@endcond PRIVATE
 
-#endif // QGSLAYOUTMOUSEHANDLES_H
+#endif // QGSMODELVIEWMOUSEHANDLES_H

--- a/src/gui/processing/models/qgsmodelviewmousehandles.h
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.h
@@ -59,6 +59,7 @@ class GUI_EXPORT QgsModelViewMouseHandles: public QgsGraphicsViewMouseHandles
     QList<QGraphicsItem *> selectedSceneItems( bool includeLockedItems = true ) const override;
     QRectF itemRect( QGraphicsItem *item ) const override;
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
+    void previewItemMove( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
 
   public slots:

--- a/src/gui/processing/models/qgsmodelviewmousehandles.h
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.h
@@ -61,6 +61,8 @@ class GUI_EXPORT QgsModelViewMouseHandles: public QgsGraphicsViewMouseHandles
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void previewItemMove( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
+    void startMacroCommand( const QString &text ) override;
+    void endMacroCommand() override;
 
   public slots:
 

--- a/src/gui/processing/models/qgsmodelviewmousehandles.h
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.h
@@ -58,9 +58,11 @@ class GUI_EXPORT QgsModelViewMouseHandles: public QgsGraphicsViewMouseHandles
     QList<QGraphicsItem *> sceneItemsAtPoint( QPointF scenePoint ) override;
     QList<QGraphicsItem *> selectedSceneItems( bool includeLockedItems = true ) const override;
     QRectF itemRect( QGraphicsItem *item ) const override;
+    QRectF storedItemRect( QGraphicsItem *item ) const override;
     void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void previewItemMove( QGraphicsItem *item, double deltaX, double deltaY ) override;
     void setItemRect( QGraphicsItem *item, QRectF rect ) override;
+    void previewSetItemRect( QGraphicsItem *item, QRectF rect ) override;
     void startMacroCommand( const QString &text ) override;
     void endMacroCommand() override;
 

--- a/src/gui/processing/models/qgsmodelviewrubberband.cpp
+++ b/src/gui/processing/models/qgsmodelviewrubberband.cpp
@@ -30,15 +30,6 @@ QgsModelGraphicsView *QgsModelViewRubberBand::view() const
   return mView;
 }
 
-QgsProcessingAlgorithmModel *QgsModelViewRubberBand::model() const
-{
-#if 0
-  return mView->currentLayout();
-#endif
-
-  return nullptr;
-}
-
 QRectF QgsModelViewRubberBand::updateRect( QPointF start, QPointF position, bool constrainSquare, bool fromCenter )
 {
   double x = 0;

--- a/src/gui/processing/models/qgsmodelviewrubberband.cpp
+++ b/src/gui/processing/models/qgsmodelviewrubberband.cpp
@@ -1,0 +1,188 @@
+/***************************************************************************
+                             qgsmodelviewrubberband.cpp
+                             ---------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgsmodelviewrubberband.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsmodelgraphicsscene.h"
+#include <QGraphicsRectItem>
+
+QgsModelViewRubberBand::QgsModelViewRubberBand( QgsModelGraphicsView *view )
+  : mView( view )
+{
+
+}
+
+QgsModelGraphicsView *QgsModelViewRubberBand::view() const
+{
+  return mView;
+}
+
+QgsProcessingAlgorithmModel *QgsModelViewRubberBand::model() const
+{
+#if 0
+  return mView->currentLayout();
+#endif
+
+  return nullptr;
+}
+
+QRectF QgsModelViewRubberBand::updateRect( QPointF start, QPointF position, bool constrainSquare, bool fromCenter )
+{
+  double x = 0;
+  double y = 0;
+  double width = 0;
+  double height = 0;
+
+  double dx = position.x() - start.x();
+  double dy = position.y() - start.y();
+
+  if ( constrainSquare )
+  {
+    if ( std::fabs( dx ) > std::fabs( dy ) )
+    {
+      width = std::fabs( dx );
+      height = width;
+    }
+    else
+    {
+      height = std::fabs( dy );
+      width = height;
+    }
+
+    x = start.x() - ( ( dx < 0 ) ? width : 0 );
+    y = start.y() - ( ( dy < 0 ) ? height : 0 );
+  }
+  else
+  {
+    //not constraining
+    if ( dx < 0 )
+    {
+      x = position.x();
+      width = -dx;
+    }
+    else
+    {
+      x = start.x();
+      width = dx;
+    }
+
+    if ( dy < 0 )
+    {
+      y = position.y();
+      height = -dy;
+    }
+    else
+    {
+      y = start.y();
+      height = dy;
+    }
+  }
+
+  if ( fromCenter )
+  {
+    x = start.x() - width;
+    y = start.y() - height;
+    width *= 2.0;
+    height *= 2.0;
+  }
+
+  return QRectF( x, y, width, height );
+}
+
+QPen QgsModelViewRubberBand::pen() const
+{
+  return mPen;
+}
+
+void QgsModelViewRubberBand::setPen( const QPen &pen )
+{
+  mPen = pen;
+}
+
+QBrush QgsModelViewRubberBand::brush() const
+{
+  return mBrush;
+}
+
+void QgsModelViewRubberBand::setBrush( const QBrush &brush )
+{
+  mBrush = brush;
+}
+
+
+QgsModelViewRectangularRubberBand::QgsModelViewRectangularRubberBand( QgsModelGraphicsView *view )
+  : QgsModelViewRubberBand( view )
+{
+}
+
+QgsModelViewRectangularRubberBand *QgsModelViewRectangularRubberBand::create( QgsModelGraphicsView *view ) const
+{
+  return new QgsModelViewRectangularRubberBand( view );
+}
+
+QgsModelViewRectangularRubberBand::~QgsModelViewRectangularRubberBand()
+{
+  if ( mRubberBandItem )
+  {
+    view()->scene()->removeItem( mRubberBandItem );
+    delete mRubberBandItem;
+  }
+}
+
+void QgsModelViewRectangularRubberBand::start( QPointF position, Qt::KeyboardModifiers )
+{
+  QTransform t;
+  mRubberBandItem = new QGraphicsRectItem( 0, 0, 0, 0 );
+  mRubberBandItem->setBrush( brush() );
+  mRubberBandItem->setPen( pen() );
+  mRubberBandStartPos = position;
+  t.translate( position.x(), position.y() );
+  mRubberBandItem->setTransform( t );
+  mRubberBandItem->setZValue( QgsModelGraphicsScene::RubberBand );
+  view()->scene()->addItem( mRubberBandItem );
+  view()->scene()->update();
+}
+
+void QgsModelViewRectangularRubberBand::update( QPointF position, Qt::KeyboardModifiers modifiers )
+{
+  if ( !mRubberBandItem )
+  {
+    return;
+  }
+
+  bool constrainSquare = modifiers & Qt::ShiftModifier;
+  bool fromCenter = modifiers & Qt::AltModifier;
+
+  QRectF newRect = updateRect( mRubberBandStartPos, position, constrainSquare, fromCenter );
+  mRubberBandItem->setRect( 0, 0, newRect.width(), newRect.height() );
+  QTransform t;
+  t.translate( newRect.x(), newRect.y() );
+  mRubberBandItem->setTransform( t );
+}
+
+QRectF QgsModelViewRectangularRubberBand::finish( QPointF position, Qt::KeyboardModifiers modifiers )
+{
+  bool constrainSquare = modifiers & Qt::ShiftModifier;
+  bool fromCenter = modifiers & Qt::AltModifier;
+
+  if ( mRubberBandItem )
+  {
+    view()->scene()->removeItem( mRubberBandItem );
+    delete mRubberBandItem;
+    mRubberBandItem = nullptr;
+  }
+  return updateRect( mRubberBandStartPos, position, constrainSquare, fromCenter );
+}

--- a/src/gui/processing/models/qgsmodelviewrubberband.h
+++ b/src/gui/processing/models/qgsmodelviewrubberband.h
@@ -28,7 +28,6 @@ class QgsModelGraphicsView;
 class QGraphicsRectItem;
 class QGraphicsEllipseItem;
 class QGraphicsPolygonItem;
-class QgsProcessingAlgorithmModel;
 
 /**
  * \ingroup gui
@@ -76,15 +75,8 @@ class GUI_EXPORT QgsModelViewRubberBand : public QObject
 
     /**
      * Returns the view associated with the rubber band.
-     * \see model()
      */
     QgsModelGraphicsView *view() const;
-
-    /**
-     * Returns the model associated with the rubber band.
-     * \see view()
-     */
-    QgsProcessingAlgorithmModel *model() const;
 
     /**
      * Returns the brush used for drawing the rubber band.

--- a/src/gui/processing/models/qgsmodelviewrubberband.h
+++ b/src/gui/processing/models/qgsmodelviewrubberband.h
@@ -1,0 +1,180 @@
+/***************************************************************************
+                             qgsmodelviewrubberband.h
+                             -------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWRUBBERBAND_H
+#define QGSMODELVIEWRUBBERBAND_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include <QBrush>
+#include <QPen>
+#include <QObject>
+
+#define SIP_NO_FILE
+
+class QgsModelGraphicsView;
+class QGraphicsRectItem;
+class QGraphicsEllipseItem;
+class QGraphicsPolygonItem;
+class QgsProcessingAlgorithmModel;
+
+/**
+ * \ingroup gui
+ * QgsModelViewRubberBand is an abstract base class for temporary rubber band items
+ * in various shapes, for use within QgsModelGraphicsView widgets.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewRubberBand : public QObject
+{
+
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewRubberBand.
+     */
+    QgsModelViewRubberBand( QgsModelGraphicsView *view = nullptr );
+
+    ~QgsModelViewRubberBand() override = default;
+
+    /**
+     * Creates a new instance of the QgsModelViewRubberBand subclass.
+     */
+    virtual QgsModelViewRubberBand *create( QgsModelGraphicsView *view ) const = 0 SIP_FACTORY;
+
+    /**
+     * Called when a rubber band should be created at the specified
+     * starting \a position (in model coordinate space).
+     */
+    virtual void start( QPointF position, Qt::KeyboardModifiers modifiers ) = 0;
+
+    /**
+     * Called when a rubber band should be updated to reflect a temporary
+     * ending \a position (in model coordinate space).
+     */
+    virtual void update( QPointF position, Qt::KeyboardModifiers modifiers ) = 0;
+
+    /**
+     * Called when a rubber band use has finished and the rubber
+     * band is no longer required.
+     * Returns the final bounding box of the rubber band.
+     */
+    virtual QRectF finish( QPointF position = QPointF(), Qt::KeyboardModifiers modifiers = nullptr ) = 0;
+
+    /**
+     * Returns the view associated with the rubber band.
+     * \see model()
+     */
+    QgsModelGraphicsView *view() const;
+
+    /**
+     * Returns the model associated with the rubber band.
+     * \see view()
+     */
+    QgsProcessingAlgorithmModel *model() const;
+
+    /**
+     * Returns the brush used for drawing the rubber band.
+     * \see setBrush()
+     * \see pen()
+     */
+    QBrush brush() const;
+
+    /**
+     * Sets the \a brush used for drawing the rubber band.
+     * \see brush()
+     * \see setPen()
+     */
+    void setBrush( const QBrush &brush );
+
+    /**
+     * Returns the pen used for drawing the rubber band.
+     * \see setPen()
+     * \see brush()
+     */
+    QPen pen() const;
+
+    /**
+     * Sets the \a pen used for drawing the rubber band.
+     * \see pen()
+     * \see setBrush()
+     */
+    void setPen( const QPen &pen );
+
+  signals:
+
+    /**
+     * Emitted when the size of the rubber band is changed. The \a size
+     * argument gives a translated string describing the new rubber band size,
+     * with a format which differs per subclass (e.g. rectangles may describe
+     * a size using width and height, while circles may describe a size by radius).
+     */
+    void sizeChanged( const QString &size );
+
+  protected:
+
+    /**
+     * Calculates an updated bounding box rectangle from a original \a start position
+     * and new \a position. If \a constrainSquare is TRUE then the bounding box will be
+     * forced to a square shape. If \a fromCenter is TRUE then the original \a start
+     * position will form the center point of the returned rectangle.
+     */
+    QRectF updateRect( QPointF start, QPointF position, bool constrainSquare, bool fromCenter );
+
+  private:
+
+    QgsModelGraphicsView *mView = nullptr;
+
+    QBrush mBrush = Qt::NoBrush;
+    QPen mPen = QPen( QBrush( QColor( 227, 22, 22, 200 ) ), 0 );
+
+};
+
+
+/**
+ * \ingroup gui
+ * QgsModelViewRectangularRubberBand is rectangular rubber band for use within QgsModelGraphicsView widgets.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewRectangularRubberBand : public QgsModelViewRubberBand
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewRectangularRubberBand.
+     */
+    QgsModelViewRectangularRubberBand( QgsModelGraphicsView *view = nullptr );
+    QgsModelViewRectangularRubberBand *create( QgsModelGraphicsView *view ) const override SIP_FACTORY;
+
+    ~QgsModelViewRectangularRubberBand() override;
+
+    void start( QPointF position, Qt::KeyboardModifiers modifiers ) override;
+    void update( QPointF position, Qt::KeyboardModifiers modifiers ) override;
+    QRectF finish( QPointF position = QPointF(), Qt::KeyboardModifiers modifiers = nullptr ) override;
+
+  private:
+
+    //! Rubber band item
+    QGraphicsRectItem *mRubberBandItem = nullptr;
+
+    //! Start of rubber band creation
+    QPointF mRubberBandStartPos;
+
+};
+
+#endif // QGSMODELVIEWRUBBERBAND_H

--- a/src/gui/processing/models/qgsmodelviewtool.cpp
+++ b/src/gui/processing/models/qgsmodelviewtool.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmodelviewtool.h"
 #include "qgsmodelgraphicsview.h"
+#include "qgsmodelgraphicsscene.h"
 #include "qgsmodelviewmouseevent.h"
 
 QgsModelViewTool::QgsModelViewTool( QgsModelGraphicsView *view, const QString &name )
@@ -40,9 +41,9 @@ QgsModelGraphicsView *QgsModelViewTool::view() const
   return mView;
 }
 
-QgsProcessingAlgorithmModel *QgsModelViewTool::model() const
+QgsModelGraphicsScene *QgsModelViewTool::scene() const
 {
-  return nullptr;// mView->currentLayout();
+  return qobject_cast< QgsModelGraphicsScene * >( mView->scene() );
 }
 
 QgsModelViewTool::~QgsModelViewTool()

--- a/src/gui/processing/models/qgsmodelviewtool.cpp
+++ b/src/gui/processing/models/qgsmodelviewtool.cpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+                             qgsmodelviewtool.cpp
+                             ---------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewtool.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsmodelviewmouseevent.h"
+
+QgsModelViewTool::QgsModelViewTool( QgsModelGraphicsView *view, const QString &name )
+  : QObject( view )
+  , mView( view )
+  , mToolName( name )
+{
+  connect( mView, &QgsModelGraphicsView::willBeDeleted, this, [ = ]
+  {
+    mView = nullptr;
+  } );
+}
+
+bool QgsModelViewTool::isClickAndDrag( QPoint startViewPoint, QPoint endViewPoint ) const
+{
+  int diffX = endViewPoint.x() - startViewPoint.x();
+  int diffY = endViewPoint.y() - startViewPoint.y();
+  return std::abs( diffX ) >= 2 || std::abs( diffY ) >= 2;
+}
+
+QgsModelGraphicsView *QgsModelViewTool::view() const
+{
+  return mView;
+}
+
+QgsProcessingAlgorithmModel *QgsModelViewTool::model() const
+{
+  return nullptr;// mView->currentLayout();
+}
+
+QgsModelViewTool::~QgsModelViewTool()
+{
+  if ( mView )
+    mView->unsetTool( this );
+}
+
+QgsModelViewTool::Flags QgsModelViewTool::flags() const
+{
+  return mFlags;
+}
+
+void QgsModelViewTool::setFlags( QgsModelViewTool::Flags flags )
+{
+  mFlags = flags;
+}
+
+void QgsModelViewTool::modelMoveEvent( QgsModelViewMouseEvent *event )
+{
+  event->ignore();
+}
+
+void QgsModelViewTool::modelDoubleClickEvent( QgsModelViewMouseEvent *event )
+{
+  event->ignore();
+}
+
+void QgsModelViewTool::modelPressEvent( QgsModelViewMouseEvent *event )
+{
+  event->ignore();
+}
+
+void QgsModelViewTool::modelReleaseEvent( QgsModelViewMouseEvent *event )
+{
+  event->ignore();
+}
+
+void QgsModelViewTool::wheelEvent( QWheelEvent *event )
+{
+  event->ignore();
+}
+
+void QgsModelViewTool::keyPressEvent( QKeyEvent *event )
+{
+  event->ignore();
+}
+
+void QgsModelViewTool::keyReleaseEvent( QKeyEvent *event )
+{
+  event->ignore();
+}
+
+bool QgsModelViewTool::allowItemInteraction()
+{
+  return false;
+}
+
+void QgsModelViewTool::setAction( QAction *action )
+{
+  mAction = action;
+}
+
+QAction *QgsModelViewTool::action()
+{
+  return mAction;
+}
+
+void QgsModelViewTool::setCursor( const QCursor &cursor )
+{
+  mCursor = cursor;
+}
+
+void QgsModelViewTool::activate()
+{
+  // make action and/or button active
+  if ( mAction )
+    mAction->setChecked( true );
+
+  mView->viewport()->setCursor( mCursor );
+  emit activated();
+}
+
+void QgsModelViewTool::deactivate()
+{
+  if ( mAction )
+    mAction->setChecked( false );
+
+  emit deactivated();
+}

--- a/src/gui/processing/models/qgsmodelviewtool.h
+++ b/src/gui/processing/models/qgsmodelviewtool.h
@@ -27,8 +27,8 @@ class QWheelEvent;
 class QKeyEvent;
 class QgsModelGraphicsView;
 class QgsModelViewMouseEvent;
-class QgsProcessingAlgorithmModel;
 class QgsModelComponentGraphicItem;
+class QgsModelGraphicsScene;
 
 #define SIP_NO_FILE
 
@@ -149,15 +149,15 @@ class GUI_EXPORT QgsModelViewTool : public QObject
 
     /**
      * Returns the view associated with the tool.
-     * \see model()
+     * \see scene()
      */
     QgsModelGraphicsView *view() const;
 
     /**
-     * Returns the model associated with the tool.
+     * Returns the scene associated with the tool.
      * \see view()
      */
-    QgsProcessingAlgorithmModel *model() const;
+    QgsModelGraphicsScene *scene() const;
 
   signals:
 

--- a/src/gui/processing/models/qgsmodelviewtool.h
+++ b/src/gui/processing/models/qgsmodelviewtool.h
@@ -1,0 +1,221 @@
+/***************************************************************************
+                             qgsmodelviewtool.h
+                             -------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWTOOL_H
+#define QGSMODELVIEWTOOL_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include <QCursor>
+#include <QAction>
+#include <QPointer>
+
+class QMouseEvent;
+class QWheelEvent;
+class QKeyEvent;
+class QgsModelGraphicsView;
+class QgsModelViewMouseEvent;
+class QgsProcessingAlgorithmModel;
+class QgsModelComponentGraphicItem;
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * Abstract base class for all model designer view tools.
+ *
+ * Model designer view tools are user interactive tools for manipulating and adding items
+ * within the model designer.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewTool : public QObject
+{
+
+    Q_OBJECT
+
+  public:
+
+    //! Flags for controlling how a tool behaves
+    enum Flag
+    {
+      FlagSnaps = 1 << 1,  //!< Tool utilizes snapped coordinates.
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    ~QgsModelViewTool() override;
+
+    /**
+     * Returns the current combination of flags set for the tool.
+     * \see setFlags()
+     */
+    QgsModelViewTool::Flags flags() const;
+
+    /**
+     * Mouse move event for overriding. Default implementation does nothing.
+     */
+    virtual void modelMoveEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Mouse double-click event for overriding. Default implementation does nothing.
+     */
+    virtual void modelDoubleClickEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Mouse press event for overriding. Default implementation does nothing.
+     * Note that subclasses must ensure that they correctly handle cases
+     * when a modelPressEvent is called without a corresponding
+     * modelReleaseEvent (e.g. due to tool being changed mid way
+     * through a press-release operation).
+     */
+    virtual void modelPressEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Mouse release event for overriding. Default implementation does nothing.
+     * Note that subclasses must ensure that they correctly handle cases
+     * when a modelPressEvent is called without a corresponding
+     * modelReleaseEvent (e.g. due to tool being changed mid way
+     * through a press-release operation).
+     */
+    virtual void modelReleaseEvent( QgsModelViewMouseEvent *event );
+
+    /**
+     * Mouse wheel event for overriding. Default implementation does nothing.
+     */
+    virtual void wheelEvent( QWheelEvent *event );
+
+    /**
+     * Key press event for overriding. Default implementation does nothing.
+     */
+    virtual void keyPressEvent( QKeyEvent *event );
+
+    /**
+     * Key release event for overriding. Default implementation does nothing.
+     */
+    virtual void keyReleaseEvent( QKeyEvent *event );
+
+    /**
+     * Returns TRUE if the tool allows interaction with component graphic items.
+     */
+    virtual bool allowItemInteraction();
+
+    /**
+     * Associates an \a action with this tool. When the setModelTool
+     * method of QgsModelGraphicsView is called the action's state will be set to on.
+     * Usually this will cause a toolbutton to appear pressed in and
+     * the previously used toolbutton to pop out.
+     * \see action()
+    */
+    void setAction( QAction *action );
+
+    /**
+     * Returns the action associated with the tool or NULLPTR if no action is associated.
+     * \see setAction()
+     */
+    QAction *action();
+
+    /**
+     * Sets a user defined \a cursor for use when the tool is active.
+     */
+    void setCursor( const QCursor &cursor );
+
+    /**
+     * Called when tool is set as the currently active model tool.
+     * Overridden implementations must take care to call the base class implementation.
+     */
+    virtual void activate();
+
+    /**
+     * Called when tool is deactivated.
+     * Overridden implementations must take care to call the base class implementation.
+     */
+    virtual void deactivate();
+
+    /**
+     * Returns a user-visible, translated name for the tool.
+     */
+    QString toolName() const { return mToolName; }
+
+    /**
+     * Returns the view associated with the tool.
+     * \see model()
+     */
+    QgsModelGraphicsView *view() const;
+
+    /**
+     * Returns the model associated with the tool.
+     * \see view()
+     */
+    QgsProcessingAlgorithmModel *model() const;
+
+  signals:
+
+    /**
+     * Emitted when the tool is activated.
+     */
+    void activated();
+
+    /**
+     * Emitted when the tool is deactivated.
+     */
+    void deactivated();
+
+    /**
+     * Emitted when an \a item is "focused" by the tool, i.e. it should become the active
+     * item and should have its properties displayed in any designer windows.
+     */
+    void itemFocused( QgsModelComponentGraphicItem *item );
+
+  protected:
+
+    /**
+     * Sets the combination of \a flags that will be used for the tool.
+     * \see flags()
+     */
+    void setFlags( QgsModelViewTool::Flags flags );
+
+    /**
+     * Constructor for QgsModelViewTool, taking a model \a view and
+     * tool \a name as parameters.
+     */
+    QgsModelViewTool( QgsModelGraphicsView *view SIP_TRANSFERTHIS, const QString &name );
+
+    /**
+     * Returns TRUE if a mouse press/release operation which started at
+     * \a startViewPoint and ended at \a endViewPoint should be considered
+     * a "click and drag". If FALSE is returned, the operation should be
+     * instead treated as just a click on \a startViewPoint.
+     */
+    bool isClickAndDrag( QPoint startViewPoint, QPoint endViewPoint ) const;
+
+  private:
+
+    //! Pointer to model view.
+    QgsModelGraphicsView *mView = nullptr;
+
+    QgsModelViewTool::Flags mFlags = nullptr;
+
+    //! Cursor used by tool
+    QCursor mCursor = Qt::ArrowCursor;
+
+    //! Optional action associated with tool
+    QPointer< QAction > mAction;
+
+    //! Translated name of the map tool
+    QString mToolName;
+
+
+};
+
+#endif // QGSMODELVIEWTOOL_H

--- a/src/gui/processing/models/qgsmodelviewtoolselect.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.cpp
@@ -38,7 +38,7 @@ QgsModelViewToolSelect::~QgsModelViewToolSelect()
     // want to force them to be removed from the scene
     if ( mMouseHandles->scene() )
       mMouseHandles->scene()->removeItem( mMouseHandles );
-    mMouseHandles->deleteLater();
+    delete mMouseHandles;
   }
 }
 

--- a/src/gui/processing/models/qgsmodelviewtoolselect.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.cpp
@@ -1,0 +1,298 @@
+/***************************************************************************
+                             qgsmodelviewtoolselect.cpp
+                             ---------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewtoolselect.h"
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsprocessingmodelalgorithm.h"
+
+
+QgsModelViewToolSelect::QgsModelViewToolSelect( QgsModelGraphicsView *view )
+  : QgsModelViewTool( view, tr( "Select" ) )
+{
+  setCursor( Qt::ArrowCursor );
+
+  mRubberBand.reset( new QgsModelViewRectangularRubberBand( view ) );
+  mRubberBand->setBrush( QBrush( QColor( 224, 178, 76, 63 ) ) );
+  mRubberBand->setPen( QPen( QBrush( QColor( 254, 58, 29, 100 ) ), 0, Qt::DotLine ) );
+}
+
+QgsModelViewToolSelect::~QgsModelViewToolSelect()
+{
+#if 0
+  if ( mMouseHandles )
+  {
+    // want to force them to be removed from the scene
+    if ( mMouseHandles->scene() )
+      mMouseHandles->scene()->removeItem( mMouseHandles );
+    mMouseHandles->deleteLater();
+  }
+#endif
+}
+
+void QgsModelViewToolSelect::modelPressEvent( QgsModelViewMouseEvent *event )
+{
+#if 0
+  if ( mMouseHandles->shouldBlockEvent( event ) )
+  {
+    //swallow clicks while dragging/resizing items
+    return;
+  }
+
+  if ( mMouseHandles->isVisible() )
+  {
+    //selection handles are being shown, get mouse action for current cursor position
+    QgsLayoutMouseHandles::MouseAction mouseAction = mMouseHandles->mouseActionForScenePos( event->layoutPoint() );
+
+    if ( mouseAction != QgsLayoutMouseHandles::MoveItem
+         && mouseAction != QgsLayoutMouseHandles::NoAction
+         && mouseAction != QgsLayoutMouseHandles::SelectItem )
+    {
+      //mouse is over a resize handle, so propagate event onward
+      event->ignore();
+      return;
+    }
+  }
+#endif
+
+  if ( event->button() != Qt::LeftButton )
+  {
+    event->ignore();
+    return;
+  }
+
+#if 0
+  QgsLayoutItem *selectedItem = nullptr;
+  QgsLayoutItem *previousSelectedItem = nullptr;
+
+  QList<QgsLayoutItem *> selectedItems = layout()->selectedLayoutItems();
+
+  //select topmost item at position of event
+  selectedItem = layout()->layoutItemAt( event->layoutPoint(), true );
+
+  if ( !selectedItem )
+  {
+    //not clicking over an item, so start marquee selection
+    mIsSelecting = true;
+    mMousePressStartPos = event->pos();
+    mRubberBand->start( event->modelPoint(), nullptr );
+    return;
+  }
+
+  if ( ( event->modifiers() & Qt::ShiftModifier ) && ( selectedItem->isSelected() ) )
+  {
+    //SHIFT-clicking a selected item deselects it
+    selectedItem->setSelected( false );
+
+    //Check if we have any remaining selected items, and if so, update the item panel
+    const QList<QgsLayoutItem *> selectedItems = layout()->selectedLayoutItems();
+    if ( !selectedItems.isEmpty() )
+    {
+      emit itemFocused( selectedItems.at( 0 ) );
+    }
+    else
+    {
+      emit itemFocused( nullptr );
+    }
+  }
+  else
+  {
+    if ( ( !selectedItem->isSelected() ) &&       //keep selection if an already selected item pressed
+         !( event->modifiers() & Qt::ShiftModifier ) ) //keep selection if shift key pressed
+    {
+      layout()->setSelectedItem( selectedItem ); // clears existing selection
+    }
+    else
+    {
+      selectedItem->setSelected( true );
+    }
+    event->ignore();
+    emit itemFocused( selectedItem );
+  }
+#endif
+  event->ignore();
+}
+
+void QgsModelViewToolSelect::modelMoveEvent( QgsModelViewMouseEvent *event )
+{
+  if ( mIsSelecting )
+  {
+    mRubberBand->update( event->modelPoint(), nullptr );
+  }
+  else
+  {
+    event->ignore();
+  }
+}
+
+void QgsModelViewToolSelect::modelReleaseEvent( QgsModelViewMouseEvent *event )
+{
+#if 0
+  if ( event->button() != Qt::LeftButton && mMouseHandles->shouldBlockEvent( event ) )
+  {
+    //swallow clicks while dragging/resizing items
+    return;
+  }
+#endif
+
+  if ( !mIsSelecting || event->button() != Qt::LeftButton )
+  {
+    event->ignore();
+    return;
+  }
+
+#if 0
+
+  mIsSelecting = false;
+  bool wasClick = !isClickAndDrag( mMousePressStartPos, event->pos() );
+
+  // important -- we don't pass the event modifiers here, because we use them for a different meaning!
+  // (modifying how the selection interacts with the items, rather than modifying the selection shape)
+  QRectF rect = mRubberBand->finish( event->modelPoint() );
+
+  bool subtractingSelection = false;
+  if ( event->modifiers() & Qt::ShiftModifier )
+  {
+    //shift modifier means adding to selection, nothing required here
+  }
+  else if ( event->modifiers() & Qt::ControlModifier )
+  {
+    //control modifier means subtract from current selection
+    subtractingSelection = true;
+  }
+  else
+  {
+    //not adding to or removing from selection, so clear current selection
+    whileBlocking( layout() )->deselectAll();
+  }
+
+  //determine item selection mode, default to intersection
+  Qt::ItemSelectionMode selectionMode = Qt::IntersectsItemShape;
+  if ( event->modifiers() & Qt::AltModifier )
+  {
+    //alt modifier switches to contains selection mode
+    selectionMode = Qt::ContainsItemShape;
+  }
+
+  //find all items in rect
+  QList<QGraphicsItem *> itemList;
+  if ( wasClick )
+    itemList = layout()->items( rect.center(), selectionMode );
+  else
+    itemList = layout()->items( rect, selectionMode );
+  for ( QGraphicsItem *item : qgis::as_const( itemList ) )
+  {
+    QgsLayoutItem *layoutItem = dynamic_cast<QgsLayoutItem *>( item );
+    QgsLayoutItemPage *paperItem = dynamic_cast<QgsLayoutItemPage *>( item );
+    if ( layoutItem && !paperItem )
+    {
+      if ( !layoutItem->isLocked() )
+      {
+        if ( subtractingSelection )
+        {
+          layoutItem->setSelected( false );
+        }
+        else
+        {
+          layoutItem->setSelected( true );
+        }
+        if ( wasClick )
+        {
+          // found an item, and only a click - nothing more to do
+          break;
+        }
+      }
+    }
+  }
+
+  //update item panel
+  const QList<QgsLayoutItem *> selectedItemList = layout()->selectedLayoutItems();
+  if ( !selectedItemList.isEmpty() )
+  {
+    emit itemFocused( selectedItemList.at( 0 ) );
+  }
+  else
+  {
+    emit itemFocused( nullptr );
+  }
+  mMouseHandles->selectionChanged();
+#endif
+}
+
+void QgsModelViewToolSelect::wheelEvent( QWheelEvent *event )
+{
+#if 0
+  if ( mMouseHandles->shouldBlockEvent( event ) )
+  {
+    //ignore wheel events while dragging/resizing items
+    return;
+  }
+  else
+#endif
+  {
+    event->ignore();
+  }
+}
+
+void QgsModelViewToolSelect::keyPressEvent( QKeyEvent *event )
+{
+
+#if 0
+  if ( mMouseHandles->isDragging() || mMouseHandles->isResizing() )
+  {
+    return;
+  }
+  else
+#endif
+  {
+    event->ignore();
+  }
+}
+
+void QgsModelViewToolSelect::deactivate()
+{
+  if ( mIsSelecting )
+  {
+    mRubberBand->finish();
+    mIsSelecting = false;
+  }
+  QgsModelViewTool::deactivate();
+}
+
+bool QgsModelViewToolSelect::allowItemInteraction()
+{
+  return !mIsSelecting;
+}
+
+QgsModelViewMouseHandles *QgsModelViewToolSelect::mouseHandles()
+{
+  return nullptr; //mMouseHandles;
+}
+
+void QgsModelViewToolSelect::setModel( QgsProcessingAlgorithmModel *model )
+{
+#if 0
+  // existing handles are owned by previous layout
+  if ( mMouseHandles )
+    mMouseHandles->deleteLater();
+
+  //add mouse selection handles to layout, and initially hide
+  mMouseHandles = new QgsLayoutMouseHandles( layout, view() );
+  mMouseHandles->hide();
+  mMouseHandles->setZValue( QgsLayout::ZMouseHandles );
+  layout->addItem( mMouseHandles );
+#endif
+}
+///@endcond

--- a/src/gui/processing/models/qgsmodelviewtoolselect.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.cpp
@@ -19,6 +19,7 @@
 #include "qgsprocessingmodelalgorithm.h"
 #include "qgsmodelgraphicsscene.h"
 #include "qgsmodelcomponentgraphicitem.h"
+#include "qgsmodelviewmousehandles.h"
 
 QgsModelViewToolSelect::QgsModelViewToolSelect( QgsModelGraphicsView *view )
   : QgsModelViewTool( view, tr( "Select" ) )
@@ -32,7 +33,6 @@ QgsModelViewToolSelect::QgsModelViewToolSelect( QgsModelGraphicsView *view )
 
 QgsModelViewToolSelect::~QgsModelViewToolSelect()
 {
-#if 0
   if ( mMouseHandles )
   {
     // want to force them to be removed from the scene
@@ -40,12 +40,10 @@ QgsModelViewToolSelect::~QgsModelViewToolSelect()
       mMouseHandles->scene()->removeItem( mMouseHandles );
     mMouseHandles->deleteLater();
   }
-#endif
 }
 
 void QgsModelViewToolSelect::modelPressEvent( QgsModelViewMouseEvent *event )
 {
-#if 0
   if ( mMouseHandles->shouldBlockEvent( event ) )
   {
     //swallow clicks while dragging/resizing items
@@ -55,18 +53,17 @@ void QgsModelViewToolSelect::modelPressEvent( QgsModelViewMouseEvent *event )
   if ( mMouseHandles->isVisible() )
   {
     //selection handles are being shown, get mouse action for current cursor position
-    QgsLayoutMouseHandles::MouseAction mouseAction = mMouseHandles->mouseActionForScenePos( event->layoutPoint() );
+    QgsGraphicsViewMouseHandles::MouseAction mouseAction = mMouseHandles->mouseActionForScenePos( event->modelPoint() );
 
-    if ( mouseAction != QgsLayoutMouseHandles::MoveItem
-         && mouseAction != QgsLayoutMouseHandles::NoAction
-         && mouseAction != QgsLayoutMouseHandles::SelectItem )
+    if ( mouseAction != QgsGraphicsViewMouseHandles::MoveItem
+         && mouseAction != QgsGraphicsViewMouseHandles::NoAction
+         && mouseAction != QgsGraphicsViewMouseHandles::SelectItem )
     {
       //mouse is over a resize handle, so propagate event onward
       event->ignore();
       return;
     }
   }
-#endif
 
   if ( event->button() != Qt::LeftButton )
   {
@@ -139,13 +136,11 @@ void QgsModelViewToolSelect::modelMoveEvent( QgsModelViewMouseEvent *event )
 
 void QgsModelViewToolSelect::modelReleaseEvent( QgsModelViewMouseEvent *event )
 {
-#if 0
   if ( event->button() != Qt::LeftButton && mMouseHandles->shouldBlockEvent( event ) )
   {
     //swallow clicks while dragging/resizing items
     return;
   }
-#endif
 
   if ( !mIsSelecting || event->button() != Qt::LeftButton )
   {
@@ -220,21 +215,17 @@ void QgsModelViewToolSelect::modelReleaseEvent( QgsModelViewMouseEvent *event )
   {
     emit itemFocused( nullptr );
   }
-#if 0
   mMouseHandles->selectionChanged();
-#endif
 }
 
 void QgsModelViewToolSelect::wheelEvent( QWheelEvent *event )
 {
-#if 0
   if ( mMouseHandles->shouldBlockEvent( event ) )
   {
     //ignore wheel events while dragging/resizing items
     return;
   }
   else
-#endif
   {
     event->ignore();
   }
@@ -242,14 +233,11 @@ void QgsModelViewToolSelect::wheelEvent( QWheelEvent *event )
 
 void QgsModelViewToolSelect::keyPressEvent( QKeyEvent *event )
 {
-
-#if 0
   if ( mMouseHandles->isDragging() || mMouseHandles->isResizing() )
   {
     return;
   }
   else
-#endif
   {
     event->ignore();
   }
@@ -272,21 +260,19 @@ bool QgsModelViewToolSelect::allowItemInteraction()
 
 QgsModelViewMouseHandles *QgsModelViewToolSelect::mouseHandles()
 {
-  return nullptr; //mMouseHandles;
+  return mMouseHandles;
 }
 
-void QgsModelViewToolSelect::setScene( QgsModelGraphicsScene *model )
+void QgsModelViewToolSelect::setScene( QgsModelGraphicsScene *scene )
 {
-#if 0
   // existing handles are owned by previous layout
   if ( mMouseHandles )
     mMouseHandles->deleteLater();
 
-  //add mouse selection handles to layout, and initially hide
-  mMouseHandles = new QgsLayoutMouseHandles( layout, view() );
+  //add mouse selection handles to scene, and initially hide
+  mMouseHandles = new QgsModelViewMouseHandles( view() );
   mMouseHandles->hide();
-  mMouseHandles->setZValue( QgsLayout::ZMouseHandles );
-  layout->addItem( mMouseHandles );
-#endif
+  mMouseHandles->setZValue( QgsModelGraphicsScene::MouseHandles );
+  scene->addItem( mMouseHandles );
 }
 ///@endcond

--- a/src/gui/processing/models/qgsmodelviewtoolselect.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.cpp
@@ -361,4 +361,9 @@ void QgsModelViewToolSelect::setScene( QgsModelGraphicsScene *scene )
   mMouseHandles->setZValue( QgsModelGraphicsScene::MouseHandles );
   scene->addItem( mMouseHandles );
 }
+
+void QgsModelViewToolSelect::resetCache()
+{
+  mHoverEnteredItems.clear();
+}
 ///@endcond

--- a/src/gui/processing/models/qgsmodelviewtoolselect.h
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.h
@@ -63,6 +63,9 @@ class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
     //! Sets the a \a scene.
     void setScene( QgsModelGraphicsScene *scene );
 
+    /**
+     * Resets the internal cache following a scene change.
+     */
     void resetCache();
 
   private:

--- a/src/gui/processing/models/qgsmodelviewtoolselect.h
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.h
@@ -63,6 +63,8 @@ class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
     //! Sets the a \a scene.
     void setScene( QgsModelGraphicsScene *scene );
 
+    void resetCache();
+
   private:
 
     bool mIsSelecting = false;

--- a/src/gui/processing/models/qgsmodelviewtoolselect.h
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 class QgsModelViewMouseHandles;
+class QGraphicsItem;
 
 #define SIP_NO_FILE
 
@@ -47,6 +48,7 @@ class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
 
     void modelPressEvent( QgsModelViewMouseEvent *event ) override;
     void modelMoveEvent( QgsModelViewMouseEvent *event ) override;
+    void modelDoubleClickEvent( QgsModelViewMouseEvent *event ) override;
     void modelReleaseEvent( QgsModelViewMouseEvent *event ) override;
     void wheelEvent( QWheelEvent *event ) override;
     void keyPressEvent( QKeyEvent *event ) override;
@@ -75,6 +77,7 @@ class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
     QPointF mRubberBandStartPos;
 
     QPointer< QgsModelViewMouseHandles > mMouseHandles; //owned by scene
+    QList< QGraphicsItem * > mHoverEnteredItems;
 };
 
 #endif // QGSMODELVIEWTOOLSELECT_H

--- a/src/gui/processing/models/qgsmodelviewtoolselect.h
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.h
@@ -1,0 +1,80 @@
+/***************************************************************************
+                             qgsmodelviewtoolselect.h
+                             -------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWTOOLSELECT_H
+#define QGSMODELVIEWTOOLSELECT_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgsmodelviewtool.h"
+#include "qgsmodelviewrubberband.h"
+#include <memory>
+
+class QgsModelViewMouseHandles;
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * Model designer view tool for selecting items in the model.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
+{
+
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewToolSelect.
+     */
+    QgsModelViewToolSelect( QgsModelGraphicsView *view SIP_TRANSFERTHIS );
+    ~QgsModelViewToolSelect() override;
+
+    void modelPressEvent( QgsModelViewMouseEvent *event ) override;
+    void modelMoveEvent( QgsModelViewMouseEvent *event ) override;
+    void modelReleaseEvent( QgsModelViewMouseEvent *event ) override;
+    void wheelEvent( QWheelEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
+    void deactivate() override;
+    bool allowItemInteraction() override;
+
+    /**
+     * Returns the view's mouse handles.
+     */
+    QgsModelViewMouseHandles *mouseHandles();
+
+    //! Sets the a \a model.
+    void setModel( QgsProcessingAlgorithmModel *model );
+
+  private:
+
+    bool mIsSelecting = false;
+
+    //! Rubber band item
+    std::unique_ptr< QgsModelViewRubberBand > mRubberBand;
+
+    //! Start position for mouse press
+    QPoint mMousePressStartPos;
+
+    //! Start of rubber band creation
+    QPointF mRubberBandStartPos;
+
+    // QPointer< QgsLayoutMouseHandles > mMouseHandles; //owned by scene
+};
+
+#endif // QGSMODELVIEWTOOLSELECT_H

--- a/src/gui/processing/models/qgsmodelviewtoolselect.h
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.h
@@ -74,7 +74,7 @@ class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
     //! Start of rubber band creation
     QPointF mRubberBandStartPos;
 
-    // QPointer< QgsLayoutMouseHandles > mMouseHandles; //owned by scene
+    QPointer< QgsModelViewMouseHandles > mMouseHandles; //owned by scene
 };
 
 #endif // QGSMODELVIEWTOOLSELECT_H

--- a/src/gui/processing/models/qgsmodelviewtoolselect.h
+++ b/src/gui/processing/models/qgsmodelviewtoolselect.h
@@ -58,8 +58,8 @@ class GUI_EXPORT QgsModelViewToolSelect : public QgsModelViewTool
      */
     QgsModelViewMouseHandles *mouseHandles();
 
-    //! Sets the a \a model.
-    void setModel( QgsProcessingAlgorithmModel *model );
+    //! Sets the a \a scene.
+    void setScene( QgsModelGraphicsScene *scene );
 
   private:
 

--- a/src/gui/processing/models/qgsmodelviewtooltemporarykeypan.cpp
+++ b/src/gui/processing/models/qgsmodelviewtooltemporarykeypan.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+                             qgsmodelviewtooltemporarykeypan.cpp
+                             ------------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewtooltemporarykeypan.h"
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelgraphicsview.h"
+#include <QScrollBar>
+
+QgsModelViewToolTemporaryKeyPan::QgsModelViewToolTemporaryKeyPan( QgsModelGraphicsView *view )
+  : QgsModelViewTool( view, tr( "Pan" ) )
+{
+  setCursor( Qt::ClosedHandCursor );
+}
+
+void QgsModelViewToolTemporaryKeyPan::modelMoveEvent( QgsModelViewMouseEvent *event )
+{
+  view()->horizontalScrollBar()->setValue( view()->horizontalScrollBar()->value() - ( event->x() - mLastMousePos.x() ) );
+  view()->verticalScrollBar()->setValue( view()->verticalScrollBar()->value() - ( event->y() - mLastMousePos.y() ) );
+  mLastMousePos = event->pos();
+}
+
+void QgsModelViewToolTemporaryKeyPan::keyReleaseEvent( QKeyEvent *event )
+{
+  if ( event->key() == Qt::Key_Space && !event->isAutoRepeat() )
+  {
+    view()->setTool( mPreviousViewTool );
+  }
+}
+
+void QgsModelViewToolTemporaryKeyPan::activate()
+{
+  mLastMousePos = view()->mapFromGlobal( QCursor::pos() );
+  mPreviousViewTool = view()->tool();
+  QgsModelViewTool::activate();
+}

--- a/src/gui/processing/models/qgsmodelviewtooltemporarykeypan.h
+++ b/src/gui/processing/models/qgsmodelviewtooltemporarykeypan.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+                             qgsmodelviewtooltemporarykeypan.h
+                             ----------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWTOOLTEMPORARYKEYPAN_H
+#define QGSMODELVIEWTOOLTEMPORARYKEYPAN_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgsmodelviewtool.h"
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * Model designer view tool for temporarily panning a layout while a key is depressed.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewToolTemporaryKeyPan : public QgsModelViewTool
+{
+
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewToolTemporaryKeyPan.
+     */
+    QgsModelViewToolTemporaryKeyPan( QgsModelGraphicsView *view SIP_TRANSFERTHIS );
+
+    void modelMoveEvent( QgsModelViewMouseEvent *event ) override;
+    void keyReleaseEvent( QKeyEvent *event ) override;
+    void activate() override;
+
+  private:
+
+    QPoint mLastMousePos;
+    QPointer< QgsModelViewTool > mPreviousViewTool;
+
+};
+#endif // QGSMODELVIEWTOOLTEMPORARYKEYPAN_H

--- a/src/gui/processing/models/qgsmodelviewtooltemporarykeyzoom.cpp
+++ b/src/gui/processing/models/qgsmodelviewtooltemporarykeyzoom.cpp
@@ -1,0 +1,113 @@
+/***************************************************************************
+                             qgsmodelviewtooltemporarykeyzoom.cpp
+                             -------------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewtooltemporarykeyzoom.h"
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsapplication.h"
+#include <QScrollBar>
+#include <QApplication>
+
+QgsModelViewToolTemporaryKeyZoom::QgsModelViewToolTemporaryKeyZoom( QgsModelGraphicsView *view )
+  : QgsModelViewToolZoom( view )
+{
+}
+
+void QgsModelViewToolTemporaryKeyZoom::modelReleaseEvent( QgsModelViewMouseEvent *event )
+{
+  QgsModelViewToolZoom::modelReleaseEvent( event );
+  if ( !event->isAccepted() )
+    return;
+
+  //end of temporary zoom tool
+  if ( mDeactivateOnMouseRelease )
+    view()->setTool( mPreviousViewTool );
+}
+
+void QgsModelViewToolTemporaryKeyZoom::keyPressEvent( QKeyEvent *event )
+{
+  if ( event->isAutoRepeat() )
+  {
+    event->ignore();
+    return;
+  }
+
+  //respond to changes in ctrl key status
+  if ( !( event->modifiers() & Qt::ControlModifier ) )
+  {
+    if ( !mMarqueeZoom )
+    {
+      //space pressed, but control key was released, end of temporary zoom tool
+      view()->setTool( mPreviousViewTool );
+    }
+    else
+    {
+      mDeactivateOnMouseRelease = true;
+    }
+  }
+  else
+  {
+    //both control and space pressed
+    //set cursor to zoom in/out depending on alt key status
+    updateCursor( event->modifiers() );
+    if ( event->key() == Qt::Key_Space )
+    {
+      mDeactivateOnMouseRelease = false;
+    }
+  }
+}
+
+void QgsModelViewToolTemporaryKeyZoom::keyReleaseEvent( QKeyEvent *event )
+{
+  if ( event->isAutoRepeat() )
+  {
+    event->ignore();
+    return;
+  }
+
+  if ( event->key() == Qt::Key_Space )
+  {
+    //temporary keyboard-based zoom tool is active and space key has been released
+    if ( !mMarqueeZoom )
+    {
+      //not mid-way through an operation, so immediately switch tool back
+      view()->setTool( mPreviousViewTool );
+    }
+    else
+    {
+      mDeactivateOnMouseRelease = true;
+    }
+  }
+  else
+  {
+    updateCursor( event->modifiers() );
+    event->ignore();
+  }
+}
+
+void QgsModelViewToolTemporaryKeyZoom::activate()
+{
+  mDeactivateOnMouseRelease = false;
+  mPreviousViewTool = view()->tool();
+  QgsModelViewToolZoom::activate();
+  updateCursor( QApplication::keyboardModifiers() );
+}
+
+void QgsModelViewToolTemporaryKeyZoom::updateCursor( Qt::KeyboardModifiers modifiers )
+{
+  view()->viewport()->setCursor( ( modifiers & Qt::AltModifier ) ?
+                                 QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomOut ) :
+                                 QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomIn ) );
+}

--- a/src/gui/processing/models/qgsmodelviewtooltemporarykeyzoom.h
+++ b/src/gui/processing/models/qgsmodelviewtooltemporarykeyzoom.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+                             qgsmodelviewtooltemporarykeyzoom.h
+                             -----------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWTOOLTEMPORARYKEYZOOM_H
+#define QGSMODELVIEWTOOLTEMPORARYKEYZOOM_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgsmodelviewtoolzoom.h"
+#include "qgsmodelviewrubberband.h"
+#include <memory>
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * Model view tool for temporarily zooming a model while a key is depressed.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewToolTemporaryKeyZoom : public QgsModelViewToolZoom
+{
+
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewToolTemporaryKeyZoom.
+     */
+    QgsModelViewToolTemporaryKeyZoom( QgsModelGraphicsView *view SIP_TRANSFERTHIS );
+
+    void modelReleaseEvent( QgsModelViewMouseEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
+    void keyReleaseEvent( QKeyEvent *event ) override;
+    void activate() override;
+
+  private:
+
+    QPointer< QgsModelViewTool > mPreviousViewTool;
+
+    bool mDeactivateOnMouseRelease = false;
+
+    void updateCursor( Qt::KeyboardModifiers modifiers );
+};
+
+#endif // QGSMODELVIEWTOOLTEMPORARYKEYZOOM_H

--- a/src/gui/processing/models/qgsmodelviewtooltemporarymousepan.cpp
+++ b/src/gui/processing/models/qgsmodelviewtooltemporarymousepan.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+                             qgsmodelviewtooltemporarymousepan.cpp
+                             --------------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewtooltemporarymousepan.h"
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelgraphicsview.h"
+#include <QScrollBar>
+
+QgsModelViewToolTemporaryMousePan::QgsModelViewToolTemporaryMousePan( QgsModelGraphicsView *view )
+  : QgsModelViewTool( view, tr( "Pan" ) )
+{
+  setCursor( Qt::ClosedHandCursor );
+}
+
+void QgsModelViewToolTemporaryMousePan::modelMoveEvent( QgsModelViewMouseEvent *event )
+{
+  view()->horizontalScrollBar()->setValue( view()->horizontalScrollBar()->value() - ( event->x() - mLastMousePos.x() ) );
+  view()->verticalScrollBar()->setValue( view()->verticalScrollBar()->value() - ( event->y() - mLastMousePos.y() ) );
+  mLastMousePos = event->pos();
+}
+
+void QgsModelViewToolTemporaryMousePan::modelReleaseEvent( QgsModelViewMouseEvent *event )
+{
+  if ( event->button() == Qt::MidButton )
+  {
+    view()->setTool( mPreviousViewTool );
+  }
+}
+
+void QgsModelViewToolTemporaryMousePan::activate()
+{
+  mLastMousePos = view()->mapFromGlobal( QCursor::pos() );
+  mPreviousViewTool = view()->tool();
+  QgsModelViewTool::activate();
+}

--- a/src/gui/processing/models/qgsmodelviewtooltemporarymousepan.h
+++ b/src/gui/processing/models/qgsmodelviewtooltemporarymousepan.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+                             qgsmodelviewtooltemporarymousepan.h
+                             ------------------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QgsModelViewToolTemporaryMousePan_H
+#define QgsModelViewToolTemporaryMousePan_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgsmodelviewtool.h"
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * Model view tool for temporarily panning a model while a mouse button is depressed.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewToolTemporaryMousePan : public QgsModelViewTool
+{
+
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewToolTemporaryMousePan.
+     */
+    QgsModelViewToolTemporaryMousePan( QgsModelGraphicsView *view SIP_TRANSFERTHIS );
+
+    void modelMoveEvent( QgsModelViewMouseEvent *event ) override;
+    void modelReleaseEvent( QgsModelViewMouseEvent *event ) override;
+    void activate() override;
+
+  private:
+
+    QPoint mLastMousePos;
+    QPointer< QgsModelViewTool > mPreviousViewTool;
+
+};
+
+#endif // QgsModelViewToolTemporaryMousePan_H

--- a/src/gui/processing/models/qgsmodelviewtoolzoom.cpp
+++ b/src/gui/processing/models/qgsmodelviewtoolzoom.cpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+                             qgsmodelviewtoolzoom.cpp
+                             -------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelviewtoolzoom.h"
+#include "qgsmodelviewmouseevent.h"
+#include "qgsmodelgraphicsview.h"
+#include "qgsmodelviewrubberband.h"
+#include "qgsrectangle.h"
+#include "qgsapplication.h"
+#include <QScrollBar>
+
+QgsModelViewToolZoom::QgsModelViewToolZoom( QgsModelGraphicsView *view )
+  : QgsModelViewTool( view, tr( "Pan" ) )
+{
+  setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomIn ) );
+  mRubberBand.reset( new QgsModelViewRectangularRubberBand( view ) );
+  mRubberBand->setBrush( QBrush( QColor( 70, 50, 255, 25 ) ) );
+  mRubberBand->setPen( QPen( QBrush( QColor( 70, 50, 255, 100 ) ), 0 ) );
+}
+
+void QgsModelViewToolZoom::modelPressEvent( QgsModelViewMouseEvent *event )
+{
+  if ( event->button() != Qt::LeftButton )
+  {
+    event->ignore();
+    return;
+  }
+
+  mMousePressStartPos = event->pos();
+  if ( event->modifiers() & Qt::AltModifier )
+  {
+    //zoom out action, so zoom out and recenter on clicked point
+    double scaleFactor = 2;
+    //get current visible part of scene
+    QRect viewportRect( 0, 0, view()->viewport()->width(), view()->viewport()->height() );
+    QgsRectangle visibleRect = QgsRectangle( view()->mapToScene( viewportRect ).boundingRect() );
+
+    visibleRect.scale( scaleFactor, event->modelPoint().x(), event->modelPoint().y() );
+    QRectF boundsRect = visibleRect.toRectF();
+
+    //zoom view to fit desired bounds
+    view()->fitInView( boundsRect, Qt::KeepAspectRatio );
+  }
+  else
+  {
+    //zoom in action
+    startMarqueeZoom( event->modelPoint() );
+  }
+}
+
+void QgsModelViewToolZoom::modelMoveEvent( QgsModelViewMouseEvent *event )
+{
+  if ( !mMarqueeZoom )
+  {
+    event->ignore();
+    return;
+  }
+
+  mRubberBand->update( event->modelPoint(), nullptr );
+}
+
+void QgsModelViewToolZoom::modelReleaseEvent( QgsModelViewMouseEvent *event )
+{
+  if ( !mMarqueeZoom || event->button() != Qt::LeftButton )
+  {
+    event->ignore();
+    return;
+  }
+
+  mMarqueeZoom = false;
+  QRectF newBoundsRect = mRubberBand->finish( event->modelPoint() );
+
+  // click? or click-and-drag?
+  if ( !isClickAndDrag( mMousePressStartPos, event->pos() ) )
+  {
+    //just a click, so zoom to clicked point and recenter
+    double scaleFactor = 0.5;
+    //get current visible part of scene
+    QRect viewportRect( 0, 0, view()->viewport()->width(), view()->viewport()->height() );
+    QgsRectangle visibleRect = QgsRectangle( view()->mapToScene( viewportRect ).boundingRect() );
+
+    visibleRect.scale( scaleFactor, event->modelPoint().x(), event->modelPoint().y() );
+    newBoundsRect = visibleRect.toRectF();
+  }
+
+  //zoom view to fit desired bounds
+  view()->fitInView( newBoundsRect, Qt::KeepAspectRatio );
+}
+
+void QgsModelViewToolZoom::keyPressEvent( QKeyEvent *event )
+{
+  //respond to changes in the alt key status and update cursor accordingly
+  if ( !event->isAutoRepeat() )
+  {
+
+    view()->viewport()->setCursor( ( event->modifiers() & Qt::AltModifier ) ?
+                                   QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomOut ) :
+                                   QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomIn ) );
+  }
+  event->ignore();
+}
+
+void QgsModelViewToolZoom::keyReleaseEvent( QKeyEvent *event )
+{
+  //respond to changes in the alt key status and update cursor accordingly
+  if ( !event->isAutoRepeat() )
+  {
+
+    view()->viewport()->setCursor( ( event->modifiers() & Qt::AltModifier ) ?
+                                   QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomOut ) :
+                                   QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomIn ) );
+  }
+  event->ignore();
+}
+
+void QgsModelViewToolZoom::deactivate()
+{
+  if ( mMarqueeZoom )
+  {
+    mMarqueeZoom = false;
+    mRubberBand->finish();
+  }
+  QgsModelViewTool::deactivate();
+}
+
+void QgsModelViewToolZoom::startMarqueeZoom( QPointF scenePoint )
+{
+  mMarqueeZoom = true;
+
+  mRubberBandStartPos = scenePoint;
+  mRubberBand->start( scenePoint, nullptr );
+}

--- a/src/gui/processing/models/qgsmodelviewtoolzoom.h
+++ b/src/gui/processing/models/qgsmodelviewtoolzoom.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+                             qgsmodelviewtoolzoom.h
+                             -----------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELVIEWTOOLZOOM_H
+#define QGSMODELVIEWTOOLZOOM_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgsmodelviewtool.h"
+#include "qgsmodelviewrubberband.h"
+#include <memory>
+
+#define SIP_NO_FILE
+
+/**
+ * \ingroup gui
+ * Model view tool for zooming into and out of the model.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelViewToolZoom : public QgsModelViewTool
+{
+
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelViewToolZoom.
+     */
+    QgsModelViewToolZoom( QgsModelGraphicsView *view SIP_TRANSFERTHIS );
+
+    void modelPressEvent( QgsModelViewMouseEvent *event ) override;
+    void modelMoveEvent( QgsModelViewMouseEvent *event ) override;
+    void modelReleaseEvent( QgsModelViewMouseEvent *event ) override;
+    void keyPressEvent( QKeyEvent *event ) override;
+    void keyReleaseEvent( QKeyEvent *event ) override;
+    void deactivate() override;
+
+  protected:
+
+    //! Will be TRUE will marquee zoom operation is in progress
+    bool mMarqueeZoom = false;
+
+  private:
+
+    //! Start position for mouse press
+    QPoint mMousePressStartPos;
+
+    QPointF mRubberBandStartPos;
+
+    //! Rubber band item
+    std::unique_ptr< QgsModelViewRectangularRubberBand > mRubberBand;
+
+    void startMarqueeZoom( QPointF scenePoint );
+
+};
+
+#endif // QGSMODELVIEWTOOLZOOM_H

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -1,0 +1,369 @@
+/***************************************************************************
+                             qgsgraphicsviewmousehandles.cpp
+                             ------------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall.dawson@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgraphicsviewmousehandles.h"
+#include "qgis.h"
+#include <QGraphicsView>
+#include <QGraphicsSceneHoverEvent>
+#include <QPainter>
+#include <QWidget>
+#include <limits>
+
+///@cond PRIVATE
+
+QgsGraphicsViewMouseHandles::QgsGraphicsViewMouseHandles( QGraphicsView *view )
+  : QObject( nullptr )
+  , QGraphicsRectItem( nullptr )
+  , mView( view )
+{
+  //accept hover events, required for changing cursor to resize cursors
+  setAcceptHoverEvents( true );
+}
+
+void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
+{
+  if ( !showHandles )
+  {
+    return;
+  }
+
+  if ( showBoundingBoxes )
+  {
+    //draw resize handles around bounds of entire selection
+    double rectHandlerSize = rectHandlerBorderTolerance();
+    drawHandles( painter, rectHandlerSize );
+  }
+
+  if ( mIsResizing || mIsDragging || showBoundingBoxes )
+  {
+    //draw dotted boxes around selected items
+    drawSelectedItemBounds( painter );
+  }
+}
+
+void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHandlerSize )
+{
+  //blue, zero width cosmetic pen for outline
+  QPen handlePen = QPen( QColor( 55, 140, 195, 255 ) );
+  handlePen.setWidth( 0 );
+  painter->setPen( handlePen );
+
+  //draw box around entire selection bounds
+  painter->setBrush( Qt::NoBrush );
+  painter->drawRect( QRectF( 0, 0, rect().width(), rect().height() ) );
+
+  //draw resize handles, using a filled white box
+  painter->setBrush( QColor( 255, 255, 255, 255 ) );
+  //top left
+  painter->drawRect( QRectF( 0, 0, rectHandlerSize, rectHandlerSize ) );
+  //mid top
+  painter->drawRect( QRectF( ( rect().width() - rectHandlerSize ) / 2, 0, rectHandlerSize, rectHandlerSize ) );
+  //top right
+  painter->drawRect( QRectF( rect().width() - rectHandlerSize, 0, rectHandlerSize, rectHandlerSize ) );
+  //mid left
+  painter->drawRect( QRectF( 0, ( rect().height() - rectHandlerSize ) / 2, rectHandlerSize, rectHandlerSize ) );
+  //mid right
+  painter->drawRect( QRectF( rect().width() - rectHandlerSize, ( rect().height() - rectHandlerSize ) / 2, rectHandlerSize, rectHandlerSize ) );
+  //bottom left
+  painter->drawRect( QRectF( 0, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
+  //mid bottom
+  painter->drawRect( QRectF( ( rect().width() - rectHandlerSize ) / 2, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
+  //bottom right
+  painter->drawRect( QRectF( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
+}
+
+double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance()
+{
+  if ( !mView )
+    return 0;
+
+  //calculate size for resize handles
+  //get view scale factor
+  double viewScaleFactor = mView->transform().m11();
+
+  //size of handle boxes depends on zoom level in layout view
+  double rectHandlerSize = 10.0 / viewScaleFactor;
+
+  //make sure the boxes don't get too large
+  if ( rectHandlerSize > ( rect().width() / 3 ) )
+  {
+    rectHandlerSize = rect().width() / 3;
+  }
+  if ( rectHandlerSize > ( rect().height() / 3 ) )
+  {
+    rectHandlerSize = rect().height() / 3;
+  }
+  return rectHandlerSize;
+}
+
+Qt::CursorShape QgsGraphicsViewMouseHandles::cursorForPosition( QPointF itemCoordPos )
+{
+  QgsGraphicsViewMouseHandles::MouseAction mouseAction = mouseActionForPosition( itemCoordPos );
+  switch ( mouseAction )
+  {
+    case NoAction:
+      return Qt::ForbiddenCursor;
+    case MoveItem:
+      return Qt::SizeAllCursor;
+    case ResizeUp:
+    case ResizeDown:
+      //account for rotation
+      if ( ( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeVerCursor;
+      }
+      else if ( ( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeBDiagCursor;
+      }
+      else if ( ( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeHorCursor;
+      }
+      else
+      {
+        return Qt::SizeFDiagCursor;
+      }
+    case ResizeLeft:
+    case ResizeRight:
+      //account for rotation
+      if ( ( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeHorCursor;
+      }
+      else if ( ( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeFDiagCursor;
+      }
+      else if ( ( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeVerCursor;
+      }
+      else
+      {
+        return Qt::SizeBDiagCursor;
+      }
+
+    case ResizeLeftUp:
+    case ResizeRightDown:
+      //account for rotation
+      if ( ( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeFDiagCursor;
+      }
+      else if ( ( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeVerCursor;
+      }
+      else if ( ( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeBDiagCursor;
+      }
+      else
+      {
+        return Qt::SizeHorCursor;
+      }
+    case ResizeRightUp:
+    case ResizeLeftDown:
+      //account for rotation
+      if ( ( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeBDiagCursor;
+      }
+      else if ( ( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeHorCursor;
+      }
+      else if ( ( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeFDiagCursor;
+      }
+      else
+      {
+        return Qt::SizeVerCursor;
+      }
+    case SelectItem:
+      return Qt::ArrowCursor;
+  }
+
+  return Qt::ArrowCursor;
+}
+
+QgsGraphicsViewMouseHandles::MouseAction QgsGraphicsViewMouseHandles::mouseActionForPosition( QPointF itemCoordPos )
+{
+  bool nearLeftBorder = false;
+  bool nearRightBorder = false;
+  bool nearLowerBorder = false;
+  bool nearUpperBorder = false;
+
+  bool withinWidth = false;
+  bool withinHeight = false;
+  if ( itemCoordPos.x() >= 0 && itemCoordPos.x() <= rect().width() )
+  {
+    withinWidth = true;
+  }
+  if ( itemCoordPos.y() >= 0 && itemCoordPos.y() <= rect().height() )
+  {
+    withinHeight = true;
+  }
+
+  double borderTolerance = rectHandlerBorderTolerance();
+
+  if ( itemCoordPos.x() >= 0 && itemCoordPos.x() < borderTolerance )
+  {
+    nearLeftBorder = true;
+  }
+  if ( itemCoordPos.y() >= 0 && itemCoordPos.y() < borderTolerance )
+  {
+    nearUpperBorder = true;
+  }
+  if ( itemCoordPos.x() <= rect().width() && itemCoordPos.x() > ( rect().width() - borderTolerance ) )
+  {
+    nearRightBorder = true;
+  }
+  if ( itemCoordPos.y() <= rect().height() && itemCoordPos.y() > ( rect().height() - borderTolerance ) )
+  {
+    nearLowerBorder = true;
+  }
+
+  if ( nearLeftBorder && nearUpperBorder )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeLeftUp;
+  }
+  else if ( nearLeftBorder && nearLowerBorder )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeLeftDown;
+  }
+  else if ( nearRightBorder && nearUpperBorder )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeRightUp;
+  }
+  else if ( nearRightBorder && nearLowerBorder )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeRightDown;
+  }
+  else if ( nearLeftBorder && withinHeight )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeLeft;
+  }
+  else if ( nearRightBorder && withinHeight )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeRight;
+  }
+  else if ( nearUpperBorder && withinWidth )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeUp;
+  }
+  else if ( nearLowerBorder && withinWidth )
+  {
+    return QgsGraphicsViewMouseHandles::ResizeDown;
+  }
+
+  //find out if cursor position is over a selected item
+  QPointF scenePoint = mapToScene( itemCoordPos );
+  const QList<QGraphicsItem *> itemsAtCursorPos = sceneItemsAtPoint( scenePoint );
+  if ( itemsAtCursorPos.isEmpty() )
+  {
+    //no items at cursor position
+    return QgsGraphicsViewMouseHandles::SelectItem;
+  }
+  for ( QGraphicsItem *graphicsItem : itemsAtCursorPos )
+  {
+    if ( graphicsItem && graphicsItem->isSelected() )
+    {
+      //cursor is over a selected layout item
+      return QgsGraphicsViewMouseHandles::MoveItem;
+    }
+  }
+
+  //default
+  return QgsGraphicsViewMouseHandles::SelectItem;
+}
+
+QgsGraphicsViewMouseHandles::MouseAction QgsGraphicsViewMouseHandles::mouseActionForScenePos( QPointF sceneCoordPos )
+{
+  // convert sceneCoordPos to item coordinates
+  QPointF itemPos = mapFromScene( sceneCoordPos );
+  return mouseActionForPosition( itemPos );
+}
+
+bool QgsGraphicsViewMouseHandles::shouldBlockEvent( QInputEvent * ) const
+{
+  return mIsDragging || mIsResizing;
+}
+
+void QgsGraphicsViewMouseHandles::hoverMoveEvent( QGraphicsSceneHoverEvent *event )
+{
+  setViewportCursor( cursorForPosition( event->pos() ) );
+}
+
+void QgsGraphicsViewMouseHandles::hoverLeaveEvent( QGraphicsSceneHoverEvent *event )
+{
+  Q_UNUSED( event )
+  setViewportCursor( Qt::ArrowCursor );
+}
+
+
+void QgsGraphicsViewMouseHandles::mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event )
+{
+  Q_UNUSED( event )
+}
+
+QSizeF QgsGraphicsViewMouseHandles::calcCursorEdgeOffset( QPointF cursorPos )
+{
+  //find offset between cursor position and actual edge of item
+  QPointF sceneMousePos = mapFromScene( cursorPos );
+
+  switch ( mCurrentMouseMoveAction )
+  {
+    //vertical resize
+    case QgsGraphicsViewMouseHandles::ResizeUp:
+      return QSizeF( 0, sceneMousePos.y() );
+
+    case QgsGraphicsViewMouseHandles::ResizeDown:
+      return QSizeF( 0, sceneMousePos.y() - rect().height() );
+
+    //horizontal resize
+    case QgsGraphicsViewMouseHandles::ResizeLeft:
+      return QSizeF( sceneMousePos.x(), 0 );
+
+    case QgsGraphicsViewMouseHandles::ResizeRight:
+      return QSizeF( sceneMousePos.x() - rect().width(), 0 );
+
+    //diagonal resize
+    case QgsGraphicsViewMouseHandles::ResizeLeftUp:
+      return QSizeF( sceneMousePos.x(), sceneMousePos.y() );
+
+    case QgsGraphicsViewMouseHandles::ResizeRightDown:
+      return QSizeF( sceneMousePos.x() - rect().width(), sceneMousePos.y() - rect().height() );
+
+    case QgsGraphicsViewMouseHandles::ResizeRightUp:
+      return QSizeF( sceneMousePos.x() - rect().width(), sceneMousePos.y() );
+
+    case QgsGraphicsViewMouseHandles::ResizeLeftDown:
+      return QSizeF( sceneMousePos.x(), sceneMousePos.y() - rect().height() );
+
+    case MoveItem:
+    case SelectItem:
+    case NoAction:
+      return QSizeF();
+  }
+
+  return QSizeF();
+}
+
+///@endcond PRIVATE

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -211,7 +211,7 @@ double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance()
   double viewScaleFactor = mView->transform().m11();
 
   //size of handle boxes depends on zoom level in layout view
-  double rectHandlerSize = 10.0 / viewScaleFactor;
+  double rectHandlerSize = mHandleSize / viewScaleFactor;
 
   //make sure the boxes don't get too large
   if ( rectHandlerSize > ( rect().width() / 3 ) )
@@ -1041,6 +1041,11 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
   //show current size of selection in status bar
   showStatusMessage( tr( "width: %1 mm height: %2 mm" ).arg( rect().width() ).arg( rect().height() ) );
 
+}
+
+void QgsGraphicsViewMouseHandles::setHandleSize( double size )
+{
+  mHandleSize = size;
 }
 
 void QgsGraphicsViewMouseHandles::mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event )

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -34,25 +34,30 @@ QgsGraphicsViewMouseHandles::QgsGraphicsViewMouseHandles( QGraphicsView *view )
   setAcceptHoverEvents( true );
 }
 
-void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
+void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes, bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *, QWidget * )
 {
   if ( !showHandles )
   {
     return;
   }
 
-  if ( showBoundingBoxes )
+  if ( showStaticBoundingBoxes )
   {
     //draw resize handles around bounds of entire selection
     double rectHandlerSize = rectHandlerBorderTolerance();
     drawHandles( painter, rectHandlerSize );
   }
 
-  if ( mIsResizing || mIsDragging || showBoundingBoxes )
+  if ( showTemporaryBoundingBoxes && ( mIsResizing || mIsDragging || showStaticBoundingBoxes ) )
   {
     //draw dotted boxes around selected items
     drawSelectedItemBounds( painter );
   }
+}
+
+void QgsGraphicsViewMouseHandles::previewItemMove( QGraphicsItem *, double, double )
+{
+
 }
 
 void QgsGraphicsViewMouseHandles::startMacroCommand( const QString & )
@@ -727,6 +732,11 @@ void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool l
   moveTransform.translate( moveRectX, moveRectY );
   setTransform( moveTransform );
 
+  const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  for ( QGraphicsItem *item : selectedItems )
+  {
+    previewItemMove( item, moveRectX, moveRectY );
+  }
   //show current displacement of selection in status bar
   showStatusMessage( tr( "dx: %1 mm dy: %2 mm" ).arg( moveRectX ).arg( moveRectY ) );
 }

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -60,6 +60,11 @@ void QgsGraphicsViewMouseHandles::startMacroCommand( const QString & )
 
 }
 
+void QgsGraphicsViewMouseHandles::endMacroCommand()
+{
+
+}
+
 void QgsGraphicsViewMouseHandles::endItemCommand( QGraphicsItem * )
 {
 

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -452,6 +452,12 @@ void QgsGraphicsViewMouseHandles::hoverLeaveEvent( QGraphicsSceneHoverEvent *eve
 
 void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *event )
 {
+  if ( event->button() != Qt::LeftButton )
+  {
+    event->ignore();
+    return;
+  }
+
   //save current cursor position
   mMouseMoveStartPos = event->lastScenePos();
   mLastMouseEventPos = event->lastScenePos();
@@ -526,6 +532,12 @@ void QgsGraphicsViewMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *even
 
 void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
 {
+  if ( event->button() != Qt::LeftButton )
+  {
+    event->ignore();
+    return;
+  }
+
   QPointF mouseMoveStopPoint = event->lastScenePos();
   double diffX = mouseMoveStopPoint.x() - mMouseMoveStartPos.x();
   double diffY = mouseMoveStopPoint.y() - mMouseMoveStartPos.y();

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -55,7 +55,17 @@ void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHan
   }
 }
 
+QRectF QgsGraphicsViewMouseHandles::storedItemRect( QGraphicsItem *item ) const
+{
+  return itemRect( item );
+}
+
 void QgsGraphicsViewMouseHandles::previewItemMove( QGraphicsItem *, double, double )
+{
+
+}
+
+void QgsGraphicsViewMouseHandles::previewSetItemRect( QGraphicsItem *, QRectF )
 {
 
 }
@@ -1004,6 +1014,17 @@ void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool
   }
 
   setRect( 0, 0, std::fabs( mBeginHandleWidth + rx ), std::fabs( mBeginHandleHeight + ry ) );
+
+  const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  for ( QGraphicsItem *item : selectedItems )
+  {
+    //get stored item bounds in mouse handle item's coordinate system
+    QRectF thisItemRect = mapRectFromScene( storedItemRect( item ) );
+    //now, resize it relative to the current resized dimensions of the mouse handles
+    relativeResizeRect( thisItemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
+
+    previewSetItemRect( item, mapRectToScene( thisItemRect ) );
+  }
 
   //show current size of selection in status bar
   showStatusMessage( tr( "width: %1 mm height: %2 mm" ).arg( rect().width() ).arg( rect().height() ) );

--- a/src/gui/qgsgraphicsviewmousehandles.cpp
+++ b/src/gui/qgsgraphicsviewmousehandles.cpp
@@ -55,6 +55,31 @@ void QgsGraphicsViewMouseHandles::paintInternal( QPainter *painter, bool showHan
   }
 }
 
+void QgsGraphicsViewMouseHandles::startMacroCommand( const QString & )
+{
+
+}
+
+void QgsGraphicsViewMouseHandles::endItemCommand( QGraphicsItem * )
+{
+
+}
+
+void QgsGraphicsViewMouseHandles::createItemCommand( QGraphicsItem * )
+{
+
+}
+
+QPointF QgsGraphicsViewMouseHandles::snapPoint( QPointF originalPoint, QgsGraphicsViewMouseHandles::SnapGuideMode, bool, bool )
+{
+  return originalPoint;
+}
+
+void QgsGraphicsViewMouseHandles::expandItemList( const QList<QGraphicsItem *> &items, QList<QGraphicsItem *> &collected ) const
+{
+  collected = items;
+}
+
 void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHandlerSize )
 {
   //blue, zero width cosmetic pen for outline
@@ -84,6 +109,76 @@ void QgsGraphicsViewMouseHandles::drawHandles( QPainter *painter, double rectHan
   painter->drawRect( QRectF( ( rect().width() - rectHandlerSize ) / 2, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
   //bottom right
   painter->drawRect( QRectF( rect().width() - rectHandlerSize, rect().height() - rectHandlerSize, rectHandlerSize, rectHandlerSize ) );
+}
+
+void QgsGraphicsViewMouseHandles::drawSelectedItemBounds( QPainter *painter )
+{
+  //draw dotted border around selected items to give visual feedback which items are selected
+  const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  if ( selectedItems.isEmpty() )
+  {
+    return;
+  }
+
+  //use difference mode so that they are visible regardless of item colors
+  painter->save();
+  painter->setCompositionMode( QPainter::CompositionMode_Difference );
+
+  // use a grey dashed pen - in difference mode this should always be visible
+  QPen selectedItemPen = QPen( QColor( 144, 144, 144, 255 ) );
+  selectedItemPen.setStyle( Qt::DashLine );
+  selectedItemPen.setWidth( 0 );
+  painter->setPen( selectedItemPen );
+  painter->setBrush( Qt::NoBrush );
+
+  QList< QGraphicsItem * > itemsToDraw;
+  expandItemList( selectedItems, itemsToDraw );
+
+  for ( QGraphicsItem *item : qgis::as_const( itemsToDraw ) )
+  {
+    //get bounds of selected item
+    QPolygonF itemBounds;
+    if ( isDragging() && !itemIsLocked( item ) )
+    {
+      //if currently dragging, draw selected item bounds relative to current mouse position
+      //first, get bounds of current item in scene coordinates
+      QPolygonF itemSceneBounds = item->mapToScene( itemRect( item ) );
+      //now, translate it by the current movement amount
+      //IMPORTANT - this is done in scene coordinates, since we don't want any rotation/non-translation transforms to affect the movement
+      itemSceneBounds.translate( transform().dx(), transform().dy() );
+      //finally, remap it to the mouse handle item's coordinate system so it's ready for drawing
+      itemBounds = mapFromScene( itemSceneBounds );
+    }
+    else if ( isResizing() && !itemIsLocked( item ) )
+    {
+      //if currently resizing, calculate relative resize of this item
+      if ( selectedItems.size() > 1 )
+      {
+        //get item bounds in mouse handle item's coordinate system
+        QRectF thisItemRect = mapRectFromItem( item, itemRect( item ) );
+        //now, resize it relative to the current resized dimensions of the mouse handles
+        relativeResizeRect( thisItemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
+        itemBounds = QPolygonF( thisItemRect );
+      }
+      else
+      {
+        //single item selected
+        itemBounds = rect();
+      }
+    }
+    else
+    {
+      //not resizing or moving, so just map from scene bounds
+      itemBounds = mapRectFromItem( item, itemRect( item ) );
+    }
+
+    // drawPolygon causes issues on windows - corners of path may be missing resulting in triangles being drawn
+    // instead of rectangles! (Same cause as #13343)
+    QPainterPath path;
+    path.addPolygon( itemBounds );
+    painter->drawPath( path );
+  }
+  painter->restore();
 }
 
 double QgsGraphicsViewMouseHandles::rectHandlerBorderTolerance()
@@ -306,6 +401,24 @@ bool QgsGraphicsViewMouseHandles::shouldBlockEvent( QInputEvent * ) const
   return mIsDragging || mIsResizing;
 }
 
+void QgsGraphicsViewMouseHandles::selectedItemSizeChanged()
+{
+  if ( !isDragging() && !isResizing() )
+  {
+    //only required for non-mouse initiated size changes
+    updateHandles();
+  }
+}
+
+void QgsGraphicsViewMouseHandles::selectedItemRotationChanged()
+{
+  if ( !isDragging() && !isResizing() )
+  {
+    //only required for non-mouse initiated rotation changes
+    updateHandles();
+  }
+}
+
 void QgsGraphicsViewMouseHandles::hoverMoveEvent( QGraphicsSceneHoverEvent *event )
 {
   setViewportCursor( cursorForPosition( event->pos() ) );
@@ -317,6 +430,570 @@ void QgsGraphicsViewMouseHandles::hoverLeaveEvent( QGraphicsSceneHoverEvent *eve
   setViewportCursor( Qt::ArrowCursor );
 }
 
+void QgsGraphicsViewMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent *event )
+{
+  //save current cursor position
+  mMouseMoveStartPos = event->lastScenePos();
+  mLastMouseEventPos = event->lastScenePos();
+  //save current item geometry
+  mBeginMouseEventPos = event->lastScenePos();
+  mBeginHandlePos = scenePos();
+  mBeginHandleWidth = rect().width();
+  mBeginHandleHeight = rect().height();
+  //type of mouse move action
+  mCurrentMouseMoveAction = mouseActionForPosition( event->pos() );
+
+  hideAlignItems();
+
+  if ( mCurrentMouseMoveAction == MoveItem )
+  {
+    //moving items
+    mIsDragging = true;
+  }
+  else if ( mCurrentMouseMoveAction != SelectItem &&
+            mCurrentMouseMoveAction != NoAction )
+  {
+    //resizing items
+    mIsResizing = true;
+    mResizeRect = QRectF( 0, 0, mBeginHandleWidth, mBeginHandleHeight );
+    mResizeMoveX = 0;
+    mResizeMoveY = 0;
+    mCursorOffset = calcCursorEdgeOffset( mMouseMoveStartPos );
+
+  }
+}
+
+void QgsGraphicsViewMouseHandles::resetStatusBar()
+{
+  const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  int selectedCount = selectedItems.size();
+  if ( selectedCount > 1 )
+  {
+    //set status bar message to count of selected items
+    showStatusMessage( tr( "%1 items selected" ).arg( selectedCount ) );
+  }
+  else if ( selectedCount == 1 )
+  {
+    //set status bar message to count of selected items
+    showStatusMessage( tr( "1 item selected" ) );
+  }
+  else
+  {
+    //clear status bar message
+    showStatusMessage( QString() );
+  }
+}
+
+void QgsGraphicsViewMouseHandles::mouseMoveEvent( QGraphicsSceneMouseEvent *event )
+{
+  if ( isDragging() )
+  {
+    //currently dragging a selection
+    //if shift depressed, constrain movement to horizontal/vertical
+    //if control depressed, ignore snapping
+    dragMouseMove( event->lastScenePos(), event->modifiers() & Qt::ShiftModifier, event->modifiers() & Qt::ControlModifier );
+  }
+  else if ( isResizing() )
+  {
+    //currently resizing a selection
+    //lock aspect ratio if shift depressed
+    //resize from center if alt depressed
+    resizeMouseMove( event->lastScenePos(), event->modifiers() & Qt::ShiftModifier, event->modifiers() & Qt::AltModifier );
+  }
+
+  mLastMouseEventPos = event->lastScenePos();
+}
+
+void QgsGraphicsViewMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
+{
+  QPointF mouseMoveStopPoint = event->lastScenePos();
+  double diffX = mouseMoveStopPoint.x() - mMouseMoveStartPos.x();
+  double diffY = mouseMoveStopPoint.y() - mMouseMoveStartPos.y();
+
+  //it was only a click
+  if ( std::fabs( diffX ) < std::numeric_limits<double>::min() && std::fabs( diffY ) < std::numeric_limits<double>::min() )
+  {
+    mIsDragging = false;
+    mIsResizing = false;
+    update();
+    hideAlignItems();
+    return;
+  }
+
+  if ( mCurrentMouseMoveAction == MoveItem )
+  {
+    //move selected items
+    startMacroCommand( tr( "Move Items" ) );
+
+    QPointF mEndHandleMovePos = scenePos();
+
+    double deltaX = mEndHandleMovePos.x() - mBeginHandlePos.x();
+    double deltaY = mEndHandleMovePos.y() - mBeginHandlePos.y();
+
+    //move all selected items
+    const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+    for ( QGraphicsItem *item : selectedItems )
+    {
+      if ( itemIsLocked( item ) || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 || itemIsGroupMember( item ) )
+      {
+        //don't move locked items, or grouped items (group takes care of that)
+        continue;
+      }
+
+      createItemCommand( item );
+      moveItem( item, deltaX, deltaY );
+      endItemCommand( item );
+    }
+    endMacroCommand();
+  }
+  else if ( mCurrentMouseMoveAction != NoAction )
+  {
+    //resize selected items
+    startMacroCommand( tr( "Resize Items" ) );
+
+    //resize all selected items
+    const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+    for ( QGraphicsItem *item : selectedItems )
+    {
+      if ( itemIsLocked( item ) || ( item->flags() & QGraphicsItem::ItemIsSelectable ) == 0 )
+      {
+        //don't resize locked items or deselectable items (e.g., items which make up an item group)
+        continue;
+      }
+      createItemCommand( item );
+
+      QRectF thisItemRect;
+      if ( selectedItems.size() == 1 )
+      {
+        //only a single item is selected, so set its size to the final resized mouse handle size
+        thisItemRect = mResizeRect;
+      }
+      else
+      {
+        //multiple items selected, so each needs to be scaled relatively to the final size of the mouse handles
+        thisItemRect = mapRectFromItem( item, itemRect( item ) );
+        relativeResizeRect( thisItemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
+      }
+
+      thisItemRect = thisItemRect.normalized();
+      QPointF newPos = mapToScene( thisItemRect.topLeft() );
+      thisItemRect.moveTopLeft( newPos );
+      setItemRect( item, thisItemRect );
+
+      endItemCommand( item );
+    }
+    endMacroCommand();
+  }
+
+  hideAlignItems();
+  if ( mIsDragging )
+  {
+    mIsDragging = false;
+  }
+  if ( mIsResizing )
+  {
+    mIsResizing = false;
+  }
+
+  //reset default action
+  mCurrentMouseMoveAction = MoveItem;
+  setViewportCursor( Qt::ArrowCursor );
+  //redraw handles
+  resetTransform();
+  updateHandles();
+  //reset status bar message
+  resetStatusBar();
+}
+
+bool QgsGraphicsViewMouseHandles::selectionRotation( double &rotation ) const
+{
+  //check if all selected items have same rotation
+  QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  auto itemIter = selectedItems.constBegin();
+
+  //start with rotation of first selected item
+  double firstItemRotation = ( *itemIter )->rotation();
+
+  //iterate through remaining items, checking if they have same rotation
+  for ( ++itemIter; itemIter != selectedItems.constEnd(); ++itemIter )
+  {
+    if ( !qgsDoubleNear( ( *itemIter )->rotation(), firstItemRotation ) )
+    {
+      //item has a different rotation, so return false
+      return false;
+    }
+  }
+
+  //all items have the same rotation, so set the rotation variable and return true
+  rotation = firstItemRotation;
+  return true;
+}
+
+void QgsGraphicsViewMouseHandles::updateHandles()
+{
+  //recalculate size and position of handle item
+
+  //first check to see if any items are selected
+  QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  if ( !selectedItems.isEmpty() )
+  {
+    //one or more items are selected, get bounds of all selected items
+
+    //update rotation of handle object
+    double rotation;
+    if ( selectionRotation( rotation ) )
+    {
+      //all items share a common rotation value, so we rotate the mouse handles to match
+      setRotation( rotation );
+    }
+    else
+    {
+      //items have varying rotation values - we can't rotate the mouse handles to match
+      setRotation( 0 );
+    }
+
+    //get bounds of all selected items
+    QRectF newHandleBounds = selectionBounds();
+
+    //update size and position of handle object
+    setRect( 0, 0, newHandleBounds.width(), newHandleBounds.height() );
+    setPos( mapToScene( newHandleBounds.topLeft() ) );
+
+    show();
+  }
+  else
+  {
+    //no items selected, hide handles
+    hide();
+  }
+  //force redraw
+  update();
+}
+
+void QgsGraphicsViewMouseHandles::dragMouseMove( QPointF currentPosition, bool lockMovement, bool preventSnap )
+{
+  if ( !scene() )
+  {
+    return;
+  }
+
+  //calculate total amount of mouse movement since drag began
+  double moveX = currentPosition.x() - mBeginMouseEventPos.x();
+  double moveY = currentPosition.y() - mBeginMouseEventPos.y();
+
+  //find target position before snapping (in scene coordinates)
+  QPointF upperLeftPoint( mBeginHandlePos.x() + moveX, mBeginHandlePos.y() + moveY );
+
+  QPointF snappedLeftPoint;
+
+  //no snapping for rotated items for now
+  if ( !preventSnap && qgsDoubleNear( rotation(), 0.0 ) )
+  {
+    //snap to grid and guides
+    snappedLeftPoint = snapPoint( upperLeftPoint, Item );
+  }
+  else
+  {
+    //no snapping
+    snappedLeftPoint = upperLeftPoint;
+    hideAlignItems();
+  }
+
+  //calculate total shift for item from beginning of drag operation to current position
+  double moveRectX = snappedLeftPoint.x() - mBeginHandlePos.x();
+  double moveRectY = snappedLeftPoint.y() - mBeginHandlePos.y();
+
+  if ( lockMovement )
+  {
+    //constrained (shift) moving should lock to horizontal/vertical movement
+    //reset the smaller of the x/y movements
+    if ( std::fabs( moveRectX ) <= std::fabs( moveRectY ) )
+    {
+      moveRectX = 0;
+    }
+    else
+    {
+      moveRectY = 0;
+    }
+  }
+
+  //shift handle item to new position
+  QTransform moveTransform;
+  moveTransform.translate( moveRectX, moveRectY );
+  setTransform( moveTransform );
+
+  //show current displacement of selection in status bar
+  showStatusMessage( tr( "dx: %1 mm dy: %2 mm" ).arg( moveRectX ).arg( moveRectY ) );
+}
+
+void QgsGraphicsViewMouseHandles::resizeMouseMove( QPointF currentPosition, bool lockRatio, bool fromCenter )
+{
+  if ( !scene() )
+  {
+    return;
+  }
+
+  double mx = 0.0, my = 0.0, rx = 0.0, ry = 0.0;
+
+  QPointF beginMousePos;
+  QPointF finalPosition;
+  if ( qgsDoubleNear( rotation(), 0.0 ) )
+  {
+    //snapping only occurs if handles are not rotated for now
+
+    bool snapVertical = mCurrentMouseMoveAction == ResizeLeft ||
+                        mCurrentMouseMoveAction == ResizeRight ||
+                        mCurrentMouseMoveAction == ResizeLeftUp ||
+                        mCurrentMouseMoveAction == ResizeRightUp ||
+                        mCurrentMouseMoveAction == ResizeLeftDown ||
+                        mCurrentMouseMoveAction == ResizeRightDown;
+
+    bool snapHorizontal = mCurrentMouseMoveAction == ResizeUp ||
+                          mCurrentMouseMoveAction == ResizeDown ||
+                          mCurrentMouseMoveAction == ResizeLeftUp ||
+                          mCurrentMouseMoveAction == ResizeRightUp ||
+                          mCurrentMouseMoveAction == ResizeLeftDown ||
+                          mCurrentMouseMoveAction == ResizeRightDown;
+
+    //subtract cursor edge offset from begin mouse event and current cursor position, so that snapping occurs to edge of mouse handles
+    //rather then cursor position
+    beginMousePos = mapFromScene( QPointF( mBeginMouseEventPos.x() - mCursorOffset.width(), mBeginMouseEventPos.y() - mCursorOffset.height() ) );
+    QPointF snappedPosition = snapPoint( QPointF( currentPosition.x() - mCursorOffset.width(), currentPosition.y() - mCursorOffset.height() ), Point, snapHorizontal, snapVertical );
+    finalPosition = mapFromScene( snappedPosition );
+  }
+  else
+  {
+    //no snapping for rotated items for now
+    beginMousePos = mapFromScene( mBeginMouseEventPos );
+    finalPosition = mapFromScene( currentPosition );
+  }
+
+  double diffX = finalPosition.x() - beginMousePos.x();
+  double diffY = finalPosition.y() - beginMousePos.y();
+
+  double ratio = 0;
+  if ( lockRatio && !qgsDoubleNear( mBeginHandleHeight, 0.0 ) )
+  {
+    ratio = mBeginHandleWidth / mBeginHandleHeight;
+  }
+
+  switch ( mCurrentMouseMoveAction )
+  {
+    //vertical resize
+    case ResizeUp:
+    {
+      if ( ratio )
+      {
+        diffX = ( ( mBeginHandleHeight - diffY ) * ratio ) - mBeginHandleWidth;
+        mx = -diffX / 2;
+        my = diffY;
+        rx = diffX;
+        ry = -diffY;
+      }
+      else
+      {
+        mx = 0;
+        my = diffY;
+        rx = 0;
+        ry = -diffY;
+      }
+      break;
+    }
+
+    case ResizeDown:
+    {
+      if ( ratio )
+      {
+        diffX = ( ( mBeginHandleHeight + diffY ) * ratio ) - mBeginHandleWidth;
+        mx = -diffX / 2;
+        my = 0;
+        rx = diffX;
+        ry = diffY;
+      }
+      else
+      {
+        mx = 0;
+        my = 0;
+        rx = 0;
+        ry = diffY;
+      }
+      break;
+    }
+
+    //horizontal resize
+    case ResizeLeft:
+    {
+      if ( ratio )
+      {
+        diffY = ( ( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
+        mx = diffX;
+        my = -diffY / 2;
+        rx = -diffX;
+        ry = diffY;
+      }
+      else
+      {
+        mx = diffX, my = 0;
+        rx = -diffX;
+        ry = 0;
+      }
+      break;
+    }
+
+    case ResizeRight:
+    {
+      if ( ratio )
+      {
+        diffY = ( ( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
+        mx = 0;
+        my = -diffY / 2;
+        rx = diffX;
+        ry = diffY;
+      }
+      else
+      {
+        mx = 0;
+        my = 0;
+        rx = diffX, ry = 0;
+      }
+      break;
+    }
+
+    //diagonal resize
+    case ResizeLeftUp:
+    {
+      if ( ratio )
+      {
+        //ratio locked resize
+        if ( ( mBeginHandleWidth - diffX ) / ( mBeginHandleHeight - diffY ) > ratio )
+        {
+          diffX = mBeginHandleWidth - ( ( mBeginHandleHeight - diffY ) * ratio );
+        }
+        else
+        {
+          diffY = mBeginHandleHeight - ( ( mBeginHandleWidth - diffX ) / ratio );
+        }
+      }
+      mx = diffX, my = diffY;
+      rx = -diffX;
+      ry = -diffY;
+      break;
+    }
+
+    case ResizeRightDown:
+    {
+      if ( ratio )
+      {
+        //ratio locked resize
+        if ( ( mBeginHandleWidth + diffX ) / ( mBeginHandleHeight + diffY ) > ratio )
+        {
+          diffX = ( ( mBeginHandleHeight + diffY ) * ratio ) - mBeginHandleWidth;
+        }
+        else
+        {
+          diffY = ( ( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
+        }
+      }
+      mx = 0;
+      my = 0;
+      rx = diffX, ry = diffY;
+      break;
+    }
+
+    case ResizeRightUp:
+    {
+      if ( ratio )
+      {
+        //ratio locked resize
+        if ( ( mBeginHandleWidth + diffX ) / ( mBeginHandleHeight - diffY ) > ratio )
+        {
+          diffX = ( ( mBeginHandleHeight - diffY ) * ratio ) - mBeginHandleWidth;
+        }
+        else
+        {
+          diffY = mBeginHandleHeight - ( ( mBeginHandleWidth + diffX ) / ratio );
+        }
+      }
+      mx = 0;
+      my = diffY, rx = diffX, ry = -diffY;
+      break;
+    }
+
+    case ResizeLeftDown:
+    {
+      if ( ratio )
+      {
+        //ratio locked resize
+        if ( ( mBeginHandleWidth - diffX ) / ( mBeginHandleHeight + diffY ) > ratio )
+        {
+          diffX = mBeginHandleWidth - ( ( mBeginHandleHeight + diffY ) * ratio );
+        }
+        else
+        {
+          diffY = ( ( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
+        }
+      }
+      mx = diffX, my = 0;
+      rx = -diffX;
+      ry = diffY;
+      break;
+    }
+
+    case MoveItem:
+    case SelectItem:
+    case NoAction:
+      break;
+  }
+
+  //resizing from center of objects?
+  if ( fromCenter )
+  {
+    my = -ry;
+    mx = -rx;
+    ry = 2 * ry;
+    rx = 2 * rx;
+  }
+
+  //update selection handle rectangle
+
+  //make sure selection handle size rectangle is normalized (ie, left coord < right coord)
+  mResizeMoveX = mBeginHandleWidth + rx > 0 ? mx : mx + mBeginHandleWidth + rx;
+  mResizeMoveY = mBeginHandleHeight + ry > 0 ? my : my + mBeginHandleHeight + ry;
+
+  //calculate movement in scene coordinates
+  QLineF translateLine = QLineF( 0, 0, mResizeMoveX, mResizeMoveY );
+  translateLine.setAngle( translateLine.angle() - rotation() );
+  QPointF sceneTranslate = translateLine.p2();
+
+  //move selection handles
+  QTransform itemTransform;
+  itemTransform.translate( sceneTranslate.x(), sceneTranslate.y() );
+  setTransform( itemTransform );
+
+  //handle non-normalised resizes - e.g., dragging the left handle so far to the right that it's past the right handle
+  if ( mBeginHandleWidth + rx >= 0 && mBeginHandleHeight + ry >= 0 )
+  {
+    mResizeRect = QRectF( 0, 0, mBeginHandleWidth + rx, mBeginHandleHeight + ry );
+  }
+  else if ( mBeginHandleHeight + ry >= 0 )
+  {
+    mResizeRect = QRectF( QPointF( -( mBeginHandleWidth + rx ), 0 ), QPointF( 0, mBeginHandleHeight + ry ) );
+  }
+  else if ( mBeginHandleWidth + rx >= 0 )
+  {
+    mResizeRect = QRectF( QPointF( 0, -( mBeginHandleHeight + ry ) ), QPointF( mBeginHandleWidth + rx, 0 ) );
+  }
+  else
+  {
+    mResizeRect = QRectF( QPointF( -( mBeginHandleWidth + rx ), -( mBeginHandleHeight + ry ) ), QPointF( 0, 0 ) );
+  }
+
+  setRect( 0, 0, std::fabs( mBeginHandleWidth + rx ), std::fabs( mBeginHandleHeight + ry ) );
+
+  //show current size of selection in status bar
+  showStatusMessage( tr( "width: %1 mm height: %2 mm" ).arg( rect().width() ).arg( rect().height() ) );
+
+}
 
 void QgsGraphicsViewMouseHandles::mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event )
 {
@@ -364,6 +1041,45 @@ QSizeF QgsGraphicsViewMouseHandles::calcCursorEdgeOffset( QPointF cursorPos )
   }
 
   return QSizeF();
+}
+
+QRectF QgsGraphicsViewMouseHandles::selectionBounds() const
+{
+  //calculate bounds of all currently selected items in mouse handle coordinate system
+  const QList<QGraphicsItem *> selectedItems = selectedSceneItems( false );
+  auto itemIter = selectedItems.constBegin();
+
+  //start with handle bounds of first selected item
+  QRectF bounds = mapFromItem( ( *itemIter ), itemRect( *itemIter ) ).boundingRect();
+
+  //iterate through remaining items, expanding the bounds as required
+  for ( ++itemIter; itemIter != selectedItems.constEnd(); ++itemIter )
+  {
+    bounds = bounds.united( mapFromItem( ( *itemIter ), itemRect( *itemIter ) ).boundingRect() );
+  }
+
+  return bounds;
+}
+
+void QgsGraphicsViewMouseHandles::relativeResizeRect( QRectF &rectToResize, const QRectF &boundsBefore, const QRectF &boundsAfter )
+{
+  //linearly scale rectToResize relative to the scaling from boundsBefore to boundsAfter
+  double left = relativePosition( rectToResize.left(), boundsBefore.left(), boundsBefore.right(), boundsAfter.left(), boundsAfter.right() );
+  double right = relativePosition( rectToResize.right(), boundsBefore.left(), boundsBefore.right(), boundsAfter.left(), boundsAfter.right() );
+  double top = relativePosition( rectToResize.top(), boundsBefore.top(), boundsBefore.bottom(), boundsAfter.top(), boundsAfter.bottom() );
+  double bottom = relativePosition( rectToResize.bottom(), boundsBefore.top(), boundsBefore.bottom(), boundsAfter.top(), boundsAfter.bottom() );
+
+  rectToResize.setRect( left, top, right - left, bottom - top );
+}
+
+double QgsGraphicsViewMouseHandles::relativePosition( double position, double beforeMin, double beforeMax, double afterMin, double afterMax )
+{
+  //calculate parameters for linear scale between before and after ranges
+  double m = ( afterMax - afterMin ) / ( beforeMax - beforeMin );
+  double c = afterMin - ( beforeMin * m );
+
+  //return linearly scaled position
+  return m * position + c;
 }
 
 ///@endcond PRIVATE

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -105,7 +105,8 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
 
   protected:
 
-    void paintInternal( QPainter *painter, bool showHandles, bool showBoundingBoxes, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr );
+    void paintInternal( QPainter *painter, bool showHandles, bool showStaticBoundingBoxes,
+                        bool showTemporaryBoundingBoxes, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr );
 
     //! Sets the mouse cursor for the QGraphicsView attached to the composition
     virtual void setViewportCursor( Qt::CursorShape cursor ) = 0;
@@ -116,6 +117,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     virtual bool itemIsGroupMember( QGraphicsItem *item ) { Q_UNUSED( item ); return false; }
     virtual QRectF itemRect( QGraphicsItem *item ) const = 0;
     virtual void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) = 0;
+    virtual void previewItemMove( QGraphicsItem *item, double deltaX, double deltaY );
     virtual void setItemRect( QGraphicsItem *item, QRectF rect ) = 0;
     virtual void startMacroCommand( const QString &text );
     virtual void endMacroCommand();

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -1,0 +1,170 @@
+/***************************************************************************
+                             qgsgraphicsviewmousehandles.h
+                             -----------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall.dawson@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSGRAPHICSVIEWMOUSEHANDLES_H
+#define QGSGRAPHICSVIEWMOUSEHANDLES_H
+
+// We don't want to expose this in the public API
+#define SIP_NO_FILE
+
+#include <QGraphicsRectItem>
+#include <QObject>
+#include <QPointer>
+#include <memory>
+
+#include "qgis_gui.h"
+
+class QGraphicsView;
+class QInputEvent;
+
+///@cond PRIVATE
+
+/**
+ * \ingroup gui
+ * Base class for an item handling drawing of selection outlines and mouse handles in a QGraphicsView
+ *
+ * Also is responsible for mouse interactions such as resizing and moving selected items.
+ *
+ * \note not available in Python bindings
+ *
+ * \since QGIS 3.14
+*/
+class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRectItem
+{
+    Q_OBJECT
+  public:
+
+    //! Describes the action (move or resize in different direction) to be done during mouse move
+    enum MouseAction
+    {
+      MoveItem,
+      ResizeUp,
+      ResizeDown,
+      ResizeLeft,
+      ResizeRight,
+      ResizeLeftUp,
+      ResizeRightUp,
+      ResizeLeftDown,
+      ResizeRightDown,
+      SelectItem,
+      NoAction
+    };
+
+    enum ItemPositionMode
+    {
+      UpperLeft,
+      UpperMiddle,
+      UpperRight,
+      MiddleLeft,
+      Middle,
+      MiddleRight,
+      LowerLeft,
+      LowerMiddle,
+      LowerRight
+    };
+
+    enum SnapGuideMode
+    {
+      Item,
+      Point
+    };
+
+    QgsGraphicsViewMouseHandles( QGraphicsView *view );
+
+    //! Finds out which mouse move action to choose depending on the scene cursor position
+    QgsGraphicsViewMouseHandles::MouseAction mouseActionForScenePos( QPointF sceneCoordPos );
+
+    //! Returns TRUE is user is currently dragging the handles
+    bool isDragging() const { return mIsDragging; }
+
+    //! Returns TRUE is user is currently resizing with the handles
+    bool isResizing() const { return mIsResizing; }
+
+    bool shouldBlockEvent( QInputEvent *event ) const;
+
+  protected:
+
+    void paintInternal( QPainter *painter, bool showHandles, bool showBoundingBoxes, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr );
+
+    //! Draw outlines for selected items
+    virtual void drawSelectedItemBounds( QPainter *painter ) = 0;
+    //! Sets the mouse cursor for the QGraphicsView attached to the composition
+    virtual void setViewportCursor( Qt::CursorShape cursor ) = 0;
+
+    virtual QList<QGraphicsItem *> sceneItemsAtPoint( QPointF scenePoint ) = 0;
+
+    void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event ) override;
+    void hoverMoveEvent( QGraphicsSceneHoverEvent *event ) override;
+    void hoverLeaveEvent( QGraphicsSceneHoverEvent *event ) override;
+
+
+    QSizeF mCursorOffset;
+    double mResizeMoveX = 0;
+    double mResizeMoveY = 0;
+
+    //! Width and height of layout handles at beginning of resize
+    double mBeginHandleWidth = 0;
+    double mBeginHandleHeight = 0;
+
+    QRectF mResizeRect;
+
+    //! Start point of the last mouse move action (in scene coordinates)
+    QPointF mMouseMoveStartPos;
+
+    //! Position of the last mouse move event (in scene coordinates)
+    QPointF mLastMouseEventPos;
+
+    MouseAction mCurrentMouseMoveAction = NoAction;
+
+    //! True if user is currently dragging items
+    bool mIsDragging = false;
+    //! True is user is currently resizing items
+    bool mIsResizing = false;
+
+    //! Position of the mouse at beginning of move/resize (in scene coordinates)
+    QPointF mBeginMouseEventPos;
+
+    //! Position of layout handles at beginning of move/resize (in scene coordinates)
+    QPointF mBeginHandlePos;
+
+    //! Finds out which mouse move action to choose depending on the cursor position inside the widget
+    MouseAction mouseActionForPosition( QPointF itemCoordPos );
+
+    //! Calculates the distance of the mouse cursor from thed edge of the mouse handles
+    QSizeF calcCursorEdgeOffset( QPointF cursorPos );
+
+  private:
+
+    QGraphicsView *mView = nullptr;
+
+    //! Draws the handles
+    void drawHandles( QPainter *painter, double rectHandlerSize );
+
+    /**
+     * Returns the current (zoom level dependent) tolerance to decide if mouse position is close enough to the
+    item border for resizing*/
+    double rectHandlerBorderTolerance();
+
+    //! Finds out the appropriate cursor for the current mouse position in the widget (e.g. move in the middle, resize at border)
+    Qt::CursorShape cursorForPosition( QPointF itemCoordPos );
+
+
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSLAYOUTMOUSEHANDLES_H

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -116,9 +116,11 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     virtual bool itemIsLocked( QGraphicsItem *item ) { Q_UNUSED( item ); return false; }
     virtual bool itemIsGroupMember( QGraphicsItem *item ) { Q_UNUSED( item ); return false; }
     virtual QRectF itemRect( QGraphicsItem *item ) const = 0;
+    virtual QRectF storedItemRect( QGraphicsItem *item ) const;
     virtual void moveItem( QGraphicsItem *item, double deltaX, double deltaY ) = 0;
     virtual void previewItemMove( QGraphicsItem *item, double deltaX, double deltaY );
     virtual void setItemRect( QGraphicsItem *item, QRectF rect ) = 0;
+    virtual void previewSetItemRect( QGraphicsItem *item, QRectF rect );
     virtual void startMacroCommand( const QString &text );
     virtual void endMacroCommand();
     virtual void createItemCommand( QGraphicsItem *item );

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -152,34 +152,6 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     void resizeMouseMove( QPointF currentPosition, bool lockAspect, bool fromCenter );
 
 
-    QSizeF mCursorOffset;
-    double mResizeMoveX = 0;
-    double mResizeMoveY = 0;
-
-    //! Width and height of layout handles at beginning of resize
-    double mBeginHandleWidth = 0;
-    double mBeginHandleHeight = 0;
-
-    QRectF mResizeRect;
-
-    //! Start point of the last mouse move action (in scene coordinates)
-    QPointF mMouseMoveStartPos;
-
-    //! Position of the last mouse move event (in scene coordinates)
-    QPointF mLastMouseEventPos;
-
-    MouseAction mCurrentMouseMoveAction = NoAction;
-
-    //! True if user is currently dragging items
-    bool mIsDragging = false;
-    //! True is user is currently resizing items
-    bool mIsResizing = false;
-
-    //! Position of the mouse at beginning of move/resize (in scene coordinates)
-    QPointF mBeginMouseEventPos;
-
-    //! Position of layout handles at beginning of move/resize (in scene coordinates)
-    QPointF mBeginHandlePos;
 
     //! Finds out which mouse move action to choose depending on the cursor position inside the widget
     MouseAction mouseActionForPosition( QPointF itemCoordPos );
@@ -214,6 +186,35 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
   private:
 
     QGraphicsView *mView = nullptr;
+
+    QSizeF mCursorOffset;
+    double mResizeMoveX = 0;
+    double mResizeMoveY = 0;
+
+    //! Width and height of layout handles at beginning of resize
+    double mBeginHandleWidth = 0;
+    double mBeginHandleHeight = 0;
+
+    QRectF mResizeRect;
+
+    //! Start point of the last mouse move action (in scene coordinates)
+    QPointF mMouseMoveStartPos;
+
+    //! Position of the last mouse move event (in scene coordinates)
+    QPointF mLastMouseEventPos;
+
+    MouseAction mCurrentMouseMoveAction = NoAction;
+
+    //! True if user is currently dragging items
+    bool mIsDragging = false;
+    //! True is user is currently resizing items
+    bool mIsResizing = false;
+
+    //! Position of the mouse at beginning of move/resize (in scene coordinates)
+    QPointF mBeginMouseEventPos;
+
+    //! Position of layout handles at beginning of move/resize (in scene coordinates)
+    QPointF mBeginHandlePos;
 
     //! Draws the handles
     void drawHandles( QPainter *painter, double rectHandlerSize );

--- a/src/gui/qgsgraphicsviewmousehandles.h
+++ b/src/gui/qgsgraphicsviewmousehandles.h
@@ -155,7 +155,7 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
     //! Handles resizing of items during mouse move
     void resizeMouseMove( QPointF currentPosition, bool lockAspect, bool fromCenter );
 
-
+    void setHandleSize( double size );
 
     //! Finds out which mouse move action to choose depending on the cursor position inside the widget
     MouseAction mouseActionForPosition( QPointF itemCoordPos );
@@ -190,6 +190,8 @@ class GUI_EXPORT QgsGraphicsViewMouseHandles: public QObject, public QGraphicsRe
   private:
 
     QGraphicsView *mView = nullptr;
+
+    double mHandleSize = 10;
 
     QSizeF mCursorOffset;
     double mResizeMoveX = 0;

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -85,6 +85,7 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <addaction name="mActionDeleteComponents"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
@@ -156,7 +157,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>97</height>
+          <height>98</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout">
@@ -246,7 +247,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>153</height>
+          <height>152</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -592,6 +593,21 @@
    </property>
    <property name="text">
     <string>Export as Script Algorithm…</string>
+   </property>
+  </action>
+  <action name="mActionDeleteComponents">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionDeleteSelected.svg</normaloff>:/images/themes/default/mActionDeleteSelected.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Delete Selected Components</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete selected model components</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Adds:
- the ability to select multiple items at once in the model designer
- the ability to resize individual or multiple items
- the ability to delete multiple selected items
- improved model designer "tool" interaction, following the layout designer approach (e.g. alt + space = zoom drag mode, and selection tools follow their counterparts in layouts so shift+selection adds to selection, ctrl+selection removes, etc)
- selected items can be moved by the cursor keys


There's a lot of code in common with the layout classes here. I've tried to avoid as much duplication as possible, but in many cases this simple wasn't possible (due to the diamond QObject inheritance patterns which would result). I'm personally ok with the code duplication, because:
- there's still a fair amount of specialised behavior in the model/layout versions 
- I managed to refactor and keep a single common base class for the most complex code -- the mouse handle code, so there's no duplication there.
- the remaining code duplication all relates to layout / model designer view tools. And this code is very stable and hasn't been touched since the layout refactor in 3.0. It's low churn, low risk code.

Refs NRCan Contract#3000707093

Here's how it looks in action (with a particular ugly looking test model I use!)

![Peek 2020-03-11 16-18](https://user-images.githubusercontent.com/1829991/76388083-f9d4f380-63b3-11ea-8f06-97249e85ac2e.gif)
