### PR TITLE
[Tests] GeoJSON stringToFields with a feature collection

### DIFF
--- a/tests/src/core/testqgsogrutils.cpp
+++ b/tests/src/core/testqgsogrutils.cpp
@@ -479,6 +479,14 @@ void TestQgsOgrUtils::stringToFields()
   QCOMPARE( fields.at( 0 ).type(), QVariant::String );
   QCOMPARE( fields.at( 1 ).name(), QString( "height" ) );
   QCOMPARE( fields.at( 1 ).type(), QVariant::Double );
+
+  // geojson string with 2 features
+  fields = QgsOgrUtils::stringToFields( QStringLiteral( "{ \"type\": \"FeatureCollection\",\"features\":[{\n\"type\": \"Feature\",\"geometry\": {\"type\": \"Point\",\"coordinates\": [125, 10]},\"properties\": {\"name\": \"Dinagat Islands\",\"height\":5.5}}, {\n\"type\": \"Feature\",\"geometry\": {\"type\": \"Point\",\"coordinates\": [110, 20]},\"properties\": {\"name\": \"Henry Gale Island\",\"height\":6.5}}]}" ), QTextCodec::codecForName( "System" ) );
+  QCOMPARE( fields.count(), 2 );
+  QCOMPARE( fields.at( 0 ).name(), QString( "name" ) );
+  QCOMPARE( fields.at( 0 ).type(), QVariant::String );
+  QCOMPARE( fields.at( 1 ).name(), QString( "height" ) );
+  QCOMPARE( fields.at( 1 ).type(), QVariant::Double );
 }
 
 

--- a/tests/src/python/test_qgsjsonutils.py
+++ b/tests/src/python/test_qgsjsonutils.py
@@ -96,6 +96,14 @@ class TestQgsJsonUtils(unittest.TestCase):
         self.assertEqual(fields[1].name(), "height")
         self.assertEqual(fields[1].type(), QVariant.Double)
 
+        # geojson string with 2 features
+        fields = QgsJsonUtils.stringToFields('{ "type": "FeatureCollection","features":[{\n"type": "Feature","geometry": {"type": "Point","coordinates": [125, 10]},"properties": {"name": "Dinagat Islands","height":5.5}}, {\n"type": "Feature","geometry": {"type": "Point","coordinates": [110, 20]},"properties": {"name": "Henry Gale Island","height":6.5}}]}', codec)
+        self.assertEqual(fields.count(), 2)
+        self.assertEqual(fields[0].name(), "name")
+        self.assertEqual(fields[0].type(), QVariant.String)
+        self.assertEqual(fields[1].name(), "height")
+        self.assertEqual(fields[1].type(), QVariant.Double)
+
     def testEncodeValue(self):
         """ test encoding various values for use in GeoJSON strings """
         self.assertEqual(QgsJsonUtils.encodeValue(NULL), 'null')


### PR DESCRIPTION
The methode `QgsJsonUtils::stringToFields` is a wrapper to `QgsOgrUtils::stringToFields`

The `QgsOgrUtils::stringToFields` is described as
> Attempts to retrieve the fields from a string representing a collection of features using OGR.

The GeoJSON feature collection string was not covered by tests.
