### PR TITLE
Add ability to edit, import and export user expressions

### DIFF
--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -381,6 +381,14 @@ the selected expression must be a user stored expression.
 .. versionadded:: 3.12
 %End
 
+    void editSelectedUserExpression();
+%Docstring
+Edits the selected expression from the stored user expressions,
+the selected expression must be a user stored expression.
+
+.. versionadded:: 3.14
+%End
+
     const QList<QgsExpressionItem *> findExpressions( const QString &label );
 %Docstring
 Returns the list of expression items matching a ``label``.

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -389,6 +389,24 @@ the selected expression must be a user stored expression.
 .. versionadded:: 3.14
 %End
 
+    QJsonDocument exportUserExpressions();
+%Docstring
+Create the expressions JSON document storing all the user expressions to be exported.
+
+:return: the created expressions JSON file
+
+.. versionadded:: 3.14
+%End
+
+    void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
+%Docstring
+Load and permanently store the expressions from the expressions JSON document.
+
+:param expressionsDocument: the parsed expressions JSON file
+
+.. versionadded:: 3.14
+%End
+
     const QList<QgsExpressionItem *> findExpressions( const QString &label );
 %Docstring
 Returns the list of expression items matching a ``label``.

--- a/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
+++ b/python/gui/auto_generated/qgsexpressionstoredialog.sip.in
@@ -26,7 +26,7 @@ A generic dialog for editing expression text, label and help text.
     QgsExpressionStoreDialog( const QString &label,
                               const QString &expression,
                               const QString &helpText,
-                              const QStringList &existingLabels,
+                              const QStringList &existingLabels = QStringList(),
                               QWidget *parent = 0 );
 %Docstring
 Creates a QgsExpressionStoreDialog with given ``label``, ``expression`` and ``helpText``.

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -1432,20 +1432,20 @@ void QgsExpressionBuilderWidget::exportUserExpressions_pressed()
 
   settings.setValue( QStringLiteral( "lastExportExpressionsDir" ), saveFileInfo.absolutePath(), QgsSettings::App );
 
-  std::unique_ptr< QJsonDocument > exportJson = exportUserExpressions();
+  QJsonDocument exportJson = exportUserExpressions();
   QFile jsonFile( saveFileName );
 
   if ( !jsonFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
     QMessageBox::warning( this, tr( "Export user expressions" ), tr( "Error while creating the expressions file." ) );
 
-  if ( ! jsonFile.write( exportJson->toJson() ) )
+  if ( ! jsonFile.write( exportJson.toJson() ) )
     QMessageBox::warning( this, tr( "Export user expressions" ), tr( "Error while creating the expressions file." ) );
   else
     jsonFile.close();
 }
 
 
-std::unique_ptr< QJsonDocument > QgsExpressionBuilderWidget::exportUserExpressions()
+QJsonDocument QgsExpressionBuilderWidget::exportUserExpressions()
 {
   const QString group = QStringLiteral( "user" );
   QgsSettings settings;
@@ -1482,7 +1482,7 @@ std::unique_ptr< QJsonDocument > QgsExpressionBuilderWidget::exportUserExpressio
   }
 
   exportObject["expressions"] = exportList;
-  std::unique_ptr< QJsonDocument > exportJson = qgis::make_unique< QJsonDocument >( exportObject );
+  QJsonDocument exportJson = QJsonDocument( exportObject );
 
   return exportJson;
 }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -69,8 +69,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   connect( btnSaveExpression, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::storeCurrentUserExpression );
   connect( btnEditExpression, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::editSelectedUserExpression );
   connect( btnRemoveExpression, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::removeSelectedUserExpression );
-  connect( mActionImportUserExpressions, &QAction::triggered, this, &QgsExpressionBuilderWidget::importUserExpressions_pressed );
-  connect( mActionExportUserExpressions, &QAction::triggered, this, &QgsExpressionBuilderWidget::exportUserExpressions_pressed );
+  connect( btnImportExpressions, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::importUserExpressions_pressed );
+  connect( btnExportExpressions, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::exportUserExpressions_pressed );
   connect( btnClearEditor, &QPushButton::pressed, txtExpressionString, &QgsCodeEditorExpression::clear );
 
   txtHelpText->setOpenExternalLinks( true );
@@ -94,7 +94,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   btnSaveExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ) );
   btnEditExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionToggleEditing.svg" ) ) );
   btnRemoveExpression->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionDeleteSelected.svg" ) ) );
-  btnImportExportExpressions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSaveAs.svg" ) ) );
+  btnExportExpressions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionSharingExport.svg" ) ) );
+  btnImportExpressions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionSharingImport.svg" ) ) );
   btnClearEditor->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileNew.svg" ) ) );
 
   expressionTree->setContextMenuPolicy( Qt::CustomContextMenu );
@@ -1377,7 +1378,9 @@ void QgsExpressionBuilderWidget::editSelectedUserExpression()
        ( item->parent() && item->parent()->text() != mUserExpressionsGroupName ) )
     return;
 
-  QgsExpressionStoreDialog dlg { item->text(), item->getExpressionText(), item->getHelpText() };
+  QgsSettings settings;
+  QString helpText = settings.value( QStringLiteral( "user/%1/helpText" ).arg( item->text() ), "", QgsSettings::Section::Expressions ).toString();
+  QgsExpressionStoreDialog dlg { item->text(), item->getExpressionText(), helpText };
 
   if ( dlg.exec() == QDialog::DialogCode::Accepted )
   {
@@ -1490,11 +1493,11 @@ QJsonDocument QgsExpressionBuilderWidget::exportUserExpressions()
 void QgsExpressionBuilderWidget::importUserExpressions_pressed()
 {
   QgsSettings settings;
-  QString lastSaveDir = settings.value( QStringLiteral( "lastImportExpressionsDir" ), QDir::homePath(), QgsSettings::App ).toString();
+  QString lastImportDir = settings.value( QStringLiteral( "lastImportExpressionsDir" ), QDir::homePath(), QgsSettings::App ).toString();
   QString loadFileName = QFileDialog::getOpenFileName(
                            this,
                            tr( "Import User Expressions" ),
-                           lastSaveDir,
+                           lastImportDir,
                            tr( "User expressions" ) + " (*.json)" );
 
   if ( loadFileName.isEmpty() )

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -258,7 +258,7 @@ void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const
 
   // Get the item
   QModelIndex idx = mProxyModel->mapToSource( index );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -355,8 +355,8 @@ void QgsExpressionBuilderWidget::updateFunctionFileList( const QString &path )
   {
     // Create default sample entry.
     newFunctionFile( "default" );
-    txtPython->setText( QString( "'''\n#Sample custom function file\n "
-                                 "(uncomment to use and customize or Add button to create a new file) \n%1 \n '''" ).arg( txtPython->text() ) );
+    txtPython->setText( QStringLiteral( "'''\n#Sample custom function file\n "
+                                        "(uncomment to use and customize or Add button to create a new file) \n%1 \n '''" ).arg( txtPython->text() ) );
     saveFunctionFile( "default" );
   }
 }
@@ -416,7 +416,7 @@ void QgsExpressionBuilderWidget::loadFunctionCode( const QString &code )
 void QgsExpressionBuilderWidget::expressionTree_doubleClicked( const QModelIndex &index )
 {
   QModelIndex idx = mProxyModel->mapToSource( index );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -1250,7 +1250,7 @@ void QgsExpressionBuilderWidget::showContextMenu( QPoint pt )
 {
   QModelIndex idx = expressionTree->indexAt( pt );
   idx = mProxyModel->mapToSource( idx );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -1272,7 +1272,7 @@ void QgsExpressionBuilderWidget::showContextMenu( QPoint pt )
 void QgsExpressionBuilderWidget::loadSampleValues()
 {
   QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1285,7 +1285,7 @@ void QgsExpressionBuilderWidget::loadSampleValues()
 void QgsExpressionBuilderWidget::loadAllValues()
 {
   QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1298,7 +1298,7 @@ void QgsExpressionBuilderWidget::loadAllValues()
 void QgsExpressionBuilderWidget::loadSampleUsedValues()
 {
   QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1311,7 +1311,7 @@ void QgsExpressionBuilderWidget::loadSampleUsedValues()
 void QgsExpressionBuilderWidget::loadAllUsedValues()
 {
   QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1367,7 +1367,7 @@ void QgsExpressionBuilderWidget::editSelectedUserExpression()
 {
   // Get the item
   QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -1390,7 +1390,7 @@ void QgsExpressionBuilderWidget::removeSelectedUserExpression()
 
 // Get the item
   QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = dynamic_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -1603,14 +1603,14 @@ void QgsExpressionBuilderWidget::loadExpressionsFromJson( const QJsonDocument &e
     }
 
     // we want to import only items of type expression for now
-    if ( expressionObj["type"].toString() != "expression" )
+    if ( expressionObj["type"].toString() != QStringLiteral( "expression" ) )
     {
       skippedExpressionLabels.append( expressionObj["name"].toString() );
       continue;
     }
 
     // we want to import only items of type expression for now
-    if ( expressionObj["group"].toString() != "user" )
+    if ( expressionObj["group"].toString() != QStringLiteral( "user" ) )
     {
       skippedExpressionLabels.append( expressionObj["name"].toString() );
       continue;
@@ -1621,7 +1621,7 @@ void QgsExpressionBuilderWidget::loadExpressionsFromJson( const QJsonDocument &e
     const QString helpText = expressionObj["description"].toString();
 
     // make sure they have valid name
-    if ( label.contains( "\\" ) || label.contains( "/" ) )
+    if ( label.contains( "\\" ) || label.contains( '/' ) )
     {
       skippedExpressionLabels.append( expressionObj["name"].toString() );
       continue;
@@ -1657,11 +1657,11 @@ void QgsExpressionBuilderWidget::loadExpressionsFromJson( const QJsonDocument &e
   {
     QStringList skippedExpressionLabelsQuoted;
     for ( const QString &skippedExpressionLabel : skippedExpressionLabels )
-      skippedExpressionLabelsQuoted.append( QString( "'%1'" ).arg( skippedExpressionLabel ) );
+      skippedExpressionLabelsQuoted.append( QStringLiteral( "'%1'" ).arg( skippedExpressionLabel ) );
 
     QMessageBox::information( this,
                               tr( "Skipped Expression Imports" ),
-                              QString( "%1\n%2" ).arg( tr( "The following expressions have been skipped:" ),
+                              QStringLiteral( "%1\n%2" ).arg( tr( "The following expressions have been skipped:" ),
                                   skippedExpressionLabelsQuoted.join( ", " ) ) );
   }
 }
@@ -1711,7 +1711,7 @@ const QList<QgsExpressionItem *> QgsExpressionBuilderWidget::findExpressions( co
   const QList<QStandardItem *> found { mModel->findItems( label, Qt::MatchFlag::MatchRecursive ) };
   for ( const auto &item : qgis::as_const( found ) )
   {
-    result.push_back( dynamic_cast<QgsExpressionItem *>( item ) );
+    result.push_back( static_cast<QgsExpressionItem *>( item ) );
   }
   return result;
 }

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -396,8 +396,8 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     /**
      * Create the expressions JSON document storing all the user expressions to be exported.
-     * \since QGIS 3.14
      * \returns the created expressions JSON file
+     * \since QGIS 3.14
      */
     QJsonDocument *exportUserExpressions();
 
@@ -410,8 +410,8 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     /**
      * Load and permanently store the expressions from the expressions JSON document.
-     * \since QGIS 3.14
      * \param expressionsDocument the parsed expressions JSON file
+     * \since QGIS 3.14
      */
     void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
 
@@ -427,7 +427,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * \param oldExpression the old expression for a given label
      * \param newExpression the new expression for a given label
      */
-    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, QString &oldExpression, QString &newExpression );
+    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, const QString &oldExpression, const QString &newExpression );
 
     /**
      * Returns the list of expression items matching a \a label.

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -399,7 +399,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * \returns the created expressions JSON file
      * \since QGIS 3.14
      */
-    QJsonDocument *exportUserExpressions();
+    std::unique_ptr< QJsonDocument > exportUserExpressions();
 
     /**
      * Display a file dialog to choose where to load the expression JSON file from

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -388,6 +388,48 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void editSelectedUserExpression();
 
     /**
+     * Display a file dialog to choose where to store the exported expressions JSON file
+     * and saves them to the selected destination.
+     * \since QGIS 3.14
+     */
+    void exportUserExpressions_pressed();
+
+    /**
+     * Create the expressions JSON document storing all the user expressions to be exported.
+     * \since QGIS 3.14
+     * \returns the created expressions JSON file
+     */
+    QJsonDocument *exportUserExpressions();
+
+    /**
+     * Display a file dialog to choose where to load the expression JSON file from
+     * and adds them to user expressions group.
+     * \since QGIS 3.14
+     */
+    void importUserExpressions_pressed();
+
+    /**
+     * Load and permanently store the expressions from the expressions JSON document.
+     * \since QGIS 3.14
+     * \param expressionsDocument the parsed expressions JSON file
+     */
+    void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
+
+    /**
+     * Display a message box to ask the user what to do when an expression
+     * with the same \a label already exists. Answering "Yes" will replace
+     * the old expression with the one from the file, while "No" will keep
+     * the old expression.
+     * \since QGIS 3.14
+     * \param isApplyToAll whether the decision of the user should be applied to any future label collision
+     * \param isOkToOverwrite whether to overwrite the old expression with the new one in case of label collision
+     * \param label the label of the expression
+     * \param oldExpression the old expression for a given label
+     * \param newExpression the new expression for a given label
+     */
+    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, QString &oldExpression, QString &newExpression );
+
+    /**
      * Returns the list of expression items matching a \a label.
      * \since QGIS 3.12
      */

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -381,6 +381,13 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void removeSelectedUserExpression( );
 
     /**
+     * Edits the selected expression from the stored user expressions,
+     * the selected expression must be a user stored expression.
+     * \since QGIS 3.14
+     */
+    void editSelectedUserExpression();
+
+    /**
      * Returns the list of expression items matching a \a label.
      * \since QGIS 3.12
      */

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -388,25 +388,11 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void editSelectedUserExpression();
 
     /**
-     * Display a file dialog to choose where to store the exported expressions JSON file
-     * and saves them to the selected destination.
-     * \since QGIS 3.14
-     */
-    void exportUserExpressions_pressed();
-
-    /**
      * Create the expressions JSON document storing all the user expressions to be exported.
      * \returns the created expressions JSON file
      * \since QGIS 3.14
      */
-    std::unique_ptr< QJsonDocument > exportUserExpressions();
-
-    /**
-     * Display a file dialog to choose where to load the expression JSON file from
-     * and adds them to user expressions group.
-     * \since QGIS 3.14
-     */
-    void importUserExpressions_pressed();
+    QJsonDocument exportUserExpressions();
 
     /**
      * Load and permanently store the expressions from the expressions JSON document.
@@ -414,20 +400,6 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * \since QGIS 3.14
      */
     void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
-
-    /**
-     * Display a message box to ask the user what to do when an expression
-     * with the same \a label already exists. Answering "Yes" will replace
-     * the old expression with the one from the file, while "No" will keep
-     * the old expression.
-     * \since QGIS 3.14
-     * \param isApplyToAll whether the decision of the user should be applied to any future label collision
-     * \param isOkToOverwrite whether to overwrite the old expression with the new one in case of label collision
-     * \param label the label of the expression
-     * \param oldExpression the old expression for a given label
-     * \param newExpression the new expression for a given label
-     */
-    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, const QString &oldExpression, const QString &newExpression );
 
     /**
      * Returns the list of expression items matching a \a label.
@@ -444,6 +416,18 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void operatorButtonClicked();
     void btnRun_pressed();
     void btnNewFile_pressed();
+    /**
+     * Display a file dialog to choose where to store the exported expressions JSON file
+     * and saves them to the selected destination.
+     * \since QGIS 3.14
+     */
+    void exportUserExpressions_pressed();
+    /**
+     * Display a file dialog to choose where to load the expression JSON file from
+     * and adds them to user expressions group.
+     * \since QGIS 3.14
+     */
+    void importUserExpressions_pressed();
     void cmbFileNames_currentItemChanged( QListWidgetItem *item, QListWidgetItem *lastitem );
     void expressionTree_doubleClicked( const QModelIndex &index );
     void txtExpressionString_textChanged();
@@ -564,6 +548,20 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void loadFieldValues( const QVariantMap &values );
 
     void loadFieldsAndValues( const QMap<QString, QVariantMap> &fieldValues );
+
+    /**
+     * Display a message box to ask the user what to do when an expression
+     * with the same \a label already exists. Answering "Yes" will replace
+     * the old expression with the one from the file, while "No" will keep
+     * the old expression.
+     * \param isApplyToAll whether the decision of the user should be applied to any future label collision
+     * \param isOkToOverwrite whether to overwrite the old expression with the new one in case of label collision
+     * \param label the label of the expression
+     * \param oldExpression the old expression for a given label
+     * \param newExpression the new expression for a given label
+     * \since QGIS 3.14
+     */
+    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, const QString &oldExpression, const QString &newExpression );
 
     bool mAutoSave = true;
     QString mFunctionsPath;

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -416,12 +416,14 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void operatorButtonClicked();
     void btnRun_pressed();
     void btnNewFile_pressed();
+
     /**
      * Display a file dialog to choose where to store the exported expressions JSON file
      * and saves them to the selected destination.
      * \since QGIS 3.14
      */
     void exportUserExpressions_pressed();
+
     /**
      * Display a file dialog to choose where to load the expression JSON file from
      * and adds them to user expressions group.

--- a/src/gui/qgsexpressionstoredialog.h
+++ b/src/gui/qgsexpressionstoredialog.h
@@ -39,7 +39,7 @@ class GUI_EXPORT QgsExpressionStoreDialog : public QDialog, private Ui::QgsExpre
     QgsExpressionStoreDialog( const QString &label,
                               const QString &expression,
                               const QString &helpText,
-                              const QStringList &existingLabels,
+                              const QStringList &existingLabels = QStringList(),
                               QWidget *parent = nullptr );
 
     /**

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -963,15 +963,12 @@ Saved scripts are auto loaded on QGIS startup.</string>
   </layout>
   <action name="mActionImportUserExpressions">
    <property name="text">
-    <string>Import user expressions</string>
+    <string>Import User Expressions</string>
    </property>
   </action>
   <action name="mActionExportUserExpressions">
    <property name="text">
-    <string>Export user expressions</string>
-   </property>
-   <property name="toolTip">
-    <string>Export user expressions</string>
+    <string>Export User Expressions</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -101,20 +101,7 @@
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,1,0,1">
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,0">
-                <item>
-                 <spacer name="horizontalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
+               <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0">
                 <item>
                  <widget class="QFrame" name="frame_2">
                   <property name="frameShape">
@@ -169,13 +156,6 @@
                     </widget>
                    </item>
                    <item>
-                    <widget class="Line" name="line">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
                     <widget class="QToolButton" name="btnEditExpression">
                      <property name="enabled">
                       <bool>false</bool>
@@ -220,6 +200,13 @@
                       <string>Export</string>
                      </property>
                     </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_3">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                    </spacer>
                    </item>
                   </layout>
                  </widget>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -357,6 +357,19 @@
                     </widget>
                    </item>
                    <item>
+                    <widget class="QToolButton" name="btnEditExpression">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="toolTip">
+                      <string>Edit selected expression from user expressions</string>
+                     </property>
+                     <property name="text">
+                      <string>Edit</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
                     <widget class="QToolButton" name="btnRemoveExpression">
                      <property name="enabled">
                       <bool>false</bool>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -99,197 +99,9 @@
                <height>0</height>
               </size>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,1,1">
+             <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,1,0,1">
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,0,0">
-                <item>
-                 <widget class="QFrame" name="mOperatorsGroupBox">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>27</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>300</width>
-                    <height>16777215</height>
-                   </size>
-                  </property>
-                  <property name="sizeIncrement">
-                   <size>
-                    <width>20</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="baseSize">
-                   <size>
-                    <width>7</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="layoutDirection">
-                   <enum>Qt::LeftToRight</enum>
-                  </property>
-                  <property name="autoFillBackground">
-                   <bool>false</bool>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_2">
-                   <property name="spacing">
-                    <number>2</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QPushButton" name="btnEqualPushButton">
-                     <property name="toolTip">
-                      <string>Equal operator</string>
-                     </property>
-                     <property name="text">
-                      <string>=</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnPlusPushButton">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="toolTip">
-                      <string>Addition operator</string>
-                     </property>
-                     <property name="text">
-                      <string>+</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnMinusPushButton">
-                     <property name="toolTip">
-                      <string>Subtraction operator</string>
-                     </property>
-                     <property name="text">
-                      <string>-</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnDividePushButton">
-                     <property name="toolTip">
-                      <string>Division operator</string>
-                     </property>
-                     <property name="text">
-                      <string>/</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnMultiplyPushButton">
-                     <property name="toolTip">
-                      <string>Multiplication operator</string>
-                     </property>
-                     <property name="text">
-                      <string>*</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnExpButton">
-                     <property name="toolTip">
-                      <string>Power operator</string>
-                     </property>
-                     <property name="text">
-                      <string>^</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnConcatButton">
-                     <property name="toolTip">
-                      <string>String Concatenation</string>
-                     </property>
-                     <property name="text">
-                      <string>||</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnOpenBracketPushButton">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="minimumSize">
-                      <size>
-                       <width>0</width>
-                       <height>10</height>
-                      </size>
-                     </property>
-                     <property name="toolTip">
-                      <string>Open Bracket </string>
-                     </property>
-                     <property name="text">
-                      <string>(</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnCloseBracketPushButton">
-                     <property name="toolTip">
-                      <string>Close Bracket </string>
-                     </property>
-                     <property name="text">
-                      <string>)</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="btnNewLinePushButton">
-                     <property name="toolTip">
-                      <string>New Line</string>
-                     </property>
-                     <property name="text">
-                      <string>'\n'</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <spacer name="horizontalSpacer">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
+               <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,0">
                 <item>
                  <spacer name="horizontalSpacer_3">
                   <property name="orientation">
@@ -331,21 +143,6 @@
                     <number>0</number>
                    </property>
                    <item>
-                    <widget class="QToolButton" name="btnImportExportExpressions">
-                     <property name="toolTip">
-                      <string>Import/Export User Expressions</string>
-                     </property>
-                     <property name="text">
-                      <string>Import/Export</string>
-                     </property>
-                     <property name="popupMode">
-                      <enum>QToolButton::InstantPopup</enum>
-                     </property>
-                     <addaction name="mActionImportUserExpressions"/>
-                     <addaction name="mActionExportUserExpressions"/>
-                    </widget>
-                   </item>
-                   <item>
                     <widget class="QToolButton" name="btnClearEditor">
                      <property name="enabled">
                       <bool>false</bool>
@@ -368,6 +165,13 @@
                      </property>
                      <property name="text">
                       <string>Save</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
                      </property>
                     </widget>
                    </item>
@@ -397,6 +201,26 @@
                      </property>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QToolButton" name="btnImportExpressions">
+                     <property name="toolTip">
+                      <string>Import User Expressions</string>
+                     </property>
+                     <property name="text">
+                      <string>Import</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QToolButton" name="btnExportExpressions">
+                     <property name="toolTip">
+                      <string>Export User Expressions</string>
+                     </property>
+                     <property name="text">
+                      <string>Export</string>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </widget>
                 </item>
@@ -404,6 +228,194 @@
               </item>
               <item>
                <widget class="QgsCodeEditorExpression" name="txtExpressionString" native="true"/>
+              </item>
+              <item>
+               <widget class="QFrame" name="mOperatorsGroupBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>27</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>300</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="sizeIncrement">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="baseSize">
+                 <size>
+                  <width>7</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="autoFillBackground">
+                 <bool>false</bool>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_2">
+                 <property name="spacing">
+                  <number>2</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="btnEqualPushButton">
+                   <property name="toolTip">
+                    <string>Equal operator</string>
+                   </property>
+                   <property name="text">
+                    <string>=</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnPlusPushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                    <string>Addition operator</string>
+                   </property>
+                   <property name="text">
+                    <string>+</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnMinusPushButton">
+                   <property name="toolTip">
+                    <string>Subtraction operator</string>
+                   </property>
+                   <property name="text">
+                    <string>-</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnDividePushButton">
+                   <property name="toolTip">
+                    <string>Division operator</string>
+                   </property>
+                   <property name="text">
+                    <string>/</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnMultiplyPushButton">
+                   <property name="toolTip">
+                    <string>Multiplication operator</string>
+                   </property>
+                   <property name="text">
+                    <string>*</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnExpButton">
+                   <property name="toolTip">
+                    <string>Power operator</string>
+                   </property>
+                   <property name="text">
+                    <string>^</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnConcatButton">
+                   <property name="toolTip">
+                    <string>String Concatenation</string>
+                   </property>
+                   <property name="text">
+                    <string>||</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnOpenBracketPushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>10</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Open Bracket </string>
+                   </property>
+                   <property name="text">
+                    <string>(</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnCloseBracketPushButton">
+                   <property name="toolTip">
+                    <string>Close Bracket </string>
+                   </property>
+                   <property name="text">
+                    <string>)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnNewLinePushButton">
+                   <property name="toolTip">
+                    <string>New Line</string>
+                   </property>
+                   <property name="text">
+                    <string>'\n'</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </widget>
               </item>
               <item>
                <layout class="QGridLayout" name="gridLayout">
@@ -961,18 +973,14 @@ Saved scripts are auto loaded on QGIS startup.</string>
     </widget>
    </item>
   </layout>
-  <action name="mActionImportUserExpressions">
-   <property name="text">
-    <string>Import User Expressions</string>
-   </property>
-  </action>
-  <action name="mActionExportUserExpressions">
-   <property name="text">
-    <string>Export User Expressions</string>
-   </property>
-  </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
@@ -988,12 +996,6 @@ Saved scripts are auto loaded on QGIS startup.</string>
    <class>QgsCodeEditorPython</class>
    <extends>QWidget</extends>
    <header>qgscodeeditorpython.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -331,6 +331,21 @@
                     <number>0</number>
                    </property>
                    <item>
+                    <widget class="QToolButton" name="btnImportExportExpressions">
+                     <property name="toolTip">
+                      <string>Import/Export User Expressions</string>
+                     </property>
+                     <property name="text">
+                      <string>Import/Export</string>
+                     </property>
+                     <property name="popupMode">
+                      <enum>QToolButton::InstantPopup</enum>
+                     </property>
+                     <addaction name="mActionImportUserExpressions"/>
+                     <addaction name="mActionExportUserExpressions"/>
+                    </widget>
+                   </item>
+                   <item>
                     <widget class="QToolButton" name="btnClearEditor">
                      <property name="enabled">
                       <bool>false</bool>
@@ -946,6 +961,19 @@ Saved scripts are auto loaded on QGIS startup.</string>
     </widget>
    </item>
   </layout>
+  <action name="mActionImportUserExpressions">
+   <property name="text">
+    <string>Import user expressions</string>
+   </property>
+  </action>
+  <action name="mActionExportUserExpressions">
+   <property name="text">
+    <string>Export user expressions</string>
+   </property>
+   <property name="toolTip">
+    <string>Export user expressions</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
## Description

Add ability to edit, import and export user expressions

Fixes qgis#34690, qgis#28478

#### Edit
A new button is added that allow to edit saved expressions. It is only active when a user expression is selected in the expressions tree. When pressed, it opens a window that allows editing the currently selected user expression. Changing the label of the expression makes a copy of the currently existing one.
Demo [Edit](https://imgur.com/w3UEOoR)
#### Import/Export
A new button with menu is added, that allows to import/export user expressions from/to a JSON file. Clicking on either of the menu entries opens a file selector dialog for the expressions JSON file source/destination. In case of label conflicts, additional dialog asks how to proceed - either to overwrite or to skip the current expression.
Demo [Import/Export](https://imgur.com/0eiaFfu)
