### PR TITLE
[server] Use request.data() instead of parameter REQUEST_BODY

### DIFF
--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -111,7 +111,7 @@ namespace QgsWfs
     QStringList typeNameList;
     QDomDocument queryDoc;
     QString errorMsg;
-    if ( queryDoc.setContent( parameters.value( QStringLiteral( "REQUEST_BODY" ) ), true, &errorMsg ) )
+    if ( queryDoc.setContent( request.data(), true, &errorMsg ) )
     {
       //read doc
       QDomElement queryDocElem = queryDoc.documentElement();

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -103,7 +103,7 @@ namespace QgsWfs
     QDomDocument doc;
     QString errorMsg;
 
-    if ( doc.setContent( mRequestParameters.value( QStringLiteral( "REQUEST_BODY" ) ), true, &errorMsg ) )
+    if ( doc.setContent( request.data(), true, &errorMsg ) )
     {
       QDomElement docElem = doc.documentElement();
       aRequest = parseGetFeatureRequestBody( docElem, project );

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -72,7 +72,7 @@ namespace QgsWfs
     QDomDocument doc;
     QString errorMsg;
 
-    if ( doc.setContent( parameters.value( QStringLiteral( "REQUEST_BODY" ) ), true, &errorMsg ) )
+    if ( doc.setContent( request.data(), true, &errorMsg ) )
     {
       QDomElement docElem = doc.documentElement();
       aRequest = parseTransactionRequestBody( docElem, project );

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -70,7 +70,7 @@ namespace QgsWfs
       QDomDocument doc;
       QString errorMsg;
 
-      if ( doc.setContent( parameters.value( QStringLiteral( "REQUEST_BODY" ) ), true, &errorMsg ) )
+      if ( doc.setContent( request.data(), true, &errorMsg ) )
       {
         QDomElement docElem = doc.documentElement();
         aRequest = parseTransactionRequestBody( docElem, project );


### PR DESCRIPTION
#34701  Description

Better fix than https://github.com/qgis/QGIS/pull/34268

Use `request.data()` REQUEST_BODY parameter to create `QDomDocument` in POST requests.

Parameter REQUEST_BODY is not used anymore except in tests, but I've not removed it in case some plugins use it, but it might be completely removed in future version.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
