### PR TITLE
fix 'fields and values' not accessible in expression editor in default values

### DIFF
--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -71,6 +71,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   }
 
   mExpressionWidget->registerExpressionContextGenerator( this );
+  mExpressionWidget->setLayer( mLayer );
 
   connect( mExpressionWidget, &QgsExpressionLineEdit::expressionChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
   connect( mUniqueCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -79,15 +79,16 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
     mCheckBoxEnforceUnique->setEnabled( checked );
     if ( !checked )
       mCheckBoxEnforceUnique->setChecked( false );
-  }
-         );
+  } );
   connect( notNullCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )
   {
     mCheckBoxEnforceNotNull->setEnabled( checked );
     if ( !checked )
       mCheckBoxEnforceNotNull->setChecked( false );
-  }
-         );
+  } );
+
+  mWarnDefaultValueHasFieldsWidget->setVisible( false );
+  connect( mApplyDefaultValueOnUpdateCheckBox, &QCheckBox::stateChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
 
   constraintExpressionWidget->setAllowEmptyFieldName( true );
   constraintExpressionWidget->setLayer( vl );
@@ -358,6 +359,8 @@ void QgsAttributeTypeDialog::setLabelOnTop( bool onTop )
 
 void QgsAttributeTypeDialog::defaultExpressionChanged()
 {
+  mWarnDefaultValueHasFieldsWidget->hide();
+
   QString expression = mExpressionWidget->expression();
   if ( expression.isEmpty() )
   {
@@ -391,6 +394,11 @@ void QgsAttributeTypeDialog::defaultExpressionChanged()
     mDefaultPreviewLabel->setText( "<i>" + exp.evalErrorString() + "</i>" );
     return;
   }
+
+  // if the expression uses fields and it's not on update,
+  // there is no warranty that the field will be available
+  bool expressionHasFields = exp.referencedAttributeIndexes( mLayer->fields() ).count() > 0;
+  mWarnDefaultValueHasFieldsWidget->setVisible( expressionHasFields && !mApplyDefaultValueOnUpdateCheckBox->isChecked() );
 
   QgsFieldFormatter *fieldFormatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( editorWidgetType() );
 

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -235,7 +235,7 @@
          <item>
           <widget class="QLabel" name="label_7">
            <property name="text">
-            <string>The expression is using fields on insert. This behavior is not guaranteed.</string>
+            <string>Using fields in a default value expression only works if "Apply default value on update" is checked.</string>
            </property>
           </widget>
          </item>

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -184,36 +184,65 @@
      <property name="title">
       <string>Defaults</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-      <item row="1" column="0">
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Default value</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="mDefaultPreviewLabel">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsExpressionLineEdit" name="mExpressionWidget" native="true">
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Preview</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="4" column="1">
+       <widget class="QgsExpressionLineEdit" name="mExpressionWidget" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="mDefaultPreviewLabel">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QWidget" name="mWarnDefaultValueHasFieldsWidget" native="true">
+        <layout class="QHBoxLayout" name="mWarnDefaultValueHasFields">
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="pixmap">
+            <pixmap resource="../../../images/images.qrc">:/images/themes/default/mIconWarning.svg</pixmap>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>The expression is using fields on insert. This behavior is not guaranteed.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="2">
        <widget class="QCheckBox" name="mApplyDefaultValueOnUpdateCheckBox">
         <property name="toolTip">
          <string>&lt;p&gt;With this option checked, the default value will not only be used when the feature is first created, but also whenever a feature's attribute or geometry is changed.&lt;/p&gt;&lt;p&gt;This is often useful for a last_modified timestamp or to record the username that last modified the feature.&lt;/p&gt;</string>
@@ -274,8 +303,10 @@
   <tabstop>leConstraintExpressionDescription</tabstop>
   <tabstop>mCheckBoxEnforceExpression</tabstop>
   <tabstop>mExpressionWidget</tabstop>
-  <tabstop>mApplyDefaultValueOnUpdateCheckBox</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
even if the expression generator is set, the expression dialog needs a pointer to the vector layer to behave es expected
