### PR TITLE
Refresh features in Attribute Table on data change

### DIFF
--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -242,11 +242,13 @@ selection state of the feature in case selected features are to be shown on top.
 
   public slots:
 
-    void reloadVisible();
+ void extentsChanged();
 %Docstring
-Is called upon every change of the visible extents on the map canvas or when data of
-the master table model change.
+Is called upon every change of the visible extents on the map canvas.
 When a change is signalled, the filter is updated and invalidated if needed.
+
+.. deprecated:: QGIS 3.10.3
+   - made private as reloadVisible()
 %End
 
     void filterFeatures();

--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -234,9 +234,10 @@ selection state of the feature in case selected features are to be shown on top.
 
   public slots:
 
-    void extentsChanged();
+    void reloadVisible();
 %Docstring
-Is called upon every change of the visible extents on the map canvas.
+Is called upon every change of the visible extents on the map canvas or when data of
+the master table model changes.
 When a change is signalled, the filter is updated and invalidated if needed.
 %End
 

--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -200,8 +200,8 @@ is shown.
 
     void setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context );
 %Docstring
-Set the ``expression`` to be stored in case of the features need to be
-filtered (like on filter or on main model data change).
+Set the ``expression`` and the ``context`` to be stored in case of the features
+need to be filtered again (like on filter or on main model data change).
 %End
 
   signals:
@@ -243,11 +243,14 @@ selection state of the feature in case selected features are to be shown on top.
     void reloadVisible();
 %Docstring
 Is called upon every change of the visible extents on the map canvas or when data of
-the master table model changes.
+the master table model change.
 When a change is signalled, the filter is updated and invalidated if needed.
 %End
 
     void filterFeatures();
+%Docstring
+Is called when the data changed of the main table moment to update the filter model.
+%End
 
 };
 

--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -202,6 +202,8 @@ is shown.
 %Docstring
 Set the ``expression`` and the ``context`` to be stored in case of the features
 need to be filtered again (like on filter or on main model data change).
+
+.. versionadded:: 3.10.3
 %End
 
   signals:
@@ -249,7 +251,10 @@ When a change is signalled, the filter is updated and invalidated if needed.
 
     void filterFeatures();
 %Docstring
-Is called when the data changed of the main table moment to update the filter model.
+Updates the filtered features in the filter model. It is called when the data of the
+main table or the filter expression changed.
+
+.. versionadded:: 3.10.3
 %End
 
 };

--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -198,6 +198,12 @@ in which order they are shown as well as if and where an action column
 is shown.
 %End
 
+    void setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context );
+%Docstring
+Set the ``expression`` to be stored in case of the features need to be
+filtered (like on filter or on main model data change).
+%End
+
   signals:
 
     void sortColumnChanged( int column, Qt::SortOrder order );
@@ -240,6 +246,8 @@ Is called upon every change of the visible extents on the map canvas or when dat
 the master table model changes.
 When a change is signalled, the filter is updated and invalidated if needed.
 %End
+
+    void filterFeatures();
 
 };
 

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -133,6 +133,12 @@ Set a list of currently visible features
 %End
 
     void filterFeatures( const QgsExpression &filterExpression, const QgsExpressionContext &context );
+%Docstring
+Sets the expression and Updates the filtered features in the filter model.
+It is called when the filter expression changed.
+
+.. versionadded:: 3.10.3
+%End
 
     QgsFeatureIds filteredFeatures();
 %Docstring

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -122,12 +122,17 @@ filter restrictions
 :return: Number of features
 %End
 
-    void setFilteredFeatures( const QgsFeatureIds &filteredFeatures );
+ void setFilteredFeatures( const QgsFeatureIds &filteredFeatures );
 %Docstring
 Set a list of currently visible features
 
 :param filteredFeatures: A list of feature ids
+
+.. deprecated::
+   since filterFeatures is handled in the attribute filter model itself
 %End
+
+    void filterFeatures( const QgsExpression &filterExpression, const QgsExpressionContext &context );
 
     QgsFeatureIds filteredFeatures();
 %Docstring

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -389,6 +389,11 @@ bool QgsAttributeTableFilterModel::filterAcceptsRow( int sourceRow, const QModel
   // returns are handled in their respective case statement above
 }
 
+void QgsAttributeTableFilterModel::extentsChanged()
+{
+  reloadVisible();
+}
+
 void QgsAttributeTableFilterModel::reloadVisible()
 {
   generateListOfVisibleFeatures();

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -227,6 +227,12 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
     sort( config.sortExpression(), config.sortOrder() );
 }
 
+void QgsAttributeTableFilterModel::setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context )
+{
+  mFilterExpression = expression;
+  mFilterExpressionContext = context;
+}
+
 void QgsAttributeTableFilterModel::sort( const QString &expression, Qt::SortOrder order )
 {
   if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
@@ -395,16 +401,16 @@ void QgsAttributeTableFilterModel::filterFeatures()
     return;
 
   QgsFeatureIds filteredFeatures;
-  QgsDistanceArea myDa;
+  QgsDistanceArea distanceArea;
 
-  myDa.setSourceCrs( mTableModel->layer()->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  distanceArea.setSourceCrs( mTableModel->layer()->crs(), QgsProject::instance()->transformContext() );
+  distanceArea.setEllipsoid( QgsProject::instance()->ellipsoid() );
 
-  bool fetchGeom = mFilterExpression.needsGeometry();
+  const bool fetchGeom = mFilterExpression.needsGeometry();
 
   QApplication::setOverrideCursor( Qt::WaitCursor );
 
-  mFilterExpression.setGeomCalculator( &myDa );
+  mFilterExpression.setGeomCalculator( &distanceArea );
   mFilterExpression.setDistanceUnits( QgsProject::instance()->distanceUnits() );
   mFilterExpression.setAreaUnits( QgsProject::instance()->areaUnits() );
   QgsFeatureRequest request( mTableModel->request() );

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -313,12 +313,14 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
   {
     if ( filterMode == ShowVisible )
     {
-      connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::extentsChanged );
+      connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+      connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
       generateListOfVisibleFeatures();
     }
     else
     {
-      disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::extentsChanged );
+      disconnect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
+      disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
     }
 
     mFilterMode = filterMode;
@@ -371,7 +373,7 @@ bool QgsAttributeTableFilterModel::filterAcceptsRow( int sourceRow, const QModel
   // returns are handled in their respective case statement above
 }
 
-void QgsAttributeTableFilterModel::extentsChanged()
+void QgsAttributeTableFilterModel::reloadVisible()
 {
   generateListOfVisibleFeatures();
   invalidateFilter();

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -26,6 +26,7 @@
 #include "qgsrenderer.h"
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsexpressioncontextutils.h"
+#include "qgsapplication.h"
 
 //////////////////
 // Filter Model //
@@ -323,6 +324,15 @@ void QgsAttributeTableFilterModel::setFilterMode( FilterMode filterMode )
       disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::reloadVisible );
     }
 
+    if ( filterMode == ShowFilteredList )
+    {
+      connect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+    }
+    else
+    {
+      disconnect( mTableModel, &QgsAttributeTableModel::dataChanged, this, &QgsAttributeTableFilterModel::filterFeatures );
+    }
+
     mFilterMode = filterMode;
     invalidateFilter();
   }
@@ -378,6 +388,58 @@ void QgsAttributeTableFilterModel::reloadVisible()
   generateListOfVisibleFeatures();
   invalidateFilter();
 }
+
+void QgsAttributeTableFilterModel::filterFeatures()
+{
+  if ( !mFilterExpression.isValid() )
+    return;
+
+  QgsFeatureIds filteredFeatures;
+  QgsDistanceArea myDa;
+
+  myDa.setSourceCrs( mTableModel->layer()->crs(), QgsProject::instance()->transformContext() );
+  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+
+  bool fetchGeom = mFilterExpression.needsGeometry();
+
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+
+  mFilterExpression.setGeomCalculator( &myDa );
+  mFilterExpression.setDistanceUnits( QgsProject::instance()->distanceUnits() );
+  mFilterExpression.setAreaUnits( QgsProject::instance()->areaUnits() );
+  QgsFeatureRequest request( mTableModel->request() );
+  request.setSubsetOfAttributes( mFilterExpression.referencedColumns(), mTableModel->layer()->fields() );
+  if ( !fetchGeom )
+  {
+    request.setFlags( QgsFeatureRequest::NoGeometry );
+  }
+  else
+  {
+    // force geometry extraction if the filter requests it
+    request.setFlags( request.flags() & ~QgsFeatureRequest::NoGeometry );
+  }
+  QgsFeatureIterator featIt = mTableModel->layer()->getFeatures( request );
+
+  QgsFeature f;
+
+  while ( featIt.nextFeature( f ) )
+  {
+    mFilterExpressionContext.setFeature( f );
+    if ( mFilterExpression.evaluate( &mFilterExpressionContext ).toInt() != 0 )
+      filteredFeatures << f.id();
+
+    // check if there were errors during evaluating
+    if ( mFilterExpression.hasEvalError() )
+      break;
+  }
+
+  featIt.close();
+
+  setFilteredFeatures( filteredFeatures );
+
+  QApplication::restoreOverrideCursor();
+}
+
 
 void QgsAttributeTableFilterModel::selectionChanged()
 {

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -221,6 +221,12 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig &config );
 
+    /**
+     * Set the \a expression to be stored in case of the features need to be
+     * filtered (like on filter or on main model data change).
+     */
+    void setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context ) { mFilterExpression = expression; mFilterExpressionContext = context; }
+
   signals:
 
     /**
@@ -261,6 +267,8 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     void reloadVisible();
 
+    void filterFeatures();
+
   private slots:
     void selectionChanged();
     void onColumnsChanged();
@@ -274,6 +282,9 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
 
     QgsAttributeTableConfig mConfig;
     QVector<int> mColumnMapping;
+    QgsExpression mFilterExpression;
+    QgsExpressionContext mFilterExpressionContext;
+
     int mapColumnToSource( int column ) const;
     int mapColumnFromSource( int column ) const;
 

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -224,6 +224,8 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     /**
      * Set the \a expression and the \a context to be stored in case of the features
      * need to be filtered again (like on filter or on main model data change).
+     *
+     * \since QGIS 3.10.3
      */
     void setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context );
 
@@ -268,7 +270,10 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     void reloadVisible();
 
     /**
-     * Is called when the data changed of the main table moment to update the filter model.
+     * Updates the filtered features in the filter model. It is called when the data of the
+     * main table or the filter expression changed.
+     *
+     * \since QGIS 3.10.3
      */
     void filterFeatures();
 

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -263,11 +263,12 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
   public slots:
 
     /**
-     * Is called upon every change of the visible extents on the map canvas or when data of
-     * the master table model change.
+     * Is called upon every change of the visible extents on the map canvas.
      * When a change is signalled, the filter is updated and invalidated if needed.
+     *
+     * \deprecated since QGIS 3.10.3 - made private as reloadVisible()
      */
-    void reloadVisible();
+    Q_DECL_DEPRECATED void extentsChanged();
 
     /**
      * Updates the filtered features in the filter model. It is called when the data of the
@@ -280,6 +281,7 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
   private slots:
     void selectionChanged();
     void onColumnsChanged();
+    void reloadVisible();
 
   private:
     QgsFeatureIds mFilteredFeatures;

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -255,10 +255,11 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
   public slots:
 
     /**
-     * Is called upon every change of the visible extents on the map canvas.
+     * Is called upon every change of the visible extents on the map canvas or when data of
+     * the master table model changes.
      * When a change is signalled, the filter is updated and invalidated if needed.
      */
-    void extentsChanged();
+    void reloadVisible();
 
   private slots:
     void selectionChanged();

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -222,10 +222,10 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     void setAttributeTableConfig( const QgsAttributeTableConfig &config );
 
     /**
-     * Set the \a expression to be stored in case of the features need to be
-     * filtered (like on filter or on main model data change).
+     * Set the \a expression and the \a context to be stored in case of the features
+     * need to be filtered again (like on filter or on main model data change).
      */
-    void setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context ) { mFilterExpression = expression; mFilterExpressionContext = context; }
+    void setFilterExpression( const QgsExpression &expression, const QgsExpressionContext &context );
 
   signals:
 
@@ -262,11 +262,14 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
 
     /**
      * Is called upon every change of the visible extents on the map canvas or when data of
-     * the master table model changes.
+     * the master table model change.
      * When a change is signalled, the filter is updated and invalidated if needed.
      */
     void reloadVisible();
 
+    /**
+     * Is called when the data changed of the main table moment to update the filter model.
+     */
     void filterFeatures();
 
   private slots:

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -1076,6 +1076,13 @@ void QgsDualView::setFilteredFeatures( const QgsFeatureIds &filteredFeatures )
   mFilterModel->setFilteredFeatures( filteredFeatures );
 }
 
+void QgsDualView::filterFeatures( const QgsExpression &filterExpression, const QgsExpressionContext &context )
+{
+  mFilterModel->setFilterExpression( filterExpression, context );
+  mFilterModel->filterFeatures();
+}
+
+
 void QgsDualView::setRequest( const QgsFeatureRequest &request )
 {
   mMasterModel->setRequest( request );

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -157,8 +157,11 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      *
      * \param filteredFeatures  A list of feature ids
      *
-     */
-    void setFilteredFeatures( const QgsFeatureIds &filteredFeatures );
+     * \deprecated since filterFeatures is handled in the attribute filter model itself
+    */
+    Q_DECL_DEPRECATED void setFilteredFeatures( const QgsFeatureIds &filteredFeatures );
+
+    void filterFeatures( const QgsExpression &filterExpression, const QgsExpressionContext &context );
 
     /**
      * Gets a list of currently visible feature ids.

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -161,6 +161,12 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     */
     Q_DECL_DEPRECATED void setFilteredFeatures( const QgsFeatureIds &filteredFeatures );
 
+    /**
+     * Sets the expression and Updates the filtered features in the filter model.
+     * It is called when the filter expression changed.
+     *
+     * \since QGIS 3.10.3
+     */
     void filterFeatures( const QgsExpression &filterExpression, const QgsExpressionContext &context );
 
     /**

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -89,7 +89,6 @@ void QgsFeatureFilterWidget::init( QgsVectorLayer *layer, const QgsAttributeEdit
 
   connect( mLayer, &QgsVectorLayer::attributeAdded, this, &QgsFeatureFilterWidget::columnBoxInit );
   connect( mLayer, &QgsVectorLayer::attributeDeleted, this, &QgsFeatureFilterWidget::columnBoxInit );
-  connect( mMainView->masterModel(), &QgsAttributeTableModel::dataChanged, this, &QgsFeatureFilterWidget::filterQueryAccepted );
 
   //set delay on entering text
   mFilterQueryTimer.setSingleShot( true );
@@ -447,12 +446,6 @@ void QgsFeatureFilterWidget::setFilterExpression( const QString &filterString, Q
     }
   }
 
-  QgsFeatureIds filteredFeatures;
-  QgsDistanceArea myDa;
-
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
-
   // parse search string and build parsed tree
   QgsExpression filterExpression( filter );
   if ( filterExpression.hasParserError() )
@@ -468,50 +461,8 @@ void QgsFeatureFilterWidget::setFilterExpression( const QString &filterString, Q
     mMessageBar->pushMessage( tr( "Evaluation error" ), filterExpression.evalErrorString(), Qgis::Warning, mMessageBarTimeout );
   }
 
-  bool fetchGeom = filterExpression.needsGeometry();
+  mMainView->filterFeatures( filterExpression, context );
 
-  QApplication::setOverrideCursor( Qt::WaitCursor );
-
-  filterExpression.setGeomCalculator( &myDa );
-  filterExpression.setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  filterExpression.setAreaUnits( QgsProject::instance()->areaUnits() );
-  QgsFeatureRequest request( mMainView->masterModel()->request() );
-  request.setSubsetOfAttributes( filterExpression.referencedColumns(), mLayer->fields() );
-  if ( !fetchGeom )
-  {
-    request.setFlags( QgsFeatureRequest::NoGeometry );
-  }
-  else
-  {
-    // force geometry extraction if the filter requests it
-    request.setFlags( request.flags() & ~QgsFeatureRequest::NoGeometry );
-  }
-  QgsFeatureIterator featIt = mLayer->getFeatures( request );
-
-  QgsFeature f;
-
-  while ( featIt.nextFeature( f ) )
-  {
-    context.setFeature( f );
-    if ( filterExpression.evaluate( &context ).toInt() != 0 )
-      filteredFeatures << f.id();
-
-    // check if there were errors during evaluating
-    if ( filterExpression.hasEvalError() )
-      break;
-  }
-
-  featIt.close();
-
-  mMainView->setFilteredFeatures( filteredFeatures );
-
-  QApplication::restoreOverrideCursor();
-
-  if ( filterExpression.hasEvalError() )
-  {
-    mMessageBar->pushMessage( tr( "Error filtering" ), filterExpression.evalErrorString(), Qgis::Warning, mMessageBarTimeout );
-    return;
-  }
   mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowFilteredList );
 }
 

--- a/src/gui/attributetable/qgsfeaturefilterwidget.cpp
+++ b/src/gui/attributetable/qgsfeaturefilterwidget.cpp
@@ -89,6 +89,7 @@ void QgsFeatureFilterWidget::init( QgsVectorLayer *layer, const QgsAttributeEdit
 
   connect( mLayer, &QgsVectorLayer::attributeAdded, this, &QgsFeatureFilterWidget::columnBoxInit );
   connect( mLayer, &QgsVectorLayer::attributeDeleted, this, &QgsFeatureFilterWidget::columnBoxInit );
+  connect( mMainView->masterModel(), &QgsAttributeTableModel::dataChanged, this, &QgsFeatureFilterWidget::filterQueryAccepted );
 
   //set delay on entering text
   mFilterQueryTimer.setSingleShot( true );

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -162,7 +162,11 @@ void QgsFeatureListView::editSelectionChanged( const QItemSelection &deselected,
     QItemSelection localSelected = mModel->mapSelectionFromMaster( selected );
     viewport()->update( visualRegionForSelection( localDeselected ) | visualRegionForSelection( localSelected ) );
   }
+  updateEditSelectionDependencies();
+}
 
+void QgsFeatureListView::updateEditSelectionDependencies()
+{
   QItemSelection currentSelection = mCurrentEditSelectionModel->selection();
   if ( currentSelection.size() == 1 )
   {
@@ -463,6 +467,7 @@ void QgsFeatureListView::ensureEditSelection( bool inSelection )
     }
     mUpdateEditSelectionTimer.start();
   }
+  updateEditSelectionDependencies();
 }
 
 void QgsFeatureListView::setFeatureSelectionManager( QgsIFeatureSelectionManager *featureSelectionManager )

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -215,6 +215,11 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     void editSelectionChanged( const QItemSelection &deselected, const QItemSelection &selected );
 
     /**
+     * Emmits the signal for the feature and the selection information
+     */
+    void updateEditSelectionDependencies();
+
+    /**
      * Make sure, there is an edit selection. If there is none, choose the first item.
      * If \a inSelection is set to TRUE, the edit selection is done in selected entries if
      * there is a selected entry visible.

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -215,7 +215,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     void editSelectionChanged( const QItemSelection &deselected, const QItemSelection &selected );
 
     /**
-     * Emmits the signal for the feature and the selection information
+     * Emits the signal for the feature and the selection information
      */
     void updateEditSelectionDependencies();
 

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -53,6 +53,7 @@ class TestQgsAttributeTable : public QObject
     void testSelectedOnTop();
     void testSortByDisplayExpression();
     void testOrderColumn();
+    void testFilteredFeatures();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -403,6 +404,86 @@ void TestQgsAttributeTable::testOrderColumn()
 
   // column 0 is indeed column 2 since we move it
   QCOMPARE( filterModel->sortColumn(), 2 );
+}
+
+void TestQgsAttributeTable::testFilteredFeatures()
+{
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=col1:int&field=col2:int" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+
+  QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
+  f1.setAttribute( 0, 1 );
+  f1.setAttribute( 1, 2 );
+  QgsFeature f2( tempLayer->dataProvider()->fields(), 2 );
+  f2.setAttribute( 0, 2 );
+  f2.setAttribute( 1, 4 );
+  QgsFeature f3( tempLayer->dataProvider()->fields(), 3 );
+  f3.setAttribute( 0, 3 );
+  f3.setAttribute( 1, 6 );
+  QgsFeature f4( tempLayer->dataProvider()->fields(), 4 );
+  f4.setAttribute( 0, 4 );
+  f4.setAttribute( 1, 8 );
+
+  QVERIFY( tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 << f3 ) );
+
+  std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( tempLayer.get(), QgsAttributeTableFilterModel::ShowAll ) );
+
+  // show all (three features)
+  dlg->mFeatureFilterWidget->filterShowAll();
+  QCOMPARE( dlg->mMainView->featureCount(), 3 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 3 );
+
+  // add a feature
+  tempLayer->startEditing();
+  QVERIFY( tempLayer->addFeatures( QgsFeatureList() << f4 ) );
+  //still show all (four features)
+  QCOMPARE( tempLayer->featureCount(), 4L );
+  QCOMPARE( dlg->mMainView->featureCount(), 4 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 4 );
+
+  // bigger 5 (two of four features)
+  dlg->mFeatureFilterWidget->setFilterExpression( QStringLiteral( "col1>5" ), QgsAttributeForm::ReplaceFilter, true );
+  QCOMPARE( dlg->mMainView->featureCount(), 4 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 2 );
+  // bigger 7 (one of four features)
+  dlg->mFeatureFilterWidget->setFilterExpression( QStringLiteral( "col1>7" ), QgsAttributeForm::ReplaceFilter, true );
+  QCOMPARE( dlg->mMainView->featureCount(), 4 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 1 );
+  // bigger 9 (no of four features)
+  dlg->mFeatureFilterWidget->setFilterExpression( QStringLiteral( "col1>9" ), QgsAttributeForm::ReplaceFilter, true );
+  QCOMPARE( dlg->mMainView->featureCount(), 4 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 0 );
+
+  //add two features
+  QgsFeature f5( tempLayer->dataProvider()->fields(), 5 );
+  f5.setAttribute( 0, 5 );
+  f5.setAttribute( 1, 10 );
+  QgsFeature f6( tempLayer->dataProvider()->fields(), 6 );
+  f6.setAttribute( 0, 6 );
+  f6.setAttribute( 1, 12 );
+  QVERIFY( tempLayer->addFeatures( QgsFeatureList() << f5 << f6 ) );
+  tempLayer->commitChanges();
+
+  //no filter change -> now two of six features
+  QCOMPARE( dlg->mMainView->featureCount(), 6 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 2 );
+
+  //remove a feature not affecting the filter
+  tempLayer->startEditing();
+  QVERIFY( tempLayer->deleteFeature( f2.id() ) );
+  //no filter change -> now two of five features
+  QCOMPARE( dlg->mMainView->featureCount(), 5 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 2 );
+
+  //remove a feature affecting the filter
+  QVERIFY( tempLayer->deleteFeature( f5.id() ) );
+  //no filter change -> now one of four features
+  QCOMPARE( dlg->mMainView->featureCount(), 4 );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 1 );
+
+  // smaller 11 (three of four features)
+  dlg->mFeatureFilterWidget->setFilterExpression( QStringLiteral( "col1<11" ), QgsAttributeForm::ReplaceFilter, true );
+  QCOMPARE( dlg->mMainView->filteredFeatureCount(), 3 );
 }
 
 QGSTEST_MAIN( TestQgsAttributeTable )


### PR DESCRIPTION
On adding / removing / changing features.

- On filter "Show Visible" the list is updated
- On custom filters the list is updated

(since the update needs to be done on data changed and not only on filter changed, I moved the filter functionality to the model instead the widget)

- update of count of features in the AttributeEdit mode of the DualView, on FeatureListModel adding or removing feature