### PR TITLE
do not show empty config when loading attribute form properties

### DIFF
--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -60,18 +60,6 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   mFormLayoutTree->setHeaderLabels( QStringList() << tr( "Form Layout" ) );
   mFormLayoutTree->setType( QgsAttributesDnDTree::Type::Drop );
 
-  // AttributeTypeDialog
-  mAttributeTypeDialog = new QgsAttributeTypeDialog( mLayer, -1, mAttributeTypeFrame );
-  mAttributeTypeDialog->layout()->setMargin( 0 );
-  mAttributeTypeFrame->layout()->setMargin( 0 );
-  mAttributeTypeFrame->layout()->addWidget( mAttributeTypeDialog );
-
-  // AttributeRelationEdit
-  mAttributeRelationEdit = new QgsAttributeRelationEdit( "", mAttributeTypeFrame );
-  mAttributeRelationEdit->layout()->setMargin( 0 );
-  mAttributeTypeFrame->layout()->setMargin( 0 );
-  mAttributeTypeFrame->layout()->addWidget( mAttributeRelationEdit );
-
   connect( mAvailableWidgetsTree, &QTreeWidget::itemSelectionChanged, this, &QgsAttributesFormProperties::onAttributeSelectionChanged );
   connect( mFormLayoutTree, &QTreeWidget::itemSelectionChanged, this, &QgsAttributesFormProperties::onFormLayoutSelectionChanged );
   connect( mAddTabOrGroupButton, &QAbstractButton::clicked, this, &QgsAttributesFormProperties::addTabOrGroupButton );
@@ -250,12 +238,6 @@ void QgsAttributesFormProperties::loadAttributeTypeDialog()
   if ( index < 0 )
     return;
 
-  mAttributeTypeDialog = new QgsAttributeTypeDialog( mLayer, index, mAttributeTypeFrame );
-  mAttributeTypeDialog->setEnabled( true );
-
-  // AttributeTypeDialog delete and recreate
-  mAttributeTypeFrame->layout()->removeWidget( mAttributeTypeDialog );
-  delete mAttributeTypeDialog;
   mAttributeTypeDialog = new QgsAttributeTypeDialog( mLayer, index, mAttributeTypeFrame );
 
   QgsFieldConstraints constraints = cfg.mFieldConstraints;


### PR DESCRIPTION
when loading the form properties, it was showing an empty config:
![image](https://user-images.githubusercontent.com/127259/76546634-23f9e480-648c-11ea-9913-cee7c97a5bea.png)


now, the frame is empty:
![image](https://user-images.githubusercontent.com/127259/76546572-0a589d00-648c-11ea-9197-42079d0f9452.png)
