### PR TITLE
Fix for temporal layers refresh issue after temporal range update

### DIFF
--- a/python/core/auto_generated/qgstemporalproperty.sip.in
+++ b/python/core/auto_generated/qgstemporalproperty.sip.in
@@ -53,6 +53,11 @@ Returns ``True`` if the temporal property is active.
 Emitted when the temporal properties have changed.
 %End
 
+    void temporalRangeChanged( const QgsDateTimeRange &range );
+%Docstring
+Emitted when the temporal range in the properties have changed.
+%End
+
 };
 
 /************************************************************************

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14050,6 +14050,11 @@ bool QgisApp::addRasterLayer( QgsRasterLayer *rasterLayer )
   myList << rasterLayer;
   QgsProject::instance()->addMapLayers( myList );
 
+  // connect the temporal range changes of the this layer to the map canvas
+  if ( rasterLayer->temporalProperties() )
+    connect( rasterLayer->temporalProperties(), &QgsRasterLayerTemporalProperties::temporalRangeChanged,
+             mMapCanvas, &QgsMapCanvas::setTemporalRange );
+
   askUserForDatumTransform( rasterLayer->crs(), QgsProject::instance()->crs(), rasterLayer );
 
   return true;

--- a/src/core/qgstemporalproperty.h
+++ b/src/core/qgstemporalproperty.h
@@ -21,6 +21,7 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
+#include "qgsrange.h"
 
 #include <QObject>
 
@@ -65,6 +66,11 @@ class CORE_EXPORT QgsTemporalProperty : public QObject
      * Emitted when the temporal properties have changed.
      */
     void changed();
+
+    /**
+     * Emitted when the temporal range in the properties have changed.
+     */
+    void temporalRangeChanged( const QgsDateTimeRange &range );
 
   private:
 

--- a/src/core/raster/qgsrasterlayertemporalproperties.cpp
+++ b/src/core/raster/qgsrasterlayertemporalproperties.cpp
@@ -76,7 +76,10 @@ void QgsRasterLayerTemporalProperties::setTemporalRange( const QgsDateTimeRange 
     setIsActive( true );
 
   if ( mFixedRange.contains( dateTimeRange ) )
+  {
     mRange = dateTimeRange;
+    emit temporalRangeChanged( dateTimeRange );
+  }
   else
     mRange = mFixedRange;
 }


### PR DESCRIPTION
This PR provide a fix for temporal layers to be refreshed when user has update the layer's temporal range through editing temporal layer properties.