### PR TITLE
[ui] Fix spacing issue with temporal widget in the raster layer properties

### DIFF
--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -357,22 +357,6 @@ border-radius: 2px;</string>
                  </property>
                 </widget>
                </item>
-               <item>
-                <spacer name="verticalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>17</width>
-                   <height>111</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
               </layout>
              </widget>
             </widget>


### PR DESCRIPTION
## Description

This PR removes a spacer item (made obsolete by the temporal widget) that was messing with the layout of the source tab in the raster layer properties dialog.

Screenshot of the problem being fixed here:
![image](https://user-images.githubusercontent.com/1728657/76584023-5d266900-650d-11ea-87c2-6b38ce13bd9d.png)
