### PR TITLE
[Backport release-3_12] add "Organize Columns" button to the attribute table toolbar (fix #23397)

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -54,6 +54,7 @@
 #include "qgsguiutils.h"
 #include "qgsproxyprogresstask.h"
 #include "qgisapp.h"
+#include "qgsorganizetablecolumnsdialog.h"
 
 QgsExpressionContext QgsAttributeTableDialog::createExpressionContext() const
 {
@@ -105,6 +106,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mActionSelectedToTop, &QAction::toggled, this, &QgsAttributeTableDialog::mActionSelectedToTop_toggled );
   connect( mActionAddAttribute, &QAction::triggered, this, &QgsAttributeTableDialog::mActionAddAttribute_triggered );
   connect( mActionRemoveAttribute, &QAction::triggered, this, &QgsAttributeTableDialog::mActionRemoveAttribute_triggered );
+  connect( mActionOrganizeColumns, &QAction::triggered, this, &QgsAttributeTableDialog::mActionOrganizeColumns_triggered );
   connect( mActionOpenFieldCalculator, &QAction::triggered, this, &QgsAttributeTableDialog::mActionOpenFieldCalculator_triggered );
   connect( mActionDeleteSelected, &QAction::triggered, this, &QgsAttributeTableDialog::mActionDeleteSelected_triggered );
   connect( mMainView, &QgsDualView::currentChanged, this, &QgsAttributeTableDialog::mMainView_currentChanged );
@@ -835,6 +837,20 @@ void QgsAttributeTableDialog::mActionRemoveAttribute_triggered()
   }
 }
 
+void QgsAttributeTableDialog::mActionOrganizeColumns_triggered()
+{
+  if ( !mLayer )
+  {
+    return;
+  }
+
+  QgsOrganizeTableColumnsDialog dlg( mLayer, mLayer->attributeTableConfig(), this );
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    QgsAttributeTableConfig config = dlg.config();
+    mMainView->setAttributeTableConfig( config );
+  }
+}
 
 void QgsAttributeTableDialog::openConditionalStyles()
 {

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -154,6 +154,11 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     void mActionDeleteSelected_triggered();
 
     /**
+     * Opens organize columns dialog
+     */
+    void mActionOrganizeColumns_triggered();
+
+    /**
      * Called when the current index changes in the main view
      * i.e. when the view mode is switched from table to form view
      * or vice versa.

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -208,6 +208,7 @@
      <addaction name="separator"/>
      <addaction name="mActionAddAttribute"/>
      <addaction name="mActionRemoveAttribute"/>
+     <addaction name="mActionOrganizeColumns"/>
      <addaction name="mActionOpenFieldCalculator"/>
      <addaction name="separator"/>
      <addaction name="mActionSetStyles"/>
@@ -532,6 +533,15 @@
    </property>
    <property name="toolTip">
     <string>Dock Attribute Table</string>
+   </property>
+  </action>
+  <action name="mActionOrganizeColumns">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditTable.svg</normaloff>:/images/themes/default/mActionEditTable.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Organize Columns</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
## Description
Add "Organize Columns" button to the attribute table toolbar to allow  unhiding columns if all of them were hidden by accident (fix #23397).

Manual backport of #33918 to the 3.12 branch.