### PR TITLE
[UI] Couple of UI/UX fixes for Text format widget

### DIFF
--- a/src/gui/labeling/qgslabelinggui.cpp
+++ b/src/gui/labeling/qgslabelinggui.cpp
@@ -186,6 +186,7 @@ QgsLabelingGui::QgsLabelingGui( QgsVectorLayer *layer, QgsMapCanvas *mapCanvas, 
   connect( mBufferDrawChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mEnableMaskChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mShapeDrawChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
+  connect( mCalloutsDrawCheckBox, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mShadowDrawChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mDirectSymbChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
   connect( mFormatNumChkBx, &QAbstractButton::toggled, this, &QgsLabelingGui::updateUi );
@@ -626,6 +627,7 @@ void QgsLabelingGui::updateUi()
   syncDefinedCheckboxFrame( mEnableMaskDDBtn, mEnableMaskChkBx, mMaskFrame );
   syncDefinedCheckboxFrame( mShapeDrawDDBtn, mShapeDrawChkBx, mShapeFrame );
   syncDefinedCheckboxFrame( mShadowDrawDDBtn, mShadowDrawChkBx, mShadowFrame );
+  syncDefinedCheckboxFrame( mCalloutDrawDDBtn, mCalloutsDrawCheckBox, mCalloutFrame );
 
   syncDefinedCheckboxFrame( mDirectSymbDDBtn, mDirectSymbChkBx, mDirectSymbFrame );
   syncDefinedCheckboxFrame( mFormatNumDDBtn, mFormatNumChkBx, mFormatNumFrame );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -493,6 +493,11 @@ void QgsTextFormatWidget::initWidget()
   {
     updateShadowFrameStatus();
   } );
+  connect( mCalloutDrawDDBtn, &QgsPropertyOverrideButton::activated, this, &QgsTextFormatWidget::updateCalloutFrameStatus );
+  connect( mCalloutsDrawCheckBox, &QCheckBox::stateChanged, this, [ = ]( int )
+  {
+    updateCalloutFrameStatus();
+  } );
 
   mGeometryGeneratorType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconPolygonLayer.svg" ) ), tr( "Polygon / MultiPolygon" ), QgsWkbTypes::GeometryType::PolygonGeometry );
   mGeometryGeneratorType->addItem( QgsApplication::getThemeIcon( QStringLiteral( "/mIconLineLayer.svg" ) ), tr( "LineString / MultiLineString" ), QgsWkbTypes::GeometryType::LineGeometry );
@@ -800,6 +805,8 @@ void QgsTextFormatWidget::populateDataDefinedButtons()
   registerDataDefinedButton( mZIndexDDBtn, QgsPalLayerSettings::ZIndex );
 
   registerDataDefinedButton( mCalloutDrawDDBtn, QgsPalLayerSettings::CalloutDraw );
+  mCalloutDrawDDBtn->registerCheckedWidget( mCalloutsDrawCheckBox );
+
   registerDataDefinedButton( mLabelAllPartsDDBtn, QgsPalLayerSettings::LabelAllParts );
 }
 
@@ -1730,6 +1737,11 @@ void QgsTextFormatWidget::updateBufferFrameStatus()
 void QgsTextFormatWidget::updateShadowFrameStatus()
 {
   mShadowFrame->setEnabled( mShadowDrawDDBtn->isActive() || mShadowDrawChkBx->isChecked() );
+}
+
+void QgsTextFormatWidget::updateCalloutFrameStatus()
+{
+  mCalloutFrame->setEnabled( mCalloutDrawDDBtn->isActive() || mCalloutsDrawCheckBox->isChecked() );
 }
 
 void QgsTextFormatWidget::setFormatFromStyle( const QString &name, QgsStyle::StyleEntity type )

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -533,7 +533,12 @@ void QgsTextFormatWidget::setWidgetMode( QgsTextFormatWidget::Mode mode )
       mOptionsTab->removeTab( 8 );
       mOptionsTab->removeTab( 7 );
       mOptionsTab->removeTab( 6 );
-      mOptionsTab->removeTab( 5 );
+      mOptionsTab->removeTab( 3 );
+      mLabelStackedWidget->removeWidget( mLabelPage_Rendering );
+      mLabelStackedWidget->removeWidget( mLabelPage_Callouts );
+      mLabelStackedWidget->removeWidget( mLabelPage_Mask );
+      mLabelStackedWidget->removeWidget( mLabelPage_Placement );
+      mLabelStackedWidget->setCurrentIndex( 0 );
 
       frameLabelWith->hide();
       mDirectSymbolsFrame->hide();

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -304,6 +304,7 @@ class GUI_EXPORT QgsTextFormatWidget : public QWidget, public QgsExpressionConte
     void updateShapeFrameStatus();
     void updateBufferFrameStatus();
     void updateShadowFrameStatus();
+    void updateCalloutFrameStatus();
 };
 
 

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>880</width>
-    <height>516</height>
+    <height>589</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -694,7 +694,7 @@
               <item>
                <widget class="QStackedWidget" name="mLabelStackedWidget">
                 <property name="currentIndex">
-                 <number>3</number>
+                 <number>6</number>
                 </property>
                 <widget class="QWidget" name="mLabelPage_Text">
                  <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -723,8 +723,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>782</width>
-                       <height>387</height>
+                       <width>317</width>
+                       <height>260</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -1306,8 +1306,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>374</width>
-                       <height>708</height>
+                       <width>348</width>
+                       <height>624</height>
                       </rect>
                      </property>
                      <layout class="QGridLayout" name="gridLayout_42">
@@ -2205,8 +2205,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>308</width>
-                       <height>308</height>
+                       <width>284</width>
+                       <height>273</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2551,8 +2551,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>831</width>
-                       <height>295</height>
+                       <width>830</width>
+                       <height>376</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_121">
@@ -2829,8 +2829,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>474</width>
-                       <height>786</height>
+                       <width>816</width>
+                       <height>696</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3590,8 +3590,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>318</width>
-                       <height>457</height>
+                       <width>816</width>
+                       <height>406</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -4018,8 +4018,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>156</width>
-                       <height>185</height>
+                       <width>830</width>
+                       <height>376</height>
                       </rect>
                      </property>
                      <layout class="QGridLayout" name="gridLayout_46">
@@ -4037,61 +4037,6 @@ font-style: italic;</string>
                       </property>
                       <item row="0" column="0">
                        <layout class="QGridLayout" name="gridLayout_43">
-                        <item row="0" column="0">
-                         <widget class="QLabel" name="label_511">
-                          <property name="text">
-                           <string>Callouts</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="1" column="1">
-                         <widget class="QgsPropertyOverrideButton" name="mCalloutDrawDDBtn">
-                          <property name="text">
-                           <string>…</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="0" colspan="3">
-                         <layout class="QGridLayout" name="gridLayout_45" columnstretch="0,0,0">
-                          <property name="leftMargin">
-                           <number>20</number>
-                          </property>
-                          <property name="topMargin">
-                           <number>0</number>
-                          </property>
-                          <item row="0" column="1" colspan="2">
-                           <widget class="QComboBox" name="mCalloutStyleComboBox"/>
-                          </item>
-                          <item row="0" column="0">
-                           <widget class="QLabel" name="label_11">
-                            <property name="text">
-                             <string>Style</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item row="1" column="0" colspan="3">
-                           <widget class="QStackedWidget" name="mCalloutStackedWidget">
-                            <widget class="QWidget" name="pageDummy">
-                             <layout class="QVBoxLayout" name="verticalLayout_19">
-                              <item>
-                               <widget class="QLabel" name="label_45">
-                                <property name="text">
-                                 <string>This callout type doesn't have any editable properties</string>
-                                </property>
-                                <property name="alignment">
-                                 <set>Qt::AlignCenter</set>
-                                </property>
-                                <property name="wordWrap">
-                                 <bool>true</bool>
-                                </property>
-                               </widget>
-                              </item>
-                             </layout>
-                            </widget>
-                           </widget>
-                          </item>
-                         </layout>
-                        </item>
                         <item row="1" column="0">
                          <widget class="QCheckBox" name="mCalloutsDrawCheckBox">
                           <property name="sizePolicy">
@@ -4102,6 +4047,13 @@ font-style: italic;</string>
                           </property>
                           <property name="text">
                            <string>Draw callouts</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_511">
+                          <property name="text">
+                           <string>Callouts</string>
                           </property>
                          </widget>
                         </item>
@@ -4117,6 +4069,56 @@ font-style: italic;</string>
                            </size>
                           </property>
                          </spacer>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QgsPropertyOverrideButton" name="mCalloutDrawDDBtn">
+                          <property name="text">
+                           <string>…</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="0" colspan="3">
+                         <widget class="QFrame" name="mCalloutFrame">
+                          <layout class="QGridLayout" name="gridLayout_45" columnstretch="0,0,0">
+                           <property name="leftMargin">
+                            <number>20</number>
+                           </property>
+                           <property name="topMargin">
+                            <number>1</number>
+                           </property>
+                           <item row="0" column="1" colspan="2">
+                            <widget class="QComboBox" name="mCalloutStyleComboBox"/>
+                           </item>
+                           <item row="1" column="0" colspan="3">
+                            <widget class="QStackedWidget" name="mCalloutStackedWidget">
+                             <widget class="QWidget" name="pageDummy">
+                              <layout class="QVBoxLayout" name="verticalLayout_19">
+                               <item>
+                                <widget class="QLabel" name="label_45">
+                                 <property name="text">
+                                  <string>This callout type doesn't have any editable properties</string>
+                                 </property>
+                                 <property name="alignment">
+                                  <set>Qt::AlignCenter</set>
+                                 </property>
+                                 <property name="wordWrap">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                              </layout>
+                             </widget>
+                            </widget>
+                           </item>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_11">
+                             <property name="text">
+                              <string>Style</string>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
+                         </widget>
                         </item>
                        </layout>
                       </item>
@@ -4166,8 +4168,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>440</width>
-                       <height>1154</height>
+                       <width>431</width>
+                       <height>1108</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -5991,8 +5993,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>415</width>
-                       <height>853</height>
+                       <width>383</width>
+                       <height>624</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -3991,7 +3991,7 @@ font-style: italic;</string>
                   </item>
                  </layout>
                 </widget>
-                <widget class="QWidget" name="page">
+                <widget class="QWidget" name="mLabelPage_Callouts">
                  <layout class="QVBoxLayout" name="verticalLayout_14">
                   <property name="leftMargin">
                    <number>0</number>


### PR DESCRIPTION
## Description
Couple of UI/UX fixes for text format widget:

- fix wrong widgets order when adding new text format via Style manager. Fixes #33056
- disable content of the "Callout" tab if corresponding checkbox/datadefined button is not active. Fixes #32067
