### PR TITLE
Visual improvements in sublayers dialog

### DIFF
--- a/python/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgssublayersdialog.sip.in
@@ -37,7 +37,8 @@ class QgsSublayersDialog : QDialog
     QgsSublayersDialog( ProviderType providerType,
                         const QString &name,
                         QWidget *parent /TransferThis/ = 0,
-                        Qt::WindowFlags fl = 0 );
+                        Qt::WindowFlags fl = 0,
+                        const QString providerSource = QString() );
 %Docstring
 Constructor for QgsSublayersDialog
 %End

--- a/python/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgssublayersdialog.sip.in
@@ -15,6 +15,7 @@ class QgsSublayersDialog : QDialog
 #include "qgssublayersdialog.h"
 %End
   public:
+
     enum PromptMode
     {
 

--- a/python/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgssublayersdialog.sip.in
@@ -15,6 +15,17 @@ class QgsSublayersDialog : QDialog
 #include "qgssublayersdialog.h"
 %End
   public:
+    enum PromptMode
+    {
+
+      PromptAlways,
+
+      PromptIfNeeded,
+
+      PromptNever,
+
+      PromptLoadAll
+    };
 
     enum ProviderType
     {
@@ -90,6 +101,9 @@ Returns column with count or -1
   public slots:
     virtual int exec();
 
+
+  protected slots:
+    void layersTable_selectionChanged( const QItemSelection &, const QItemSelection & );
 
   protected:
 

--- a/python/gui/auto_generated/qgssublayersdialog.sip.in
+++ b/python/gui/auto_generated/qgssublayersdialog.sip.in
@@ -102,9 +102,6 @@ Returns column with count or -1
     virtual int exec();
 
 
-  protected slots:
-    void layersTable_selectionChanged( const QItemSelection &, const QItemSelection & );
-
   protected:
 
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5462,7 +5462,7 @@ bool QgisApp::askUserForZipItemLayers( const QString &path )
   QVector<QgsDataItem *> childItems;
   QgsZipItem *zipItem = nullptr;
   QgsSettings settings;
-  int promptLayers = settings.value( QStringLiteral( "qgis/promptForRasterSublayers" ), 1 ).toInt();
+  QgsSublayersDialog::PromptMode promptLayers = settings.enumValue( QStringLiteral( "qgis/promptForSublayers" ), QgsSublayersDialog::PromptAlways );
 
   QgsDebugMsg( "askUserForZipItemLayers( " + path + ')' );
 
@@ -5487,12 +5487,12 @@ bool QgisApp::askUserForZipItemLayers( const QString &path )
   }
 
   // if promptLayers=Load all, load all layers without prompting
-  if ( promptLayers == 3 )
+  if ( promptLayers == QgsSublayersDialog::PromptLoadAll )
   {
     childItems = zipItem->children();
   }
   // exit if promptLayers=Never
-  else if ( promptLayers == 2 )
+  else if ( promptLayers == QgsSublayersDialog::PromptNever )
   {
     delete zipItem;
     return false;
@@ -5584,7 +5584,7 @@ QList< QgsMapLayer * > QgisApp::askUserForGDALSublayers( QgsRasterLayer *layer )
 
   // if promptLayers=Load all, load all sublayers without prompting
   QgsSettings settings;
-  if ( settings.value( QStringLiteral( "qgis/promptForRasterSublayers" ), 1 ).toInt() == 3 )
+  if ( settings.enumValue( QStringLiteral( "qgis/promptForSublayers" ), QgsSublayersDialog::PromptAlways ) == QgsSublayersDialog::PromptLoadAll )
   {
     result.append( loadGDALSublayers( layer->source(), sublayers ) );
     return result;
@@ -5708,13 +5708,11 @@ bool QgisApp::shouldAskUserForGDALSublayers( QgsRasterLayer *layer )
     return false;
 
   QgsSettings settings;
-  int promptLayers = settings.value( QStringLiteral( "qgis/promptForRasterSublayers" ), 1 ).toInt();
-  // 0 = Always -> always ask (if there are existing sublayers)
-  // 1 = If needed -> ask if layer has no bands, but has sublayers
-  // 2 = Never -> never prompt, will not load anything
-  // 3 = Load all -> never prompt, but load all sublayers
+  QgsSublayersDialog::PromptMode promptLayers = settings.enumValue( QStringLiteral( "qgis/promptForSublayers" ), QgsSublayersDialog::PromptAlways );
 
-  return promptLayers == 0 || promptLayers == 3 || ( promptLayers == 1 && layer->bandCount() == 0 );
+  return  promptLayers == QgsSublayersDialog::PromptAlways ||
+          promptLayers == QgsSublayersDialog::PromptLoadAll ||
+          ( promptLayers == QgsSublayersDialog::PromptIfNeeded && layer->bandCount() == 0 );
 }
 
 // This method will load with GDAL the layers in parameter.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5851,10 +5851,9 @@ QList<QgsMapLayer *> QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
     }
 
     QgsDebugMsg( "Creating new vector layer using " + composedURI );
-    QString name = fileName + " " + def.layerName;
     QgsVectorLayer::LayerOptions options { QgsProject::instance()->transformContext() };
     options.loadDefaultStyle = false;
-    QgsVectorLayer *layer = new QgsVectorLayer( composedURI, name, QStringLiteral( "ogr" ), options );
+    QgsVectorLayer *layer = new QgsVectorLayer( composedURI, def.layerName, QStringLiteral( "ogr" ), options );
     if ( layer && layer->isValid() )
     {
       result << layer;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5500,7 +5500,7 @@ bool QgisApp::askUserForZipItemLayers( const QString &path )
   else
   {
     // We initialize a selection dialog and display it.
-    QgsSublayersDialog chooseSublayersDialog( QgsSublayersDialog::Vsifile, QStringLiteral( "vsi" ), this );
+    QgsSublayersDialog chooseSublayersDialog( QgsSublayersDialog::Vsifile, QStringLiteral( "vsi" ), this, nullptr, path );
     QgsSublayersDialog::LayerDefinitionList layers;
 
     for ( int i = 0; i < zipItem->children().size(); i++ )
@@ -5591,7 +5591,7 @@ QList< QgsMapLayer * > QgisApp::askUserForGDALSublayers( QgsRasterLayer *layer )
   }
 
   // We initialize a selection dialog and display it.
-  QgsSublayersDialog chooseSublayersDialog( QgsSublayersDialog::Gdal, QStringLiteral( "gdal" ), this );
+  QgsSublayersDialog chooseSublayersDialog( QgsSublayersDialog::Gdal, QStringLiteral( "gdal" ), this, nullptr, layer->dataProvider()->dataSourceUri() );
   chooseSublayersDialog.setShowAddToGroupCheckbox( true );
 
   QgsSublayersDialog::LayerDefinitionList layers;
@@ -5814,7 +5814,7 @@ QList<QgsMapLayer *> QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
   // Check if the current layer uri contains the
 
   // We initialize a selection dialog and display it.
-  QgsSublayersDialog chooseSublayersDialog( QgsSublayersDialog::Ogr, QStringLiteral( "ogr" ), this );
+  QgsSublayersDialog chooseSublayersDialog( QgsSublayersDialog::Ogr, QStringLiteral( "ogr" ), this, nullptr, layer->dataProvider()->dataSourceUri() );
   chooseSublayersDialog.setShowAddToGroupCheckbox( true );
   chooseSublayersDialog.populateLayerTable( list );
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -58,6 +58,7 @@
 #include "qgswelcomepage.h"
 #include "qgsnewsfeedparser.h"
 #include "qgsbearingnumericformat.h"
+#include "qgssublayersdialog.h"
 
 #ifdef HAVE_OPENCL
 #include "qgsopenclutils.h"
@@ -422,17 +423,12 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   spinBoxAttrTableRowCache->setValue( mSettings->value( QStringLiteral( "/qgis/attributeTableRowCache" ), 10000 ).toInt() );
   spinBoxAttrTableRowCache->setSpecialValueText( tr( "All" ) );
 
-  // set the prompt for raster sublayers
-  // 0 = Always -> always ask (if there are existing sublayers)
-  // 1 = If needed -> ask if layer has no bands, but has sublayers
-  // 2 = Never -> never prompt, will not load anything
-  // 3 = Load all -> never prompt, but load all sublayers
-  cmbPromptRasterSublayers->clear();
-  cmbPromptRasterSublayers->addItem( tr( "Always" ) );
-  cmbPromptRasterSublayers->addItem( tr( "If needed" ) ); //this means, prompt if there are sublayers but no band in the main dataset
-  cmbPromptRasterSublayers->addItem( tr( "Never" ) );
-  cmbPromptRasterSublayers->addItem( tr( "Load all" ) );
-  cmbPromptRasterSublayers->setCurrentIndex( mSettings->value( QStringLiteral( "/qgis/promptForRasterSublayers" ), 0 ).toInt() );
+  cmbPromptSublayers->clear();
+  cmbPromptSublayers->addItem( tr( "Always" ), QgsSublayersDialog::PromptAlways );
+  cmbPromptSublayers->addItem( tr( "If needed" ), QgsSublayersDialog::PromptIfNeeded ); //this means, prompt if there are sublayers but no band in the main dataset
+  cmbPromptSublayers->addItem( tr( "Never" ), QgsSublayersDialog::PromptNever );
+  cmbPromptSublayers->addItem( tr( "Load all" ), QgsSublayersDialog::PromptLoadAll ); // check if this is true
+  cmbPromptSublayers->setCurrentIndex( cmbPromptSublayers->findData( mSettings->enumValue( QStringLiteral( "/qgis/promptForSublayers" ), QgsSublayersDialog::PromptAlways ) ) );
 
   // Scan for valid items in the browser dock
   cmbScanItemsInBrowser->clear();
@@ -1484,7 +1480,8 @@ void QgsOptions::saveOptions()
   mSettings->setEnumValue( QStringLiteral( "/qgis/attributeTableBehavior" ), ( QgsAttributeTableFilterModel::FilterMode )cmbAttrTableBehavior->currentData().toInt() );
   mSettings->setValue( QStringLiteral( "/qgis/attributeTableView" ), mAttrTableViewComboBox->currentData() );
   mSettings->setValue( QStringLiteral( "/qgis/attributeTableRowCache" ), spinBoxAttrTableRowCache->value() );
-  mSettings->setValue( QStringLiteral( "/qgis/promptForRasterSublayers" ), cmbPromptRasterSublayers->currentIndex() );
+  mSettings->setEnumValue( QStringLiteral( "/qgis/promptForSublayers" ), ( QgsSublayersDialog::PromptMode )cmbPromptSublayers->currentData().toInt() );
+
   mSettings->setValue( QStringLiteral( "/qgis/scanItemsInBrowser2" ),
                        cmbScanItemsInBrowser->currentData().toString() );
   mSettings->setValue( QStringLiteral( "/qgis/scanZipInBrowser2" ),

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -179,17 +179,18 @@ void QgsSublayersDialog::populateLayerTable( const QgsSublayersDialog::LayerDefi
 int QgsSublayersDialog::exec()
 {
   QgsSettings settings;
-  QString promptLayers = settings.value( QStringLiteral( "qgis/promptForSublayers" ), 1 ).toString();
+  PromptMode promptLayers = settings.enumValue( QStringLiteral( "qgis/promptForSublayers" ), PromptAlways );
 
   // make sure three are sublayers to choose
   if ( layersTable->topLevelItemCount() == 0 )
     return QDialog::Rejected;
 
   layersTable->selectAll();
+
   // check promptForSublayers settings - perhaps this should be in QgsDataSource instead?
-  if ( promptLayers == QLatin1String( "no" ) )
+  if ( promptLayers == PromptNever )
     return QDialog::Rejected;
-  else if ( promptLayers == QLatin1String( "all" ) )
+  else if ( promptLayers == PromptLoadAll )
     return QDialog::Accepted;
 
   // if there is only 1 sublayer (probably the main layer), just select that one and return

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -17,6 +17,7 @@
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
+#include "qgsproviderregistry.h"
 
 #include <QTableWidgetItem>
 #include <QPushButton>
@@ -43,16 +44,17 @@ class SubLayerItem : public QTreeWidgetItem
 //! @endcond
 
 QgsSublayersDialog::QgsSublayersDialog( ProviderType providerType, const QString &name,
-                                        QWidget *parent, Qt::WindowFlags fl )
+                                        QWidget *parent, Qt::WindowFlags fl, const QString providerSource )
   : QDialog( parent, fl )
   , mName( name )
 {
   setupUi( this );
   QgsGui::enableAutoGeometryRestore( this );
 
+  QString title;
   if ( providerType == QgsSublayersDialog::Ogr )
   {
-    setWindowTitle( tr( "Select Vector Layers to Add…" ) );
+    title = tr( "Select Vector Layers to Add…" );
     layersTable->setHeaderLabels( QStringList() << tr( "Layer ID" ) << tr( "Layer name" )
                                   << tr( "Number of features" ) << tr( "Geometry type" ) << tr( "Description" ) );
     mShowCount = true;
@@ -61,16 +63,20 @@ QgsSublayersDialog::QgsSublayersDialog( ProviderType providerType, const QString
   }
   else if ( providerType == QgsSublayersDialog::Gdal )
   {
-    setWindowTitle( tr( "Select Raster Layers to Add…" ) );
+    title = tr( "Select Raster Layers to Add…" );
     layersTable->setHeaderLabels( QStringList() << tr( "Layer ID" ) << tr( "Layer name" ) );
   }
   else
   {
-    setWindowTitle( tr( "Select Layers to Add…" ) );
+    title = tr( "Select Layers to Add…" );
     layersTable->setHeaderLabels( QStringList() << tr( "Layer ID" ) << tr( "Layer name" )
                                   << tr( "Type" ) );
     mShowType = true;
   }
+
+  QVariantMap uriComponents = QgsProviderRegistry::instance()->decodeUri( name, providerSource );
+  QString path = uriComponents[QStringLiteral( "path" )].toString();
+  setWindowTitle( path.isEmpty() ? title : QStringLiteral( "%1 | %2" ).arg( title, QDir::toNativeSeparators( path ) ) );
 
   // add a "Select All" button - would be nicer with an icon
   QPushButton *button = new QPushButton( tr( "Select All" ) );

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -74,16 +74,16 @@ QgsSublayersDialog::QgsSublayersDialog( ProviderType providerType, const QString
     mShowType = true;
   }
 
-  QString filename = providerType == QgsSublayersDialog::Vsifile
-                     ? providerSource
-                     : QgsProviderRegistry::instance()->decodeUri( name, providerSource )[QStringLiteral( "path" )].toString();
+  QString fileFullPath = providerType == QgsSublayersDialog::Vsifile
+                         ? providerSource
+                         : QgsProviderRegistry::instance()->decodeUri( name, providerSource )[QStringLiteral( "path" )].toString();
+  QString filename = QFileInfo( fileFullPath ).fileName();
 
-  txtFilePath->setText( QDir::toNativeSeparators( QFileInfo( filename ).canonicalFilePath() ) );
+  setWindowTitle( filename.isEmpty() ? title : QStringLiteral( "%1 | %2" ).arg( title, filename ) );
+  txtFilePath->setText( QDir::toNativeSeparators( QFileInfo( fileFullPath ).canonicalFilePath() ) );
 
   if ( filename.isEmpty() )
-    grpFilePath->setVisible( false );
-
-  setWindowTitle( title );
+    txtFilePath->setVisible( false );
 
   // add a "Select All" button - would be nicer with an icon
   connect( btnSelectAll, &QAbstractButton::pressed, layersTable, &QTreeView::selectAll );

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -32,7 +32,7 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
   public:
 
     /**
-     * Prompt behaviour of the QgsSublayersDialog
+     * Prompt behavior of the QgsSublayersDialog
      */
     enum PromptMode
     {

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -30,6 +30,10 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
 {
     Q_OBJECT
   public:
+
+    /**
+     * Prompt behaviour of the QgsSublayersDialog
+     */
     enum PromptMode
     {
 

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -30,6 +30,30 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
 {
     Q_OBJECT
   public:
+    enum PromptMode
+    {
+
+      /**
+       * always ask if there are existing sublayers
+       */
+      PromptAlways,
+
+      /**
+       * always ask if there are existing sublayers, but skip if there are bands for rasters
+       */
+      PromptIfNeeded,
+
+      /**
+       * never prompt, will not load anything
+       */
+      PromptNever,
+
+      /**
+       * never prompt, but load all sublayers
+       */
+      PromptLoadAll
+    };
+    Q_ENUM( PromptMode )
 
     enum ProviderType
     {
@@ -104,6 +128,9 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
 
   public slots:
     int exec() override;
+
+  protected slots:
+    void layersTable_selectionChanged( const QItemSelection &, const QItemSelection & );
 
   protected:
     QString mName;

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -61,7 +61,8 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
     QgsSublayersDialog( ProviderType providerType,
                         const QString &name,
                         QWidget *parent SIP_TRANSFERTHIS = nullptr,
-                        Qt::WindowFlags fl = nullptr );
+                        Qt::WindowFlags fl = nullptr,
+                        const QString providerSource = QString() );
 
     ~QgsSublayersDialog() override;
 

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -118,7 +118,7 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
      * If we should add layers in a group
      * \since QGIS 3.0
      */
-    bool addToGroupCheckbox() const { return mCheckboxAddToGroup->isChecked(); }
+    bool addToGroupCheckbox() const { return cbxAddToGroup->isChecked(); }
 
     /**
      * Returns column with count or -1
@@ -129,8 +129,9 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
   public slots:
     int exec() override;
 
-  protected slots:
+  private slots:
     void layersTable_selectionChanged( const QItemSelection &, const QItemSelection & );
+    void btnDeselectAll_pressed();
 
   protected:
     QString mName;
@@ -142,7 +143,6 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
   private:
 
     bool mShowAddToGroupCheckbox = false;   //!< Whether to show the add to group checkbox
-    QCheckBox *mCheckboxAddToGroup = nullptr;
 };
 
 #endif

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1999,14 +1999,18 @@
                   <item row="0" column="2">
                    <widget class="QComboBox" name="cmbScanItemsInBrowser"/>
                   </item>
-                  <item row="2" column="2">
-                   <widget class="QComboBox" name="cmbPromptRasterSublayers">
-                    <item>
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </item>
+                  <item row="6" column="0" colspan="4">
+                   <widget class="QCheckBox" name="cbxEvaluateDefaultValues">
+                    <property name="toolTip">
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When digitizing a new feature, default values are retrieved from the database. With this option turned on, the default values will be evaluated at the time of digitizing. With this option turned off, the default values will be evaluated at the time of saving.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                    </property>
+                    <property name="text">
+                     <string>Evaluate default values</string>
+                    </property>
                    </widget>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="cmbScanZipInBrowser"/>
                   </item>
                   <item row="1" column="1">
                    <spacer name="horizontalSpacer_3">
@@ -2021,28 +2025,26 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_29">
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="textLabel1_13">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
                     <property name="text">
-                     <string>Scan for contents of compressed files (.zip) in browser dock</string>
+                     <string>Prompt for sublayers when opening</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="0" colspan="4">
-                   <widget class="QCheckBox" name="cbxEvaluateDefaultValues">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When digitizing a new feature, default values are retrieved from the database. With this option turned on, the default values will be evaluated at the time of digitizing. With this option turned off, the default values will be evaluated at the time of saving.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                    </property>
-                    <property name="text">
-                     <string>Evaluate default values</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QComboBox" name="cmbScanZipInBrowser">
-                    <property name="currentIndex">
-                     <number>-1</number>
-                    </property>
+                  <item row="2" column="2">
+                   <widget class="QComboBox" name="cmbPromptSublayers">
+                    <item>
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </item>
                    </widget>
                   </item>
                   <item row="0" column="0">
@@ -2059,16 +2061,10 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="textLabel1_13">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_29">
                     <property name="text">
-                     <string>Prompt for raster sublayers when opening</string>
+                     <string>Scan for contents of compressed files (.zip) in browser dock</string>
                     </property>
                    </widget>
                   </item>
@@ -5756,7 +5752,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>leNullValue</tabstop>
   <tabstop>cmbScanItemsInBrowser</tabstop>
   <tabstop>cmbScanZipInBrowser</tabstop>
-  <tabstop>cmbPromptRasterSublayers</tabstop>
+  <tabstop>cmbPromptSublayers</tabstop>
   <tabstop>cbxCompileExpressions</tabstop>
   <tabstop>cbxEvaluateDefaultValues</tabstop>
   <tabstop>mBtnRemoveHiddenPath</tabstop>

--- a/src/ui/qgssublayersdialogbase.ui
+++ b/src/ui/qgssublayersdialogbase.ui
@@ -91,12 +91,18 @@
    </item>
    <item row="0" column="0">
     <widget class="QLineEdit" name="txtFilePath">
-    <property name="enabled">
-      <bool>false</bool>
-    </property>
-    <property name="toolTip">
+     <property name="toolTip">
       <string>Current file source</string>
-    </property>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: #505050;
+background-color: #F0F0F0;
+border: 1px solid #B0B0B0;
+border-radius: 2px;</string>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgssublayersdialogbase.ui
+++ b/src/ui/qgssublayersdialogbase.ui
@@ -90,38 +90,13 @@
     </layout>
    </item>
    <item row="0" column="0">
-    <widget class="QFrame" name="grpFilePath">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="lblFilePath">
-        <property name="text">
-         <string>Path</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="txtFilePath">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
+    <widget class="QLineEdit" name="txtFilePath">
+    <property name="enabled">
+      <bool>false</bool>
+    </property>
+    <property name="toolTip">
+      <string>Current file source</string>
+    </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgssublayersdialogbase.ui
+++ b/src/ui/qgssublayersdialogbase.ui
@@ -20,7 +20,7 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="QTreeWidget" name="layersTable">
      <property name="selectionMode">
       <enum>QAbstractItemView::ExtendedSelection</enum>
@@ -41,7 +41,7 @@
      </column>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -49,6 +49,79 @@
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btnSelectAll">
+       <property name="text">
+        <string>Select All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnDeselectAll">
+       <property name="text">
+        <string>Deselect All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbxAddToGroup">
+       <property name="text">
+        <string>Add layers to a group</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="QFrame" name="grpFilePath">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="lblFilePath">
+        <property name="text">
+         <string>Path</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="txtFilePath">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
An annoying lack of context when adding multiple layers:
1) select multiple multi-layer geopackage layers from a directory in the file browser
2) drag and drop them in QGIS
3) the "Select Layers to Add..." dialog does not give any hint about the source file

This PR fixes 3) by adding the current file name in the window title.
![Peek 2020-03-14 01-11](https://user-images.githubusercontent.com/2820439/76666233-5e00de80-6591-11ea-9416-ba2fda0bb353.gif)

Fixes: https://github.com/qgis/QGIS/issues/26905