### PR TITLE
improve GTIFF JPEG compression by adding PHOTOMETRIC=YCBCR (fix #35002)

### DIFF
--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -71,7 +71,7 @@ QgsRasterFormatSaveOptionsWidget::QgsRasterFormatSaveOptionsWidget( QWidget *par
         << QStringLiteral( "COMPRESS=DEFLATE PREDICTOR=2 ZLEVEL=9" ) );
     sBuiltinProfiles[ QStringLiteral( "z_gtiff_4jpeg" )] =
       ( QStringList() << QStringLiteral( "GTiff" ) << tr( "JPEG Compression" )
-        << QStringLiteral( "COMPRESS=JPEG JPEG_QUALITY=75" ) );
+        << QStringLiteral( "COMPRESS=JPEG JPEG_QUALITY=75 PHOTOMETRIC=YCBCR" ) );
 
     // overview compression schemes for GTiff format, see
     // http://www.gdal.org/gdaladdo.html and http://www.gdal.org/frmt_gtiff.html


### PR DESCRIPTION
## Description
Improve JPEG compression for GTIFF format by using YCBCR color space. This reduces size of the image even more as JPEG compression works better with this color space.

Fixes #35002.