### PR TITLE
Feature: Add toolbutton to "Deselect Features from the Current Active layer"

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -268,6 +268,7 @@
         <file>themes/default/mActionDeleteSelected.svg</file>
         <file>themes/default/mActionDeleteTable.svg</file>
         <file>themes/default/mActionDeselectAll.svg</file>
+        <file>themes/default/mActionDeselectActiveLayer.svg</file>
         <file>themes/default/mActionDuplicateLayer.svg</file>
         <file>themes/default/mActionDuplicateComposer.svg</file>
         <file>themes/default/mActionEditCopy.svg</file>

--- a/images/themes/default/mActionDeselectActiveLayer.svg
+++ b/images/themes/default/mActionDeselectActiveLayer.svg
@@ -1,7 +1,6 @@
 <svg enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
 <g transform="translate(0 -8)">
 <path d="m2.5384614 10.538462h12.923078v12.923077h-12.923078z" fill="#fce94f" overflow="visible" stroke="#c4a000" stroke-linecap="round" stroke-width="1.07692313"/>
-<path d="m6.5384614 14.538462h12.923078v12.923077h-12.923078z" fill="#fce94f" overflow="visible" stroke="#c4a000" stroke-linecap="round" stroke-width="1.07692313"/>
 <g transform="translate(-.00000002 8.0000001)">
 <path d="m14.357 13.5h8.285c.474 0 .857.384.857.857v8.285c0 .474-.384.857-.857.857h-8.285c-.474 0-.857-.384-.857-.857v-8.285c0-.473.384-.857.857-.857z" fill="#c00" opacity=".9" stroke="#c00" stroke-linecap="square" stroke-linejoin="round"/>
 <path d="m13.5 18.5h10v-3.334c0-1.666 0-1.666-2.5-1.666-.582 0-5.061 0-5.834 0-1.666 0-1.666 0-1.666 1.666 0 .834 0 1.668 0 3.334z" fill="#fcffff" opacity=".5"/>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3110,43 +3110,71 @@ void QgisApp::createToolBars()
 
   mToolbarMenu->addActions( toolbarMenuActions );
 
-  // selection tool button
-
+  // advanced selection tool button
   QToolButton *bt = new QToolButton( mAttributesToolBar );
   bt->setPopupMode( QToolButton::MenuButtonPopup );
-  QList<QAction *> selectionActions;
-  selectionActions << mActionSelectByForm << mActionSelectByExpression << mActionSelectAll
-                   << mActionInvertSelection;
-  bt->addActions( selectionActions );
+  bt->addAction( mActionSelectByForm );
+  bt->addAction( mActionSelectByExpression );
+  bt->addAction( mActionSelectAll );
+  bt->addAction( mActionInvertSelection );
 
-  QAction *defSelectionAction = mActionSelectByForm;
+  QAction *defAdvancedSelectionAction = mActionSelectByForm;
   switch ( settings.value( QStringLiteral( "UI/selectionTool" ), 0 ).toInt() )
   {
     case 0:
-      defSelectionAction = mActionSelectByForm;
+      defAdvancedSelectionAction = mActionSelectByForm;
       break;
     case 1:
-      defSelectionAction = mActionSelectByExpression;
+      defAdvancedSelectionAction = mActionSelectByExpression;
       break;
     case 2:
-      defSelectionAction = mActionSelectAll;
+      defAdvancedSelectionAction = mActionSelectAll;
       break;
     case 3:
-      defSelectionAction = mActionInvertSelection;
+      defAdvancedSelectionAction = mActionInvertSelection;
       break;
   }
-  bt->setDefaultAction( defSelectionAction );
-  QAction *selectionAction = mAttributesToolBar->insertWidget( mActionOpenTable, bt );
-  selectionAction->setObjectName( QStringLiteral( "ActionSelection" ) );
+  bt->setDefaultAction( defAdvancedSelectionAction );
+  QAction *advancedSelectionAction = mAttributesToolBar->insertWidget( mActionOpenTable, bt );
+  advancedSelectionAction->setObjectName( QStringLiteral( "ActionSelection" ) );
+  connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
+
+
+  // mouse select tool button
+  bt = new QToolButton( mAttributesToolBar );
+  bt->setPopupMode( QToolButton::MenuButtonPopup );
+  bt->addAction( mActionSelectFeatures );
+  bt->addAction( mActionSelectPolygon );
+  bt->addAction( mActionSelectFreehand );
+  bt->addAction( mActionSelectRadius );
+
+  QAction *defMouseSelectAction = mActionSelectFeatures;
+  switch ( settings.value( QStringLiteral( "UI/selectTool" ), 1 ).toInt() )
+  {
+    case 1:
+      defMouseSelectAction = mActionSelectFeatures;
+      break;
+    case 2:
+      defMouseSelectAction = mActionSelectRadius;
+      break;
+    case 3:
+      defMouseSelectAction = mActionSelectPolygon;
+      break;
+    case 4:
+      defMouseSelectAction = mActionSelectFreehand;
+      break;
+  }
+  bt->setDefaultAction( defMouseSelectAction );
+  QAction *mouseSelectionAction = mAttributesToolBar->insertWidget( advancedSelectionAction, bt );
+  mouseSelectionAction->setObjectName( QStringLiteral( "ActionSelect" ) );
   connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
 
 
   // deselection tool button
   bt = new QToolButton( mAttributesToolBar );
   bt->setPopupMode( QToolButton::MenuButtonPopup );
-  QList<QAction *> deselectionActions;
-  deselectionActions << mActionDeselectAll << mActionDeselectActiveLayer;
-  bt->addActions( deselectionActions );
+  bt->addAction( mActionDeselectAll );
+  bt->addAction( mActionDeselectActiveLayer );
 
   QAction *defDeselectionAction = mActionDeselectAll;
   switch ( settings.value( QStringLiteral( "UI/deselectionTool" ), 0 ).toInt() )
@@ -3164,36 +3192,6 @@ void QgisApp::createToolBars()
   connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
 
 
-  // select tool button
-
-  bt = new QToolButton( mAttributesToolBar );
-  bt->setPopupMode( QToolButton::MenuButtonPopup );
-  QList<QAction *> selectActions;
-  selectActions << mActionSelectFeatures << mActionSelectPolygon
-                << mActionSelectFreehand << mActionSelectRadius;
-  bt->addActions( selectActions );
-
-  QAction *defSelectAction = mActionSelectFeatures;
-  switch ( settings.value( QStringLiteral( "UI/selectTool" ), 1 ).toInt() )
-  {
-    case 1:
-      defSelectAction = mActionSelectFeatures;
-      break;
-    case 2:
-      defSelectAction = mActionSelectRadius;
-      break;
-    case 3:
-      defSelectAction = mActionSelectPolygon;
-      break;
-    case 4:
-      defSelectAction = mActionSelectFreehand;
-      break;
-  }
-  bt->setDefaultAction( defSelectAction );
-  QAction *selectAction = mAttributesToolBar->insertWidget( deselectionAction, bt );
-  selectAction->setObjectName( QStringLiteral( "ActionSelect" ) );
-  connect( bt, &QToolButton::triggered, this, &QgisApp::toolButtonActionTriggered );
-
   // feature action tool button
 
   bt = new QToolButton( mAttributesToolBar );
@@ -3204,7 +3202,7 @@ void QgisApp::createToolBars()
   connect( mFeatureActionMenu, &QMenu::triggered, this, &QgisApp::doFeatureAction );
   connect( mFeatureActionMenu, &QMenu::aboutToShow, this, &QgisApp::refreshFeatureActions );
   bt->setMenu( mFeatureActionMenu );
-  QAction *featureActionAction = mAttributesToolBar->insertWidget( selectAction, bt );
+  QAction *featureActionAction = mAttributesToolBar->insertWidget( mouseSelectionAction, bt );
   featureActionAction->setObjectName( QStringLiteral( "ActionFeatureAction" ) );
 
   // measure tool button

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1497,6 +1497,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! deselect features from all layers
     void deselectAll();
 
+    //! deselect features from the current active layer
+    void deselectActiveLayer();
+
     //! select all features
     void selectAll();
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -292,6 +292,7 @@
      <addaction name="mActionSelectByForm"/>
      <addaction name="mActionSelectByExpression"/>
      <addaction name="mActionDeselectAll"/>
+     <addaction name="mActionDeselectActiveLayer"/>
      <addaction name="mActionReselect"/>
      <addaction name="mActionSelectAll"/>
      <addaction name="mActionInvertSelection"/>
@@ -542,7 +543,6 @@
     <bool>true</bool>
    </attribute>
    <addaction name="mActionIdentify"/>
-   <addaction name="mActionDeselectAll"/>
    <addaction name="mActionOpenTable"/>
    <addaction name="mActionOpenFieldCalc"/>
    <addaction name="mActionStatisticalSummary"/>
@@ -1211,6 +1211,15 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+A</string>
+   </property>
+  </action>
+  <action name="mActionDeselectActiveLayer">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionDeselectActiveLayer.svg</normaloff>:/images/themes/default/mActionDeselectActiveLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Deselect Features from the Current Active Layer</string>
    </property>
   </action>
   <action name="mActionSelectAll">


### PR DESCRIPTION
Pretty much the title.
![Peek 2020-03-15 01-55](https://user-images.githubusercontent.com/2820439/76692569-26616780-6661-11ea-9071-fd4c712860db.gif)

CODE NOTE: Only the three selection tools were using the `addActions` way of adding actions, so I rewrote them to be the same as the rest of the function.
```diff
- bt->addActions( actionsList )
+ bt->addAction ( singleAction )
```
The function is still extremely ugly and needs some love one day.

Fixes: https://github.com/qgis/QGIS/issues/31598