### PR TITLE
Allow resizing and moving columns in bad layer handler

### DIFF
--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -113,6 +113,9 @@ QgsHandleBadLayers::QgsHandleBadLayers( const QList<QDomNode> &layers )
                                          << tr( "Datasource" )
                                        );
 
+  mLayerList->horizontalHeader()->setSectionMovable( true );
+  mLayerList->horizontalHeader()->setSectionResizeMode( QHeaderView::Interactive );
+
   int j = 0;
   for ( int i = 0; i < mLayers.size(); i++ )
   {

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -113,7 +113,7 @@ QgsHandleBadLayers::QgsHandleBadLayers( const QList<QDomNode> &layers )
                                          << tr( "Datasource" )
                                        );
 
-  mLayerList->horizontalHeader()->setSectionMovable( true );
+  mLayerList->horizontalHeader()->setSectionsMovable( true );
   mLayerList->horizontalHeader()->setSectionResizeMode( QHeaderView::Interactive );
 
   int j = 0;


### PR DESCRIPTION
## Description

Fixes #26920

Enable interactive resize mode and allow moving columns in the bad layer handler QTableWidget.