### PR TITLE
clear model before loading new attribute values (fix #34544)

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -475,6 +475,7 @@ void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int 
   QList<QVariant> values = mLayer->uniqueValues( fieldIndex, countLimit ).toList();
   std::sort( values.begin(), values.end() );
 
+  mValuesModel->clear();
   for ( const QVariant &value : qgis::as_const( values ) )
   {
     QString strValue;


### PR DESCRIPTION
## Description
In QGIS 3.10 in the Field Calculator or expression builder clicking on "All unique" or "10 samples" buttons cause adding new values to the list withon clearing it. Proposed PR fixes this by clearing list model before adding anything new to it. Only 3.10 is affected.

Fixes #34544.