### PR TITLE
Snapping enabled on a configurable scale range

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -684,6 +684,7 @@
         <file>themes/default/mIconSnappingArea.svg</file>
         <file>themes/default/mIconSnappingCentroid.svg</file>
         <file>themes/default/mIconSnappingMiddle.svg</file>
+        <file>themes/default/mIconSnappingOnScale.svg</file>
         <file>themes/default/mIconSnappingVertex.svg</file>
         <file>themes/default/mIconSnappingSegment.svg</file>
         <file>themes/default/mIconTopologicalEditing.svg</file>

--- a/images/themes/default/mIconSnappingOnScale.svg
+++ b/images/themes/default/mIconSnappingOnScale.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg7302"
+   sodipodi:docname="mIconSnapping.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata7308">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7306" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1171"
+     id="namedview7304"
+     showgrid="false"
+     inkscape:showpageshadow="false"
+     inkscape:zoom="23.393298"
+     inkscape:cx="14.684039"
+     inkscape:cy="11.598263"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7302"
+     inkscape:snap-global="true" />
+  <path
+     d="m 13.178333,7.3757775 3.707633,3.8795835 c 2.42837,2.42837 -0.69923,5.643032 -3.334371,3.197319 l -3.900157,-3.550008 -2.116137,2.116137 4.10594,4.062746 0.304487,0.295282 c 2.01388,1.895018 5.296031,1.700951 7.371786,-0.435881 2.091969,-2.140268 2.281205,-5.47878 0.315809,-7.4422485 L 19.431056,9.2956512 15.29447,5.2596406 Z"
+     id="path7296"
+     inkscape:connector-curvature="0"
+     style="fill:#d00000;stroke:#860000;stroke-width:0.67199868;stroke-linecap:square;stroke-linejoin:round" />
+  <path
+     d="M 11.740021,13.228218 9.7592562,11.255364 8.0046724,13.006085 10.004126,15.00434 Z"
+     id="path7298"
+     inkscape:connector-curvature="0"
+     style="fill:#eeeeec;stroke-width:1.06720102" />
+  <path
+     d="M 17.324822,7.7284671 15.297296,5.7283353 13.628048,7.4016289 15.64716,9.4687692 Z"
+     id="path7300"
+     inkscape:connector-curvature="0"
+     style="fill:#eeeeec;stroke-width:1.06720102" />
+  <rect
+     style="opacity:1;fill:#860000;fill-opacity:1;stroke:none;stroke-width:3.14419723;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853"
+     width="18.76606"
+     height="0.67092407"
+     x="4.4457178"
+     y="3.381155" />
+  <rect
+     style="opacity:1;fill:#860000;fill-opacity:1;stroke:none;stroke-width:3.14419723;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853-0"
+     width="18.76606"
+     height="0.67092407"
+     x="4.4457178"
+     y="19.853975" />
+  <rect
+     style="opacity:1;fill:#860000;fill-opacity:1;stroke:none;stroke-width:7.77270412;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853-7"
+     width="3.3770342"
+     height="22.784304"
+     x="-3.8480341"
+     y="0.57448733"
+     transform="scale(-1,1)" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.48809075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853-6"
+     width="6.0701156"
+     height="1.2988601"
+     x="0.57448733"
+     y="-2.1595175"
+     transform="rotate(90)" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.48809075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853-6-0"
+     width="6.0701156"
+     height="1.2988601"
+     x="6.6446028"
+     y="-3.4583771"
+     transform="rotate(90)"
+     inkscape:transform-center-x="1.558632"
+     inkscape:transform-center-y="-2.6503317" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.48809075;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853-6-0-1"
+     width="6.0701156"
+     height="1.2988601"
+     x="12.714718"
+     y="-2.1595175"
+     transform="rotate(90)"
+     inkscape:transform-center-x="1.5586321"
+     inkscape:transform-center-y="-2.6503317" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2.19980192;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+     id="rect7853-6-0-1-0"
+     width="4.7449498"
+     height="1.2988601"
+     x="18.784834"
+     y="-3.4583778"
+     transform="rotate(90)"
+     inkscape:transform-center-x="1.558632"
+     inkscape:transform-center-y="-2.0717382" />
+  <g
+     id="g7964"
+     transform="translate(-18.851552,-7.2242912)"
+     style="stroke:#860000;stroke-opacity:1">
+    <path
+       inkscape:connector-curvature="0"
+       id="path7945"
+       d="M 31.120024,8.4827354 32.6803,10.043011"
+       style="fill:none;stroke:#860000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7945-2"
+       d="M 34.240576,8.4827354 32.6803,10.043011"
+       style="fill:none;stroke:#860000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     id="g7964-5"
+     transform="rotate(-180,23.254524,15.5916)"
+     style="stroke:#860000;stroke-opacity:1">
+    <path
+       inkscape:connector-curvature="0"
+       id="path7945-1"
+       d="M 31.120024,8.4827354 32.6803,10.043011"
+       style="fill:none;stroke:#860000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7945-2-9"
+       d="M 34.240576,8.4827354 32.6803,10.043011"
+       style="fill:none;stroke:#860000;stroke-width:0.69999999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/python/core/auto_additions/qgssnappingconfig.py
+++ b/python/core/auto_additions/qgssnappingconfig.py
@@ -3,3 +3,4 @@ QgsSnappingConfig.SnappingMode.baseClass = QgsSnappingConfig
 QgsSnappingConfig.SnappingTypes.baseClass = QgsSnappingConfig
 QgsSnappingConfig.SnappingTypeFlag.baseClass = QgsSnappingConfig
 SnappingTypeFlag = QgsSnappingConfig  # dirty hack since SIP seems to introduce the flags in module
+QgsSnappingConfig.ScaleDependencyMode.baseClass = QgsSnappingConfig

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -73,7 +73,7 @@ This is a container of advanced configuration (per layer) of the snapping of the
 %End
       public:
 
- IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale  ) /Deprecated/;
+ IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale ) /Deprecated/;
 %Docstring
 IndividualLayerSettings
 
@@ -81,6 +81,8 @@ IndividualLayerSettings
 :param type:
 :param tolerance:
 :param units:
+:param minScale:
+:param maxScale:
 
 .. deprecated:: QGIS 3.12
    use the method with SnappingTypeFlag instead.
@@ -96,6 +98,7 @@ IndividualLayerSettings
 :param units:
 :param minScale:
 :param maxScale:
+
 .. versionadded:: 3.12
 %End
 

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -51,6 +51,13 @@ This is a container for configuration of the snapping of the project
     typedef QFlags<QgsSnappingConfig::SnappingTypes> SnappingTypeFlag;
 
 
+    enum ScaleDependencyMode
+    {
+      Disabled,
+      ScaleDependentGlobal,
+      ScaleDependentPerLayer
+    };
+
     static const QString snappingTypeFlagToString( SnappingTypeFlag type );
 %Docstring
 Convenient method to returns the translated name of the enum type
@@ -154,42 +161,59 @@ define the type of snapping
 
         double tolerance() const;
 %Docstring
+!
 Returns the tolerance
+
+.. versionadded:: 3.12
 %End
 
         void setTolerance( double tolerance );
 %Docstring
 Sets the tolerance
+
+.. versionadded:: 3.12
 %End
 
         QgsTolerance::UnitType units() const;
 %Docstring
 Returns the type of units
+
+.. versionadded:: 3.12
 %End
 
         void setUnits( QgsTolerance::UnitType units );
 %Docstring
 Sets the type of units
+
+.. versionadded:: 3.12
 %End
 
         double minScale() const;
 %Docstring
 Returns min scale on which snapping is limited
+
+.. versionadded:: 3.14
 %End
 
         void setMinScale( double p_minScale );
 %Docstring
 Sets the min scale value on which snapping is used, 0.0 disable scale limit
+
+.. versionadded:: 3.14
 %End
 
         double maxScale() const;
 %Docstring
-Returns max scale on which snapping is limite
+Returns max scale on which snapping is limited
+
+.. versionadded:: 3.14
 %End
 
         void setMaxScale( double p_maxScale );
 %Docstring
 Sets the max scale value on which snapping is used, 0.0 disable scale limit
+
+.. versionadded:: 3.14
 %End
 
         bool operator!= ( const QgsSnappingConfig::IndividualLayerSettings &other ) const;
@@ -273,31 +297,43 @@ Sets the tolerance
     double minScale() const;
 %Docstring
 Returns the min scale
+
+.. versionadded:: 3.14
 %End
 
     void setMinScale( double pMinScale );
 %Docstring
 Sets the min scale on which snapping is enabled, 0.0 disable scale limit
+
+.. versionadded:: 3.14
 %End
 
     double maxScale() const;
 %Docstring
 Returns the max scale
+
+.. versionadded:: 3.14
 %End
 
     void setMaxScale( double pMaxScale );
 %Docstring
 Set the max scale on which snapping is enabled, 0.0 disable scale limit
+
+.. versionadded:: 3.14
 %End
 
-    bool limitToScale() const;
+    void setScaleDependencyMode( ScaleDependencyMode mode );
 %Docstring
-Returns limit to scale
+Set the scale dependency mode
+
+.. versionadded:: 3.14
 %End
 
-    void setLimitToScale( bool pLimitSnapping );
+    ScaleDependencyMode scaleDependencyMode() const;
 %Docstring
-Set limit to scale, true means snapping will be limited to the [minScale, maxScale] range
+Returns the scale dependency mode
+
+.. versionadded:: 3.14
 %End
 
     QgsTolerance::UnitType units() const;

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -73,7 +73,7 @@ This is a container of advanced configuration (per layer) of the snapping of the
 %End
       public:
 
- IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale ) /Deprecated/;
+ IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units ) /Deprecated/;
 %Docstring
 IndividualLayerSettings
 

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -184,7 +184,7 @@ Returns minimum scale on which snapping is limited
 .. versionadded:: 3.14
 %End
 
-        void setMinimumScale( double p_minScale );
+        void setMinimumScale( double minScale );
 %Docstring
 Sets the min scale value on which snapping is used, 0.0 disable scale limit
 
@@ -198,7 +198,7 @@ Returns max scale on which snapping is limited
 .. versionadded:: 3.14
 %End
 
-        void setMaximumScale( double p_maxScale );
+        void setMaximumScale( double maxScale );
 %Docstring
 Sets the max scale value on which snapping is used, 0.0 disable scale limit
 
@@ -290,7 +290,7 @@ Returns the min scale
 .. versionadded:: 3.14
 %End
 
-    void setMinimumScale( double pMinScale );
+    void setMinimumScale( double minScale );
 %Docstring
 Sets the min scale on which snapping is enabled, 0.0 disable scale limit
 
@@ -304,7 +304,7 @@ Returns the max scale
 .. versionadded:: 3.14
 %End
 
-    void setMaximumScale( double pMaxScale );
+    void setMaximumScale( double maxScale );
 %Docstring
 Set the max scale on which snapping is enabled, 0.0 disable scale limit
 

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -267,6 +267,36 @@ Returns the tolerance
 Sets the tolerance
 %End
 
+    double minScale() const;
+%Docstring
+Returns the min scale
+%End
+
+    void setMinScale( double pMinScale );
+%Docstring
+Sets the min scale
+%End
+
+    double maxScale() const;
+%Docstring
+Returns the max scale
+%End
+
+    void setMaxScale( double pMaxScale );
+%Docstring
+Set the max scale
+%End
+
+    bool limitToScale() const;
+%Docstring
+Returns limit to scale
+%End
+
+    void setLimitToScale( bool pLimitSnapping );
+%Docstring
+Set limit to scale
+%End
+
     QgsTolerance::UnitType units() const;
 %Docstring
 Returns the type of units

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -93,7 +93,7 @@ IndividualLayerSettings
    use the method with SnappingTypeFlag instead.
 %End
 
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale = 0.0, double maxScale = 0.0 );
 %Docstring
 IndividualLayerSettings
 
@@ -159,55 +159,46 @@ define the type of snapping
 
         double tolerance() const;
 %Docstring
-!
 Returns the tolerance
-
-.. versionadded:: 3.12
 %End
 
         void setTolerance( double tolerance );
 %Docstring
 Sets the tolerance
-
-.. versionadded:: 3.12
 %End
 
         QgsTolerance::UnitType units() const;
 %Docstring
 Returns the type of units
-
-.. versionadded:: 3.12
 %End
 
         void setUnits( QgsTolerance::UnitType units );
 %Docstring
 Sets the type of units
-
-.. versionadded:: 3.12
 %End
 
-        double minScale() const;
+        double minimumScale() const;
 %Docstring
-Returns min scale on which snapping is limited
+Returns minimun scale on which snapping is limited
 
 .. versionadded:: 3.14
 %End
 
-        void setMinScale( double p_minScale );
+        void setMinimumScale( double p_minScale );
 %Docstring
 Sets the min scale value on which snapping is used, 0.0 disable scale limit
 
 .. versionadded:: 3.14
 %End
 
-        double maxScale() const;
+        double maximumScale() const;
 %Docstring
 Returns max scale on which snapping is limited
 
 .. versionadded:: 3.14
 %End
 
-        void setMaxScale( double p_maxScale );
+        void setMaximumScale( double p_maxScale );
 %Docstring
 Sets the max scale value on which snapping is used, 0.0 disable scale limit
 
@@ -292,28 +283,28 @@ Returns the tolerance
 Sets the tolerance
 %End
 
-    double minScale() const;
+    double minimumScale() const;
 %Docstring
 Returns the min scale
 
 .. versionadded:: 3.14
 %End
 
-    void setMinScale( double pMinScale );
+    void setMinimumScale( double pMinScale );
 %Docstring
 Sets the min scale on which snapping is enabled, 0.0 disable scale limit
 
 .. versionadded:: 3.14
 %End
 
-    double maxScale() const;
+    double maximumScale() const;
 %Docstring
 Returns the max scale
 
 .. versionadded:: 3.14
 %End
 
-    void setMaxScale( double pMaxScale );
+    void setMaximumScale( double pMaxScale );
 %Docstring
 Set the max scale on which snapping is enabled, 0.0 disable scale limit
 

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -54,8 +54,8 @@ This is a container for configuration of the snapping of the project
     enum ScaleDependencyMode
     {
       Disabled,
-      ScaleDependentGlobal,
-      ScaleDependentPerLayer
+      Global,
+      PerLayer
     };
 
     static const QString snappingTypeFlagToString( SnappingTypeFlag type );

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -73,7 +73,7 @@ This is a container of advanced configuration (per layer) of the snapping of the
 %End
       public:
 
- IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units ) /Deprecated/;
+ IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  ) /Deprecated/;
 %Docstring
 IndividualLayerSettings
 
@@ -86,7 +86,7 @@ IndividualLayerSettings
    use the method with SnappingTypeFlag instead.
 %End
 
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  );
 %Docstring
 IndividualLayerSettings
 
@@ -166,6 +166,36 @@ Returns the type of units
         void setUnits( QgsTolerance::UnitType units );
 %Docstring
 Sets the type of units
+%End
+
+        bool limitToScaleRange() const;
+%Docstring
+Returns whether the snapping is limited on a scale iterval
+%End
+
+        void setLimitToScaleRange( bool p_uselimit );
+%Docstring
+Sets whether the scale limites are used or not
+%End
+
+        double minScale() const;
+%Docstring
+Returns min scale on which snapping is limited
+%End
+
+        void setMinScale( double p_minScale );
+%Docstring
+Sets the min scale value on which snapping is used
+%End
+
+        double maxScale() const;
+%Docstring
+Returns max scale on which snapping is limite
+%End
+
+        void setMaxScale( double p_maxScale );
+%Docstring
+Sets the max scale value on which snapping is used
 %End
 
         bool operator!= ( const QgsSnappingConfig::IndividualLayerSettings &other ) const;

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -81,8 +81,8 @@ IndividualLayerSettings
 :param type:
 :param tolerance:
 :param units:
-:param minScale:
-:param maxScale:
+:param minScale: 0.0 disable scale limit
+:param maxScale: 0.0 disable scale limit
 
 .. deprecated:: QGIS 3.12
    use the method with SnappingTypeFlag instead.
@@ -96,8 +96,8 @@ IndividualLayerSettings
 :param type:
 :param tolerance:
 :param units:
-:param minScale:
-:param maxScale:
+:param minScale: 0.0 disable scale limit
+:param maxScale: 0.0 disable scale limit
 
 .. versionadded:: 3.12
 %End
@@ -179,7 +179,7 @@ Returns min scale on which snapping is limited
 
         void setMinScale( double p_minScale );
 %Docstring
-Sets the min scale value on which snapping is used
+Sets the min scale value on which snapping is used, 0.0 disable scale limit
 %End
 
         double maxScale() const;
@@ -189,7 +189,7 @@ Returns max scale on which snapping is limite
 
         void setMaxScale( double p_maxScale );
 %Docstring
-Sets the max scale value on which snapping is used
+Sets the max scale value on which snapping is used, 0.0 disable scale limit
 %End
 
         bool operator!= ( const QgsSnappingConfig::IndividualLayerSettings &other ) const;
@@ -277,7 +277,7 @@ Returns the min scale
 
     void setMinScale( double pMinScale );
 %Docstring
-Sets the min scale
+Sets the min scale on which snapping is enabled, 0.0 disable scale limit
 %End
 
     double maxScale() const;
@@ -287,7 +287,7 @@ Returns the max scale
 
     void setMaxScale( double pMaxScale );
 %Docstring
-Set the max scale
+Set the max scale on which snapping is enabled, 0.0 disable scale limit
 %End
 
     bool limitToScale() const;
@@ -297,7 +297,7 @@ Returns limit to scale
 
     void setLimitToScale( bool pLimitSnapping );
 %Docstring
-Set limit to scale
+Set limit to scale, true means snapping will be limited to the [minScale, maxScale] range
 %End
 
     QgsTolerance::UnitType units() const;

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -73,7 +73,7 @@ This is a container of advanced configuration (per layer) of the snapping of the
 %End
       public:
 
- IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  ) /Deprecated/;
+ IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale  ) /Deprecated/;
 %Docstring
 IndividualLayerSettings
 
@@ -86,7 +86,7 @@ IndividualLayerSettings
    use the method with SnappingTypeFlag instead.
 %End
 
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale );
 %Docstring
 IndividualLayerSettings
 
@@ -94,7 +94,8 @@ IndividualLayerSettings
 :param type:
 :param tolerance:
 :param units:
-
+:param minScale:
+:param maxScale:
 .. versionadded:: 3.12
 %End
 
@@ -166,16 +167,6 @@ Returns the type of units
         void setUnits( QgsTolerance::UnitType units );
 %Docstring
 Sets the type of units
-%End
-
-        bool limitToScaleRange() const;
-%Docstring
-Returns whether the snapping is limited on a scale iterval
-%End
-
-        void setLimitToScaleRange( bool p_uselimit );
-%Docstring
-Sets whether the scale limites are used or not
 %End
 
         double minScale() const;

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -88,8 +88,6 @@ IndividualLayerSettings
 :param type:
 :param tolerance:
 :param units:
-:param minScale: 0.0 disable scale limit
-:param maxScale: 0.0 disable scale limit
 
 .. deprecated:: QGIS 3.12
    use the method with SnappingTypeFlag instead.

--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -179,7 +179,7 @@ Sets the type of units
 
         double minimumScale() const;
 %Docstring
-Returns minimun scale on which snapping is limited
+Returns minimum scale on which snapping is limited
 
 .. versionadded:: 3.14
 %End

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -27,6 +27,7 @@
 #include "qgssnappingconfig.h"
 #include "qgsvectorlayer.h"
 #include "qgsapplication.h"
+#include "qgsscalewidget.h"
 
 QgsSnappingLayerDelegate::QgsSnappingLayerDelegate( QgsMapCanvas *canvas, QObject *parent )
   : QItemDelegate( parent )
@@ -102,23 +103,15 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
 
   if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn )
   {
-    QDoubleSpinBox *minLimitSp = new QDoubleSpinBox( parent );
-    minLimitSp->setDecimals( 5 );
-    minLimitSp->setMinimum( 0.0 );
-    minLimitSp->setMaximum( 99999999.990000 );
+    QgsScaleWidget *minLimitSp = new QgsScaleWidget( parent );
     minLimitSp->setToolTip( tr( "Min Scale" ) );
-    minLimitSp->setSpecialValueText( "NULL" );
     return minLimitSp;
   }
 
   if ( index.column() == QgsSnappingLayerTreeModel::MaxScaleColumn )
   {
-    QDoubleSpinBox *maxLimitSp = new QDoubleSpinBox( parent );
-    maxLimitSp->setDecimals( 5 );
-    maxLimitSp->setMinimum( 0.0 );
-    maxLimitSp->setMaximum( 99999999.990000 );
+    QgsScaleWidget *maxLimitSp = new QgsScaleWidget( parent );
     maxLimitSp->setToolTip( tr( "Max Scale" ) );
-    maxLimitSp->setSpecialValueText( "NULL" );
     return maxLimitSp;
   }
 
@@ -163,13 +156,20 @@ void QgsSnappingLayerDelegate::setEditorData( QWidget *editor, const QModelIndex
       w->setCurrentIndex( w->findData( units ) );
     }
   }
-  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn ||
-            index.column() == QgsSnappingLayerTreeModel::MaxScaleColumn )
+  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn)
   {
-    QDoubleSpinBox *w = qobject_cast<QDoubleSpinBox *>( editor );
+    QgsScaleWidget *w = qobject_cast<QgsScaleWidget *>( editor );
     if ( w )
     {
-      w->setValue( val.toDouble() );
+      w->setScale( val.toDouble() );
+    }
+  }
+  else if ( index.column() == QgsSnappingLayerTreeModel::MaxScaleColumn )
+  {
+    QgsScaleWidget *w = qobject_cast<QgsScaleWidget *>( editor );
+    if ( w )
+    {
+      w->setScale( val.toDouble() );
     }
   }
 }
@@ -214,13 +214,20 @@ void QgsSnappingLayerDelegate::setModelData( QWidget *editor, QAbstractItemModel
       model->setData( index, w->value(), Qt::EditRole );
     }
   }
-  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn ||
-            index.column() == QgsSnappingLayerTreeModel::MaxScaleColumn )
+  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn)
   {
-    QDoubleSpinBox *w = qobject_cast<QDoubleSpinBox *>( editor );
+    QgsScaleWidget *w = qobject_cast<QgsScaleWidget *>( editor );
     if ( w )
     {
-      model->setData( index, w->value(), Qt::EditRole );
+      model->setData( index, w->scale(), Qt::EditRole );
+    }
+  }
+  else if ( index.column() == QgsSnappingLayerTreeModel::MaxScaleColumn )
+  {
+    QgsScaleWidget *w = qobject_cast<QgsScaleWidget *>( editor );
+    if ( w )
+    {
+      model->setData( index, w->scale(), Qt::EditRole );
     }
   }
 }
@@ -630,7 +637,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
       {
         if ( ls.minScale() <= 0.0 )
         {
-          return QString( "NULL" );
+          return QString( "not set" );
         }
         else
         {
@@ -650,7 +657,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
       {
         if ( ls.maxScale() <= 0.0 )
         {
-          return QString( "NULL" );
+          return QString( "not set" );
         }
         else
         {

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -104,9 +104,10 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
   {
     QDoubleSpinBox *minLimitSp = new QDoubleSpinBox( parent );
     minLimitSp->setDecimals( 5 );
-    minLimitSp->setMinimum( -1.0 );
+    minLimitSp->setMinimum( 0.0 );
     minLimitSp->setMaximum( 99999999.990000 );
     minLimitSp->setToolTip( tr( "Min Scale" ) );
+    minLimitSp->setSpecialValueText("NULL");
     return minLimitSp;
   }
 
@@ -114,9 +115,10 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
   {
     QDoubleSpinBox *maxLimitSp = new QDoubleSpinBox( parent );
     maxLimitSp->setDecimals( 5 );
-    maxLimitSp->setMinimum( -1.0 );
+    maxLimitSp->setMinimum( 0.0 );
     maxLimitSp->setMaximum( 99999999.990000 );
     maxLimitSp->setToolTip( tr( "Max Scale" ) );
+    maxLimitSp->setSpecialValueText("NULL");
     return maxLimitSp;
   }
 
@@ -626,7 +628,14 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        return QString::number( ls.minScale() );
+        if( ls.minScale() <= 0.0)
+        {
+          return QString( "NULL" );
+        }
+        else
+        {
+          return QString::number( ls.minScale() );
+        }
       }
 
       if ( role == Qt::UserRole )
@@ -639,7 +648,14 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        return QString::number( ls.maxScale() );
+        if( ls.maxScale() <= 0.0 )
+        {
+          return QString( "NULL" );
+        }
+        else
+        {
+          return QString::number( ls.maxScale() );
+        }
       }
 
       if ( role == Qt::UserRole )

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -107,7 +107,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
     minLimitSp->setMinimum( 0.0 );
     minLimitSp->setMaximum( 99999999.990000 );
     minLimitSp->setToolTip( tr( "Min Scale" ) );
-    minLimitSp->setSpecialValueText("NULL");
+    minLimitSp->setSpecialValueText( "NULL" );
     return minLimitSp;
   }
 
@@ -118,7 +118,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
     maxLimitSp->setMinimum( 0.0 );
     maxLimitSp->setMaximum( 99999999.990000 );
     maxLimitSp->setToolTip( tr( "Max Scale" ) );
-    maxLimitSp->setSpecialValueText("NULL");
+    maxLimitSp->setSpecialValueText( "NULL" );
     return maxLimitSp;
   }
 
@@ -628,7 +628,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        if( ls.minScale() <= 0.0)
+        if ( ls.minScale() <= 0.0 )
         {
           return QString( "NULL" );
         }
@@ -648,7 +648,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        if( ls.maxScale() <= 0.0 )
+        if ( ls.maxScale() <= 0.0 )
         {
           return QString( "NULL" );
         }

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -278,6 +278,13 @@ Qt::ItemFlags QgsSnappingLayerTreeModel::flags( const QModelIndex &idx ) const
           return Qt::NoItemFlags;
         }
       }
+      else if( idx.column() == MaxScaleColumn || idx.column() == MinScaleColumn )
+      {
+        if( mProject->snappingConfig().limitToScale() )
+        {
+          return Qt::ItemIsEnabled | Qt::ItemIsEditable;
+        }
+      }
       else
       {
         return Qt::ItemIsEnabled | Qt::ItemIsEditable;
@@ -381,7 +388,7 @@ void QgsSnappingLayerTreeModel::hasRowchanged( QgsLayerTreeNode *node, const QHa
     {
       emit dataChanged( QModelIndex(), idx );
     }
-    if ( oldSettings.value( vl ) != mProject->snappingConfig().individualLayerSettings().value( vl ) )
+    else
     {
       mIndividualLayerSettings.insert( vl, mProject->snappingConfig().individualLayerSettings().value( vl ) );
       emit dataChanged( idx, index( idx.row(), columnCount( idx ) - 1 ) );
@@ -637,7 +644,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
       {
         if ( ls.minScale() <= 0.0 )
         {
-          return QString( "not set" );
+          return QString( tr( "not set" ) );
         }
         else
         {
@@ -657,7 +664,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
       {
         if ( ls.maxScale() <= 0.0 )
         {
-          return QString( "not set" );
+          return QString( tr( "not set" ) );
         }
         else
         {

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -238,7 +238,7 @@ QgsSnappingLayerTreeModel::QgsSnappingLayerTreeModel( QgsProject *project, QgsMa
   , mProject( project )
   , mCanvas( canvas )
   , mIndividualLayerSettings( project->snappingConfig().individualLayerSettings() )
-  , mEnableMinMaxColumn( project->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer )
+  , mEnableMinMaxColumn( project->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::PerLayer )
 
 {
   connect( project, &QgsProject::snappingConfigChanged, this, &QgsSnappingLayerTreeModel::onSnappingSettingsChanged );
@@ -369,7 +369,7 @@ void QgsSnappingLayerTreeModel::onSnappingSettingsChanged()
     }
   }
 
-  mEnableMinMaxColumn = ( mProject->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer );
+  mEnableMinMaxColumn = ( mProject->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::PerLayer );
   hasRowchanged( mLayerTreeModel->rootGroup(), oldSettings, wasMinMaxEnabled != mEnableMinMaxColumn );
 }
 

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -112,7 +112,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
     QDoubleSpinBox *minLimitSp = new QDoubleSpinBox( parent );
     minLimitSp->setDecimals( 5 );
     minLimitSp->setMaximum( 99999999.990000 );
-    minLimitSp->setToolTip( tr( "Snapping scale range min" ) );
+    minLimitSp->setToolTip( tr( "Min Scale" ) );
     return minLimitSp;
   }
 
@@ -121,7 +121,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
     QDoubleSpinBox *maxLimitSp = new QDoubleSpinBox( parent );
     maxLimitSp->setDecimals( 5 );
     maxLimitSp->setMaximum( 99999999.990000 );
-    maxLimitSp->setToolTip( tr( "Snapping scale range max" ) );
+    maxLimitSp->setToolTip( tr( "Max Scale" ) );
     return maxLimitSp;
   }
 
@@ -460,11 +460,11 @@ QVariant QgsSnappingLayerTreeModel::headerData( int section, Qt::Orientation ori
         case 4:
           return tr( "Avoid overlap" );
         case 5:
-          return tr( "Activate snapping on scale range" );
+          return tr( "Scale range limit" );
         case 6:
-          return tr( "Range min" );
+          return tr( "Min Scale" );
         case 7:
-          return tr( "Range max" );
+          return tr( "Max Scale" );
         default:
           return QVariant();
       }

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -156,7 +156,7 @@ void QgsSnappingLayerDelegate::setEditorData( QWidget *editor, const QModelIndex
       w->setCurrentIndex( w->findData( units ) );
     }
   }
-  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn)
+  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn )
   {
     QgsScaleWidget *w = qobject_cast<QgsScaleWidget *>( editor );
     if ( w )
@@ -214,7 +214,7 @@ void QgsSnappingLayerDelegate::setModelData( QWidget *editor, QAbstractItemModel
       model->setData( index, w->value(), Qt::EditRole );
     }
   }
-  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn)
+  else if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn )
   {
     QgsScaleWidget *w = qobject_cast<QgsScaleWidget *>( editor );
     if ( w )

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -645,19 +645,19 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        if ( ls.minScale() <= 0.0 )
+        if ( ls.minimumScale() <= 0.0 )
         {
           return QString( tr( "not set" ) );
         }
         else
         {
-          return QString::number( ls.minScale() );
+          return QString::number( ls.minimumScale() );
         }
       }
 
       if ( role == Qt::UserRole )
       {
-        return ls.minScale();
+        return ls.minimumScale();
       }
     }
 
@@ -665,19 +665,19 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
     {
       if ( role == Qt::DisplayRole )
       {
-        if ( ls.maxScale() <= 0.0 )
+        if ( ls.maximumScale() <= 0.0 )
         {
           return QString( tr( "not set" ) );
         }
         else
         {
-          return QString::number( ls.maxScale() );
+          return QString::number( ls.maximumScale() );
         }
       }
 
       if ( role == Qt::UserRole )
       {
-        return ls.maxScale();
+        return ls.maximumScale();
       }
     }
   }
@@ -825,7 +825,7 @@ bool QgsSnappingLayerTreeModel::setData( const QModelIndex &index, const QVarian
       if ( !ls.valid() )
         return false;
 
-      ls.setMinScale( value.toDouble() );
+      ls.setMinimumScale( value.toDouble() );
       QgsSnappingConfig config = mProject->snappingConfig();
       config.setIndividualLayerSettings( vl, ls );
       mProject->setSnappingConfig( config );
@@ -846,7 +846,7 @@ bool QgsSnappingLayerTreeModel::setData( const QModelIndex &index, const QVarian
       if ( !ls.valid() )
         return false;
 
-      ls.setMaxScale( value.toDouble() );
+      ls.setMaximumScale( value.toDouble() );
       QgsSnappingConfig config = mProject->snappingConfig();
       config.setIndividualLayerSettings( vl, ls );
       mProject->setSnappingConfig( config );

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -238,7 +238,7 @@ QgsSnappingLayerTreeModel::QgsSnappingLayerTreeModel( QgsProject *project, QgsMa
   , mProject( project )
   , mCanvas( canvas )
   , mIndividualLayerSettings( project->snappingConfig().individualLayerSettings() )
-  , mEnableMinMaxColumn( project->snappingConfig().limitToScale() )
+  , mEnableMinMaxColumn( project->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer )
 
 {
   connect( project, &QgsProject::snappingConfigChanged, this, &QgsSnappingLayerTreeModel::onSnappingSettingsChanged );
@@ -369,7 +369,7 @@ void QgsSnappingLayerTreeModel::onSnappingSettingsChanged()
     }
   }
 
-  mEnableMinMaxColumn = mProject->snappingConfig().limitToScale();
+  mEnableMinMaxColumn = ( mProject->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer );
   hasRowchanged( mLayerTreeModel->rootGroup(), oldSettings, wasMinMaxEnabled != mEnableMinMaxColumn );
 }
 

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -95,8 +95,9 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
     QString mFilterText;
     QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> mIndividualLayerSettings;
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
+    bool mEnableMinMaxColumn = true;
 
-    void hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings );
+    void hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings, bool forceRefresh );
 };
 
 #endif // QGSSNAPPINGLAYERTREEVIEW_H

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -56,7 +56,10 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
       TypeColumn,
       ToleranceColumn,
       UnitsColumn,
-      AvoidIntersectionColumn
+      AvoidIntersectionColumn,
+      LimitToScaleRangeColumn,
+      MinScaleColumn,
+      MaxScaleColumn
     };
 
     QgsSnappingLayerTreeModel( QgsProject *project, QgsMapCanvas *canvas, QObject *parent = nullptr );

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -57,7 +57,6 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
       ToleranceColumn,
       UnitsColumn,
       AvoidIntersectionColumn,
-      LimitToScaleRangeColumn,
       MinScaleColumn,
       MaxScaleColumn
     };

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -513,15 +513,15 @@ void QgsSnappingWidget::changeTolerance( double tolerance )
   mProject->setSnappingConfig( mConfig );
 }
 
-void QgsSnappingWidget::changeMinScale( double pMinScale )
+void QgsSnappingWidget::changeMinScale( double minScale )
 {
-  mConfig.setMinimumScale( pMinScale );
+  mConfig.setMinimumScale( minScale );
   mProject->setSnappingConfig( mConfig );
 }
 
-void QgsSnappingWidget::changeMaxScale( double pMaxScale )
+void QgsSnappingWidget::changeMaxScale( double maxScale )
 {
-  mConfig.setMaximumScale( pMaxScale );
+  mConfig.setMaximumScale( maxScale );
   mProject->setSnappingConfig( mConfig );
 }
 

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -180,7 +180,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   mMinScaleSpinBox->setMinimum( 0.0 );
   mMinScaleSpinBox->setToolTip( tr( "Min scale on which snapping is enabled" ) );
   mMinScaleSpinBox->setObjectName( QStringLiteral( "SnappingMinScaleSpinBox" ) );
-  mMinScaleSpinBox->setSpecialValueText("NULL");
+  mMinScaleSpinBox->setSpecialValueText( "NULL" );
   connect( mMinScaleSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSnappingWidget::changeMinScale );
 
   mMaxScaleSpinBox = new QDoubleSpinBox();
@@ -189,7 +189,7 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   mMaxScaleSpinBox->setMinimum( 0.0 );
   mMaxScaleSpinBox->setToolTip( tr( "Max scale on which snapping is enabled" ) );
   mMaxScaleSpinBox->setObjectName( QStringLiteral( "SnappingMaxScaleSpinBox" ) );
-  mMaxScaleSpinBox->setSpecialValueText("NULL");
+  mMaxScaleSpinBox->setSpecialValueText( "NULL" );
   connect( mMaxScaleSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSnappingWidget::changeMaxScale );
 
 
@@ -447,11 +447,7 @@ void QgsSnappingWidget::projectSnapSettingsChanged()
     mMaxScaleSpinBox->setValue( config.maxScale() );
   }
 
-  mLimitToScale->setChecked(config.limitToScale());
-  /*if( mLimitToScale->isChecked() != config.limitToScale() )
-  {
-    mLimitToScale->setCheckState( config.limitToScale() ? Qt::Checked : Qt::Unchecked );
-  }*/
+  mLimitToScale->setChecked( config.limitToScale() );
 
   if ( config.intersectionSnapping() != mIntersectionSnappingAction->isChecked() )
   {
@@ -519,8 +515,8 @@ void QgsSnappingWidget::changeMaxScale( double pMaxScale )
 void QgsSnappingWidget::changeLimitToScale( bool enabled )
 {
   mConfig.setLimitToScale( enabled );
-  mMinScaleSpinBox->setEnabled(mConfig.limitToScale());
-  mMaxScaleSpinBox->setEnabled(mConfig.limitToScale());
+  mMinScaleSpinBox->setEnabled( mConfig.limitToScale() );
+  mMaxScaleSpinBox->setEnabled( mConfig.limitToScale() );
   mProject->setSnappingConfig( mConfig );
 }
 

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -186,10 +186,10 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   connect( mMaxScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsSnappingWidget::changeMaxScale );
 
 
-  mLimitToScale = new QAction( tr( "Toggle Snapping limit on scale" ), this );
+  mLimitToScale = new QAction( tr( "Toggle scale dependent snapping" ), this );
   mLimitToScale->setCheckable( true );
   mLimitToScale->setIcon( QIcon( QgsApplication::getThemeIcon( "/mIconSnappingOnScale.svg" ) ) );
-  mLimitToScale->setObjectName( QStringLiteral( "EnableSnappinLimitOnScaleAction" ) );
+  mLimitToScale->setObjectName( QStringLiteral( "EnableSnappingLimitOnScaleAction" ) );
   connect( mLimitToScale, &QAction::toggled, this, &QgsSnappingWidget::changeLimitToScale );
 
   // units
@@ -472,10 +472,12 @@ void QgsSnappingWidget::toggleSnappingWidgets( bool enabled )
   mMinScaleWidget->setEnabled( enabled && mConfig.limitToScale() );
   mMaxScaleWidget->setEnabled( enabled && mConfig.limitToScale() );
   mUnitsComboBox->setEnabled( enabled );
+
   if ( mEditAdvancedConfigAction )
   {
     mEditAdvancedConfigAction->setEnabled( enabled );
   }
+
   if ( mAdvancedConfigWidget )
   {
     mAdvancedConfigWidget->setEnabled( enabled );

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -176,12 +176,12 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   connect( mToleranceSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSnappingWidget::changeTolerance );
 
   mMinScaleWidget = new QgsScaleWidget();
-  mMinScaleWidget->setToolTip( tr( "Min scale on which snapping is enabled" ) );
+  mMinScaleWidget->setToolTip( tr( "Minimum scale from which snapping is enabled" ) );
   mMinScaleWidget->setObjectName( QStringLiteral( "SnappingMinScaleSpinBox" ) );
   connect( mMinScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsSnappingWidget::changeMinScale );
 
   mMaxScaleWidget = new QgsScaleWidget();
-  mMaxScaleWidget->setToolTip( tr( "Max scale on which snapping is enabled" ) );
+  mMaxScaleWidget->setToolTip( tr( "Maximum scale up to which snapping is enabled" ) );
   mMaxScaleWidget->setObjectName( QStringLiteral( "SnappingMaxScaleSpinBox" ) );
   connect( mMaxScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsSnappingWidget::changeMaxScale );
 

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -451,11 +451,11 @@ void QgsSnappingWidget::projectSnapSettingsChanged()
   {
     mSnappingScaleModeButton->setDefaultAction( mDefaultSnappingScaleAct );
   }
-  else if ( config.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentGlobal )
+  else if ( config.scaleDependencyMode() == QgsSnappingConfig::Global )
   {
     mSnappingScaleModeButton->setDefaultAction( mGlobalSnappingScaleAct );
   }
-  else if ( config.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer )
+  else if ( config.scaleDependencyMode() == QgsSnappingConfig::PerLayer )
   {
     mSnappingScaleModeButton->setDefaultAction( mPerLayerSnappingScaleAct );
   }
@@ -490,8 +490,8 @@ void QgsSnappingWidget::toggleSnappingWidgets( bool enabled )
   mTypeButton->setEnabled( enabled );
   mToleranceSpinBox->setEnabled( enabled );
   mSnappingScaleModeButton->setEnabled( enabled );
-  mMinScaleWidget->setEnabled( enabled && mConfig.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentGlobal );
-  mMaxScaleWidget->setEnabled( enabled && mConfig.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentGlobal );
+  mMinScaleWidget->setEnabled( enabled && mConfig.scaleDependencyMode() == QgsSnappingConfig::Global );
+  mMaxScaleWidget->setEnabled( enabled && mConfig.scaleDependencyMode() == QgsSnappingConfig::Global );
   mUnitsComboBox->setEnabled( enabled );
 
   if ( mEditAdvancedConfigAction )
@@ -613,22 +613,23 @@ void QgsSnappingWidget::typeButtonTriggered( QAction *action )
 void QgsSnappingWidget::snappingScaleModeTriggered( QAction *action )
 {
   mSnappingScaleModeButton->setDefaultAction( action );
-  QgsSnappingConfig::ScaleDependencyMode mode;
+  QgsSnappingConfig::ScaleDependencyMode mode = mConfig.scaleDependencyMode();
+
   if ( action == mDefaultSnappingScaleAct )
   {
     mode =  QgsSnappingConfig::Disabled;
   }
   else if ( action == mGlobalSnappingScaleAct )
   {
-    mode = QgsSnappingConfig::ScaleDependentGlobal;
+    mode = QgsSnappingConfig::Global;
   }
   else if ( action == mPerLayerSnappingScaleAct )
   {
-    mode = QgsSnappingConfig::ScaleDependentPerLayer;
+    mode = QgsSnappingConfig::PerLayer;
   }
 
-  mMinScaleWidget->setEnabled( mode == QgsSnappingConfig::ScaleDependentGlobal );
-  mMaxScaleWidget->setEnabled( mode == QgsSnappingConfig::ScaleDependentGlobal );
+  mMinScaleWidget->setEnabled( mode == QgsSnappingConfig::Global );
+  mMaxScaleWidget->setEnabled( mode == QgsSnappingConfig::Global );
   mConfig.setScaleDependencyMode( mode );
   mProject->setSnappingConfig( mConfig );
 }

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -437,14 +437,14 @@ void QgsSnappingWidget::projectSnapSettingsChanged()
     mToleranceSpinBox->setValue( config.tolerance() );
   }
 
-  if ( mMinScaleWidget->scale() != config.minScale() )
+  if ( mMinScaleWidget->scale() != config.minimumScale() )
   {
-    mMinScaleWidget->setScale( config.minScale() );
+    mMinScaleWidget->setScale( config.minimumScale() );
   }
 
-  if ( mMaxScaleWidget->scale() != config.maxScale() )
+  if ( mMaxScaleWidget->scale() != config.maximumScale() )
   {
-    mMaxScaleWidget->setScale( config.maxScale() );
+    mMaxScaleWidget->setScale( config.maximumScale() );
   }
 
   if ( config.scaleDependencyMode() == QgsSnappingConfig::Disabled )
@@ -515,13 +515,13 @@ void QgsSnappingWidget::changeTolerance( double tolerance )
 
 void QgsSnappingWidget::changeMinScale( double pMinScale )
 {
-  mConfig.setMinScale( pMinScale );
+  mConfig.setMinimumScale( pMinScale );
   mProject->setSnappingConfig( mConfig );
 }
 
 void QgsSnappingWidget::changeMaxScale( double pMaxScale )
 {
-  mConfig.setMaxScale( pMaxScale );
+  mConfig.setMaximumScale( pMaxScale );
   mProject->setSnappingConfig( mConfig );
 }
 

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -32,6 +32,7 @@ class QgsLayerTreeNode;
 class QgsLayerTreeView;
 class QgsMapCanvas;
 class QgsProject;
+class QgsScaleWidget;
 
 
 #include "qgssnappingconfig.h"
@@ -152,12 +153,10 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QAction *mMiddleAction = nullptr;
     QDoubleSpinBox *mToleranceSpinBox = nullptr;
     QAction *mLimitToScale = nullptr;
-    QDoubleSpinBox *mMinScaleSpinBox = nullptr;
-    QDoubleSpinBox *mMaxScaleSpinBox = nullptr;
+    QgsScaleWidget *mMinScaleWidget = nullptr;
+    QgsScaleWidget *mMaxScaleWidget = nullptr;
     QAction *mToleranceAction = nullptr; // hide widget does not work on toolbar, action needed
     QAction *mLimitToScaleAction = nullptr;
-    QAction *mMinScaleAction = nullptr;
-    QAction *mMaxScaleAction = nullptr;
     QComboBox *mUnitsComboBox = nullptr;
     QAction *mUnitAction = nullptr; // hide widget does not work on toolbar, action needed
     QAction *mTopologicalEditingAction = nullptr;

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -23,6 +23,7 @@ class QDoubleSpinBox;
 class QFont;
 class QToolButton;
 class QTreeView;
+class QCheckBox;
 
 class QgsDoubleSpinBox;
 class QgsFloatingWidget;
@@ -100,6 +101,12 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void changeTolerance( double tolerance );
 
+    void changeMinScale( double pMinScale );
+
+    void changeMaxScale( double pMaxScale );
+
+    void changeLimitToScale(bool enabled);
+
     void changeUnit( int idx );
 
     void enableTopologicalEditing( bool enabled );
@@ -144,7 +151,13 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QAction *mCentroidAction = nullptr;
     QAction *mMiddleAction = nullptr;
     QDoubleSpinBox *mToleranceSpinBox = nullptr;
+    QAction* mLimitToScale = nullptr;
+    QDoubleSpinBox *mMinScaleSpinBox = nullptr;
+    QDoubleSpinBox *mMaxScaleSpinBox = nullptr;
     QAction *mToleranceAction = nullptr; // hide widget does not work on toolbar, action needed
+    QAction *mLimitToScaleAction = nullptr;
+    QAction *mMinScaleAction = nullptr;
+    QAction *mMaxScaleAction = nullptr;
     QComboBox *mUnitsComboBox = nullptr;
     QAction *mUnitAction = nullptr; // hide widget does not work on toolbar, action needed
     QAction *mTopologicalEditingAction = nullptr;

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -106,8 +106,6 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void changeMaxScale( double pMaxScale );
 
-    void changeLimitToScale( bool enabled );
-
     void changeUnit( int idx );
 
     void enableTopologicalEditing( bool enabled );
@@ -116,6 +114,7 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void modeButtonTriggered( QAction *action );
     void typeButtonTriggered( QAction *action );
+    void snappingScaleModeTriggered( QAction *action );
 
     //! number of decimals of the tolerance spin box depends on map units
     void updateToleranceDecimals();
@@ -152,11 +151,13 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QAction *mCentroidAction = nullptr;
     QAction *mMiddleAction = nullptr;
     QDoubleSpinBox *mToleranceSpinBox = nullptr;
-    QAction *mLimitToScale = nullptr;
     QgsScaleWidget *mMinScaleWidget = nullptr;
     QgsScaleWidget *mMaxScaleWidget = nullptr;
     QAction *mToleranceAction = nullptr; // hide widget does not work on toolbar, action needed
-    QAction *mLimitToScaleAction = nullptr;
+    QToolButton *mSnappingScaleModeButton = nullptr;
+    QAction *mDefaultSnappingScaleAct = nullptr;
+    QAction *mGlobalSnappingScaleAct = nullptr;
+    QAction *mPerLayerSnappingScaleAct = nullptr;
     QComboBox *mUnitsComboBox = nullptr;
     QAction *mUnitAction = nullptr; // hide widget does not work on toolbar, action needed
     QAction *mTopologicalEditingAction = nullptr;

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -102,9 +102,9 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void changeTolerance( double tolerance );
 
-    void changeMinScale( double pMinScale );
+    void changeMinScale( double minScale );
 
-    void changeMaxScale( double pMaxScale );
+    void changeMaxScale( double maxScale );
 
     void changeUnit( int idx );
 
@@ -130,7 +130,7 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     DisplayMode mDisplayMode;
 
     //! modeChanged determines if widget are visible or not based on mode
-    void modeChanged( );
+    void modeChanged();
 
     QgsProject *mProject = nullptr;
     QgsSnappingConfig mConfig;

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -105,7 +105,7 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void changeMaxScale( double pMaxScale );
 
-    void changeLimitToScale(bool enabled);
+    void changeLimitToScale( bool enabled );
 
     void changeUnit( int idx );
 
@@ -151,7 +151,7 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QAction *mCentroidAction = nullptr;
     QAction *mMiddleAction = nullptr;
     QDoubleSpinBox *mToleranceSpinBox = nullptr;
-    QAction* mLimitToScale = nullptr;
+    QAction *mLimitToScale = nullptr;
     QDoubleSpinBox *mMinScaleSpinBox = nullptr;
     QDoubleSpinBox *mMaxScaleSpinBox = nullptr;
     QAction *mToleranceAction = nullptr; // hide widget does not work on toolbar, action needed

--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -131,7 +131,7 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     DisplayMode mDisplayMode;
 
     //! modeChanged determines if widget are visible or not based on mode
-    void modeChanged();
+    void modeChanged( );
 
     QgsProject *mProject = nullptr;
     QgsSnappingConfig mConfig;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -769,7 +769,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
           continue;
 
         config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-          vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, 0.0, 0.0 ) );
+          vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, -1.0, -1.0 ) );
       }
 
       snapUtils->setConfig( config );
@@ -796,7 +796,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
         continue;
 
       config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-        vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, 0.0, 0.0 ) );
+        vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, -1.0, -1.0 ) );
     }
 
     snapUtils->setConfig( config );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -769,7 +769,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
           continue;
 
         config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-                                             vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits ) );
+          vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, 0.0, 0.0 ) );
       }
 
       snapUtils->setConfig( config );
@@ -796,7 +796,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
         continue;
 
       config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-                                           vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits ) );
+        vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, 0.0, 0.0 ) );
     }
 
     snapUtils->setConfig( config );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -769,7 +769,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
           continue;
 
         config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-          vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, -1.0, -1.0 ) );
+          vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
       }
 
       snapUtils->setConfig( config );
@@ -796,7 +796,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
         continue;
 
       config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-        vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, false, -1.0, -1.0 ) );
+        vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
     }
 
     snapUtils->setConfig( config );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -769,7 +769,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
           continue;
 
         config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-          vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
+                                             vlayer == currentVlayer, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
       }
 
       snapUtils->setConfig( config );
@@ -796,7 +796,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
         continue;
 
       config.setIndividualLayerSettings( vlayer, QgsSnappingConfig::IndividualLayerSettings(
-        vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
+                                           vlayer->isEditable(), static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::VertexFlag | QgsSnappingConfig::SegmentFlag ), tol, QgsTolerance::ProjectUnits, 0.0, 0.0 ) );
     }
 
     snapUtils->setConfig( config );

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -180,7 +180,7 @@ bool QgsSnappingConfig::operator==( const QgsSnappingConfig &other ) const
          && mUnits == other.mUnits
          && mIntersectionSnapping == other.mIntersectionSnapping
          && mIndividualLayerSettings == other.mIndividualLayerSettings
-         && mLimitToScale == other.mLimitToScale
+         && mScaleDependencyMode == other.mScaleDependencyMode
          && mMinScale == other.mMinScale
          && mMaxScale == other.mMaxScale;
 }
@@ -205,7 +205,7 @@ void QgsSnappingConfig::reset()
   mMode = mode;
   mType = type;
   mTolerance = tolerance;
-  mLimitToScale = false;
+  mScaleDependencyMode = Disabled;
   mMinScale = 0.0;
   mMaxScale = 0.0;
   // do not allow unit to be "layer" if not in advanced configuration
@@ -378,7 +378,7 @@ bool QgsSnappingConfig::operator!=( const QgsSnappingConfig &other ) const
          || mTolerance != other.mTolerance
          || mUnits != other.mUnits
          || mIndividualLayerSettings != other.mIndividualLayerSettings
-         || mLimitToScale != other.mLimitToScale
+         || mScaleDependencyMode != other.mScaleDependencyMode
          || mMinScale != other.mMinScale
          || mMaxScale != other.mMaxScale;
 }
@@ -444,8 +444,8 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
   if ( snapSettingsElem.hasAttribute( QStringLiteral( "tolerance" ) ) )
     mTolerance = snapSettingsElem.attribute( QStringLiteral( "tolerance" ) ).toDouble();
 
-  if ( snapSettingsElem.hasAttribute( QStringLiteral( "limitToScale" ) ) )
-    mLimitToScale = snapSettingsElem.attribute( QStringLiteral( "limitToScale" ) ) == QLatin1String( "1" );
+  if ( snapSettingsElem.hasAttribute( QStringLiteral( "scaleDependencyMode" ) ) )
+    mScaleDependencyMode = static_cast<QgsSnappingConfig::ScaleDependencyMode>( snapSettingsElem.attribute( QStringLiteral( "scaleDependencyMode" ) ).toInt() );
 
   if ( snapSettingsElem.hasAttribute( QStringLiteral( "minScale" ) ) )
     mMinScale = snapSettingsElem.attribute( QStringLiteral( "minScale" ) ).toDouble();
@@ -504,7 +504,7 @@ void QgsSnappingConfig::writeProject( QDomDocument &doc )
   snapSettingsElem.setAttribute( QStringLiteral( "tolerance" ), mTolerance );
   snapSettingsElem.setAttribute( QStringLiteral( "unit" ), static_cast<int>( mUnits ) );
   snapSettingsElem.setAttribute( QStringLiteral( "intersection-snapping" ), QString::number( mIntersectionSnapping ) );
-  snapSettingsElem.setAttribute( QStringLiteral( "limitToScale" ), QString::number( mLimitToScale ) );
+  snapSettingsElem.setAttribute( QStringLiteral( "scaleDependencyMode" ), QString::number( mScaleDependencyMode ) );
   snapSettingsElem.setAttribute( QStringLiteral( "minScale" ), mMinScale );
   snapSettingsElem.setAttribute( QStringLiteral( "maxScale" ), mMaxScale );
 
@@ -668,15 +668,16 @@ void QgsSnappingConfig::setMaxScale( double pMaxScale )
   mMaxScale = pMaxScale;
 }
 
-bool QgsSnappingConfig::limitToScale() const
+void QgsSnappingConfig::setScaleDependencyMode( QgsSnappingConfig::ScaleDependencyMode mode )
 {
-  return mLimitToScale;
+  mScaleDependencyMode = mode;
 }
 
-void QgsSnappingConfig::setLimitToScale( bool pLimitSnapping )
+QgsSnappingConfig::ScaleDependencyMode QgsSnappingConfig::scaleDependencyMode() const
 {
-  mLimitToScale = pLimitSnapping;
+  return mScaleDependencyMode;
 }
+
 
 
 

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -31,8 +31,8 @@ QgsSnappingConfig::IndividualLayerSettings::IndividualLayerSettings( bool enable
   , mType( type )
   , mTolerance( tolerance )
   , mUnits( units )
-  , mMinScale( minScale )
-  , mMaxScale( maxScale )
+  , mMinimumScale( minScale )
+  , mMaximumScale( maxScale )
 {}
 
 QgsSnappingConfig::IndividualLayerSettings::IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units )
@@ -121,24 +121,24 @@ void QgsSnappingConfig::IndividualLayerSettings::setUnits( QgsTolerance::UnitTyp
   mUnits = units;
 }
 
-double QgsSnappingConfig::IndividualLayerSettings::minScale() const
+double QgsSnappingConfig::IndividualLayerSettings::minimumScale() const
 {
-  return mMinScale;
+  return mMinimumScale;
 }
 
-void QgsSnappingConfig::IndividualLayerSettings::setMinScale( double p_minScale )
+void QgsSnappingConfig::IndividualLayerSettings::setMinimumScale( double p_minScale )
 {
-  mMinScale = p_minScale;
+  mMinimumScale = p_minScale;
 }
 
-double QgsSnappingConfig::IndividualLayerSettings::maxScale() const
+double QgsSnappingConfig::IndividualLayerSettings::maximumScale() const
 {
-  return mMaxScale;
+  return mMaximumScale;
 }
 
-void QgsSnappingConfig::IndividualLayerSettings::setMaxScale( double p_maxScale )
+void QgsSnappingConfig::IndividualLayerSettings::setMaximumScale( double p_maxScale )
 {
-  mMaxScale = p_maxScale;
+  mMaximumScale = p_maxScale;
 }
 
 bool QgsSnappingConfig::IndividualLayerSettings::operator !=( const QgsSnappingConfig::IndividualLayerSettings &other ) const
@@ -148,8 +148,8 @@ bool QgsSnappingConfig::IndividualLayerSettings::operator !=( const QgsSnappingC
          || mType != other.mType
          || mTolerance != other.mTolerance
          || mUnits != other.mUnits
-         || mMinScale != other.mMinScale
-         || mMaxScale != other.mMaxScale;
+         || mMinimumScale != other.mMinimumScale
+         || mMaximumScale != other.mMaximumScale;
 }
 
 bool QgsSnappingConfig::IndividualLayerSettings::operator ==( const QgsSnappingConfig::IndividualLayerSettings &other ) const
@@ -159,8 +159,8 @@ bool QgsSnappingConfig::IndividualLayerSettings::operator ==( const QgsSnappingC
          && mType == other.mType
          && mTolerance == other.mTolerance
          && mUnits == other.mUnits
-         && mMinScale == other.mMinScale
-         && mMaxScale == other.mMaxScale;
+         && mMinimumScale == other.mMinimumScale
+         && mMaximumScale == other.mMaximumScale;
 }
 
 
@@ -181,8 +181,8 @@ bool QgsSnappingConfig::operator==( const QgsSnappingConfig &other ) const
          && mIntersectionSnapping == other.mIntersectionSnapping
          && mIndividualLayerSettings == other.mIndividualLayerSettings
          && mScaleDependencyMode == other.mScaleDependencyMode
-         && mMinScale == other.mMinScale
-         && mMaxScale == other.mMaxScale;
+         && mMinimumScale == other.mMinimumScale
+         && mMaximumScale == other.mMaximumScale;
 }
 
 void QgsSnappingConfig::reset()
@@ -206,8 +206,8 @@ void QgsSnappingConfig::reset()
   mType = type;
   mTolerance = tolerance;
   mScaleDependencyMode = Disabled;
-  mMinScale = 0.0;
-  mMaxScale = 0.0;
+  mMinimumScale = 0.0;
+  mMaximumScale = 0.0;
   // do not allow unit to be "layer" if not in advanced configuration
   if ( mUnits == QgsTolerance::LayerUnits && mMode != AdvancedConfiguration )
   {
@@ -379,8 +379,8 @@ bool QgsSnappingConfig::operator!=( const QgsSnappingConfig &other ) const
          || mUnits != other.mUnits
          || mIndividualLayerSettings != other.mIndividualLayerSettings
          || mScaleDependencyMode != other.mScaleDependencyMode
-         || mMinScale != other.mMinScale
-         || mMaxScale != other.mMaxScale;
+         || mMinimumScale != other.mMinimumScale
+         || mMaximumScale != other.mMaximumScale;
 }
 
 void QgsSnappingConfig::readProject( const QDomDocument &doc )
@@ -448,10 +448,10 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
     mScaleDependencyMode = static_cast<QgsSnappingConfig::ScaleDependencyMode>( snapSettingsElem.attribute( QStringLiteral( "scaleDependencyMode" ) ).toInt() );
 
   if ( snapSettingsElem.hasAttribute( QStringLiteral( "minScale" ) ) )
-    mMinScale = snapSettingsElem.attribute( QStringLiteral( "minScale" ) ).toDouble();
+    mMinimumScale = snapSettingsElem.attribute( QStringLiteral( "minScale" ) ).toDouble();
 
   if ( snapSettingsElem.hasAttribute( QStringLiteral( "maxScale" ) ) )
-    mMaxScale = snapSettingsElem.attribute( QStringLiteral( "maxScale" ) ).toDouble();
+    mMaximumScale = snapSettingsElem.attribute( QStringLiteral( "maxScale" ) ).toDouble();
 
   if ( snapSettingsElem.hasAttribute( QStringLiteral( "unit" ) ) )
     mUnits = ( QgsTolerance::UnitType )snapSettingsElem.attribute( QStringLiteral( "unit" ) ).toInt();
@@ -505,8 +505,8 @@ void QgsSnappingConfig::writeProject( QDomDocument &doc )
   snapSettingsElem.setAttribute( QStringLiteral( "unit" ), static_cast<int>( mUnits ) );
   snapSettingsElem.setAttribute( QStringLiteral( "intersection-snapping" ), QString::number( mIntersectionSnapping ) );
   snapSettingsElem.setAttribute( QStringLiteral( "scaleDependencyMode" ), QString::number( mScaleDependencyMode ) );
-  snapSettingsElem.setAttribute( QStringLiteral( "minScale" ), mMinScale );
-  snapSettingsElem.setAttribute( QStringLiteral( "maxScale" ), mMaxScale );
+  snapSettingsElem.setAttribute( QStringLiteral( "minScale" ), mMinimumScale );
+  snapSettingsElem.setAttribute( QStringLiteral( "maxScale" ), mMaximumScale );
 
   QDomElement ilsElement = doc.createElement( QStringLiteral( "individual-layer-settings" ) );
   QHash<QgsVectorLayer *, IndividualLayerSettings>::const_iterator layerIt = mIndividualLayerSettings.constBegin();
@@ -520,8 +520,8 @@ void QgsSnappingConfig::writeProject( QDomDocument &doc )
     layerElement.setAttribute( QStringLiteral( "type" ), static_cast<int>( setting.typeFlag() ) );
     layerElement.setAttribute( QStringLiteral( "tolerance" ), setting.tolerance() );
     layerElement.setAttribute( QStringLiteral( "units" ), static_cast<int>( setting.units() ) );
-    layerElement.setAttribute( QStringLiteral( "minScale" ), setting.minScale() );
-    layerElement.setAttribute( QStringLiteral( "maxScale" ), setting.maxScale() );
+    layerElement.setAttribute( QStringLiteral( "minScale" ), setting.minimumScale() );
+    layerElement.setAttribute( QStringLiteral( "maxScale" ), setting.maximumScale() );
     ilsElement.appendChild( layerElement );
   }
   snapSettingsElem.appendChild( ilsElement );
@@ -648,24 +648,24 @@ void QgsSnappingConfig::setProject( QgsProject *project )
   reset();
 }
 
-double QgsSnappingConfig::minScale() const
+double QgsSnappingConfig::minimumScale() const
 {
-  return mMinScale;
+  return mMinimumScale;
 }
 
-void QgsSnappingConfig::setMinScale( double pMinScale )
+void QgsSnappingConfig::setMinimumScale( double pMinScale )
 {
-  mMinScale = pMinScale;
+  mMinimumScale = pMinScale;
 }
 
-double QgsSnappingConfig::maxScale() const
+double QgsSnappingConfig::maximumScale() const
 {
-  return mMaxScale;
+  return mMaximumScale;
 }
 
-void QgsSnappingConfig::setMaxScale( double pMaxScale )
+void QgsSnappingConfig::setMaximumScale( double pMaxScale )
 {
-  mMaxScale = pMaxScale;
+  mMaximumScale = pMaxScale;
 }
 
 void QgsSnappingConfig::setScaleDependencyMode( QgsSnappingConfig::ScaleDependencyMode mode )

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -126,9 +126,9 @@ double QgsSnappingConfig::IndividualLayerSettings::minimumScale() const
   return mMinimumScale;
 }
 
-void QgsSnappingConfig::IndividualLayerSettings::setMinimumScale( double p_minScale )
+void QgsSnappingConfig::IndividualLayerSettings::setMinimumScale( double minScale )
 {
-  mMinimumScale = p_minScale;
+  mMinimumScale = minScale;
 }
 
 double QgsSnappingConfig::IndividualLayerSettings::maximumScale() const
@@ -136,9 +136,9 @@ double QgsSnappingConfig::IndividualLayerSettings::maximumScale() const
   return mMaximumScale;
 }
 
-void QgsSnappingConfig::IndividualLayerSettings::setMaximumScale( double p_maxScale )
+void QgsSnappingConfig::IndividualLayerSettings::setMaximumScale( double maxScale )
 {
-  mMaximumScale = p_maxScale;
+  mMaximumScale = maxScale;
 }
 
 bool QgsSnappingConfig::IndividualLayerSettings::operator !=( const QgsSnappingConfig::IndividualLayerSettings &other ) const
@@ -653,9 +653,9 @@ double QgsSnappingConfig::minimumScale() const
   return mMinimumScale;
 }
 
-void QgsSnappingConfig::setMinimumScale( double pMinScale )
+void QgsSnappingConfig::setMinimumScale( double minScale )
 {
-  mMinimumScale = pMinScale;
+  mMinimumScale = minScale;
 }
 
 double QgsSnappingConfig::maximumScale() const
@@ -663,9 +663,9 @@ double QgsSnappingConfig::maximumScale() const
   return mMaximumScale;
 }
 
-void QgsSnappingConfig::setMaximumScale( double pMaxScale )
+void QgsSnappingConfig::setMaximumScale( double maxScale )
 {
-  mMaximumScale = pMaxScale;
+  mMaximumScale = maxScale;
 }
 
 void QgsSnappingConfig::setScaleDependencyMode( QgsSnappingConfig::ScaleDependencyMode mode )

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -35,13 +35,11 @@ QgsSnappingConfig::IndividualLayerSettings::IndividualLayerSettings( bool enable
   , mMaxScale( maxScale )
 {}
 
-QgsSnappingConfig::IndividualLayerSettings::IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale )
+QgsSnappingConfig::IndividualLayerSettings::IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units )
   : mValid( true )
   , mEnabled( enabled )
   , mTolerance( tolerance )
   , mUnits( units )
-  , mMinScale( minScale )
-  , mMaxScale( maxScale )
 {
   Q_NOWARN_DEPRECATED_PUSH
   setType( type );

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -475,7 +475,7 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
       QgsSnappingConfig::SnappingTypeFlag type = static_cast<QgsSnappingConfig::SnappingTypeFlag>( settingElement.attribute( QStringLiteral( "type" ) ).toInt() );
       double tolerance = settingElement.attribute( QStringLiteral( "tolerance" ) ).toDouble();
       QgsTolerance::UnitType units = ( QgsTolerance::UnitType )settingElement.attribute( QStringLiteral( "units" ) ).toInt();
-      bool limitSnappingToScale = settingElement.attribute( QStringLiteral( "limitSnappingToScale" ) ) == QLatin1String( "1" );
+      bool limitToScaleRange = settingElement.attribute( QStringLiteral( "limitToScaleRange" ) ) == QLatin1String( "1" );
       double minScale = settingElement.attribute( QStringLiteral( "minScale" ) ).toDouble();
       double maxScale = settingElement.attribute( QStringLiteral( "maxScale" ) ).toDouble();
 
@@ -486,7 +486,7 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
       QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
 
       IndividualLayerSettings setting = IndividualLayerSettings( enabled, type, tolerance, units,
-                                        limitSnappingToScale, minScale, maxScale );
+                                        limitToScaleRange, minScale, maxScale );
       mIndividualLayerSettings.insert( vl, setting );
     }
   }
@@ -514,6 +514,9 @@ void QgsSnappingConfig::writeProject( QDomDocument &doc )
     layerElement.setAttribute( QStringLiteral( "type" ), static_cast<int>( setting.typeFlag() ) );
     layerElement.setAttribute( QStringLiteral( "tolerance" ), setting.tolerance() );
     layerElement.setAttribute( QStringLiteral( "units" ), static_cast<int>( setting.units() ) );
+    layerElement.setAttribute( QStringLiteral( "limitToScaleRange" ), QString::number( setting.limitToScaleRange() ) );
+    layerElement.setAttribute( QStringLiteral( "minScale" ), setting.minScale() );
+    layerElement.setAttribute( QStringLiteral( "maxScale" ), setting.maxScale() );
     ilsElement.appendChild( layerElement );
   }
   snapSettingsElem.appendChild( ilsElement );

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -655,7 +655,7 @@ double QgsSnappingConfig::minScale() const
   return mMinScale;
 }
 
-void QgsSnappingConfig::setMinScale(double pMinScale)
+void QgsSnappingConfig::setMinScale( double pMinScale )
 {
   mMinScale = pMinScale;
 }
@@ -665,7 +665,7 @@ double QgsSnappingConfig::maxScale() const
   return mMaxScale;
 }
 
-void QgsSnappingConfig::setMaxScale(double pMaxScale)
+void QgsSnappingConfig::setMaxScale( double pMaxScale )
 {
   mMaxScale = pMaxScale;
 }

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -120,7 +120,7 @@ class CORE_EXPORT QgsSnappingConfig
          * \param maxScale 0.0 disable scale limit
          * \deprecated since QGIS 3.12 use the method with SnappingTypeFlag instead.
          */
-        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale ) SIP_DEPRECATED;
+        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units ) SIP_DEPRECATED;
 
         /**
          * \brief IndividualLayerSettings
@@ -172,28 +172,52 @@ class CORE_EXPORT QgsSnappingConfig
          */
         void setTypeFlag( QgsSnappingConfig::SnappingTypeFlag type );
 
-        //! Returns the tolerance
+        /**!
+         * Returns the tolerance
+         * \since QGIS 3.12
+         */
         double tolerance() const;
 
-        //! Sets the tolerance
+        /**
+         * Sets the tolerance
+         * \since QGIS 3.12
+         */
         void setTolerance( double tolerance );
 
-        //! Returns the type of units
+        /**
+         * Returns the type of units
+         * \since QGIS 3.12
+         */
         QgsTolerance::UnitType units() const;
 
-        //! Sets the type of units
+        /**
+         * Sets the type of units
+         * \since QGIS 3.12
+         */
         void setUnits( QgsTolerance::UnitType units );
 
-        //! Returns min scale on which snapping is limited
+        /**
+         * Returns min scale on which snapping is limited
+         * \since QGIS 3.14
+         */
         double minScale() const;
 
-        //! Sets the min scale value on which snapping is used, 0.0 disable scale limit
+        /**
+         * Sets the min scale value on which snapping is used, 0.0 disable scale limit
+         * \since QGIS 3.14
+         */
         void setMinScale( double p_minScale );
 
-        //! Returns max scale on which snapping is limite
+        /**
+         * Returns max scale on which snapping is limited
+         * \since QGIS 3.14
+         */
         double maxScale() const;
 
-        //! Sets the max scale value on which snapping is used, 0.0 disable scale limit
+        /**
+         * Sets the max scale value on which snapping is used, 0.0 disable scale limit
+         * \since QGIS 3.14
+         */
         void setMaxScale( double p_maxScale );
 
         /**
@@ -265,22 +289,40 @@ class CORE_EXPORT QgsSnappingConfig
     //! Sets the tolerance
     void setTolerance( double tolerance );
 
-    //! Returns the min scale
+    /**
+     * Returns the min scale
+     * \since QGIS 3.14
+     */
     double minScale() const;
 
-    //! Sets the min scale on which snapping is enabled, 0.0 disable scale limit
+    /**
+     * Sets the min scale on which snapping is enabled, 0.0 disable scale limit
+     * \since QGIS 3.14
+     */
     void setMinScale( double pMinScale );
 
-    //! Returns the max scale
+    /**
+     * Returns the max scale
+     * \since QGIS 3.14
+     */
     double maxScale() const;
 
-    //! Set the max scale on which snapping is enabled, 0.0 disable scale limit
+    /**
+     * Set the max scale on which snapping is enabled, 0.0 disable scale limit
+     * \since QGIS 3.14
+     */
     void setMaxScale( double pMaxScale );
 
-    //! Returns limit to scale
+    /**
+     * Returns limit to scale
+     * \since QGIS 3.14
+     */
     bool limitToScale() const;
 
-    //! Set limit to scale, true means snapping will be limited to the [minScale, maxScale] range
+    /**
+     * Set limit to scale, true means snapping will be limited to the [minScale, maxScale] range
+     * \since QGIS 3.14
+     */
     void setLimitToScale( bool pLimitSnapping );
 
     //! Returns the type of units

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -195,7 +195,7 @@ class CORE_EXPORT QgsSnappingConfig
         void setUnits( QgsTolerance::UnitType units );
 
         /**
-         * Returns minimun scale on which snapping is limited
+         * Returns minimum scale on which snapping is limited
          * \since QGIS 3.14
          */
         double minimumScale() const;

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -128,8 +128,6 @@ class CORE_EXPORT QgsSnappingConfig
          * \param type
          * \param tolerance
          * \param units
-         * \param minScale 0.0 disable scale limit
-         * \param maxScale 0.0 disable scale limit
          * \deprecated since QGIS 3.12 use the method with SnappingTypeFlag instead.
          */
         Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units ) SIP_DEPRECATED;

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -83,8 +83,8 @@ class CORE_EXPORT QgsSnappingConfig
     enum ScaleDependencyMode
     {
       Disabled = 0,
-      ScaleDependentGlobal,
-      ScaleDependentPerLayer
+      Global = 1,
+      PerLayer = 2
     };
 
     /**

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -142,7 +142,7 @@ class CORE_EXPORT QgsSnappingConfig
          * \param maxScale 0.0 disable scale limit
          * \since QGIS 3.12
          */
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale = 0.0, double maxScale = 0.0 );
 
         /**
          * Constructs an invalid setting
@@ -182,54 +182,41 @@ class CORE_EXPORT QgsSnappingConfig
          */
         void setTypeFlag( QgsSnappingConfig::SnappingTypeFlag type );
 
-        /**
-         * !
-         * Returns the tolerance
-         * \since QGIS 3.12
-         */
+        //! Returns the tolerance
         double tolerance() const;
 
-        /**
-         * Sets the tolerance
-         * \since QGIS 3.12
-         */
+        //! Sets the tolerance
         void setTolerance( double tolerance );
 
-        /**
-         * Returns the type of units
-         * \since QGIS 3.12
-         */
+        //! Returns the type of units
         QgsTolerance::UnitType units() const;
 
-        /**
-         * Sets the type of units
-         * \since QGIS 3.12
-         */
+        //! Sets the type of units
         void setUnits( QgsTolerance::UnitType units );
 
         /**
-         * Returns min scale on which snapping is limited
+         * Returns minimun scale on which snapping is limited
          * \since QGIS 3.14
          */
-        double minScale() const;
+        double minimumScale() const;
 
         /**
          * Sets the min scale value on which snapping is used, 0.0 disable scale limit
          * \since QGIS 3.14
          */
-        void setMinScale( double p_minScale );
+        void setMinimumScale( double p_minScale );
 
         /**
          * Returns max scale on which snapping is limited
          * \since QGIS 3.14
          */
-        double maxScale() const;
+        double maximumScale() const;
 
         /**
          * Sets the max scale value on which snapping is used, 0.0 disable scale limit
          * \since QGIS 3.14
          */
-        void setMaxScale( double p_maxScale );
+        void setMaximumScale( double p_maxScale );
 
         /**
          * Compare this configuration to other.
@@ -244,8 +231,8 @@ class CORE_EXPORT QgsSnappingConfig
         SnappingTypeFlag mType = VertexFlag;
         double mTolerance = 0;
         QgsTolerance::UnitType mUnits = QgsTolerance::Pixels;
-        double mMinScale = 0.0;
-        double mMaxScale = 0.0;
+        double mMinimumScale = 0.0;
+        double mMaximumScale = 0.0;
     };
 
     /**
@@ -304,25 +291,25 @@ class CORE_EXPORT QgsSnappingConfig
      * Returns the min scale
      * \since QGIS 3.14
      */
-    double minScale() const;
+    double minimumScale() const;
 
     /**
      * Sets the min scale on which snapping is enabled, 0.0 disable scale limit
      * \since QGIS 3.14
      */
-    void setMinScale( double pMinScale );
+    void setMinimumScale( double pMinScale );
 
     /**
      * Returns the max scale
      * \since QGIS 3.14
      */
-    double maxScale() const;
+    double maximumScale() const;
 
     /**
      * Set the max scale on which snapping is enabled, 0.0 disable scale limit
      * \since QGIS 3.14
      */
-    void setMaxScale( double pMaxScale );
+    void setMaximumScale( double pMaxScale );
 
     /**
      * Set the scale dependency mode
@@ -467,8 +454,8 @@ class CORE_EXPORT QgsSnappingConfig
     SnappingTypeFlag mType = VertexFlag;
     double mTolerance = 0.0;
     ScaleDependencyMode mScaleDependencyMode = Disabled;
-    double mMinScale = 0.0;
-    double mMaxScale = 0.0;
+    double mMinimumScale = 0.0;
+    double mMaximumScale = 0.0;
     QgsTolerance::UnitType mUnits = QgsTolerance::ProjectUnits;
     bool mIntersectionSnapping = false;
 

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -204,7 +204,7 @@ class CORE_EXPORT QgsSnappingConfig
          * Sets the min scale value on which snapping is used, 0.0 disable scale limit
          * \since QGIS 3.14
          */
-        void setMinimumScale( double p_minScale );
+        void setMinimumScale( double minScale );
 
         /**
          * Returns max scale on which snapping is limited
@@ -216,7 +216,7 @@ class CORE_EXPORT QgsSnappingConfig
          * Sets the max scale value on which snapping is used, 0.0 disable scale limit
          * \since QGIS 3.14
          */
-        void setMaximumScale( double p_maxScale );
+        void setMaximumScale( double maxScale );
 
         /**
          * Compare this configuration to other.
@@ -297,7 +297,7 @@ class CORE_EXPORT QgsSnappingConfig
      * Sets the min scale on which snapping is enabled, 0.0 disable scale limit
      * \since QGIS 3.14
      */
-    void setMinimumScale( double pMinScale );
+    void setMinimumScale( double minScale );
 
     /**
      * Returns the max scale
@@ -309,7 +309,7 @@ class CORE_EXPORT QgsSnappingConfig
      * Set the max scale on which snapping is enabled, 0.0 disable scale limit
      * \since QGIS 3.14
      */
-    void setMaximumScale( double pMaxScale );
+    void setMaximumScale( double maxScale );
 
     /**
      * Set the scale dependency mode

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -80,12 +80,17 @@ class CORE_EXPORT QgsSnappingConfig
     Q_DECLARE_FLAGS( SnappingTypeFlag, SnappingTypes )
     Q_FLAG( SnappingTypeFlag )
 
+    /**
+     * ScaleDependencyMode the scale dependency mode of snapping
+     * \since QGIS 3.14
+     */
     enum ScaleDependencyMode
     {
-      Disabled = 0,
-      Global = 1,
-      PerLayer = 2
+      Disabled = 0,//!< No scale dependency
+      Global = 1,//!< Scale dependency using global min max range
+      PerLayer = 2//!< Scale dependency using min max range per layer
     };
+    Q_ENUM( ScaleDependencyMode )
 
     /**
      * Convenient method to returns the translated name of the enum type

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -120,7 +120,7 @@ class CORE_EXPORT QgsSnappingConfig
          * \param maxScale
          * \deprecated since QGIS 3.12 use the method with SnappingTypeFlag instead.
          */
-        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale  ) SIP_DEPRECATED;
+        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale ) SIP_DEPRECATED;
 
         /**
          * \brief IndividualLayerSettings
@@ -132,7 +132,7 @@ class CORE_EXPORT QgsSnappingConfig
          * \param maxScale
          * \since QGIS 3.12
          */
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale  );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale );
 
         /**
          * Constructs an invalid setting

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -265,6 +265,24 @@ class CORE_EXPORT QgsSnappingConfig
     //! Sets the tolerance
     void setTolerance( double tolerance );
 
+    //! Returns the min scale
+    double minScale() const;
+
+    //! Sets the min scale
+    void setMinScale( double pMinScale );
+
+    //! Returns the max scale
+    double maxScale() const;
+
+    //! Set the max scale
+    void setMaxScale( double pMaxScale );
+
+    //! Returns limit to scale
+    bool limitToScale() const;
+
+    //! Set limit to scale
+    void setLimitToScale( bool pLimitSnapping );
+
     //! Returns the type of units
     QgsTolerance::UnitType units() const;
 
@@ -395,6 +413,9 @@ class CORE_EXPORT QgsSnappingConfig
     SnappingMode mMode = ActiveLayer;
     SnappingTypeFlag mType = VertexFlag;
     double mTolerance = 0.0;
+    bool mLimitToScale = false;
+    double mMinScale = 0.0;
+    double mMaxScale = 0.0;
     QgsTolerance::UnitType mUnits = QgsTolerance::ProjectUnits;
     bool mIntersectionSnapping = false;
 

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -80,6 +80,13 @@ class CORE_EXPORT QgsSnappingConfig
     Q_DECLARE_FLAGS( SnappingTypeFlag, SnappingTypes )
     Q_FLAG( SnappingTypeFlag )
 
+    enum ScaleDependencyMode
+    {
+      Disabled = 0,
+      ScaleDependentGlobal,
+      ScaleDependentPerLayer
+    };
+
     /**
      * Convenient method to returns the translated name of the enum type
      * QgsSnappingConfig::SnappingTypeFlag
@@ -172,7 +179,8 @@ class CORE_EXPORT QgsSnappingConfig
          */
         void setTypeFlag( QgsSnappingConfig::SnappingTypeFlag type );
 
-        /**!
+        /**
+         * !
          * Returns the tolerance
          * \since QGIS 3.12
          */
@@ -314,16 +322,16 @@ class CORE_EXPORT QgsSnappingConfig
     void setMaxScale( double pMaxScale );
 
     /**
-     * Returns limit to scale
+     * Set the scale dependency mode
      * \since QGIS 3.14
      */
-    bool limitToScale() const;
+    void setScaleDependencyMode( ScaleDependencyMode mode );
 
     /**
-     * Set limit to scale, true means snapping will be limited to the [minScale, maxScale] range
+     * Returns the scale dependency mode
      * \since QGIS 3.14
      */
-    void setLimitToScale( bool pLimitSnapping );
+    ScaleDependencyMode scaleDependencyMode() const;
 
     //! Returns the type of units
     QgsTolerance::UnitType units() const;
@@ -455,7 +463,7 @@ class CORE_EXPORT QgsSnappingConfig
     SnappingMode mMode = ActiveLayer;
     SnappingTypeFlag mType = VertexFlag;
     double mTolerance = 0.0;
-    bool mLimitToScale = false;
+    ScaleDependencyMode mScaleDependencyMode = Disabled;
     double mMinScale = 0.0;
     double mMaxScale = 0.0;
     QgsTolerance::UnitType mUnits = QgsTolerance::ProjectUnits;

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -116,9 +116,11 @@ class CORE_EXPORT QgsSnappingConfig
          * \param type
          * \param tolerance
          * \param units
+         * \param minScale
+         * \param maxScale
          * \deprecated since QGIS 3.12 use the method with SnappingTypeFlag instead.
          */
-        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  ) SIP_DEPRECATED;
+        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale  ) SIP_DEPRECATED;
 
         /**
          * \brief IndividualLayerSettings
@@ -126,9 +128,11 @@ class CORE_EXPORT QgsSnappingConfig
          * \param type
          * \param tolerance
          * \param units
+         * \param minScale
+         * \param maxScale
          * \since QGIS 3.12
          */
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale  );
 
         /**
          * Constructs an invalid setting
@@ -180,12 +184,6 @@ class CORE_EXPORT QgsSnappingConfig
         //! Sets the type of units
         void setUnits( QgsTolerance::UnitType units );
 
-        //! Returns whether the snapping is limited on a scale iterval
-        bool limitToScaleRange() const;
-
-        //! Sets whether the scale limites are used or not
-        void setLimitToScaleRange( bool p_uselimit );
-
         //! Returns min scale on which snapping is limited
         double minScale() const;
 
@@ -211,9 +209,8 @@ class CORE_EXPORT QgsSnappingConfig
         SnappingTypeFlag mType = VertexFlag;
         double mTolerance = 0;
         QgsTolerance::UnitType mUnits = QgsTolerance::Pixels;
-        bool mLimitToScaleRange = false;
-        double mMinScale = 0;
-        double mMaxScale = 0;
+        double mMinScale = -1.0;
+        double mMaxScale = -1.0;
     };
 
     /**

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -116,8 +116,8 @@ class CORE_EXPORT QgsSnappingConfig
          * \param type
          * \param tolerance
          * \param units
-         * \param minScale
-         * \param maxScale
+         * \param minScale 0.0 disable scale limit
+         * \param maxScale 0.0 disable scale limit
          * \deprecated since QGIS 3.12 use the method with SnappingTypeFlag instead.
          */
         Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale ) SIP_DEPRECATED;
@@ -128,8 +128,8 @@ class CORE_EXPORT QgsSnappingConfig
          * \param type
          * \param tolerance
          * \param units
-         * \param minScale
-         * \param maxScale
+         * \param minScale 0.0 disable scale limit
+         * \param maxScale 0.0 disable scale limit
          * \since QGIS 3.12
          */
         IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, double minScale, double maxScale );
@@ -187,13 +187,13 @@ class CORE_EXPORT QgsSnappingConfig
         //! Returns min scale on which snapping is limited
         double minScale() const;
 
-        //! Sets the min scale value on which snapping is used
+        //! Sets the min scale value on which snapping is used, 0.0 disable scale limit
         void setMinScale( double p_minScale );
 
         //! Returns max scale on which snapping is limite
         double maxScale() const;
 
-        //! Sets the max scale value on which snapping is used
+        //! Sets the max scale value on which snapping is used, 0.0 disable scale limit
         void setMaxScale( double p_maxScale );
 
         /**
@@ -209,8 +209,8 @@ class CORE_EXPORT QgsSnappingConfig
         SnappingTypeFlag mType = VertexFlag;
         double mTolerance = 0;
         QgsTolerance::UnitType mUnits = QgsTolerance::Pixels;
-        double mMinScale = -1.0;
-        double mMaxScale = -1.0;
+        double mMinScale = 0.0;
+        double mMaxScale = 0.0;
     };
 
     /**
@@ -268,19 +268,19 @@ class CORE_EXPORT QgsSnappingConfig
     //! Returns the min scale
     double minScale() const;
 
-    //! Sets the min scale
+    //! Sets the min scale on which snapping is enabled, 0.0 disable scale limit
     void setMinScale( double pMinScale );
 
     //! Returns the max scale
     double maxScale() const;
 
-    //! Set the max scale
+    //! Set the max scale on which snapping is enabled, 0.0 disable scale limit
     void setMaxScale( double pMaxScale );
 
     //! Returns limit to scale
     bool limitToScale() const;
 
-    //! Set limit to scale
+    //! Set limit to scale, true means snapping will be limited to the [minScale, maxScale] range
     void setLimitToScale( bool pLimitSnapping );
 
     //! Returns the type of units

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -118,7 +118,7 @@ class CORE_EXPORT QgsSnappingConfig
          * \param units
          * \deprecated since QGIS 3.12 use the method with SnappingTypeFlag instead.
          */
-        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units ) SIP_DEPRECATED;
+        Q_DECL_DEPRECATED IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  ) SIP_DEPRECATED;
 
         /**
          * \brief IndividualLayerSettings
@@ -128,7 +128,7 @@ class CORE_EXPORT QgsSnappingConfig
          * \param units
          * \since QGIS 3.12
          */
-        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units );
+        IndividualLayerSettings( bool enabled, SnappingTypeFlag type, double tolerance, QgsTolerance::UnitType units, bool limitToScaleRange, double minScale, double maxScale  );
 
         /**
          * Constructs an invalid setting
@@ -180,6 +180,24 @@ class CORE_EXPORT QgsSnappingConfig
         //! Sets the type of units
         void setUnits( QgsTolerance::UnitType units );
 
+        //! Returns whether the snapping is limited on a scale iterval
+        bool limitToScaleRange() const;
+
+        //! Sets whether the scale limites are used or not
+        void setLimitToScaleRange( bool p_uselimit );
+
+        //! Returns min scale on which snapping is limited
+        double minScale() const;
+
+        //! Sets the min scale value on which snapping is used
+        void setMinScale( double p_minScale );
+
+        //! Returns max scale on which snapping is limite
+        double maxScale() const;
+
+        //! Sets the max scale value on which snapping is used
+        void setMaxScale( double p_maxScale );
+
         /**
          * Compare this configuration to other.
          */
@@ -193,6 +211,9 @@ class CORE_EXPORT QgsSnappingConfig
         SnappingTypeFlag mType = VertexFlag;
         double mTolerance = 0;
         QgsTolerance::UnitType mUnits = QgsTolerance::Pixels;
+        bool mLimitToScaleRange = false;
+        double mMinScale = 0;
+        double mMaxScale = 0;
     };
 
     /**

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -297,17 +297,17 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     bool inRangeGlobal = ( mSnappingConfig.minScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.minScale() )
                          && ( mSnappingConfig.maxScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maxScale() );
 
-    for ( const LayerConfig &layerConfig : qgis::as_const( mLayers ))
+    for ( const LayerConfig &layerConfig : qgis::as_const( mLayers ) )
     {
       QgsSnappingConfig::IndividualLayerSettings layerSettings = mSnappingConfig.individualLayerSettings( layerConfig.layer );
 
-      //Default value for layer config means it is not set ( appears NULL ) layerSpecificRange <- false
-      bool layerSpecificRange = layerSettings.minScale() > 0.0 || layerSettings.maxScale() > 0.0;
-      bool inRangeLayer = ( layerSettings.minScale() < 0.0 || mMapSettings.scale() >= layerSettings.minScale() ) && ( layerSettings.maxScale() < 0.0 || mMapSettings.scale() <= layerSettings.maxScale() );
+      bool inRangeLayer = ( layerSettings.minScale() <= 0.0 || mMapSettings.scale() >= layerSettings.minScale() ) && ( layerSettings.maxScale() <= 0.0 || mMapSettings.scale() <= layerSettings.maxScale() );
 
       //If limit to scale is disabled, snapping activated on all layer
       //If no per layer config is set use the global one, otherwise use the layer config
-      if ( !mSnappingConfig.limitToScale() || ( ( !layerSpecificRange && inRangeGlobal ) || ( layerSpecificRange && inRangeLayer ) ) )
+      if ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::Disabled
+           || ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentGlobal && inRangeGlobal )
+           || ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer  && inRangeLayer ) )
       {
         double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
         layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -300,9 +300,9 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       const LayerConfig &layerConfig = *it;
       QgsSnappingConfig::IndividualLayerSettings layerSettings = mSnappingConfig.individualLayerSettings( layerConfig.layer );
 
-      //Add the layers only if snapping scale limit is disabled or scale is in specified range
-      bool inRange = mMapSettings.scale() >= layerSettings.minScale() && mMapSettings.scale() <= layerSettings.maxScale();
-      if ( !layerSettings.limitToScaleRange() || inRange )
+      //Add the layers only if scale is in specified range. Value < 0.0 disable the limit.
+      bool inRange = ( layerSettings.minScale() < 0.0 || mMapSettings.scale() >= layerSettings.minScale() ) && ( layerSettings.maxScale() < 0.0 || mMapSettings.scale() <= layerSettings.maxScale() );
+      if ( inRange )
       {
         double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
         layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -294,14 +294,15 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     QList<LayerAndAreaOfInterest> layers;
     QList<LayerConfig> filteredConfigs;
 
-    bool inRangeGlobal = ( mSnappingConfig.minScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.minScale() )
-                         && ( mSnappingConfig.maxScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maxScale() );
+    bool inRangeGlobal = ( mSnappingConfig.minimumScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.minimumScale() )
+                         && ( mSnappingConfig.maximumScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maximumScale() );
 
     for ( const LayerConfig &layerConfig : qgis::as_const( mLayers ) )
     {
       QgsSnappingConfig::IndividualLayerSettings layerSettings = mSnappingConfig.individualLayerSettings( layerConfig.layer );
 
-      bool inRangeLayer = ( layerSettings.minScale() <= 0.0 || mMapSettings.scale() >= layerSettings.minScale() ) && ( layerSettings.maxScale() <= 0.0 || mMapSettings.scale() <= layerSettings.maxScale() );
+      bool inRangeLayer = ( layerSettings.minimumScale() <= 0.0 || mMapSettings.scale() >= layerSettings.minimumScale() )
+                          && ( layerSettings.maximumScale() <= 0.0 || mMapSettings.scale() <= layerSettings.maximumScale() );
 
       //If limit to scale is disabled, snapping activated on all layer
       //If no per layer config is set use the global one, otherwise use the layer config

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -291,16 +291,14 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
   }
   else if ( mSnappingConfig.mode() == QgsSnappingConfig::AdvancedConfiguration )
   {
-    typedef QList<LayerConfig>::const_iterator LayerConfigIterator;
     QList<LayerAndAreaOfInterest> layers;
-    QList<LayerConfigIterator> filteredConfigs;
+    QList<LayerConfig> filteredConfigs;
 
     bool inRangeGlobal = ( mSnappingConfig.minScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.minScale() )
                          && ( mSnappingConfig.maxScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maxScale() );
 
-    for ( LayerConfigIterator it = mLayers.begin(); it != mLayers.end(); ++it )
+    for ( const LayerConfig &layerConfig : qgis::as_const( mLayers ))
     {
-      const LayerConfig &layerConfig = *it;
       QgsSnappingConfig::IndividualLayerSettings layerSettings = mSnappingConfig.individualLayerSettings( layerConfig.layer );
 
       //Default value for layer config means it is not set ( appears NULL ) layerSpecificRange <- false
@@ -313,7 +311,7 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       {
         double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
         layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );
-        filteredConfigs << it;
+        filteredConfigs << layerConfig;
       }
     }
     prepareIndex( layers, relaxed );
@@ -322,9 +320,8 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     QgsPointLocator::MatchList edges; // for snap on intersection
     double maxSnapIntTolerance = 0;
 
-    for ( LayerConfigIterator &it : filteredConfigs )
+    for ( const LayerConfig &layerConfig : qgis::as_const( filteredConfigs ) )
     {
-      const LayerConfig &layerConfig = *it;
       double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
       if ( QgsPointLocator *loc = locatorForLayerUsingStrategy( layerConfig.layer, pointMap, tolerance ) )
       {

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -296,19 +296,20 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     QList<LayerConfigIterator> filteredConfigs;
 
     bool inRangeGlobal = ( mSnappingConfig.minScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.minScale() )
-      && ( mSnappingConfig.maxScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maxScale() );
+                         && ( mSnappingConfig.maxScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maxScale() );
 
     for ( LayerConfigIterator it = mLayers.begin(); it != mLayers.end(); ++it )
     {
       const LayerConfig &layerConfig = *it;
       QgsSnappingConfig::IndividualLayerSettings layerSettings = mSnappingConfig.individualLayerSettings( layerConfig.layer );
 
-      //Default value for layer config means it is not set (appears NULL)
+      //Default value for layer config means it is not set ( appears NULL ) layerSpecificRange <- false
       bool layerSpecificRange = layerSettings.minScale() > 0.0 || layerSettings.maxScale() > 0.0;
       bool inRangeLayer = ( layerSettings.minScale() < 0.0 || mMapSettings.scale() >= layerSettings.minScale() ) && ( layerSettings.maxScale() < 0.0 || mMapSettings.scale() <= layerSettings.maxScale() );
 
-      //If no per layer config is set use the global one otherwise use the layer config if it is set
-      if ( ( !layerSpecificRange && inRangeGlobal ) || ( layerSpecificRange && inRangeLayer) )
+      //If limit to scale is disabled, snapping activated on all layer
+      //If no per layer config is set use the global one, otherwise use the layer config
+      if ( !mSnappingConfig.limitToScale() || ( ( !layerSpecificRange && inRangeGlobal ) || ( layerSpecificRange && inRangeLayer ) ) )
       {
         double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
         layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -306,8 +306,8 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       //If limit to scale is disabled, snapping activated on all layer
       //If no per layer config is set use the global one, otherwise use the layer config
       if ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::Disabled
-           || ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentGlobal && inRangeGlobal )
-           || ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::ScaleDependentPerLayer  && inRangeLayer ) )
+           || ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::Global && inRangeGlobal )
+           || ( mSnappingConfig.scaleDependencyMode() == QgsSnappingConfig::PerLayer  && inRangeLayer ) )
       {
         double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
         layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -300,7 +300,6 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
       bool inRange = mMapSettings.scale() >= layerSettings.minScale() && mMapSettings.scale() <= layerSettings.maxScale();
       if ( !layerSettings.limitToScaleRange() || inRange )
       {
-        QgsDebugMsg( "Adding layer " );
         double tolerance = QgsTolerance::toleranceInProjectUnits( layerConfig.tolerance, layerConfig.layer, mMapSettings, layerConfig.unit );
         layers << qMakePair( layerConfig.layer, _areaOfInterest( pointMap, tolerance ) );
       }

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -33,7 +33,7 @@ struct FilterExcludePoint : public QgsPointLocator::MatchFilter
 {
   explicit FilterExcludePoint( const QgsPointXY &p ) : mPoint( p ) {}
 
-  bool acceptMatch( const QgsPointLocator::Match &match ) override { return match.point() != mPoint; }
+  bool acceptMatch( const QgsPointLocator::Match &match ) override { return match.point() != mPoint;  }
 
   QgsPointXY mPoint;
 };
@@ -349,7 +349,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, 0.0, 0.0  );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, 0.0, 0.0 );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vCurveZ.get(), layerSettings );
       u.setConfig( snappingConfig );

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -457,6 +457,78 @@ class TestQgsSnappingUtils : public QObject
       QCOMPARE( m.point(), QgsPointXY( 1, 0 ) );
     }
 
+    void testSnapScaleDependency()
+    {
+      QgsMapSettings mapSettings;
+      mapSettings.setOutputSize( QSize( 100, 100 ) );
+      mapSettings.setExtent( QgsRectangle( 0, 0, 1, 1 ) );
+      //Cannot set a specific scale directly, so play with Dpi in map settings, default scale is now 43295.7
+      mapSettings.setOutputDpi( 1 );
+      QVERIFY( mapSettings.hasValidSettings() );
+
+      QgsSnappingUtils u;
+      QgsSnappingConfig snappingConfig = u.config();
+      u.setMapSettings( mapSettings );
+      snappingConfig.setEnabled( true );
+      snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Disabled );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, -1.0, -1.0 ) );
+      u.setConfig( snappingConfig );
+
+      //No limit on scale
+      QgsPointLocator::Match m = u.snapToMap( QPoint( 100, 100 ) );
+      QVERIFY( m.isValid() );
+      QVERIFY( m.hasVertex() );
+      QCOMPARE( m.point(), QgsPointXY( 1, 0 ) );
+
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentGlobal );
+      snappingConfig.setMinScale( 0.0 );
+      snappingConfig.setMaxScale( 0.0 );
+      u.setConfig( snappingConfig );
+
+      //Global settings for scale limit, but scale are set to 0 -> snapping enabled
+      QgsPointLocator::Match m1 = u.snapToMap( QPoint( 100, 100 ) );
+      QVERIFY( m1.isValid() );
+      QVERIFY( m1.hasVertex() );
+
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentGlobal );
+      snappingConfig.setMinScale( 1000.0 );
+      snappingConfig.setMaxScale( 10000.0 );
+      u.setConfig( snappingConfig );
+
+      //Global settings for scale limit, but scale outside min max range -> no snapping
+      QgsPointLocator::Match m2 = u.snapToMap( QPoint( 100, 100 ) );
+      QVERIFY( m2.isValid() == false );
+      QVERIFY( m2.hasVertex() == false );
+
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentGlobal );
+      snappingConfig.setMinScale( 1000.0 );
+      snappingConfig.setMaxScale( 100000.0 );
+      u.setConfig( snappingConfig );
+
+      //Global settings for scale limit, scale inside min max range -> snapping enabled
+      QgsPointLocator::Match m3 = u.snapToMap( QPoint( 100, 100 ) );
+      QVERIFY( m3.isValid() );
+      QVERIFY( m3.hasVertex() );
+
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentPerLayer );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 1000.0, 10000.0 ) );
+      u.setConfig( snappingConfig );
+
+      //Per layer settings, but scale outside min max range of layer -> no snapping
+      QgsPointLocator::Match m4 = u.snapToMap( QPoint( 100, 100 ) );
+      QVERIFY( m4.isValid() == false );
+      QVERIFY( m4.hasVertex() == false );
+
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentPerLayer );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 1000.0, 100000.0 ) );
+      u.setConfig( snappingConfig );
+
+      //Per layer settings, scale inside min max range of layer -> snapping enabled
+      QgsPointLocator::Match m5 = u.snapToMap( QPoint( 100, 100 ) );
+      QVERIFY( m5.isValid() );
+      QVERIFY( m5.hasVertex() );
+    }
 };
 
 QGSTEST_MAIN( TestQgsSnappingUtils )

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -250,7 +250,7 @@ class TestQgsSnappingUtils : public QObject
       u.setMapSettings( mapSettings );
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, false, 0.0, 0.0 ) );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, -1.0, -1.0 ) );
       u.setConfig( snappingConfig );
 
       QgsPointLocator::Match m = u.snapToMap( QPoint( 100, 100 ) );
@@ -297,7 +297,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.1, QgsTolerance::ProjectUnits, false, 0.0, 0.0 );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.1, QgsTolerance::ProjectUnits, -1.0, -1.0 );
       snappingConfig.setIndividualLayerSettings( vl, layerSettings );
       u.setConfig( snappingConfig );
 
@@ -349,7 +349,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, false, 0.0, 0.0  );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, -1.0, -1.0  );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vCurveZ.get(), layerSettings );
       u.setConfig( snappingConfig );
@@ -386,7 +386,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, false, 0.0, 0.0 );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, -1.0, -1.0 );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vMulti.get(), layerSettings );
       u.setConfig( snappingConfig );

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -33,7 +33,7 @@ struct FilterExcludePoint : public QgsPointLocator::MatchFilter
 {
   explicit FilterExcludePoint( const QgsPointXY &p ) : mPoint( p ) {}
 
-  bool acceptMatch( const QgsPointLocator::Match &match ) override { return match.point() != mPoint;  }
+  bool acceptMatch( const QgsPointLocator::Match &match ) override { return match.point() != mPoint; }
 
   QgsPointXY mPoint;
 };

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -481,7 +481,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m.hasVertex() );
       QCOMPARE( m.point(), QgsPointXY( 1, 0 ) );
 
-      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentGlobal );
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
       snappingConfig.setMinScale( 0.0 );
       snappingConfig.setMaxScale( 0.0 );
       u.setConfig( snappingConfig );
@@ -491,7 +491,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m1.isValid() );
       QVERIFY( m1.hasVertex() );
 
-      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentGlobal );
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
       snappingConfig.setMinScale( 1000.0 );
       snappingConfig.setMaxScale( 10000.0 );
       u.setConfig( snappingConfig );
@@ -501,7 +501,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m2.isValid() == false );
       QVERIFY( m2.hasVertex() == false );
 
-      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentGlobal );
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
       snappingConfig.setMinScale( 1000.0 );
       snappingConfig.setMaxScale( 100000.0 );
       u.setConfig( snappingConfig );
@@ -511,7 +511,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m3.isValid() );
       QVERIFY( m3.hasVertex() );
 
-      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentPerLayer );
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::PerLayer );
       snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 1000.0, 10000.0 ) );
       u.setConfig( snappingConfig );
 
@@ -520,7 +520,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m4.isValid() == false );
       QVERIFY( m4.hasVertex() == false );
 
-      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::ScaleDependentPerLayer );
+      snappingConfig.setScaleDependencyMode( QgsSnappingConfig::PerLayer );
       snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 1000.0, 100000.0 ) );
       u.setConfig( snappingConfig );
 

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -250,7 +250,7 @@ class TestQgsSnappingUtils : public QObject
       u.setMapSettings( mapSettings );
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels ) );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, false, 0.0, 0.0 ) );
       u.setConfig( snappingConfig );
 
       QgsPointLocator::Match m = u.snapToMap( QPoint( 100, 100 ) );
@@ -297,7 +297,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.1, QgsTolerance::ProjectUnits );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.1, QgsTolerance::ProjectUnits, false, 0.0, 0.0 );
       snappingConfig.setIndividualLayerSettings( vl, layerSettings );
       u.setConfig( snappingConfig );
 
@@ -349,7 +349,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, false, 0.0, 0.0  );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vCurveZ.get(), layerSettings );
       u.setConfig( snappingConfig );
@@ -386,7 +386,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, false, 0.0, 0.0 );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vMulti.get(), layerSettings );
       u.setConfig( snappingConfig );

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -482,8 +482,8 @@ class TestQgsSnappingUtils : public QObject
       QCOMPARE( m.point(), QgsPointXY( 1, 0 ) );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
-      snappingConfig.setMinScale( 0.0 );
-      snappingConfig.setMaxScale( 0.0 );
+      snappingConfig.setMinimumScale( 0.0 );
+      snappingConfig.setMaximumScale( 0.0 );
       u.setConfig( snappingConfig );
 
       //Global settings for scale limit, but scale are set to 0 -> snapping enabled
@@ -492,8 +492,8 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m1.hasVertex() );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
-      snappingConfig.setMinScale( 1000.0 );
-      snappingConfig.setMaxScale( 10000.0 );
+      snappingConfig.setMinimumScale( 1000.0 );
+      snappingConfig.setMaximumScale( 10000.0 );
       u.setConfig( snappingConfig );
 
       //Global settings for scale limit, but scale outside min max range -> no snapping
@@ -502,8 +502,8 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m2.hasVertex() == false );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
-      snappingConfig.setMinScale( 1000.0 );
-      snappingConfig.setMaxScale( 100000.0 );
+      snappingConfig.setMinimumScale( 1000.0 );
+      snappingConfig.setMaximumScale( 100000.0 );
       u.setConfig( snappingConfig );
 
       //Global settings for scale limit, scale inside min max range -> snapping enabled

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -297,7 +297,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.1, QgsTolerance::ProjectUnits, -1.0, -1.0 );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.1, QgsTolerance::ProjectUnits, 0.0, 0.0 );
       snappingConfig.setIndividualLayerSettings( vl, layerSettings );
       u.setConfig( snappingConfig );
 
@@ -349,7 +349,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, -1.0, -1.0  );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, 0.0, 0.0  );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vCurveZ.get(), layerSettings );
       u.setConfig( snappingConfig );
@@ -386,7 +386,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, -1.0, -1.0 );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, QgsSnappingConfig::VertexFlag, 0.2, QgsTolerance::ProjectUnits, 0.0, 0.0 );
       snappingConfig.setIntersectionSnapping( true );
       snappingConfig.setIndividualLayerSettings( vMulti.get(), layerSettings );
       u.setConfig( snappingConfig );
@@ -424,7 +424,7 @@ class TestQgsSnappingUtils : public QObject
       QgsSnappingConfig snappingConfig = u.config();
       snappingConfig.setEnabled( true );
       snappingConfig.setMode( QgsSnappingConfig::AdvancedConfiguration );
-      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::MiddleOfSegmentFlag | QgsSnappingConfig::CentroidFlag ), 0.2, QgsTolerance::ProjectUnits );
+      QgsSnappingConfig::IndividualLayerSettings layerSettings( true, static_cast<QgsSnappingConfig::SnappingTypeFlag>( QgsSnappingConfig::MiddleOfSegmentFlag | QgsSnappingConfig::CentroidFlag ), 0.2, QgsTolerance::ProjectUnits, 0.0, 0.0 );
       snappingConfig.setIndividualLayerSettings( vSnapCentroidMiddle.get(), layerSettings );
       u.setConfig( snappingConfig );
 

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -113,7 +113,7 @@ class TestLayerDependencies(unittest.TestCase):
         cfg.setMode(QgsSnappingConfig.AdvancedConfiguration)
         cfg.setIndividualLayerSettings(self.pointsLayer,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
+                                                                                 QgsSnappingConfig.VertexFlag, 20, QgsTolerance.Pixels, 0.0, 0.0))
         u.setConfig(cfg)
 
         m = u.snapToMap(QPoint(95, 100))
@@ -156,7 +156,7 @@ class TestLayerDependencies(unittest.TestCase):
         # test chained layer dependencies A -> B -> C
         cfg.setIndividualLayerSettings(self.pointsLayer2,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
+                                                                                 QgsSnappingConfig.VertexFlag, 20, QgsTolerance.Pixels, 0.0, 0.0))
         u.setConfig(cfg)
         self.pointsLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())])
         self.pointsLayer2.setDependencies([QgsMapLayerDependency(self.pointsLayer.id())])
@@ -304,10 +304,10 @@ class TestLayerDependencies(unittest.TestCase):
         cfg.setMode(QgsSnappingConfig.AdvancedConfiguration)
         cfg.setIndividualLayerSettings(self.pointsLayer,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
+                                                                                 QgsSnappingConfig.VertexFlag, 20, QgsTolerance.Pixels, 0.0, 0.0))
         cfg.setIndividualLayerSettings(self.pointsLayer2,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
+                                                                                 QgsSnappingConfig.VertexFlag, 20, QgsTolerance.Pixels, 0.0, 0.0))
         u.setConfig(cfg)
         # add another line
         f = QgsFeature(self.linesLayer.fields())

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -113,7 +113,7 @@ class TestLayerDependencies(unittest.TestCase):
         cfg.setMode(QgsSnappingConfig.AdvancedConfiguration)
         cfg.setIndividualLayerSettings(self.pointsLayer,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels))
+                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
         u.setConfig(cfg)
 
         m = u.snapToMap(QPoint(95, 100))
@@ -156,7 +156,7 @@ class TestLayerDependencies(unittest.TestCase):
         # test chained layer dependencies A -> B -> C
         cfg.setIndividualLayerSettings(self.pointsLayer2,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels))
+                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
         u.setConfig(cfg)
         self.pointsLayer.setDependencies([QgsMapLayerDependency(self.linesLayer.id())])
         self.pointsLayer2.setDependencies([QgsMapLayerDependency(self.pointsLayer.id())])
@@ -304,10 +304,10 @@ class TestLayerDependencies(unittest.TestCase):
         cfg.setMode(QgsSnappingConfig.AdvancedConfiguration)
         cfg.setIndividualLayerSettings(self.pointsLayer,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels))
+                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
         cfg.setIndividualLayerSettings(self.pointsLayer2,
                                        QgsSnappingConfig.IndividualLayerSettings(True,
-                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels))
+                                                                                 QgsSnappingConfig.Vertex, 20, QgsTolerance.Pixels, 0.0, 0.0))
         u.setConfig(cfg)
         # add another line
         f = QgsFeature(self.linesLayer.fields())


### PR DESCRIPTION
## Description

This pull request follows the qgis enhancement proposal 167 described in details here : [Snapping enabled on a configurable scale range](https://github.com/qgis/QGIS-Enhancement-Proposals/issues/167)

The goal is to provide a way to optimizing the snapping feature by allowing the user to enable it only on specified scale range. A global setting and a per layer setting are available.

For more details please refer to the qgis enhancement proposal description and discussion.