### PR TITLE
Determine primary key from Oracle view

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -895,8 +895,8 @@ bool QgsOracleProvider::determinePrimaryKey()
   if ( !mIsQuery )
   {
     if ( !exec( qry, QString( "SELECT column_name"
-                              " FROM all_ind_columns a"
-                              " JOIN all_constraints b ON a.index_name=constraint_name AND a.index_owner=b.owner"
+                              " FROM all_cons_columns a"
+                              " JOIN all_constraints b ON a.constraint_name=b.constraint_name AND a.owner=b.owner"
                               " WHERE b.constraint_type='P' AND b.owner=? AND b.table_name=?" ),
                 QVariantList() << mOwnerName << mTableName ) )
     {


### PR DESCRIPTION
## Description

From an Oracle database, you can specify a disabled primary key constraint so tools can easily determine primary key. 

> View Constraints Oracle Database does not enforce view constraints. However, you can enforce constraints on views through constraints on base tables.
> 
> You can specify only unique, primary key, and foreign key constraints on views, and they are supported only in DISABLE NOVALIDATE mode. You cannot define view constraints on attributes of an object column.

https://docs.oracle.com/cd/B19306_01/server.102/b14200/clauses002.htm

This PR use this behavior to determine primary key on view.

