### PR TITLE
Don't override all cursors in bad layer handler dialog

### DIFF
--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -44,7 +44,8 @@
 
 void QgsHandleBadLayersHandler::handleBadLayers( const QList<QDomNode> &layers )
 {
-  QApplication::setOverrideCursor( Qt::ArrowCursor );
+  QgsTemporaryCursorRestoreOverride cursorOverride;
+
   QgsHandleBadLayers *dialog = new QgsHandleBadLayers( layers );
 
   dialog->buttonBox->button( QDialogButtonBox::Ignore )->setToolTip( tr( "Import all unavailable layers unmodified (you can fix them later)." ) );
@@ -70,7 +71,6 @@ void QgsHandleBadLayersHandler::handleBadLayers( const QList<QDomNode> &layers )
   }
 
   delete dialog;
-  QApplication::restoreOverrideCursor();
 }
 
 QgsHandleBadLayers::QgsHandleBadLayers( const QList<QDomNode> &layers )


### PR DESCRIPTION
Avoids the arrow cursor showing everywhere in this dialog, which is odd UX