### PR TITLE
Add "filter by geometry type" and "filter by layer type" algorithms to processing

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -47,6 +47,7 @@ Abstract base class for processing algorithms.
       FlagSupportsInPlaceEdits,
       FlagKnownIssues,
       FlagCustomException,
+      FlagPruneModelBranchesBasedOnAlgorithmResults,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_line.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_line.gml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_lines_line.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>11</gml:X><gml:Y>5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:filter_geom_lines_line fid="lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>6,2 9,2 9,3 11,5</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:filter_geom_lines_line>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_lines_line fid="lines.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-1,-1 1,-1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:filter_geom_lines_line>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_lines_line fid="lines.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>2,0 2,2 3,2 3,3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:filter_geom_lines_line>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_lines_line fid="lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>3,1 5,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:filter_geom_lines_line>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_lines_line fid="lines.4">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>7,-3 10,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:filter_geom_lines_line>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_lines_line fid="lines.5">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>6,-3 10,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:filter_geom_lines_line>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_line.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_line.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_lines_line" type="ogr:filter_geom_lines_line_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_lines_line_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_null.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_null.gml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_lines_null.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+  <gml:featureMember>
+    <ogr:filter_geom_lines_null fid="lines.6">
+    </ogr:filter_geom_lines_null>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_null.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_null.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_lines_null" type="ogr:filter_geom_lines_null_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_lines_null_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_point.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_point.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_lines_point.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_point.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_point.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_lines_point" type="ogr:filter_geom_lines_point_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_lines_point_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_poly.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_poly.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_lines_poly.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_lines_poly.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_lines_poly.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_lines_poly" type="ogr:filter_geom_lines_poly_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_lines_poly_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_line.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_line.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_points_line.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_line.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_line.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_points_line" type="ogr:filter_geom_points_line_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_points_line_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_null.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_null.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_points_null.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_null.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_null.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_points_null" type="ogr:filter_geom_points_null_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_points_null_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_point.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_point.gml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_points_point.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_points_point fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+    </ogr:filter_geom_points_point>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_point.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_point.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_points_point" type="ogr:filter_geom_points_point_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_points_point_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_poly.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_poly.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_points_poly.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_points_poly.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_points_poly.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_points_poly" type="ogr:filter_geom_points_poly_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_points_poly_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_line.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_line.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_polys_line.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_line.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_line.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_polys_line" type="ogr:filter_geom_polys_line_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_polys_line_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_null.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_null.gml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_polys_null.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+  <gml:featureMember>
+    <ogr:filter_geom_polys_null fid="polys.4">
+      <ogr:name xsi:nil="true"/>
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+    </ogr:filter_geom_polys_null>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_null.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_null.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_polys_null" type="ogr:filter_geom_polys_null_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_polys_null_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_point.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_point.gml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_polys_point.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
+                                                                                                                                                                                                                                                                                                
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_point.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_point.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_polys_point" type="ogr:filter_geom_polys_point_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_polys_point_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_poly.gml
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_poly.gml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ filter_geom_polys_poly.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:filter_geom_polys_poly fid="polys.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+    </ogr:filter_geom_polys_poly>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_polys_poly fid="polys.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>5,5 6,4 4,4 5,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval>-33</ogr:intval>
+      <ogr:floatval>0</ogr:floatval>
+    </ogr:filter_geom_polys_poly>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_polys_poly fid="polys.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,5 2,6 3,6 3,5 2,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:filter_geom_polys_poly>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_polys_poly fid="polys.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+    </ogr:filter_geom_polys_poly>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:filter_geom_polys_poly fid="polys.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 2,2 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+    </ogr:filter_geom_polys_poly>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/filter_geom_polys_poly.xsd
+++ b/python/plugins/processing/tests/testdata/expected/filter_geom_polys_poly.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="filter_geom_polys_poly" type="ogr:filter_geom_polys_poly_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="filter_geom_polys_poly_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2425,5 +2425,5 @@ tests:
         name: expected/filter_geom_lines_poly.gml
         type: vector
 
-  
+
 # See ../README.md for a description of the file format

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests4.yaml
@@ -2365,5 +2365,65 @@ tests:
         name: expected/renamed_field.gml
         type: vector
 
+  - algorithm: native:filterbygeometry
+    name: Filter by geometry type polygon input
+    params:
+      INPUT:
+        name: polys.gml|layername=polys2
+        type: vector
+    results:
+      LINES:
+        name: expected/filter_geom_polys_line.gml
+        type: vector
+      NO_GEOMETRY:
+        name: expected/filter_geom_polys_null.gml
+        type: vector
+      POINTS:
+        name: expected/filter_geom_polys_point.gml
+        type: vector
+      POLYGONS:
+        name: expected/filter_geom_polys_poly.gml
+        type: vector
 
+  - algorithm: native:filterbygeometry
+    name: Filter by geometry type point input
+    params:
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+    results:
+      LINES:
+        name: expected/filter_geom_points_line.gml
+        type: vector
+      NO_GEOMETRY:
+        name: expected/filter_geom_points_null.gml
+        type: vector
+      POINTS:
+        name: expected/filter_geom_points_point.gml
+        type: vector
+      POLYGONS:
+        name: expected/filter_geom_points_poly.gml
+        type: vector
+
+  - algorithm: native:filterbygeometry
+    name: Filter by geometry type line input
+    params:
+      INPUT:
+        name: lines.gml|layername=lines
+        type: vector
+    results:
+      LINES:
+        name: expected/filter_geom_lines_line.gml
+        type: vector
+      NO_GEOMETRY:
+        name: expected/filter_geom_lines_null.gml
+        type: vector
+      POINTS:
+        name: expected/filter_geom_lines_point.gml
+        type: vector
+      POLYGONS:
+        name: expected/filter_geom_lines_poly.gml
+        type: vector
+
+  
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -66,6 +66,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmfiledownloader.cpp
   processing/qgsalgorithmfillnodata.cpp
   processing/qgsalgorithmfilter.cpp
+  processing/qgsalgorithmfilterbygeometry.cpp
   processing/qgsalgorithmfiltervertices.cpp
   processing/qgsalgorithmfixgeometries.cpp
   processing/qgsalgorithmforcerhr.cpp

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
@@ -1,0 +1,216 @@
+/***************************************************************************
+                         qgsalgorithmfilterbygeometry.cpp
+                         ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmfilterbygeometry.h"
+
+///@cond PRIVATE
+
+QString QgsFilterByGeometryAlgorithm::name() const
+{
+  return QStringLiteral( "filterbygeometry" );
+}
+
+QString QgsFilterByGeometryAlgorithm::displayName() const
+{
+  return QObject::tr( "Filter by geometry type" );
+}
+
+QStringList QgsFilterByGeometryAlgorithm::tags() const
+{
+  return QObject::tr( "extract,filter,geometry,linestring,point,polygon" ).split( ',' );
+}
+
+QString QgsFilterByGeometryAlgorithm::group() const
+{
+  return QObject::tr( "Vector selection" );
+}
+
+QString QgsFilterByGeometryAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorselection" );
+}
+
+void QgsFilterByGeometryAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
+                QList< int >() << QgsProcessing::TypeVector ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "POINTS" ),  QObject::tr( "Point features" ),
+                QgsProcessing::TypeVectorPoint, QVariant(), true, true ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "LINES" ),  QObject::tr( "Line features" ),
+                QgsProcessing::TypeVectorLine, QVariant(), true, true ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "POLYGONS" ),  QObject::tr( "Polygon features" ),
+                QgsProcessing::TypeVectorPolygon, QVariant(), true, true ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "NO_GEOMETRY" ),  QObject::tr( "Features with no geometry" ),
+                QgsProcessing::TypeVector, QVariant(), true, true ) );
+
+  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "POINT_COUNT" ), QObject::tr( "Total count of point features" ) ) );
+  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "LINE_COUNT" ), QObject::tr( "Total count of line features" ) ) );
+  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "POLYGON_COUNT" ), QObject::tr( "Total count of polygon features" ) ) );
+  addOutput( new QgsProcessingOutputNumber( QStringLiteral( "NO_GEOMETRY_COUNT" ), QObject::tr( "Total count of features without geometry" ) ) );
+}
+
+QString QgsFilterByGeometryAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm filters features by their geometry type. Incoming features will be directed to different "
+                      "outputs based on whether they have a point, line or polygon geometry." );
+}
+
+QString QgsFilterByGeometryAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Filters features by geometry type" );
+}
+
+QgsFilterByGeometryAlgorithm *QgsFilterByGeometryAlgorithm::createInstance() const
+{
+  return new QgsFilterByGeometryAlgorithm();
+}
+
+QVariantMap QgsFilterByGeometryAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+  if ( !source )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
+
+  const bool hasM = QgsWkbTypes::hasM( source->wkbType() );
+  const bool hasZ = QgsWkbTypes::hasZ( source->wkbType() );
+
+  QgsWkbTypes::Type pointType = QgsWkbTypes::Point;
+  QgsWkbTypes::Type lineType = QgsWkbTypes::LineString;
+  QgsWkbTypes::Type polygonType = QgsWkbTypes::Polygon;
+  if ( hasM )
+  {
+    pointType = QgsWkbTypes::addM( pointType );
+    lineType = QgsWkbTypes::addM( lineType );
+    polygonType = QgsWkbTypes::addM( polygonType );
+  }
+  if ( hasZ )
+  {
+    pointType = QgsWkbTypes::addZ( pointType );
+    lineType = QgsWkbTypes::addZ( lineType );
+    polygonType = QgsWkbTypes::addZ( polygonType );
+  }
+
+  QString pointSinkId;
+  std::unique_ptr< QgsFeatureSink > pointSink( parameterAsSink( parameters, QStringLiteral( "POINTS" ), context, pointSinkId, source->fields(),
+      pointType, source->sourceCrs() ) );
+  if ( parameters.value( QStringLiteral( "POINTS" ), QVariant() ).isValid() && !pointSink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "POINTS" ) ) );
+
+  QString lineSinkId;
+  std::unique_ptr< QgsFeatureSink > lineSink( parameterAsSink( parameters, QStringLiteral( "LINES" ), context, lineSinkId, source->fields(),
+      lineType, source->sourceCrs() ) );
+  if ( parameters.value( QStringLiteral( "LINES" ), QVariant() ).isValid() && !lineSink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "LINES" ) ) );
+
+  QString polygonSinkId;
+  std::unique_ptr< QgsFeatureSink > polygonSink( parameterAsSink( parameters, QStringLiteral( "POLYGONS" ), context, polygonSinkId, source->fields(),
+      polygonType, source->sourceCrs() ) );
+  if ( parameters.value( QStringLiteral( "POLYGONS" ), QVariant() ).isValid() && !polygonSink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "POLYGONS" ) ) );
+
+  QString noGeomSinkId;
+  std::unique_ptr< QgsFeatureSink > noGeomSink( parameterAsSink( parameters, QStringLiteral( "NO_GEOMETRY" ), context, noGeomSinkId, source->fields(),
+      QgsWkbTypes::NoGeometry ) );
+  if ( parameters.value( QStringLiteral( "NO_GEOMETRY" ), QVariant() ).isValid() && !noGeomSink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "NO_GEOMETRY" ) ) );
+
+  long count = source->featureCount();
+  long long pointCount = 0;
+  long long lineCount = 0;
+  long long polygonCount = 0;
+  long long nullCount = 0;
+
+  double step = count > 0 ? 100.0 / count : 1;
+  int current = 0;
+
+  QgsFeatureIterator it = source->getFeatures();
+  QgsFeature f;
+  while ( it.nextFeature( f ) )
+  {
+    if ( feedback->isCanceled() )
+    {
+      break;
+    }
+
+    if ( f.hasGeometry() )
+    {
+      switch ( f.geometry().type() )
+      {
+        case QgsWkbTypes::PointGeometry:
+          if ( pointSink )
+          {
+            pointSink->addFeature( f, QgsFeatureSink::FastInsert );
+          }
+          pointCount++;
+          break;
+        case QgsWkbTypes::LineGeometry:
+          if ( lineSink )
+          {
+            lineSink->addFeature( f, QgsFeatureSink::FastInsert );
+          }
+          lineCount++;
+          break;
+        case QgsWkbTypes::PolygonGeometry:
+          if ( polygonSink )
+          {
+            polygonSink->addFeature( f, QgsFeatureSink::FastInsert );
+          }
+          polygonCount++;
+          break;
+        case QgsWkbTypes::NullGeometry:
+        case QgsWkbTypes::UnknownGeometry:
+          break;
+      }
+    }
+    else
+    {
+      if ( noGeomSink )
+      {
+        noGeomSink->addFeature( f, QgsFeatureSink::FastInsert );
+      }
+      nullCount++;
+    }
+
+    feedback->setProgress( current * step );
+    current++;
+  }
+
+  QVariantMap outputs;
+
+  if ( pointSink )
+    outputs.insert( QStringLiteral( "POINTS" ), pointSinkId );
+  if ( lineSink )
+    outputs.insert( QStringLiteral( "LINES" ), lineSinkId );
+  if ( polygonSink )
+    outputs.insert( QStringLiteral( "POLYGONS" ), polygonSinkId );
+  if ( noGeomSink )
+    outputs.insert( QStringLiteral( "NO_GEOMETRY" ), noGeomSinkId );
+
+  outputs.insert( QStringLiteral( "POINT_COUNT" ), pointCount );
+  outputs.insert( QStringLiteral( "LINE_COUNT" ), lineCount );
+  outputs.insert( QStringLiteral( "POLYGON_COUNT" ), polygonCount );
+  outputs.insert( QStringLiteral( "NO_GEOMETRY_COUNT" ), nullCount );
+
+  return outputs;
+}
+
+///@endcond
+

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.cpp
@@ -44,6 +44,13 @@ QString QgsFilterByGeometryAlgorithm::groupId() const
   return QStringLiteral( "vectorselection" );
 }
 
+QgsProcessingAlgorithm::Flags QgsFilterByGeometryAlgorithm::flags() const
+{
+  Flags f = QgsProcessingAlgorithm::flags();
+  f |= QgsProcessingAlgorithm::FlagHideFromToolbox;
+  return f;
+}
+
 void QgsFilterByGeometryAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ),
@@ -208,6 +215,96 @@ QVariantMap QgsFilterByGeometryAlgorithm::processAlgorithm( const QVariantMap &p
   outputs.insert( QStringLiteral( "LINE_COUNT" ), lineCount );
   outputs.insert( QStringLiteral( "POLYGON_COUNT" ), polygonCount );
   outputs.insert( QStringLiteral( "NO_GEOMETRY_COUNT" ), nullCount );
+
+  return outputs;
+}
+
+
+
+//
+// QgsFilterByLayerTypeAlgorithm
+//
+
+QString QgsFilterByLayerTypeAlgorithm::name() const
+{
+  return QStringLiteral( "filterlayersbytype" );
+}
+
+QString QgsFilterByLayerTypeAlgorithm::displayName() const
+{
+  return QObject::tr( "Filter layers by type" );
+}
+
+QStringList QgsFilterByLayerTypeAlgorithm::tags() const
+{
+  return QObject::tr( "filter,vector,raster,select" ).split( ',' );
+}
+
+QString QgsFilterByLayerTypeAlgorithm::group() const
+{
+  return QObject::tr( "Layer tools" );
+}
+
+QString QgsFilterByLayerTypeAlgorithm::groupId() const
+{
+  return QStringLiteral( "layertools" );
+}
+
+QgsProcessingAlgorithm::Flags QgsFilterByLayerTypeAlgorithm::flags() const
+{
+  Flags f = QgsProcessingAlgorithm::flags();
+  f |= FlagHideFromToolbox | FlagPruneModelBranchesBasedOnAlgorithmResults;
+  return f;
+}
+
+void QgsFilterByLayerTypeAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterMapLayer( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
+
+  addParameter( new QgsProcessingParameterVectorDestination( QStringLiteral( "VECTOR" ),  QObject::tr( "Vector features" ),
+                QgsProcessing::TypeVectorAnyGeometry, QVariant(), true, false ) );
+
+  addParameter( new QgsProcessingParameterRasterDestination( QStringLiteral( "RASTER" ),  QObject::tr( "Raster layer" ), QVariant(), true, false ) );
+}
+
+QString QgsFilterByLayerTypeAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm filters layer by their type. Incoming layers will be directed to different "
+                      "outputs based on whether they are a vector or raster layer." );
+}
+
+QString QgsFilterByLayerTypeAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Filters layers by type" );
+}
+
+QgsFilterByLayerTypeAlgorithm *QgsFilterByLayerTypeAlgorithm::createInstance() const
+{
+  return new QgsFilterByLayerTypeAlgorithm();
+}
+
+QVariantMap QgsFilterByLayerTypeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  const QgsMapLayer *layer = parameterAsLayer( parameters, QStringLiteral( "INPUT" ), context );
+  if ( !layer )
+    throw QgsProcessingException( QObject::tr( "Could not load input layer" ) );
+
+  QVariantMap outputs;
+
+  switch ( layer->type() )
+  {
+    case QgsMapLayerType::VectorLayer:
+      outputs.insert( QStringLiteral( "VECTOR" ), parameters.value( QStringLiteral( "INPUT" ) ) );
+      break;
+
+    case QgsMapLayerType::RasterLayer:
+      outputs.insert( QStringLiteral( "RASTER" ), parameters.value( QStringLiteral( "INPUT" ) ) );
+      break;
+
+    case QgsMapLayerType::PluginLayer:
+    case QgsMapLayerType::MeshLayer:
+      break;
+  }
 
   return outputs;
 }

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.h
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+                         qgsalgorithmfilterbygeometry.h
+                         ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMFILTERBYGEOMETRY_H
+#define QGSALGORITHMFILTERBYGEOMETRY_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native extract by expression algorithm.
+ */
+class QgsFilterByGeometryAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsFilterByGeometryAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsFilterByGeometryAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMFILTERBYGEOMETRY_H
+
+

--- a/src/analysis/processing/qgsalgorithmfilterbygeometry.h
+++ b/src/analysis/processing/qgsalgorithmfilterbygeometry.h
@@ -26,7 +26,7 @@
 ///@cond PRIVATE
 
 /**
- * Native extract by expression algorithm.
+ * Native filter by geometry type algorithm.
  */
 class QgsFilterByGeometryAlgorithm : public QgsProcessingAlgorithm
 {
@@ -34,6 +34,7 @@ class QgsFilterByGeometryAlgorithm : public QgsProcessingAlgorithm
   public:
 
     QgsFilterByGeometryAlgorithm() = default;
+    Flags flags() const override;
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;
     QString displayName() const override;
@@ -43,6 +44,34 @@ class QgsFilterByGeometryAlgorithm : public QgsProcessingAlgorithm
     QString shortHelpString() const override;
     QString shortDescription() const override;
     QgsFilterByGeometryAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+};
+
+
+/**
+ * Native filter by layer type algorithm.
+ */
+class QgsFilterByLayerTypeAlgorithm : public QgsProcessingAlgorithm
+{
+
+  public:
+
+    QgsFilterByLayerTypeAlgorithm() = default;
+    Flags flags() const override;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsFilterByLayerTypeAlgorithm *createInstance() const override SIP_FACTORY;
 
   protected:
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -61,6 +61,7 @@
 #include "qgsalgorithmfiledownloader.h"
 #include "qgsalgorithmfillnodata.h"
 #include "qgsalgorithmfilter.h"
+#include "qgsalgorithmfilterbygeometry.h"
 #include "qgsalgorithmfiltervertices.h"
 #include "qgsalgorithmfixgeometries.h"
 #include "qgsalgorithmforcerhr.h"
@@ -251,6 +252,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsFileDownloaderAlgorithm() );
   addAlgorithm( new QgsFillNoDataAlgorithm() );
   addAlgorithm( new QgsFilterAlgorithm() );
+  addAlgorithm( new QgsFilterByGeometryAlgorithm() );
   addAlgorithm( new QgsFilterVerticesByM() );
   addAlgorithm( new QgsFilterVerticesByZ() );
   addAlgorithm( new QgsFixGeometriesAlgorithm() );

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -253,6 +253,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsFillNoDataAlgorithm() );
   addAlgorithm( new QgsFilterAlgorithm() );
   addAlgorithm( new QgsFilterByGeometryAlgorithm() );
+  addAlgorithm( new QgsFilterByLayerTypeAlgorithm() );
   addAlgorithm( new QgsFilterVerticesByM() );
   addAlgorithm( new QgsFilterVerticesByZ() );
   addAlgorithm( new QgsFixGeometriesAlgorithm() );

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -350,7 +350,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       if ( childAlg->flags() & QgsProcessingAlgorithm::FlagPruneModelBranchesBasedOnAlgorithmResults )
       {
         // check if any dependent algorithms should be canceled based on the outputs of this algorithm run
-        // first find all direct dependancies of this algorithm by looking through all remaining child algorithms
+        // first find all direct dependencies of this algorithm by looking through all remaining child algorithms
         for ( const QString &candidateId : qgis::as_const( toExecute ) )
         {
           if ( executed.contains( candidateId ) )

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -259,8 +259,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
   while ( executedAlg && executed.count() < toExecute.count() )
   {
     executedAlg = false;
-    const auto constToExecute = toExecute;
-    for ( const QString &childId : constToExecute )
+    for ( const QString &childId : qgis::as_const( toExecute ) )
     {
       if ( feedback && feedback->isCanceled() )
         break;
@@ -269,8 +268,8 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
         continue;
 
       bool canExecute = true;
-      const auto constDependsOnChildAlgorithms = dependsOnChildAlgorithms( childId );
-      for ( const QString &dependency : constDependsOnChildAlgorithms )
+      const QSet< QString > dependencies = dependsOnChildAlgorithms( childId );
+      for ( const QString &dependency : dependencies )
       {
         if ( !executed.contains( dependency ) )
         {
@@ -321,7 +320,6 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
         const QString error = childAlg->flags() & QgsProcessingAlgorithm::FlagCustomException ? QString() : QObject::tr( "Error encountered while running %1" ).arg( child.description() );
         throw QgsProcessingException( error );
       }
-      childAlg.reset( nullptr );
       childResults.insert( childId, results );
 
       // look through child alg's outputs to determine whether any of these should be copied
@@ -334,6 +332,62 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       }
 
       executed.insert( childId );
+
+      std::function< void( const QString & )> pruneAlgorithmBranchRecursive;
+      pruneAlgorithmBranchRecursive = [&]( const QString & id )
+      {
+        const QSet<QString> toPrune = dependentChildAlgorithms( id );
+        for ( const QString &targetId : toPrune )
+        {
+          if ( executed.contains( targetId ) )
+            continue;
+
+          executed.insert( targetId );
+          pruneAlgorithmBranchRecursive( targetId );
+        }
+      };
+
+      if ( childAlg->flags() & QgsProcessingAlgorithm::FlagPruneModelBranchesBasedOnAlgorithmResults )
+      {
+        // check if any dependent algorithms should be canceled based on the outputs of this algorithm run
+        // first find all direct dependancies of this algorithm by looking through all remaining child algorithms
+        for ( const QString &candidateId : qgis::as_const( toExecute ) )
+        {
+          if ( executed.contains( candidateId ) )
+            continue;
+
+          // a pending algorithm was found..., check it's parameter sources to see if it links to any of the current
+          // algorithm's outputs
+          const QgsProcessingModelChildAlgorithm &candidate = mChildAlgorithms[ candidateId ];
+          const QMap<QString, QgsProcessingModelChildParameterSources> candidateParams = candidate.parameterSources();
+          QMap<QString, QgsProcessingModelChildParameterSources>::const_iterator paramIt = candidateParams.constBegin();
+          bool pruned = false;
+          for ( ; paramIt != candidateParams.constEnd(); ++paramIt )
+          {
+            for ( const QgsProcessingModelChildParameterSource &source : paramIt.value() )
+            {
+              if ( source.source() == QgsProcessingModelChildParameterSource::ChildOutput && source.outputChildId() == childId )
+              {
+                // ok, this one is dependent on the current alg. Did we get a value for it?
+                if ( !results.contains( source.outputName() ) )
+                {
+                  // oh no, nothing returned for this parameter. Gotta trim the branch back!
+                  pruned = true;
+                  // skip the dependent alg..
+                  executed.insert( candidateId );
+                  //... and everything which depends on it
+                  pruneAlgorithmBranchRecursive( candidateId );
+                  break;
+                }
+              }
+            }
+            if ( pruned )
+              break;
+          }
+        }
+      }
+
+      childAlg.reset( nullptr );
       modelFeedback.setCurrentStep( executed.count() );
       if ( feedback )
         feedback->pushInfo( QObject::tr( "OK. Execution took %1 s (%2 outputs)." ).arg( childTime.elapsed() / 1000.0 ).arg( results.count() ) );

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -77,6 +77,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagSupportsInPlaceEdits = 1 << 8, //!< Algorithm supports in-place editing
       FlagKnownIssues = 1 << 9, //!< Algorithm has known issues
       FlagCustomException = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
+      FlagPruneModelBranchesBasedOnAlgorithmResults = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -82,7 +82,7 @@ void QgsProcessingLayerOutputDestinationWidget::setValue( const QVariant &value 
     else if ( value.canConvert< QgsProcessingOutputLayerDefinition >() )
     {
       const QgsProcessingOutputLayerDefinition def = value.value< QgsProcessingOutputLayerDefinition >();
-      if ( def.sink.staticValue().toString() == QStringLiteral( "memory:" ) || def.sink.staticValue().toString().isEmpty() )
+      if ( def.sink.staticValue().toString() == QStringLiteral( "memory:" ) || def.sink.staticValue().toString() == QgsProcessing::TEMPORARY_OUTPUT || def.sink.staticValue().toString().isEmpty() )
       {
         saveToTemporary();
       }

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -5237,10 +5237,21 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 0 );
 
+  QgsProcessingOutputLayerDefinition def;
+  def.sink.setStaticValue( QgsProcessing::TEMPORARY_OUTPUT );
+  def.createOptions.insert( QStringLiteral( "fileEncoding" ), QStringLiteral( "utf8" ) );
+  panel.setValue( def );
+  QCOMPARE( skipSpy.count(), 0 );
+  QCOMPARE( changedSpy.count(), 0 );
+  v = panel.value();
+  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
+
   panel.setValue( QStringLiteral( "memory:" ) );
   v = panel.value();
   QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -5249,13 +5260,21 @@ void TestProcessingGui::testOutputDefinitionWidget()
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 0 );
 
+  def.sink.setStaticValue( QStringLiteral( "memory:" ) );
+  panel.setValue( def );
+  QCOMPARE( skipSpy.count(), 0 );
+  QCOMPARE( changedSpy.count(), 0 );
+  v = panel.value();
+  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QgsProcessing::TEMPORARY_OUTPUT );
 
   panel.setValue( QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QCOMPARE( skipSpy.count(), 0 );
   QCOMPARE( changedSpy.count(), 1 );
   v = panel.value();
   QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
   QVERIFY( !panel.outputIsSkipped() );
   panel.setValue( QStringLiteral( "ogr:dbname='/me/a.gpkg' table=\"d\" (geom) sql=''" ) );
@@ -5265,7 +5284,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel.setValue( QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   v = panel.value();
   QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "postgis:dbname='oraclesux' host=10.1.1.221 port=5432 user='qgis' password='qgis' table=\"stufff\".\"output\" (the_geom) sql=" ) );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -5277,7 +5296,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel.setValue( QStringLiteral( "/home/me/test.shp" ) );
   v = panel.value();
   QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), QStringLiteral( "/home/me/test.shp" ) );
   QVERIFY( !panel.outputIsSkipped() );
   QCOMPARE( skipSpy.count(), 0 );
@@ -5294,7 +5313,7 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel.setValue( QStringLiteral( "test.shp" ) );
   v = panel.value();
   QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
-  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "System" ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().createOptions.value( QStringLiteral( "fileEncoding" ) ).toString(), QStringLiteral( "utf8" ) );
   QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().sink.staticValue().toString(), TEST_DATA_DIR + QStringLiteral( "/test.shp" ) );
 
   // optional, test skipping


### PR DESCRIPTION
This PR adds two new algorithms to processing:

- "Filter by geometry type": This algorithm filters features by their geometry type. Incoming features will be directed to different outputs based on whether they have a point, line or polygon geometry. It allows for model creation which responds to different input layer geometry types by applying different logic depending on the input geometry type.

- "Filter by layer type": This algorithm allows conditional model branching based on an input
layer type. For instance, it allows a model to adapt to the actual layer type of a generic "map layer" parameter input, and decide which branch of the model to run as a result.

It also adds in the required api to allow algorithms to "prune" model branches based on their calculated results. E.g. a model which returns the new FlagPruneModelBranchesBasedOnAlgorithmResults flag will cause any remaining parts of the model which are dependent on the outputs of that algorithm to be entirely skipped IF the algorithm does not return that particular output. (This is a prerequisite component for a future generic "conditional branching by expression" algorithm, and also used by "filter by layer type" to control the model flow based on the input layer type)

Refs NRCan Contract#3000707093