### PR TITLE
Enable loading wms category/collection layers in the layers panel.

### DIFF
--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -267,14 +267,80 @@ bool QgsWMSConnectionItem::equal( const QgsDataItem *other )
 }
 
 // ---------------------------------------------------------------------------
-
-QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QString name, QString path, const QgsWmsCapabilitiesProperty &capabilitiesProperty, const QgsDataSourceUri &dataSourceUri, const QgsWmsLayerProperty &layerProperty )
-  : QgsDataCollectionItem( parent, name, path, QStringLiteral( "WMS" ) )
-  , mCapabilitiesProperty( capabilitiesProperty )
+QgsWMSItemBase::QgsWMSItemBase( const QgsWmsCapabilitiesProperty &capabilitiesProperty, const QgsDataSourceUri &dataSourceUri, const QgsWmsLayerProperty &layerProperty )
+  : mCapabilitiesProperty( capabilitiesProperty )
   , mDataSourceUri( dataSourceUri )
   , mLayerProperty( layerProperty )
 {
+}
+
+QString QgsWMSItemBase::createUri()
+{
+  if ( mLayerProperty.name.isEmpty() )
+    return QString(); // layer collection
+
+  // Number of styles must match number of layers
+  mDataSourceUri.setParam( QStringLiteral( "layers" ), mLayerProperty.name );
+  QString style = !mLayerProperty.style.isEmpty() ? mLayerProperty.style.at( 0 ).name : QString();
+  mDataSourceUri.setParam( QStringLiteral( "styles" ), style );
+
+  // Check for layer dimensions
+  for ( const QgsWmsDimensionProperty &dimension : qgis::as_const( mLayerProperty.dimensions ) )
+  {
+    // add temporal dimensions only
+    if ( dimension.name == QLatin1String( "time" ) || dimension.name == QLatin1String( "reference_time" ) )
+    {
+      if ( !( mDataSourceUri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) ) )
+        mDataSourceUri.setParam( QLatin1String( "type" ), QLatin1String( "wmst" ) );
+      mDataSourceUri.setParam( dimension.name, dimension.extent );
+    }
+  }
+
+  QString format;
+  // get first supported by qt and server
+  QVector<QgsWmsSupportedFormat> formats( QgsWmsProvider::supportedFormats() );
+  const auto constFormats = formats;
+  for ( const QgsWmsSupportedFormat &f : constFormats )
+  {
+    if ( mCapabilitiesProperty.capability.request.getMap.format.indexOf( f.format ) >= 0 )
+    {
+      format = f.format;
+      break;
+    }
+  }
+  mDataSourceUri.setParam( QStringLiteral( "format" ), format );
+
+  QString crs;
+  // get first known if possible
+  QgsCoordinateReferenceSystem testCrs;
+  for ( const QString &c : qgis::as_const( mLayerProperty.crs ) )
+  {
+    testCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( c );
+    if ( testCrs.isValid() )
+    {
+      crs = c;
+      break;
+    }
+  }
+  if ( crs.isEmpty() && !mLayerProperty.crs.isEmpty() )
+  {
+    crs = mLayerProperty.crs[0];
+  }
+  mDataSourceUri.setParam( QStringLiteral( "crs" ), crs );
+  //uri = rasterLayerPath + "|layers=" + layers.join( "," ) + "|styles=" + styles.join( "," ) + "|format=" + format + "|crs=" + crs;
+
+  return mDataSourceUri.encodedUri();
+}
+
+
+// ---------------------------------------------------------------------------
+
+QgsWMSLayerCollectionItem::QgsWMSLayerCollectionItem( QgsDataItem *parent, QString name, QString path, const QgsWmsCapabilitiesProperty &capabilitiesProperty, const QgsDataSourceUri &dataSourceUri, const QgsWmsLayerProperty &layerProperty )
+  : QgsDataCollectionItem( parent, name, path, QStringLiteral( "wms" ) )
+  , QgsWMSItemBase( capabilitiesProperty, dataSourceUri, layerProperty )
+{
   mIconName = QStringLiteral( "mIconWms.svg" );
+  mUri = createUri();
 
   // Populate everything, it costs nothing, all info about layers is collected
   for ( const QgsWmsLayerProperty &layerProperty : qgis::as_const( mLayerProperty.layer ) )
@@ -334,17 +400,35 @@ bool QgsWMSLayerCollectionItem::equal( const QgsDataItem *other )
     }
   }
 
-
   return ( mPath == otherCollectionItem->mPath && mName == otherCollectionItem->mName );
+}
+
+bool QgsWMSLayerCollectionItem::hasDragEnabled() const
+{
+  if ( !mLayerProperty.name.isEmpty() )
+    return true;
+  return false;
+}
+
+QgsMimeDataUtils::Uri QgsWMSLayerCollectionItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+
+  u.layerType = QStringLiteral( "raster" );
+  u.providerKey = providerKey();
+  u.name = name();
+  u.uri = mUri;
+  u.supportedCrs = mLayerProperty.crs;
+  u.supportedFormats = mCapabilitiesProperty.capability.request.getMap.format;
+
+  return u;
 }
 
 // ---------------------------------------------------------------------------
 
 QgsWMSLayerItem::QgsWMSLayerItem( QgsDataItem *parent, QString name, QString path, const QgsWmsCapabilitiesProperty &capabilitiesProperty, const QgsDataSourceUri &dataSourceUri, const QgsWmsLayerProperty &layerProperty )
   : QgsLayerItem( parent, name, path, QString(), QgsLayerItem::Raster, QStringLiteral( "wms" ) )
-  , mCapabilitiesProperty( capabilitiesProperty )
-  , mDataSourceUri( dataSourceUri )
-  , mLayerProperty( layerProperty )
+  ,  QgsWMSItemBase( capabilitiesProperty, dataSourceUri, layerProperty )
 {
   mSupportedCRS = mLayerProperty.crs;
   mSupportFormats = mCapabilitiesProperty.capability.request.getMap.format;
@@ -353,73 +437,6 @@ QgsWMSLayerItem::QgsWMSLayerItem( QgsDataItem *parent, QString name, QString pat
   mUri = createUri();
   mIconName = QStringLiteral( "mIconWms.svg" );
   setState( Populated );
-}
-
-QString QgsWMSLayerItem::createUri()
-{
-  if ( mLayerProperty.name.isEmpty() )
-    return QString(); // layer collection
-
-  // Number of styles must match number of layers
-  mDataSourceUri.setParam( QStringLiteral( "layers" ), mLayerProperty.name );
-  QString style = !mLayerProperty.style.isEmpty() ? mLayerProperty.style.at( 0 ).name : QString();
-  mDataSourceUri.setParam( QStringLiteral( "styles" ), style );
-
-  // Check for layer dimensions
-  for ( const QgsWmsDimensionProperty &dimension : qgis::as_const( mLayerProperty.dimensions ) )
-  {
-    // add temporal dimensions only
-    if ( dimension.name == QLatin1String( "time" ) || dimension.name == QLatin1String( "reference_time" ) )
-    {
-      QString name = dimension.name == QLatin1String( "time" ) ? QString( "timeDimensionExtent" ) : QString( "referenceTimeDimensionExtent" );
-
-      if ( !( mDataSourceUri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) ) )
-        mDataSourceUri.setParam( QLatin1String( "type" ), QLatin1String( "wmst" ) );
-      mDataSourceUri.setParam( name, dimension.extent );
-    }
-  }
-
-  // WMS-T defaults settings
-  if ( mDataSourceUri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) )
-  {
-    mDataSourceUri.setParam( QLatin1String( "temporalSource" ), QLatin1String( "provider" ) );
-    mDataSourceUri.setParam( QLatin1String( "enableTime" ), QLatin1String( "yes" ) );
-  }
-
-  QString format;
-  // get first supported by qt and server
-  QVector<QgsWmsSupportedFormat> formats( QgsWmsProvider::supportedFormats() );
-  const auto constFormats = formats;
-  for ( const QgsWmsSupportedFormat &f : constFormats )
-  {
-    if ( mCapabilitiesProperty.capability.request.getMap.format.indexOf( f.format ) >= 0 )
-    {
-      format = f.format;
-      break;
-    }
-  }
-  mDataSourceUri.setParam( QStringLiteral( "format" ), format );
-
-  QString crs;
-  // get first known if possible
-  QgsCoordinateReferenceSystem testCrs;
-  for ( const QString &c : qgis::as_const( mLayerProperty.crs ) )
-  {
-    testCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( c );
-    if ( testCrs.isValid() )
-    {
-      crs = c;
-      break;
-    }
-  }
-  if ( crs.isEmpty() && !mLayerProperty.crs.isEmpty() )
-  {
-    crs = mLayerProperty.crs[0];
-  }
-  mDataSourceUri.setParam( QStringLiteral( "crs" ), crs );
-  //uri = rasterLayerPath + "|layers=" + layers.join( "," ) + "|styles=" + styles.join( "," ) + "|format=" + format + "|crs=" + crs;
-
-  return mDataSourceUri.encodedUri();
 }
 
 bool QgsWMSLayerItem::equal( const QgsDataItem *other )
@@ -436,7 +453,6 @@ bool QgsWMSLayerItem::equal( const QgsDataItem *other )
 
   if ( !mLayerProperty.equal( otherLayer->mLayerProperty ) )
     return false;
-
 
   return ( mPath == otherLayer->mPath && mName == otherLayer->mName );
 }

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -274,7 +274,7 @@ QgsWMSItemBase::QgsWMSItemBase( const QgsWmsCapabilitiesProperty &capabilitiesPr
 {
 }
 
-QString QgsWMSItemBase::createUri()
+QString QgsWMSLayerItem::createUri()
 {
   if ( mLayerProperty.name.isEmpty() )
     return QString(); // layer collection
@@ -290,10 +290,19 @@ QString QgsWMSItemBase::createUri()
     // add temporal dimensions only
     if ( dimension.name == QLatin1String( "time" ) || dimension.name == QLatin1String( "reference_time" ) )
     {
+      QString name = dimension.name == QLatin1String( "time" ) ? QString( "timeDimensionExtent" ) : QString( "referenceTimeDimensionExtent" );
+
       if ( !( mDataSourceUri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) ) )
         mDataSourceUri.setParam( QLatin1String( "type" ), QLatin1String( "wmst" ) );
-      mDataSourceUri.setParam( dimension.name, dimension.extent );
+      mDataSourceUri.setParam( name, dimension.extent );
     }
+  }
+
+  // WMS-T defaults settings
+  if ( mDataSourceUri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) )
+  {
+    mDataSourceUri.setParam( QLatin1String( "temporalSource" ), QLatin1String( "provider" ) );
+    mDataSourceUri.setParam( QLatin1String( "enableTime" ), QLatin1String( "yes" ) );
   }
 
   QString format;

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -274,7 +274,7 @@ QgsWMSItemBase::QgsWMSItemBase( const QgsWmsCapabilitiesProperty &capabilitiesPr
 {
 }
 
-QString QgsWMSLayerItem::createUri()
+QString QgsWMSItemBase::createUri()
 {
   if ( mLayerProperty.name.isEmpty() )
     return QString(); // layer collection

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -42,11 +42,35 @@ class QgsWMSConnectionItem : public QgsDataCollectionItem
 };
 
 /**
+ * Base class which contains similar basic attributes and functions needed by the
+ * wms collection layers and child layers.
+ *
+ */
+class QgsWMSItemBase
+{
+  public:
+    QgsWMSItemBase( const QgsWmsCapabilitiesProperty &capabilitiesProperty,
+                    const QgsDataSourceUri &dataSourceUri,
+                    const QgsWmsLayerProperty &layerProperty );
+
+    QString createUri();
+
+    //! Stores GetCapabilities response
+    QgsWmsCapabilitiesProperty mCapabilitiesProperty;
+
+    //! Stores WMS connection information
+    QgsDataSourceUri mDataSourceUri;
+
+    //! WMS Layer properties, can be inherited by subsidiary layers
+    QgsWmsLayerProperty mLayerProperty;
+};
+
+/**
  * \brief WMS Layer Collection.
  *
- *  This collection contains a WMS Layer element that can enclose other layers
+ *  This collection contains a WMS Layer element that can enclose other layers.
  */
-class QgsWMSLayerCollectionItem : public QgsDataCollectionItem
+class QgsWMSLayerCollectionItem : public QgsDataCollectionItem, public QgsWMSItemBase
 {
     Q_OBJECT
   public:
@@ -57,14 +81,13 @@ class QgsWMSLayerCollectionItem : public QgsDataCollectionItem
 
     bool equal( const QgsDataItem *other ) override;
 
-    //! Stores GetCapabilities response
-    QgsWmsCapabilitiesProperty mCapabilitiesProperty;
+    bool hasDragEnabled() const override;
 
-    //! Stores WMS connection information
-    QgsDataSourceUri mDataSourceUri;
+    QgsMimeDataUtils::Uri mimeUri() const override;
 
-    //! WMS Layer properties, can be inherited by subsidiary layers
-    QgsWmsLayerProperty mLayerProperty;
+  protected:
+    //! The URI
+    QString mUri;
 
     // QgsDataItem interface
   public:
@@ -73,7 +96,7 @@ class QgsWMSLayerCollectionItem : public QgsDataCollectionItem
 
 // WMS Layers may be nested, so that they may be both QgsDataCollectionItem and QgsLayerItem
 // We have to use QgsDataCollectionItem and support layer methods if necessary
-class QgsWMSLayerItem : public QgsLayerItem
+class QgsWMSLayerItem : public QgsLayerItem, public QgsWMSItemBase
 {
     Q_OBJECT
   public:
@@ -83,11 +106,7 @@ class QgsWMSLayerItem : public QgsLayerItem
                      const QgsWmsLayerProperty &layerProperty );
 
     bool equal( const QgsDataItem *other ) override;
-    QString createUri();
 
-    QgsWmsCapabilitiesProperty mCapabilitiesProperty;
-    QgsDataSourceUri mDataSourceUri;
-    QgsWmsLayerProperty mLayerProperty;
 };
 
 class QgsWMTSLayerItem : public QgsLayerItem


### PR DESCRIPTION
This is a follow up addition from https://github.com/qgis/QGIS/pull/34808 , this PR adds the logic for adding wms category/collection layers as QGIS layers.

**Note:** A category/collection layer without a name ( an element name from the wms capabilities ) won't be able to be added as a layer.

Example
![Enable_category_layer_loading](https://user-images.githubusercontent.com/2663775/76903507-340c2c80-68af-11ea-8d28-d35e5732aab5.gif)
