### PR TITLE
Fixes double type in ogcapif api document

### DIFF
--- a/src/server/qgsserverquerystringparameter.cpp
+++ b/src/server/qgsserverquerystringparameter.cpp
@@ -123,6 +123,10 @@ json QgsServerQueryStringParameter::data() const
   {
     dataType = "string";
   }
+  else if ( dataType == "double" )
+  {
+    dataType = "number";
+  }
   return
   {
     { "name", nameString },


### PR DESCRIPTION
## Description

For now the OGCAPIF certification is failing on the `apiDefinitionValidation` test because of 2 issues.

This PR fixes the first issue:

```
ERROR: Value 'double' does not match required pattern 'boolean|object|array|number|integer|string' 
```