### PR TITLE
Rework picture item UI and behavior

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
@@ -62,11 +62,13 @@ The caller takes responsibility for deleting the returned object.
 %End
 
 
-    void setPicturePath( const QString &path );
+    void setPicturePath( const QString &path, Format format = FormatUnknown );
 %Docstring
 Sets the source ``path`` of the image (may be svg or a raster format). Data defined
 picture source may override this value. The path can either be a local path
 or a remote (http) path.
+
+Ideally, the ``format`` argument should specify the image format.
 
 .. seealso:: :py:func:`picturePath`
 %End
@@ -249,6 +251,17 @@ Sets the stroke ``width`` (in layout units) used for parametrized SVG files.
     Format mode() const;
 %Docstring
 Returns the current picture mode (image format).
+
+.. seealso:: :py:func:`setMode`
+%End
+
+    void setMode( Format mode );
+%Docstring
+Sets the current picture ``mode`` (image format).
+
+.. seealso:: :py:func:`mode`
+
+.. versionadded:: 3.14
 %End
 
     virtual void finalizeRestoreFromXml();

--- a/src/core/layout/qgslayoutitempicture.h
+++ b/src/core/layout/qgslayoutitempicture.h
@@ -85,9 +85,12 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
      * Sets the source \a path of the image (may be svg or a raster format). Data defined
      * picture source may override this value. The path can either be a local path
      * or a remote (http) path.
+     *
+     * Ideally, the \a format argument should specify the image format.
+     *
      * \see picturePath()
      */
-    void setPicturePath( const QString &path );
+    void setPicturePath( const QString &path, Format format = FormatUnknown );
 
     /**
      * Returns the path of the source image. Data defined picture source may override
@@ -226,8 +229,16 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
 
     /**
      * Returns the current picture mode (image format).
+     * \see setMode()
      */
     Format mode() const { return mMode; }
+
+    /**
+     * Sets the current picture \a mode (image format).
+     * \see mode()
+     * \since QGIS 3.14
+     */
+    void setMode( Format mode );
 
     void finalizeRestoreFromXml() override;
 
@@ -357,6 +368,8 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
      * Loads a local picture for the item
      */
     void loadLocalPicture( const QString &path );
+
+    void loadPictureUsingCache( const QString &path );
 
     void disconnectMap( QgsLayoutItemMap *map );
 

--- a/src/gui/layout/qgslayoutpicturewidget.cpp
+++ b/src/gui/layout/qgslayoutpicturewidget.cpp
@@ -338,6 +338,7 @@ void QgsLayoutPictureWidget::setGuiElementValues()
     {
       whileBlocking( mSvgSourceLineEdit )->setSource( mPicture->picturePath() );
 
+      mBlockSvgModelChanges++;
       QAbstractItemModel *m = viewImages->model();
       QItemSelectionModel *selModel = viewImages->selectionModel();
       for ( int i = 0; i < m->rowCount(); i++ )
@@ -350,6 +351,7 @@ void QgsLayoutPictureWidget::setGuiElementValues()
           break;
         }
       }
+      mBlockSvgModelChanges--;
     }
     else if ( mRadioRaster->isChecked() )
     {
@@ -537,6 +539,9 @@ void QgsLayoutPictureWidget::populateIcons( const QModelIndex &idx )
 
 void QgsLayoutPictureWidget::setSvgName( const QModelIndex &idx )
 {
+  if ( mBlockSvgModelChanges )
+    return;
+
   QString name = idx.data( Qt::UserRole ).toString();
   whileBlocking( mSvgSourceLineEdit )->setSource( name );
   svgSourceChanged( name );

--- a/src/gui/layout/qgslayoutpicturewidget.cpp
+++ b/src/gui/layout/qgslayoutpicturewidget.cpp
@@ -23,6 +23,7 @@
 #include "qgsexpressionbuilderdialog.h"
 #include "qgssvgcache.h"
 #include "qgssettings.h"
+#include "qgssvgselectorwidget.h"
 
 #include <QDoubleValidator>
 #include <QFileDialog>
@@ -55,12 +56,7 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
   mAnchorPointComboBox->addItem( tr( "Bottom Center" ), QgsLayoutItem::LowerMiddle );
   mAnchorPointComboBox->addItem( tr( "Bottom Right" ), QgsLayoutItem::LowerRight );
 
-  connect( mPictureBrowseButton, &QPushButton::clicked, this, &QgsLayoutPictureWidget::mPictureBrowseButton_clicked );
-  connect( mPictureLineEdit, &QLineEdit::editingFinished, this, &QgsLayoutPictureWidget::mPictureLineEdit_editingFinished );
   connect( mPictureRotationSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutPictureWidget::mPictureRotationSpinBox_valueChanged );
-  connect( mPreviewListWidget, &QListWidget::currentItemChanged, this, &QgsLayoutPictureWidget::mPreviewListWidget_currentItemChanged );
-  connect( mAddDirectoryButton, &QPushButton::clicked, this, &QgsLayoutPictureWidget::mAddDirectoryButton_clicked );
-  connect( mRemoveDirectoryButton, &QPushButton::clicked, this, &QgsLayoutPictureWidget::mRemoveDirectoryButton_clicked );
   connect( mRotationFromComposerMapCheckBox, &QCheckBox::stateChanged, this, &QgsLayoutPictureWidget::mRotationFromComposerMapCheckBox_stateChanged );
   connect( mResizeModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutPictureWidget::mResizeModeComboBox_currentIndexChanged );
   connect( mAnchorPointComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutPictureWidget::mAnchorPointComboBox_currentIndexChanged );
@@ -69,6 +65,13 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
   connect( mStrokeWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutPictureWidget::mStrokeWidthSpinBox_valueChanged );
   connect( mPictureRotationOffsetSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutPictureWidget::mPictureRotationOffsetSpinBox_valueChanged );
   connect( mNorthTypeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutPictureWidget::mNorthTypeComboBox_currentIndexChanged );
+  connect( mRadioSVG, &QRadioButton::toggled, this, &QgsLayoutPictureWidget::modeChanged );
+  connect( mRadioRaster, &QRadioButton::toggled, this, &QgsLayoutPictureWidget::modeChanged );
+  connect( mSvgSourceLineEdit, &QgsSvgSourceLineEdit::sourceChanged, this, &QgsLayoutPictureWidget::svgSourceChanged );
+  connect( mImageSourceLineEdit, &QgsImageSourceLineEdit::sourceChanged, this, &QgsLayoutPictureWidget::rasterSourceChanged );
+
+  mSvgSourceLineEdit->setLastPathSettingsKey( QStringLiteral( "/UI/lastComposerPictureDir" ) );
+
   setPanelTitle( tr( "Picture Properties" ) );
 
   mFillColorButton->setAllowOpacity( true );
@@ -88,6 +91,19 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
   mPictureRotationOffsetSpinBox->setClearValue( 0.0 );
   mPictureRotationSpinBox->setClearValue( 0.0 );
 
+  viewGroups->setHeaderHidden( true );
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
+  mIconSize = std::max( 30, static_cast< int >( std::round( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 4 ) ) );
+#else
+  mIconSize = std::max( 30, static_cast< int >( std::round( Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 4 ) ) );
+#endif
+  viewImages->setGridSize( QSize( mIconSize * 1.2, mIconSize * 1.2 ) );
+  populateList();
+
+  connect( viewImages->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsLayoutPictureWidget::setSvgName );
+  connect( viewGroups->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsLayoutPictureWidget::populateIcons );
+
+
   //add widget for general composer item properties
   mItemPropertiesWidget = new QgsLayoutItemPropertiesWidget( this, picture );
   mainLayout->addWidget( mItemPropertiesWidget );
@@ -100,92 +116,26 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
   }
 
   setGuiElementValues();
-  mPreviewsLoadingLabel->hide();
-
-  mPreviewListWidget->setIconSize( QSize( 30, 30 ) );
-
-  // mSearchDirectoriesGroupBox is a QgsCollapsibleGroupBoxBasic, so its collapsed state should not be saved/restored
-  mSearchDirectoriesGroupBox->setCollapsed( true );
-  // setup connection for loading previews on first expansion of group box
-  connect( mSearchDirectoriesGroupBox, &QgsCollapsibleGroupBoxBasic::collapsedStateChanged, this, &QgsLayoutPictureWidget::loadPicturePreviews );
 
   connect( mPicture, &QgsLayoutObject::changed, this, &QgsLayoutPictureWidget::setGuiElementValues );
   connect( mPicture, &QgsLayoutItemPicture::pictureRotationChanged, this, &QgsLayoutPictureWidget::setPicRotationSpinValue );
 
   //connections for data defined buttons
-  connect( mSourceDDBtn, &QgsPropertyOverrideButton::activated, mPictureLineEdit, &QLineEdit::setDisabled );
+  mSourceDDBtn->registerEnabledWidget( mImageSourceLineEdit, false );
+  mSourceDDBtn->registerEnabledWidget( mSvgSourceLineEdit, false );
+
   registerDataDefinedButton( mSourceDDBtn, QgsLayoutObject::PictureSource );
   registerDataDefinedButton( mFillColorDDBtn, QgsLayoutObject::PictureSvgBackgroundColor );
   registerDataDefinedButton( mStrokeColorDDBtn, QgsLayoutObject::PictureSvgStrokeColor );
   registerDataDefinedButton( mStrokeWidthDDBtn, QgsLayoutObject::PictureSvgStrokeWidth );
+
+  updatePictureTypeWidgets();
 }
 
 void QgsLayoutPictureWidget::setMasterLayout( QgsMasterLayoutInterface *masterLayout )
 {
   if ( mItemPropertiesWidget )
     mItemPropertiesWidget->setMasterLayout( masterLayout );
-}
-
-void QgsLayoutPictureWidget::mPictureBrowseButton_clicked()
-{
-  QgsSettings s;
-  QString openDir;
-  QString lineEditText = mPictureLineEdit->text();
-  if ( !lineEditText.isEmpty() )
-  {
-    QFileInfo openDirFileInfo( lineEditText );
-    openDir = openDirFileInfo.path();
-  }
-
-  if ( openDir.isEmpty() )
-  {
-    openDir = s.value( QStringLiteral( "/UI/lastComposerPictureDir" ), QDir::homePath() ).toString();
-  }
-
-  //show file dialog
-  QString filePath = QFileDialog::getOpenFileName( this, tr( "Select SVG or Image File" ), openDir );
-  if ( filePath.isEmpty() )
-  {
-    return;
-  }
-
-  //check if file exists
-  QFileInfo fileInfo( filePath );
-  if ( !fileInfo.exists() || !fileInfo.isReadable() )
-  {
-    QMessageBox::critical( nullptr, tr( "Select File" ), tr( "Error, file does not exist or is not readable." ) );
-    return;
-  }
-
-  s.setValue( QStringLiteral( "/UI/lastComposerPictureDir" ), fileInfo.absolutePath() );
-
-  mPictureLineEdit->blockSignals( true );
-  mPictureLineEdit->setText( filePath );
-  mPictureLineEdit->blockSignals( false );
-  updateSvgParamGui();
-
-  //pass file path to QgsLayoutItemPicture
-  if ( mPicture )
-  {
-    mPicture->beginCommand( tr( "Change Picture" ) );
-    mPicture->setPicturePath( filePath );
-    mPicture->update();
-    mPicture->endCommand();
-  }
-}
-
-void QgsLayoutPictureWidget::mPictureLineEdit_editingFinished()
-{
-  if ( mPicture )
-  {
-    QString filePath = mPictureLineEdit->text();
-
-    mPicture->beginCommand( tr( "Change Picture" ) );
-    mPicture->setPicturePath( filePath );
-    mPicture->update();
-    mPicture->endCommand();
-    updateSvgParamGui();
-  }
 }
 
 void QgsLayoutPictureWidget::mPictureRotationSpinBox_valueChanged( double d )
@@ -196,74 +146,6 @@ void QgsLayoutPictureWidget::mPictureRotationSpinBox_valueChanged( double d )
     mPicture->setPictureRotation( d );
     mPicture->endCommand();
   }
-}
-
-void QgsLayoutPictureWidget::mPreviewListWidget_currentItemChanged( QListWidgetItem *current, QListWidgetItem *previous )
-{
-  Q_UNUSED( previous )
-  if ( !mPicture || !current )
-  {
-    return;
-  }
-
-  QString absoluteFilePath = current->data( Qt::UserRole ).toString();
-  mPicture->beginCommand( tr( "Change Picture" ) );
-  mPicture->setPicturePath( absoluteFilePath );
-  mPictureLineEdit->setText( absoluteFilePath );
-  mPicture->update();
-  mPicture->endCommand();
-  updateSvgParamGui();
-}
-
-void QgsLayoutPictureWidget::mAddDirectoryButton_clicked()
-{
-  //let user select a directory
-  QString directory = QFileDialog::getExistingDirectory( this, tr( "Select New Preview Directory" ) );
-  if ( directory.isNull() )
-  {
-    return; //dialog canceled by user
-  }
-
-  //add entry to mSearchDirectoriesComboBox
-  mSearchDirectoriesComboBox->addItem( directory );
-
-  //and add icons to the preview
-  addDirectoryToPreview( directory );
-
-  //update the image directory list in the settings
-  QgsSettings s;
-  QStringList userDirList = s.value( QStringLiteral( "/Composer/PictureWidgetDirectories" ) ).toStringList();
-  if ( !userDirList.contains( directory ) )
-  {
-    userDirList.append( directory );
-  }
-  s.setValue( QStringLiteral( "/Composer/PictureWidgetDirectories" ), userDirList );
-}
-
-void QgsLayoutPictureWidget::mRemoveDirectoryButton_clicked()
-{
-  QString directoryToRemove = mSearchDirectoriesComboBox->currentText();
-  if ( directoryToRemove.isEmpty() )
-  {
-    return;
-  }
-  mSearchDirectoriesComboBox->removeItem( mSearchDirectoriesComboBox->currentIndex() );
-
-  //remove entries from back to front (to have the indices of existing items constant)
-  for ( int i = ( mPreviewListWidget->count() - 1 ); i >= 0; --i )
-  {
-    QListWidgetItem *currentItem = mPreviewListWidget->item( i );
-    if ( currentItem && currentItem->data( Qt::UserRole ).toString().startsWith( directoryToRemove ) )
-    {
-      delete ( mPreviewListWidget->takeItem( i ) );
-    }
-  }
-
-  //update the image directory list in the settings
-  QgsSettings s;
-  QStringList userDirList = s.value( QStringLiteral( "/Composer/PictureWidgetDirectories" ) ).toStringList();
-  userDirList.removeOne( directoryToRemove );
-  s.setValue( QStringLiteral( "/Composer/PictureWidgetDirectories" ), userDirList );
 }
 
 void QgsLayoutPictureWidget::mResizeModeComboBox_currentIndexChanged( int )
@@ -398,7 +280,6 @@ void QgsLayoutPictureWidget::setGuiElementValues()
   if ( mPicture )
   {
     mPictureRotationSpinBox->blockSignals( true );
-    mPictureLineEdit->blockSignals( true );
     mComposerMapComboBox->blockSignals( true );
     mRotationFromComposerMapCheckBox->blockSignals( true );
     mNorthTypeComboBox->blockSignals( true );
@@ -409,7 +290,6 @@ void QgsLayoutPictureWidget::setGuiElementValues()
     mStrokeColorButton->blockSignals( true );
     mStrokeWidthSpinBox->blockSignals( true );
 
-    mPictureLineEdit->setText( mPicture->picturePath() );
     mPictureRotationSpinBox->setValue( mPicture->pictureRotation() );
 
     mComposerMapComboBox->setItem( mPicture->linkedMap() );
@@ -450,6 +330,32 @@ void QgsLayoutPictureWidget::setGuiElementValues()
       mAnchorPointComboBox->setEnabled( false );
     }
 
+    whileBlocking( mRadioSVG )->setChecked( mPicture->mode() == QgsLayoutItemPicture::FormatSVG );
+    whileBlocking( mRadioRaster )->setChecked( mPicture->mode() == QgsLayoutItemPicture::FormatRaster );
+    updatePictureTypeWidgets();
+
+    if ( mRadioSVG->isChecked() )
+    {
+      whileBlocking( mSvgSourceLineEdit )->setSource( mPicture->picturePath() );
+
+      QAbstractItemModel *m = viewImages->model();
+      QItemSelectionModel *selModel = viewImages->selectionModel();
+      for ( int i = 0; i < m->rowCount(); i++ )
+      {
+        QModelIndex idx( m->index( i, 0 ) );
+        if ( m->data( idx ).toString() == mPicture->picturePath() )
+        {
+          selModel->select( idx, QItemSelectionModel::SelectCurrent );
+          selModel->setCurrentIndex( idx, QItemSelectionModel::SelectCurrent );
+          break;
+        }
+      }
+    }
+    else if ( mRadioRaster->isChecked() )
+    {
+      whileBlocking( mImageSourceLineEdit )->setSource( mPicture->picturePath() );
+    }
+
     updateSvgParamGui( false );
     mFillColorButton->setColor( mPicture->svgFillColor() );
     mStrokeColorButton->setColor( mPicture->svgStrokeColor() );
@@ -457,7 +363,6 @@ void QgsLayoutPictureWidget::setGuiElementValues()
 
     mRotationFromComposerMapCheckBox->blockSignals( false );
     mPictureRotationSpinBox->blockSignals( false );
-    mPictureLineEdit->blockSignals( false );
     mComposerMapComboBox->blockSignals( false );
     mNorthTypeComboBox->blockSignals( false );
     mPictureRotationOffsetSpinBox->blockSignals( false );
@@ -469,35 +374,6 @@ void QgsLayoutPictureWidget::setGuiElementValues()
 
     populateDataDefinedButtons();
   }
-}
-
-QIcon QgsLayoutPictureWidget::svgToIcon( const QString &filePath ) const
-{
-  QColor fill, stroke;
-  double strokeWidth, fillOpacity, strokeOpacity;
-  bool fillParam, fillOpacityParam, strokeParam, strokeWidthParam, strokeOpacityParam;
-  bool hasDefaultFillColor = false, hasDefaultFillOpacity = false, hasDefaultStrokeColor = false,
-       hasDefaultStrokeWidth = false, hasDefaultStrokeOpacity = false;
-  QgsApplication::svgCache()->containsParams( filePath, fillParam, hasDefaultFillColor, fill,
-      fillOpacityParam, hasDefaultFillOpacity, fillOpacity,
-      strokeParam, hasDefaultStrokeColor, stroke,
-      strokeWidthParam, hasDefaultStrokeWidth, strokeWidth,
-      strokeOpacityParam, hasDefaultStrokeOpacity, strokeOpacity );
-
-  //if defaults not set in symbol, use these values
-  if ( !hasDefaultFillColor )
-    fill = QColor( 200, 200, 200 );
-  fill.setAlphaF( hasDefaultFillOpacity ? fillOpacity : 1.0 );
-  if ( !hasDefaultStrokeColor )
-    stroke = Qt::black;
-  stroke.setAlphaF( hasDefaultStrokeOpacity ? strokeOpacity : 1.0 );
-  if ( !hasDefaultStrokeWidth )
-    strokeWidth = 0.6;
-
-  bool fitsInCache; // should always fit in cache at these sizes (i.e. under 559 px ^ 2, or half cache size)
-  const QImage &img = QgsApplication::svgCache()->svgAsImage( filePath, 30.0, fill, stroke, strokeWidth, 3.5 /*appr. 88 dpi*/, fitsInCache );
-
-  return QIcon( QPixmap::fromImage( img ) );
 }
 
 void QgsLayoutPictureWidget::updateSvgParamGui( bool resetValues )
@@ -558,161 +434,6 @@ void QgsLayoutPictureWidget::updateSvgParamGui( bool resetValues )
   mStrokeWidthSpinBox->setEnabled( hasStrokeWidthParam );
 }
 
-int QgsLayoutPictureWidget::addDirectoryToPreview( const QString &path )
-{
-  //go through all files of a directory
-  QDir directory( path );
-  if ( !directory.exists() || !directory.isReadable() )
-  {
-    return 1; //error
-  }
-
-  QFileInfoList fileList = directory.entryInfoList( QDir::Files );
-  QFileInfoList::const_iterator fileIt = fileList.constBegin();
-
-  QProgressDialog progress( tr( "Adding Icons…" ), tr( "Abort" ), 0, fileList.size() - 1, this );
-  //cancel button does not seem to work properly with modal dialog
-  //progress.setWindowModality(Qt::WindowModal);
-
-  int counter = 0;
-  for ( ; fileIt != fileList.constEnd(); ++fileIt )
-  {
-
-    progress.setLabelText( tr( "Creating icon for file %1" ).arg( fileIt->fileName() ) );
-    progress.setValue( counter );
-    QCoreApplication::processEvents();
-    if ( progress.wasCanceled() )
-    {
-      break;
-    }
-    QString filePath = fileIt->absoluteFilePath();
-
-    //test if file is svg or pixel format
-    bool fileIsPixel = false;
-    bool fileIsSvg = testSvgFile( filePath );
-    if ( !fileIsSvg )
-    {
-      fileIsPixel = testImageFile( filePath );
-    }
-
-    //exclude files that are not svg or image
-    if ( !fileIsSvg && !fileIsPixel )
-    {
-      ++counter;
-      continue;
-    }
-
-    QListWidgetItem *listItem = new QListWidgetItem( mPreviewListWidget );
-    listItem->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled );
-
-    if ( fileIsSvg )
-    {
-      // render SVG file
-      QIcon icon = svgToIcon( filePath );
-      listItem->setIcon( icon );
-    }
-    else //for pixel formats: create icon from scaled pixmap
-    {
-      QPixmap iconPixmap( filePath );
-      if ( iconPixmap.isNull() )
-      {
-        ++counter;
-        continue; //unknown file format or other problem
-      }
-      //set pixmap hardcoded to 30/30, same as icon size for mPreviewListWidget
-      QPixmap scaledPixmap( iconPixmap.scaled( QSize( 30, 30 ), Qt::KeepAspectRatio ) );
-      QIcon icon( scaledPixmap );
-      listItem->setIcon( icon );
-    }
-
-    listItem->setText( QString() );
-    //store the absolute icon file path as user data
-    listItem->setData( Qt::UserRole, fileIt->absoluteFilePath() );
-    ++counter;
-  }
-
-  return 0;
-}
-
-void QgsLayoutPictureWidget::addStandardDirectoriesToPreview()
-{
-  mPreviewListWidget->clear();
-
-  //list all directories in $prefix/share/qgis/svg
-  QStringList svgPaths = QgsApplication::svgPaths();
-  for ( int i = 0; i < svgPaths.size(); i++ )
-  {
-    QDir svgDirectory( svgPaths[i] );
-    if ( !svgDirectory.exists() || !svgDirectory.isReadable() )
-    {
-      continue;
-    }
-
-    //add directory itself
-    mSearchDirectoriesComboBox->addItem( svgDirectory.absolutePath() );
-    addDirectoryToPreview( svgDirectory.absolutePath() );
-
-    //and also subdirectories
-    QFileInfoList directoryList = svgDirectory.entryInfoList( QDir::Dirs | QDir::NoDotAndDotDot );
-    QFileInfoList::const_iterator dirIt = directoryList.constBegin();
-    for ( ; dirIt != directoryList.constEnd(); ++dirIt )
-    {
-      if ( addDirectoryToPreview( dirIt->absoluteFilePath() ) == 0 )
-      {
-        mSearchDirectoriesComboBox->addItem( dirIt->absoluteFilePath() );
-      }
-    }
-  }
-
-  //include additional user-defined directories for images
-  QgsSettings s;
-  QStringList userDirList = s.value( QStringLiteral( "/Composer/PictureWidgetDirectories" ) ).toStringList();
-  QStringList::const_iterator userDirIt = userDirList.constBegin();
-  for ( ; userDirIt != userDirList.constEnd(); ++userDirIt )
-  {
-    addDirectoryToPreview( *userDirIt );
-    mSearchDirectoriesComboBox->addItem( *userDirIt );
-  }
-
-  mPreviewsLoaded = true;
-}
-
-bool QgsLayoutPictureWidget::testSvgFile( const QString &filename ) const
-{
-  //QSvgRenderer crashes with some (non-svg) xml documents.
-  //So at least we try to sort out the ones with different suffixes
-  if ( !filename.endsWith( QLatin1String( ".svg" ) ) )
-  {
-    return false;
-  }
-
-  QSvgRenderer svgRenderer( filename );
-  return svgRenderer.isValid();
-}
-
-bool QgsLayoutPictureWidget::testImageFile( const QString &filename ) const
-{
-  QString formatName = QString( QImageReader::imageFormat( filename ) );
-  return !formatName.isEmpty(); //file is in a supported pixel format
-}
-
-void QgsLayoutPictureWidget::loadPicturePreviews( bool collapsed )
-{
-  if ( mPreviewsLoaded )
-  {
-    return;
-  }
-
-  if ( !collapsed ) // load the previews only on first parent group box expansion
-  {
-    mPreviewListWidget->hide();
-    mPreviewsLoadingLabel->show();
-    addStandardDirectoriesToPreview();
-    mPreviewsLoadingLabel->hide();
-    mPreviewListWidget->show();
-  }
-}
-
 void QgsLayoutPictureWidget::mFillColorButton_colorChanged( const QColor &color )
 {
   mPicture->beginCommand( tr( "Change Picture Fill Color" ), QgsLayoutItem::UndoPictureFillColor );
@@ -753,10 +474,95 @@ void QgsLayoutPictureWidget::mNorthTypeComboBox_currentIndexChanged( int index )
   mPicture->update();
 }
 
-void QgsLayoutPictureWidget::resizeEvent( QResizeEvent *event )
+void QgsLayoutPictureWidget::modeChanged()
 {
-  Q_UNUSED( event )
-  mSearchDirectoriesComboBox->setMinimumWidth( mPreviewListWidget->sizeHint().width() );
+  const QgsLayoutItemPicture::Format newFormat = mRadioSVG->isChecked() ? QgsLayoutItemPicture::FormatSVG : QgsLayoutItemPicture::FormatRaster;
+  if ( mPicture && mPicture->mode() != newFormat )
+  {
+    whileBlocking( mSvgSourceLineEdit )->setSource( QString() );
+    whileBlocking( mImageSourceLineEdit )->setSource( QString() );
+    mPicture->beginCommand( tr( "Change Picture Type" ) );
+    mPicture->setPicturePath( QString(), newFormat );
+    mPicture->endCommand();
+  }
+  updatePictureTypeWidgets();
+}
+
+void QgsLayoutPictureWidget::updatePictureTypeWidgets()
+{
+  mRasterFrame->setVisible( mRadioRaster->isChecked() );
+  mSVGFrame->setVisible( mRadioSVG->isChecked() );
+  mSVGParamsGroupBox->setVisible( mRadioSVG->isChecked() );
+
+  // need to move the data defined button to the appropriate frame -- we can't have two buttons linked to the one property!
+  if ( mRadioSVG->isChecked() )
+    mSvgDDBtnFrame->layout()->addWidget( mSourceDDBtn );
+  else
+    mRasterDDBtnFrame->layout()->addWidget( mSourceDDBtn );
+}
+
+void QgsLayoutPictureWidget::populateList()
+{
+  QAbstractItemModel *oldModel = viewGroups->model();
+  QgsSvgSelectorGroupsModel *g = new QgsSvgSelectorGroupsModel( viewGroups );
+  viewGroups->setModel( g );
+  delete oldModel;
+
+  // Set the tree expanded at the first level
+  int rows = g->rowCount( g->indexFromItem( g->invisibleRootItem() ) );
+  for ( int i = 0; i < rows; i++ )
+  {
+    viewGroups->setExpanded( g->indexFromItem( g->item( i ) ), true );
+  }
+
+  // Initially load the icons in the List view without any grouping
+  oldModel = viewImages->model();
+  QgsSvgSelectorListModel *m = new QgsSvgSelectorListModel( viewImages, mIconSize );
+  viewImages->setModel( m );
+
+  delete oldModel;
+}
+
+void QgsLayoutPictureWidget::populateIcons( const QModelIndex &idx )
+{
+  QString path = idx.data( Qt::UserRole + 1 ).toString();
+
+  QAbstractItemModel *oldModel = viewImages->model();
+  QgsSvgSelectorListModel *m = new QgsSvgSelectorListModel( viewImages, path, mIconSize );
+  viewImages->setModel( m );
+  delete oldModel;
+
+  connect( viewImages->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsLayoutPictureWidget::setSvgName );
+}
+
+void QgsLayoutPictureWidget::setSvgName( const QModelIndex &idx )
+{
+  QString name = idx.data( Qt::UserRole ).toString();
+  whileBlocking( mSvgSourceLineEdit )->setSource( name );
+  svgSourceChanged( name );
+}
+
+void QgsLayoutPictureWidget::svgSourceChanged( const QString &source )
+{
+  if ( mPicture )
+  {
+    mPicture->beginCommand( tr( "Change Picture" ) );
+    mPicture->setPicturePath( source, QgsLayoutItemPicture::FormatSVG );
+    mPicture->update();
+    mPicture->endCommand();
+    updateSvgParamGui();
+  }
+}
+
+void QgsLayoutPictureWidget::rasterSourceChanged( const QString &source )
+{
+  if ( mPicture )
+  {
+    mPicture->beginCommand( tr( "Change Picture" ) );
+    mPicture->setPicturePath( source, QgsLayoutItemPicture::FormatRaster );
+    mPicture->update();
+    mPicture->endCommand();
+  }
 }
 
 void QgsLayoutPictureWidget::populateDataDefinedButtons()
@@ -767,6 +573,7 @@ void QgsLayoutPictureWidget::populateDataDefinedButtons()
   updateDataDefinedButton( mStrokeWidthDDBtn );
 
   //initial state of controls - disable related controls when dd buttons are active
-  mPictureLineEdit->setEnabled( !mSourceDDBtn->isActive() );
+  mImageSourceLineEdit->setEnabled( !mSourceDDBtn->isActive() );
+  mSvgSourceLineEdit->setEnabled( !mSourceDDBtn->isActive() );
 }
 

--- a/src/gui/layout/qgslayoutpicturewidget.h
+++ b/src/gui/layout/qgslayoutpicturewidget.h
@@ -43,16 +43,8 @@ class GUI_EXPORT QgsLayoutPictureWidget: public QgsLayoutItemBaseWidget, private
     explicit QgsLayoutPictureWidget( QgsLayoutItemPicture *picture );
     void setMasterLayout( QgsMasterLayoutInterface *masterLayout ) override;
 
-    //! Add the icons of the standard directories to the preview
-    void addStandardDirectoriesToPreview();
-
   private slots:
-    void mPictureBrowseButton_clicked();
-    void mPictureLineEdit_editingFinished();
     void mPictureRotationSpinBox_valueChanged( double d );
-    void mPreviewListWidget_currentItemChanged( QListWidgetItem *current, QListWidgetItem *previous );
-    void mAddDirectoryButton_clicked();
-    void mRemoveDirectoryButton_clicked();
     void mRotationFromComposerMapCheckBox_stateChanged( int state );
     void mapChanged( QgsLayoutItem *item );
     void mResizeModeComboBox_currentIndexChanged( int index );
@@ -61,8 +53,6 @@ class GUI_EXPORT QgsLayoutPictureWidget: public QgsLayoutItemBaseWidget, private
   protected:
 
     bool setNewItem( QgsLayoutItem *item ) override;
-
-    void resizeEvent( QResizeEvent *event ) override;
 
   protected slots:
     //! Initializes data defined buttons to current atlas coverage layer
@@ -75,35 +65,23 @@ class GUI_EXPORT QgsLayoutPictureWidget: public QgsLayoutItemBaseWidget, private
     //! Sets the picture rotation GUI control value
     void setPicRotationSpinValue( double r );
 
-    /**
-     * Load SVG and pixel-based image previews
-     * \param collapsed Whether the parent group box is collapsed */
-    void loadPicturePreviews( bool collapsed );
-
     void mFillColorButton_colorChanged( const QColor &color );
     void mStrokeColorButton_colorChanged( const QColor &color );
     void mStrokeWidthSpinBox_valueChanged( double d );
     void mPictureRotationOffsetSpinBox_valueChanged( double d );
     void mNorthTypeComboBox_currentIndexChanged( int index );
+    void modeChanged();
+    void updatePictureTypeWidgets();
 
+    void populateList();
+    void populateIcons( const QModelIndex &idx );
+    void setSvgName( const QModelIndex &idx );
+    void svgSourceChanged( const QString &source );
+    void rasterSourceChanged( const QString &source );
   private:
     QPointer< QgsLayoutItemPicture > mPicture;
     QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;
-
-
-    //! Whether the picture selection previews have been loaded
-    bool mPreviewsLoaded = false;
-
-    //! Add the icons of a directory to the preview. Returns 0 in case of success
-    int addDirectoryToPreview( const QString &path );
-
-    //! Tests if a file is valid svg
-    bool testSvgFile( const QString &filename ) const;
-    //! Tests if a file is a valid pixel format
-    bool testImageFile( const QString &filename ) const;
-
-    //! Renders an svg file to a QIcon, correctly handling any SVG parameters present in the file
-    QIcon svgToIcon( const QString &filePath ) const;
+    int mIconSize = 30;
 
     void updateSvgParamGui( bool resetValues = true );
 };

--- a/src/gui/layout/qgslayoutpicturewidget.h
+++ b/src/gui/layout/qgslayoutpicturewidget.h
@@ -82,6 +82,7 @@ class GUI_EXPORT QgsLayoutPictureWidget: public QgsLayoutItemBaseWidget, private
     QPointer< QgsLayoutItemPicture > mPicture;
     QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;
     int mIconSize = 30;
+    int mBlockSvgModelChanges = 0;
 
     void updateSvgParamGui( bool resetValues = true );
 };

--- a/src/ui/layout/qgslayoutpicturewidgetbase.ui
+++ b/src/ui/layout/qgslayoutpicturewidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>334</width>
-    <height>572</height>
+    <width>536</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -60,203 +60,239 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>318</width>
-        <height>928</height>
+        <y>-4</y>
+        <width>520</width>
+        <height>881</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
        <item>
-        <widget class="QgsCollapsibleGroupBoxBasic" name="mPreviewGroupBox">
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
+        <widget class="QRadioButton" name="mRadioSVG">
+         <property name="text">
+          <string>SVG image</string>
          </property>
-         <property name="title">
-          <string>Main Properties</string>
-         </property>
-         <property name="syncGroup" stdset="0">
-          <string notr="true">composeritem</string>
-         </property>
-         <property name="collapsed" stdset="0">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Image source</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLineEdit" name="mPictureLineEdit"/>
-            </item>
-            <item>
-             <widget class="QPushButton" name="mPictureBrowseButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>30</width>
-                <height>32767</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>…</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QgsPropertyOverrideButton" name="mSourceDDBtn">
-              <property name="text">
-               <string>…</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Resize mode</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QComboBox" name="mResizeModeComboBox"/>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Placement</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QComboBox" name="mAnchorPointComboBox"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsCollapsibleGroupBoxBasic" name="mSearchDirectoriesGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="focusPolicy">
-          <enum>Qt::StrongFocus</enum>
-         </property>
-         <property name="title">
-          <string>Search Directories</string>
-         </property>
-         <property name="syncGroup" stdset="0">
-          <string notr="true">composeritem</string>
-         </property>
-         <property name="collapsed" stdset="0">
+         <property name="checked">
           <bool>true</bool>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="mRadioRaster">
+         <property name="text">
+          <string>Raster image</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="mRasterFrame">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
           <item>
-           <widget class="QLabel" name="mPreviewsLoadingLabel">
-            <property name="font">
-             <font>
-              <italic>true</italic>
-             </font>
-            </property>
-            <property name="text">
-             <string>Loading previews…</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
+           <widget class="QgsImageSourceLineEdit" name="mImageSourceLineEdit" native="true">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QListWidget" name="mPreviewListWidget">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>200</height>
-             </size>
+           <widget class="QFrame" name="mRasterDDBtnFrame">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
             </property>
-            <property name="showDropIndicator" stdset="0">
-             <bool>false</bool>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
             </property>
-            <property name="dragDropMode">
-             <enum>QAbstractItemView::DragDrop</enum>
-            </property>
-            <property name="movement">
-             <enum>QListView::Free</enum>
-            </property>
-            <property name="flow">
-             <enum>QListView::LeftToRight</enum>
-            </property>
-            <property name="isWrapping" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="resizeMode">
-             <enum>QListView::Adjust</enum>
-            </property>
-            <property name="gridSize">
-             <size>
-              <width>30</width>
-              <height>30</height>
-             </size>
-            </property>
-            <property name="viewMode">
-             <enum>QListView::IconMode</enum>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QgsPropertyOverrideButton" name="mSourceDDBtn">
+               <property name="text">
+                <string>…</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Image search paths</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="mSearchDirectoriesComboBox">
-            <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QPushButton" name="mRemoveDirectoryButton">
-              <property name="text">
-               <string>Remove</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="mAddDirectoryButton">
-              <property name="text">
-               <string>Add…</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </item>
          </layout>
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
+        <widget class="QFrame" name="mSVGFrame">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="1" column="0">
+           <widget class="QgsSvgSourceLineEdit" name="mSvgSourceLineEdit" native="true">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QFrame" name="mSvgDDBtnFrame">
+            <property name="frameShape">
+             <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+            </layout>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QSplitter" name="splitter">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <widget class="QWidget" name="layoutWidget">
+             <layout class="QVBoxLayout" name="verticalLayout_3">
+              <item>
+               <widget class="QLabel" name="label_9">
+                <property name="text">
+                 <string>SVG Groups</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QTreeView" name="viewGroups">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>3</horstretch>
+                  <verstretch>1</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="layoutWidget1">
+             <layout class="QVBoxLayout" name="verticalLayout_4">
+              <item>
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>SVG Image</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QListView" name="viewImages">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>5</horstretch>
+                  <verstretch>1</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>250</height>
+                 </size>
+                </property>
+                <property name="editTriggers">
+                 <set>QAbstractItemView::NoEditTriggers</set>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>32</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="movement">
+                 <enum>QListView::Static</enum>
+                </property>
+                <property name="resizeMode">
+                 <enum>QListView::Adjust</enum>
+                </property>
+                <property name="layoutMode">
+                 <enum>QListView::Batched</enum>
+                </property>
+                <property name="spacing">
+                 <number>2</number>
+                </property>
+                <property name="gridSize">
+                 <size>
+                  <width>36</width>
+                  <height>36</height>
+                 </size>
+                </property>
+                <property name="viewMode">
+                 <enum>QListView::IconMode</enum>
+                </property>
+                <property name="uniformItemSizes">
+                 <bool>true</bool>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBoxBasic" name="mSVGParamsGroupBox">
          <property name="title">
           <string>SVG Parameters</string>
          </property>
@@ -398,6 +434,44 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBoxBasic" name="mPreviewGroupBox">
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+         </property>
+         <property name="title">
+          <string>Size and Placement</string>
+         </property>
+         <property name="syncGroup" stdset="0">
+          <string notr="true">composeritem</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="0">
+           <widget class="QComboBox" name="mResizeModeComboBox"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Placement</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Resize mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QComboBox" name="mAnchorPointComboBox"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="mRotationGroupBox">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
@@ -515,26 +589,36 @@
    <extends>QComboBox</extends>
    <header>qgslayoutitemcombobox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsImageSourceLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsfilecontentsourcelineedit.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSvgSourceLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgsfilecontentsourcelineedit.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
-  <tabstop>mPreviewGroupBox</tabstop>
-  <tabstop>mPictureLineEdit</tabstop>
-  <tabstop>mPictureBrowseButton</tabstop>
-  <tabstop>mSourceDDBtn</tabstop>
-  <tabstop>mResizeModeComboBox</tabstop>
-  <tabstop>mAnchorPointComboBox</tabstop>
-  <tabstop>mSearchDirectoriesGroupBox</tabstop>
-  <tabstop>mPreviewListWidget</tabstop>
-  <tabstop>mSearchDirectoriesComboBox</tabstop>
-  <tabstop>mRemoveDirectoryButton</tabstop>
-  <tabstop>mAddDirectoryButton</tabstop>
+  <tabstop>mRadioSVG</tabstop>
+  <tabstop>mRadioRaster</tabstop>
+  <tabstop>mImageSourceLineEdit</tabstop>
+  <tabstop>viewGroups</tabstop>
+  <tabstop>viewImages</tabstop>
+  <tabstop>mSvgSourceLineEdit</tabstop>
   <tabstop>mFillColorButton</tabstop>
   <tabstop>mFillColorDDBtn</tabstop>
   <tabstop>mStrokeColorButton</tabstop>
   <tabstop>mStrokeColorDDBtn</tabstop>
   <tabstop>mStrokeWidthSpinBox</tabstop>
   <tabstop>mStrokeWidthDDBtn</tabstop>
+  <tabstop>mPreviewGroupBox</tabstop>
+  <tabstop>mResizeModeComboBox</tabstop>
+  <tabstop>mAnchorPointComboBox</tabstop>
   <tabstop>mRotationGroupBox</tabstop>
   <tabstop>mPictureRotationSpinBox</tabstop>
   <tabstop>mRotationFromComposerMapCheckBox</tabstop>

--- a/tests/src/core/testqgslayoutpicture.cpp
+++ b/tests/src/core/testqgslayoutpicture.cpp
@@ -37,6 +37,8 @@ class TestQgsLayoutPicture : public QObject
     void cleanup();// will be called after every testfunction.
 
     void pictureRender();
+    void pictureRaster();
+    void pictureSvg();
     void pictureRotation(); //test if picture pictureRotation is functioning
     void pictureItemRotation(); //test if composer picture item rotation is functioning
 
@@ -129,6 +131,39 @@ void TestQgsLayoutPicture::pictureRender()
   QVERIFY( checker.testLayout( mReport, 0, 0 ) );
 
   mLayout->removeItem( mPicture );
+}
+
+void TestQgsLayoutPicture::pictureRaster()
+{
+  QgsLayout l( QgsProject::instance() );
+  l.initializeDefaults();
+  QgsLayoutItemPicture *p = new QgsLayoutItemPicture( &l );
+  p->setPicturePath( mPngImage, QgsLayoutItemPicture::FormatRaster );
+  p->attemptSetSceneRect( QRectF( 70, 70, 100, 100 ) );
+  p->setFrameEnabled( true );
+
+  l.addLayoutItem( p );
+
+  QgsLayoutChecker checker( QStringLiteral( "composerpicture_render" ), &l );
+  checker.setControlPathPrefix( QStringLiteral( "composer_picture" ) );
+  QVERIFY( checker.testLayout( mReport, 0, 0 ) );
+}
+
+void TestQgsLayoutPicture::pictureSvg()
+{
+  QgsLayout l( QgsProject::instance() );
+  l.initializeDefaults();
+  QgsLayoutItemPicture *p = new QgsLayoutItemPicture( &l );
+  p->setResizeMode( QgsLayoutItemPicture::Zoom );
+  p->setPicturePath( mSvgImage, QgsLayoutItemPicture::FormatSVG );
+  p->attemptSetSceneRect( QRectF( 70, 70, 100, 100 ) );
+  p->setFrameEnabled( true );
+
+  l.addLayoutItem( p );
+
+  QgsLayoutChecker checker( QStringLiteral( "composerpicture_svg_zoom" ), &l );
+  checker.setControlPathPrefix( QStringLiteral( "composer_picture" ) );
+  QVERIFY( checker.testLayout( mReport, 0, 0 ) );
 }
 
 void TestQgsLayoutPicture::pictureRotation()

--- a/tests/src/python/test_qgslayoutpicture.py
+++ b/tests/src/python/test_qgslayoutpicture.py
@@ -17,13 +17,15 @@ import socketserver
 import threading
 import http.server
 from qgis.PyQt.QtCore import QRectF, QDir
-
+from qgis.PyQt.QtTest import QSignalSpy
+from qgis.PyQt.QtXml import QDomDocument
 from qgis.core import (QgsLayoutItemPicture,
                        QgsLayout,
                        QgsLayoutItemMap,
                        QgsRectangle,
                        QgsCoordinateReferenceSystem,
-                       QgsProject
+                       QgsProject,
+                       QgsReadWriteContext
                        )
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -57,6 +59,7 @@ class TestQgsLayoutPicture(unittest.TestCase, LayoutItemTestCase):
 
         TEST_DATA_DIR = unitTestDataPath()
         self.pngImage = TEST_DATA_DIR + "/sample_image.png"
+        self.svgImage = TEST_DATA_DIR + "/sample_svg.svg"
 
         # create composition
         self.layout = QgsLayout(QgsProject.instance())
@@ -75,6 +78,59 @@ class TestQgsLayoutPicture(unittest.TestCase, LayoutItemTestCase):
         report_file_path = "%s/qgistest.html" % QDir.tempPath()
         with open(report_file_path, 'a') as report_file:
             report_file.write(self.report)
+
+    def testMode(self):
+        pic = QgsLayoutItemPicture(self.layout)
+        # should default to unknown
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatUnknown)
+        spy = QSignalSpy(pic.changed)
+        pic.setMode(QgsLayoutItemPicture.FormatRaster)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatRaster)
+        self.assertEqual(len(spy), 1)
+        pic.setMode(QgsLayoutItemPicture.FormatRaster)
+        self.assertEqual(len(spy), 1)
+        pic.setMode(QgsLayoutItemPicture.FormatSVG)
+        self.assertEqual(len(spy), 3) # ideally only 2!
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatSVG)
+
+        # set picture path without explicit format
+        pic.setPicturePath(self.pngImage)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatRaster)
+        pic.setPicturePath(self.svgImage)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatSVG)
+        # forced format
+        pic.setPicturePath(self.pngImage, QgsLayoutItemPicture.FormatSVG)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatSVG)
+        pic.setPicturePath(self.pngImage, QgsLayoutItemPicture.FormatRaster)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatRaster)
+        pic.setPicturePath(self.svgImage, QgsLayoutItemPicture.FormatSVG)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatSVG)
+        pic.setPicturePath(self.svgImage, QgsLayoutItemPicture.FormatRaster)
+        self.assertEquals(pic.mode(), QgsLayoutItemPicture.FormatRaster)
+
+    def testReadWriteXml(self):
+        pr = QgsProject()
+        l = QgsLayout(pr)
+
+        pic = QgsLayoutItemPicture(l)
+        # mode should be saved/restored
+        pic.setMode(QgsLayoutItemPicture.FormatRaster)
+
+        #save original item to xml
+        doc = QDomDocument("testdoc")
+        elem = doc.createElement("test")
+        self.assertTrue(pic.writeXml(elem, doc, QgsReadWriteContext()))
+
+        pic2 = QgsLayoutItemPicture(l)
+        self.assertTrue(pic2.readXml(elem.firstChildElement(), doc, QgsReadWriteContext()))
+        self.assertEqual(pic2.mode(), QgsLayoutItemPicture.FormatRaster)
+
+        pic.setMode(QgsLayoutItemPicture.FormatSVG)
+        elem = doc.createElement("test2")
+        self.assertTrue(pic.writeXml(elem, doc, QgsReadWriteContext()))
+        pic3 = QgsLayoutItemPicture(l)
+        self.assertTrue(pic3.readXml(elem.firstChildElement(), doc, QgsReadWriteContext()))
+        self.assertEqual(pic3.mode(), QgsLayoutItemPicture.FormatSVG)
 
     def testResizeZoom(self):
         """Test picture resize zoom mode."""


### PR DESCRIPTION
Adds an explicit choice between SVG or raster image sources, which allows us to clean up the configuration panel for layout pictures by hiding options which don't apply to a certain picture source. Also permits us to:
- Reuse the standard svg selector tree widget, which loads images in a background thread and fixes #17061
- Uses the standard SVG and image selector line edit, which permit drag and drop of images and expose options to embed images and link to online sources

Ultimately this is motivated by a desire to allow users to embed images in layouts and layout templates

Sponsored by SLYR
