### PR TITLE
Update help URLs for copyright and title decorations

### DIFF
--- a/src/app/decorations/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/decorations/qgsdecorationcopyrightdialog.cpp
@@ -130,5 +130,5 @@ void QgsDecorationCopyrightDialog::apply()
 
 void QgsDecorationCopyrightDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#copyright-and-title-labels" ) );
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#copyright-label" ) );
 }

--- a/src/app/decorations/qgsdecorationtitledialog.cpp
+++ b/src/app/decorations/qgsdecorationtitledialog.cpp
@@ -138,5 +138,5 @@ void QgsDecorationTitleDialog::apply()
 
 void QgsDecorationTitleDialog::showHelp()
 {
-  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#copyright-and-title-labels" ) );
+  QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#title-label" ) );
 }


### PR DESCRIPTION
## Description

Documentation has been improved, splitting the description of the copyright and title decorations, and in that process, the labels were changed (https://github.com/qgis/QGIS-Documentation/pull/5026). This PR updates the URLs accordingly.

Should be backported to QGIS 3.10.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
