### PR TITLE
Show data defined buttons for dynamic parameters even in batch mode

### DIFF
--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -125,7 +125,7 @@ QWidget *QgsAbstractProcessingParameterWidgetWrapper::createWrappedWidget( QgsPr
 
   mWidget = createWidget();
   QWidget *wrappedWidget = mWidget;
-  if ( mType != QgsProcessingGui::Batch && mParameterDefinition->isDynamic() )
+  if ( mParameterDefinition->isDynamic() )
   {
     QHBoxLayout *hLayout = new QHBoxLayout();
     hLayout->setMargin( 0 );


### PR DESCRIPTION
I recall I initially hid these in batch mode because it didn't seem like there'd be a use case for them, but recent discussion on the dev mailing list has revealed otherwise!

Anyway, they work fine in batch mode, we just need to show them.