### PR TITLE
In batch mode, don't try to run rows with invalid parameter values

### DIFF
--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -102,8 +102,11 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         project = QgsProject.instance() if load_layers else None
 
         for row in range(self.mainWidget().batchRowCount()):
-            parameters = self.mainWidget().parametersForRow(row, destinationProject=project, warnOnInvalid=True)
-            alg_parameters.append(parameters)
+            parameters, ok = self.mainWidget().parametersForRow(row, destinationProject=project, warnOnInvalid=True)
+            if ok:
+                alg_parameters.append(parameters)
+        if not alg_parameters:
+            return
 
         task = QgsScopedProxyProgressTask(self.tr('Batch Processing - {0}').format(self.algorithm().displayName()))
         multi_feedback = BatchFeedback(len(alg_parameters), feedback)

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -210,7 +210,7 @@ class BatchPanelFillWidget(QToolButton):
         expression_context = context.expressionContext()
 
         # use the first row parameter values as a preview during expression creation
-        params = self.panel.parametersForRow(0, warnOnInvalid=False)
+        params, ok = self.panel.parametersForRow(0, warnOnInvalid=False)
         alg_scope = QgsExpressionContextUtils.processingAlgorithmScope(self.panel.alg, params, context)
 
         # create explicit variables corresponding to every parameter
@@ -247,7 +247,7 @@ class BatchPanelFillWidget(QToolButton):
                 self.setRowValue(row + first_row, value, context)
         else:
             for row in range(self.panel.batchRowCount()):
-                params = self.panel.parametersForRow(row, warnOnInvalid=False)
+                params, ok = self.panel.parametersForRow(row, warnOnInvalid=False)
 
                 # remove previous algorithm scope -- we need to rebuild this completely, using the
                 # other parameter values from the current row
@@ -600,7 +600,7 @@ class BatchPanel(BASE, WIDGET):
                                                      self.tr('Wrong or missing parameter value: {0} (row {1})').format(
                                                          param.description(), row + 1),
                                                      level=Qgis.Warning, duration=5)
-                return {}
+                return {}, False
             col += 1
         count_visible_outputs = 0
         for out in self.alg.destinationParameterDefinitions():
@@ -623,5 +623,5 @@ class BatchPanel(BASE, WIDGET):
                 self.parent.messageBar().pushMessage("", self.tr('Wrong or missing output value: {0} (row {1})').format(
                     out.description(), row + 1),
                     level=Qgis.Warning, duration=5)
-                return {}
-        return parameters
+                return {}, False
+        return parameters, True


### PR DESCRIPTION
Previously we would show a warning about these, but then go ahead and try to run the row anyway (using an empty set of parameters), resulting in the log being filled with confusing error messages.

Instead, keep the existing warning advising about which values are invalid, but skip the affected row and don't try to run it at all.

@alexbruy the other option would be to not run ANY rows if any are invalid, and completely block the execution until all rows are fixed. What do you think is better?
