### PR TITLE
FIX #15144 Add tooltip on fields in identify window/attribute window/feature form

### DIFF
--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -104,6 +104,18 @@ represents.
 .. versionadded:: 3.12
 %End
 
+
+    QString displayType( bool showConstraints = false ) const;
+%Docstring
+Returns the type to use when displaying this field, including the length and precision of the datatype if applicable.
+
+This will be used when the full datatype with details has to displayed to the user.
+
+.. seealso:: :py:func:`type`
+
+.. versionadded:: 3.14
+%End
+
     QVariant::Type type() const;
 %Docstring
 Gets variant type of the field as it will be retrieved from data source

--- a/python/core/auto_generated/qgsfieldmodel.sip.in
+++ b/python/core/auto_generated/qgsfieldmodel.sip.in
@@ -128,12 +128,20 @@ Returns the layer associated with the model.
     virtual QVariant data( const QModelIndex &index, int role ) const;
 
 
-    static QString fieldToolTip( const QgsField &field, const QString &expression = QString() );
+    static QString fieldToolTip( const QgsField &field );
 %Docstring
 Returns a HTML formatted tooltip string for a ``field``, containing details
 like the field name, alias and type.
 
 .. versionadded:: 3.0
+%End
+
+    static QString fieldToolTipExtended( const QgsField &field, const QgsVectorLayer *layer );
+%Docstring
+Returns a HTML formatted tooltip string for a ``field``, containing details
+like the field name, alias, type and expression.
+
+.. versionadded:: 3.14
 %End
 
     void setFields( const QgsFields &fields );

--- a/python/core/auto_generated/qgsfieldmodel.sip.in
+++ b/python/core/auto_generated/qgsfieldmodel.sip.in
@@ -128,7 +128,7 @@ Returns the layer associated with the model.
     virtual QVariant data( const QModelIndex &index, int role ) const;
 
 
-    static QString fieldToolTip( const QgsField &field );
+    static QString fieldToolTip( const QgsField &field, const QString &expression = QString() );
 %Docstring
 Returns a HTML formatted tooltip string for a ``field``, containing details
 like the field name, alias and type.

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -616,11 +616,8 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     QgsTreeWidgetItem *attrItem = new QgsTreeWidgetItem( QStringList() << QString::number( i ) << value );
     featItem->addChild( attrItem );
 
-    QString expressionString = fields.fieldOrigin( i ) == QgsFields::OriginExpression
-                               ? vlayer->expressionField( i )
-                               : QString();
     attrItem->setData( 0, Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
-    attrItem->setToolTip( 0, QgsFieldModel::fieldToolTip( fields.at( i ), expressionString ) );
+    attrItem->setToolTip( 0, QgsFieldModel::fieldToolTipExtended( fields.at( i ), vlayer ) );
     attrItem->setData( 0, Qt::UserRole, fields.at( i ).name() );
     attrItem->setData( 0, Qt::UserRole + 1, i );
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -77,6 +77,7 @@
 #include "qgsfiledownloaderdialog.h"
 #include "qgsfieldformatterregistry.h"
 #include "qgsfieldformatter.h"
+#include "qgsfieldmodel.h"
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsexpressioncontextutils.h"
@@ -615,8 +616,11 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     QgsTreeWidgetItem *attrItem = new QgsTreeWidgetItem( QStringList() << QString::number( i ) << value );
     featItem->addChild( attrItem );
 
+    QString expressionString = fields.fieldOrigin( i ) == QgsFields::OriginExpression
+                               ? vlayer->expressionField( i )
+                               : QStringLiteral();
     attrItem->setData( 0, Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
-    attrItem->setToolTip( 0, vlayer->attributeDisplayName( i ) );
+    attrItem->setToolTip( 0, QgsFieldModel::fieldToolTip( fields.at( i ), expressionString ) );
     attrItem->setData( 0, Qt::UserRole, fields.at( i ).name() );
     attrItem->setData( 0, Qt::UserRole + 1, i );
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -618,7 +618,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
     QString expressionString = fields.fieldOrigin( i ) == QgsFields::OriginExpression
                                ? vlayer->expressionField( i )
-                               : QStringLiteral();
+                               : QString();
     attrItem->setData( 0, Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
     attrItem->setToolTip( 0, QgsFieldModel::fieldToolTip( fields.at( i ), expressionString ) );
     attrItem->setData( 0, Qt::UserRole, fields.at( i ).name() );

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -103,6 +103,29 @@ QString QgsField::displayNameWithAlias() const
   return QStringLiteral( "%1 (%2)" ).arg( name() ).arg( alias() );
 }
 
+QString QgsField::displayType( const bool showConstraints ) const
+{
+  QString typeStr = typeName();
+
+  if ( length() > 0 && precision() > 0 )
+    typeStr += QStringLiteral( "(%1, %2)" ).arg( length() ).arg( precision() );
+  else if ( length() > 0 )
+    typeStr += QStringLiteral( "(%1)" ).arg( length() );
+
+  if ( showConstraints )
+  {
+    typeStr += constraints().constraints() & QgsFieldConstraints::ConstraintNotNull
+               ? QStringLiteral( " NOT NULL" )
+               : QStringLiteral( " NULL" );
+
+    typeStr += constraints().constraints() & QgsFieldConstraints::ConstraintUnique
+               ? QStringLiteral( " UNIQUE" )
+               : QStringLiteral( "" );
+  }
+
+  return typeStr;
+}
+
 QVariant::Type QgsField::type() const
 {
   return d->type;

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -120,7 +120,7 @@ QString QgsField::displayType( const bool showConstraints ) const
 
     typeStr += constraints().constraints() & QgsFieldConstraints::ConstraintUnique
                ? QStringLiteral( " UNIQUE" )
-               : QStringLiteral( "" );
+               : QString();
   }
 
   return typeStr;

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -130,6 +130,17 @@ class CORE_EXPORT QgsField
      */
     QString displayNameWithAlias() const;
 
+
+    /**
+     * Returns the type to use when displaying this field, including the length and precision of the datatype if applicable.
+     *
+     * This will be used when the full datatype with details has to displayed to the user.
+     *
+     * \see type()
+     * \since QGIS 3.14
+     */
+    QString displayType( bool showConstraints = false ) const;
+
     //! Gets variant type of the field as it will be retrieved from data source
     QVariant::Type type() const;
 

--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -464,7 +464,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
   }
 }
 
-QString QgsFieldModel::fieldToolTip( const QgsField &field )
+QString QgsFieldModel::fieldToolTip( const QgsField &field, const QString &expression )
 {
   QString toolTip;
   if ( !field.alias().isEmpty() )
@@ -475,23 +475,21 @@ QString QgsFieldModel::fieldToolTip( const QgsField &field )
   {
     toolTip = QStringLiteral( "<b>%1</b>" ).arg( field.name() );
   }
-  QString typeString;
-  if ( field.length() > 0 )
+
+  toolTip += QStringLiteral( "<br><font style='font-family:monospace; white-space: nowrap;'>%3</font>" ).arg( field.displayType( true ) );
+
+  QString comment = field.comment();
+
+  if ( ! comment.isEmpty() )
   {
-    if ( field.precision() > 0 )
-    {
-      typeString = QStringLiteral( "%1 (%2, %3)" ).arg( field.typeName() ).arg( field.length() ).arg( field.precision() );
-    }
-    else
-    {
-      typeString = QStringLiteral( "%1 (%2)" ).arg( field.typeName() ).arg( field.length() );
-    }
+    toolTip += QStringLiteral( "<br><em>%1</em>" ).arg( comment );
   }
-  else
+
+  if ( ! expression.isEmpty() )
   {
-    typeString = field.typeName();
+    toolTip += QStringLiteral( "<br><font style='font-family:monospace;'>%3</font>" ).arg( expression );
   }
-  toolTip += QStringLiteral( "<p>%1</p>" ).arg( typeString );
+
   return toolTip;
 }
 

--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -464,7 +464,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
   }
 }
 
-QString QgsFieldModel::fieldToolTip( const QgsField &field, const QString &expression )
+QString QgsFieldModel::fieldToolTip( const QgsField &field )
 {
   QString toolTip;
   if ( !field.alias().isEmpty() )
@@ -485,9 +485,25 @@ QString QgsFieldModel::fieldToolTip( const QgsField &field, const QString &expre
     toolTip += QStringLiteral( "<br><em>%1</em>" ).arg( comment );
   }
 
-  if ( ! expression.isEmpty() )
+  return toolTip;
+}
+
+QString QgsFieldModel::fieldToolTipExtended( const QgsField &field, const QgsVectorLayer *layer )
+{
+  QString toolTip = QgsFieldModel::fieldToolTip( field );
+  const QgsFields fields = layer->fields();
+  int fieldIdx = fields.indexOf( field.name() );
+
+  if ( fieldIdx < 0 )
+    return QString();
+
+  QString expressionString = fields.fieldOrigin( fieldIdx ) == QgsFields::OriginExpression
+                             ? layer->expressionField( fieldIdx )
+                             : QString();
+
+  if ( !expressionString.isEmpty() )
   {
-    toolTip += QStringLiteral( "<br><font style='font-family:monospace;'>%3</font>" ).arg( expression );
+    toolTip += QStringLiteral( "<br><font style='font-family:monospace;'>%3</font>" ).arg( expressionString );
   }
 
   return toolTip;

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -135,7 +135,14 @@ class CORE_EXPORT QgsFieldModel : public QAbstractItemModel
      * like the field name, alias and type.
      * \since QGIS 3.0
      */
-    static QString fieldToolTip( const QgsField &field, const QString &expression = QString() );
+    static QString fieldToolTip( const QgsField &field );
+
+    /**
+     * Returns a HTML formatted tooltip string for a \a field, containing details
+     * like the field name, alias, type and expression.
+     * \since QGIS 3.14
+     */
+    static QString fieldToolTipExtended( const QgsField &field, const QgsVectorLayer *layer );
 
     /**
      * Manually sets the \a fields to use for the model.

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -135,7 +135,7 @@ class CORE_EXPORT QgsFieldModel : public QAbstractItemModel
      * like the field name, alias and type.
      * \since QGIS 3.0
      */
-    static QString fieldToolTip( const QgsField &field );
+    static QString fieldToolTip( const QgsField &field, const QString &expression = QString() );
 
     /**
      * Manually sets the \a fields to use for the model.

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -626,7 +626,7 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
       const QgsField field = layer()->fields().at( mAttributes.at( section ) );
       QString expressionString = layer()->fields().fieldOrigin( mAttributes.at( section ) ) == QgsFields::OriginExpression
                                  ? layer()->expressionField( mAttributes.at( section ) )
-                                 : QStringLiteral();
+                                 : QString();
       return QgsFieldModel::fieldToolTip( field, expressionString );
     }
   }

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -624,10 +624,7 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
     else
     {
       const QgsField field = layer()->fields().at( mAttributes.at( section ) );
-      QString expressionString = layer()->fields().fieldOrigin( mAttributes.at( section ) ) == QgsFields::OriginExpression
-                                 ? layer()->expressionField( mAttributes.at( section ) )
-                                 : QString();
-      return QgsFieldModel::fieldToolTip( field, expressionString );
+      return QgsFieldModel::fieldToolTipExtended( field, layer() );
     }
   }
   else

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -624,7 +624,10 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
     else
     {
       const QgsField field = layer()->fields().at( mAttributes.at( section ) );
-      return QgsFieldModel::fieldToolTip( field );
+      QString expressionString = layer()->fields().fieldOrigin( mAttributes.at( section ) ) == QgsFields::OriginExpression
+                                 ? layer()->expressionField( mAttributes.at( section ) )
+                                 : QStringLiteral();
+      return QgsFieldModel::fieldToolTip( field, expressionString );
     }
   }
   else

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1508,7 +1508,7 @@ void QgsAttributeForm::init()
       // This will also create the widget
       QString expressionString = fields.fieldOrigin( idx ) == QgsFields::OriginExpression
                                  ? mLayer->expressionField( idx )
-                                 : QStringLiteral();
+                                 : QString();
       QLabel *l = new QLabel( labelText );
       l->setToolTip( QgsFieldModel::fieldToolTip( field, expressionString ) );
       QSvgWidget *i = new QSvgWidget();

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1506,11 +1506,8 @@ void QgsAttributeForm::init()
       bool labelOnTop = mLayer->editFormConfig().labelOnTop( idx );
 
       // This will also create the widget
-      QString expressionString = fields.fieldOrigin( idx ) == QgsFields::OriginExpression
-                                 ? mLayer->expressionField( idx )
-                                 : QString();
       QLabel *l = new QLabel( labelText );
-      l->setToolTip( QgsFieldModel::fieldToolTip( field, expressionString ) );
+      l->setToolTip( QgsFieldModel::fieldToolTipExtended( field, mLayer ) );
       QSvgWidget *i = new QSvgWidget();
       i->setFixedSize( 18, 18 );
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -43,6 +43,7 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsfeaturerequest.h"
 #include "qgstexteditwrapper.h"
+#include "qgsfieldmodel.h"
 
 #include <QDir>
 #include <QTextStream>
@@ -1505,8 +1506,11 @@ void QgsAttributeForm::init()
       bool labelOnTop = mLayer->editFormConfig().labelOnTop( idx );
 
       // This will also create the widget
+      QString expressionString = fields.fieldOrigin( idx ) == QgsFields::OriginExpression
+                                 ? mLayer->expressionField( idx )
+                                 : QStringLiteral();
       QLabel *l = new QLabel( labelText );
-      l->setToolTip( QStringLiteral( "<b>%1</b><p>%2</p>" ).arg( fieldName, field.comment() ) );
+      l->setToolTip( QgsFieldModel::fieldToolTip( field, expressionString ) );
       QSvgWidget *i = new QSvgWidget();
       i->setFixedSize( 18, 18 );
 

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -48,6 +48,7 @@ class TestQgsField: public QObject
     void dataStream();
     void displayName();
     void displayNameWithAlias();
+    void displayType();
     void editorWidgetSetup();
     void collection();
 
@@ -749,6 +750,24 @@ void TestQgsField::displayNameWithAlias()
   QCOMPARE( field.displayNameWithAlias(), QString( "name (alias)" ) );
   field.setAlias( QString() );
   QCOMPARE( field.displayNameWithAlias(), QString( "name" ) );
+}
+
+
+void TestQgsField::displayType()
+{
+  QgsField field;
+  field.setTypeName( QStringLiteral( "numeric" ) );
+  QCOMPARE( field.displayType(), QString( "numeric" ) );
+  field.setLength( 20 );
+  QCOMPARE( field.displayType(), QString( "numeric(20)" ) );
+  field.setPrecision( 10 );
+  field.setPrecision( 10 );
+  QCOMPARE( field.displayType(), QString( "numeric(20, 10)" ) );
+  QCOMPARE( field.displayType( true ), QString( "numeric(20, 10) NULL" ) );
+  QgsFieldConstraints constraints;
+  constraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
+  field.setConstraints( constraints );
+  QCOMPARE( field.displayType( true ), QString( "numeric(20, 10) NULL UNIQUE" ) );
 }
 
 

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -360,12 +360,19 @@ class TestQgsFieldModel(unittest.TestCase):
         self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font>")
         f.setComment('Comment text')
         self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font><br><em>Comment text</em>")
-        self.assertEqual(QgsFieldModel.fieldToolTip(f, '1+1'), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font><br><em>Comment text</em><br><font style='font-family:monospace;'>1+1</font>")
+
+    def testFieldTooltipExtended(self):
+        layer = QgsVectorLayer("Point?", "tooltip", "memory")
+        f = QgsField('my_real', QVariant.Double, 'real', 8, 3, 'Comment text')
+        layer.addExpressionField('1+1', f)
+        layer.updateFields()
+        self.assertEqual(QgsFieldModel.fieldToolTipExtended(QgsField('my_string', QVariant.String, 'string'), layer), '')
+        self.assertEqual(QgsFieldModel.fieldToolTipExtended(f, layer), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font><br><em>Comment text</em><br><font style='font-family:monospace;'>1+1</font>")
         f.setAlias('my alias')
         constraints = f.constraints()
         constraints.setConstraint(QgsFieldConstraints.ConstraintUnique)
         f.setConstraints(constraints)
-        self.assertEqual(QgsFieldModel.fieldToolTip(f, '1+1'), "<b>my alias</b> (my_real)<br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL UNIQUE</font><br><em>Comment text</em><br><font style='font-family:monospace;'>1+1</font>")
+        self.assertEqual(QgsFieldModel.fieldToolTipExtended(f, layer), "<b>my alias</b> (my_real)<br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL UNIQUE</font><br><em>Comment text</em><br><font style='font-family:monospace;'>1+1</font>")
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -19,7 +19,8 @@ from qgis.core import (QgsField,
                        QgsFieldProxyModel,
                        QgsEditorWidgetSetup,
                        QgsProject,
-                       QgsVectorLayerJoinInfo)
+                       QgsVectorLayerJoinInfo,
+                       QgsFieldConstraints)
 from qgis.PyQt.QtCore import QVariant, Qt, QModelIndex
 
 from qgis.testing import start_app, unittest
@@ -350,13 +351,21 @@ class TestQgsFieldModel(unittest.TestCase):
 
     def testFieldTooltip(self):
         f = QgsField('my_string', QVariant.String, 'string')
-        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my_string</b><p>string</p>')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my_string</b><br><font style='font-family:monospace; white-space: nowrap;'>string NULL</font>")
         f.setAlias('my alias')
-        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my alias</b> (my_string)<p>string</p>')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my alias</b> (my_string)<br><font style='font-family:monospace; white-space: nowrap;'>string NULL</font>")
         f.setLength(20)
-        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my alias</b> (my_string)<p>string (20)</p>')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my alias</b> (my_string)<br><font style='font-family:monospace; white-space: nowrap;'>string(20) NULL</font>")
         f = QgsField('my_real', QVariant.Double, 'real', 8, 3)
-        self.assertEqual(QgsFieldModel.fieldToolTip(f), '<b>my_real</b><p>real (8, 3)</p>')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font>")
+        f.setComment('Comment text')
+        self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font><br><em>Comment text</em>")
+        self.assertEqual(QgsFieldModel.fieldToolTip(f, '1+1'), "<b>my_real</b><br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL</font><br><em>Comment text</em><br><font style='font-family:monospace;'>1+1</font>")
+        f.setAlias('my alias')
+        constraints = f.constraints()
+        constraints.setConstraint(QgsFieldConstraints.ConstraintUnique)
+        f.setConstraints(constraints)
+        self.assertEqual(QgsFieldModel.fieldToolTip(f, '1+1'), "<b>my alias</b> (my_real)<br><font style='font-family:monospace; white-space: nowrap;'>real(8, 3) NULL UNIQUE</font><br><em>Comment text</em><br><font style='font-family:monospace;'>1+1</font>")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- added new `QString QgsField::displayType( const bool showConstraints = false )` to unify the display of field types
- added new argument `expression` to `QgsFieldModel::fieldToolTip( const QgsField &field, const QString &expression = QStringLiteral() )`. 
Now the tooltip shows:
```
<alias> (<field>)\n<type>\n<comment>\n<expression>
``` 

with appropriate formatting
- added meaningful tooltips in the "Identify Results" dialog
- unified the tooltips across "Feature Attributes" form, "Attribute Table" and "Identify Tool" 

Fixes #15144

## Description
Tooltip field:
![image](https://user-images.githubusercontent.com/2820439/77023696-41034b80-6995-11ea-992f-859a3bd3f21e.png)
Tooltip virtual field:
![image](https://user-images.githubusercontent.com/2820439/77024064-309fa080-6996-11ea-9c3b-9ba6fd4f73c4.png)

