### PR TITLE
Make "Ctrl+Shift+A" shortcut to trigger "Deselect current layer" instead of  "Deselect all layers"

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1210,7 +1210,7 @@
     <string>Deselect Features from All Layers</string>
    </property>
     <property name="shortcut">
-    <string>Alt+Shift+A</string>
+    <string>Ctrl+Alt+A</string>
    </property>
   </action>
   <action name="mActionDeselectActiveLayer">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1209,6 +1209,9 @@
    <property name="text">
     <string>Deselect Features from All Layers</string>
    </property>
+    <property name="shortcut">
+    <string>Alt+Shift+A</string>
+   </property>
   </action>
   <action name="mActionDeselectActiveLayer">
    <property name="icon">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1209,9 +1209,6 @@
    <property name="text">
     <string>Deselect Features from All Layers</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+Shift+A</string>
-   </property>
   </action>
   <action name="mActionDeselectActiveLayer">
    <property name="icon">
@@ -1220,6 +1217,9 @@
    </property>
    <property name="text">
     <string>Deselect Features from the Current Active Layer</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+A</string>
    </property>
   </action>
   <action name="mActionSelectAll">


### PR DESCRIPTION
As I said in https://github.com/qgis/QGIS/pull/35085 , the "Ctrl+Shift+A" shortcut should be exactly the opposite of "Ctrl+A" to match user expectations. 