### PR TITLE
 FIX #15670 Show count in Identify Results dialog

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -38,6 +38,7 @@
 #include <QFileInfo>
 #include <QRegExp>
 #include <QScreen>
+#include <QFont>
 
 //graph
 #include <qwt_plot.h>
@@ -511,6 +512,9 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     layItem = new QTreeWidgetItem( QStringList() << vlayer->name() );
     layItem->setData( 0, Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( vlayer ) ) );
     lstResults->addTopLevelItem( layItem );
+    QFont boldFont;
+    boldFont.setBold( true );
+    layItem->setFont( 0, boldFont );
 
     connect( vlayer, &QObject::destroyed, this, &QgsIdentifyResultsDialog::layerDestroyed );
     connect( vlayer, &QgsMapLayer::crsChanged, this, &QgsIdentifyResultsDialog::layerDestroyed );
@@ -527,10 +531,10 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
   mFeatures << f;
   layItem->addChild( featItem );
   layItem->setFirstColumnSpanned( true );
-  QString countSuffix = lstResults->topLevelItemCount() > 1 || layItem->childCount() > 1
+
+  QString countSuffix = layItem->childCount() > 1
                         ? QStringLiteral( " [%1]" ).arg( layItem->childCount() )
                         : QString();
-  QgsLogger::warning( countSuffix + QStringLiteral( __FILE__ ) + ": " + QString::number( __LINE__ ) );
   layItem->setText( 0, QStringLiteral( "%1 %2" ).arg( vlayer->name(), countSuffix ) );
 
   if ( derivedAttributes.size() >= 0 )

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -508,7 +508,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
   if ( !layItem )
   {
-    layItem = new QTreeWidgetItem( QStringList() << vlayer->name() );
+    layItem = new QTreeWidgetItem( QStringList() << vlayer->name() << tr( "Selected features: %1" ).arg( 0 ) );
     layItem->setData( 0, Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( vlayer ) ) );
     lstResults->addTopLevelItem( layItem );
 
@@ -526,6 +526,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
   featItem->setData( 0, Qt::UserRole + 1, mFeatures.size() );
   mFeatures << f;
   layItem->addChild( featItem );
+  layItem->setText( 1, tr( "Selected features: %1" ).arg( layItem->childCount() ) );
 
   if ( derivedAttributes.size() >= 0 )
   {

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -481,19 +481,6 @@ QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QObject *object )
   return nullptr;
 }
 
-QTreeWidgetItem *QgsIdentifyResultsDialog::findResultFeaturesItem( QTreeWidgetItem *layerItem )
-{
-  for ( int i = 0; i < layerItem->childCount(); i++ )
-  {
-    QTreeWidgetItem *item = layerItem->child( i );
-
-    if ( item->data( 0, Qt::UserRole ).toString() == QLatin1String( "count" ) )
-      return item;
-  }
-
-  return nullptr;
-}
-
 void QgsIdentifyResultsDialog::addFeature( const QgsMapToolIdentify::IdentifyResult &result )
 {
   switch ( result.mLayer->type() )
@@ -539,19 +526,12 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
   featItem->setData( 0, Qt::UserRole + 1, mFeatures.size() );
   mFeatures << f;
   layItem->addChild( featItem );
-
-  QTreeWidgetItem *resultFeaturesCountItem = findResultFeaturesItem( layItem );
-  if ( ! resultFeaturesCountItem )
-  {
-    resultFeaturesCountItem = new QTreeWidgetItem( QStringList() << tr( "(Count Results)" ) );
-    resultFeaturesCountItem->setData( 0, Qt::UserRole, QLatin1String( "count" ) );
-    layItem->insertChild( 0, resultFeaturesCountItem );
-  }
-
-  if ( resultFeaturesCountItem )
-  {
-    resultFeaturesCountItem->setText( 1, QString::number( layItem->childCount() - 1 ) );
-  }
+  layItem->setFirstColumnSpanned( true );
+  QString countSuffix = lstResults->topLevelItemCount() > 1 || layItem->childCount() > 1
+                        ? QStringLiteral( " [%1]" ).arg( layItem->childCount() )
+                        : QString();
+  QgsLogger::warning( countSuffix + QStringLiteral( __FILE__ ) + ": " + QString::number( __LINE__ ) );
+  layItem->setText( 0, QStringLiteral( "%1 %2" ).arg( vlayer->name(), countSuffix ) );
 
   if ( derivedAttributes.size() >= 0 )
   {
@@ -1131,9 +1111,6 @@ void QgsIdentifyResultsDialog::editingToggled()
   for ( i = 0; i < layItem->childCount(); i++ )
   {
     QTreeWidgetItem *featItem = layItem->child( i );
-
-    if ( featItem->data( 0, Qt::UserRole ).toString() == QLatin1String( "result features" ) )
-      continue;
 
     int j;
     for ( j = 0; j < featItem->childCount() && featItem->child( j )->data( 0, Qt::UserRole ).toString() != QLatin1String( "actions" ); j++ )

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -278,7 +278,6 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QTreeWidgetItem *featureItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QObject *layer );
-    QTreeWidgetItem *findResultFeaturesItem( QTreeWidgetItem *layerItem );
 
 
     void highlightLayer( QTreeWidgetItem *object );

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -278,6 +278,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QTreeWidgetItem *featureItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QObject *layer );
+    QTreeWidgetItem *findResultFeaturesItem( QTreeWidgetItem *layerItem );
 
 
     void highlightLayer( QTreeWidgetItem *object );

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -311,7 +311,7 @@
     <string>Copy Feature</string>
    </property>
    <property name="toolTip">
-    <string>Copy Selected Feature to Clipboard</string>
+    <string>Copy the Identified Feature to Clipboard</string>
    </property>
   </action>
   <action name="mActionPrint">


### PR DESCRIPTION
Added "selected features: <FEATURES_COUNT>" next to the layer name in the "Identify Results" dialog. 

Fixes #15670

![image](https://user-images.githubusercontent.com/2820439/77023822-8de72200-6995-11ea-8498-afa33e70bab9.png)

