### PR TITLE
[Backport 3.12] Fix relation reference widget

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -288,7 +288,7 @@ void QgsFeatureFilterModel::updateCompleter()
     int firstRow = 0;
 
     // Move the extra entry to the first position
-    if ( mExtraIdentifierValueIndex != -1 )
+    if ( mExtraIdentifierValueIndex != -1 && currentEntryInNewList != -1 )
     {
       if ( mExtraIdentifierValueIndex != 0 )
       {
@@ -302,6 +302,12 @@ void QgsFeatureFilterModel::updateCompleter()
     // Remove all entries (except for extra entry if existent)
     beginRemoveRows( QModelIndex(), firstRow, mEntries.size() - firstRow );
     mEntries.remove( firstRow, mEntries.size() - firstRow );
+
+    // we need to reset mExtraIdentifierValueIndex variable if we remove all rows
+    // before endRemoveRows, if not setExtraIdentifierValuesUnguarded will be called
+    // and a null value will be added to mEntries
+    mExtraIdentifierValueIndex = firstRow > 0 ? mExtraIdentifierValueIndex : 0;
+
     endRemoveRows();
 
     if ( currentEntryInNewList == -1 )
@@ -309,7 +315,7 @@ void QgsFeatureFilterModel::updateCompleter()
       beginInsertRows( QModelIndex(), 1, entries.size() + 1 );
       mEntries += entries;
       endInsertRows();
-      setExtraIdentifierValuesIndex( 0 );
+      setExtraIdentifierValuesIndex( mAllowNull && !mEntries.isEmpty() ? 1 : 0 );
     }
     else
     {

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -623,7 +623,7 @@ QVariantList QgsFeatureFilterModel::extraIdentifierValues() const
   {
     QVariantList nullValues;
     for ( int i = 0; i < mIdentifierFields.count(); i++ )
-      nullValues << QVariant();
+      nullValues << QVariant( QVariant::Int );
     return nullValues;
   }
   return mExtraIdentifierValues;

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -353,6 +353,8 @@ void QgsFeatureFilterModel::updateCompleter()
 
 void QgsFeatureFilterModel::gathererThreadFinished()
 {
+  // It's possible that gatherer run method is not completely over, so we wait
+  mGatherer->wait();
   delete mGatherer;
   mGatherer = nullptr;
   emit isLoadingChanged();

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -225,7 +225,7 @@ QVariant QgsFeatureFilterModel::data( const QModelIndex &index, int role ) const
 void QgsFeatureFilterModel::updateCompleter()
 {
   emit beginUpdate();
-  if( !mGatherer )
+  if ( !mGatherer )
   {
     emit endUpdate();
     return;

--- a/src/core/qgsfeaturefiltermodel.h
+++ b/src/core/qgsfeaturefiltermodel.h
@@ -296,7 +296,6 @@ class CORE_EXPORT QgsFeatureFilterModel : public QAbstractItemModel
 
   private slots:
     void updateCompleter();
-    void gathererThreadFinished();
     void scheduledReload();
 
   private:

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -165,45 +165,12 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget *parent )
   connect( mRemoveFKButton, &QAbstractButton::clicked, this, &QgsRelationReferenceWidget::deleteForeignKeys );
   connect( mAddEntryButton, &QAbstractButton::clicked, this, &QgsRelationReferenceWidget::addEntry );
   connect( mComboBox, &QComboBox::editTextChanged, this, &QgsRelationReferenceWidget::updateAddEntryButton );
-  connect( mComboBox, &QgsFeatureListComboBox::modelUpdated, this, &QgsRelationReferenceWidget::updateIndex );
 }
 
 QgsRelationReferenceWidget::~QgsRelationReferenceWidget()
 {
   deleteHighlight();
   unsetMapTool();
-}
-
-void QgsRelationReferenceWidget::updateIndex()
-{
-  if ( mChainFilters && mComboBox->count() > 0 )
-  {
-    int index = -1;
-
-    // uninitialized filter
-    if ( ! mFilterComboBoxes.isEmpty()
-         && mFilterComboBoxes[0]->currentIndex() == 0 && mAllowNull )
-    {
-      index = mComboBox->nullIndex();
-    }
-    else if ( mComboBox->count() > mComboBox->nullIndex() )
-    {
-      index = mComboBox->nullIndex() + 1;
-    }
-    else if ( mAllowNull )
-    {
-      index = mComboBox->nullIndex();
-    }
-    else
-    {
-      index = 0;
-    }
-
-    if ( mComboBox->count() > index )
-    {
-      mComboBox->setCurrentIndex( index );
-    }
-  }
 }
 
 void QgsRelationReferenceWidget::setRelation( const QgsRelation &relation, bool allowNullValue )
@@ -620,8 +587,6 @@ void QgsRelationReferenceWidget::init()
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
-    //call it for the first time
-    emit mComboBox->currentIndexChanged( mComboBox->currentIndex() );
 
     QApplication::restoreOverrideCursor();
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -287,12 +287,6 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void entryAdded( const QgsFeature &f );
     void onKeyPressed( QKeyEvent *e );
 
-    /**
-     * Updates the FK index as soon as the underlying model is updated when
-     * the chainFilter option is activated.
-     */
-    void updateIndex();
-
   private:
     void highlightFeature( QgsFeature f = QgsFeature(), CanvasExtent canvasExtent = Fixed );
     void updateAttributeEditorFrame( const QgsFeature &feature );

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -236,6 +236,7 @@ bool QgsFeatureListComboBox::allowNull() const
 void QgsFeatureListComboBox::setAllowNull( bool allowNull )
 {
   mModel->setAllowNull( allowNull );
+  mLineEdit->setClearMode( allowNull ? QgsFilterLineEdit::ClearToNull : QgsFilterLineEdit::ClearToDefault );
 }
 
 QVariant QgsFeatureListComboBox::identifierValue() const

--- a/tests/src/gui/testqgsfeaturelistcombobox.cpp
+++ b/tests/src/gui/testqgsfeaturelistcombobox.cpp
@@ -163,14 +163,14 @@ void TestQgsFeatureListComboBox::testMultipleForeignKeys()
 
   cb->setIdentifierValuesToNull();
   QCOMPARE( cb->identifierValues().count(), 3 );
-  QCOMPARE( cb->identifierValues(), QVariantList() << QVariant() << QVariant() << QVariant() );
+  QCOMPARE( cb->identifierValues(), QVariantList() << QVariant( QVariant::Int ) << QVariant( QVariant::Int ) << QVariant( QVariant::Int ) );
 
   cb->setIdentifierValues( QVariantList() << "silver" << 888 << "fish" );
   QCOMPARE( cb->identifierValues(), QVariantList() << "silver" << 888 << "fish" );
 
   cb->setIdentifierValuesToNull();
   QCOMPARE( cb->identifierValues().count(), 3 );
-  QCOMPARE( cb->identifierValues(), QVariantList() << QVariant() << QVariant() << QVariant() );
+  QCOMPARE( cb->identifierValues(), QVariantList() << QVariant( QVariant::Int ) << QVariant( QVariant::Int ) << QVariant( QVariant::Int ) );
 
   cb->setIdentifierFields( QStringList() << "material" << "raccord" );
   cb->setDisplayExpression( "\"material\" || ' ' || \"raccord\"" );
@@ -182,7 +182,7 @@ void TestQgsFeatureListComboBox::testMultipleForeignKeys()
 
   cb->setIdentifierValuesToNull();
   QCOMPARE( cb->identifierValues().count(), 2 );
-  QCOMPARE( cb->identifierValues(), QVariantList() << QVariant() << QVariant() );
+  QCOMPARE( cb->identifierValues(), QVariantList() << QVariant( QVariant::Int ) << QVariant( QVariant::Int ) );
 }
 
 void TestQgsFeatureListComboBox::testAllowNull()

--- a/tests/src/gui/testqgsfeaturelistcombobox.cpp
+++ b/tests/src/gui/testqgsfeaturelistcombobox.cpp
@@ -46,10 +46,11 @@ class TestQgsFeatureListComboBox : public QObject
     void testMultipleForeignKeys();
     void testAllowNull();
     void testValuesAndSelection();
+    void testValuesAndSelection_data();
     void nullRepresentation();
+    void testNotExistingYetFeature();
 
   private:
-    void waitForLoaded( QgsFeatureListComboBox *cb );
 
     std::unique_ptr<QgsVectorLayer> mLayer;
 
@@ -122,6 +123,10 @@ void TestQgsFeatureListComboBox::testSetGetForeignKey()
 {
   std::unique_ptr<QgsFeatureListComboBox> cb( new QgsFeatureListComboBox() );
 
+  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
+  QEventLoop loop;
+  connect( model, &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
   Q_NOWARN_DEPRECATED_PUSH
   QVERIFY( cb->identifierValue().isNull() );
 
@@ -131,7 +136,7 @@ void TestQgsFeatureListComboBox::testSetGetForeignKey()
   emit cb->lineEdit()->textChanged( "ro" );
   QVERIFY( cb->identifierValue().isNull() );
 
-  waitForLoaded( cb.get() );
+  loop.exec();
 
   QVERIFY( cb->identifierValue().isNull() );
 
@@ -186,65 +191,95 @@ void TestQgsFeatureListComboBox::testAllowNull()
   // Note to self: implement this!
 }
 
+void TestQgsFeatureListComboBox::testValuesAndSelection_data()
+{
+  QTest::addColumn<bool>( "allowNull" );
+
+  QTest::newRow( "allowNull=true" ) << true;
+  QTest::newRow( "allowNull=false" ) << false;
+}
+
 void TestQgsFeatureListComboBox::testValuesAndSelection()
 {
+  QFETCH( bool, allowNull );
+
+
   QgsApplication::setNullRepresentation( QStringLiteral( "nope" ) );
   std::unique_ptr<QgsFeatureListComboBox> cb( new QgsFeatureListComboBox() );
 
+  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
+  QEventLoop loop;
+  connect( model, &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
   cb->setSourceLayer( mLayer.get() );
   cb->setDisplayExpression( QStringLiteral( "\"raccord\"" ) );
-  cb->setAllowNull( true );
+  cb->setAllowNull( allowNull );
 
   //check if everything is fine:
-  waitForLoaded( cb.get() );
-  QCOMPARE( cb->currentIndex(), cb->nullIndex() );
-  QCOMPARE( cb->currentText(), QStringLiteral( "nope" ) );
+  loop.exec();
+  QCOMPARE( cb->currentIndex(), allowNull ? cb->nullIndex() : 0 );
+  QCOMPARE( cb->currentText(), allowNull ? QStringLiteral( "nope" ) : QStringLiteral( "brides" ) );
 
   //check if text correct, selected and if the clear button disappeared:
   cb->mLineEdit->clearValue();
-  waitForLoaded( cb.get() );
-  QCOMPARE( cb->currentIndex(), cb->nullIndex() );
-  QCOMPARE( cb->currentText(), QStringLiteral( "nope" ) );
-  QCOMPARE( cb->lineEdit()->selectedText(), QStringLiteral( "nope" ) );
+  QCOMPARE( cb->currentIndex(), allowNull ? cb->nullIndex() : 0 );
+  QCOMPARE( cb->currentText(), allowNull ? QStringLiteral( "nope" ) : QString() );
+  QCOMPARE( cb->lineEdit()->selectedText(), allowNull ? QStringLiteral( "nope" ) : QString() );
   QVERIFY( ! cb->mLineEdit->mClearAction );
 
   //check if text is selected after receiving focus
   cb->setFocus();
-  waitForLoaded( cb.get() );
-  QCOMPARE( cb->currentIndex(), cb->nullIndex() );
-  QCOMPARE( cb->currentText(), QStringLiteral( "nope" ) );
-  QCOMPARE( cb->lineEdit()->selectedText(), QStringLiteral( "nope" ) );
+  QCOMPARE( cb->currentIndex(), allowNull ? cb->nullIndex() : 0 );
+  QCOMPARE( cb->currentText(), allowNull ? QStringLiteral( "nope" ) : QString() );
+  QCOMPARE( cb->lineEdit()->selectedText(), allowNull ? QStringLiteral( "nope" ) : QString() );
   QVERIFY( ! cb->mLineEdit->mClearAction );
 
   //check with another entry, clear button needs to be there then:
   QTest::keyClicks( cb.get(), QStringLiteral( "sleeve" ) );
-  //QTest::keyClick(cb.get(), Qt::Key_Enter );
-  waitForLoaded( cb.get() );
+  loop.exec();
   QCOMPARE( cb->currentText(), QStringLiteral( "sleeve" ) );
   QVERIFY( cb->mLineEdit->mClearAction );
-  //QVERIFY( cb->currentIndex() != cb->nullIndex());
-  //QCOMPARE( cb->model()->data( cb->currentModelIndex() ).toString(), QStringLiteral( "sleeve" )  );
 }
 
 void TestQgsFeatureListComboBox::nullRepresentation()
 {
-
   QgsApplication::setNullRepresentation( QStringLiteral( "nope" ) );
   std::unique_ptr<QgsFeatureListComboBox> cb( new QgsFeatureListComboBox() );
-  cb->setAllowNull( true );
 
+  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
+  QEventLoop loop;
+  connect( model, &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
+  cb->setAllowNull( true );
+  cb->setSourceLayer( mLayer.get() );
+
+  loop.exec();
   QCOMPARE( cb->lineEdit()->text(), QStringLiteral( "nope" ) );
   QCOMPARE( cb->nullIndex(), 0 );
-
 }
 
-void TestQgsFeatureListComboBox::waitForLoaded( QgsFeatureListComboBox *cb )
-{
-  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
 
-  // Wait
-  while ( model->isLoading() )
-  {}
+void TestQgsFeatureListComboBox::testNotExistingYetFeature()
+{
+  // test behavior when feature list combo box identifier values references a
+  // not existing yet feature (created but not saved for instance)
+
+  std::unique_ptr<QgsFeatureListComboBox> cb( new QgsFeatureListComboBox() );
+  QgsFeatureFilterModel *model = qobject_cast<QgsFeatureFilterModel *>( cb->model() );
+  QEventLoop loop;
+  connect( model, &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
+  QgsApplication::setNullRepresentation( QStringLiteral( "nope" ) );
+
+  QVERIFY( cb->identifierValues().isEmpty() );
+
+  cb->setSourceLayer( mLayer.get() );
+  cb->setAllowNull( true );
+
+  cb->setIdentifierValues( QVariantList() << 42 );
+
+  loop.exec();
+  QCOMPARE( cb->currentText(), QStringLiteral( "(42)" ) );
 }
 
 QGSTEST_MAIN( TestQgsFeatureListComboBox )

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -33,6 +33,15 @@
 #include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsmaptooldigitizefeature.h"
 
+QStringList getComboBoxItems( const QComboBox *cb )
+{
+  QStringList items;
+  for ( int i = 0; i < cb->count(); i++ )
+    items << cb->itemText( i );
+
+  return items;
+}
+
 class TestQgsRelationReferenceWidget : public QObject
 {
     Q_OBJECT
@@ -47,6 +56,8 @@ class TestQgsRelationReferenceWidget : public QObject
 
     void testChainFilter();
     void testChainFilter_data();
+    void testChainFilterFirstInit_data();
+    void testChainFilterFirstInit();
     void testChainFilterRefreshed();
     void testChainFilterDeleteForeignKey();
     void testInvalidRelation();
@@ -165,6 +176,10 @@ void TestQgsRelationReferenceWidget::testChainFilter()
 
   QWidget parentWidget;
   QgsRelationReferenceWidget w( &parentWidget );
+
+  QEventLoop loop;
+  connect( qobject_cast<QgsFeatureFilterModel *>( w.mComboBox->model() ), &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
   w.setChainFilters( true );
   w.setFilterFields( filterFields );
   w.setRelation( *mRelation, allowNull );
@@ -183,9 +198,18 @@ void TestQgsRelationReferenceWidget::testChainFilter()
       QCOMPARE( cb->count(), 3 );
   }
 
+  loop.exec();
+  QStringList items = getComboBoxItems( w.mComboBox );
+  QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
+
   // set first filter
   cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "iron" ) ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
+
   cbs[1]->setCurrentIndex( cbs[1]->findText( QStringLiteral( "120" ) ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
 
   Q_FOREACH ( const QComboBox *cb, cbs )
   {
@@ -195,9 +219,7 @@ void TestQgsRelationReferenceWidget::testChainFilter()
       QCOMPARE( cb->count(), 2 );
     else if ( cb->itemText( 0 ) == QLatin1String( "raccord" ) )
     {
-      QStringList items;
-      for ( int i = 0; i < cb->count(); i++ )
-        items << cb->itemText( i );
+      QStringList items = getComboBoxItems( cb );
 
       QCOMPARE( cb->count(), 3 );
       QCOMPARE( items.contains( "collar" ), false );
@@ -207,38 +229,67 @@ void TestQgsRelationReferenceWidget::testChainFilter()
     }
   }
 
+
   // set the filter for "raccord" and then reset filter for "diameter". As
   // chain filter is activated, the filter on "raccord" field should be reset
-  QEventLoop loop;
-  connect( qobject_cast<QgsFeatureFilterModel *>( w.mComboBox->model() ), &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
 
   cbs[0]->setCurrentIndex( 0 );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" << "12" );
+
+  if ( allowNull )
+  {
+    w.mComboBox->setCurrentIndex( w.mComboBox->findText( QStringLiteral( "10" ) ) );
+    QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+    QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" << "12" );
+  }
 
   cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
 
+  // prefer 12 over NULL
   cbs[0]->setCurrentIndex( cbs[0]->findText( "steel" ) );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "12" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "12" );
 
+  if ( allowNull )
+  {
+    w.mComboBox->setCurrentIndex( w.mComboBox->findText( QStringLiteral( "12" ) ) );
+    QCOMPARE( w.mComboBox->currentText(), QString( "12" ) );
+    QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "12" );
+  }
+
+  // reset IRON, prefer 10 over NULL
   cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
+
+  if ( allowNull )
+  {
+    w.mComboBox->setCurrentIndex( w.mComboBox->findText( QStringLiteral( "10" ) ) );
+    QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+    QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
+  }
 
   cbs[1]->setCurrentIndex( cbs[1]->findText( "120" ) );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
 
   cbs[2]->setCurrentIndex( cbs[2]->findText( QStringLiteral( "brides" ) ) );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" );
 
   cbs[1]->setCurrentIndex( cbs[1]->findText( QStringLiteral( "diameter" ) ) );
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
 
   // combobox should propose NULL (if allowNull is true), 10 and 11 because the filter is now:
   // "material" == 'iron'
@@ -248,8 +299,105 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "material" ) ) );
   loop.exec();
   QCOMPARE( w.mComboBox->count(), allowNull ? 4 : 3 );
-  QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
+  QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" << "12" );
+
+  // change item to check that currently selected item remains
+  w.mComboBox->setCurrentIndex( w.mComboBox->findText( QStringLiteral( "11" ) ) );
+  cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "11" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
+
+  // reset all filter
+  cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "material" ) ) );
+  loop.exec();
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" << "12" );
+
+  // set value with foreign key -> all the comboboxes matches feature values
+  w.setForeignKeys( QVariantList() << "11" );
+  loop.exec();
+  QCOMPARE( cbs[0]->currentText(), QString( "iron" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "sleeve" ) );
+  QCOMPARE( w.mComboBox->currentText(), QString( "11" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "11" );
+
+  // remove filter on raccord
+  cbs[2]->setCurrentIndex( cbs[2]->findText( "raccord" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "11" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
+
+  // change material, prever 12 over NULL
+  cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "steel" ) ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "12" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "12" );
 }
+
+void TestQgsRelationReferenceWidget::testChainFilterFirstInit_data()
+{
+  QTest::addColumn<bool>( "allowNull" );
+
+  QTest::newRow( "allowNull=true" ) << true;
+  QTest::newRow( "allowNull=false" ) << false;
+}
+
+void TestQgsRelationReferenceWidget::testChainFilterFirstInit()
+{
+  QFETCH( bool, allowNull );
+
+  // init a relation reference widget
+  QStringList filterFields = { "material", "diameter", "raccord" };
+
+  QWidget parentWidget;
+  QgsRelationReferenceWidget w( &parentWidget );
+  w.setChainFilters( true );
+  w.setFilterFields( filterFields );
+  w.setRelation( *mRelation, allowNull );
+  w.init();
+
+  // check default status for comboboxes
+  QList<QComboBox *> cbs = w.mFilterComboBoxes;
+  QCOMPARE( cbs.count(), 3 );
+  Q_FOREACH ( const QComboBox *cb, cbs )
+  {
+    if ( cb->currentText() == QLatin1String( "raccord" ) )
+      QCOMPARE( cb->count(), 5 );
+    else if ( cb->currentText() == QLatin1String( "material" ) )
+      QCOMPARE( cb->count(), 4 );
+    else if ( cb->currentText() == QLatin1String( "diameter" ) )
+      QCOMPARE( cb->count(), 3 );
+  }
+
+  // set the filter for "raccord" and then reset filter for "diameter". As
+  // chain filter is activated, the filter on "raccord" field should be reset
+  QEventLoop loop;
+  connect( qobject_cast<QgsFeatureFilterModel *>( w.mComboBox->model() ), &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
+  // set value with foreign key -> all the comboboxes matches feature values
+  w.setForeignKeys( QVariantList() << "11" );
+  loop.exec();
+  QCOMPARE( cbs[0]->currentText(), QString( "iron" ) );
+  QCOMPARE( cbs[1]->currentText(), QString( "120" ) );
+  QCOMPARE( cbs[2]->currentText(), QString( "sleeve" ) );
+  QCOMPARE( w.mComboBox->currentText(), QString( "11" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "11" );
+
+  // remove filter on raccord
+  cbs[2]->setCurrentIndex( cbs[2]->findText( "raccord" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "11" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "10" << "11" );
+
+  // change material prever 12 over NULL
+  cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "steel" ) ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "12" ) );
+  QCOMPARE( getComboBoxItems( w.mComboBox ), ( allowNull ? QStringList() << "NULL" : QStringList() ) << "12" );
+}
+
 
 void TestQgsRelationReferenceWidget::testChainFilterRefreshed()
 {

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -528,8 +528,9 @@ void TestQgsRelationReferenceWidget::testSetGetForeignKey()
   QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(12)" ) );
   QCOMPARE( spy.count(), 2 );
 
-  w.setForeignKeys( QVariantList() << QVariant( QVariant::Int ) );
-  Q_ASSERT( w.foreignKeys().at( 0 ).isNull() );
+  w.setForeignKeys( QVariantList() << QVariant() );
+  QVERIFY( w.foreignKeys().at( 0 ).isNull() );
+  QVERIFY( w.foreignKeys().at( 0 ).isValid() );
   QCOMPARE( spy.count(), 3 );
 }
 

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -46,6 +46,7 @@ class TestQgsRelationReferenceWidget : public QObject
     void cleanup(); // will be called after every testfunction.
 
     void testChainFilter();
+    void testChainFilter_data();
     void testChainFilterRefreshed();
     void testChainFilterDeleteForeignKey();
     void testInvalidRelation();
@@ -147,8 +148,18 @@ void TestQgsRelationReferenceWidget::cleanup()
   QgsProject::instance()->removeMapLayer( mLayer2.get() );
 }
 
+void TestQgsRelationReferenceWidget::testChainFilter_data()
+{
+  QTest::addColumn<bool>( "allowNull" );
+
+  QTest::newRow( "allowNull=true" ) << true;
+  QTest::newRow( "allowNull=false" ) << false;
+}
+
 void TestQgsRelationReferenceWidget::testChainFilter()
 {
+  QFETCH( bool, allowNull );
+
   // init a relation reference widget
   QStringList filterFields = { "material", "diameter", "raccord" };
 
@@ -156,7 +167,7 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   QgsRelationReferenceWidget w( &parentWidget );
   w.setChainFilters( true );
   w.setFilterFields( filterFields );
-  w.setRelation( *mRelation, true );
+  w.setRelation( *mRelation, allowNull );
   w.init();
 
   // check default status for comboboxes
@@ -203,7 +214,7 @@ void TestQgsRelationReferenceWidget::testChainFilter()
 
   cbs[0]->setCurrentIndex( 0 );
   loop.exec();
-  QCOMPARE( w.mComboBox->currentText(), QString( "NULL" ) );
+  QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
 
   cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
   loop.exec();
@@ -229,15 +240,15 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   loop.exec();
   QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
 
-  // combobox should propose NULL, 10 and 11 because the filter is now:
+  // combobox should propose NULL (if allowNull is true), 10 and 11 because the filter is now:
   // "material" == 'iron'
-  QCOMPARE( w.mComboBox->count(), 3 );
+  QCOMPARE( w.mComboBox->count(), allowNull ? 3 : 2 );
 
   // if there's no filter at all, all features' id should be proposed
   cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "material" ) ) );
   loop.exec();
-  QCOMPARE( w.mComboBox->count(), 4 );
-  QCOMPARE( w.mComboBox->currentText(), QString( "NULL" ) );
+  QCOMPARE( w.mComboBox->count(), allowNull ? 4 : 3 );
+  QCOMPARE( w.mComboBox->currentText(), allowNull ? QString( "NULL" ) : QString( "10" ) );
 }
 
 void TestQgsRelationReferenceWidget::testChainFilterRefreshed()


### PR DESCRIPTION
## Description

Backport of #34943 and #34818, #34581, #34355

All these PRs were about fixing relation reference widget combobox and none of them have been backported until then. I didn't squash commits in order to have the same history than master.

I don't plan to backport this to 3.10 because I don't think it's a good idea to backport so much modifications in LTR. 



