### PR TITLE
add maptip, expression display and eval_template expressions

### DIFF
--- a/resources/function_help/json/display_expression
+++ b/resources/function_help/json/display_expression
@@ -1,0 +1,39 @@
+{
+        "name": "display_expression",
+	"type": "function",
+        "description": "Returns the display expression for a given feature in a layer. If called with no parameters, it evaluates the current feature. The expression is evaluated by default.",
+        "arguments": [
+                {
+                        "arg": "feature",
+                        "optional": true,
+                        "default": "current feature",
+                        "description": "The feature which should be evaluated."
+		},
+                {
+                        "arg": "layer",
+                        "optional": true,
+                        "default": "current layer",
+                        "description": "The layer (or its id or name)."
+                },
+		{
+			"arg": "evaluate",
+                        "description": "If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval' function).",
+			"optional": true,
+			"default": "true"
+		}
+	],
+        "examples": [
+                {
+                        "expression": "display_expression()",
+                        "returns": "The display expression of the current feature."
+                },
+                {
+                        "expression": "display_expression($currentfeature)",
+                        "returns": "The display expression for a given feature."
+		},
+		{
+                        "expression": "display_expression('a_layer_id', $currentfeature, 'False')",
+                        "returns": "The display expression of the current feature not evaluated."
+		}
+	]
+}

--- a/resources/function_help/json/eval_template
+++ b/resources/function_help/json/eval_template
@@ -1,0 +1,13 @@
+{
+	"name": "eval_template",
+	"type": "function",
+	"description": "Evaluates a template which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields.",
+	"arguments": [{
+		"arg": "template",
+		"description": "a template string"
+	}],
+	"examples": [{
+                "expression": "eval_template('QGIS [% upper(\\\\'rocks\\\\') %]')",
+                "returns": "QGIS ROCKS"
+	}]
+}

--- a/resources/function_help/json/maptip
+++ b/resources/function_help/json/maptip
@@ -1,0 +1,39 @@
+{
+	"name": "maptip",
+	"type": "function",
+        "description": "Returns the maptip for a given feature in a layer. If called with no parameters, it evaluates the current feature. The maptip is evaluated by default.",
+        "arguments": [
+            {
+                    "arg": "feature",
+                    "optional": true,
+                    "default": "current feature",
+                    "description": "The feature which should be evaluated."
+            },
+            {
+                    "arg": "layer",
+                    "optional": true,
+                    "default": "current layer",
+                    "description": "The layer (or its id or name)."
+            },
+            {
+                    "arg": "evaluate",
+                    "description": "If the expression must be evaluated. If false, the expression will be returned as a string literal only (which could potentially be later evaluated using the 'eval_template' function).",
+                    "optional": true,
+                    "default": "true"
+            }
+	],
+        "examples": [
+                {
+                        "expression": "maptip()",
+                        "returns": "The maptip of the current feature."
+		},
+                {
+                        "expression": "maptip($currentFeature)",
+                        "returns": "The maptip of the current feature."
+                },
+		{
+			"expression": "maptip('a_layer_id', $currentFeature, 'False')",
+                        "returns": "The maptip of the current feature not evaluated."
+		}
+	]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -272,6 +272,12 @@ static QVariant fcnGetVariable( const QVariantList &values, const QgsExpressionC
   return context->variable( name );
 }
 
+static QVariant fcnEvalTemplate( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QString templateString = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+  return QgsExpression::replaceExpressionText( templateString, context );
+}
+
 static QVariant fcnEval( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   if ( !context )
@@ -1511,6 +1517,96 @@ static QVariant fcnAttributes( const QVariantList &values, const QgsExpressionCo
     result.insert( fields.at( i ).name(), feature.attribute( i ) );
   }
   return result;
+}
+
+static QVariant fcnCoreFeatureMaptipDisplay( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const bool isMaptip )
+{
+  QgsVectorLayer *layer = nullptr;
+  QgsFeature feature;
+  bool evaluate = true;
+
+  if ( values.isEmpty() )
+  {
+    feature = context->feature();
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+  }
+  else if ( values.size() == 1 )
+  {
+    layer = QgsExpressionUtils::getVectorLayer( context->variable( QStringLiteral( "layer" ) ), parent );
+    feature = QgsExpressionUtils::getFeature( values.at( 0 ), parent );
+  }
+  else if ( values.size() == 2 )
+  {
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    feature = QgsExpressionUtils::getFeature( values.at( 1 ), parent );
+  }
+  else if ( values.size() == 3 )
+  {
+    layer = QgsExpressionUtils::getVectorLayer( values.at( 0 ), parent );
+    feature = QgsExpressionUtils::getFeature( values.at( 1 ), parent );
+    evaluate = values.value( 2 ).toBool();
+  }
+  else
+  {
+    if ( isMaptip )
+    {
+      parent->setEvalErrorString( QObject::tr( "Function `maptip` requires no more than three parameters. %1 given." ).arg( values.length() ) );
+    }
+    else
+    {
+      parent->setEvalErrorString( QObject::tr( "Function `display` requires no more than three parameters. %1 given." ).arg( values.length() ) );
+    }
+    return QVariant();
+  }
+
+  if ( !layer )
+  {
+    parent->setEvalErrorString( QObject::tr( "The layer is not valid." ) );
+    return QVariant( );
+  }
+
+  if ( !feature.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "The feature is not valid." ) );
+    return QVariant( );
+  }
+
+  if ( ! evaluate )
+  {
+    if ( isMaptip )
+    {
+      return layer->mapTipTemplate();
+    }
+    else
+    {
+      return layer->displayExpression();
+    }
+  }
+
+  QgsExpressionContext subContext( *context );
+  subContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( layer ) );
+  subContext.setFeature( feature );
+
+  if ( isMaptip )
+  {
+    return QgsExpression::replaceExpressionText( layer->mapTipTemplate(), &subContext );
+  }
+  else
+  {
+    QgsExpression exp( layer->displayExpression() );
+    exp.prepare( &subContext );
+    return exp.evaluate( &subContext ).toString();
+  }
+}
+
+static QVariant fcnFeatureDisplayExpression( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  return fcnCoreFeatureMaptipDisplay( values, context, parent, false );
+}
+
+static QVariant fcnFeatureMaptip( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  return fcnCoreFeatureMaptipDisplay( values, context, parent, true );
 }
 
 static QVariant fcnIsSelected( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -5903,6 +5999,30 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "attributes" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "feature" ), true ),
                                             fcnAttributes, QStringLiteral( "Record and Attributes" ), QString(), false, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES );
 
+    QgsStaticExpressionFunction *maptipFunc = new QgsStaticExpressionFunction(
+      QStringLiteral( "maptip" ),
+      -1,
+      fcnFeatureMaptip,
+      QStringLiteral( "Record and Attributes" ),
+      QString(),
+      false,
+      QSet<QString>()
+    );
+    maptipFunc->setIsStatic( false );
+    functions << maptipFunc;
+
+    QgsStaticExpressionFunction *displayFunc = new QgsStaticExpressionFunction(
+      QStringLiteral( "display_expression" ),
+      -1,
+      fcnFeatureDisplayExpression,
+      QStringLiteral( "Record and Attributes" ),
+      QString(),
+      false,
+      QSet<QString>()
+    );
+    displayFunc->setIsStatic( false );
+    functions << displayFunc;
+
     QgsStaticExpressionFunction *isSelectedFunc = new QgsStaticExpressionFunction(
       QStringLiteral( "is_selected" ),
       -1,
@@ -6015,6 +6135,9 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
 
     functions
         << varFunction;
+
+    functions << new QgsStaticExpressionFunction( QStringLiteral( "eval_template" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "template" ) ), fcnEvalTemplate, QStringLiteral( "General" ), QString(), true );
+
     QgsStaticExpressionFunction *evalFunc = new QgsStaticExpressionFunction( QStringLiteral( "eval" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "expression" ) ), fcnEval, QStringLiteral( "General" ), QString(), true, QSet<QString>() << QgsFeatureRequest::ALL_ATTRIBUTES );
     evalFunc->setIsStaticFunction(
       []( const QgsExpressionNodeFunction * node, QgsExpression * parent, const QgsExpressionContext * context )


### PR DESCRIPTION
## Description

Expose the display expression and the maptip in expressions.

This is useful if we don't want to copy/paste the maptip in the composer when we generate an atlas.

By default, these are evaluated. But we can choose to not evaluate the expression, so it can be modified on runtime (search and replace, remove first line...).
In this case, we need to use the `eval` function. For the maptip, as it's a template with `[% ... %]`, I needed to add `eval_template`. 

Expressions added:

```
eval_template
display_expression
maptip
```

Previous PR https://github.com/qgis/QGIS/pull/32630 closed by stalebot
