### PR TITLE
Fixed two typos

### DIFF
--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -68,11 +68,11 @@ class QgsMesh3dAveragingMethod;
  *      "3.0, 2.0 \n" \
  *      "2.0, 3.0 \n" \
  *      "1.0, 3.0 \n" \
- *      "---"
+ *      "---" \
  *      "0, 1, 3, 4 \n" \
  *      "1, 2, 3 \n"
  *    );
- *    QgsMeshLayer *scratchLayer = new QgsMeshLayer(uri, "My Scratch layer", "memory_mesh");
+ *    QgsMeshLayer *scratchLayer = new QgsMeshLayer(uri, "My Scratch layer", "mesh_memory");
  * \endcode
  *
  * \subsection mdal MDAL data provider (mdal)


### PR DESCRIPTION
## Description

Since this is also used to the python documentation the average user might fail copying the example.
