### PR TITLE
Fix absolute paths in qlr export (bug #27497)

### DIFF
--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -211,7 +211,7 @@ bool QgsLayerDefinition::exportLayerDefinition( QString path, const QList<QgsLay
 
   QgsReadWriteContext context;
   bool writeAbsolutePath = QgsProject::instance()->readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
-  context.setPathResolver( QgsPathResolver( writeAbsolutePath ? QStringLiteral( "" ) : path ) );
+  context.setPathResolver( QgsPathResolver( writeAbsolutePath ? QString() : path ) );
 
   QDomDocument doc( QStringLiteral( "qgis-layer-definition" ) );
   if ( !exportLayerDefinition( doc, selectedTreeNodes, errorMessage, context ) )

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -210,7 +210,8 @@ bool QgsLayerDefinition::exportLayerDefinition( QString path, const QList<QgsLay
   }
 
   QgsReadWriteContext context;
-  context.setPathResolver( QgsPathResolver( path ) );
+  bool writeAbsolutePath = QgsProject::instance()->readBoolEntry( QStringLiteral( "Paths" ), QStringLiteral( "/Absolute" ), false );
+  context.setPathResolver( QgsPathResolver( writeAbsolutePath ? QStringLiteral( "" ) : path ) );
 
   QDomDocument doc( QStringLiteral( "qgis-layer-definition" ) );
   if ( !exportLayerDefinition( doc, selectedTreeNodes, errorMessage, context ) )


### PR DESCRIPTION
Even if 'save absolute paths' is selected in the project properties, the qlr-export does not export an absolute path. This PR provides a fix
See https://github.com/qgis/QGIS/issues/27497