### PR TITLE
Responses are object instead of array in the {root}/api json document

### DIFF
--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1031,9 +1031,13 @@ json QgsWfs3CollectionsItemsHandler::schema( const QgsServerApiContext &context 
                 "201", {
                   { "description", "A new feature was successfully added to the collection" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
                 }
@@ -1963,12 +1967,16 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                 "200", {
                   { "description", "The feature was successfully updated" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
-                }
+                },
               },
               { "default", defaultResponse() }
             }
@@ -1987,12 +1995,16 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                 "200", {
                   { "description", "The feature was successfully updated" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
-                }
+                },
               },
               { "default", defaultResponse() }
             }
@@ -2011,9 +2023,13 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                 "201", {
                   { "description", "The feature was successfully deleted from the collection" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
                 }

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -782,40 +782,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -827,40 +819,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -915,40 +899,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -957,40 +933,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1151,40 +1119,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -1196,40 +1156,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1284,40 +1236,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -1326,40 +1270,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1520,40 +1456,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -1565,40 +1493,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1653,40 +1573,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -1695,40 +1607,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1889,40 +1793,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer20150528120452665_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -1934,40 +1830,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -2022,40 +1910,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -2064,40 +1944,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",


### PR DESCRIPTION
## Description

This PR fixes an error in the `apiDefinitionValidation` test within the OGC API Feature testsuite:

``` bash
java.lang.AssertionError: Landing Page is not valid. Found following validation items: 

- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object 
- ERROR: Incorrect JSON value type: Array; allowed types: Object
```