### PR TITLE
Ensure expected button order in QgsProcessingAlgorithmDialogBase

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -75,11 +75,6 @@ Returns the main widget for the dialog, usually a panel for configuring algorith
 Switches the dialog to the log page.
 %End
 
-    void showParameters();
-%Docstring
-Switches the dialog to the parameters page.
-%End
-
     bool wasExecuted() const;
 %Docstring
 Returns ``True`` if an algorithm was executed in the dialog.
@@ -187,6 +182,11 @@ Copies the current log contents to the clipboard.
 .. versionadded:: 3.2
 %End
 
+    void showParameters();
+%Docstring
+Switches the dialog to the parameters page.
+%End
+
   protected:
 
     virtual void closeEvent( QCloseEvent *e );
@@ -235,7 +235,6 @@ Sets whether the algorithm was executed through the dialog.
 %Docstring
 Sets whether the algorithm was executed through the dialog (no matter the result).
 %End
-
 
     void setResults( const QVariantMap &results );
 %Docstring

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -95,20 +95,20 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
   mSplitterState = splitter->saveState();
   splitterChanged( 0, 0 );
 
-  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsProcessingAlgorithmDialogBase::closeClicked );
-  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsProcessingAlgorithmDialogBase::runAlgorithm );
-
   // Rename OK button to Run
   mButtonRun = mButtonBox->button( QDialogButtonBox::Ok );
   mButtonRun->setText( tr( "Run" ) );
 
+  // Rename Yes button. Yes is used to ensure same position of Run and Change Parameters with respect to Close button.
+  mButtonChangeParameters = mButtonBox->button( QDialogButtonBox::Yes );
+  mButtonChangeParameters->setText( tr( "Change Parameters" ) );
+
   buttonCancel->setEnabled( false );
   mButtonClose = mButtonBox->button( QDialogButtonBox::Close );
 
-  mButtonChangeParameters = new QPushButton( tr( "Change Parameters" ) );
-  mButtonBox->addButton( mButtonChangeParameters, QDialogButtonBox::ActionRole );
-
+  connect( mButtonRun, &QPushButton::clicked, this, &QgsProcessingAlgorithmDialogBase::runAlgorithm );
   connect( mButtonChangeParameters, &QPushButton::clicked, this, &QgsProcessingAlgorithmDialogBase::showParameters );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QgsProcessingAlgorithmDialogBase::closeClicked );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsProcessingAlgorithmDialogBase::openHelp );
   connect( mButtonCollapse, &QToolButton::clicked, this, &QgsProcessingAlgorithmDialogBase::toggleCollapsed );
   connect( splitter, &QSplitter::splitterMoved, this, &QgsProcessingAlgorithmDialogBase::splitterChanged );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -69,7 +69,6 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
     void pushDebugInfo( const QString &info ) override;
     void pushConsoleInfo( const QString &info ) override;
 
-
 };
 #endif
 
@@ -132,11 +131,6 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * Switches the dialog to the log page.
      */
     void showLog();
-
-    /**
-     * Switches the dialog to the parameters page.
-     */
-    void showParameters();
 
     /**
      * Returns TRUE if an algorithm was executed in the dialog.
@@ -235,6 +229,11 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      */
     void copyLogToClipboard();
 
+    /**
+     * Switches the dialog to the parameters page.
+     */
+    void showParameters();
+
   protected:
 
     void closeEvent( QCloseEvent *e ) override;
@@ -280,7 +279,6 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * Sets whether the algorithm was executed through the dialog (no matter the result).
      */
     void setExecutedAnyResult( bool executedAnyResult );
-
 
     /**
      * Sets the algorithm results.

--- a/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
+++ b/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
@@ -211,7 +211,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::Yes</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Description

Follow up #34928 
Fix https://github.com/qgis/QGIS/pull/34928#issuecomment-601477165

**Rationale:** 

Wrong position was caused by using an `ActionRole` for `Change Parameters` button. Now, we use the `YesRole`, which is always in the same side as `Run` (`AcceptRole`) with respect to `Close` (`RejectRole`). Source: [qtbase](https://github.com/meta-qt5/qtbase/blob/9a0b9b4a12d29f27eca1f079f6a3c6cf5c9af7c9/src/widgets/widgets/qdialogbuttonbox.cpp#L213-L233)