### PR TITLE
Enable snapping to grid for models in designer

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -108,11 +108,6 @@ Shows a preview of moving the item from its stored position by ``dx``, ``dy``.
 Sets a new scene ``rect`` for the item.
 %End
 
-    QRectF previewItemRectChange( QRectF rect );
-%Docstring
-Shows a preview of setting a new ``rect`` for the item.
-%End
-
     virtual void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event );
 
     virtual void hoverEnterEvent( QGraphicsSceneHoverEvent *event );

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -96,6 +96,11 @@ Returns list of selected component items.
 Returns the topmost component item at a specified ``position``.
 %End
 
+    void selectAll();
+%Docstring
+Selects all the components in the scene.
+%End
+
     void deselectAll();
 %Docstring
 Clears any selected items in the scene.

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -80,6 +80,13 @@ Starts a macro command, containing a group of interactions in the view.
 Ends a macro command, containing a group of interactions in the view.
 %End
 
+  public slots:
+
+    void snapSelected();
+%Docstring
+Snaps the selected items to the grid.
+%End
+
   signals:
 
     void algorithmDropped( const QString &algorithmId, const QPointF &pos );

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -128,22 +128,29 @@ void QgsModelComponentGraphicItem::previewItemMove( qreal dx, qreal dy )
   emit updateArrowPaths();
 }
 
-void QgsModelComponentGraphicItem::setItemRect( QRectF )
+void QgsModelComponentGraphicItem::setItemRect( QRectF rect )
 {
-  mComponent->setPosition( pos() );
+  rect = rect.normalized();
+
+  if ( rect.width() < MIN_COMPONENT_WIDTH )
+    rect.setWidth( MIN_COMPONENT_WIDTH );
+  if ( rect.height() < MIN_COMPONENT_HEIGHT )
+    rect.setHeight( MIN_COMPONENT_HEIGHT );
+
+  setPos( rect.center() );
   prepareGeometryChange();
-  mComponent->setSize( mTempSize );
-  mTempSize = QSizeF();
 
   emit aboutToChange( tr( "Resize %1" ).arg( mComponent->description() ) );
+
+  mComponent->setPosition( pos() );
+  mComponent->setSize( rect.size() );
   updateStoredComponentPosition( pos(), mComponent->size() );
 
   updateButtonPositions();
-
   emit changed();
 
-  emit sizePositionChanged();
   emit updateArrowPaths();
+  emit sizePositionChanged();
 }
 
 QRectF QgsModelComponentGraphicItem::previewItemRectChange( QRectF rect )
@@ -164,6 +171,24 @@ QRectF QgsModelComponentGraphicItem::previewItemRectChange( QRectF rect )
   emit updateArrowPaths();
 
   return rect;
+}
+
+void QgsModelComponentGraphicItem::finalizePreviewedItemRectChange( QRectF )
+{
+  mComponent->setPosition( pos() );
+  prepareGeometryChange();
+  mComponent->setSize( mTempSize );
+  mTempSize = QSizeF();
+
+  emit aboutToChange( tr( "Resize %1" ).arg( mComponent->description() ) );
+  updateStoredComponentPosition( pos(), mComponent->size() );
+
+  updateButtonPositions();
+
+  emit changed();
+
+  emit sizePositionChanged();
+  emit updateArrowPaths();
 }
 
 void QgsModelComponentGraphicItem::modelHoverEnterEvent( QgsModelViewMouseEvent *event )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -130,12 +130,17 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void setItemRect( QRectF rect );
 
+#ifndef SIP_RUN
+
     /**
      * Shows a preview of setting a new \a rect for the item.
      */
     QRectF previewItemRectChange( QRectF rect );
 
-#ifndef SIP_RUN
+    /**
+     * Sets a new scene \a rect for the item.
+     */
+    void finalizePreviewedItemRectChange( QRectF rect );
 
     /**
      * Handles a model hover enter \a event.
@@ -359,7 +364,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     QgsModelDesignerFlatButtonGraphicItem *mDeleteButton = nullptr;
 
     static constexpr double MIN_COMPONENT_WIDTH = 70;
-    static constexpr double MIN_COMPONENT_HEIGHT = 50;
+    static constexpr double MIN_COMPONENT_HEIGHT = 30;
 
     static constexpr double DEFAULT_BUTTON_WIDTH = 16;
     static constexpr double DEFAULT_BUTTON_HEIGHT = 16;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -134,7 +134,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
   connect( mActionSnapSelected, &QAction::triggered, mView, &QgsModelGraphicsView::snapSelected );
 
-  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), true ).toBool() );
+  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), false ).toBool() );
   connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
   {
     mView->snapper()->setSnapToGrid( enabled );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -118,6 +118,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mainLayout->insertWidget( 0, mMessageBar );
 
   mView->setAcceptDrops( true );
+  QgsSettings settings;
 
   connect( mActionClose, &QAction::triggered, this, &QWidget::close );
   connect( mActionZoomIn, &QAction::triggered, this, &QgsModelDesignerDialog::zoomIn );
@@ -131,6 +132,14 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionSave, &QAction::triggered, this, [ = ] { saveModel( false ); } );
   connect( mActionSaveAs, &QAction::triggered, this, [ = ] { saveModel( true ); } );
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
+
+  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), true ).toBool() );
+  connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
+  {
+    mView->snapper()->setSnapToGrid( enabled );
+    QgsSettings().setValue( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), enabled );
+  } );
+  mView->snapper()->setSnapToGrid( mActionSnappingEnabled->isChecked() );
 
   mUndoAction = mUndoStack->createUndoAction( this );
   mUndoAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionUndo.svg" ) ) );
@@ -146,7 +155,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mToolbar->insertAction( mActionZoomIn, mRedoAction );
   mToolbar->insertSeparator( mActionZoomIn );
 
-  QgsSettings settings;
+
   QgsProcessingToolboxProxyModel::Filters filters = QgsProcessingToolboxProxyModel::FilterModeler;
   if ( settings.value( QStringLiteral( "Processing/Configuration/SHOW_ALGORITHMS_KNOWN_ISSUES" ), false ).toBool() )
   {

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -142,6 +142,11 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   } );
   mView->snapper()->setSnapToGrid( mActionSnappingEnabled->isChecked() );
 
+  connect( mActionSelectAll, &QAction::triggered, this, [ = ]
+  {
+    mScene->selectAll();
+  } );
+
   mUndoAction = mUndoStack->createUndoAction( this );
   mUndoAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionUndo.svg" ) ) );
   mUndoAction->setShortcuts( QKeySequence::Undo );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -132,12 +132,13 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionSave, &QAction::triggered, this, [ = ] { saveModel( false ); } );
   connect( mActionSaveAs, &QAction::triggered, this, [ = ] { saveModel( true ); } );
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
+  connect( mActionSnapSelected, &QAction::triggered, mView, &QgsModelGraphicsView::snapSelected );
 
-  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), true ).toBool() );
+  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), true ).toBool() );
   connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
   {
     mView->snapper()->setSnapToGrid( enabled );
-    QgsSettings().setValue( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), enabled );
+    QgsSettings().setValue( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), enabled );
   } );
   mView->snapper()->setSnapToGrid( mActionSnappingEnabled->isChecked() );
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -222,6 +222,23 @@ QgsModelComponentGraphicItem *QgsModelGraphicsScene::componentItemAt( QPointF po
   return nullptr;
 }
 
+void QgsModelGraphicsScene::selectAll()
+{
+  //select all items in scene
+  QgsModelComponentGraphicItem *focusedItem = nullptr;
+  const QList<QGraphicsItem *> itemList = items();
+  for ( QGraphicsItem *graphicsItem : itemList )
+  {
+    if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( graphicsItem ) )
+    {
+      componentItem->setSelected( true );
+      if ( !focusedItem )
+        focusedItem = componentItem;
+    }
+  }
+  emit selectedItemChanged( focusedItem );
+}
+
 void QgsModelGraphicsScene::deselectAll()
 {
   //we can't use QGraphicsScene::clearSelection, as that emits no signals

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -107,6 +107,11 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     QgsModelComponentGraphicItem *componentItemAt( QPointF position ) const;
 
     /**
+     * Selects all the components in the scene.
+     */
+    void selectAll();
+
+    /**
      * Clears any selected items in the scene.
      *
      * Call this method rather than QGraphicsScene::clearSelection, as the latter does

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -439,9 +439,9 @@ void QgsModelGraphicsView::snapSelected()
 {
   QgsModelGraphicsScene *s = modelScene();
   const QList<QgsModelComponentGraphicItem *> itemList = s->selectedComponentItems();
+  startMacroCommand( tr( "Snap Items" ) );
   if ( !itemList.empty() )
   {
-    itemList.at( 0 )->aboutToChange( tr( "Snap Items" ) );
     bool prevSetting = mSnapper.snapToGrid();
     mSnapper.setSnapToGrid( true );
     for ( QgsModelComponentGraphicItem *item : itemList )
@@ -454,8 +454,8 @@ void QgsModelGraphicsView::snapSelected()
       }
     }
     mSnapper.setSnapToGrid( prevSetting );
-    itemList.at( 0 )->changed();
   }
+  endMacroCommand();
 }
 
 

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -435,6 +435,29 @@ void QgsModelGraphicsView::endMacroCommand()
   emit macroCommandEnded();
 }
 
+void QgsModelGraphicsView::snapSelected()
+{
+  QgsModelGraphicsScene *s = modelScene();
+  const QList<QgsModelComponentGraphicItem *> itemList = s->selectedComponentItems();
+  if ( !itemList.empty() )
+  {
+    itemList.at( 0 )->aboutToChange( tr( "Snap Items" ) );
+    bool prevSetting = mSnapper.snapToGrid();
+    mSnapper.setSnapToGrid( true );
+    for ( QgsModelComponentGraphicItem *item : itemList )
+    {
+      bool wasSnapped = false;
+      QRectF snapped = mSnapper.snapRectWithResize( item->mapRectToScene( item->itemRect( ) ), transform().m11(), wasSnapped );
+      if ( wasSnapped )
+      {
+        item->setItemRect( snapped );
+      }
+    }
+    mSnapper.setSnapToGrid( prevSetting );
+    itemList.at( 0 )->changed();
+  }
+}
+
 
 QgsModelViewSnapMarker::QgsModelViewSnapMarker()
   : QGraphicsRectItem( QRectF( 0, 0, 0, 0 ) )

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -110,6 +110,13 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      */
     void endMacroCommand();
 
+  public slots:
+
+    /**
+     * Snaps the selected items to the grid.
+     */
+    void snapSelected();
+
   signals:
 
     /**

--- a/src/gui/processing/models/qgsmodelsnapper.cpp
+++ b/src/gui/processing/models/qgsmodelsnapper.cpp
@@ -21,7 +21,7 @@
 QgsModelSnapper::QgsModelSnapper()
 {
   QgsSettings s;
-  mTolerance = s.value( QStringLiteral( "LayoutDesigner/defaultSnapTolerancePixels" ), 5, QgsSettings::Gui ).toInt();
+  mTolerance = s.value( QStringLiteral( "/Processing/modelDesignerSnapTolerancePixels" ), 20 ).toInt();
 }
 
 void QgsModelSnapper::setSnapTolerance( const int snapTolerance )
@@ -34,19 +34,19 @@ void QgsModelSnapper::setSnapToGrid( bool enabled )
   mSnapToGrid = enabled;
 }
 
-QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &snapped ) const
+QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &snapped, bool snapHorizontal, bool snapVertical ) const
 {
   snapped = false;
 
   bool snappedXToGrid = false;
   bool snappedYToGrid = false;
   QPointF res = snapPointToGrid( point, scaleFactor, snappedXToGrid, snappedYToGrid );
-  if ( snappedXToGrid )
+  if ( snappedXToGrid && snapVertical )
   {
     snapped = true;
     point.setX( res.x() );
   }
-  if ( snappedYToGrid )
+  if ( snappedYToGrid && snapHorizontal )
   {
     snapped = true;
     point.setY( res.y() );
@@ -55,7 +55,7 @@ QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &sna
   return point;
 }
 
-QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &snapped ) const
+QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &snapped, bool snapHorizontal, bool snapVertical ) const
 {
   snapped = false;
   QRectF snappedRect = rect;
@@ -70,12 +70,12 @@ QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &
   QList< QPointF > points;
   points << rect.topLeft() << rect.topRight() << rect.bottomLeft() << rect.bottomRight();
   QPointF res = snapPointsToGrid( points, scaleFactor, snappedXToGrid, snappedYToGrid );
-  if ( snappedXToGrid )
+  if ( snappedXToGrid && snapVertical )
   {
     snapped = true;
     snappedRect.translate( res.x(), 0 );
   }
-  if ( snappedYToGrid )
+  if ( snappedYToGrid && snapHorizontal )
   {
     snapped = true;
     snappedRect.translate( 0, res.y() );
@@ -111,7 +111,7 @@ QPointF QgsModelSnapper::snapPointsToGrid( const QList<QPointF> &points, double 
   for ( QPointF point : points )
   {
     //snap x coordinate
-    double gridRes = 10; //mLayout->convertToLayoutUnits( grid.resolution() );
+    double gridRes = 30; //mLayout->convertToLayoutUnits( grid.resolution() );
     int xRatio = static_cast< int >( ( point.x() ) / gridRes + 0.5 ); //NOLINT
     int yRatio = static_cast< int >( ( point.y() ) / gridRes + 0.5 ); //NOLINT
 

--- a/src/gui/processing/models/qgsmodelsnapper.cpp
+++ b/src/gui/processing/models/qgsmodelsnapper.cpp
@@ -21,7 +21,7 @@
 QgsModelSnapper::QgsModelSnapper()
 {
   QgsSettings s;
-  mTolerance = s.value( QStringLiteral( "/Processing/modelDesignerSnapTolerancePixels" ), 20 ).toInt();
+  mTolerance = s.value( QStringLiteral( "/Processing/Modeler/snapTolerancePixels" ), 40 ).toInt();
 }
 
 void QgsModelSnapper::setSnapTolerance( const int snapTolerance )
@@ -60,11 +60,6 @@ QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &
   snapped = false;
   QRectF snappedRect = rect;
 
-  QList< double > xCoords;
-  xCoords << rect.left() << rect.center().x() << rect.right();
-  QList< double > yCoords;
-  yCoords << rect.top() << rect.center().y() << rect.bottom();
-
   bool snappedXToGrid = false;
   bool snappedYToGrid = false;
   QList< QPointF > points;
@@ -79,6 +74,39 @@ QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &
   {
     snapped = true;
     snappedRect.translate( 0, res.y() );
+  }
+
+  return snappedRect;
+}
+
+QRectF QgsModelSnapper::snapRectWithResize( const QRectF &rect, double scaleFactor, bool &snapped, bool snapHorizontal, bool snapVertical ) const
+{
+  snapped = false;
+  QRectF snappedRect = rect;
+
+  bool snappedXToGrid = false;
+  bool snappedYToGrid = false;
+  QPointF res = snapPointsToGrid( QList< QPointF >() << rect.topLeft(), scaleFactor, snappedXToGrid, snappedYToGrid );
+  if ( snappedXToGrid && snapVertical )
+  {
+    snapped = true;
+    snappedRect.setLeft( snappedRect.left() + res.x() );
+  }
+  if ( snappedYToGrid && snapHorizontal )
+  {
+    snapped = true;
+    snappedRect.setTop( snappedRect.top() + res.y() );
+  }
+  res = snapPointsToGrid( QList< QPointF >() << rect.bottomRight(), scaleFactor, snappedXToGrid, snappedYToGrid );
+  if ( snappedXToGrid && snapVertical )
+  {
+    snapped = true;
+    snappedRect.setRight( snappedRect.right() + res.x() );
+  }
+  if ( snappedYToGrid && snapHorizontal )
+  {
+    snapped = true;
+    snappedRect.setBottom( snappedRect.bottom() + res.y() );
   }
 
   return snappedRect;

--- a/src/gui/processing/models/qgsmodelsnapper.h
+++ b/src/gui/processing/models/qgsmodelsnapper.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsModelSnapper
 
      * \see snapRect()
      */
-    QPointF snapPoint( QPointF point, double scaleFactor, bool &snapped SIP_OUT ) const;
+    QPointF snapPoint( QPointF point, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
 
     /**
      * Snaps a layout coordinate \a rect. If \a rect was snapped, \a snapped will be set to TRUE.
@@ -101,7 +101,7 @@ class GUI_EXPORT QgsModelSnapper
      *
      * \see snapPoint()
      */
-    QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT ) const;
+    QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
 
     /**
      * Snaps a layout coordinate \a point to the grid. If \a point

--- a/src/gui/processing/models/qgsmodelsnapper.h
+++ b/src/gui/processing/models/qgsmodelsnapper.h
@@ -104,6 +104,24 @@ class GUI_EXPORT QgsModelSnapper
     QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
 
     /**
+     * Snaps a layout coordinate \a rect. If \a rect was snapped, \a snapped will be set to TRUE.
+     *
+     * The \a scaleFactor argument should be set to the transformation from
+     * scalar transform from layout coordinates to pixels, i.e. the
+     * graphics view transform().m11() value.
+     *
+     * This method considers snapping to the grid, snap lines, etc.
+     *
+     * If the \a horizontalSnapLine and \a verticalSnapLine arguments are specified, then the snapper
+     * will automatically display and position these lines to indicate snapping positions to item bounds.
+     *
+     * A list of items to ignore during the snapping can be specified via the \a ignoreItems list.
+     *
+     * \see snapPoint()
+     */
+    QRectF snapRectWithResize( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
+
+    /**
      * Snaps a layout coordinate \a point to the grid. If \a point
      * was snapped horizontally, \a snappedX will be set to TRUE. If \a point
      * was snapped vertically, \a snappedY will be set to TRUE.

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -137,7 +137,7 @@ void QgsModelViewMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
   if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
   {
-    componentItem->setItemRect( rect );
+    componentItem->finalizePreviewedItemRectChange( rect );
   }
 }
 
@@ -164,13 +164,10 @@ QPointF QgsModelViewMouseHandles::snapPoint( QPointF originalPoint, QgsGraphicsV
 {
   bool snapped = false;
 
-  //depending on the mode, we either snap just the single point, or all the bounds of the selection
   QPointF snappedPoint;
   switch ( mode )
   {
     case Item:
-      snappedPoint = mView->snapper()->snapRect( rect().translated( originalPoint ), mView->transform().m11(), snapped, snapHorizontal, snapVertical ).topLeft();
-      break;
     case Point:
       snappedPoint = mView->snapper()->snapPoint( originalPoint, mView->transform().m11(), snapped, snapHorizontal, snapVertical );
       break;

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -160,5 +160,24 @@ void QgsModelViewMouseHandles::endMacroCommand()
   mView->endMacroCommand();
 }
 
+QPointF QgsModelViewMouseHandles::snapPoint( QPointF originalPoint, QgsGraphicsViewMouseHandles::SnapGuideMode mode, bool snapHorizontal, bool snapVertical )
+{
+  bool snapped = false;
+
+  //depending on the mode, we either snap just the single point, or all the bounds of the selection
+  QPointF snappedPoint;
+  switch ( mode )
+  {
+    case Item:
+      snappedPoint = mView->snapper()->snapRect( rect().translated( originalPoint ), mView->transform().m11(), snapped, snapHorizontal, snapVertical ).topLeft();
+      break;
+    case Point:
+      snappedPoint = mView->snapper()->snapPoint( originalPoint, mView->transform().m11(), snapped, snapHorizontal, snapVertical );
+      break;
+  }
+
+  return snapped ? snappedPoint : originalPoint;
+}
+
 
 ///@endcond PRIVATE

--- a/src/gui/processing/models/qgsmodelviewmousehandles.h
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.h
@@ -65,6 +65,7 @@ class GUI_EXPORT QgsModelViewMouseHandles: public QgsGraphicsViewMouseHandles
     QRectF previewSetItemRect( QGraphicsItem *item, QRectF rect ) override;
     void startMacroCommand( const QString &text ) override;
     void endMacroCommand() override;
+    QPointF snapPoint( QPointF originalPoint, SnapGuideMode mode, bool snapHorizontal = true, bool snapVertical = true ) override;
 
   public slots:
 

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -80,6 +80,8 @@
     <addaction name="mActionZoomToItems"/>
     <addaction name="separator"/>
     <addaction name="mActionShowComments"/>
+    <addaction name="separator"/>
+    <addaction name="mActionSnappingEnabled"/>
    </widget>
    <widget class="QMenu" name="mMenuEdit">
     <property name="title">
@@ -608,6 +610,14 @@
    </property>
    <property name="shortcut">
     <string>Del</string>
+   </property>
+  </action>
+  <action name="mActionSnappingEnabled">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Snapping</string>
    </property>
   </action>
  </widget>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -88,6 +88,8 @@
      <string>&amp;Edit</string>
     </property>
     <addaction name="mActionDeleteComponents"/>
+    <addaction name="separator"/>
+    <addaction name="mActionSnapSelected"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
@@ -159,7 +161,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>98</height>
+          <height>97</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout">
@@ -249,7 +251,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>152</height>
+          <height>153</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -618,6 +620,11 @@
    </property>
    <property name="text">
     <string>Enable Snapping</string>
+   </property>
+  </action>
+  <action name="mActionSnapSelected">
+   <property name="text">
+    <string>Snap Selected Components to Grid</string>
    </property>
   </action>
  </widget>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -87,9 +87,11 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <addaction name="mActionSelectAll"/>
+    <addaction name="mActionSnapSelected"/>
+    <addaction name="separator"/>
     <addaction name="mActionDeleteComponents"/>
     <addaction name="separator"/>
-    <addaction name="mActionSnapSelected"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
@@ -625,6 +627,18 @@
   <action name="mActionSnapSelected">
    <property name="text">
     <string>Snap Selected Components to Grid</string>
+   </property>
+  </action>
+  <action name="mActionSelectAll">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSelectAll.svg</normaloff>:/images/themes/default/mActionSelectAll.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select All</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This PR implements two "snapping" features in the Processing model designer:

1. Users can enable a new "Enable Snapping" option from the view menu, which will cause all component moving or resizing operations to automatically snap to grids

2. After selecting some components, users can select Edit -> Snap Selected Components to Grid to manually snap just those selected components.

Additionally, I've added a helpful "select all" action for quickly selecting all components in a model.

Refs NRCan Contract#3000707093