### PR TITLE
[Symbology][Feature] Allow centroid fill markers to be clipped within polygon

### DIFF
--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -2183,6 +2183,8 @@ Caller takes ownership of the returned symbol layer.
 %Docstring
 Sets whether a point is drawn for all parts or only on the biggest part of multi-part features.
 
+.. seealso:: :py:func:`pointOnAllParts`
+
 .. versionadded:: 2.16
 %End
 
@@ -2190,10 +2192,62 @@ Sets whether a point is drawn for all parts or only on the biggest part of multi
 %Docstring
 Returns whether a point is drawn for all parts or only on the biggest part of multi-part features.
 
+.. seealso:: :py:func:`setPointOnAllParts`
+
 .. versionadded:: 2.16
 %End
 
+    bool clipPoints() const;
+%Docstring
+Returns ``True`` if point markers should be clipped to the polygon boundary.
+
+.. seealso:: :py:func:`setClipPoints`
+
+.. versionadded:: 3.14
+%End
+
+    void setClipPoints( bool clipPoints );
+%Docstring
+Sets whether point markers should be ``clipped`` to the polygon boundary.
+
+.. seealso:: :py:func:`clipPoints`
+
+.. versionadded:: 3.14
+%End
+
+    bool clipOnCurrentPartOnly() const;
+%Docstring
+Returns ``True`` if point markers should be clipped to the current part boundary only.
+
+.. seealso:: :py:func:`setClipPoints`
+
+.. versionadded:: 3.14
+%End
+
+    void setClipOnCurrentPartOnly( bool clipOnCurrentPartOnly );
+%Docstring
+Sets whether point markers should be ``clipped`` to the current part boundary only.
+
+.. seealso:: :py:func:`clipOnCurrentPartOnly`
+
+.. versionadded:: 3.14
+%End
+
+    virtual void startFeatureRender( const QgsFeature &feature, QgsRenderContext &context );
+
+    virtual void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context );
+
+
   protected:
+    struct Part
+    {
+      QPolygonF exterior;
+      QList<QPolygonF> rings;
+    };
+
+    void render( QgsRenderContext &context, const QVector<Part> &parts, const QgsFeature &feature, bool selected );
+
+
 
 
   private:

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -2239,13 +2239,6 @@ Sets whether point markers should be ``clipped`` to the current part boundary on
 
 
   protected:
-    struct Part
-    {
-      QPolygonF exterior;
-      QList<QPolygonF> rings;
-    };
-
-    void render( QgsRenderContext &context, const QVector<Part> &parts, const QgsFeature &feature, bool selected );
 
 
 

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -706,7 +706,7 @@ Determines an SVG symbol's name from its ``path``.
 Calculate the centroid point of a QPolygonF
 %End
 
-    static QPointF polygonPointOnSurface( const QPolygonF &points, QList<QPolygonF> *rings = 0 );
+    static QPointF polygonPointOnSurface( const QPolygonF &points, const QList<QPolygonF> *rings = 0 );
 %Docstring
 Calculate a point on the surface of a QPolygonF
 %End

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -108,11 +108,6 @@ Shows a preview of moving the item from its stored position by ``dx``, ``dy``.
 Sets a new scene ``rect`` for the item.
 %End
 
-    QRectF previewItemRectChange( QRectF rect );
-%Docstring
-Shows a preview of setting a new ``rect`` for the item.
-%End
-
     virtual void mouseDoubleClickEvent( QGraphicsSceneMouseEvent *event );
 
     virtual void hoverEnterEvent( QGraphicsSceneHoverEvent *event );

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -96,6 +96,11 @@ Returns list of selected component items.
 Returns the topmost component item at a specified ``position``.
 %End
 
+    void selectAll();
+%Docstring
+Selects all the components in the scene.
+%End
+
     void deselectAll();
 %Docstring
 Clears any selected items in the scene.

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsview.sip.in
@@ -80,6 +80,13 @@ Starts a macro command, containing a group of interactions in the view.
 Ends a macro command, containing a group of interactions in the view.
 %End
 
+  public slots:
+
+    void snapSelected();
+%Docstring
+Snaps the selected items to the grid.
+%End
+
   signals:
 
     void algorithmDropped( const QString &algorithmId, const QPointF &pos );

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -16,14 +16,16 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QFont>
+#include <QStyle>
+
 #include "qgisappstylesheet.h"
 #include "qgsapplication.h"
 #include "qgisapp.h"
+#include "qgsproxystyle.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
 
-#include <QFont>
-#include <QStyle>
 
 QgisAppStyleSheet::QgisAppStyleSheet( QObject *parent )
   : QObject( parent )
@@ -106,17 +108,23 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
   if ( fontSize != defaultSize || fontFamily != defaultFamily )
     ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( fontSize, fontFamily );
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 2)
   // Fix for macOS Qt 5.9+, where close boxes do not show on document mode tab bar tabs
-  // See: https://bugreports.qt.io/browse/QTBUG-61092
-  //      https://bugreports.qt.io/browse/QTBUG-61742
+  // See: https://bugreports.qt.io/browse/QTBUG-61092 => fixed in 5.12.2 / 5.14
+  //      https://bugreports.qt.io/browse/QTBUG-61742 => fixed in 5.9.2
   // Setting any stylesheet makes the default close button disappear.
   // Specifically setting a custom close button temporarily works around issue.
-  // TODO: Remove when regression is fixed (Qt 5.9.3 or 5.10?); though hard to tell,
-  //       since we are overriding the default close button image now.
   if ( mMacStyle )
   {
     ss += QLatin1String( "QTabBar::close-button{ image: url(:/images/themes/default/mIconCloseTab.svg); }" );
     ss += QLatin1String( "QTabBar::close-button:hover{ image: url(:/images/themes/default/mIconCloseTabHover.svg); }" );
+  }
+#endif
+  if ( mMacStyle )
+  {
+    ss += QLatin1String( "QWidget#QgsTextFormatWidgetBase QTabWidget#mOptionsTab QTabBar::tab," );
+    ss += QLatin1String( "QWidget#QgsRendererMeshPropsWidgetBase QTabWidget#mStyleOptionsTab" );
+    ss += QLatin1String( "QTabBar::tab { width: 1.2em; }" );
   }
 
   ss += QLatin1String( "QGroupBox{ font-weight: 600; }" );
@@ -191,7 +199,8 @@ void QgisAppStyleSheet::saveToSettings( const QMap<QString, QVariant> &opts )
 
 void QgisAppStyleSheet::setActiveValues()
 {
-  mStyle = qApp->style()->objectName(); // active style name (lowercase)
+  QgsAppStyle *style = dynamic_cast<QgsAppStyle *>( qApp->style() );
+  mStyle = style ? style->baseStyle() : qApp->style()->objectName(); // active style name (lowercase)
   QgsDebugMsgLevel( QStringLiteral( "Style name: %1" ).arg( mStyle ), 2 );
 
   mMacStyle = mStyle.contains( QLatin1String( "macintosh" ) ); // macintosh (aqua)

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -3471,6 +3471,10 @@ QgsSymbolLayer *QgsCentroidFillSymbolLayer::create( const QgsStringMap &properti
     sl->setPointOnSurface( properties[QStringLiteral( "point_on_surface" )].toInt() != 0 );
   if ( properties.contains( QStringLiteral( "point_on_all_parts" ) ) )
     sl->setPointOnAllParts( properties[QStringLiteral( "point_on_all_parts" )].toInt() != 0 );
+  if ( properties.contains( QStringLiteral( "clip_points" ) ) )
+    sl->setClipPoints( properties[QStringLiteral( "clip_points" )].toInt() != 0 );
+  if ( properties.contains( QStringLiteral( "clip_on_current_part_only" ) ) )
+    sl->setClipOnCurrentPartOnly( properties[QStringLiteral( "clip_on_current_part_only" )].toInt() != 0 );
 
   sl->restoreOldDataDefinedProperties( properties );
 
@@ -3509,41 +3513,118 @@ void QgsCentroidFillSymbolLayer::stopRender( QgsSymbolRenderContext &context )
 
 void QgsCentroidFillSymbolLayer::renderPolygon( const QPolygonF &points, QList<QPolygonF> *rings, QgsSymbolRenderContext &context )
 {
-  if ( !mPointOnAllParts )
+  Part part;
+  part.exterior = points;
+  if ( rings )
+    part.rings = *rings;
+
+  if ( mRenderingFeature )
   {
-    const QgsFeature *feature = context.feature();
-    if ( feature )
+    // in the middle of rendering a possibly multi-part feature, so we collect all the parts and defer the actual rendering
+    // until after we've received the final part
+    mCurrentParts << part;
+  }
+  else
+  {
+    // not rendering a feature, so we can just render the polygon immediately
+    render( context.renderContext(), QVector<Part>() << part, context.feature() ? *context.feature() : QgsFeature(), context.selected() );
+  }
+}
+
+void QgsCentroidFillSymbolLayer::startFeatureRender( const QgsFeature &, QgsRenderContext & )
+{
+  mRenderingFeature = true;
+  mCurrentParts.clear();
+}
+
+void QgsCentroidFillSymbolLayer::stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context )
+{
+  mRenderingFeature = false;
+  render( context, mCurrentParts, feature, false );
+}
+
+void QgsCentroidFillSymbolLayer::render( QgsRenderContext &context, const QVector<QgsCentroidFillSymbolLayer::Part> &parts, const QgsFeature &feature, bool selected )
+{
+  bool pointOnAllParts = mPointOnAllParts;
+  bool pointOnSurface = mPointOnSurface;
+  bool clipPoints = mClipPoints;
+  bool clipOnCurrentPartOnly = mClipOnCurrentPartOnly;
+
+  // TODO add expressions support
+
+  QVector< QgsGeometry > geometryParts;
+  geometryParts.reserve( parts.size() );
+  QPainterPath globalPath;
+
+  int maxArea = 0;
+  int maxAreaPartIdx = 0;
+
+  for ( int i = 0; i < parts.size(); i++ )
+  {
+    const Part part = parts[i];
+    QgsGeometry geom = QgsGeometry::fromQPolygonF( part.exterior );
+
+    if ( !geom.isNull() && !part.rings.empty() )
     {
-      if ( feature->id() != mCurrentFeatureId )
+      QgsPolygon *poly = qgsgeometry_cast< QgsPolygon * >( geom.get() );
+
+      if ( !pointOnAllParts )
       {
-        mCurrentFeatureId = feature->id();
-        mBiggestPartIndex = 1;
+        int area = poly->area();
 
-        if ( context.geometryPartCount() > 1 )
+        if ( area > maxArea )
         {
-          const QgsGeometry geom = feature->geometry();
-          const QgsGeometryCollection *geomCollection = static_cast<const QgsGeometryCollection *>( geom.constGet() );
-
-          double area = 0;
-          double areaBiggest = 0;
-          for ( int i = 0; i < context.geometryPartCount(); ++i )
-          {
-            area = geomCollection->geometryN( i )->area();
-            if ( area > areaBiggest )
-            {
-              areaBiggest = area;
-              mBiggestPartIndex = i + 1;
-            }
-          }
+          maxArea = area;
+          maxAreaPartIdx = i;
         }
+      }
+    }
+
+    if ( clipPoints && !clipOnCurrentPartOnly )
+    {
+      globalPath.addPolygon( part.exterior );
+      for ( const QPolygonF &ring : part.rings )
+      {
+        globalPath.addPolygon( ring );
       }
     }
   }
 
-  if ( mPointOnAllParts || ( context.geometryPartNum() == mBiggestPartIndex ) )
+  for ( int i = 0; i < parts.size(); i++ )
   {
-    QPointF centroid = mPointOnSurface ? QgsSymbolLayerUtils::polygonPointOnSurface( points, rings ) : QgsSymbolLayerUtils::polygonCentroid( points );
-    mMarker->renderPoint( centroid, context.feature(), context.renderContext(), -1, context.selected() );
+    if ( !pointOnAllParts && i != maxAreaPartIdx )
+      continue;
+
+    const Part part = parts[i];
+
+    if ( clipPoints )
+    {
+      QPainterPath path;
+
+      if ( clipOnCurrentPartOnly )
+      {
+        path.addPolygon( part.exterior );
+        for ( const QPolygonF &ring : part.rings )
+        {
+          path.addPolygon( ring );
+        }
+      }
+      else
+      {
+        path = globalPath;
+      }
+
+      context.painter()->save();
+      context.painter()->setClipPath( path );
+    }
+
+    QPointF centroid = pointOnSurface ? QgsSymbolLayerUtils::polygonPointOnSurface( part.exterior, &part.rings ) : QgsSymbolLayerUtils::polygonCentroid( part.exterior );
+    mMarker->renderPoint( centroid, feature.isValid() ? &feature : nullptr, context, -1, selected );
+
+    if ( clipPoints )
+    {
+      context.painter()->restore();
+    }
   }
 }
 
@@ -3552,6 +3633,8 @@ QgsStringMap QgsCentroidFillSymbolLayer::properties() const
   QgsStringMap map;
   map[QStringLiteral( "point_on_surface" )] = QString::number( mPointOnSurface );
   map[QStringLiteral( "point_on_all_parts" )] = QString::number( mPointOnAllParts );
+  map[QStringLiteral( "clip_points" )] = QString::number( mClipPoints );
+  map[QStringLiteral( "clip_on_current_part_only" )] = QString::number( mClipOnCurrentPartOnly );
   return map;
 }
 
@@ -3563,6 +3646,8 @@ QgsCentroidFillSymbolLayer *QgsCentroidFillSymbolLayer::clone() const
   x->setSubSymbol( mMarker->clone() );
   x->setPointOnSurface( mPointOnSurface );
   x->setPointOnAllParts( mPointOnAllParts );
+  x->setClipPoints( mClipPoints );
+  x->setClipOnCurrentPartOnly( mClipOnCurrentPartOnly );
   copyDataDefinedProperties( x.get() );
   copyPaintEffect( x.get() );
   return x.release();
@@ -4056,6 +4141,8 @@ void QgsRandomMarkerFillSymbolLayer::render( QgsRenderContext &context, const QV
 
   if ( clipPoints )
   {
+    QgsLogger::warning( "down2" + QStringLiteral( __FILE__ ) + ": " + QString::number( __LINE__ ) );
+    qInfo() << path;
     context.painter()->save();
     context.painter()->setClipPath( path );
   }

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -1970,18 +1970,68 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
 
     /**
      * Sets whether a point is drawn for all parts or only on the biggest part of multi-part features.
+     * \see pointOnAllParts()
      * \since QGIS 2.16 */
     void setPointOnAllParts( bool pointOnAllParts ) { mPointOnAllParts = pointOnAllParts; }
 
     /**
      * Returns whether a point is drawn for all parts or only on the biggest part of multi-part features.
+     * \see setPointOnAllParts()
      * \since QGIS 2.16 */
     bool pointOnAllParts() const { return mPointOnAllParts; }
 
+    /**
+     * Returns TRUE if point markers should be clipped to the polygon boundary.
+     *
+     * \see setClipPoints()
+     * \since 3.14
+     */
+    bool clipPoints() const { return mClipPoints; }
+
+    /**
+     * Sets whether point markers should be \a clipped to the polygon boundary.
+     *
+     * \see clipPoints()
+     * \since 3.14
+     */
+    void setClipPoints( bool clipPoints ) { mClipPoints = clipPoints; }
+
+    /**
+     * Returns TRUE if point markers should be clipped to the current part boundary only.
+     *
+     * \see setClipPoints()
+     * \since 3.14
+     */
+    bool clipOnCurrentPartOnly() const { return mClipOnCurrentPartOnly; }
+
+    /**
+     * Sets whether point markers should be \a clipped to the current part boundary only.
+     *
+     * \see clipOnCurrentPartOnly()
+     * \since 3.14
+     */
+    void setClipOnCurrentPartOnly( bool clipOnCurrentPartOnly ) { mClipOnCurrentPartOnly = clipOnCurrentPartOnly; }
+
+    void startFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
+    void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
+
   protected:
+    struct Part
+    {
+      QPolygonF exterior;
+      QList<QPolygonF> rings;
+    };
+
+    void render( QgsRenderContext &context, const QVector<Part> &parts, const QgsFeature &feature, bool selected );
+
     std::unique_ptr< QgsMarkerSymbol > mMarker;
     bool mPointOnSurface = false;
     bool mPointOnAllParts = true;
+    bool mClipPoints = false;
+    bool mClipOnCurrentPartOnly = false;
+
+    QVector<Part> mCurrentParts;
+    bool mRenderingFeature = false;
 
     QgsFeatureId mCurrentFeatureId = -1;
     int mBiggestPartIndex = -1;
@@ -1990,6 +2040,7 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
 #ifdef SIP_RUN
     QgsCentroidFillSymbolLayer( const QgsCentroidFillSymbolLayer &other );
 #endif
+
 };
 
 #endif

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -2016,13 +2016,6 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
     void stopFeatureRender( const QgsFeature &feature, QgsRenderContext &context ) override;
 
   protected:
-    struct Part
-    {
-      QPolygonF exterior;
-      QList<QPolygonF> rings;
-    };
-
-    void render( QgsRenderContext &context, const QVector<Part> &parts, const QgsFeature &feature, bool selected );
 
     std::unique_ptr< QgsMarkerSymbol > mMarker;
     bool mPointOnSurface = false;
@@ -2030,7 +2023,6 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
     bool mClipPoints = false;
     bool mClipOnCurrentPartOnly = false;
 
-    QVector<Part> mCurrentParts;
     bool mRenderingFeature = false;
 
     QgsFeatureId mCurrentFeatureId = -1;
@@ -2040,7 +2032,14 @@ class CORE_EXPORT QgsCentroidFillSymbolLayer : public QgsFillSymbolLayer
 #ifdef SIP_RUN
     QgsCentroidFillSymbolLayer( const QgsCentroidFillSymbolLayer &other );
 #endif
+    struct Part
+    {
+      QPolygonF exterior;
+      QList<QPolygonF> rings;
+    };
 
+    void render( QgsRenderContext &context, const QVector<Part> &parts, const QgsFeature &feature, bool selected );
+    QVector<Part> mCurrentParts;
 };
 
 #endif

--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -4008,7 +4008,7 @@ QPointF QgsSymbolLayerUtils::polygonCentroid( const QPolygonF &points )
   return QPointF( cx, cy );
 }
 
-QPointF QgsSymbolLayerUtils::polygonPointOnSurface( const QPolygonF &points, QList<QPolygonF> *rings )
+QPointF QgsSymbolLayerUtils::polygonPointOnSurface( const QPolygonF &points, const QList<QPolygonF> *rings )
 {
   QPointF centroid = QgsSymbolLayerUtils::polygonCentroid( points );
 

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -639,7 +639,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
     static QPointF polygonCentroid( const QPolygonF &points );
 
     //! Calculate a point on the surface of a QPolygonF
-    static QPointF polygonPointOnSurface( const QPolygonF &points, QList<QPolygonF> *rings = nullptr );
+    static QPointF polygonPointOnSurface( const QPolygonF &points, const QList<QPolygonF> *rings = nullptr );
 
     //! Calculate whether a point is within of a QPolygonF
     static bool pointInPolygon( const QPolygonF &points, QPointF point );

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -128,22 +128,29 @@ void QgsModelComponentGraphicItem::previewItemMove( qreal dx, qreal dy )
   emit updateArrowPaths();
 }
 
-void QgsModelComponentGraphicItem::setItemRect( QRectF )
+void QgsModelComponentGraphicItem::setItemRect( QRectF rect )
 {
-  mComponent->setPosition( pos() );
+  rect = rect.normalized();
+
+  if ( rect.width() < MIN_COMPONENT_WIDTH )
+    rect.setWidth( MIN_COMPONENT_WIDTH );
+  if ( rect.height() < MIN_COMPONENT_HEIGHT )
+    rect.setHeight( MIN_COMPONENT_HEIGHT );
+
+  setPos( rect.center() );
   prepareGeometryChange();
-  mComponent->setSize( mTempSize );
-  mTempSize = QSizeF();
 
   emit aboutToChange( tr( "Resize %1" ).arg( mComponent->description() ) );
+
+  mComponent->setPosition( pos() );
+  mComponent->setSize( rect.size() );
   updateStoredComponentPosition( pos(), mComponent->size() );
 
   updateButtonPositions();
-
   emit changed();
 
-  emit sizePositionChanged();
   emit updateArrowPaths();
+  emit sizePositionChanged();
 }
 
 QRectF QgsModelComponentGraphicItem::previewItemRectChange( QRectF rect )
@@ -164,6 +171,24 @@ QRectF QgsModelComponentGraphicItem::previewItemRectChange( QRectF rect )
   emit updateArrowPaths();
 
   return rect;
+}
+
+void QgsModelComponentGraphicItem::finalizePreviewedItemRectChange( QRectF )
+{
+  mComponent->setPosition( pos() );
+  prepareGeometryChange();
+  mComponent->setSize( mTempSize );
+  mTempSize = QSizeF();
+
+  emit aboutToChange( tr( "Resize %1" ).arg( mComponent->description() ) );
+  updateStoredComponentPosition( pos(), mComponent->size() );
+
+  updateButtonPositions();
+
+  emit changed();
+
+  emit sizePositionChanged();
+  emit updateArrowPaths();
 }
 
 void QgsModelComponentGraphicItem::modelHoverEnterEvent( QgsModelViewMouseEvent *event )

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -130,12 +130,17 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
      */
     void setItemRect( QRectF rect );
 
+#ifndef SIP_RUN
+
     /**
      * Shows a preview of setting a new \a rect for the item.
      */
     QRectF previewItemRectChange( QRectF rect );
 
-#ifndef SIP_RUN
+    /**
+     * Sets a new scene \a rect for the item.
+     */
+    void finalizePreviewedItemRectChange( QRectF rect );
 
     /**
      * Handles a model hover enter \a event.
@@ -359,7 +364,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     QgsModelDesignerFlatButtonGraphicItem *mDeleteButton = nullptr;
 
     static constexpr double MIN_COMPONENT_WIDTH = 70;
-    static constexpr double MIN_COMPONENT_HEIGHT = 50;
+    static constexpr double MIN_COMPONENT_HEIGHT = 30;
 
     static constexpr double DEFAULT_BUTTON_WIDTH = 16;
     static constexpr double DEFAULT_BUTTON_HEIGHT = 16;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -134,7 +134,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
   connect( mActionSnapSelected, &QAction::triggered, mView, &QgsModelGraphicsView::snapSelected );
 
-  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), true ).toBool() );
+  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), false ).toBool() );
   connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
   {
     mView->snapper()->setSnapToGrid( enabled );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -118,6 +118,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mainLayout->insertWidget( 0, mMessageBar );
 
   mView->setAcceptDrops( true );
+  QgsSettings settings;
 
   connect( mActionClose, &QAction::triggered, this, &QWidget::close );
   connect( mActionZoomIn, &QAction::triggered, this, &QgsModelDesignerDialog::zoomIn );
@@ -131,6 +132,14 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionSave, &QAction::triggered, this, [ = ] { saveModel( false ); } );
   connect( mActionSaveAs, &QAction::triggered, this, [ = ] { saveModel( true ); } );
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
+
+  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), true ).toBool() );
+  connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
+  {
+    mView->snapper()->setSnapToGrid( enabled );
+    QgsSettings().setValue( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), enabled );
+  } );
+  mView->snapper()->setSnapToGrid( mActionSnappingEnabled->isChecked() );
 
   mUndoAction = mUndoStack->createUndoAction( this );
   mUndoAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionUndo.svg" ) ) );
@@ -146,7 +155,7 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mToolbar->insertAction( mActionZoomIn, mRedoAction );
   mToolbar->insertSeparator( mActionZoomIn );
 
-  QgsSettings settings;
+
   QgsProcessingToolboxProxyModel::Filters filters = QgsProcessingToolboxProxyModel::FilterModeler;
   if ( settings.value( QStringLiteral( "Processing/Configuration/SHOW_ALGORITHMS_KNOWN_ISSUES" ), false ).toBool() )
   {

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -142,6 +142,11 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   } );
   mView->snapper()->setSnapToGrid( mActionSnappingEnabled->isChecked() );
 
+  connect( mActionSelectAll, &QAction::triggered, this, [ = ]
+  {
+    mScene->selectAll();
+  } );
+
   mUndoAction = mUndoStack->createUndoAction( this );
   mUndoAction->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "/mActionUndo.svg" ) ) );
   mUndoAction->setShortcuts( QKeySequence::Undo );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -132,12 +132,13 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionSave, &QAction::triggered, this, [ = ] { saveModel( false ); } );
   connect( mActionSaveAs, &QAction::triggered, this, [ = ] { saveModel( true ); } );
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
+  connect( mActionSnapSelected, &QAction::triggered, mView, &QgsModelGraphicsView::snapSelected );
 
-  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), true ).toBool() );
+  mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), true ).toBool() );
   connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
   {
     mView->snapper()->setSnapToGrid( enabled );
-    QgsSettings().setValue( QStringLiteral( "/Processing/modelDesignerEnableSnap" ), enabled );
+    QgsSettings().setValue( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), enabled );
   } );
   mView->snapper()->setSnapToGrid( mActionSnappingEnabled->isChecked() );
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -222,6 +222,23 @@ QgsModelComponentGraphicItem *QgsModelGraphicsScene::componentItemAt( QPointF po
   return nullptr;
 }
 
+void QgsModelGraphicsScene::selectAll()
+{
+  //select all items in scene
+  QgsModelComponentGraphicItem *focusedItem = nullptr;
+  const QList<QGraphicsItem *> itemList = items();
+  for ( QGraphicsItem *graphicsItem : itemList )
+  {
+    if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( graphicsItem ) )
+    {
+      componentItem->setSelected( true );
+      if ( !focusedItem )
+        focusedItem = componentItem;
+    }
+  }
+  emit selectedItemChanged( focusedItem );
+}
+
 void QgsModelGraphicsScene::deselectAll()
 {
   //we can't use QGraphicsScene::clearSelection, as that emits no signals

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -107,6 +107,11 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     QgsModelComponentGraphicItem *componentItemAt( QPointF position ) const;
 
     /**
+     * Selects all the components in the scene.
+     */
+    void selectAll();
+
+    /**
      * Clears any selected items in the scene.
      *
      * Call this method rather than QGraphicsScene::clearSelection, as the latter does

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -439,9 +439,9 @@ void QgsModelGraphicsView::snapSelected()
 {
   QgsModelGraphicsScene *s = modelScene();
   const QList<QgsModelComponentGraphicItem *> itemList = s->selectedComponentItems();
+  startMacroCommand( tr( "Snap Items" ) );
   if ( !itemList.empty() )
   {
-    itemList.at( 0 )->aboutToChange( tr( "Snap Items" ) );
     bool prevSetting = mSnapper.snapToGrid();
     mSnapper.setSnapToGrid( true );
     for ( QgsModelComponentGraphicItem *item : itemList )
@@ -454,8 +454,8 @@ void QgsModelGraphicsView::snapSelected()
       }
     }
     mSnapper.setSnapToGrid( prevSetting );
-    itemList.at( 0 )->changed();
   }
+  endMacroCommand();
 }
 
 

--- a/src/gui/processing/models/qgsmodelgraphicsview.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsview.cpp
@@ -435,6 +435,29 @@ void QgsModelGraphicsView::endMacroCommand()
   emit macroCommandEnded();
 }
 
+void QgsModelGraphicsView::snapSelected()
+{
+  QgsModelGraphicsScene *s = modelScene();
+  const QList<QgsModelComponentGraphicItem *> itemList = s->selectedComponentItems();
+  if ( !itemList.empty() )
+  {
+    itemList.at( 0 )->aboutToChange( tr( "Snap Items" ) );
+    bool prevSetting = mSnapper.snapToGrid();
+    mSnapper.setSnapToGrid( true );
+    for ( QgsModelComponentGraphicItem *item : itemList )
+    {
+      bool wasSnapped = false;
+      QRectF snapped = mSnapper.snapRectWithResize( item->mapRectToScene( item->itemRect( ) ), transform().m11(), wasSnapped );
+      if ( wasSnapped )
+      {
+        item->setItemRect( snapped );
+      }
+    }
+    mSnapper.setSnapToGrid( prevSetting );
+    itemList.at( 0 )->changed();
+  }
+}
+
 
 QgsModelViewSnapMarker::QgsModelViewSnapMarker()
   : QGraphicsRectItem( QRectF( 0, 0, 0, 0 ) )

--- a/src/gui/processing/models/qgsmodelgraphicsview.h
+++ b/src/gui/processing/models/qgsmodelgraphicsview.h
@@ -110,6 +110,13 @@ class GUI_EXPORT QgsModelGraphicsView : public QGraphicsView
      */
     void endMacroCommand();
 
+  public slots:
+
+    /**
+     * Snaps the selected items to the grid.
+     */
+    void snapSelected();
+
   signals:
 
     /**

--- a/src/gui/processing/models/qgsmodelsnapper.cpp
+++ b/src/gui/processing/models/qgsmodelsnapper.cpp
@@ -21,7 +21,7 @@
 QgsModelSnapper::QgsModelSnapper()
 {
   QgsSettings s;
-  mTolerance = s.value( QStringLiteral( "LayoutDesigner/defaultSnapTolerancePixels" ), 5, QgsSettings::Gui ).toInt();
+  mTolerance = s.value( QStringLiteral( "/Processing/modelDesignerSnapTolerancePixels" ), 20 ).toInt();
 }
 
 void QgsModelSnapper::setSnapTolerance( const int snapTolerance )
@@ -34,19 +34,19 @@ void QgsModelSnapper::setSnapToGrid( bool enabled )
   mSnapToGrid = enabled;
 }
 
-QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &snapped ) const
+QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &snapped, bool snapHorizontal, bool snapVertical ) const
 {
   snapped = false;
 
   bool snappedXToGrid = false;
   bool snappedYToGrid = false;
   QPointF res = snapPointToGrid( point, scaleFactor, snappedXToGrid, snappedYToGrid );
-  if ( snappedXToGrid )
+  if ( snappedXToGrid && snapVertical )
   {
     snapped = true;
     point.setX( res.x() );
   }
-  if ( snappedYToGrid )
+  if ( snappedYToGrid && snapHorizontal )
   {
     snapped = true;
     point.setY( res.y() );
@@ -55,7 +55,7 @@ QPointF QgsModelSnapper::snapPoint( QPointF point, double scaleFactor, bool &sna
   return point;
 }
 
-QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &snapped ) const
+QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &snapped, bool snapHorizontal, bool snapVertical ) const
 {
   snapped = false;
   QRectF snappedRect = rect;
@@ -70,12 +70,12 @@ QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &
   QList< QPointF > points;
   points << rect.topLeft() << rect.topRight() << rect.bottomLeft() << rect.bottomRight();
   QPointF res = snapPointsToGrid( points, scaleFactor, snappedXToGrid, snappedYToGrid );
-  if ( snappedXToGrid )
+  if ( snappedXToGrid && snapVertical )
   {
     snapped = true;
     snappedRect.translate( res.x(), 0 );
   }
-  if ( snappedYToGrid )
+  if ( snappedYToGrid && snapHorizontal )
   {
     snapped = true;
     snappedRect.translate( 0, res.y() );
@@ -111,7 +111,7 @@ QPointF QgsModelSnapper::snapPointsToGrid( const QList<QPointF> &points, double 
   for ( QPointF point : points )
   {
     //snap x coordinate
-    double gridRes = 10; //mLayout->convertToLayoutUnits( grid.resolution() );
+    double gridRes = 30; //mLayout->convertToLayoutUnits( grid.resolution() );
     int xRatio = static_cast< int >( ( point.x() ) / gridRes + 0.5 ); //NOLINT
     int yRatio = static_cast< int >( ( point.y() ) / gridRes + 0.5 ); //NOLINT
 

--- a/src/gui/processing/models/qgsmodelsnapper.cpp
+++ b/src/gui/processing/models/qgsmodelsnapper.cpp
@@ -21,7 +21,7 @@
 QgsModelSnapper::QgsModelSnapper()
 {
   QgsSettings s;
-  mTolerance = s.value( QStringLiteral( "/Processing/modelDesignerSnapTolerancePixels" ), 20 ).toInt();
+  mTolerance = s.value( QStringLiteral( "/Processing/Modeler/snapTolerancePixels" ), 40 ).toInt();
 }
 
 void QgsModelSnapper::setSnapTolerance( const int snapTolerance )
@@ -60,11 +60,6 @@ QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &
   snapped = false;
   QRectF snappedRect = rect;
 
-  QList< double > xCoords;
-  xCoords << rect.left() << rect.center().x() << rect.right();
-  QList< double > yCoords;
-  yCoords << rect.top() << rect.center().y() << rect.bottom();
-
   bool snappedXToGrid = false;
   bool snappedYToGrid = false;
   QList< QPointF > points;
@@ -79,6 +74,39 @@ QRectF QgsModelSnapper::snapRect( const QRectF &rect, double scaleFactor, bool &
   {
     snapped = true;
     snappedRect.translate( 0, res.y() );
+  }
+
+  return snappedRect;
+}
+
+QRectF QgsModelSnapper::snapRectWithResize( const QRectF &rect, double scaleFactor, bool &snapped, bool snapHorizontal, bool snapVertical ) const
+{
+  snapped = false;
+  QRectF snappedRect = rect;
+
+  bool snappedXToGrid = false;
+  bool snappedYToGrid = false;
+  QPointF res = snapPointsToGrid( QList< QPointF >() << rect.topLeft(), scaleFactor, snappedXToGrid, snappedYToGrid );
+  if ( snappedXToGrid && snapVertical )
+  {
+    snapped = true;
+    snappedRect.setLeft( snappedRect.left() + res.x() );
+  }
+  if ( snappedYToGrid && snapHorizontal )
+  {
+    snapped = true;
+    snappedRect.setTop( snappedRect.top() + res.y() );
+  }
+  res = snapPointsToGrid( QList< QPointF >() << rect.bottomRight(), scaleFactor, snappedXToGrid, snappedYToGrid );
+  if ( snappedXToGrid && snapVertical )
+  {
+    snapped = true;
+    snappedRect.setRight( snappedRect.right() + res.x() );
+  }
+  if ( snappedYToGrid && snapHorizontal )
+  {
+    snapped = true;
+    snappedRect.setBottom( snappedRect.bottom() + res.y() );
   }
 
   return snappedRect;

--- a/src/gui/processing/models/qgsmodelsnapper.h
+++ b/src/gui/processing/models/qgsmodelsnapper.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsModelSnapper
 
      * \see snapRect()
      */
-    QPointF snapPoint( QPointF point, double scaleFactor, bool &snapped SIP_OUT ) const;
+    QPointF snapPoint( QPointF point, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
 
     /**
      * Snaps a layout coordinate \a rect. If \a rect was snapped, \a snapped will be set to TRUE.
@@ -101,7 +101,7 @@ class GUI_EXPORT QgsModelSnapper
      *
      * \see snapPoint()
      */
-    QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT ) const;
+    QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
 
     /**
      * Snaps a layout coordinate \a point to the grid. If \a point

--- a/src/gui/processing/models/qgsmodelsnapper.h
+++ b/src/gui/processing/models/qgsmodelsnapper.h
@@ -104,6 +104,24 @@ class GUI_EXPORT QgsModelSnapper
     QRectF snapRect( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
 
     /**
+     * Snaps a layout coordinate \a rect. If \a rect was snapped, \a snapped will be set to TRUE.
+     *
+     * The \a scaleFactor argument should be set to the transformation from
+     * scalar transform from layout coordinates to pixels, i.e. the
+     * graphics view transform().m11() value.
+     *
+     * This method considers snapping to the grid, snap lines, etc.
+     *
+     * If the \a horizontalSnapLine and \a verticalSnapLine arguments are specified, then the snapper
+     * will automatically display and position these lines to indicate snapping positions to item bounds.
+     *
+     * A list of items to ignore during the snapping can be specified via the \a ignoreItems list.
+     *
+     * \see snapPoint()
+     */
+    QRectF snapRectWithResize( const QRectF &rect, double scaleFactor, bool &snapped SIP_OUT, bool snapHorizontal = true, bool snapVertical = true ) const;
+
+    /**
      * Snaps a layout coordinate \a point to the grid. If \a point
      * was snapped horizontally, \a snappedX will be set to TRUE. If \a point
      * was snapped vertically, \a snappedY will be set to TRUE.

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -137,7 +137,7 @@ void QgsModelViewMouseHandles::setItemRect( QGraphicsItem *item, QRectF rect )
 {
   if ( QgsModelComponentGraphicItem *componentItem = dynamic_cast<QgsModelComponentGraphicItem *>( item ) )
   {
-    componentItem->setItemRect( rect );
+    componentItem->finalizePreviewedItemRectChange( rect );
   }
 }
 
@@ -164,13 +164,10 @@ QPointF QgsModelViewMouseHandles::snapPoint( QPointF originalPoint, QgsGraphicsV
 {
   bool snapped = false;
 
-  //depending on the mode, we either snap just the single point, or all the bounds of the selection
   QPointF snappedPoint;
   switch ( mode )
   {
     case Item:
-      snappedPoint = mView->snapper()->snapRect( rect().translated( originalPoint ), mView->transform().m11(), snapped, snapHorizontal, snapVertical ).topLeft();
-      break;
     case Point:
       snappedPoint = mView->snapper()->snapPoint( originalPoint, mView->transform().m11(), snapped, snapHorizontal, snapVertical );
       break;

--- a/src/gui/processing/models/qgsmodelviewmousehandles.cpp
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.cpp
@@ -160,5 +160,24 @@ void QgsModelViewMouseHandles::endMacroCommand()
   mView->endMacroCommand();
 }
 
+QPointF QgsModelViewMouseHandles::snapPoint( QPointF originalPoint, QgsGraphicsViewMouseHandles::SnapGuideMode mode, bool snapHorizontal, bool snapVertical )
+{
+  bool snapped = false;
+
+  //depending on the mode, we either snap just the single point, or all the bounds of the selection
+  QPointF snappedPoint;
+  switch ( mode )
+  {
+    case Item:
+      snappedPoint = mView->snapper()->snapRect( rect().translated( originalPoint ), mView->transform().m11(), snapped, snapHorizontal, snapVertical ).topLeft();
+      break;
+    case Point:
+      snappedPoint = mView->snapper()->snapPoint( originalPoint, mView->transform().m11(), snapped, snapHorizontal, snapVertical );
+      break;
+  }
+
+  return snapped ? snappedPoint : originalPoint;
+}
+
 
 ///@endcond PRIVATE

--- a/src/gui/processing/models/qgsmodelviewmousehandles.h
+++ b/src/gui/processing/models/qgsmodelviewmousehandles.h
@@ -65,6 +65,7 @@ class GUI_EXPORT QgsModelViewMouseHandles: public QgsGraphicsViewMouseHandles
     QRectF previewSetItemRect( QGraphicsItem *item, QRectF rect ) override;
     void startMacroCommand( const QString &text ) override;
     void endMacroCommand() override;
+    QPointF snapPoint( QPointF originalPoint, SnapGuideMode mode, bool snapHorizontal = true, bool snapVertical = true ) override;
 
   public slots:
 

--- a/src/gui/qgsproxystyle.h
+++ b/src/gui/qgsproxystyle.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsAppStyle : public QProxyStyle
     explicit QgsAppStyle( const QString &base );
     QPixmap generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *opt ) const override;
 
-    QString baseStyle() const {return mBaseStyle;}
+    QString baseStyle() const { return mBaseStyle; }
 
     /**
      * Returns a new QgsAppStyle instance, with the same base style as this instance.

--- a/src/gui/qgsproxystyle.h
+++ b/src/gui/qgsproxystyle.h
@@ -57,6 +57,8 @@ class GUI_EXPORT QgsAppStyle : public QProxyStyle
     explicit QgsAppStyle( const QString &base );
     QPixmap generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *opt ) const override;
 
+    QString baseStyle() const {return mBaseStyle;}
+
     /**
      * Returns a new QgsAppStyle instance, with the same base style as this instance.
      *

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -505,6 +505,8 @@ void QgsTextFormatWidget::initWidget()
 
   // set correct initial tab to match displayed setting page
   whileBlocking( mOptionsTab )->setCurrentIndex( mLabelStackedWidget->currentIndex() );
+  mOptionsTab->tabBar()->setUsesScrollButtons( true );
+
 
   if ( mMapCanvas )
   {

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3635,6 +3635,8 @@ QgsCentroidFillSymbolLayerWidget::QgsCentroidFillSymbolLayerWidget( QgsVectorLay
   setupUi( this );
   connect( mDrawInsideCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mDrawInsideCheckBox_stateChanged );
   connect( mDrawAllPartsCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mDrawAllPartsCheckBox_stateChanged );
+  connect( mClipPointsCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mClipPointsCheckBox_stateChanged );
+  connect( mClipOnCurrentPartOnlyCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mClipOnCurrentPartOnlyCheckBox_stateChanged );
 }
 
 void QgsCentroidFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
@@ -3648,6 +3650,8 @@ void QgsCentroidFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   // set values
   whileBlocking( mDrawInsideCheckBox )->setChecked( mLayer->pointOnSurface() );
   whileBlocking( mDrawAllPartsCheckBox )->setChecked( mLayer->pointOnAllParts() );
+  whileBlocking( mClipPointsCheckBox )->setChecked( mLayer->clipPoints() );
+  whileBlocking( mClipOnCurrentPartOnlyCheckBox )->setChecked( mLayer->clipOnCurrentPartOnly() );
 }
 
 QgsSymbolLayer *QgsCentroidFillSymbolLayerWidget::symbolLayer()
@@ -3664,6 +3668,18 @@ void QgsCentroidFillSymbolLayerWidget::mDrawInsideCheckBox_stateChanged( int sta
 void QgsCentroidFillSymbolLayerWidget::mDrawAllPartsCheckBox_stateChanged( int state )
 {
   mLayer->setPointOnAllParts( state == Qt::Checked );
+  emit changed();
+}
+
+void QgsCentroidFillSymbolLayerWidget::mClipPointsCheckBox_stateChanged( int state )
+{
+  mLayer->setClipPoints( state == Qt::Checked );
+  emit changed();
+}
+
+void QgsCentroidFillSymbolLayerWidget::mClipOnCurrentPartOnlyCheckBox_stateChanged( int state )
+{
+  mLayer->setClipOnCurrentPartOnly( state == Qt::Checked );
   emit changed();
 }
 

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -3575,6 +3575,8 @@ QgsCentroidFillSymbolLayerWidget::QgsCentroidFillSymbolLayerWidget( QgsVectorLay
   setupUi( this );
   connect( mDrawInsideCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mDrawInsideCheckBox_stateChanged );
   connect( mDrawAllPartsCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mDrawAllPartsCheckBox_stateChanged );
+  connect( mClipPointsCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mClipPointsCheckBox_stateChanged );
+  connect( mClipOnCurrentPartOnlyCheckBox, &QCheckBox::stateChanged, this, &QgsCentroidFillSymbolLayerWidget::mClipOnCurrentPartOnlyCheckBox_stateChanged );
 }
 
 void QgsCentroidFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
@@ -3588,6 +3590,8 @@ void QgsCentroidFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
   // set values
   whileBlocking( mDrawInsideCheckBox )->setChecked( mLayer->pointOnSurface() );
   whileBlocking( mDrawAllPartsCheckBox )->setChecked( mLayer->pointOnAllParts() );
+  whileBlocking( mClipPointsCheckBox )->setChecked( mLayer->clipPoints() );
+  whileBlocking( mClipOnCurrentPartOnlyCheckBox )->setChecked( mLayer->clipOnCurrentPartOnly() );
 }
 
 QgsSymbolLayer *QgsCentroidFillSymbolLayerWidget::symbolLayer()
@@ -3604,6 +3608,18 @@ void QgsCentroidFillSymbolLayerWidget::mDrawInsideCheckBox_stateChanged( int sta
 void QgsCentroidFillSymbolLayerWidget::mDrawAllPartsCheckBox_stateChanged( int state )
 {
   mLayer->setPointOnAllParts( state == Qt::Checked );
+  emit changed();
+}
+
+void QgsCentroidFillSymbolLayerWidget::mClipPointsCheckBox_stateChanged( int state )
+{
+  mLayer->setClipPoints( state == Qt::Checked );
+  emit changed();
+}
+
+void QgsCentroidFillSymbolLayerWidget::mClipOnCurrentPartOnlyCheckBox_stateChanged( int state )
+{
+  mLayer->setClipOnCurrentPartOnly( state == Qt::Checked );
   emit changed();
 }
 

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -1073,7 +1073,8 @@ class GUI_EXPORT QgsCentroidFillSymbolLayerWidget : public QgsSymbolLayerWidget,
   private slots:
     void mDrawInsideCheckBox_stateChanged( int state );
     void mDrawAllPartsCheckBox_stateChanged( int state );
-
+    void mClipPointsCheckBox_stateChanged( int state );
+    void mClipOnCurrentPartOnlyCheckBox_stateChanged( int state );
 };
 
 

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -1059,7 +1059,8 @@ class GUI_EXPORT QgsCentroidFillSymbolLayerWidget : public QgsSymbolLayerWidget,
   private slots:
     void mDrawInsideCheckBox_stateChanged( int state );
     void mDrawAllPartsCheckBox_stateChanged( int state );
-
+    void mClipPointsCheckBox_stateChanged( int state );
+    void mClipOnCurrentPartOnlyCheckBox_stateChanged( int state );
 };
 
 

--- a/src/server/services/wfs3/qgswfs3handlers.cpp
+++ b/src/server/services/wfs3/qgswfs3handlers.cpp
@@ -1031,9 +1031,13 @@ json QgsWfs3CollectionsItemsHandler::schema( const QgsServerApiContext &context 
                 "201", {
                   { "description", "A new feature was successfully added to the collection" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
                 }
@@ -1963,12 +1967,16 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                 "200", {
                   { "description", "The feature was successfully updated" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
-                }
+                },
               },
               { "default", defaultResponse() }
             }
@@ -1987,12 +1995,16 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                 "200", {
                   { "description", "The feature was successfully updated" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
-                }
+                },
               },
               { "default", defaultResponse() }
             }
@@ -2011,9 +2023,13 @@ json QgsWfs3CollectionsFeatureHandler::schema( const QgsServerApiContext &contex
                 "201", {
                   { "description", "The feature was successfully deleted from the collection" }
                 },
+              },
+              {
                 "403", {
                   { "description", "Forbidden: the operation requested was not authorized" }
                 },
+              },
+              {
                 "500", {
                   { "description", "Posted data could not be parsed correctly or another error occurred" }
                 }

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -80,6 +80,8 @@
     <addaction name="mActionZoomToItems"/>
     <addaction name="separator"/>
     <addaction name="mActionShowComments"/>
+    <addaction name="separator"/>
+    <addaction name="mActionSnappingEnabled"/>
    </widget>
    <widget class="QMenu" name="mMenuEdit">
     <property name="title">
@@ -608,6 +610,14 @@
    </property>
    <property name="shortcut">
     <string>Del</string>
+   </property>
+  </action>
+  <action name="mActionSnappingEnabled">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Snapping</string>
    </property>
   </action>
  </widget>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -88,6 +88,8 @@
      <string>&amp;Edit</string>
     </property>
     <addaction name="mActionDeleteComponents"/>
+    <addaction name="separator"/>
+    <addaction name="mActionSnapSelected"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
@@ -159,7 +161,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>98</height>
+          <height>97</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout">
@@ -249,7 +251,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>152</height>
+          <height>153</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -618,6 +620,11 @@
    </property>
    <property name="text">
     <string>Enable Snapping</string>
+   </property>
+  </action>
+  <action name="mActionSnapSelected">
+   <property name="text">
+    <string>Snap Selected Components to Grid</string>
    </property>
   </action>
  </widget>

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -87,9 +87,11 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <addaction name="mActionSelectAll"/>
+    <addaction name="mActionSnapSelected"/>
+    <addaction name="separator"/>
     <addaction name="mActionDeleteComponents"/>
     <addaction name="separator"/>
-    <addaction name="mActionSnapSelected"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
@@ -625,6 +627,18 @@
   <action name="mActionSnapSelected">
    <property name="text">
     <string>Snap Selected Components to Grid</string>
+   </property>
+  </action>
+  <action name="mActionSelectAll">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSelectAll.svg</normaloff>:/images/themes/default/mActionSelectAll.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Select All</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
    </property>
   </action>
  </widget>

--- a/src/ui/symbollayer/widget_centroidfill.ui
+++ b/src/ui/symbollayer/widget_centroidfill.ui
@@ -32,14 +32,39 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QCheckBox" name="mDrawAllPartsCheckBox">
+       <property name="toolTip">
+        <string>When unchecked, a single point will be drawn on the biggest part of multi-part features</string>
+       </property>
        <property name="text">
         <string>Draw point on every part of multi-part features</string>
        </property>
-       <property name="toolTip">
-        <string>When unchecked, a single point will be drawn on the biggest part of multi-part features</string>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QCheckBox" name="mClipPointsCheckBox">
+       <property name="text">
+        <string>Clip markers to polygon boundary</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QCheckBox" name="mClipOnCurrentPartOnlyCheckBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Clip markers to current part boundary only</string>
        </property>
       </widget>
      </item>
@@ -50,16 +75,27 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>350</width>
-       <height>81</height>
-      </size>
-     </property>
     </spacer>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>mClipPointsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mClipOnCurrentPartOnlyCheckBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>183</x>
+     <y>77</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>183</x>
+     <y>107</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/tests/testdata/qgis_server/api/test_wfs3_api_project.json
+++ b/tests/testdata/qgis_server/api/test_wfs3_api_project.json
@@ -782,40 +782,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer_èé_2_a5f61891_b949_43e3_ad30_84013fc922de_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -827,40 +819,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -915,40 +899,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -957,40 +933,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1151,40 +1119,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer_èé_cf86cf11_222f_4b62_929c_12cfc82b9774_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -1196,40 +1156,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1284,40 +1236,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -1326,40 +1270,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1520,40 +1456,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer_c0988fd7_97ca_451d_adbc_37ad6d10583a_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -1565,40 +1493,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1653,40 +1573,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -1695,40 +1607,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -1889,40 +1793,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "post": {
         "description": "Adds a new feature to the collection {collectionId}",
         "operationId": "getFeatures_testlayer20150528120452665_POST",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "A new feature was successfully added to the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "A new feature was successfully added to the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Adds a new feature to the collection {collectionId}",
         "tags": [
           "edit",
@@ -1934,40 +1830,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "delete": {
         "description": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeatureDELETE",
-        "responses": [
-          [
-            "201",
-            {
-              "description": "The feature was successfully deleted from the collection"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "201": {
+            "description": "The feature was successfully deleted from the collection"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Deletes the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",
@@ -2022,40 +1910,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "patch": {
         "description": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Changes attributes of feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit"
@@ -2064,40 +1944,32 @@ Content-Type: application/vnd.oai.openapi+json;version=3.0
       "put": {
         "description": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "operationId": "getFeaturePUT",
-        "responses": [
-          [
-            "200",
-            {
-              "description": "The feature was successfully updated"
-            },
-            "403",
-            {
-              "description": "Forbidden: the operation requested was not authorized"
-            },
-            "500",
-            {
-              "description": "Posted data could not be parsed correctly or another error occurred"
-            }
-          ],
-          [
-            "default",
-            {
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/exception"
-                  }
-                },
-                "text/html": {
-                  "schema": {
-                    "type": "string"
-                  }
+        "responses": {
+          "200": {
+            "description": "The feature was successfully updated"
+          },
+          "403": {
+            "description": "Forbidden: the operation requested was not authorized"
+          },
+          "500": {
+            "description": "Posted data could not be parsed correctly or another error occurred"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/exception"
                 }
               },
-              "description": "An error occurred."
-            }
-          ]
-        ],
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An error occurred."
+          }
+        },
         "summary": "Replaces the feature with ID {featureId} in the collection {collectionId}",
         "tags": [
           "edit",


### PR DESCRIPTION
Allow centroid fill markers to be clipped within polygon or polygon part. 

Added two options to the centroid fill widget:
- **Clip markers to polygon boundary** - works exactly how the `Random points` clip works
- **Clip markers to current part boundary only** - clips the marker symbol only within the current part in case of multipart geometry

### Demo:
![Peek 2020-03-23 07-20](https://user-images.githubusercontent.com/2820439/77284303-0a03a180-6cd7-11ea-813e-3654c4d6a041.gif)


### Applications:

The only way to properly create this kind of maps.
![Screenshot_20200323_062016](https://user-images.githubusercontent.com/2820439/77282260-176a5d00-6cd2-11ea-80bb-7cb62ae82b19.png)

### TODOs:
- add some tests
- add expressions support for centroid fill
