### PR TITLE
Per feature source properties (feature limit, invalid geometry handling)

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -25,19 +25,43 @@ Encapsulates settings relating to a feature source input to a processing algorit
 %End
   public:
 
-    QgsProcessingFeatureSourceDefinition( const QString &source = QString(), bool selectedFeaturesOnly = false );
+    QgsProcessingFeatureSourceDefinition( const QString &source = QString(), bool selectedFeaturesOnly = false, long long featureLimit = -1,
+                                          bool overrideDefaultGeometryCheck = false, QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid );
 %Docstring
-Constructor for QgsProcessingFeatureSourceDefinition, accepting a static string source.
+Constructor for QgsProcessingFeatureSourceDefinition, accepting a static string ``source``.
+
+If ``selectedFeaturesOnly`` is ``True``, then only selected features from the source will be used.
+
+The optional ``featureLimit`` can be set to a value > 0 to place a hard limit on the maximum number
+of features which will be read from the source.
+
+If ``overrideDefaultGeometryCheck`` is ``True``, then the value of ``geometryCheck`` will override
+the default geometry check method (as dictated by :py:class:`QgsProcessingContext`) for this source.
 %End
 
-    QgsProcessingFeatureSourceDefinition( const QgsProperty &source, bool selectedFeaturesOnly = false );
+    QgsProcessingFeatureSourceDefinition( const QgsProperty &source, bool selectedFeaturesOnly = false, long long featureLimit = -1,
+                                          bool overrideDefaultGeometryCheck = false, QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid );
 %Docstring
 Constructor for QgsProcessingFeatureSourceDefinition, accepting a QgsProperty source.
+
+If ``selectedFeaturesOnly`` is ``True``, then only selected features from the source will be used.
+
+The optional ``featureLimit`` can be set to a value > 0 to place a hard limit on the maximum number
+of features which will be read from the source.
+
+If ``overrideDefaultGeometryCheck`` is ``True``, then the value of ``geometryCheck`` will override
+the default geometry check method (as dictated by :py:class:`QgsProcessingContext`) for this source.
 %End
 
     QgsProperty source;
 
     bool selectedFeaturesOnly;
+
+    long long featureLimit;
+
+    bool overrideDefaultGeometryCheck;
+
+    QgsFeatureRequest::InvalidGeometryCheck geometryCheck;
 
     bool operator==( const QgsProcessingFeatureSourceDefinition &other );
 

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -379,13 +379,17 @@ results according to the settings in a :py:class:`QgsProcessingContext`.
     typedef QFlags<QgsProcessingFeatureSource::Flag> Flags;
 
 
-    QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource = false );
+    QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource = false,
+                                long long featureLimit = -1 );
 %Docstring
 Constructor for QgsProcessingFeatureSource, accepting an original feature source ``originalSource``
 and processing ``context``.
 Ownership of ``originalSource`` is dictated by ``ownsOriginalSource``. If ``ownsOriginalSource`` is ``False``,
 ownership is not transferred, and callers must ensure that ``originalSource`` exists for the lifetime of this object.
 If ``ownsOriginalSource`` is ``True``, then this object will take ownership of ``originalSource``.
+
+If ``featureLimit`` is set to a value > 0, then a limit is placed on the maximum number of features which will be
+read from the source.
 %End
 
     ~QgsProcessingFeatureSource();
@@ -428,6 +432,13 @@ iterator, eg by restricting the returned attributes or geometry.
     QgsExpressionContextScope *createExpressionContextScope() const /Factory/;
 %Docstring
 Returns an expression context scope suitable for this source.
+%End
+
+    void setInvalidGeometryCheck( QgsFeatureRequest::InvalidGeometryCheck method );
+%Docstring
+Overrides the default geometry check method for the source.
+
+.. versionadded:: 3.14
 %End
 
 };

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -241,7 +241,7 @@ a specified ``algorithm``.
         const QStringList &compatibleFormats,
         const QString &preferredFormat,
         QgsProcessingContext &context,
-        QgsProcessingFeedback *feedback );
+        QgsProcessingFeedback *feedback, long long featureLimit = -1 );
 %Docstring
 Converts a source vector ``layer`` to a file path of a vector layer of compatible format.
 
@@ -253,6 +253,8 @@ in a temporary location using ``baseName``. The function will then return the pa
 
 The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
 layer export is required. This defaults to shapefiles.
+
+The ``featureLimit`` argument can be used to specify a limit on the number of features read from the layer.
 
 When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
 to use convertToCompatibleFormatAndLayerName() which may avoid conversion in more situations.
@@ -267,7 +269,7 @@ to use convertToCompatibleFormatAndLayerName() which may avoid conversion in mor
         const QString &preferredFormat,
         QgsProcessingContext &context,
         QgsProcessingFeedback *feedback,
-        QString &layerName /Out/ );
+        QString &layerName /Out/, long long featureLimit = -1 );
 %Docstring
 Converts a source vector ``layer`` to a file path and layer name of a vector layer of compatible format.
 
@@ -276,6 +278,8 @@ If the specified ``layer`` is not of the format listed in the
 in a temporary location using ``baseName``. The function will then return the path to that temporary file.
 
 ``compatibleFormats`` should consist entirely of lowercase file extensions, e.g. 'shp'.
+
+The ``featureLimit`` argument can be used to specify a limit on the number of features read from the layer.
 
 The ``preferredFormat`` argument is used to specify to desired file extension to use when a temporary
 layer export is required. This defaults to shapefiles.
@@ -291,6 +295,7 @@ a conversion in this case and will return the target layer name in the ``layerNa
 :param preferredFormat: preferred format extension to use if conversion if required
 :param context: processing context
 :param feedback: feedback object
+:param featureLimit: can be used to place a limit on the maximum number of features read from the layer
 
 :return: - path to source layer, or nearly converted compatible layer
          - layerName: will be set to the target layer name for multi-layer sources (e.g. Geopackage)

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -56,19 +56,43 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
   public:
 
     /**
-     * Constructor for QgsProcessingFeatureSourceDefinition, accepting a static string source.
+     * Constructor for QgsProcessingFeatureSourceDefinition, accepting a static string \a source.
+     *
+     * If \a selectedFeaturesOnly is TRUE, then only selected features from the source will be used.
+     *
+     * The optional \a featureLimit can be set to a value > 0 to place a hard limit on the maximum number
+     * of features which will be read from the source.
+     *
+     * If \a overrideDefaultGeometryCheck is TRUE, then the value of \a geometryCheck will override
+     * the default geometry check method (as dictated by QgsProcessingContext) for this source.
      */
-    QgsProcessingFeatureSourceDefinition( const QString &source = QString(), bool selectedFeaturesOnly = false )
+    QgsProcessingFeatureSourceDefinition( const QString &source = QString(), bool selectedFeaturesOnly = false, long long featureLimit = -1,
+                                          bool overrideDefaultGeometryCheck = false, QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid )
       : source( QgsProperty::fromValue( source ) )
       , selectedFeaturesOnly( selectedFeaturesOnly )
+      , featureLimit( featureLimit )
+      , overrideDefaultGeometryCheck( overrideDefaultGeometryCheck )
+      , geometryCheck( geometryCheck )
     {}
 
     /**
      * Constructor for QgsProcessingFeatureSourceDefinition, accepting a QgsProperty source.
+     *
+     * If \a selectedFeaturesOnly is TRUE, then only selected features from the source will be used.
+     *
+     * The optional \a featureLimit can be set to a value > 0 to place a hard limit on the maximum number
+     * of features which will be read from the source.
+     *
+     * If \a overrideDefaultGeometryCheck is TRUE, then the value of \a geometryCheck will override
+     * the default geometry check method (as dictated by QgsProcessingContext) for this source.
      */
-    QgsProcessingFeatureSourceDefinition( const QgsProperty &source, bool selectedFeaturesOnly = false )
+    QgsProcessingFeatureSourceDefinition( const QgsProperty &source, bool selectedFeaturesOnly = false, long long featureLimit = -1,
+                                          bool overrideDefaultGeometryCheck = false, QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid )
       : source( source )
       , selectedFeaturesOnly( selectedFeaturesOnly )
+      , featureLimit( featureLimit )
+      , overrideDefaultGeometryCheck( overrideDefaultGeometryCheck )
+      , geometryCheck( geometryCheck )
     {}
 
     /**
@@ -81,9 +105,39 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
      */
     bool selectedFeaturesOnly;
 
+    /**
+     * If set to a value > 0, places a limit on the maximum number of features which will be
+     * read from the source.
+     *
+     * \since QGIS 3.14
+     */
+    long long featureLimit = -1;
+
+    /**
+     * TRUE if the default geometry check method (as dictated by QgsProcessingContext)
+     * should be overridden for this source.
+     *
+     * \see geometryCheck
+     * \since QGIS 3.14
+     */
+    bool overrideDefaultGeometryCheck = false;
+
+    /**
+     * Geometry check method to apply to this source. This setting is only
+     * utilised if QgsProcessingFeatureSourceDefinition::overrideDefaultGeometryCheck is TRUE.
+     *
+     * \see overrideDefaultGeometryCheck
+     * \since QGIS 3.14
+     */
+    QgsFeatureRequest::InvalidGeometryCheck geometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid;
+
     bool operator==( const QgsProcessingFeatureSourceDefinition &other )
     {
-      return source == other.source && selectedFeaturesOnly == other.selectedFeaturesOnly;
+      return source == other.source
+             && selectedFeaturesOnly == other.selectedFeaturesOnly
+             && featureLimit == other.featureLimit
+             && overrideDefaultGeometryCheck == other.overrideDefaultGeometryCheck
+             && geometryCheck == other.geometryCheck;
     }
 
     bool operator!=( const QgsProcessingFeatureSourceDefinition &other )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -124,7 +124,7 @@ class CORE_EXPORT QgsProcessingFeatureSourceDefinition
 
     /**
      * Geometry check method to apply to this source. This setting is only
-     * utilised if QgsProcessingFeatureSourceDefinition::overrideDefaultGeometryCheck is TRUE.
+     * utilized if QgsProcessingFeatureSourceDefinition::overrideDefaultGeometryCheck is TRUE.
      *
      * \see overrideDefaultGeometryCheck
      * \since QGIS 3.14

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -279,6 +279,8 @@ class CORE_EXPORT QgsProcessingUtils
      * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
      * layer export is required. This defaults to shapefiles.
      *
+     * The \a featureLimit argument can be used to specify a limit on the number of features read from the layer.
+     *
      * When an algorithm is capable of handling multi-layer input files (such as Geopackage), it is preferable
      * to use convertToCompatibleFormatAndLayerName() which may avoid conversion in more situations.
      *
@@ -290,7 +292,7 @@ class CORE_EXPORT QgsProcessingUtils
         const QStringList &compatibleFormats,
         const QString &preferredFormat,
         QgsProcessingContext &context,
-        QgsProcessingFeedback *feedback );
+        QgsProcessingFeedback *feedback, long long featureLimit = -1 );
 
     /**
      * Converts a source vector \a layer to a file path and layer name of a vector layer of compatible format.
@@ -300,6 +302,8 @@ class CORE_EXPORT QgsProcessingUtils
      * in a temporary location using \a baseName. The function will then return the path to that temporary file.
      *
      * \a compatibleFormats should consist entirely of lowercase file extensions, e.g. 'shp'.
+     *
+     * The \a featureLimit argument can be used to specify a limit on the number of features read from the layer.
      *
      * The \a preferredFormat argument is used to specify to desired file extension to use when a temporary
      * layer export is required. This defaults to shapefiles.
@@ -316,6 +320,7 @@ class CORE_EXPORT QgsProcessingUtils
      * \param context processing context
      * \param feedback feedback object
      * \param layerName will be set to the target layer name for multi-layer sources (e.g. Geopackage)
+     * \param featureLimit can be used to place a limit on the maximum number of features read from the layer
      *
      * \returns path to source layer, or nearly converted compatible layer
      *
@@ -329,7 +334,7 @@ class CORE_EXPORT QgsProcessingUtils
         const QString &preferredFormat,
         QgsProcessingContext &context,
         QgsProcessingFeedback *feedback,
-        QString &layerName SIP_OUT );
+        QString &layerName SIP_OUT, long long featureLimit = -1 );
 
     /**
      * Combines two field lists, avoiding duplicate field names (in a case-insensitive manner).
@@ -451,8 +456,12 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
      * Ownership of \a originalSource is dictated by \a ownsOriginalSource. If \a ownsOriginalSource is FALSE,
      * ownership is not transferred, and callers must ensure that \a originalSource exists for the lifetime of this object.
      * If \a ownsOriginalSource is TRUE, then this object will take ownership of \a originalSource.
+     *
+     * If \a featureLimit is set to a value > 0, then a limit is placed on the maximum number of features which will be
+     * read from the source.
      */
-    QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource = false );
+    QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource = false,
+                                long long featureLimit = -1 );
 
     ~QgsProcessingFeatureSource() override;
 
@@ -483,6 +492,13 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
      */
     QgsExpressionContextScope *createExpressionContextScope() const SIP_FACTORY;
 
+    /**
+     * Overrides the default geometry check method for the source.
+     *
+     * \since QGIS 3.14
+     */
+    void setInvalidGeometryCheck( QgsFeatureRequest::InvalidGeometryCheck method );
+
   private:
 
     QgsFeatureSource *mSource = nullptr;
@@ -490,6 +506,7 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
     QgsFeatureRequest::InvalidGeometryCheck mInvalidGeometryCheck = QgsFeatureRequest::GeometryNoCheck;
     std::function< void( const QgsFeature & ) > mInvalidGeometryCallback;
     std::function< void( const QgsFeature & ) > mTransformErrorCallback;
+    long long mFeatureLimit = -1;
 
 };
 

--- a/tests/testdata/invalidgeometries.gfs
+++ b/tests/testdata/invalidgeometries.gfs
@@ -1,0 +1,15 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>invalidgeometries</Name>
+    <ElementPath>invalidgeometries</ElementPath>
+    <GeometryType>3</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>1</FeatureCount>
+      <ExtentXMin>122.17632</ExtentXMin>
+      <ExtentXMax>122.19038</ExtentXMax>
+      <ExtentYMin>-8.60636</ExtentYMin>
+      <ExtentYMax>-8.59579</ExtentYMax>
+    </DatasetSpecificInfo>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/tests/testdata/invalidgeometries.gml
+++ b/tests/testdata/invalidgeometries.gml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>122.1763203897661</gml:X><gml:Y>-8.606355050987483</gml:Y></gml:coord>
+      <gml:coord><gml:X>122.1903768142314</gml:X><gml:Y>-8.595792419886385</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                              
+  <gml:featureMember>
+    <ogr:invalidgeometries fid="invalidgeometries.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>122.176320389766076,-8.601236237453875 122.179976685147238,-8.597742444089665 122.184526741621553,-8.598392452157425 122.188508041036584,-8.602129998547044 122.186395514816354,-8.606355050987483 122.183795482545321,-8.602617504597864 122.188508041036584,-8.598311201148954 122.190376814231385,-8.595792419886385 122.190376814231385,-8.595792419886385 122.176320389766076,-8.601236237453875</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+    </ogr:invalidgeometries>
+  </gml:featureMember>
+</ogr:FeatureCollection>


### PR DESCRIPTION
Hookup backend API allowing features sources to be limited to a specific maximum number of features, and allowing per-source overriding of the default "invalid geometry" handling behavior

Refs NRCan Contract#3000707093