### PR TITLE
[MESH] Resampling from vertex values to face values

### DIFF
--- a/python/analysis/auto_generated/mesh/qgsmeshcontours.sip.in
+++ b/python/analysis/auto_generated/mesh/qgsmeshcontours.sip.in
@@ -36,7 +36,7 @@ Caches the native and triangular mesh from data provider
 
     QgsGeometry exportLines( const QgsMeshDatasetIndex &index,
                              double value,
-                             QgsMeshRendererScalarSettings::DataInterpolationMethod method,
+                             QgsMeshRendererScalarSettings::DataResamplingMethod method,
                              QgsFeedback *feedback = 0 );
 %Docstring
 Exports multi line string containing the contour line for particular dataset and value
@@ -52,7 +52,7 @@ Exports multi line string containing the contour line for particular dataset and
     QgsGeometry exportPolygons( const QgsMeshDatasetIndex &index,
                                 double min_value,
                                 double max_value,
-                                QgsMeshRendererScalarSettings::DataInterpolationMethod method,
+                                QgsMeshRendererScalarSettings::DataResamplingMethod method,
                                 QgsFeedback *feedback = 0 );
 %Docstring
 Exports multi polygons representing the areas with values in range for particular dataset

--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -96,6 +96,7 @@ Represents a mesh renderer settings for scalar datasets
 #include "qgsmeshrenderersettings.h"
 %End
   public:
+
     enum DataResamplingMethod
     {
 
@@ -135,7 +136,7 @@ Returns opacity
 Sets opacity
 %End
 
-    DataResamplingMethod dataInterpolationMethod() const;
+    DataResamplingMethod dataResamplingMethod() const;
 %Docstring
 Returns the type of interpolation to use to
 convert face defined datasets to
@@ -144,7 +145,7 @@ values on vertices
 .. versionadded:: 3.12
 %End
 
-    void setDataInterpolationMethod( const DataResamplingMethod &dataInterpolationMethod );
+    void setDataResamplingMethod( const DataResamplingMethod &dataResamplingMethod );
 %Docstring
 Sets data interpolation method
 

--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -96,7 +96,7 @@ Represents a mesh renderer settings for scalar datasets
 #include "qgsmeshrenderersettings.h"
 %End
   public:
-    enum DataInterpolationMethod
+    enum DataResamplingMethod
     {
 
       None,
@@ -135,7 +135,7 @@ Returns opacity
 Sets opacity
 %End
 
-    DataInterpolationMethod dataInterpolationMethod() const;
+    DataResamplingMethod dataInterpolationMethod() const;
 %Docstring
 Returns the type of interpolation to use to
 convert face defined datasets to
@@ -144,7 +144,7 @@ values on vertices
 .. versionadded:: 3.12
 %End
 
-    void setDataInterpolationMethod( const DataInterpolationMethod &dataInterpolationMethod );
+    void setDataInterpolationMethod( const DataResamplingMethod &dataInterpolationMethod );
 %Docstring
 Sets data interpolation method
 

--- a/src/analysis/mesh/qgsmeshcalcutils.cpp
+++ b/src/analysis/mesh/qgsmeshcalcutils.cpp
@@ -107,7 +107,7 @@ std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QStri
                 mMeshLayer->nativeMesh(),
                 mMeshLayer->triangularMesh(),
                 nullptr,
-                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataInterpolationMethod()
+                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataResamplingMethod()
               );
             Q_ASSERT( dataX.size() == resultCount );
             QVector<double> dataY =
@@ -116,7 +116,7 @@ std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QStri
                 mMeshLayer->nativeMesh(),
                 mMeshLayer->triangularMesh(),
                 nullptr,
-                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataInterpolationMethod()
+                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataResamplingMethod()
               );
 
             Q_ASSERT( dataY.size() == resultCount );

--- a/src/analysis/mesh/qgsmeshcontours.cpp
+++ b/src/analysis/mesh/qgsmeshcontours.cpp
@@ -58,7 +58,7 @@ QgsGeometry QgsMeshContours::exportPolygons(
   const QgsMeshDatasetIndex &index,
   double min_value,
   double max_value,
-  QgsMeshRendererScalarSettings::DataInterpolationMethod method,
+  QgsMeshRendererScalarSettings::DataResamplingMethod method,
   QgsFeedback *feedback
 )
 {
@@ -254,7 +254,7 @@ QgsGeometry QgsMeshContours::exportPolygons(
 
 QgsGeometry QgsMeshContours::exportLines( const QgsMeshDatasetIndex &index,
     double value,
-    QgsMeshRendererScalarSettings::DataInterpolationMethod method,
+    QgsMeshRendererScalarSettings::DataResamplingMethod method,
     QgsFeedback *feedback )
 {
   // Check if the layer/mesh is valid
@@ -380,7 +380,7 @@ QgsGeometry QgsMeshContours::exportLines( const QgsMeshDatasetIndex &index,
   }
 }
 
-void QgsMeshContours::populateCache( const QgsMeshDatasetIndex &index, QgsMeshRendererScalarSettings::DataInterpolationMethod method )
+void QgsMeshContours::populateCache( const QgsMeshDatasetIndex &index, QgsMeshRendererScalarSettings::DataResamplingMethod method )
 {
   if ( mCachedIndex != index )
   {

--- a/src/analysis/mesh/qgsmeshcontours.h
+++ b/src/analysis/mesh/qgsmeshcontours.h
@@ -69,7 +69,7 @@ class ANALYSIS_EXPORT QgsMeshContours
      */
     QgsGeometry exportLines( const QgsMeshDatasetIndex &index,
                              double value,
-                             QgsMeshRendererScalarSettings::DataInterpolationMethod method,
+                             QgsMeshRendererScalarSettings::DataResamplingMethod method,
                              QgsFeedback *feedback = nullptr );
 
     /**
@@ -84,13 +84,13 @@ class ANALYSIS_EXPORT QgsMeshContours
     QgsGeometry exportPolygons( const QgsMeshDatasetIndex &index,
                                 double min_value,
                                 double max_value,
-                                QgsMeshRendererScalarSettings::DataInterpolationMethod method,
+                                QgsMeshRendererScalarSettings::DataResamplingMethod method,
                                 QgsFeedback *feedback = nullptr );
 
   private:
     void populateCache(
       const QgsMeshDatasetIndex &index,
-      QgsMeshRendererScalarSettings::DataInterpolationMethod method );
+      QgsMeshRendererScalarSettings::DataResamplingMethod method );
 
     QgsMeshLayer *mMeshLayer = nullptr;
 

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -55,13 +55,11 @@ QgsMeshRendererScalarSettingsWidget::QgsMeshRendererScalarSettingsWidget( QWidge
 void QgsMeshRendererScalarSettingsWidget::setLayer( QgsMeshLayer *layer )
 {
   mMeshLayer = layer;
-  mScalarInterpolationTypeComboBox->setEnabled( dataIsDefinedOnFaces() );
 }
 
 void QgsMeshRendererScalarSettingsWidget::setActiveDatasetGroup( int groupIndex )
 {
   mActiveDatasetGroup = groupIndex;
-  mScalarInterpolationTypeComboBox->setEnabled( dataIsDefinedOnFaces() );
 }
 
 QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() const
@@ -142,16 +140,9 @@ void QgsMeshRendererScalarSettingsWidget::recalculateMinMaxButtonClicked()
 
 QgsMeshRendererScalarSettings::DataInterpolationMethod QgsMeshRendererScalarSettingsWidget::dataIntepolationMethod() const
 {
-  if ( dataIsDefinedOnFaces() )
-  {
-    const int data = mScalarInterpolationTypeComboBox->currentData().toInt();
-    const QgsMeshRendererScalarSettings::DataInterpolationMethod method = static_cast<QgsMeshRendererScalarSettings::DataInterpolationMethod>( data );
-    return method;
-  }
-  else
-  {
-    return QgsMeshRendererScalarSettings::None;
-  }
+  const int data = mScalarInterpolationTypeComboBox->currentData().toInt();
+  const QgsMeshRendererScalarSettings::DataInterpolationMethod method = static_cast<QgsMeshRendererScalarSettings::DataInterpolationMethod>( data );
+  return method;
 }
 
 bool QgsMeshRendererScalarSettingsWidget::dataIsDefinedOnFaces() const

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -70,7 +70,7 @@ QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() co
   settings.setColorRampShader( mScalarColorRampShaderWidget->shader() );
   settings.setClassificationMinimumMaximum( lineEditValue( mScalarMinLineEdit ), lineEditValue( mScalarMaxLineEdit ) );
   settings.setOpacity( mOpacityWidget->opacity() );
-  settings.setDataInterpolationMethod( dataIntepolationMethod() );
+  settings.setDataResamplingMethod( dataIntepolationMethod() );
   settings.setEdgeWidth( mScalarEdgeWidthSpinBox->value() );
   settings.setEdgeWidthUnit( mScalarEdgeWidthUnitSelectionWidget->unit() );
   return settings;
@@ -98,7 +98,7 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer( )
   whileBlocking( mScalarColorRampShaderWidget )->setFromShader( shader );
   whileBlocking( mScalarColorRampShaderWidget )->setMinimumMaximum( min, max );
   whileBlocking( mOpacityWidget )->setOpacity( settings.opacity() );
-  int index = mScalarInterpolationTypeComboBox->findData( settings.dataInterpolationMethod() );
+  int index = mScalarInterpolationTypeComboBox->findData( settings.dataResamplingMethod() );
   whileBlocking( mScalarInterpolationTypeComboBox )->setCurrentIndex( index );
 
   bool hasEdges = ( mMeshLayer->dataProvider() &&

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -55,11 +55,13 @@ QgsMeshRendererScalarSettingsWidget::QgsMeshRendererScalarSettingsWidget( QWidge
 void QgsMeshRendererScalarSettingsWidget::setLayer( QgsMeshLayer *layer )
 {
   mMeshLayer = layer;
+  mScalarInterpolationTypeComboBox->setEnabled( !dataIsDefinedOnEdges() );
 }
 
 void QgsMeshRendererScalarSettingsWidget::setActiveDatasetGroup( int groupIndex )
 {
   mActiveDatasetGroup = groupIndex;
+  mScalarInterpolationTypeComboBox->setEnabled( !dataIsDefinedOnEdges() );
 }
 
 QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() const
@@ -138,10 +140,10 @@ void QgsMeshRendererScalarSettingsWidget::recalculateMinMaxButtonClicked()
   mScalarColorRampShaderWidget->setMinimumMaximumAndClassify( min, max );
 }
 
-QgsMeshRendererScalarSettings::DataInterpolationMethod QgsMeshRendererScalarSettingsWidget::dataIntepolationMethod() const
+QgsMeshRendererScalarSettings::DataResamplingMethod QgsMeshRendererScalarSettingsWidget::dataIntepolationMethod() const
 {
   const int data = mScalarInterpolationTypeComboBox->currentData().toInt();
-  const QgsMeshRendererScalarSettings::DataInterpolationMethod method = static_cast<QgsMeshRendererScalarSettings::DataInterpolationMethod>( data );
+  const QgsMeshRendererScalarSettings::DataResamplingMethod method = static_cast<QgsMeshRendererScalarSettings::DataResamplingMethod>( data );
   return method;
 }
 
@@ -156,6 +158,19 @@ bool QgsMeshRendererScalarSettingsWidget::dataIsDefinedOnFaces() const
   QgsMeshDatasetGroupMetadata meta = mMeshLayer->dataProvider()->datasetGroupMetadata( mActiveDatasetGroup );
   const bool onFaces = ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnFaces );
   return onFaces;
+}
+
+bool QgsMeshRendererScalarSettingsWidget::dataIsDefinedOnEdges() const
+{
+  if ( !mMeshLayer || !mMeshLayer->dataProvider() || !mMeshLayer->dataProvider()->isValid() )
+    return false;
+
+  if ( mActiveDatasetGroup < 0 )
+    return false;
+
+  QgsMeshDatasetGroupMetadata meta = mMeshLayer->dataProvider()->datasetGroupMetadata( mActiveDatasetGroup );
+  const bool onEdges = ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnEdges );
+  return onEdges;
 }
 
 

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.h
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.h
@@ -65,9 +65,10 @@ class APP_EXPORT QgsMeshRendererScalarSettingsWidget : public QWidget, private U
 
   private:
     double lineEditValue( const QLineEdit *lineEdit ) const;
-    QgsMeshRendererScalarSettings::DataInterpolationMethod dataIntepolationMethod() const;
+    QgsMeshRendererScalarSettings::DataResamplingMethod dataIntepolationMethod() const;
 
     bool dataIsDefinedOnFaces() const;
+    bool dataIsDefinedOnEdges() const;
 
     QgsMeshLayer *mMeshLayer = nullptr; // not owned
     int mActiveDatasetGroup = -1;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -70,6 +70,31 @@ void QgsMeshLayer::setDefaultRendererSettings()
     meshSettings.setEnabled( true );
     mRendererSettings.setNativeMeshSettings( meshSettings );
   }
+
+  // Sets default resample method for scalar dataset
+  for ( int i = 0; i < mDataProvider->datasetGroupCount(); ++i )
+  {
+    QgsMeshDatasetGroupMetadata meta = mDataProvider->datasetGroupMetadata( i );
+    if ( meta.isScalar() )
+    {
+      QgsMeshRendererScalarSettings scalarSettings = mRendererSettings.scalarSettings( i );
+      switch ( meta.dataType() )
+      {
+        case QgsMeshDatasetGroupMetadata::DataOnFaces:
+        case QgsMeshDatasetGroupMetadata::DataOnVolumes: // data on volumes are averaged to 2D data on faces
+          scalarSettings.setDataInterpolationMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
+          break;
+        case QgsMeshDatasetGroupMetadata::DataOnVertices:
+          scalarSettings.setDataInterpolationMethod( QgsMeshRendererScalarSettings::None );
+          break;
+        case QgsMeshDatasetGroupMetadata::DataOnEdges:
+          break;
+
+      }
+      mRendererSettings.setScalarSettings( i, scalarSettings );
+    }
+  }
+
 }
 
 void QgsMeshLayer::createSimplifiedMeshes()

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -84,10 +84,10 @@ void QgsMeshLayer::setDefaultRendererSettings()
       {
         case QgsMeshDatasetGroupMetadata::DataOnFaces:
         case QgsMeshDatasetGroupMetadata::DataOnVolumes: // data on volumes are averaged to 2D data on faces
-          scalarSettings.setDataInterpolationMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
+          scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
           break;
         case QgsMeshDatasetGroupMetadata::DataOnVertices:
-          scalarSettings.setDataInterpolationMethod( QgsMeshRendererScalarSettings::None );
+          scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
           break;
         case QgsMeshDatasetGroupMetadata::DataOnEdges:
           break;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -72,6 +72,8 @@ void QgsMeshLayer::setDefaultRendererSettings()
   }
 
   // Sets default resample method for scalar dataset
+  if ( !mDataProvider )
+    return;
   for ( int i = 0; i < mDataProvider->datasetGroupCount(); ++i )
   {
     QgsMeshDatasetGroupMetadata meta = mDataProvider->datasetGroupMetadata( i );
@@ -89,7 +91,6 @@ void QgsMeshLayer::setDefaultRendererSettings()
           break;
         case QgsMeshDatasetGroupMetadata::DataOnEdges:
           break;
-
       }
       mRendererSettings.setScalarSettings( i, scalarSettings );
     }

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -106,7 +106,7 @@ void QgsMeshLayerRenderer::copyScalarDatasetValues( QgsMeshLayer *layer )
 
   // Find out if we can use cache up to date. If yes, use it and return
   const int datasetGroupCount = layer->dataProvider()->datasetGroupCount();
-  const QgsMeshRendererScalarSettings::DataInterpolationMethod method = mRendererSettings.scalarSettings( datasetIndex.group() ).dataInterpolationMethod();
+  const QgsMeshRendererScalarSettings::DataResamplingMethod method = mRendererSettings.scalarSettings( datasetIndex.group() ).dataInterpolationMethod();
   QgsMeshLayerRendererCache *cache = layer->rendererCache();
   if ( ( cache->mDatasetGroupsCount == datasetGroupCount ) &&
        ( cache->mActiveScalarDatasetIndex == datasetIndex ) &&

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -153,16 +153,31 @@ void QgsMeshLayerRenderer::copyScalarDatasetValues( QgsMeshLayer *layer )
                                     mNativeMesh.faces.count() );
 
     // for data on faces, there could be request to interpolate the data to vertices
-    if ( ( mScalarDataType == QgsMeshDatasetGroupMetadata::DataType::DataOnFaces ) && ( method != QgsMeshRendererScalarSettings::None ) )
+    if ( method != QgsMeshRendererScalarSettings::None )
     {
-      mScalarDataType = QgsMeshDatasetGroupMetadata::DataType::DataOnVertices;
-      mScalarDatasetValues = QgsMeshLayerUtils::interpolateFromFacesData(
-                               mScalarDatasetValues,
-                               &mNativeMesh,
-                               &mTriangularMesh,
-                               &mScalarActiveFaceFlagValues,
-                               method
-                             );
+      if ( mScalarDataType == QgsMeshDatasetGroupMetadata::DataType::DataOnFaces )
+      {
+        mScalarDataType = QgsMeshDatasetGroupMetadata::DataType::DataOnVertices;
+        mScalarDatasetValues = QgsMeshLayerUtils::interpolateFromFacesData(
+                                 mScalarDatasetValues,
+                                 &mNativeMesh,
+                                 &mTriangularMesh,
+                                 &mScalarActiveFaceFlagValues,
+                                 method
+                               );
+      }
+      else if ( mScalarDataType == QgsMeshDatasetGroupMetadata::DataType::DataOnVertices )
+      {
+        mScalarDataType = QgsMeshDatasetGroupMetadata::DataType::DataOnFaces;
+        mScalarDatasetValues = QgsMeshLayerUtils::resampleFromVerticesToFaces(
+                                 mScalarDatasetValues,
+                                 &mNativeMesh,
+                                 &mTriangularMesh,
+                                 &mScalarActiveFaceFlagValues,
+                                 method
+                               );
+      }
+
     }
 
     const QgsMeshDatasetMetadata datasetMetadata = layer->dataProvider()->datasetMetadata( datasetIndex );
@@ -181,6 +196,7 @@ void QgsMeshLayerRenderer::copyScalarDatasetValues( QgsMeshLayer *layer )
   cache->mScalarDatasetMaximum = mScalarDatasetMaximum;
   cache->mScalarAveragingMethod.reset( mRendererSettings.averagingMethod() ? mRendererSettings.averagingMethod()->clone() : nullptr );
 }
+
 
 void QgsMeshLayerRenderer::copyVectorDatasetValues( QgsMeshLayer *layer )
 {

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -106,7 +106,7 @@ void QgsMeshLayerRenderer::copyScalarDatasetValues( QgsMeshLayer *layer )
 
   // Find out if we can use cache up to date. If yes, use it and return
   const int datasetGroupCount = layer->dataProvider()->datasetGroupCount();
-  const QgsMeshRendererScalarSettings::DataResamplingMethod method = mRendererSettings.scalarSettings( datasetIndex.group() ).dataInterpolationMethod();
+  const QgsMeshRendererScalarSettings::DataResamplingMethod method = mRendererSettings.scalarSettings( datasetIndex.group() ).dataResamplingMethod();
   QgsMeshLayerRendererCache *cache = layer->rendererCache();
   if ( ( cache->mDatasetGroupsCount == datasetGroupCount ) &&
        ( cache->mActiveScalarDatasetIndex == datasetIndex ) &&

--- a/src/core/mesh/qgsmeshlayerrenderer.h
+++ b/src/core/mesh/qgsmeshlayerrenderer.h
@@ -63,7 +63,7 @@ struct CORE_NO_EXPORT QgsMeshLayerRendererCache
   QgsMeshDatasetGroupMetadata::DataType mScalarDataType = QgsMeshDatasetGroupMetadata::DataType::DataOnVertices;
   double mScalarDatasetMinimum = std::numeric_limits<double>::quiet_NaN();
   double mScalarDatasetMaximum = std::numeric_limits<double>::quiet_NaN();
-  QgsMeshRendererScalarSettings::DataInterpolationMethod mDataInterpolationMethod = QgsMeshRendererScalarSettings::None;
+  QgsMeshRendererScalarSettings::DataResamplingMethod mDataInterpolationMethod = QgsMeshRendererScalarSettings::None;
   std::unique_ptr<QgsMesh3dAveragingMethod> mScalarAveragingMethod;
 
   // vector dataset

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -355,6 +355,41 @@ QVector<double> QgsMeshLayerUtils::interpolateFromFacesData(
   return res;
 }
 
+QVector<double> QgsMeshLayerUtils::resampleFromVerticesToFaces(
+  const QVector<double> valuesOnVertices,
+  const QgsMesh *nativeMesh,
+  const QgsTriangularMesh *triangularMesh,
+  const QgsMeshDataBlock *active,
+  QgsMeshRendererScalarSettings::DataInterpolationMethod method )
+{
+  Q_UNUSED( triangularMesh )
+  Q_UNUSED( method )
+
+  assert( nativeMesh );
+  assert( method == QgsMeshRendererScalarSettings::NeighbourAverage );
+
+  // assuming that native vertex count = triangular vertex count
+  assert( nativeMesh->vertices.size() == triangularMesh->vertices().size() );
+
+  QVector<double> ret( nativeMesh->faceCount(), std::numeric_limits<double>::quiet_NaN() );
+
+  for ( int i = 0; i < nativeMesh->faces.size(); ++i )
+  {
+    const QgsMeshFace face = nativeMesh->face( i );
+    if ( active->active( i ) && face.count() )
+    {
+      double value = 0;
+      for ( int j = 0; j < face.count(); ++j )
+      {
+        value += valuesOnVertices.at( face.at( j ) );
+      }
+      ret[i] = value / face.count();
+    }
+  }
+
+  return ret;
+}
+
 QVector<double> QgsMeshLayerUtils::calculateMagnitudeOnVertices( const QgsMeshLayer *meshLayer,
     const QgsMeshDatasetIndex index,
     QgsMeshDataBlock *activeFaceFlagValues,

--- a/src/core/mesh/qgsmeshlayerutils.cpp
+++ b/src/core/mesh/qgsmeshlayerutils.cpp
@@ -305,11 +305,8 @@ QVector<double> QgsMeshLayerUtils::interpolateFromFacesData(
   const QgsMesh *nativeMesh,
   const QgsTriangularMesh *triangularMesh,
   QgsMeshDataBlock *active,
-  QgsMeshRendererScalarSettings::DataInterpolationMethod method )
+  QgsMeshRendererScalarSettings::DataResamplingMethod method )
 {
-  Q_UNUSED( triangularMesh )
-  Q_UNUSED( method )
-
   assert( nativeMesh );
   assert( method == QgsMeshRendererScalarSettings::NeighbourAverage );
 
@@ -360,11 +357,8 @@ QVector<double> QgsMeshLayerUtils::resampleFromVerticesToFaces(
   const QgsMesh *nativeMesh,
   const QgsTriangularMesh *triangularMesh,
   const QgsMeshDataBlock *active,
-  QgsMeshRendererScalarSettings::DataInterpolationMethod method )
+  QgsMeshRendererScalarSettings::DataResamplingMethod method )
 {
-  Q_UNUSED( triangularMesh )
-  Q_UNUSED( method )
-
   assert( nativeMesh );
   assert( method == QgsMeshRendererScalarSettings::NeighbourAverage );
 
@@ -376,7 +370,7 @@ QVector<double> QgsMeshLayerUtils::resampleFromVerticesToFaces(
   for ( int i = 0; i < nativeMesh->faces.size(); ++i )
   {
     const QgsMeshFace face = nativeMesh->face( i );
-    if ( active->active( i ) && face.count() )
+    if ( active->active( i ) && face.count() > 2 )
     {
       double value = 0;
       for ( int j = 0; j < face.count(); ++j )
@@ -393,7 +387,7 @@ QVector<double> QgsMeshLayerUtils::resampleFromVerticesToFaces(
 QVector<double> QgsMeshLayerUtils::calculateMagnitudeOnVertices( const QgsMeshLayer *meshLayer,
     const QgsMeshDatasetIndex index,
     QgsMeshDataBlock *activeFaceFlagValues,
-    const QgsMeshRendererScalarSettings::DataInterpolationMethod method )
+    const QgsMeshRendererScalarSettings::DataResamplingMethod method )
 {
   QVector<double> ret;
 

--- a/src/core/mesh/qgsmeshlayerutils.h
+++ b/src/core/mesh/qgsmeshlayerutils.h
@@ -213,6 +213,19 @@ class CORE_EXPORT QgsMeshLayerUtils
     );
 
     /**
+    * Resample values on vertices to values on faces
+    *
+    * \since QGIS 3.14
+    */
+    static QVector<double> resampleFromVerticesToFaces(
+      const QVector<double> valuesOnVertices,
+      const QgsMesh *nativeMesh,
+      const QgsTriangularMesh *triangularMesh,
+      const QgsMeshDataBlock *active,
+      QgsMeshRendererScalarSettings::DataInterpolationMethod method
+    );
+
+    /**
      * Calculates magnitude values ont vertices from the given QgsMeshDataBlock.
      * If the values are defined on faces,
      * \param meshLayer the mesh layer

--- a/src/core/mesh/qgsmeshlayerutils.h
+++ b/src/core/mesh/qgsmeshlayerutils.h
@@ -209,11 +209,11 @@ class CORE_EXPORT QgsMeshLayerUtils
       const QgsMesh *nativeMesh,
       const QgsTriangularMesh *triangularMesh,
       QgsMeshDataBlock *active,
-      QgsMeshRendererScalarSettings::DataInterpolationMethod method
+      QgsMeshRendererScalarSettings::DataResamplingMethod method
     );
 
     /**
-    * Resample values on vertices to values on faces
+    * Resamples values on vertices to values on faces
     *
     * \since QGIS 3.14
     */
@@ -222,7 +222,7 @@ class CORE_EXPORT QgsMeshLayerUtils
       const QgsMesh *nativeMesh,
       const QgsTriangularMesh *triangularMesh,
       const QgsMeshDataBlock *active,
-      QgsMeshRendererScalarSettings::DataInterpolationMethod method
+      QgsMeshRendererScalarSettings::DataResamplingMethod method
     );
 
     /**
@@ -239,7 +239,7 @@ class CORE_EXPORT QgsMeshLayerUtils
       const QgsMeshLayer *meshLayer,
       const QgsMeshDatasetIndex index,
       QgsMeshDataBlock *activeFaceFlagValues,
-      const QgsMeshRendererScalarSettings::DataInterpolationMethod method = QgsMeshRendererScalarSettings::NeighbourAverage );
+      const QgsMeshRendererScalarSettings::DataResamplingMethod method = QgsMeshRendererScalarSettings::NeighbourAverage );
 
     /**
      * Calculates the bounding box of the triangle

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -102,12 +102,12 @@ double QgsMeshRendererScalarSettings::opacity() const { return mOpacity; }
 
 void QgsMeshRendererScalarSettings::setOpacity( double opacity ) { mOpacity = opacity; }
 
-QgsMeshRendererScalarSettings::DataInterpolationMethod QgsMeshRendererScalarSettings::dataInterpolationMethod() const
+QgsMeshRendererScalarSettings::DataResamplingMethod QgsMeshRendererScalarSettings::dataInterpolationMethod() const
 {
   return mDataInterpolationMethod;
 }
 
-void QgsMeshRendererScalarSettings::setDataInterpolationMethod( const QgsMeshRendererScalarSettings::DataInterpolationMethod &dataInterpolationMethod )
+void QgsMeshRendererScalarSettings::setDataInterpolationMethod( const QgsMeshRendererScalarSettings::DataResamplingMethod &dataInterpolationMethod )
 {
   mDataInterpolationMethod = dataInterpolationMethod;
 }
@@ -148,11 +148,11 @@ void QgsMeshRendererScalarSettings::readXml( const QDomElement &elem )
   QString methodTxt = elem.attribute( QStringLiteral( "interpolation-method" ) );
   if ( QStringLiteral( "neighbour-average" ) == methodTxt )
   {
-    mDataInterpolationMethod = DataInterpolationMethod::NeighbourAverage;
+    mDataInterpolationMethod = DataResamplingMethod::NeighbourAverage;
   }
   else
   {
-    mDataInterpolationMethod = DataInterpolationMethod::None;
+    mDataInterpolationMethod = DataResamplingMethod::None;
   }
   QDomElement elemShader = elem.firstChildElement( QStringLiteral( "colorrampshader" ) );
   mColorRampShader.readXml( elemShader );

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -102,14 +102,14 @@ double QgsMeshRendererScalarSettings::opacity() const { return mOpacity; }
 
 void QgsMeshRendererScalarSettings::setOpacity( double opacity ) { mOpacity = opacity; }
 
-QgsMeshRendererScalarSettings::DataResamplingMethod QgsMeshRendererScalarSettings::dataInterpolationMethod() const
+QgsMeshRendererScalarSettings::DataResamplingMethod QgsMeshRendererScalarSettings::dataResamplingMethod() const
 {
-  return mDataInterpolationMethod;
+  return mDataResamplingMethod;
 }
 
-void QgsMeshRendererScalarSettings::setDataInterpolationMethod( const QgsMeshRendererScalarSettings::DataResamplingMethod &dataInterpolationMethod )
+void QgsMeshRendererScalarSettings::setDataResamplingMethod( const QgsMeshRendererScalarSettings::DataResamplingMethod &dataInterpolationMethod )
 {
-  mDataInterpolationMethod = dataInterpolationMethod;
+  mDataResamplingMethod = dataInterpolationMethod;
 }
 
 QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc ) const
@@ -122,7 +122,7 @@ QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc ) const
   elem.setAttribute( QStringLiteral( "edge-width-unit" ), QgsUnitTypes::encodeUnit( mEdgeWidthUnit ) );
 
   QString methodTxt;
-  switch ( mDataInterpolationMethod )
+  switch ( mDataResamplingMethod )
   {
     case None:
       methodTxt = QStringLiteral( "none" );
@@ -148,11 +148,11 @@ void QgsMeshRendererScalarSettings::readXml( const QDomElement &elem )
   QString methodTxt = elem.attribute( QStringLiteral( "interpolation-method" ) );
   if ( QStringLiteral( "neighbour-average" ) == methodTxt )
   {
-    mDataInterpolationMethod = DataResamplingMethod::NeighbourAverage;
+    mDataResamplingMethod = DataResamplingMethod::NeighbourAverage;
   }
   else
   {
-    mDataInterpolationMethod = DataResamplingMethod::None;
+    mDataResamplingMethod = DataResamplingMethod::None;
   }
   QDomElement elemShader = elem.firstChildElement( QStringLiteral( "colorrampshader" ) );
   mColorRampShader.readXml( elemShader );

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -93,12 +93,18 @@ class CORE_EXPORT QgsMeshRendererMeshSettings
 class CORE_EXPORT QgsMeshRendererScalarSettings
 {
   public:
-    //! Interpolation of value defined on vertices from datasets with data defined on faces
-    enum DataInterpolationMethod
+    /**
+     * Resampling of value from dataset
+     *
+     * - for vertices : does a resampling from values defined on surrounding faces
+     * - for faces : does a resampling from values defined on surrounding vertices
+     * - for edges : not supported.
+     */
+    enum DataResamplingMethod
     {
 
       /**
-       * Does not use interpolation
+       * Does not use resampling
        */
       None = 0,
 
@@ -132,14 +138,14 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
      *
      * \since QGIS 3.12
      */
-    DataInterpolationMethod dataInterpolationMethod() const;
+    DataResamplingMethod dataInterpolationMethod() const;
 
     /**
      * Sets data interpolation method
      *
      * \since QGIS 3.12
      */
-    void setDataInterpolationMethod( const DataInterpolationMethod &dataInterpolationMethod );
+    void setDataInterpolationMethod( const DataResamplingMethod &dataInterpolationMethod );
 
     //! Writes configuration to a new DOM element
     QDomElement writeXml( QDomDocument &doc ) const;
@@ -176,7 +182,7 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
 
   private:
     QgsColorRampShader mColorRampShader;
-    DataInterpolationMethod mDataInterpolationMethod = DataInterpolationMethod::None;
+    DataResamplingMethod mDataInterpolationMethod = DataResamplingMethod::None;
     double mClassificationMinimum = 0;
     double mClassificationMaximum = 0;
     double mOpacity = 1;

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -98,13 +98,12 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
     {
 
       /**
-       * Use data defined on face centers, do not interpolate to vertices
+       * Does not use interpolation
        */
       None = 0,
 
       /**
-       * For each vertex does a simple average of values defined for all faces that contains
-       * given vertex
+       * Does a simple average of values defined for all surrounding faces/vertices
        */
       NeighbourAverage,
     };

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -93,6 +93,7 @@ class CORE_EXPORT QgsMeshRendererMeshSettings
 class CORE_EXPORT QgsMeshRendererScalarSettings
 {
   public:
+
     /**
      * Resampling of value from dataset
      *
@@ -138,14 +139,14 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
      *
      * \since QGIS 3.12
      */
-    DataResamplingMethod dataInterpolationMethod() const;
+    DataResamplingMethod dataResamplingMethod() const;
 
     /**
      * Sets data interpolation method
      *
      * \since QGIS 3.12
      */
-    void setDataInterpolationMethod( const DataResamplingMethod &dataInterpolationMethod );
+    void setDataResamplingMethod( const DataResamplingMethod &dataResamplingMethod );
 
     //! Writes configuration to a new DOM element
     QDomElement writeXml( QDomDocument &doc ) const;
@@ -182,7 +183,7 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
 
   private:
     QgsColorRampShader mColorRampShader;
-    DataResamplingMethod mDataInterpolationMethod = DataResamplingMethod::None;
+    DataResamplingMethod mDataResamplingMethod = DataResamplingMethod::None;
     double mClassificationMinimum = 0;
     double mClassificationMaximum = 0;
     double mOpacity = 1;

--- a/tests/src/core/testqgsmeshlayerrenderer.cpp
+++ b/tests/src/core/testqgsmeshlayerrenderer.cpp
@@ -371,7 +371,7 @@ void TestQgsMeshRenderer::test_face_scalar_dataset_interpolated_neighbour_averag
   QgsMeshRendererSettings rendererSettings = mMemoryLayer->rendererSettings();
   rendererSettings.setActiveScalarDataset( ds );
   auto scalarRendererSettings = rendererSettings.scalarSettings( 2 );
-  scalarRendererSettings.setDataInterpolationMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
+  scalarRendererSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
   rendererSettings.setScalarSettings( 2, scalarRendererSettings );
   mMemoryLayer->setRendererSettings( rendererSettings );
 
@@ -535,6 +535,9 @@ void TestQgsMeshRenderer::test_stacked_3d_mesh_single_level_averaging()
   QVERIFY( metadata.name() == "temperature" );
   QVERIFY( metadata.maximumVerticalLevelsCount() == 10 );
   rendererSettings.setActiveScalarDataset( ds );
+  QgsMeshRendererScalarSettings scalarSettings = rendererSettings.scalarSettings( ds.group() );
+  scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
+  rendererSettings.setScalarSettings( ds.group(), scalarSettings );
   // want to set active vector dataset one defined on 3d mesh
   ds = QgsMeshDatasetIndex( 6, 3 );
   metadata = mMdal3DLayer->dataProvider()->datasetGroupMetadata( ds );


### PR DESCRIPTION
Resampling is available or dataset defined on faces, e.g., the value on vertices is calculated from value on faces. 

This PR implements resampling from values on vertices to values on faces with the neighbor average method.
The default method is set to "none" for resampling from vertices to faces and to "neighbor average" for resampling from faces to vertices. Then the default rendering is always smoothie.
![resampling](https://user-images.githubusercontent.com/7416892/77320848-acc41c00-6ce7-11ea-85af-2bff553ecbb5.gif)
