### PR TITLE
take another try to get a valid relation in the relation reference widget

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -76,7 +76,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   QgsRelation relation; // invalid relation by default
   if ( relationName.isValid() )
     relation = QgsProject::instance()->relationManager()->relation( relationName.toString() );
-  else if ( ! layer()->referencingRelations( fieldIdx() ).isEmpty() )
+  if ( !relation.isValid() && !layer()->referencingRelations( fieldIdx() ).isEmpty() )
     relation = layer()->referencingRelations( fieldIdx() )[0];
 
   // If this widget is already embedded by the same relation, reduce functionality


### PR DESCRIPTION
If the relation name is invalid, try to get the relation using the field name.

I had the case with a project where relations were apparently badly configured (bad relation name).

For the referenced layer, the relation editor was saying the relation was invalid although it was correctly configured in the layer properties.
BUT the referencing layer had its referencing field configured as a relation reference widget but with a bad relation ID.

This fixes this scenario.

Who is the current master of the relation reference widget? @m-kuhn @signedav @pblottiere ? 