### PR TITLE
Fix incorrect variable name to allow deletion of geopackage from browser

### DIFF
--- a/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
+++ b/src/gui/providers/ogr/qgsgeopackageitemguiprovider.cpp
@@ -120,7 +120,7 @@ void QgsGeoPackageItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu
     QVariantMap dataDelete;
     dataDelete.insert( QStringLiteral( "path" ), collectionItem->path() );
     dataDelete.insert( QStringLiteral( "parent" ), QVariant::fromValue( QPointer< QgsDataItem >( collectionItem->parent() ) ) );
-    actionAddTable->setData( dataDelete );
+    actionDelete->setData( dataDelete );
     connect( actionDelete, &QAction::triggered, this, &QgsGeoPackageItemGuiProvider::deleteGpkg );
     menu->addAction( actionDelete );
 


### PR DESCRIPTION
Fix typo - assign deletion actions to `actionDelete`
Fixes #35262 
