### PR TITLE
Improve offline editing layer detection and code

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -38,6 +38,8 @@
 #include "qgsogrutils.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsvectorlayer.h"
+#include "qgsproviderregistry.h"
+#include "qgsprovidermetadata.h"
 
 #include <QDir>
 #include <QDomDocument>
@@ -1492,12 +1494,10 @@ void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, cons
   }
   else
   {
-    if ( dataSourceString.indexOf( QLatin1String( "|layername=" ) ) != -1 )
-    {
-      QRegularExpression regex( QStringLiteral( "\\|layername=([^|]*)" ) );
-      tableName = regex.match( dataSourceString ).captured( 1 );
-    }
-    else
+    QgsProviderMetadata *ogrProviderMetaData = QgsProviderRegistry::instance()->providerMetadata( QStringLiteral( "ogr" ) );
+    QVariantMap decodedUri = ogrProviderMetaData->decodeUri( dataSourceString );
+    tableName = decodedUri.value( QStringLiteral( "layerName" ) ).toString();
+    if ( tableName.isEmpty() )
     {
       showWarning( tr( "Could not deduce table name from data source %1." ).arg( dataSourceString ) );
     }

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1453,9 +1453,8 @@ void QgsOfflineEditing::committedAttributesAdded( const QString &qgisLayerId, co
   int layerId = getOrCreateLayerId( database.get(), qgisLayerId );
   int commitNo = getCommitNo( database.get() );
 
-  for ( QList<QgsField>::const_iterator it = addedAttributes.begin(); it != addedAttributes.end(); ++it )
+  for ( const QgsField &field : addedAttributes )
   {
-    QgsField field = *it;
     QString sql = QStringLiteral( "INSERT INTO 'log_added_attrs' VALUES ( %1, %2, '%3', %4, %5, %6, '%7' )" )
                   .arg( layerId )
                   .arg( commitNo )
@@ -1516,19 +1515,19 @@ void QgsOfflineEditing::committedFeaturesRemoved( const QString &qgisLayerId, co
   // insert log
   int layerId = getOrCreateLayerId( database.get(), qgisLayerId );
 
-  for ( QgsFeatureIds::const_iterator it = deletedFeatureIds.begin(); it != deletedFeatureIds.end(); ++it )
+  for ( QgsFeatureId id : deletedFeatureIds )
   {
-    if ( isAddedFeature( database.get(), layerId, *it ) )
+    if ( isAddedFeature( database.get(), layerId, id ) )
     {
       // remove from added features log
-      QString sql = QStringLiteral( "DELETE FROM 'log_added_features' WHERE \"layer_id\" = %1 AND \"fid\" = %2" ).arg( layerId ).arg( *it );
+      QString sql = QStringLiteral( "DELETE FROM 'log_added_features' WHERE \"layer_id\" = %1 AND \"fid\" = %2" ).arg( layerId ).arg( id );
       sqlExec( database.get(), sql );
     }
     else
     {
       QString sql = QStringLiteral( "INSERT INTO 'log_removed_features' VALUES ( %1, %2)" )
                     .arg( layerId )
-                    .arg( *it );
+                    .arg( id );
       sqlExec( database.get(), sql );
     }
   }

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1480,7 +1480,8 @@ void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, cons
 
   // get new feature ids from db
   QgsMapLayer *layer = QgsProject::instance()->mapLayer( qgisLayerId );
-  QgsDataSourceUri uri = QgsDataSourceUri( layer->source() );
+  QString dataSourceString = layer->source();
+  QgsDataSourceUri uri = QgsDataSourceUri( dataSourceString );
 
   QString offlinePath = QgsProject::instance()->readPath( QgsProject::instance()->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH ) );
   QString tableName;
@@ -1491,7 +1492,15 @@ void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, cons
   }
   else
   {
-    tableName = uri.param( offlinePath + "|layername" );
+    if ( dataSourceString.indexOf( QLatin1String( "|layername=" ) ) != -1 )
+    {
+      QRegularExpression regex( QStringLiteral( "\\|layername=([^|]*)" ) );
+      tableName = regex.match( dataSourceString ).captured( 1 );
+    }
+    else
+    {
+      showWarning( tr( "Could not deduce table name from data source %1." ).arg( dataSourceString ) );
+    }
   }
 
   // only store feature ids

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -135,7 +135,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
 
       QgsSnappingConfig snappingConfig = QgsProject::instance()->snappingConfig();
 
-      // copy selected vector layers to SpatiaLite
+      // copy selected vector layers to offline layer
       for ( int i = 0; i < layerIds.count(); i++ )
       {
         emit layerProgressUpdated( i + 1, layerIds.count() );
@@ -162,7 +162,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
 
       QgsProject::instance()->setSnappingConfig( snappingConfig );
 
-      // restore join info on new SpatiaLite layer
+      // restore join info on new offline layer
       QMap<QString, QgsVectorJoinList >::ConstIterator it;
       for ( it = joinInfoBuffer.constBegin(); it != joinInfoBuffer.constEnd(); ++it )
       {


### PR DESCRIPTION
Offline editing currently relies on

- "layername" being the exactly the first part of the URL
- `QgsDataSourceUri::param( "{file_path_to_gpkg}|layername" )` to return the layer name

This solidifies this behavior with the regex approach from the gpkg provider (still not perfect but *much* more stable).

Also comes with some general modernization of the code.