### PR TITLE
By default, do *not* force all fields to become strings when exporting to XLS/XLSX/ODS/CSV

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -424,7 +424,6 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
   {
     if ( mOptions & Fields )
       mAttributesSelection->setVisible( true );
-    fieldsAsDisplayedValues = ( sFormat == QLatin1String( "CSV" ) || sFormat == QLatin1String( "XLS" ) || sFormat == QLatin1String( "XLSX" ) || sFormat == QLatin1String( "ODS" ) );
   }
 
   // Show symbology options only for some formats


### PR DESCRIPTION
## Description

This PR reverts a change made in 2016 (https://github.com/qgis/QGIS/commit/8ee697bf2dcb7cb6329d2d6aefc009350878375d) which transformed all field types to string when saving as XLS/XLSX/ODS/CSV. That default behavior leads to data type loss and other regressions. For e.g., when you save a temporary memory output (say from a processing algorithm) as XLSX, all values become strings, and field _names_ are also lost.

@rouault , is there a technical limitation on GDAL's side that led you to force all fields to be strings for these drivers? If not, I'm begging for a reversal of default behavior here. 
