### PR TITLE
remove assert on message bar

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4484,7 +4484,7 @@ void QgisApp::freezeCanvases( bool frozen )
 
 QgsMessageBar *QgisApp::messageBar()
 {
-  Q_ASSERT( mInfoBar );
+  // Q_ASSERT( mInfoBar );
   return mInfoBar;
 }
 


### PR DESCRIPTION
When launching QGIS, I get a crash due to this message:

> Populating font family aliases took 179 ms. Replace uses of missing font family "FreeSans" with one that exists to avoid this cost

Or shall this be filtered like others here:
<img width="692" alt="Screenshot 2020-03-24 at 10 45 06" src="https://user-images.githubusercontent.com/127259/77411404-abb0ee80-6dbc-11ea-8690-e73a10d2ecb2.png">
