### PR TITLE
Check that plugin dir exists before linking to it

### DIFF
--- a/.docker/qgis_resources/test_runner/qgis_setup.sh
+++ b/.docker/qgis_resources/test_runner/qgis_setup.sh
@@ -44,7 +44,12 @@ if [[ -n "$PLUGIN_NAME" ]]; then
     printf "%s=true\n\n" "$PLUGIN_NAME" >> $CONF_MASTER_FILE
     # Install the plugin
     if [ ! -d "${PLUGIN_MASTER_FOLDER}/${PLUGIN_NAME}" ]; then
-        ln -s "/tests_directory/${PLUGIN_NAME}" "${PLUGIN_MASTER_FOLDER}"
+        plugin_dir="/tests_directory/${PLUGIN_NAME}"
+        if [ ! -d "${plugin_dir}" ]; then
+          echo "ERROR: ${plugin_dir} does not exist" >&2
+          exit 1
+        fi
+        ln -s "${plugin_dir}" "${PLUGIN_MASTER_FOLDER}"
         echo "Plugin master folder linked in ${PLUGIN_MASTER_FOLDER}/${PLUGIN_NAME}"
     fi
 fi


### PR DESCRIPTION
Reduces frustration for plugin developers willing to test
the plugin..

I can think of more improvements but I'm not sure how many people
use the tool and thus how much backward compatibility should be
retained.