### PR TITLE
Interface and API for unified development/debugging tools

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -103,6 +103,7 @@ IF(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/gui/auth
       ${CMAKE_SOURCE_DIR}/src/gui/attributetable
       ${CMAKE_SOURCE_DIR}/src/gui/callouts
+      ${CMAKE_SOURCE_DIR}/src/gui/devtools
       ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
       ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets/core
       ${CMAKE_SOURCE_DIR}/src/gui/effects

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -141,6 +141,7 @@ IF (WITH_GUI)
     ${CMAKE_SOURCE_DIR}/src/gui/raster
     ${CMAKE_SOURCE_DIR}/src/gui/attributetable
     ${CMAKE_SOURCE_DIR}/src/gui/auth
+    ${CMAKE_SOURCE_DIR}/src/gui/devtools
     ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
     ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets/core
     ${CMAKE_SOURCE_DIR}/src/gui/effects

--- a/python/gui/auto_generated/devtools/qgsdevtoolwidget.sip.in
+++ b/python/gui/auto_generated/devtools/qgsdevtoolwidget.sip.in
@@ -1,0 +1,36 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/devtools/qgsdevtoolwidget.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+class QgsDevToolWidget : QgsPanelWidget
+{
+%Docstring
+A panel widget that can be shown in the developer tools panel.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsdevtoolwidget.h"
+%End
+  public:
+
+    QgsDevToolWidget( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsDevToolWidget, with the specified ``parent`` widget.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/devtools/qgsdevtoolwidget.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/devtools/qgsdevtoolwidgetfactory.sip.in
+++ b/python/gui/auto_generated/devtools/qgsdevtoolwidgetfactory.sip.in
@@ -1,0 +1,73 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/devtools/qgsdevtoolwidgetfactory.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsDevToolWidgetFactory
+{
+%Docstring
+Factory class for creating custom developer/debugging tool pages
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsdevtoolwidgetfactory.h"
+%End
+  public:
+
+    QgsDevToolWidgetFactory( const QString &title = QString(), const QIcon &icon = QIcon() );
+%Docstring
+Constructor for a QgsDevToolWidgetFactory with the specified ``title`` and ``icon``.
+%End
+
+    virtual ~QgsDevToolWidgetFactory();
+
+    virtual QIcon icon() const;
+%Docstring
+Returns the icon that will be shown in the tool in the panel.
+
+.. seealso:: :py:func:`setIcon`
+%End
+
+    void setIcon( const QIcon &icon );
+%Docstring
+Sets the ``icon`` for the factory object, which will be shown for the tool in the panel.
+
+.. seealso:: :py:func:`icon`
+%End
+
+    virtual QString title() const;
+%Docstring
+Returns the (translated) title of the tool.
+
+.. seealso:: :py:func:`setTitle`
+%End
+
+    void setTitle( const QString &title );
+%Docstring
+Set the translated ``title`` for the tool.
+%End
+
+    virtual QgsDevToolWidget *createWidget( QWidget *parent = 0 ) const = 0 /Factory/;
+%Docstring
+Factory function to create the widget on demand as needed by the dock.
+
+The ``parent`` argument gives the correct parent for the newly created widget.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/devtools/qgsdevtoolwidgetfactory.h                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1118,6 +1118,29 @@ Unregister a previously registered tab in the options dialog.
 .. versionadded:: 3.0
 %End
 
+    virtual void registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;
+%Docstring
+Register a new tool in the development/debugging tools dock.
+
+.. note::
+
+   Ownership of the factory is not transferred, and the factory must
+   be unregistered when plugin is unloaded.
+
+.. seealso:: :py:func:`unregisterDevToolWidgetFactory`
+
+.. versionadded:: 3.14
+%End
+
+    virtual void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;
+%Docstring
+Unregister a previously registered tool factory from the development/debugging tools dock.
+
+.. seealso:: :py:func:`registerDevToolWidgetFactory`
+
+.. versionadded:: 3.14
+%End
+
     virtual void registerCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 %Docstring
 Register a new custom drop handler.

--- a/python/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
+++ b/python/gui/auto_generated/qgsmaplayerconfigwidgetfactory.sip.in
@@ -108,7 +108,7 @@ Check if the layer is supported for this widget.
 :return: ``True`` if this layer is supported for this widget
 %End
 
-    virtual QgsMapLayerConfigWidget *createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget = true, QWidget *parent /TransferThis/ = 0 ) const = 0 /Factory/;
+    virtual QgsMapLayerConfigWidget *createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget = true, QWidget *parent = 0 ) const = 0 /Factory/;
 %Docstring
 Factory function to create the widget on demand as needed by the dock.
 

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -239,6 +239,8 @@
 %Include auto_generated/auth/qgsauthsslimportdialog.sip
 %Include auto_generated/auth/qgsauthtrustedcasdialog.sip
 %Include auto_generated/callouts/qgscalloutwidget.sip
+%Include auto_generated/devtools/qgsdevtoolwidget.sip
+%Include auto_generated/devtools/qgsdevtoolwidgetfactory.sip
 %Include auto_generated/editorwidgets/core/qgseditorconfigwidget.sip
 %Include auto_generated/editorwidgets/core/qgseditorwidgetautoconf.sip
 %Include auto_generated/editorwidgets/core/qgseditorwidgetfactory.sip

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -409,6 +409,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/gui/symbology
   ${CMAKE_SOURCE_DIR}/src/gui/attributetable
   ${CMAKE_SOURCE_DIR}/src/gui/auth
+  ${CMAKE_SOURCE_DIR}/src/gui/devtools
   ${CMAKE_SOURCE_DIR}/src/gui/labeling
   ${CMAKE_SOURCE_DIR}/src/gui/numericformats
   ${CMAKE_SOURCE_DIR}/src/gui/ogr

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -27,6 +27,7 @@ SET(QGIS_APP_SRCS
   qgscustomization.cpp
   qgscustomprojectiondialog.cpp
   qgsdatumtransformtablewidget.cpp
+  qgsdevtoolspanelwidget.cpp
   qgsdiscoverrelationsdialog.cpp
   qgsdxfexportdialog.cpp
   qgsformannotationdialog.cpp

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -78,6 +78,7 @@
 #include "qgsrelationmanager.h"
 #include "qgsapplication.h"
 #include "qgslayerstylingwidget.h"
+#include "qgsdevtoolspanelwidget.h"
 #include "qgstaskmanager.h"
 #include "qgsweakrelation.h"
 #include "qgsziputils.h"
@@ -1119,6 +1120,23 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   addDockWidget( Qt::RightDockWidgetArea, mMapStylingDock );
   mMapStylingDock->hide();
+  endProfile();
+
+  startProfile( QStringLiteral( "Dev Tools dock" ) );
+  mDevToolsDock = new QgsDockWidget( this );
+  mDevToolsDock->setWindowTitle( tr( "Debugging/Development Tools" ) );
+  mDevToolsDock->setObjectName( QStringLiteral( "DevTools" ) );
+  QShortcut *showDevToolsDock = new QShortcut( QKeySequence( tr( "F12" ) ), this );
+  connect( showDevToolsDock, &QShortcut::activated, mDevToolsDock, &QgsDockWidget::toggleUserVisible );
+  showDevToolsDock->setObjectName( QStringLiteral( "ShowDevToolsPanel" ) );
+  showDevToolsDock->setWhatsThis( tr( "Show Debugging/Development Tools" ) );
+
+  mDevToolsWidget = new QgsDevToolsPanelWidget( mDevToolFactories );
+  mDevToolsDock->setWidget( mDevToolsWidget );
+//  connect( mDevToolsDock, &QDockWidget::visibilityChanged, mActionStyleDock, &QAction::setChecked );
+
+  addDockWidget( Qt::RightDockWidgetArea, mDevToolsDock );
+  mDevToolsDock->hide();
   endProfile();
 
   startProfile( QStringLiteral( "Snapping dialog" ) );
@@ -11855,6 +11873,22 @@ void QgisApp::registerOptionsWidgetFactory( QgsOptionsWidgetFactory *factory )
 void QgisApp::unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory )
 {
   mOptionsWidgetFactories.removeAll( factory );
+}
+
+void QgisApp::registerDevToolFactory( QgsDevToolWidgetFactory *factory )
+{
+  mDevToolFactories << factory;
+  if ( mDevToolsWidget )
+  {
+    // widget was already created, so we manually need to push this factory to the widget
+    mDevToolsWidget->addToolFactory( factory );
+  }
+}
+
+void QgisApp::unregisterDevToolFactory( QgsDevToolWidgetFactory *factory )
+{
+  mDevToolsWidget->removeToolFactory( factory );
+  mDevToolFactories.removeAll( factory );
 }
 
 QgsMapLayer *QgisApp::activeLayer()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -139,6 +139,8 @@ class QgsLayoutCustomDropHandler;
 class QgsProxyProgressTask;
 class QgsNetworkRequestParameters;
 class QgsBearingNumericFormat;
+class QgsDevToolsPanelWidget;
+class QgsDevToolWidgetFactory;
 
 #include <QMainWindow>
 #include <QToolBar>
@@ -681,6 +683,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Unregister a previously registered tab in the options dialog
     void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory );
+
+    //! Register a dev tool factory
+    void registerDevToolFactory( QgsDevToolWidgetFactory *factory );
+
+    //! Unregister a previously registered dev tool factory
+    void unregisterDevToolFactory( QgsDevToolWidgetFactory *factory );
 
     //! Register a new custom drop handler.
     void registerCustomDropHandler( QgsCustomDropHandler *handler );
@@ -2334,6 +2342,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsUserProfileManager *mUserProfileManager = nullptr;
     QgsDockWidget *mMapStylingDock = nullptr;
     QgsLayerStylingWidget *mMapStyleWidget = nullptr;
+    QgsDockWidget *mDevToolsDock = nullptr;
+    QgsDevToolsPanelWidget *mDevToolsWidget = nullptr;
 
     //! Persistent tile scale slider
     QgsTileScaleWidget *mpTileScaleWidget = nullptr;
@@ -2376,6 +2386,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QList<QgsMapLayerConfigWidgetFactory *> mMapLayerPanelFactories;
     QList<QPointer<QgsOptionsWidgetFactory>> mOptionsWidgetFactories;
+
+    QList<QgsDevToolWidgetFactory * > mDevToolFactories;
 
     QVector<QPointer<QgsCustomDropHandler>> mCustomDropHandlers;
     QVector<QPointer<QgsLayoutCustomDropHandler>> mCustomLayoutDropHandlers;

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -536,6 +536,16 @@ void QgisAppInterface::unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *
   qgis->unregisterOptionsWidgetFactory( factory );
 }
 
+void QgisAppInterface::registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory )
+{
+  qgis->registerDevToolFactory( factory );
+}
+
+void QgisAppInterface::unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory )
+{
+  qgis->unregisterDevToolFactory( factory );
+}
+
 void QgisAppInterface::registerCustomDropHandler( QgsCustomDropHandler *handler )
 {
   qgis->registerCustomDropHandler( handler );

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -143,6 +143,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) override;
     void registerOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
     void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
+    void registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
+    void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
     void registerCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void registerCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler ) override;

--- a/src/app/qgsdevtoolspanelwidget.cpp
+++ b/src/app/qgsdevtoolspanelwidget.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+    qgsdevtoolspanelwidget.cpp
+    ---------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsdevtoolspanelwidget.h"
+#include "qgisapp.h"
+#include "qgsdevtoolwidgetfactory.h"
+#include "qgsdevtoolwidget.h"
+#include "qgspanelwidgetstack.h"
+
+
+QgsDevToolsPanelWidget::QgsDevToolsPanelWidget( const QList<QgsDevToolWidgetFactory *> &factories, QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+
+  mOptionsListWidget->setIconSize( QgisApp::instance()->iconSize( false ) );
+  mOptionsListWidget->setMaximumWidth( static_cast< int >( mOptionsListWidget->iconSize().width() * 1.18 ) );
+
+  for ( QgsDevToolWidgetFactory *factory : factories )
+    addToolFactory( factory );
+
+  connect( mOptionsListWidget, &QListWidget::currentRowChanged, this, &QgsDevToolsPanelWidget::setCurrentTool );
+}
+
+QgsDevToolsPanelWidget::~QgsDevToolsPanelWidget() = default;
+
+void QgsDevToolsPanelWidget::addToolFactory( QgsDevToolWidgetFactory *factory )
+{
+  if ( QgsDevToolWidget *toolWidget = factory->createWidget( this ) )
+  {
+    QgsPanelWidgetStack *toolStack = new QgsPanelWidgetStack();
+    toolStack->setMainPanel( toolWidget );
+    mStackedWidget->addWidget( toolStack );
+
+    QListWidgetItem *item = new QListWidgetItem( factory->icon(), QString() );
+    item->setToolTip( factory->title() );
+    mOptionsListWidget->addItem( item );
+    int row = mOptionsListWidget->row( item );
+    mFactoryPages[factory] = row;
+
+    if ( mOptionsListWidget->count() == 1 )
+    {
+      setCurrentTool( 0 );
+    }
+  }
+}
+
+void QgsDevToolsPanelWidget::removeToolFactory( QgsDevToolWidgetFactory *factory )
+{
+  if ( mFactoryPages.contains( factory ) )
+  {
+    int currentRow = mStackedWidget->currentIndex();
+    int row = mFactoryPages.value( factory );
+    mStackedWidget->removeWidget( mStackedWidget->widget( row ) );
+    mOptionsListWidget->removeItemWidget( mOptionsListWidget->item( row ) );
+    mFactoryPages.remove( factory );
+    if ( currentRow == row )
+      setCurrentTool( 0 );
+  }
+}
+
+void QgsDevToolsPanelWidget::setCurrentTool( int row )
+{
+  whileBlocking( mOptionsListWidget )->setCurrentRow( row );
+  mStackedWidget->setCurrentIndex( row );
+}

--- a/src/app/qgsdevtoolspanelwidget.h
+++ b/src/app/qgsdevtoolspanelwidget.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+    qgsdevtoolspanelwidget.h
+    ---------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDEVTOOLSPANELWIDGET_H
+#define QGSDEVTOOLSPANELWIDGET_H
+
+#include "ui_qgsdevtoolswidgetbase.h"
+#include "qgis_app.h"
+
+class QgsDevToolWidgetFactory;
+
+class APP_EXPORT QgsDevToolsPanelWidget : public QWidget, private Ui::QgsDevToolsWidgetBase
+{
+    Q_OBJECT
+  public:
+
+    QgsDevToolsPanelWidget( const QList<QgsDevToolWidgetFactory *> &factories, QWidget *parent = nullptr );
+    ~QgsDevToolsPanelWidget() override;
+
+    void addToolFactory( QgsDevToolWidgetFactory *factory );
+
+    void removeToolFactory( QgsDevToolWidgetFactory *factory );
+
+  private slots:
+
+    void setCurrentTool( int row );
+
+  private:
+
+    QMap< QgsDevToolWidgetFactory *, int> mFactoryPages;
+};
+
+#endif // QGSDEVTOOLSPANELWIDGET_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -112,6 +112,9 @@ SET(QGIS_GUI_SRCS
   auth/qgsauthsslimportdialog.cpp
   auth/qgsauthtrustedcasdialog.cpp
 
+  devtools/qgsdevtoolwidget.cpp
+  devtools/qgsdevtoolwidgetfactory.cpp
+
   editorwidgets/core/qgseditorconfigwidget.cpp
   editorwidgets/core/qgseditorwidgetautoconf.cpp
   editorwidgets/core/qgseditorwidgetfactory.cpp
@@ -787,6 +790,9 @@ SET(QGIS_GUI_HDRS
 
   callouts/qgscalloutwidget.h
 
+  devtools/qgsdevtoolwidget.h
+  devtools/qgsdevtoolwidgetfactory.h
+
   editorwidgets/core/qgseditorconfigwidget.h
   editorwidgets/core/qgseditorwidgetautoconf.h
   editorwidgets/core/qgseditorwidgetfactory.h
@@ -1155,6 +1161,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/gui/symbology
   ${CMAKE_SOURCE_DIR}/src/gui/attributetable
   ${CMAKE_SOURCE_DIR}/src/gui/auth
+  ${CMAKE_SOURCE_DIR}/src/gui/devtools
   ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets
   ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets/core
   ${CMAKE_SOURCE_DIR}/src/gui/effects

--- a/src/gui/devtools/qgsdevtoolwidget.cpp
+++ b/src/gui/devtools/qgsdevtoolwidget.cpp
@@ -1,0 +1,21 @@
+/***************************************************************************
+    qgsdevtoolwidget.cpp
+    --------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsdevtoolwidget.h"
+
+QgsDevToolWidget::QgsDevToolWidget( QWidget *parent )
+  : QgsPanelWidget( parent )
+{
+
+}

--- a/src/gui/devtools/qgsdevtoolwidget.h
+++ b/src/gui/devtools/qgsdevtoolwidget.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgsdevtoolwidget.h
+    ------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDEVTOOLWIDGET_H
+#define QGSDEVTOOLWIDGET_H
+
+#include "qgspanelwidget.h"
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+
+/**
+ * \ingroup gui
+ * \class QgsDevToolWidget
+ * \brief A panel widget that can be shown in the developer tools panel.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsDevToolWidget : public QgsPanelWidget
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for QgsDevToolWidget, with the specified \a parent widget.
+     */
+    QgsDevToolWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+};
+
+#endif // QGSDEVTOOLWIDGET_H

--- a/src/gui/devtools/qgsdevtoolwidgetfactory.cpp
+++ b/src/gui/devtools/qgsdevtoolwidgetfactory.cpp
@@ -1,0 +1,22 @@
+/***************************************************************************
+    qgsdevtoolwidgetfactory.cpp
+     --------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdevtoolwidgetfactory.h"
+
+QgsDevToolWidgetFactory::QgsDevToolWidgetFactory( const QString &title, const QIcon &icon )
+  : mIcon( icon )
+  , mTitle( title )
+{
+}

--- a/src/gui/devtools/qgsdevtoolwidgetfactory.h
+++ b/src/gui/devtools/qgsdevtoolwidgetfactory.h
@@ -1,0 +1,79 @@
+/***************************************************************************
+    qgsdevtoolwidgetfactory.h
+     ------------------------
+    Date                 : March 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDEVTOOLWIDGETFACTORY_H
+#define QGSDEVTOOLWIDGETFACTORY_H
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include <QString>
+#include <QIcon>
+
+class QgsDevToolWidget;
+class QWidget;
+
+/**
+ * \ingroup gui
+ * \class QgsDevToolWidgetFactory
+ * Factory class for creating custom developer/debugging tool pages
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsDevToolWidgetFactory
+{
+  public:
+
+    /**
+     * Constructor for a QgsDevToolWidgetFactory with the specified \a title and \a icon.
+     */
+    QgsDevToolWidgetFactory( const QString &title = QString(), const QIcon &icon = QIcon() );
+
+    virtual ~QgsDevToolWidgetFactory() = default;
+
+    /**
+     * Returns the icon that will be shown in the tool in the panel.
+     * \see setIcon()
+     */
+    virtual QIcon icon() const { return mIcon; }
+
+    /**
+     * Sets the \a icon for the factory object, which will be shown for the tool in the panel.
+     * \see icon()
+     */
+    void setIcon( const QIcon &icon ) { mIcon = icon; }
+
+    /**
+     * Returns the (translated) title of the tool.
+     * \see setTitle()
+     */
+    virtual QString title() const { return mTitle; }
+
+    /**
+     * Set the translated \a title for the tool.
+     */
+    void setTitle( const QString &title ) { mTitle = title; }
+
+    /**
+     * Factory function to create the widget on demand as needed by the dock.
+     *
+     * The \a parent argument gives the correct parent for the newly created widget.
+     */
+    virtual QgsDevToolWidget *createWidget( QWidget *parent = nullptr ) const = 0 SIP_FACTORY;
+
+  private:
+    QIcon mIcon;
+    QString mTitle;
+};
+
+#endif // QGSDEVTOOLWIDGETFACTORY_H

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -61,6 +61,7 @@ class QgsLocatorFilter;
 class QgsStatusBar;
 class QgsMeshLayer;
 class QgsBrowserGuiModel;
+class QgsDevToolWidgetFactory;
 
 
 /**
@@ -926,6 +927,22 @@ class GUI_EXPORT QgisInterface : public QObject
      * \since QGIS 3.0
     */
     virtual void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) = 0;
+
+    /**
+     * Register a new tool in the development/debugging tools dock.
+     * \note Ownership of the factory is not transferred, and the factory must
+     *       be unregistered when plugin is unloaded.
+     * \see unregisterDevToolWidgetFactory()
+     * \since QGIS 3.14
+     */
+    virtual void registerDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;
+
+    /**
+     * Unregister a previously registered tool factory from the development/debugging tools dock.
+     * \see registerDevToolWidgetFactory()
+     * \since QGIS 3.14
+    */
+    virtual void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;
 
     /**
      * Register a new custom drop handler.

--- a/src/gui/qgsmaplayerconfigwidgetfactory.h
+++ b/src/gui/qgsmaplayerconfigwidgetfactory.h
@@ -110,7 +110,7 @@ class GUI_EXPORT QgsMapLayerConfigWidgetFactory
      * \returns A new QgsMapStylePanel which is shown in the map style dock.
      * \note This function is called each time the panel is selected. Keep it light for better UX.
      */
-    virtual QgsMapLayerConfigWidget *createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget = true, QWidget *parent SIP_TRANSFERTHIS = nullptr ) const = 0 SIP_FACTORY;
+    virtual QgsMapLayerConfigWidget *createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget = true, QWidget *parent = nullptr ) const = 0 SIP_FACTORY;
 
   private:
     QIcon mIcon;

--- a/src/ui/qgsdevtoolswidgetbase.ui
+++ b/src/ui/qgsdevtoolswidgetbase.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDevToolsWidgetBase</class>
+ <widget class="QWidget" name="QgsDevToolsWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>496</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="mOptionsListFrame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QListWidget" name="mOptionsListWidget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>38</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
+        </property>
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="textElideMode">
+         <enum>Qt::ElideNone</enum>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::Adjust</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="mStackedWidget"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Adds interface hooks to allow plugins (and c++) to register "development/debugging" tools

These tools appear in a new Development/Debugging Tools dock, and provide a unified handling and place for these tools in the UI.

The intention here is that specialised development/debugging tools will be moved to this common interface, e.g.
- network logger
- first aid style Python local variables inspector
- startup time debugging tools
- layer load and rendering time debugging tools
... ?

Here's an example demo showing a "Python locals" dev tool:

![image](https://user-images.githubusercontent.com/1829991/77492080-55f74780-6e8b-11ea-9141-1b96c42c29eb.png)

Based heavily off @NathanW2's style dock work!
