### PR TITLE
[ui] Further improve source fields properties colors to play well with any light/gray/dark themes

### DIFF
--- a/src/gui/vector/qgssourcefieldsproperties.cpp
+++ b/src/gui/vector/qgssourcefieldsproperties.cpp
@@ -154,10 +154,9 @@ void QgsSourceFieldsProperties::attributeAdded( int idx )
   setRow( row, idx, fields.at( idx ) );
   mFieldsList->setCurrentCell( row, idx );
 
-  bool dark = QgsGui::instance()->nativePlatformInterface()->hasDarkTheme();
-  QColor expressionColor = !dark ? QColor( 200, 200, 255 ) : QColor( 0, 80, 0 );
-  QColor joinColor = !dark ? QColor( 200, 255, 200 ) : QColor( 150, 0, 0 );
-  QColor defaultColor = !dark ? QColor( 255, 255, 200 ) : QColor();
+  QColor expressionColor = QColor( 103, 0, 243, 44 );
+  QColor joinColor = QColor( 0, 243, 79, 44 );
+  QColor defaultColor = QColor( 252, 255, 79, 44 );
 
   for ( int i = 0; i < mFieldsList->columnCount(); i++ )
   {


### PR DESCRIPTION
## Description

@3nids , a small follow up to your source fields properties coloring fix. Instead of using different colors when we detect a native dark mode, IMHO it's much better to use semi-transparent colors to work under all conditions.

This is how night mapping looked before vs. this PR applied:
![image](https://user-images.githubusercontent.com/1728657/77504682-9c50a480-6e93-11ea-808d-0154095a83e1.png)

