### PR TITLE
Allow running algorithms directly on database (and other non-disk) sources without loading into projects first

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -92,6 +92,28 @@ value.
 .. seealso:: :py:func:`compatibleVectorLayers`
 %End
 
+    static QString encodeProviderKeyAndUri( const QString &providerKey, const QString &uri );
+%Docstring
+Encodes a provider key and layer ``uri`` to a single string, for use with
+decodeProviderKeyAndUri()
+
+.. versionadded:: 3.14
+%End
+
+    static bool decodeProviderKeyAndUri( const QString &string, QString &providerKey /Out/, QString &uri /Out/ );
+%Docstring
+Decodes a provider key and layer ``uri`` from an encoded string, for use with
+encodeProviderKeyAndUri()
+
+:param string: encoded string, as returned by encodeProviderKeyAndUri()
+:param uri: decoded layer uri
+
+:return: - ``True`` if ``string`` was successfully decoded
+         - providerKey: ID key for corresponding data provider
+
+.. versionadded:: 3.14
+%End
+
     enum class LayerHint
     {
       UnknownType,

--- a/python/gui/auto_generated/processing/qgsprocessingmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmaplayercombobox.sip.in
@@ -80,6 +80,13 @@ Returns the current value of the widget.
 .. seealso:: :py:func:`setValue`
 %End
 
+    void setWidgetContext( QgsProcessingParameterWidgetContext *context );
+%Docstring
+Sets the ``context`` in which the widget is shown.
+
+.. versionadded:: 3.14
+%End
+
   signals:
 
     void valueChanged();

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1141,20 +1141,24 @@ class EnumWidgetWrapper(WidgetWrapper):
 class FeatureSourceWidgetWrapper(WidgetWrapper):
     NOT_SELECTED = '[Not selected]'
 
+    def __init__(self, *args, **kwargs):
+        self.map_layer_combo = None
+        super().__init__(*args, **kwargs)
+
     def createWidget(self):
         if self.dialogType == DIALOG_STANDARD:
-            self.combo = QgsProcessingMapLayerComboBox(self.parameterDefinition())
+            self.map_layer_combo = QgsProcessingMapLayerComboBox(self.parameterDefinition())
             self.context = dataobjects.createContext()
 
             try:
                 if iface.activeLayer().type() == QgsMapLayerType.VectorLayer:
-                    self.combo.setLayer(iface.activeLayer())
+                    self.map_layer_combo.setLayer(iface.activeLayer())
             except:
                 pass
 
-            self.combo.valueChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
+            self.map_layer_combo.valueChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
 
-            return self.combo
+            return self.map_layer_combo
 
         elif self.dialogType == DIALOG_BATCH:
             widget = BatchInputSelectionPanel(self.parameterDefinition(), self.row, self.col, self.dialog)
@@ -1186,8 +1190,8 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
             return widget
 
     def setWidgetContext(self, context):
-        if isinstance(self.combo, QgsProcessingMapLayerComboBox):
-            self.combo.setWidgetContext(context)
+        if self.map_layer_combo:
+            self.map_layer_combo.setWidgetContext(context)
         super().setWidgetContext(context)
 
     def selectFile(self):
@@ -1213,7 +1217,7 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
                 layer = QgsProject.instance().mapLayer(value)
                 if layer is not None:
                     value = layer
-            self.combo.setValue(value, self.context)
+            self.map_layer_combo.setValue(value, self.context)
         elif self.dialogType == DIALOG_BATCH:
             self.widget.setValue(value)
         else:
@@ -1222,7 +1226,7 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
 
     def value(self):
         if self.dialogType == DIALOG_STANDARD:
-            return self.combo.value()
+            return self.map_layer_combo.value()
         elif self.dialogType == DIALOG_BATCH:
             return self.widget.getValue()
         else:

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1153,7 +1153,6 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
                 pass
 
             self.combo.valueChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
-            self.combo.triggerFileSelection.connect(self.selectFile)
 
             return self.combo
 
@@ -1194,7 +1193,6 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
     def selectFile(self):
         filename, selected_filter = self.getFileName(self.combo.currentText())
         if filename:
-            filename = dataobjects.getRasterSublayer(filename, self.parameterDefinition())
             if isinstance(self.combo, QgsProcessingMapLayerComboBox):
                 self.combo.setValue(filename, self.context)
             elif isinstance(self.combo, QgsMapLayerComboBox):

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1186,6 +1186,11 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
             widget.setLayout(layout)
             return widget
 
+    def setWidgetContext(self, context):
+        if isinstance(self.combo, QgsProcessingMapLayerComboBox):
+            self.combo.setWidgetContext(context)
+        super().setWidgetContext(context)
+
     def selectFile(self):
         filename, selected_filter = self.getFileName(self.combo.currentText())
         if filename:

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -4745,7 +4745,7 @@ QString QgsProcessingParameterFeatureSource::valueAsPythonString( const QVariant
 
   // prefer to use layer source if possible (since it's persistent)
   if ( QgsVectorLayer *layer = qobject_cast< QgsVectorLayer * >( QgsProcessingUtils::mapLayerFromString( layerString, context, true, QgsProcessingUtils::LayerHint::Vector ) ) )
-    layerString = layer->source();
+    layerString = layer->providerType() != QLatin1String( "ogr" ) && layer->providerType() != QLatin1String( "gdal" ) && layer->providerType() != QLatin1String( "mdal" ) ? QgsProcessingUtils::encodeProviderKeyAndUri( layer->providerType(), layer->source() ) : layer->source();
 
   return QgsProcessingUtils::stringToPythonLiteral( layerString );
 }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -133,6 +133,25 @@ QList<QgsMapLayer *> QgsProcessingUtils::compatibleLayers( QgsProject *project, 
   return layers;
 }
 
+QString QgsProcessingUtils::encodeProviderKeyAndUri( const QString &providerKey, const QString &uri )
+{
+  return QStringLiteral( "%1://%2" ).arg( providerKey, uri );
+}
+
+bool QgsProcessingUtils::decodeProviderKeyAndUri( const QString &string, QString &providerKey, QString &uri )
+{
+  QRegularExpression re( QStringLiteral( "^(\\w+?):\\/\\/(.+)$" ) );
+  const QRegularExpressionMatch match = re.match( string );
+  if ( !match.hasMatch() )
+    return false;
+
+  providerKey = match.captured( 1 );
+  uri = match.captured( 2 );
+
+  // double check that provider is valid
+  return QgsProviderRegistry::instance()->providerMetadata( providerKey );
+}
+
 QgsMapLayer *QgsProcessingUtils::mapLayerFromStore( const QString &string, QgsMapLayerStore *store, QgsProcessingUtils::LayerHint typeHint )
 {
   if ( !store || string.isEmpty() )

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -106,6 +106,27 @@ class CORE_EXPORT QgsProcessingUtils
     static QList< QgsMapLayer * > compatibleLayers( QgsProject *project, bool sort = true );
 
     /**
+     * Encodes a provider key and layer \a uri to a single string, for use with
+     * decodeProviderKeyAndUri()
+     *
+     * \since QGIS 3.14
+     */
+    static QString encodeProviderKeyAndUri( const QString &providerKey, const QString &uri );
+
+    /**
+     * Decodes a provider key and layer \a uri from an encoded string, for use with
+     * encodeProviderKeyAndUri()
+     *
+     * \param string encoded string, as returned by encodeProviderKeyAndUri()
+     * \param providerKey ID key for corresponding data provider
+     * \param uri decoded layer uri
+     * \returns TRUE if \a string was successfully decoded
+     *
+     * \since QGIS 3.14
+     */
+    static bool decodeProviderKeyAndUri( const QString &string, QString &providerKey SIP_OUT, QString &uri SIP_OUT );
+
+    /**
      * Layer type hints.
      * \since QGIS 3.4
      */

--- a/src/core/providers/gdal/qgsgdalprovider.cpp
+++ b/src/core/providers/gdal/qgsgdalprovider.cpp
@@ -2827,12 +2827,12 @@ void QgsGdalProvider::initBaseDataset()
     // the min/max bounds, it would be cast to 0 by representableValue().
     if ( isValid && !QgsRaster::isRepresentableValue( myNoDataValue, dataTypeFromGdal( myGdalDataType ) ) )
     {
-      QgsDebugMsg( QStringLiteral( "GDALGetRasterNoDataValue = %1 is not representable in data type, so ignoring it" ).arg( myNoDataValue ) );
+      QgsDebugMsgLevel( QStringLiteral( "GDALGetRasterNoDataValue = %1 is not representable in data type, so ignoring it" ).arg( myNoDataValue ), 2 );
       isValid = false;
     }
     if ( isValid )
     {
-      QgsDebugMsg( QStringLiteral( "GDALGetRasterNoDataValue = %1" ).arg( myNoDataValue ) );
+      QgsDebugMsgLevel( QStringLiteral( "GDALGetRasterNoDataValue = %1" ).arg( myNoDataValue ), 2 );
       // The no data value double may be non representable by data type, it can result
       // in problems if that value is used to represent additional user defined no data
       // see #3840

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -894,7 +894,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 
   if ( !nl.count() )
   {
-    QgsDebugMsg( QStringLiteral( "unable to find title element" ) );
+    QgsDebugMsgLevel( QStringLiteral( "unable to find title element" ), 2 );
     return;
   }
 
@@ -902,7 +902,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 
   if ( !titleNode.hasChildNodes() ) // if not, then there's no actual text
   {
-    QgsDebugMsg( QStringLiteral( "unable to find title element" ) );
+    QgsDebugMsgLevel( QStringLiteral( "unable to find title element" ), 2 );
     return;
   }
 
@@ -910,7 +910,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 
   if ( !titleTextNode.isText() )
   {
-    QgsDebugMsg( QStringLiteral( "unable to find title element" ) );
+    QgsDebugMsgLevel( QStringLiteral( "unable to find title element" ), 2 );
     return;
   }
 

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -329,6 +329,10 @@ QVariant QgsProcessingMapLayerComboBox::value() const
   return QVariant();
 }
 
+void QgsProcessingMapLayerComboBox::setWidgetContext( QgsProcessingParameterWidgetContext *context )
+{
+  mBrowserModel = context->browserModel();
+}
 
 QgsMapLayer *QgsProcessingMapLayerComboBox::compatibleMapLayerFromMimeData( const QMimeData *data, bool &incompatibleLayerSelected ) const
 {

--- a/src/gui/processing/qgsprocessingmaplayercombobox.h
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.h
@@ -29,6 +29,8 @@ class QgsMapLayerComboBox;
 class QToolButton;
 class QCheckBox;
 class QgsProcessingParameterDefinition;
+class QgsBrowserGuiModel;
+class QgsProcessingParameterWidgetContext;
 
 ///@cond PRIVATE
 
@@ -92,6 +94,12 @@ class GUI_EXPORT QgsProcessingMapLayerComboBox : public QWidget
      */
     QVariant value() const;
 
+    /**
+     * Sets the \a context in which the widget is shown.
+     * \since QGIS 3.14
+     */
+    void setWidgetContext( QgsProcessingParameterWidgetContext *context );
+
   signals:
 
     /**
@@ -130,6 +138,9 @@ class GUI_EXPORT QgsProcessingMapLayerComboBox : public QWidget
     QgsFeatureRequest::InvalidGeometryCheck mGeometryCheck = QgsFeatureRequest::GeometryAbortOnInvalid;
     QPointer< QgsMapLayer> mPrevLayer;
     int mBlockChangedSignal = 0;
+
+    QgsBrowserGuiModel *mBrowserModel = nullptr;
+
     QgsMapLayer *compatibleMapLayerFromMimeData( const QMimeData *data, bool &incompatibleLayerSelected ) const;
     QString compatibleUriFromMimeData( const QMimeData *data ) const;
 };

--- a/src/gui/processing/qgsprocessingmaplayercombobox.h
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.h
@@ -124,6 +124,8 @@ class GUI_EXPORT QgsProcessingMapLayerComboBox : public QWidget
     void onLayerChanged( QgsMapLayer *layer );
     void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
     void showSourceOptions();
+    void selectFromFile();
+    void browseForLayer();
 
   private:
     std::unique_ptr< QgsProcessingParameterDefinition > mParameter;
@@ -141,6 +143,7 @@ class GUI_EXPORT QgsProcessingMapLayerComboBox : public QWidget
 
     QgsBrowserGuiModel *mBrowserModel = nullptr;
 
+    QMenu *mFeatureSourceMenu = nullptr;
     QgsMapLayer *compatibleMapLayerFromMimeData( const QMimeData *data, bool &incompatibleLayerSelected ) const;
     QString compatibleUriFromMimeData( const QMimeData *data ) const;
 };

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -311,6 +311,7 @@ QgsDataSourceSelectDialog::QgsDataSourceSelectDialog( QgsBrowserGuiModel *browse
   : QDialog( parent )
 {
   setWindowTitle( tr( "Select a Data Source" ) );
+  setObjectName( QStringLiteral( "QgsDataSourceSelectDialog" ) );
   QgsGui::enableAutoGeometryRestore( this );
 
   mWidget = new QgsDataSourceSelectWidget( browserModel, setFilterByLayerType, layerType );

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -95,8 +95,6 @@ QgsDataSourceSelectWidget::QgsDataSourceSelectWidget(
   action->setCheckable( true );
   menu->addAction( action );
 
-  mBrowserTreeView->setExpandsOnDoubleClick( false );
-
   connect( mActionRefresh, &QAction::triggered, this, [ = ] { refreshModel( QModelIndex() ); } );
   connect( mBrowserTreeView, &QgsBrowserTreeView::clicked, this, &QgsDataSourceSelectWidget::onLayerSelected );
   connect( mBrowserTreeView, &QgsBrowserTreeView::doubleClicked, this, &QgsDataSourceSelectWidget::itemDoubleClicked );

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -338,7 +338,7 @@ void QgsRendererRasterPropertiesWidget::setRendererWidget( const QString &render
   {
     if ( rendererEntry.widgetCreateFunction ) // Single band color data renderer e.g. has no widget
     {
-      QgsDebugMsg( QStringLiteral( "renderer has widgetCreateFunction" ) );
+      QgsDebugMsgLevel( QStringLiteral( "renderer has widgetCreateFunction" ), 3 );
       // Current canvas extent (used to calc min/max) in layer CRS
       QgsRectangle myExtent = mMapCanvas->mapSettings().outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() );
       if ( oldWidget )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -168,7 +168,7 @@ QgsPostgresConn *QgsPostgresConn::connectDb( const QString &conninfo, bool reado
 
     if ( connections.contains( conninfo ) )
     {
-      QgsDebugMsg( QStringLiteral( "Using cached connection for %1" ).arg( conninfo ) );
+      QgsDebugMsgLevel( QStringLiteral( "Using cached connection for %1" ).arg( conninfo ), 2 );
       connections[conninfo]->mRef++;
       return connections[conninfo];
     }
@@ -219,7 +219,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   , mLock( QMutex::Recursive )
 {
 
-  QgsDebugMsg( QStringLiteral( "New PostgreSQL connection for " ) + conninfo );
+  QgsDebugMsgLevel( QStringLiteral( "New PostgreSQL connection for " ) + conninfo, 2 );
 
   // expand connectionInfo
   QgsDataSourceUri uri( conninfo );
@@ -299,7 +299,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
       if ( !password.isEmpty() )
         uri.setPassword( password );
 
-      QgsDebugMsg( "Connecting to " + uri.connectionInfo( false ) );
+      QgsDebugMsgLevel( "Connecting to " + uri.connectionInfo( false ), 2 );
       QString connectString = uri.connectionInfo();
       addDefaultTimeout( connectString );
       mConn = PQconnectdb( connectString.toLocal8Bit() );
@@ -321,11 +321,11 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   }
 
   //set client encoding to Unicode because QString uses UTF-8 anyway
-  QgsDebugMsg( QStringLiteral( "setting client encoding to UNICODE" ) );
+  QgsDebugMsgLevel( QStringLiteral( "setting client encoding to UNICODE" ), 2 );
   int errcode = PQsetClientEncoding( mConn, QStringLiteral( "UNICODE" ).toLocal8Bit() );
   if ( errcode == 0 )
   {
-    QgsDebugMsg( QStringLiteral( "encoding successfully set" ) );
+    QgsDebugMsgLevel( QStringLiteral( "encoding successfully set" ), 2 );
   }
   else if ( errcode == -1 )
   {
@@ -336,7 +336,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
     QgsMessageLog::logMessage( tr( "undefined return value from encoding setting" ), tr( "PostGIS" ) );
   }
 
-  QgsDebugMsg( QStringLiteral( "Connection to the database was successful" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Connection to the database was successful" ), 2 );
 
   deduceEndian();
 
@@ -345,7 +345,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
   {
     /* Check to see if we have GEOS support and if not, warn the user about
        the problems they will see :) */
-    QgsDebugMsg( QStringLiteral( "Checking for GEOS support" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Checking for GEOS support" ), 3 );
 
     if ( !hasGEOS() )
     {
@@ -353,7 +353,7 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "GEOS support available!" ) );
+      QgsDebugMsgLevel( QStringLiteral( "GEOS support available!" ), 3 );
     }
   }
 
@@ -434,7 +434,7 @@ void QgsPostgresConn::addColumnInfo( QgsPostgresLayerProperty &layerProperty, co
                 .arg( supportedSpatialTypes().join( ',' ) )
                 .arg( quotedIdentifier( schemaName ),
                       quotedIdentifier( viewName ) );
-  QgsDebugMsg( "getting column info: " + sql );
+  QgsDebugMsgLevel( "getting column info: " + sql, 2 );
   QgsPostgresResult colRes( PQexec( sql ) );
 
   layerProperty.pkCols.clear();
@@ -446,7 +446,6 @@ void QgsPostgresConn::addColumnInfo( QgsPostgresLayerProperty &layerProperty, co
     {
       if ( fetchPkCandidates )
       {
-        //QgsDebugMsg( colRes.PQgetvalue( i, 0 ) );
         layerProperty.pkCols << colRes.PQgetvalue( i, 0 );
       }
 
@@ -470,8 +469,6 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
   int foundInTables = 0;
   QgsPostgresResult result;
   QString query;
-
-  //QgsDebugMsg( QStringLiteral( "Entering." ) );
 
   mLayersSupported.clear();
 
@@ -592,7 +589,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
   query += QStringLiteral( " ORDER BY 2,1,3" );
 
 
-  QgsDebugMsg( "getting table info from layer registries: " + query );
+  QgsDebugMsgLevel( "getting table info from layer registries: " + query, 2 );
   result = PQexec( query, true );
   // NOTE: we intentionally continue if the query fails
   //       (for example because PostGIS is not installed)
@@ -640,13 +637,13 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
     }
 
 #if 0
-    QgsDebugMsg( QStringLiteral( "%1 : %2.%3.%4: %5 %6 %7 %8" )
-                 .arg( gtableName )
-                 .arg( schemaName ).arg( tableName ).arg( column )
-                 .arg( type )
-                 .arg( srid )
-                 .arg( relkind )
-                 .arg( dim ) );
+    QgsDebugMsgLevel( QStringLiteral( "%1 : %2.%3.%4: %5 %6 %7 %8" )
+                      .arg( gtableName )
+                      .arg( schemaName ).arg( tableName ).arg( column )
+                      .arg( type )
+                      .arg( srid )
+                      .arg( relkind )
+                      .arg( dim ), 2 );
 #endif
 
     QgsPostgresLayerProperty layerProperty;
@@ -679,7 +676,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
 
     if ( isView && layerProperty.pkCols.empty() )
     {
-      //QgsDebugMsg( QStringLiteral( "no key columns found." ) );
+      //QgsDebugMsgLevel( QStringLiteral( "no key columns found." ), 2 );
       continue;
     }
 
@@ -739,7 +736,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       }
     }
 
-    QgsDebugMsg( "getting spatial table info from pg_catalog: " + sql );
+    QgsDebugMsgLevel( "getting spatial table info from pg_catalog: " + sql, 2 );
 
     result = PQexec( sql );
 
@@ -767,8 +764,6 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       bool isMaterializedView = relkind == QLatin1String( "m" );
       bool isForeignTable = relkind == QLatin1String( "f" );
       QString comment    = result.PQgetvalue( i, 5 ); // table comment
-
-      //QgsDebugMsg( QStringLiteral( "%1.%2.%3: %4" ).arg( schemaName ).arg( tableName ).arg( column ).arg( relkind ) );
 
       QgsPostgresLayerProperty layerProperty;
       layerProperty.types = QList<QgsWkbTypes::Type>() << QgsWkbTypes::Unknown;
@@ -814,7 +809,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
 
       if ( isView && layerProperty.pkCols.empty() )
       {
-        //QgsDebugMsg( QStringLiteral( "no key columns found." ) );
+        //QgsDebugMsgLevel( QStringLiteral( "no key columns found." ), 2 );
         continue;
       }
 
@@ -853,7 +848,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
 
     sql += QStringLiteral( " GROUP BY 1,2,3,4" );
 
-    QgsDebugMsg( "getting non-spatial table info: " + sql );
+    QgsDebugMsgLevel( "getting non-spatial table info: " + sql, 2 );
 
     result = PQexec( sql );
 
@@ -875,8 +870,6 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       bool isView = relkind == QLatin1String( "v" ) || relkind == QLatin1String( "m" );
       bool isMaterializedView = relkind == QLatin1String( "m" );
       bool isForeignTable = relkind == QLatin1String( "f" );
-
-      //QgsDebugMsg( QStringLiteral( "%1.%2: %3" ).arg( schema ).arg( table ).arg( relkind ) );
 
       QgsPostgresLayerProperty layerProperty;
       layerProperty.types = QList<QgsWkbTypes::Type>() << QgsWkbTypes::NoGeometry;
@@ -942,8 +935,6 @@ bool QgsPostgresConn::supportedLayers( QVector<QgsPostgresLayerProperty> &layers
   }
 
   layers = mLayersSupported;
-
-  //QgsDebugMsg( QStringLiteral( "Exiting." ) );
 
   return true;
 }
@@ -1031,7 +1022,7 @@ QString QgsPostgresConn::postgisVersion() const
 
   mPostgisVersionInfo = result.PQgetvalue( 0, 0 );
 
-  QgsDebugMsg( "PostGIS version info: " + mPostgisVersionInfo );
+  QgsDebugMsgLevel( "PostGIS version info: " + mPostgisVersionInfo, 2 );
 
   QStringList postgisParts = mPostgisVersionInfo.split( ' ', QString::SkipEmptyParts );
 
@@ -1053,8 +1044,8 @@ QString QgsPostgresConn::postgisVersion() const
   {
     result = PQexec( QStringLiteral( "SELECT postgis_geos_version()" ) );
     mGeosAvailable = result.PQntuples() == 1 && !result.PQgetisnull( 0, 0 );
-    QgsDebugMsg( QStringLiteral( "geos:%1 proj:%2" )
-                 .arg( mGeosAvailable ? result.PQgetvalue( 0, 0 ) : "none" ) );
+    QgsDebugMsgLevel( QStringLiteral( "geos:%1 proj:%2" )
+                      .arg( mGeosAvailable ? result.PQgetvalue( 0, 0 ) : "none" ), 2 );
   }
   else
   {
@@ -1070,7 +1061,7 @@ QString QgsPostgresConn::postgisVersion() const
   }
 
   // checking for topology support
-  QgsDebugMsg( QStringLiteral( "Checking for topology support" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Checking for topology support" ), 2 );
   mTopologyAvailable = false;
   if ( mPostgisVersionMajor > 1 )
   {
@@ -1095,18 +1086,18 @@ QString QgsPostgresConn::postgisVersion() const
 
   if ( mTopologyAvailable )
   {
-    QgsDebugMsg( QStringLiteral( "Topology support available :)" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Topology support available :)" ), 2 );
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "Topology support not available :(" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Topology support not available :(" ), 2 );
   }
 
   mGotPostgisVersion = true;
 
   if ( mPostgresqlVersion >= 90000 )
   {
-    QgsDebugMsg( QStringLiteral( "Checking for pointcloud support" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Checking for pointcloud support" ), 2 );
     result = PQexec( QStringLiteral( R"(
 SELECT
  has_table_privilege(c.oid, 'select')
@@ -1122,11 +1113,11 @@ WHERE c.relnamespace = n.oid
     if ( result.PQntuples() >= 1 && result.PQgetvalue( 0, 0 ) == QLatin1String( "t" ) )
     {
       mPointcloudAvailable = true;
-      QgsDebugMsg( QStringLiteral( "Pointcloud support available!" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Pointcloud support available!" ), 2 );
     }
   }
 
-  QgsDebugMsg( QStringLiteral( "Checking for raster support" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Checking for raster support" ), 2 );
   if ( mPostgisVersionMajor >= 2 )
   {
     result = PQexec( QStringLiteral( R"(
@@ -1141,7 +1132,7 @@ WHERE c.relnamespace = n.oid
     if ( result.PQntuples() >= 1 && result.PQgetvalue( 0, 0 ) == QLatin1String( "t" ) )
     {
       mRasterAvailable = true;
-      QgsDebugMsg( QStringLiteral( "Raster support available!" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Raster support available!" ), 2 );
     }
   }
 
@@ -1535,7 +1526,7 @@ qint64 QgsPostgresConn::getBinaryInt( QgsPostgresResult &queryResult, int row, i
       buf += QStringLiteral( "%1 " ).arg( *( unsigned char * )( p + i ), 0, 16, QLatin1Char( ' ' ) );
     }
 
-    QgsDebugMsg( QStringLiteral( "int in hex:%1" ).arg( buf ) );
+    QgsDebugMsgLevel( QStringLiteral( "int in hex:%1" ).arg( buf ), 2 );
   }
 #endif
 
@@ -1650,12 +1641,12 @@ void QgsPostgresConn::deduceEndian()
   QgsPostgresResult res( PQexec( QStringLiteral( "select regclass('pg_class')::oid" ) ) );
   QString oidValue = res.PQgetvalue( 0, 0 );
 
-  QgsDebugMsg( QStringLiteral( "Creating binary cursor" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Creating binary cursor" ), 2 );
 
   // get the same value using a binary cursor
   openCursor( QStringLiteral( "oidcursor" ), QStringLiteral( "select regclass('pg_class')::oid" ) );
 
-  QgsDebugMsg( QStringLiteral( "Fetching a record and attempting to get check endian-ness" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Fetching a record and attempting to get check endian-ness" ), 2 );
 
   res = PQexec( QStringLiteral( "fetch forward 1 from oidcursor" ) );
 
@@ -1665,8 +1656,8 @@ void QgsPostgresConn::deduceEndian()
     // get the oid value from the binary cursor
     qint64 oid = getBinaryInt( res, 0, 0 );
 
-    QgsDebugMsg( QStringLiteral( "Got oid of %1 from the binary cursor" ).arg( oid ) );
-    QgsDebugMsg( QStringLiteral( "First oid is %1" ).arg( oidValue ) );
+    QgsDebugMsgLevel( QStringLiteral( "Got oid of %1 from the binary cursor" ).arg( oid ), 2 );
+    QgsDebugMsgLevel( QStringLiteral( "First oid is %1" ).arg( oidValue ), 2 );
 
     // compare the two oid values to determine if we need to do an endian swap
     if ( oid != oidValue.toLongLong() )
@@ -1752,7 +1743,7 @@ void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &l
         }
       }
 
-      QgsDebugMsg( "Raster srids query: " + sql );
+      QgsDebugMsgLevel( "Raster srids query: " + sql, 2 );
       query += sql;
     }
     else  // vectors
@@ -1812,7 +1803,7 @@ void QgsPostgresConn::retrieveLayerTypes( QVector<QgsPostgresLayerProperty *> &l
 
       sql += " FROM " + table;
 
-      QgsDebugMsg( "Geometry types,srids and dims query: " + sql );
+      QgsDebugMsgLevel( "Geometry types,srids and dims query: " + sql, 2 );
 
       query += sql;
     }
@@ -2204,7 +2195,7 @@ void QgsPostgresConn::setSelectedConnection( const QString &name )
 
 QgsDataSourceUri QgsPostgresConn::connUri( const QString &connName )
 {
-  QgsDebugMsg( "theConnName = " + connName );
+  QgsDebugMsgLevel( "theConnName = " + connName, 2 );
 
   QgsSettings settings;
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -97,7 +97,7 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
   , mShared( new QgsPostgresSharedData )
 {
 
-  QgsDebugMsg( QStringLiteral( "URI: %1 " ).arg( uri ) );
+  QgsDebugMsgLevel( QStringLiteral( "URI: %1 " ).arg( uri ), 2 );
 
   mUri = QgsDataSourceUri( uri );
 
@@ -151,12 +151,12 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOpti
   mUseEstimatedMetadata = mUri.useEstimatedMetadata();
   mSelectAtIdDisabled = mUri.selectAtIdDisabled();
 
-  QgsDebugMsg( QStringLiteral( "Connection info is %1" ).arg( mUri.connectionInfo( false ) ) );
-  QgsDebugMsg( QStringLiteral( "Geometry column is: %1" ).arg( mGeometryColumn ) );
-  QgsDebugMsg( QStringLiteral( "Schema is: %1" ).arg( mSchemaName ) );
-  QgsDebugMsg( QStringLiteral( "Table name is: %1" ).arg( mTableName ) );
-  QgsDebugMsg( QStringLiteral( "Query is: %1" ).arg( mQuery ) );
-  QgsDebugMsg( QStringLiteral( "Where clause is: %1" ).arg( mSqlWhereClause ) );
+  QgsDebugMsgLevel( QStringLiteral( "Connection info is %1" ).arg( mUri.connectionInfo( false ) ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Geometry column is: %1" ).arg( mGeometryColumn ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Schema is: %1" ).arg( mSchemaName ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Table name is: %1" ).arg( mTableName ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Query is: %1" ).arg( mQuery ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Where clause is: %1" ).arg( mSqlWhereClause ), 2 );
 
   // no table/query passed, the provider could be used to get tables
   if ( mQuery.isEmpty() )
@@ -315,7 +315,7 @@ QgsPostgresProvider::~QgsPostgresProvider()
 {
   disconnectDb();
 
-  QgsDebugMsg( QStringLiteral( "deconstructing." ) );
+  QgsDebugMsgLevel( QStringLiteral( "deconstructing." ), 3 );
 }
 
 
@@ -521,7 +521,7 @@ void QgsPostgresProvider::appendPkParams( QgsFeatureId featureId, QStringList &p
         }
       }
 
-      QgsDebugMsg( QStringLiteral( "keys params: %1" ).arg( params.join( "; " ) ) );
+      QgsDebugMsgLevel( QStringLiteral( "keys params: %1" ).arg( params.join( "; " ) ), 2 );
     }
     break;
 
@@ -761,7 +761,7 @@ bool QgsPostgresProvider::loadFields()
 
   if ( !mIsQuery )
   {
-    QgsDebugMsg( QStringLiteral( "Loading fields for table %1" ).arg( mTableName ) );
+    QgsDebugMsgLevel( QStringLiteral( "Loading fields for table %1" ).arg( mTableName ), 2 );
 
     // Get the relation oid for use in later queries
     QString sql = QStringLiteral( "SELECT regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
@@ -1218,7 +1218,7 @@ void QgsPostgresProvider::setEditorWidgets()
 
 bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
 {
-  QgsDebugMsg( QStringLiteral( "Checking for permissions on the relation" ) );
+  QgsDebugMsgLevel( QStringLiteral( "Checking for permissions on the relation" ), 2 );
 
   QgsPostgresResult testAccess;
   if ( !mIsQuery )
@@ -1417,22 +1417,22 @@ bool QgsPostgresProvider::determinePrimaryKey()
   if ( !mIsQuery )
   {
     sql = QStringLiteral( "SELECT count(*) FROM pg_inherits WHERE inhparent=%1::regclass" ).arg( quotedValue( mQuery ) );
-    QgsDebugMsg( QStringLiteral( "Checking whether %1 is a parent table" ).arg( sql ) );
+    QgsDebugMsgLevel( QStringLiteral( "Checking whether %1 is a parent table" ).arg( sql ), 2 );
     QgsPostgresResult res( connectionRO()->PQexec( sql ) );
     bool isParentTable( res.PQntuples() == 0 || res.PQgetvalue( 0, 0 ).toInt() > 0 );
 
     sql = QStringLiteral( "SELECT indexrelid FROM pg_index WHERE indrelid=%1::regclass AND (indisprimary OR indisunique) ORDER BY CASE WHEN indisprimary THEN 1 ELSE 2 END LIMIT 1" ).arg( quotedValue( mQuery ) );
-    QgsDebugMsg( QStringLiteral( "Retrieving first primary or unique index: %1" ).arg( sql ) );
+    QgsDebugMsgLevel( QStringLiteral( "Retrieving first primary or unique index: %1" ).arg( sql ), 2 );
 
     res = connectionRO()->PQexec( sql );
-    QgsDebugMsg( QStringLiteral( "Got %1 rows." ).arg( res.PQntuples() ) );
+    QgsDebugMsgLevel( QStringLiteral( "Got %1 rows." ).arg( res.PQntuples() ), 2 );
 
     QStringList log;
 
     // no primary or unique indices found
     if ( res.PQntuples() == 0 )
     {
-      QgsDebugMsg( QStringLiteral( "Relation has no primary key -- investigating alternatives" ) );
+      QgsDebugMsgLevel( QStringLiteral( "Relation has no primary key -- investigating alternatives" ), 2 );
 
       // Two options here. If the relation is a table, see if there is
       // an oid column that can be used instead.
@@ -1443,7 +1443,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
 
       if ( type == Relkind::OrdinaryTable || type == Relkind::PartitionedTable )
       {
-        QgsDebugMsg( QStringLiteral( "Relation is a table. Checking to see if it has an oid column." ) );
+        QgsDebugMsgLevel( QStringLiteral( "Relation is a table. Checking to see if it has an oid column." ), 2 );
 
         mPrimaryKeyAttrs.clear();
         mPrimaryKeyType = PktUnknown;
@@ -1515,9 +1515,9 @@ bool QgsPostgresProvider::determinePrimaryKey()
       QString indrelid = res.PQgetvalue( 0, 0 );
       sql = QStringLiteral( "SELECT attname,attnotnull FROM pg_index,pg_attribute WHERE indexrelid=%1 AND indrelid=attrelid AND pg_attribute.attnum=any(pg_index.indkey)" ).arg( indrelid );
 
-      QgsDebugMsg( "Retrieving key columns: " + sql );
+      QgsDebugMsgLevel( "Retrieving key columns: " + sql, 2 );
       res = connectionRO()->PQexec( sql );
-      QgsDebugMsg( QStringLiteral( "Got %1 rows." ).arg( res.PQntuples() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Got %1 rows." ).arg( res.PQntuples() ), 2 );
 
       bool mightBeNull = false;
       QString primaryKey;
@@ -1539,7 +1539,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
         int idx = fieldNameIndex( name );
         if ( idx == -1 )
         {
-          QgsDebugMsg( "Skipping " + name );
+          QgsDebugMsgLevel( "Skipping " + name, 2 );
           continue;
         }
         QgsField fld = mAttributeFields.at( idx );
@@ -2115,7 +2115,7 @@ void QgsPostgresProvider::dropOrphanedTopoGeoms()
                       quotedIdentifier( mTableName ) )
                 ;
 
-  QgsDebugMsg( "TopoGeom orphans cleanup query: " + sql );
+  QgsDebugMsgLevel( "TopoGeom orphans cleanup query: " + sql, 2 );
 
   connectionRW()->PQexecNR( sql );
 }
@@ -2263,7 +2263,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
       QString fieldname = mAttributeFields.at( idx ).name();
       QString fieldTypeName = mAttributeFields.at( idx ).typeName();
 
-      QgsDebugMsg( "Checking field against: " + fieldname );
+      QgsDebugMsgLevel( "Checking field against: " + fieldname, 2 );
 
       if ( fieldname.isEmpty() || fieldname == mGeometryColumn )
         continue;
@@ -2376,7 +2376,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
       }
     }
 
-    QgsDebugMsg( QStringLiteral( "prepare addfeatures: %1" ).arg( insert ) );
+    QgsDebugMsgLevel( QStringLiteral( "prepare addfeatures: %1" ).arg( insert ), 2 );
     QgsPostgresResult stmt( conn->PQprepare( QStringLiteral( "addfeatures" ), insert, fieldId.size() + offset - 1, nullptr ) );
 
     if ( stmt.PQresultStatus() != PGRES_COMMAND_OK )
@@ -2519,7 +2519,7 @@ bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds &id )
     {
       QString sql = QStringLiteral( "DELETE FROM %1 WHERE %2" )
                     .arg( mQuery, whereClause( *it ) );
-      QgsDebugMsg( "delete sql: " + sql );
+      QgsDebugMsgLevel( "delete sql: " + sql, 2 );
 
       //send DELETE statement and do error handling
       QgsPostgresResult result( conn->PQexec( sql ) );
@@ -2579,7 +2579,7 @@ bool QgsPostgresProvider::truncate()
     conn->begin();
 
     QString sql = QStringLiteral( "TRUNCATE %1" ).arg( mQuery );
-    QgsDebugMsg( "truncate sql: " + sql );
+    QgsDebugMsgLevel( "truncate sql: " + sql, 2 );
 
     //send truncate statement and do error handling
     QgsPostgresResult result( conn->PQexec( sql ) );
@@ -3001,7 +3001,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
                             mQuery,
                             pkParamWhereClause( 1 ) );
 
-      QgsDebugMsg( "getting old topogeometry id: " + getid );
+      QgsDebugMsgLevel( "getting old topogeometry id: " + getid, 2 );
 
       result = connectionRO()->PQprepare( QStringLiteral( "getid" ), getid, 1, nullptr );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
@@ -3017,7 +3017,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
                         .arg( mQuery,
                               quotedIdentifier( mGeometryColumn ),
                               pkParamWhereClause( 2 ) );
-      QgsDebugMsg( "TopoGeom swap: " + replace );
+      QgsDebugMsgLevel( "TopoGeom swap: " + replace, 2 );
       result = conn->PQprepare( QStringLiteral( "replacetopogeom" ), replace, 2, nullptr );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
       {
@@ -3036,7 +3036,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
                      pkParamWhereClause( 2 ) );
     }
 
-    QgsDebugMsg( "updating: " + update );
+    QgsDebugMsgLevel( "updating: " + update, 2 );
 
     result = conn->PQprepare( QStringLiteral( "updatefeatures" ), update, 2, nullptr );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
@@ -3046,13 +3046,13 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
       throw PGException( result );
     }
 
-    QgsDebugMsg( QStringLiteral( "iterating over the map of changed geometries..." ) );
+    QgsDebugMsgLevel( QStringLiteral( "iterating over the map of changed geometries..." ), 2 );
 
     for ( QgsGeometryMap::const_iterator iter = geometry_map.constBegin();
           iter != geometry_map.constEnd();
           ++iter )
     {
-      QgsDebugMsg( "iterating over feature id " + FID_TO_STRING( iter.key() ) );
+      QgsDebugMsgLevel( "iterating over feature id " + FID_TO_STRING( iter.key() ), 2 );
 
       // Save the id of the current topogeometry
       long old_tg_id = -1;
@@ -3069,7 +3069,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
         }
         // TODO: watch out for NULL, handle somehow
         old_tg_id = result.PQgetvalue( 0, 0 ).toLong();
-        QgsDebugMsg( QStringLiteral( "Old TG id is %1" ).arg( old_tg_id ) );
+        QgsDebugMsgLevel( QStringLiteral( "Old TG id is %1" ).arg( old_tg_id ), 2 );
       }
 
       QStringList params;
@@ -3106,7 +3106,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
                   .arg( old_tg_id )
                   .arg( mTopoLayerInfo.layerId )
                   .arg( new_tg_id );
-        QgsDebugMsg( "relation swap: " + replace );
+        QgsDebugMsgLevel( "relation swap: " + replace, 2 );
         result = conn->PQexec( replace );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         {
@@ -3144,7 +3144,7 @@ bool QgsPostgresProvider::changeGeometryValues( const QgsGeometryMap &geometry_m
 
   conn->unlock();
 
-  QgsDebugMsg( QStringLiteral( "leaving." ) );
+  QgsDebugMsgLevel( QStringLiteral( "leaving." ), 4 );
 
   return returnvalue;
 }
@@ -3293,7 +3293,7 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
 
   conn->unlock();
 
-  QgsDebugMsg( QStringLiteral( "leaving." ) );
+  QgsDebugMsgLevel( QStringLiteral( "leaving." ), 4 );
 
   return returnvalue;
 }
@@ -3427,14 +3427,14 @@ long QgsPostgresProvider::featureCount() const
     sql = QStringLiteral( "SELECT count(*) FROM %1%2" ).arg( mQuery, filterWhereClause() );
     QgsPostgresResult result( connectionRO()->PQexec( sql ) );
 
-    QgsDebugMsg( "number of features as text: " + result.PQgetvalue( 0, 0 ) );
+    QgsDebugMsgLevel( "number of features as text: " + result.PQgetvalue( 0, 0 ), 2 );
 
     num = result.PQgetvalue( 0, 0 ).toLong();
   }
 
   mShared->setFeaturesCounted( num );
 
-  QgsDebugMsg( "number of features: " + QString::number( num ) );
+  QgsDebugMsgLevel( "number of features: " + QString::number( num ), 2 );
 
   return num;
 }
@@ -3515,7 +3515,7 @@ QgsRectangle QgsPostgresProvider::extent() const
       }
       else
       {
-        QgsDebugMsg( QStringLiteral( "no column statistics for %1.%2.%3" ).arg( mSchemaName, mTableName, mGeometryColumn ) );
+        QgsDebugMsgLevel( QStringLiteral( "no column statistics for %1.%2.%3" ).arg( mSchemaName, mTableName, mGeometryColumn ), 2 );
       }
     }
 
@@ -3537,7 +3537,7 @@ QgsRectangle QgsPostgresProvider::extent() const
 
     if ( !ext.isEmpty() )
     {
-      QgsDebugMsg( "Got extents using: " + sql );
+      QgsDebugMsgLevel( "Got extents using: " + sql, 2 );
 
       QRegExp rx( "\\((.+) (.+),(.+) (.+)\\)" );
       if ( ext.contains( rx ) )
@@ -3555,7 +3555,7 @@ QgsRectangle QgsPostgresProvider::extent() const
       }
     }
 
-    QgsDebugMsg( "Set extents to: " + mLayerExtent.toString() );
+    QgsDebugMsgLevel( "Set extents to: " + mLayerExtent.toString(), 2 );
   }
 
   return mLayerExtent;
@@ -3587,7 +3587,7 @@ bool QgsPostgresProvider::getGeometryDetails()
   {
     sql = QStringLiteral( "SELECT %1 FROM %2 LIMIT 0" ).arg( quotedIdentifier( mGeometryColumn ), mQuery );
 
-    QgsDebugMsg( QStringLiteral( "Getting geometry column: %1" ).arg( sql ) );
+    QgsDebugMsgLevel( QStringLiteral( "Getting geometry column: %1" ).arg( sql ), 2 );
 
     QgsPostgresResult result( connectionRO()->PQexec( sql ) );
     if ( PGRES_TUPLES_OK == result.PQresultStatus() )
@@ -3653,9 +3653,9 @@ bool QgsPostgresProvider::getGeometryDetails()
                 quotedValue( geomCol ),
                 quotedValue( schemaName ) );
 
-    QgsDebugMsg( QStringLiteral( "Getting geometry column: %1" ).arg( sql ) );
+    QgsDebugMsgLevel( QStringLiteral( "Getting geometry column: %1" ).arg( sql ), 2 );
     result = connectionRO()->PQexec( sql );
-    QgsDebugMsg( QStringLiteral( "Geometry column query returned %1 rows" ).arg( result.PQntuples() ) );
+    QgsDebugMsgLevel( QStringLiteral( "Geometry column query returned %1 rows" ).arg( result.PQntuples() ), 2 );
 
     if ( result.PQntuples() == 1 )
     {
@@ -3685,9 +3685,9 @@ bool QgsPostgresProvider::getGeometryDetails()
                   quotedValue( geomCol ),
                   quotedValue( schemaName ) );
 
-      QgsDebugMsg( QStringLiteral( "Getting geography column: %1" ).arg( sql ) );
+      QgsDebugMsgLevel( QStringLiteral( "Getting geography column: %1" ).arg( sql ), 2 );
       result = connectionRO()->PQexec( sql, false );
-      QgsDebugMsg( QStringLiteral( "Geography column query returned %1" ).arg( result.PQntuples() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Geography column query returned %1" ).arg( result.PQntuples() ), 2 );
 
       if ( result.PQntuples() == 1 )
       {
@@ -3718,9 +3718,9 @@ bool QgsPostgresProvider::getGeometryDetails()
                   quotedValue( geomCol ),
                   quotedValue( schemaName ) );
 
-      QgsDebugMsg( QStringLiteral( "Getting TopoGeometry column: %1" ).arg( sql ) );
+      QgsDebugMsgLevel( QStringLiteral( "Getting TopoGeometry column: %1" ).arg( sql ), 2 );
       result = connectionRO()->PQexec( sql, false );
-      QgsDebugMsg( QStringLiteral( "TopoGeometry column query returned %1" ).arg( result.PQntuples() ) );
+      QgsDebugMsgLevel( QStringLiteral( "TopoGeometry column query returned %1" ).arg( result.PQntuples() ), 2 );
 
       if ( result.PQntuples() == 1 )
       {
@@ -3742,9 +3742,9 @@ bool QgsPostgresProvider::getGeometryDetails()
                   quotedValue( geomCol ),
                   quotedValue( schemaName ) );
 
-      QgsDebugMsg( QStringLiteral( "Getting pointcloud column: %1" ).arg( sql ) );
+      QgsDebugMsgLevel( QStringLiteral( "Getting pointcloud column: %1" ).arg( sql ), 2 );
       result = connectionRO()->PQexec( sql, false );
-      QgsDebugMsg( QStringLiteral( "Pointcloud column query returned %1" ).arg( result.PQntuples() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Pointcloud column query returned %1" ).arg( result.PQntuples() ), 2 );
 
       if ( result.PQntuples() == 1 )
       {
@@ -3768,9 +3768,9 @@ bool QgsPostgresProvider::getGeometryDetails()
             .arg( quotedValue( tableName ),
                   quotedValue( geomCol ),
                   quotedValue( schemaName ) );
-      QgsDebugMsg( QStringLiteral( "Getting column datatype: %1" ).arg( sql ) );
+      QgsDebugMsgLevel( QStringLiteral( "Getting column datatype: %1" ).arg( sql ), 2 );
       result = connectionRO()->PQexec( sql, false );
-      QgsDebugMsg( QStringLiteral( "Column datatype query returned %1" ).arg( result.PQntuples() ) );
+      QgsDebugMsgLevel( QStringLiteral( "Column datatype query returned %1" ).arg( result.PQntuples() ), 2 );
       if ( result.PQntuples() == 1 )
       {
         geomColType = result.PQgetvalue( 0, 0 );
@@ -3901,10 +3901,10 @@ bool QgsPostgresProvider::getGeometryDetails()
     }
   }
 
-  QgsDebugMsg( QStringLiteral( "Detected SRID is %1" ).arg( mDetectedSrid ) );
-  QgsDebugMsg( QStringLiteral( "Requested SRID is %1" ).arg( mRequestedSrid ) );
-  QgsDebugMsg( QStringLiteral( "Detected type is %1" ).arg( mDetectedGeomType ) );
-  QgsDebugMsg( QStringLiteral( "Requested type is %1" ).arg( mRequestedGeomType ) );
+  QgsDebugMsgLevel( QStringLiteral( "Detected SRID is %1" ).arg( mDetectedSrid ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Requested SRID is %1" ).arg( mRequestedSrid ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Detected type is %1" ).arg( mDetectedGeomType ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Requested type is %1" ).arg( mRequestedGeomType ), 2 );
 
   mValid = ( mDetectedGeomType != QgsWkbTypes::Unknown || mRequestedGeomType != QgsWkbTypes::Unknown )
            && ( !mDetectedSrid.isEmpty() || !mRequestedSrid.isEmpty() );
@@ -3912,7 +3912,7 @@ bool QgsPostgresProvider::getGeometryDetails()
   if ( !mValid )
     return false;
 
-  QgsDebugMsg( QStringLiteral( "Spatial column type is %1" ).arg( QgsPostgresConn::displayStringForGeomType( mSpatialColType ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "Spatial column type is %1" ).arg( QgsPostgresConn::displayStringForGeomType( mSpatialColType ) ), 2 );
 
   return mValid;
 }
@@ -4081,10 +4081,10 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
   }
   schemaTableName += quotedIdentifier( tableName );
 
-  QgsDebugMsg( QStringLiteral( "Connection info is: %1" ).arg( dsUri.connectionInfo( false ) ) );
-  QgsDebugMsg( QStringLiteral( "Geometry column is: %1" ).arg( geometryColumn ) );
-  QgsDebugMsg( QStringLiteral( "Schema is: %1" ).arg( schemaName ) );
-  QgsDebugMsg( QStringLiteral( "Table name is: %1" ).arg( tableName ) );
+  QgsDebugMsgLevel( QStringLiteral( "Connection info is: %1" ).arg( dsUri.connectionInfo( false ) ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Geometry column is: %1" ).arg( geometryColumn ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Schema is: %1" ).arg( schemaName ), 2 );
+  QgsDebugMsgLevel( QStringLiteral( "Table name is: %1" ).arg( tableName ), 2 );
 
   // create the table
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
@@ -4272,7 +4272,7 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
   }
   conn->unref();
 
-  QgsDebugMsg( QStringLiteral( "layer %1 created" ).arg( schemaTableName ) );
+  QgsDebugMsgLevel( QStringLiteral( "layer %1 created" ).arg( schemaTableName ), 2 );
 
   // use the provider to edit the table
   dsUri.setDataSource( schemaName, tableName, geometryColumn, QString(), primaryKey );
@@ -4287,7 +4287,7 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
     return QgsVectorLayerExporter::ErrInvalidLayer;
   }
 
-  QgsDebugMsg( QStringLiteral( "layer loaded" ) );
+  QgsDebugMsgLevel( QStringLiteral( "layer loaded" ), 2 );
 
   // add fields to the layer
   if ( oldToNewAttrIdxMap )
@@ -4307,7 +4307,7 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
       {
         //the "lowercaseFieldNames" option does not affect the name of the geometry column, so we perform
         //this test before converting the field name to lowercase
-        QgsDebugMsg( QStringLiteral( "Found a field with the same name of the geometry column. Skip it!" ) );
+        QgsDebugMsgLevel( QStringLiteral( "Found a field with the same name of the geometry column. Skip it!" ), 2 );
         continue;
       }
 
@@ -4347,11 +4347,11 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
         return QgsVectorLayerExporter::ErrAttributeTypeUnsupported;
       }
 
-      QgsDebugMsg( QStringLiteral( "creating field #%1 -> #%2 name %3 type %4 typename %5 width %6 precision %7" )
-                   .arg( fldIdx ).arg( offset )
-                   .arg( fld.name(), QVariant::typeToName( fld.type() ), fld.typeName() )
-                   .arg( fld.length() ).arg( fld.precision() )
-                 );
+      QgsDebugMsgLevel( QStringLiteral( "creating field #%1 -> #%2 name %3 type %4 typename %5 width %6 precision %7" )
+                        .arg( fldIdx ).arg( offset )
+                        .arg( fld.name(), QVariant::typeToName( fld.type() ), fld.typeName() )
+                        .arg( fld.length() ).arg( fld.precision() ), 2
+                      );
 
       flist.append( fld );
       if ( oldToNewAttrIdxMap )
@@ -4366,7 +4366,7 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
       return QgsVectorLayerExporter::ErrAttributeCreationFailed;
     }
 
-    QgsDebugMsg( QStringLiteral( "Done creating fields" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Done creating fields" ), 2 );
   }
   return QgsVectorLayerExporter::NoError;
 }
@@ -5241,7 +5241,7 @@ void QgsPostgresSharedData::ensureFeaturesCountedAtLeast( long fetched )
    */
   if ( mFeaturesCounted > 0 && mFeaturesCounted < fetched )
   {
-    QgsDebugMsg( QStringLiteral( "feature count adjusted from %1 to %2" ).arg( mFeaturesCounted ).arg( fetched ) );
+    QgsDebugMsgLevel( QStringLiteral( "feature count adjusted from %1 to %2" ).arg( mFeaturesCounted ).arg( fetched ), 2 );
     mFeaturesCounted = fetched;
   }
 }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1069,8 +1069,22 @@ void TestQgsProcessing::mapLayers()
 
   delete l;
 
+  // use encoded provider/uri string
+  l = QgsProcessingUtils::loadMapLayerFromString( QStringLiteral( "gdal://%1" ).arg( raster ), QgsCoordinateTransformContext() );
+  QVERIFY( l->isValid() );
+  QCOMPARE( l->type(), QgsMapLayerType::RasterLayer );
+  QCOMPARE( l->name(), QStringLiteral( "landsat" ) );
+  delete l;
+
   //test with vector
   l = QgsProcessingUtils::loadMapLayerFromString( vector, QgsCoordinateTransformContext() );
+  QVERIFY( l->isValid() );
+  QCOMPARE( l->type(), QgsMapLayerType::VectorLayer );
+  QCOMPARE( l->name(), QStringLiteral( "points" ) );
+  delete l;
+
+  // use encoded provider/uri string
+  l = QgsProcessingUtils::loadMapLayerFromString( QStringLiteral( "ogr://%1" ).arg( vector ), QgsCoordinateTransformContext() );
   QVERIFY( l->isValid() );
   QCOMPARE( l->type(), QgsMapLayerType::VectorLayer );
   QCOMPARE( l->name(), QStringLiteral( "points" ) );
@@ -5509,6 +5523,7 @@ void TestQgsProcessing::parameterFeatureSource()
   QCOMPARE( def->valueAsPythonString( QVariant::fromValue( v2 ), context ), QStringLiteral( "'%1'" ).arg( vector2 ) );
   QCOMPARE( def->valueAsPythonString( "uri='complex' username=\"complex\"", context ), QStringLiteral( "'uri=\\'complex\\' username=\\\"complex\\\"'" ) );
   QCOMPARE( def->valueAsPythonString( QStringLiteral( "c:\\test\\new data\\test.dat" ), context ), QStringLiteral( "'c:\\\\test\\\\new data\\\\test.dat'" ) );
+  QCOMPARE( def->valueAsPythonString( QStringLiteral( "postgres://uri='complex' username=\"complex\"" ), context ), QStringLiteral( "'postgres://uri=\\'complex\\' username=\\\"complex\\\"'" ) );
 
   QVariantMap map = def->toVariantMap();
   QgsProcessingParameterFeatureSource fromMap( "x" );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -518,6 +518,7 @@ class TestQgsProcessing: public QObject
     void providerById();
     void removeProvider();
     void compatibleLayers();
+    void encodeDecodeUriProvider();
     void normalizeLayerSource();
     void context();
     void mapLayers();
@@ -858,6 +859,28 @@ void TestQgsProcessing::compatibleLayers()
   Q_FOREACH ( QgsMapLayer *l, QgsProcessingUtils::compatibleLayers( &p, false ) )
     lIds << l->name();
   QCOMPARE( lIds, QStringList() << "R1" << "ar2" << "zz"  << "V4" << "v1" << "v3" << "vvvv4" << "MX" << "mA" );
+}
+
+void TestQgsProcessing::encodeDecodeUriProvider()
+{
+  QString provider;
+  QString uri;
+  QCOMPARE( QgsProcessingUtils::encodeProviderKeyAndUri( QStringLiteral( "ogr" ), QStringLiteral( "/home/me/test.shp" ) ), QStringLiteral( "ogr:///home/me/test.shp" ) );
+  QVERIFY( QgsProcessingUtils::decodeProviderKeyAndUri( QStringLiteral( "ogr:///home/me/test.shp" ), provider, uri ) );
+  QCOMPARE( provider, QStringLiteral( "ogr" ) );
+  QCOMPARE( uri, QStringLiteral( "/home/me/test.shp" ) );
+  QCOMPARE( QgsProcessingUtils::encodeProviderKeyAndUri( QStringLiteral( "ogr" ), QStringLiteral( "http://mysourcem/a.json" ) ), QStringLiteral( "ogr://http://mysourcem/a.json" ) );
+  QVERIFY( QgsProcessingUtils::decodeProviderKeyAndUri( QStringLiteral( "ogr://http://mysourcem/a.json" ), provider, uri ) );
+  QCOMPARE( provider, QStringLiteral( "ogr" ) );
+  QCOMPARE( uri, QStringLiteral( "http://mysourcem/a.json" ) );
+  QCOMPARE( QgsProcessingUtils::encodeProviderKeyAndUri( QStringLiteral( "postgres" ), QStringLiteral( "host=blah blah etc" ) ), QStringLiteral( "postgres://host=blah blah etc" ) );
+  QVERIFY( QgsProcessingUtils::decodeProviderKeyAndUri( QStringLiteral( "postgres://host=blah blah etc" ), provider, uri ) );
+  QCOMPARE( provider, QStringLiteral( "postgres" ) );
+  QCOMPARE( uri, QStringLiteral( "host=blah blah etc" ) );
+
+  // should reject non valid providers
+  QVERIFY( !QgsProcessingUtils::decodeProviderKeyAndUri( QStringLiteral( "asdasda://host=blah blah etc" ), provider, uri ) );
+  QVERIFY( !QgsProcessingUtils::decodeProviderKeyAndUri( QStringLiteral( "http://mysourcem/a.json" ), provider, uri ) );
 }
 
 void TestQgsProcessing::normalizeLayerSource()


### PR DESCRIPTION
This change allows users to directly browse to non disk-based layer sources for any processing feature source inputs. It allows these inputs to be taken direct from postgres, sql server, oracle, wfs, afs, etc layers directly without having to first load them into a project!

We take full advantage of the QGIS browser to enable this:

![Peek 2020-03-25 16-37](https://user-images.githubusercontent.com/1829991/77508685-fca50d80-6eb6-11ea-8190-a447847f55d9.gif)


Refs NRCan Contract#3000707093