### PR TITLE
[ogr] Mark OpenStreetMap file extensions (.osm, .pbf) as featuring layers

### DIFF
--- a/src/core/providers/ogr/qgsogrdataitems.cpp
+++ b/src/core/providers/ogr/qgsogrdataitems.cpp
@@ -563,7 +563,9 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
       QStringLiteral( "sqlite" ),
       QStringLiteral( "db" ),
       QStringLiteral( "gdb" ),
-      QStringLiteral( "kml" ) };
+      QStringLiteral( "kml" ),
+      QStringLiteral( "osm" ),
+      QStringLiteral( "pbf" ) };
   static QStringList sOgrSupportedDbDriverNames { QStringLiteral( "GPKG" ),
       QStringLiteral( "db" ),
       QStringLiteral( "gdb" ) };


### PR DESCRIPTION
## Description

Because thanks to @nyalldawson , we'll be able to run processing against those OpenStreetMap files without having to add layers onto our projects to process them. Woupidou.

Backporting to 3.12 and 3.10 because it's also just useful to have the browser panel acknowledge those formats are layered.

![Peek 2020-03-25 15-53](https://user-images.githubusercontent.com/1728657/77519071-6fab8580-6eb1-11ea-995d-e961e70d6c9c.gif)
