### PR TITLE
[ui] Display info in Options window if QGIS is compiled without OpenCL

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11547,9 +11547,7 @@ QMap< QString, int > QgisApp::optionsPagesMap()
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Network" ), 13 );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Locator" ), 14 );
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Advanced" ), 15 );
-#ifdef HAVE_OPENCL
     sOptionsPagesMap.insert( QCoreApplication::translate( "QgsOptionsBase", "Acceleration" ), 16 );
-#endif
   } );
 
   QMap< QString, int > map = sOptionsPagesMap;

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1196,9 +1196,18 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
 #else
 
-  mOptionsListWidget->removeItemWidget( mOptionsListWidget->findItems( tr( "Acceleration" ), Qt::MatchExactly ).first() );
-  mOptionsStackedWidget->removeWidget( mOptionsPageAcceleration );
-
+  mGPUEnableCheckBox->setChecked( false );
+  for ( int idx = 0; idx < mOptionsPageAccelerationLayout->count(); ++idx )
+  {
+    QWidget *item = mOptionsPageAccelerationLayout->itemAt( idx )->widget();
+    if ( item )
+    {
+      item->setEnabled( false );
+    }
+  }
+  QLabel *noOpenCL = new QLabel( tr( "QGIS is compiled without OpenCL support. "
+                                     "GPU acceleration is not available." ), this );
+  mOptionsPageAccelerationLayout->insertWidget( 0, noOpenCL );
 
 #endif
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -5447,7 +5447,7 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
           </layout>
          </widget>
          <widget class="QWidget" name="mOptionsPageAcceleration">
-          <layout class="QVBoxLayout" name="verticalLayout_29">
+          <layout class="QVBoxLayout" name="mOptionsPageAccelerationLayout">
            <item>
             <widget class="QLabel" name="label_53">
              <property name="text">


### PR DESCRIPTION
Call to `mOptionsListWidget->findItems( tr( "Acceleration" ), Qt::MatchExactly ).first()` relies on a hope that word "Acceleration" is translated in the same way in both locations – src/app/qgsoptions.cpp and src/ui/qgsoptionsbase.ui. If the translations do not match (e.g. if one of strings is untranslated), findItems() call returns an empty list and subsequent .first() call is performed on an empty list – this is a no-no and leads to a QGIS crash.

As it is not possible to guarantee mapping between mOptionsListWidget "Acceleration" item and code removing it in qgsoptions.cpp (without significant changes in mOptionsListWidget to store extra data), even more elegant approach has been taken — instead of removing completely "Acceleration" options if OpenCL is not compiled in, an informational text is displayed to the user explaining why acceleration is not available. Thus user now knows why there is no acceleration + QGIS does not crash when opening Options dialog.

The same code is present in 3.10 and thus backporting is highly recommended.