### PR TITLE
Allowing saving outputs direct to more database formats (and other nice stuff)

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingoutputdestinationwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingoutputdestinationwidget.sip.in
@@ -65,6 +65,14 @@ Emitted whenever the "skip output" option is toggled in the widget.
 %Docstring
 Emitted whenever the destination value is changed in the widget.
 %End
+  protected:
+
+    virtual void dragEnterEvent( QDragEnterEvent *event );
+
+    virtual void dragLeaveEvent( QDragLeaveEvent *event );
+
+    virtual void dropEvent( QDropEvent *event );
+
 
 };
 

--- a/python/gui/auto_generated/qgsnewdatabasetablenamewidget.sip.in
+++ b/python/gui/auto_generated/qgsnewdatabasetablenamewidget.sip.in
@@ -46,6 +46,13 @@ Constructs a new QgsNewDatabaseTableNameWidget
 :param parent: optional parent for this widget
 %End
 
+    void setAcceptButtonVisible( bool visible );
+%Docstring
+Sets whether the optional "Ok"/accept button should be visible.
+
+By default this is hidden, to better allow the widget to be embedded inside other widgets and dialogs.
+%End
+
     QString schema() const;
 %Docstring
 Returns the currently selected schema or file path (in case of filesystem-based DBs like spatialite or GPKG) for the new table
@@ -121,6 +128,10 @@ This signal is emitted when the URI of the new table changes, whether or not it 
 :param uri: URI string representation
 %End
 
+    void accepted();
+%Docstring
+Emitted when the OK/accept button is clicked.
+%End
 
 };
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -813,14 +813,12 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
   QVariant val = value;
 
   QgsProject *destinationProject = nullptr;
-  QVariantMap createOptions;
   QString destName;
   if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
     QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( val );
     destinationProject = fromVar.destinationProject;
-    createOptions = fromVar.createOptions;
     val = fromVar.sink;
     destName = fromVar.destinationName;
   }

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -602,16 +602,26 @@ QString QgsProcessingUtils::stringToPythonLiteral( const QString &string )
 void QgsProcessingUtils::parseDestinationString( QString &destination, QString &providerKey, QString &uri, QString &layerName, QString &format, QMap<QString, QVariant> &options, bool &useWriter, QString &extension )
 {
   extension.clear();
-  QRegularExpression splitRx( QStringLiteral( "^(.{3,}?):(.*)$" ) );
-  QRegularExpressionMatch match = splitRx.match( destination );
-  if ( match.hasMatch() )
+  bool matched = decodeProviderKeyAndUri( destination, providerKey, uri );
+
+  if ( !matched )
   {
-    providerKey = match.captured( 1 );
+    QRegularExpression splitRx( QStringLiteral( "^(.{3,}?):(.*)$" ) );
+    QRegularExpressionMatch match = splitRx.match( destination );
+    if ( match.hasMatch() )
+    {
+      providerKey = match.captured( 1 );
+      uri = match.captured( 2 );
+      matched = true;
+    }
+  }
+
+  if ( matched )
+  {
     if ( providerKey == QStringLiteral( "postgis" ) ) // older processing used "postgis" instead of "postgres"
     {
       providerKey = QStringLiteral( "postgres" );
     }
-    uri = match.captured( 2 );
     if ( providerKey == QLatin1String( "ogr" ) )
     {
       QgsDataSourceUri dsUri( uri );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -408,6 +408,7 @@ void QgsProcessingLayerOutputDestinationWidget::saveToDatabase()
         << QStringLiteral( "ogr" )
         << QStringLiteral( "spatialite" ), this );
     widget->setPanelTitle( tr( "Save “%1” to Database Table" ).arg( mParameter->description() ) );
+    widget->setAcceptButtonVisible( true );
 
     panel->openPanel( widget );
 
@@ -445,6 +446,11 @@ void QgsProcessingLayerOutputDestinationWidget::saveToDatabase()
     connect( widget, &QgsNewDatabaseTableNameWidget::schemaNameChanged, this, [ = ] { changed(); } );
     connect( widget, &QgsNewDatabaseTableNameWidget::validationChanged, this, [ = ] { changed(); } );
     connect( widget, &QgsNewDatabaseTableNameWidget::providerKeyChanged, this, [ = ] { changed(); } );
+    connect( widget, &QgsNewDatabaseTableNameWidget::accepted, this, [ = ]
+    {
+      changed();
+      widget->acceptPanel();
+    } );
   }
 }
 

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -37,10 +37,14 @@ QgsProcessingLayerOutputDestinationWidget::QgsProcessingLayerOutputDestinationWi
   Q_ASSERT( mParameter );
 
   setupUi( this );
-  connect( mSelectButton, &QToolButton::clicked, this, &QgsProcessingLayerOutputDestinationWidget::showMenu );
+
   connect( leText, &QLineEdit::textEdited, this, &QgsProcessingLayerOutputDestinationWidget::textChanged );
 
   mMenu = new QMenu( this );
+  connect( mMenu, &QMenu::aboutToShow, this, &QgsProcessingLayerOutputDestinationWidget::menuAboutToShow );
+  mSelectButton->setMenu( mMenu );
+  mSelectButton->setPopupMode( QToolButton::InstantPopup );
+
   QgsSettings settings;
   mEncoding = settings.value( QStringLiteral( "/Processing/encoding" ), QStringLiteral( "System" ) ).toString();
 
@@ -174,7 +178,7 @@ void QgsProcessingLayerOutputDestinationWidget::setWidgetContext( const QgsProce
   mBrowserModel = context.browserModel();
 }
 
-void QgsProcessingLayerOutputDestinationWidget::showMenu()
+void QgsProcessingLayerOutputDestinationWidget::menuAboutToShow()
 {
   mMenu->clear();
 
@@ -239,7 +243,6 @@ void QgsProcessingLayerOutputDestinationWidget::showMenu()
     connect( actionSetEncoding, &QAction::triggered, this, &QgsProcessingLayerOutputDestinationWidget::selectEncoding );
     mMenu->addAction( actionSetEncoding );
   }
-  mMenu->exec( QCursor::pos() );
 }
 
 void QgsProcessingLayerOutputDestinationWidget::skipOutput()

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -233,11 +233,13 @@ void QgsProcessingLayerOutputDestinationWidget::showMenu()
     mMenu->addAction( actionSaveToPostGIS );
   }
 
-  QAction *actionSetEncoding = new QAction( tr( "Change File Encoding (%1)…" ).arg( mEncoding ), this );
-  connect( actionSetEncoding, &QAction::triggered, this, &QgsProcessingLayerOutputDestinationWidget::selectEncoding );
-  mMenu->addAction( actionSetEncoding );
+  if ( mParameter->type() == QgsProcessingParameterFeatureSink::typeName() )
+  {
+    QAction *actionSetEncoding = new QAction( tr( "Change File Encoding (%1)…" ).arg( mEncoding ), this );
+    connect( actionSetEncoding, &QAction::triggered, this, &QgsProcessingLayerOutputDestinationWidget::selectEncoding );
+    mMenu->addAction( actionSetEncoding );
+  }
   mMenu->exec( QCursor::pos() );
-
 }
 
 void QgsProcessingLayerOutputDestinationWidget::skipOutput()

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -403,7 +403,10 @@ void QgsProcessingLayerOutputDestinationWidget::saveToDatabase()
   if ( QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this ) )
   {
 
-    QgsNewDatabaseTableNameWidget *widget = new QgsNewDatabaseTableNameWidget( mBrowserModel, QStringList(), this );
+    QgsNewDatabaseTableNameWidget *widget = new QgsNewDatabaseTableNameWidget( mBrowserModel, QStringList() << QStringLiteral( "postgres" )
+        << QStringLiteral( "mssql" )
+        << QStringLiteral( "ogr" )
+        << QStringLiteral( "spatialite" ), this );
     widget->setPanelTitle( tr( "Save “%1” to Database Table" ).arg( mParameter->description() ) );
 
     panel->openPanel( widget );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.h
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
     void selectDirectory();
     void selectFile();
     void saveToGeopackage();
-    void saveToPostGIS();
+    void saveToDatabase();
     void selectEncoding();
     void textChanged( const QString &text );
 

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.h
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.h
@@ -77,6 +77,11 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
      * Emitted whenever the destination value is changed in the widget.
      */
     void destinationChanged();
+  protected:
+
+    void dragEnterEvent( QDragEnterEvent *event ) override;
+    void dragLeaveEvent( QDragLeaveEvent *event ) override;
+    void dropEvent( QDropEvent *event ) override;
 
   private slots:
 
@@ -91,6 +96,8 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
     void textChanged( const QString &text );
 
   private:
+
+    QString mimeDataToPath( const QMimeData *data );
 
     const QgsProcessingDestinationParameter *mParameter = nullptr;
     QMenu *mMenu = nullptr;

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.h
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
 
   private slots:
 
-    void showMenu();
+    void menuAboutToShow();
     void skipOutput();
     void saveToTemporary();
     void selectDirectory();

--- a/src/gui/qgsnewdatabasetablenamewidget.cpp
+++ b/src/gui/qgsnewdatabasetablenamewidget.cpp
@@ -52,6 +52,9 @@ QgsNewDatabaseTableNameWidget::QgsNewDatabaseTableNameWidget(
 
   setupUi( this );
 
+  mOkButton->hide();
+  mOkButton->setEnabled( false );
+
   QStringList shownDataItemProvidersFilter;
 
   const auto providerList { QgsApplication::dataItemProviderRegistry()->providers() };
@@ -150,7 +153,15 @@ QgsNewDatabaseTableNameWidget::QgsNewDatabaseTableNameWidget(
     }
   } );
 
+  connect( this, &QgsNewDatabaseTableNameWidget::validationChanged, mOkButton, &QWidget::setEnabled );
+  connect( mOkButton, &QPushButton::clicked, this, &QgsNewDatabaseTableNameWidget::accepted );
+
   validate();
+}
+
+void QgsNewDatabaseTableNameWidget::setAcceptButtonVisible( bool visible )
+{
+  mOkButton->setVisible( visible );
 }
 
 void QgsNewDatabaseTableNameWidget::refreshModel( const QModelIndex &index )

--- a/src/gui/qgsnewdatabasetablenamewidget.h
+++ b/src/gui/qgsnewdatabasetablenamewidget.h
@@ -61,6 +61,13 @@ class GUI_EXPORT QgsNewDatabaseTableNameWidget : public QgsPanelWidget, private 
                                             QWidget *parent = nullptr );
 
     /**
+     * Sets whether the optional "Ok"/accept button should be visible.
+     *
+     * By default this is hidden, to better allow the widget to be embedded inside other widgets and dialogs.
+     */
+    void setAcceptButtonVisible( bool visible );
+
+    /**
      * Returns the currently selected schema or file path (in case of filesystem-based DBs like spatialite or GPKG) for the new table
      */
     QString schema() const;
@@ -132,6 +139,10 @@ class GUI_EXPORT QgsNewDatabaseTableNameWidget : public QgsPanelWidget, private 
      */
     void uriChanged( const QString &uri );
 
+    /**
+     * Emitted when the OK/accept button is clicked.
+     */
+    void accepted();
 
   private:
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -96,7 +96,7 @@ void QgsMssqlConnectionItem::stop()
 
 void QgsMssqlConnectionItem::refresh()
 {
-  QgsDebugMsg( "mPath = " + mPath );
+  QgsDebugMsgLevel( "mPath = " + mPath, 3 );
   stop();
 
   // read up the schemas and layers from database
@@ -514,7 +514,7 @@ QString QgsMssqlLayerItem::createUri()
   mDisableInvalidGeometryHandling = QgsMssqlConnection::isInvalidGeometryHandlingDisabled( connItem->name() );
   uri.setParam( QStringLiteral( "disableInvalidGeometryHandling" ), mDisableInvalidGeometryHandling ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
 
-  QgsDebugMsg( QStringLiteral( "layer uri: %1" ).arg( uri.uri() ) );
+  QgsDebugMsgLevel( QStringLiteral( "layer uri: %1" ).arg( uri.uri() ), 3 );
   return uri.uri();
 }
 

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -2435,6 +2435,8 @@ QVariantMap QgsMssqlProviderMetadata::decodeUri( const QString &uri )
     uriParts[ QStringLiteral( "service" ) ] = dsUri.service();
   if ( ! dsUri.username().isEmpty() )
     uriParts[ QStringLiteral( "username" ) ] = dsUri.username();
+  if ( ! dsUri.password().isEmpty() )
+    uriParts[ QStringLiteral( "password" ) ] = dsUri.password();
 
   // Supported?
   //if ( ! dsUri.authConfigId().isEmpty() )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -5367,6 +5367,8 @@ QVariantMap QgsPostgresProviderMetadata::decodeUri( const QString &uri )
     uriParts[ QStringLiteral( "service" ) ] = dsUri.service();
   if ( ! dsUri.username().isEmpty() )
     uriParts[ QStringLiteral( "username" ) ] = dsUri.username();
+  if ( ! dsUri.password().isEmpty() )
+    uriParts[ QStringLiteral( "password" ) ] = dsUri.password();
   if ( ! dsUri.authConfigId().isEmpty() )
     uriParts[ QStringLiteral( "authcfg" ) ] = dsUri.authConfigId();
   if ( dsUri.wkbType() != QgsWkbTypes::Type::Unknown )

--- a/src/ui/processing/qgsprocessingdestinationwidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdestinationwidgetbase.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLineEdit" name="leText">
+    <widget class="QgsHighlightableLineEdit" name="leText">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -54,6 +54,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsHighlightableLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgshighlightablelineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsnewdatabasetablenamewidget.ui
+++ b/src/ui/qgsnewdatabasetablenamewidget.ui
@@ -10,7 +10,7 @@
     <height>629</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -23,7 +23,24 @@
    <property name="bottomMargin">
     <number>4</number>
    </property>
-   <item>
+   <item row="2" column="0">
+    <widget class="QLineEdit" name="mNewTableName">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>name of the new table</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="mOkButton">
+     <property name="text">
+      <string>Ok</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <property name="spacing">
       <number>0</number>
@@ -50,24 +67,14 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="1" column="0" colspan="2">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>New table name</string>
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QLineEdit" name="mNewTableName">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>name of the new table</string>
-     </property>
-    </widget>
-   </item>
-   <item>
+   <item row="3" column="0" colspan="2">
     <widget class="QLabel" name="mValidationResults">
      <property name="enabled">
       <bool>true</bool>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1629,6 +1629,21 @@ void TestQgsProcessing::parseDestinationString()
   QVERIFY( !useWriter );
   QVERIFY( extension.isEmpty() );
 
+  // newer format
+  destination = QStringLiteral( "postgres://dbname='db' host=DBHOST port=5432 table=\"calcs\".\"output\" (geom) sql=" );
+  QgsProcessingUtils::parseDestinationString( destination, providerKey, uri, layerName, format, options, useWriter, extension );
+  QCOMPARE( providerKey, QStringLiteral( "postgres" ) );
+  QCOMPARE( uri, QStringLiteral( "dbname='db' host=DBHOST port=5432 table=\"calcs\".\"output\" (geom) sql=" ) );
+  QVERIFY( !useWriter );
+  QVERIFY( extension.isEmpty() );
+  //mssql
+  destination = QStringLiteral( "mssql://dbname='db' host=DBHOST port=5432 table=\"calcs\".\"output\" (geom) sql=" );
+  QgsProcessingUtils::parseDestinationString( destination, providerKey, uri, layerName, format, options, useWriter, extension );
+  QCOMPARE( providerKey, QStringLiteral( "mssql" ) );
+  QCOMPARE( uri, QStringLiteral( "dbname='db' host=DBHOST port=5432 table=\"calcs\".\"output\" (geom) sql=" ) );
+  QVERIFY( !useWriter );
+  QVERIFY( extension.isEmpty() );
+
   // full uri shp output
   options.clear();
   destination = QStringLiteral( "ogr:d:/test.shp" );


### PR DESCRIPTION
This PR allows users to save processing vector outputs direct to more database formats.

Previously outputs could only be written direct to postgres databases. With this change, this functionality has been made more flexible and now supports direct writing to any database provider which implements the connections API (currently postgres, geopackage, spatialite and sql server)

Ultimately this exposes the new ability to directly save outputs to SQL Server or Spatialite databases (alongside the previous GPKG+Postgres options which already existed)

(As soon as oracle, db2, ... have the connections API implemented we'll instantly gain direct write support for those too!)

We do this via a nice inline version of @elpaso's new "new database table name" widget.

![Peek 2020-03-26 13-57](https://user-images.githubusercontent.com/1829991/77608752-dab89300-6f69-11ea-9c48-eefca7a4d199.gif)

Other nice stuff includes:
- you can now drag and drop file or folders from explorer or the qgis browser to output parameters in order to easily overwrite these files (or save to the folder), matching the behavior possible with inputs
- you can actually write scripts which output direct to ANY qgis data provider (including oracle and db2)... it's just that these don't get exposed in the UI because they don't yet support the connections API

Refs NRCan Contract#3000707093 
