### PR TITLE
[postgres] Do not overwrite detected type with requested type

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3659,8 +3659,7 @@ bool QgsPostgresProvider::getGeometryDetails()
 
     if ( result.PQntuples() == 1 )
     {
-      QString dt = result.PQgetvalue( 0, 0 );
-      detectedType = dt;
+      detectedType = result.PQgetvalue( 0, 0 );
 
       QString dim = result.PQgetvalue( 0, 2 );
       if ( dim == QLatin1String( "3" ) && !detectedType.endsWith( 'M' ) )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3643,7 +3643,7 @@ bool QgsPostgresProvider::getGeometryDetails()
     }
   }
 
-  QString detectedType = mRequestedGeomType == QgsWkbTypes::Unknown ? QString() : QgsPostgresConn::postgisWkbTypeName( mRequestedGeomType );
+  QString detectedType;
   QString detectedSrid = mRequestedSrid;
   if ( !schemaName.isEmpty() )
   {
@@ -3660,7 +3660,7 @@ bool QgsPostgresProvider::getGeometryDetails()
     if ( result.PQntuples() == 1 )
     {
       QString dt = result.PQgetvalue( 0, 0 );
-      if ( dt != "GEOMETRY" ) detectedType = dt;
+      detectedType = dt;
 
       QString dim = result.PQgetvalue( 0, 2 );
       if ( dim == QLatin1String( "3" ) && !detectedType.endsWith( 'M' ) )

--- a/tests/src/python/test_qgsproviderconnection_postgres.py
+++ b/tests/src/python/test_qgsproviderconnection_postgres.py
@@ -69,6 +69,13 @@ class TestPyQgsProviderConnectionPostgres(unittest.TestCase, TestPyQgsProviderCo
         rl = QgsRasterLayer(conn.tableUri('qgis_test', 'Raster1'), 'r1', 'postgresraster')
         self.assertTrue(rl.isValid())
 
+    def test_postgis_geometry_filter(self):
+        """Make sure the postgres provider only returns one matching geometry record and no polygons etc."""
+        vl = QgsVectorLayer(self.postgres_conn + ' srid=4326 type=POINT table="qgis_test"."geometries_table" (geom) sql=', 'test', 'postgres')
+
+        ids = [f.id() for f in vl.getFeatures()]
+        self.assertEqual(ids, [2])
+
     def test_postgis_table_uri(self):
         """Create a connection from a layer uri and create a table URI"""
 


### PR DESCRIPTION
Since https://github.com/qgis/QGIS/pull/32292 the "detected geometry type" was overwritten by the "requested geometry type", especially in "GEOMETRY" type situations.

The postgis provider contains logic to [add to the WHERE clause a filter on geometry type if "detected type" and "requested type" are equal](https://github.com/qgis/QGIS/blob/final-3_12_0/src/providers/postgres/qgspostgresfeatureiterator.cpp#L486-L489). This check no longer worked ever since.

Fix #34629