### PR TITLE
move tree view from the expression builder to a dedicated class

### DIFF
--- a/python/core/auto_generated/qgsfieldformatterregistry.sip.in
+++ b/python/core/auto_generated/qgsfieldformatterregistry.sip.in
@@ -63,13 +63,6 @@ Returns a basic fallback field formatter which can be used
 to represent any field in an unspectacular manner.
 %End
 
-    static bool formatterCanProvideAvailableValues( QgsVectorLayer *layer, const QString &fieldName );
-%Docstring
-Returns if the formatter for a given layer and field name can provide available values
-
-.. versionadded:: 3.14
-%End
-
   signals:
 
     void fieldFormatterAdded( QgsFieldFormatter *formatter );

--- a/python/core/auto_generated/qgsfieldformatterregistry.sip.in
+++ b/python/core/auto_generated/qgsfieldformatterregistry.sip.in
@@ -63,6 +63,13 @@ Returns a basic fallback field formatter which can be used
 to represent any field in an unspectacular manner.
 %End
 
+    static bool formatterCanProvideAvailableValues( QgsVectorLayer *layer, const QString &fieldName );
+%Docstring
+Returns if the formatter for a given layer and field name can provide available values
+
+.. versionadded:: 3.14
+%End
+
   signals:
 
     void fieldFormatterAdded( QgsFieldFormatter *formatter );

--- a/python/gui/auto_additions/qgsexpressionbuilderwidget.py
+++ b/python/gui/auto_additions/qgsexpressionbuilderwidget.py
@@ -1,0 +1,3 @@
+# The following has been generated automatically from src/gui/qgsexpressionbuilderwidget.h
+QgsExpressionBuilderWidget.Flag.baseClass = QgsExpressionBuilderWidget
+Flag = QgsExpressionBuilderWidget  # dirty hack since SIP seems to introduce the flags in module

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -25,11 +25,43 @@ See QgsExpressionBuilderDialog for example of usage.
 %End
   public:
 
+    enum Flag
+    {
+      LoadNothing,
+      LoadRecent,
+      LoadUserExpressions,
+      LoadAll,
+    };
+    typedef QFlags<QgsExpressionBuilderWidget::Flag> Flags;
+
+
+
     QgsExpressionBuilderWidget( QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Create a new expression builder widget with an optional parent.
 %End
     ~QgsExpressionBuilderWidget();
+
+    void init( const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), const Flags &flags = LoadAll );
+%Docstring
+Initialize without any layer
+
+.. versionadded:: 3.14
+%End
+
+    void initWithLayer( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), const Flags &flags = LoadAll );
+%Docstring
+Initialize with a layer
+
+.. versionadded:: 3.14
+%End
+
+    void initWithFields( const QgsFields &fields, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), const Flags &flags = LoadAll );
+%Docstring
+Initialize with given fields without any layer
+
+.. versionadded:: 3.14
+%End
 
     void setLayer( QgsVectorLayer *layer );
 %Docstring
@@ -45,20 +77,23 @@ Sets layer in order to get the fields and values
 Returns the current layer or a None.
 %End
 
- void loadFieldNames( const QgsFields &fields = QgsFields() );
+ void loadFieldNames();
 %Docstring
 
 .. deprecated:: QGIS 3.14
    this is now done automatically
 %End
 
+ void loadFieldNames( const QgsFields &fields );
+%Docstring
+
+.. deprecated:: QGIS 3.14
+   use epxressionTree()->loadFieldNames() instead
+%End
+
     void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues );
 %Docstring
 Loads field names and values from the specified map.
-
-.. note::
-
-   The field values must be quoted appropriately if they are strings.
 
 .. versionadded:: 2.12
 

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -10,85 +10,7 @@
 
 
 
-class QgsExpressionItem : QStandardItem
-{
-%Docstring
-An expression item that can be used in the QgsExpressionBuilderWidget tree.
-%End
 
-%TypeHeaderCode
-#include "qgsexpressionbuilderwidget.h"
-%End
-  public:
-    enum ItemType
-    {
-      Header,
-      Field,
-      ExpressionNode
-    };
-
-    QgsExpressionItem( const QString &label,
-                       const QString &expressionText,
-                       const QString &helpText,
-                       QgsExpressionItem::ItemType itemType = ExpressionNode );
-
-    QgsExpressionItem( const QString &label,
-                       const QString &expressionText,
-                       QgsExpressionItem::ItemType itemType = ExpressionNode );
-
-    QString getExpressionText() const;
-
-    QString getHelpText() const;
-%Docstring
-Gets the help text that is associated with this expression item.
-
-:return: The help text.
-%End
-
-    void setHelpText( const QString &helpText );
-%Docstring
-Set the help text for the current item
-
-.. note::
-
-   The help text can be set as a html string.
-%End
-
-    QgsExpressionItem::ItemType getItemType() const;
-%Docstring
-Gets the type of expression item, e.g., header, field, ExpressionNode.
-
-:return: The QgsExpressionItem.ItemType
-%End
-
-    static const int CUSTOM_SORT_ROLE;
-    static const int ITEM_TYPE_ROLE;
-    static const int SEARCH_TAGS_ROLE;
-
-};
-
-class QgsExpressionItemSearchProxy : QSortFilterProxyModel
-{
-%Docstring
-Search proxy used to filter the QgsExpressionBuilderWidget tree.
-The default search for a tree model only searches top level this will handle one
-level down
-%End
-
-%TypeHeaderCode
-#include "qgsexpressionbuilderwidget.h"
-%End
-  public:
-    QgsExpressionItemSearchProxy();
-
-    virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const;
-
-
-  protected:
-
-    virtual bool lessThan( const QModelIndex &left, const QModelIndex &right ) const;
-
-};
 
 
 class QgsExpressionBuilderWidget : QWidget
@@ -118,13 +40,17 @@ Sets layer in order to get the fields and values
    this needs to be called before calling loadFieldNames().
 %End
 
-    void loadFieldNames();
+    QgsVectorLayer *layer() const;
 %Docstring
-Loads all the field names from the layer.
-@remarks Should this really be public couldn't we just do this for the user?
+Returns the current layer or a None.
 %End
 
-    void loadFieldNames( const QgsFields &fields );
+ void loadFieldNames( const QgsFields &fields = QgsFields() );
+%Docstring
+
+.. deprecated:: QGIS 3.14
+   this is now done automatically
+%End
 
     void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues );
 %Docstring
@@ -135,6 +61,9 @@ Loads field names and values from the specified map.
    The field values must be quoted appropriately if they are strings.
 
 .. versionadded:: 2.12
+
+.. deprecated::
+   use setLayer() and expressionTree()->
 %End
 
     void setGeomCalculator( const QgsDistanceArea &da );
@@ -187,7 +116,7 @@ preview result and for populating the list of available functions and variables.
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring
 Sets the expression context for the widget. The context is used for the expression
-preview result and for populating the list of available functions and variables.
+preview result and to populate the list of available functions and variables.
 
 :param context: expression context
 
@@ -196,57 +125,54 @@ preview result and for populating the list of available functions and variables.
 .. versionadded:: 2.12
 %End
 
-    void registerItem( const QString &group, const QString &label, const QString &expressionText,
-                       const QString &helpText = QString(),
-                       QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
-                       bool highlightedItem = false, int sortOrder = 1,
-                       QIcon icon = QIcon(),
-                       const QStringList &tags = QStringList() );
-%Docstring
-Registers a node item for the expression builder.
-
-:param group: The group the item will be show in the tree view.  If the group doesn't exist it will be created.
-:param label: The label that is show to the user for the item in the tree.
-:param expressionText: The text that is inserted into the expression area when the user double clicks on the item.
-:param helpText: The help text that the user will see when item is selected.
-:param type: The type of the expression item.
-:param highlightedItem: set to ``True`` to make the item highlighted, which inserts a bold copy of the item at the top level
-:param sortOrder: sort ranking for item
-:param icon: custom icon to show for item
-:param tags: tags to find function
-%End
-
     bool isExpressionValid();
 
-    void saveToRecent( const QString &collection = "generic" );
+ void saveToRecent( const QString &collection = "generic" );
 %Docstring
 Adds the current expression to the given ``collection``.
 By default it is saved to the collection "generic".
+
+.. deprecated:: QGIS 3.14
+   use expressionTree()->saveRecent() instead
 %End
 
-    void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+ void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
 %Docstring
 Loads the recent expressions from the given ``collection``.
 By default it is loaded from the collection "generic".
+
+.. deprecated:: QGIS 3.14
+   use expressionTree()->loadRecent() instead
 %End
 
-    void loadUserExpressions( );
+    QgsExpressionTreeView *expressionTree() const;
+
+ void loadUserExpressions();
 %Docstring
 Loads the user expressions.
 
+.. deprecated:: QGIS 3.14
+   use expressionTree()->loadUserExpressions() instead
+
 .. versionadded:: 3.12
 %End
 
-    void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
+ void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
 %Docstring
 Stores the user ``expression`` with given ``label`` and ``helpText``.
 
+.. deprecated:: QGIS 3.14
+   use expressionTree()->saveToUserExpressions() instead
+
 .. versionadded:: 3.12
 %End
 
-    void removeFromUserExpressions( const QString &label );
+ void removeFromUserExpressions( const QString &label );
 %Docstring
 Removes the expression ``label`` from the user stored expressions.
+
+.. deprecated:: QGIS 3.14
+   use expressionTree()->removeFromUserExpressions() instead
 
 .. versionadded:: 3.12
 %End
@@ -276,12 +202,14 @@ Loads code into the function editor
 Updates the list of function files found at the given path
 %End
 
-    QStandardItemModel *model();
+ QStandardItemModel *model();
 %Docstring
 Returns a pointer to the dialog's function item model.
 This method is exposed for testing purposes only - it should not be used to modify the model.
 
 .. versionadded:: 3.0
+
+.. deprecated:: QGIS 3.14
 %End
 
     QgsProject *project();
@@ -389,29 +317,14 @@ the selected expression must be a user stored expression.
 .. versionadded:: 3.14
 %End
 
-    QJsonDocument exportUserExpressions();
-%Docstring
-Create the expressions JSON document storing all the user expressions to be exported.
-
-:return: the created expressions JSON file
-
-.. versionadded:: 3.14
-%End
-
-    void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
-%Docstring
-Load and permanently store the expressions from the expressions JSON document.
-
-:param expressionsDocument: the parsed expressions JSON file
-
-.. versionadded:: 3.14
-%End
-
     const QList<QgsExpressionItem *> findExpressions( const QString &label );
 %Docstring
 Returns the list of expression items matching a ``label``.
 
 .. versionadded:: 3.12
+
+.. deprecated:: QGIS 3.14
+   use expressionTree()->findExpressions instead
 %End
 
 
@@ -446,6 +359,7 @@ with the context.
     virtual void showEvent( QShowEvent *e );
 
 
+      public:
 };
 
 

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -161,6 +161,9 @@ preview result and to populate the list of available functions and variables.
 %End
 
     bool isExpressionValid();
+%Docstring
+Returns if the expression is valid
+%End
 
  void saveToRecent( const QString &collection = "generic" ) /Deprecated/;
 %Docstring
@@ -181,6 +184,11 @@ By default it is loaded from the collection "generic".
 %End
 
     QgsExpressionTreeView *expressionTree() const;
+%Docstring
+Returns the expression tree
+
+.. versionadded:: 3.14
+%End
 
  void loadUserExpressions() /Deprecated/;
 %Docstring

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -62,8 +62,8 @@ Loads field names and values from the specified map.
 
 .. versionadded:: 2.12
 
-.. deprecated::
-   use setLayer() and expressionTree()->
+.. deprecated:: QGIS 3.14
+   this will not do anything, use setLayer() instead
 %End
 
     void setGeomCalculator( const QgsDistanceArea &da );

--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -91,7 +91,7 @@ Returns the current layer or a None.
    use epxressionTree()->loadFieldNames() instead
 %End
 
-    void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues );
+ void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues ) /Deprecated/;
 %Docstring
 Loads field names and values from the specified map.
 
@@ -162,7 +162,7 @@ preview result and to populate the list of available functions and variables.
 
     bool isExpressionValid();
 
- void saveToRecent( const QString &collection = "generic" );
+ void saveToRecent( const QString &collection = "generic" ) /Deprecated/;
 %Docstring
 Adds the current expression to the given ``collection``.
 By default it is saved to the collection "generic".
@@ -171,7 +171,7 @@ By default it is saved to the collection "generic".
    use expressionTree()->saveRecent() instead
 %End
 
- void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+ void loadRecent( const QString &collection = QStringLiteral( "generic" ) )/Deprecated/;
 %Docstring
 Loads the recent expressions from the given ``collection``.
 By default it is loaded from the collection "generic".
@@ -182,7 +182,7 @@ By default it is loaded from the collection "generic".
 
     QgsExpressionTreeView *expressionTree() const;
 
- void loadUserExpressions();
+ void loadUserExpressions() /Deprecated/;
 %Docstring
 Loads the user expressions.
 
@@ -192,7 +192,7 @@ Loads the user expressions.
 .. versionadded:: 3.12
 %End
 
- void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
+ void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText ) /Deprecated/;
 %Docstring
 Stores the user ``expression`` with given ``label`` and ``helpText``.
 
@@ -202,7 +202,7 @@ Stores the user ``expression`` with given ``label`` and ``helpText``.
 .. versionadded:: 3.12
 %End
 
- void removeFromUserExpressions( const QString &label );
+ void removeFromUserExpressions( const QString &label ) /Deprecated/;
 %Docstring
 Removes the expression ``label`` from the user stored expressions.
 
@@ -237,7 +237,7 @@ Loads code into the function editor
 Updates the list of function files found at the given path
 %End
 
- QStandardItemModel *model();
+ QStandardItemModel *model() /Deprecated/;
 %Docstring
 Returns a pointer to the dialog's function item model.
 This method is exposed for testing purposes only - it should not be used to modify the model.

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -1,0 +1,253 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsexpressiontreeview.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+
+class QgsExpressionItem : QStandardItem
+{
+%Docstring
+An expression item that can be used in the QgsExpressionBuilderWidget tree.
+%End
+
+%TypeHeaderCode
+#include "qgsexpressiontreeview.h"
+%End
+  public:
+    enum ItemType
+    {
+      Header,
+      Field,
+      ExpressionNode
+    };
+
+    QgsExpressionItem( const QString &label,
+                       const QString &expressionText,
+                       const QString &helpText,
+                       QgsExpressionItem::ItemType itemType = ExpressionNode );
+
+    QgsExpressionItem( const QString &label,
+                       const QString &expressionText,
+                       QgsExpressionItem::ItemType itemType = ExpressionNode );
+
+    QString getExpressionText() const;
+
+    QString getHelpText() const;
+%Docstring
+Gets the help text that is associated with this expression item.
+
+:return: The help text.
+%End
+
+    void setHelpText( const QString &helpText );
+%Docstring
+Set the help text for the current item
+
+.. note::
+
+   The help text can be set as a html string.
+%End
+
+    QgsExpressionItem::ItemType getItemType() const;
+%Docstring
+Gets the type of expression item, e.g., header, field, ExpressionNode.
+
+:return: The QgsExpressionItem.ItemType
+%End
+
+    static const int CUSTOM_SORT_ROLE;
+    static const int ITEM_TYPE_ROLE;
+    static const int SEARCH_TAGS_ROLE;
+
+};
+
+
+class QgsExpressionItemSearchProxy : QSortFilterProxyModel
+{
+%Docstring
+Search proxy used to filter the QgsExpressionBuilderWidget tree.
+The default search for a tree model only searches top level this will handle one
+level down
+%End
+
+%TypeHeaderCode
+#include "qgsexpressiontreeview.h"
+%End
+  public:
+    QgsExpressionItemSearchProxy();
+
+    virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const;
+
+
+  protected:
+
+    virtual bool lessThan( const QModelIndex &left, const QModelIndex &right ) const;
+
+};
+
+class QgsExpressionTreeView : QTreeView
+{
+%Docstring
+QgsExpressionTreeView is a tree view to list all expressions
+functions, variables and fields that can be used in an expression.
+
+.. seealso:: :py:class:`QgsExpressionBuilderWidget`
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsexpressiontreeview.h"
+%End
+  public:
+
+    class MenuProvider
+{
+%Docstring
+Implementation of this interface can be implemented to allow QgsExpressionTreeView
+instance to provide custom context menus (opened upon right-click).
+%End
+
+%TypeHeaderCode
+#include "qgsexpressiontreeview.h"
+%End
+      public:
+        explicit MenuProvider();
+        virtual ~MenuProvider();
+
+        virtual QMenu *createContextMenu( QgsExpressionItem *item ) /Factory/;
+%Docstring
+Returns a newly created menu instance
+%End
+    };
+
+    QgsExpressionTreeView( QWidget *parent = 0 );
+
+    void setLayer( QgsVectorLayer *layer );
+%Docstring
+Sets layer in order to get the fields and values
+%End
+
+    void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression context for the tree view. The context is used
+to populate the list of available functions and variables.
+
+:param context: expression context
+
+.. seealso:: :py:func:`expressionContext`
+%End
+
+    QgsProject *project();
+%Docstring
+Returns the project currently associated with the widget.
+
+.. seealso:: :py:func:`setProject`
+%End
+
+    void setProject( QgsProject *project );
+%Docstring
+Sets the ``project`` currently associated with the widget. This
+controls which layers and relations and other project-specific items are shown in the widget.
+
+.. seealso:: :py:func:`project`
+%End
+
+    void setMenuProvider( MenuProvider *provider );
+%Docstring
+Sets the menu provider.
+This does not take ownership of the provider
+%End
+
+    void refresh();
+%Docstring
+Refreshes the content of the tree
+%End
+
+    QgsExpressionItem *currentItem() const;
+%Docstring
+Returns the current item or a None
+%End
+
+
+    void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+%Docstring
+Loads the recent expressions from the given ``collection``.
+By default it is loaded from the collection "generic".
+%End
+
+    void saveToRecent( const QString &expressionText, const QString &collection = "generic" );
+%Docstring
+Adds the current expression to the given ``collection``.
+By default it is saved to the collection "generic".
+%End
+
+    void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
+%Docstring
+Stores the user ``expression`` with given ``label`` and ``helpText``.
+%End
+
+    void removeFromUserExpressions( const QString &label );
+%Docstring
+Removes the expression ``label`` from the user stored expressions.
+%End
+
+    void loadUserExpressions( );
+%Docstring
+Loads the user expressions.
+This is done on request since it can be very slow if there are thousands of user expressions
+%End
+
+    const QList<QgsExpressionItem *> findExpressions( const QString &label );
+%Docstring
+Returns the list of expression items matching a ``label``.
+%End
+
+
+    QJsonDocument exportUserExpressions();
+%Docstring
+Create the expressions JSON document storing all the user expressions to be exported.
+
+:return: the created expressions JSON file
+%End
+
+    void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
+%Docstring
+Load and permanently store the expressions from the expressions JSON document.
+
+:param expressionsDocument: the parsed expressions JSON file
+%End
+
+  signals:
+    void expressionItemDoubleClicked( const QString &text );
+%Docstring
+Emitted when a expression item is double clicked
+%End
+
+    void currentExpressionItemChanged( QgsExpressionItem *item );
+%Docstring
+Emitter when the current expression item changed
+%End
+
+  public slots:
+    void setSearchText( const QString &text );
+
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsexpressiontreeview.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -115,6 +115,8 @@ functions, variables and fields that can be used in an expression.
 %Docstring
 Implementation of this interface can be implemented to allow QgsExpressionTreeView
 instance to provide custom context menus (opened upon right-click).
+
+.. versionadded:: 3.14
 %End
 
 %TypeHeaderCode
@@ -156,6 +158,14 @@ to populate the list of available functions and variables.
 :param context: expression context
 
 .. seealso:: :py:func:`expressionContext`
+%End
+
+    QgsExpressionContext expressionContext() const;
+%Docstring
+Returns the expression context for the widget. The context is used for the expression
+preview result and for populating the list of available functions and variables.
+
+.. seealso:: :py:func:`setExpressionContext`
 %End
 
     QgsProject *project();

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -115,6 +115,8 @@ functions, variables and fields that can be used in an expression.
 %Docstring
 Implementation of this interface can be implemented to allow QgsExpressionTreeView
 instance to provide custom context menus (opened upon right-click).
+
+.. versionadded:: 3.14
 %End
 
 %TypeHeaderCode
@@ -122,6 +124,9 @@ instance to provide custom context menus (opened upon right-click).
 %End
       public:
         explicit MenuProvider();
+%Docstring
+Constructor
+%End
         virtual ~MenuProvider();
 
         virtual QMenu *createContextMenu( QgsExpressionItem *item ) /Factory/;
@@ -131,6 +136,9 @@ Returns a newly created menu instance
     };
 
     QgsExpressionTreeView( QWidget *parent = 0 );
+%Docstring
+Constructor
+%End
 
     void setLayer( QgsVectorLayer *layer );
 %Docstring
@@ -245,6 +253,9 @@ Emitter when the current expression item changed
 
   public slots:
     void setSearchText( const QString &text );
+%Docstring
+Sets the text to filter the expression tree
+%End
 
 
 };

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -137,6 +137,11 @@ Returns a newly created menu instance
 Sets layer in order to get the fields and values
 %End
 
+    void loadFieldNames( const QgsFields &fields );
+%Docstring
+This allows to load fields without specifying a layer
+%End
+
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring
 Sets the expression context for the tree view. The context is used

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -139,7 +139,7 @@ Sets layer in order to get the fields and values
 
     void loadFieldNames( const QgsFields &fields );
 %Docstring
-This allows to load fields without specifying a layer
+This allows loading fields without specifying a layer
 %End
 
     void setExpressionContext( const QgsExpressionContext &context );

--- a/python/gui/auto_generated/qgsexpressiontreeview.sip.in
+++ b/python/gui/auto_generated/qgsexpressiontreeview.sip.in
@@ -115,8 +115,6 @@ functions, variables and fields that can be used in an expression.
 %Docstring
 Implementation of this interface can be implemented to allow QgsExpressionTreeView
 instance to provide custom context menus (opened upon right-click).
-
-.. versionadded:: 3.14
 %End
 
 %TypeHeaderCode

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -74,6 +74,7 @@
 %Include auto_generated/qgsexpressionhighlighter.sip
 %Include auto_generated/qgsexpressionlineedit.sip
 %Include auto_generated/qgsexpressionselectiondialog.sip
+%Include auto_generated/qgsexpressiontreeview.sip
 %Include auto_generated/qgsextentgroupbox.sip
 %Include auto_generated/qgsextentwidget.sip
 %Include auto_generated/qgsexternalresourcewidget.sip

--- a/src/core/qgsfieldformatterregistry.cpp
+++ b/src/core/qgsfieldformatterregistry.cpp
@@ -17,7 +17,6 @@
 #include "qgsfieldformatterregistry.h"
 #include "qgsfieldformatter.h"
 
-#include "qgsapplication.h"
 #include "qgsvaluerelationfieldformatter.h"
 #include "qgsvaluemapfieldformatter.h"
 #include "qgsdatetimefieldformatter.h"
@@ -78,21 +77,4 @@ QgsFieldFormatter *QgsFieldFormatterRegistry::fieldFormatter( const QString &id 
 QgsFieldFormatter *QgsFieldFormatterRegistry::fallbackFieldFormatter() const
 {
   return mFallbackFieldFormatter;
-}
-
-bool QgsFieldFormatterRegistry::formatterCanProvideAvailableValues( QgsVectorLayer *layer, const QString &fieldName )
-{
-  if ( layer )
-  {
-    const QgsFields fields = layer->fields();
-    int fieldIndex = fields.lookupField( fieldName );
-    if ( fieldIndex != -1 )
-    {
-      const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
-      const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
-
-      return ( formatter->flags() & QgsFieldFormatter::CanProvideAvailableValues );
-    }
-  }
-  return false;
 }

--- a/src/core/qgsfieldformatterregistry.cpp
+++ b/src/core/qgsfieldformatterregistry.cpp
@@ -13,9 +13,11 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgsfieldformatterregistry.h"
 #include "qgsfieldformatter.h"
 
+#include "qgsapplication.h"
 #include "qgsvaluerelationfieldformatter.h"
 #include "qgsvaluemapfieldformatter.h"
 #include "qgsdatetimefieldformatter.h"
@@ -76,4 +78,21 @@ QgsFieldFormatter *QgsFieldFormatterRegistry::fieldFormatter( const QString &id 
 QgsFieldFormatter *QgsFieldFormatterRegistry::fallbackFieldFormatter() const
 {
   return mFallbackFieldFormatter;
+}
+
+bool QgsFieldFormatterRegistry::formatterCanProvideAvailableValues( QgsVectorLayer *layer, const QString &fieldName )
+{
+  if ( layer )
+  {
+    const QgsFields fields = layer->fields();
+    int fieldIndex = fields.lookupField( fieldName );
+    if ( fieldIndex != -1 )
+    {
+      const QgsEditorWidgetSetup setup = fields.at( fieldIndex ).editorWidgetSetup();
+      const QgsFieldFormatter *formatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
+
+      return ( formatter->flags() & QgsFieldFormatter::CanProvideAvailableValues );
+    }
+  }
+  return false;
 }

--- a/src/core/qgsfieldformatterregistry.h
+++ b/src/core/qgsfieldformatterregistry.h
@@ -24,6 +24,7 @@
 #include "qgis_core.h"
 
 class QgsFieldFormatter;
+class QgsVectorLayer;
 
 /**
  * \ingroup core
@@ -77,6 +78,12 @@ class CORE_EXPORT QgsFieldFormatterRegistry : public QObject
      * to represent any field in an unspectacular manner.
      */
     QgsFieldFormatter *fallbackFieldFormatter() const;
+
+    /**
+     * Returns if the formatter for a given layer and field name can provide available values
+     * \since QGIS 3.14
+     */
+    static bool formatterCanProvideAvailableValues( QgsVectorLayer *layer, const QString &fieldName );
 
   signals:
 

--- a/src/core/qgsfieldformatterregistry.h
+++ b/src/core/qgsfieldformatterregistry.h
@@ -79,12 +79,6 @@ class CORE_EXPORT QgsFieldFormatterRegistry : public QObject
      */
     QgsFieldFormatter *fallbackFieldFormatter() const;
 
-    /**
-     * Returns if the formatter for a given layer and field name can provide available values
-     * \since QGIS 3.14
-     */
-    static bool formatterCanProvideAvailableValues( QgsVectorLayer *layer, const QString &fieldName );
-
   signals:
 
     /**

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -383,6 +383,7 @@ SET(QGIS_GUI_SRCS
   qgsexpressionlineedit.cpp
   qgsexpressionselectiondialog.cpp
   qgsexpressionstoredialog.cpp
+  qgsexpressiontreeview.cpp
   qgsextentgroupbox.cpp
   qgsextentwidget.cpp
   qgsexternalresourcewidget.cpp
@@ -602,6 +603,7 @@ SET(QGIS_GUI_HDRS
   qgsexpressionhighlighter.h
   qgsexpressionlineedit.h
   qgsexpressionselectiondialog.h
+  qgsexpressiontreeview.h
   qgsextentgroupbox.h
   qgsextentwidget.h
   qgsexternalresourcewidget.h

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -919,11 +919,8 @@ void QgsDualView::modifySort()
 
   QgsExpressionBuilderWidget *expressionBuilder = new QgsExpressionBuilderWidget();
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
-  expressionBuilder->setExpressionContext( context );
-  expressionBuilder->setLayer( mLayer );
-  expressionBuilder->loadFieldNames();
-  expressionBuilder->loadRecent( QStringLiteral( "generic" ) );
-  expressionBuilder->loadUserExpressions( );
+
+  expressionBuilder->initWithLayer( mLayer, context, QStringLiteral( "generic" ) );
   expressionBuilder->setExpressionText( sortExpression().isEmpty() ? mLayer->displayExpression() : sortExpression() );
 
   sortingGroupBox->layout()->addWidget( expressionBuilder );

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -80,7 +80,7 @@ void QgsExpressionBuilderDialog::done( int r )
 
 void QgsExpressionBuilderDialog::accept()
 {
-  builder->saveToRecent( mRecentKey );
+  builder->expressionTree()->saveToRecent( builder->expressionText(), mRecentKey );
   QDialog::accept();
 }
 

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -31,9 +31,8 @@ QgsExpressionBuilderDialog::QgsExpressionBuilderDialog( QgsVectorLayer *layer, c
   builder->setExpressionContext( context );
   builder->setLayer( layer );
   builder->setExpressionText( startText );
-  builder->loadFieldNames();
-  builder->loadRecent( mRecentKey );
-  builder->loadUserExpressions( );
+  builder->expressionTree()->loadRecent( mRecentKey );
+  builder->expressionTree()->loadUserExpressions( );
 
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsExpressionBuilderDialog::showHelp );
 }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -13,28 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsexpressionbuilderwidget.h"
-#include "qgslogger.h"
-#include "qgsexpression.h"
-#include "qgsexpressionfunction.h"
-#include "qgsexpressionnodeimpl.h"
-#include "qgsmessageviewer.h"
-#include "qgsapplication.h"
-#include "qgspythonrunner.h"
-#include "qgsgeometry.h"
-#include "qgsfeature.h"
-#include "qgsfeatureiterator.h"
-#include "qgsvectorlayer.h"
-#include "qgssettings.h"
-#include "qgsproject.h"
-#include "qgsrelationmanager.h"
-#include "qgsrelation.h"
-#include "qgsexpressioncontextutils.h"
-#include "qgsfieldformatterregistry.h"
-#include "qgsfieldformatter.h"
-#include "qgsexpressionstoredialog.h"
 
-#include <QMenu>
 #include <QFile>
 #include <QTextStream>
 #include <QDir>
@@ -49,6 +28,29 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QFileDialog>
+#include <QMenu>
+
+#include "qgsexpressionbuilderwidget.h"
+#include "qgslogger.h"
+#include "qgsexpression.h"
+#include "qgsexpressionfunction.h"
+#include "qgsexpressionnodeimpl.h"
+#include "qgsmessageviewer.h"
+#include "qgsapplication.h"
+#include "qgspythonrunner.h"
+#include "qgsgeometry.h"
+#include "qgsfeature.h"
+#include "qgsfeatureiterator.h"
+#include "qgsvectorlayer.h"
+#include "qgssettings.h"
+#include "qgsproject.h"
+#include "qgsrelation.h"
+#include "qgsexpressioncontextutils.h"
+#include "qgsfieldformatterregistry.h"
+#include "qgsfieldformatter.h"
+#include "qgsexpressionstoredialog.h"
+#include "qgsexpressiontreeview.h"
+
 
 QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   : QWidget( parent )
@@ -59,11 +61,9 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   connect( btnRun, &QToolButton::pressed, this, &QgsExpressionBuilderWidget::btnRun_pressed );
   connect( btnNewFile, &QToolButton::pressed, this, &QgsExpressionBuilderWidget::btnNewFile_pressed );
   connect( cmbFileNames, &QListWidget::currentItemChanged, this, &QgsExpressionBuilderWidget::cmbFileNames_currentItemChanged );
-  connect( expressionTree, &QTreeView::doubleClicked, this, &QgsExpressionBuilderWidget::expressionTree_doubleClicked );
   connect( txtExpressionString, &QgsCodeEditorExpression::textChanged, this, &QgsExpressionBuilderWidget::txtExpressionString_textChanged );
   connect( txtPython, &QgsCodeEditorPython::textChanged, this, &QgsExpressionBuilderWidget::txtPython_textChanged );
   connect( txtSearchEditValues, &QgsFilterLineEdit::textChanged, this, &QgsExpressionBuilderWidget::txtSearchEditValues_textChanged );
-  connect( txtSearchEdit, &QgsFilterLineEdit::textChanged, this, &QgsExpressionBuilderWidget::txtSearchEdit_textChanged );
   connect( lblPreview, &QLabel::linkActivated, this, &QgsExpressionBuilderWidget::lblPreview_linkActivated );
   connect( mValuesListView, &QListView::doubleClicked, this, &QgsExpressionBuilderWidget::mValuesListView_doubleClicked );
   connect( btnSaveExpression, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::storeCurrentUserExpression );
@@ -73,19 +73,16 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   connect( btnExportExpressions, &QPushButton::pressed, this, &QgsExpressionBuilderWidget::exportUserExpressions_pressed );
   connect( btnClearEditor, &QPushButton::pressed, txtExpressionString, &QgsCodeEditorExpression::clear );
 
+  connect( txtSearchEdit, &QgsFilterLineEdit::textChanged, mExpressionTreeView, &QgsExpressionTreeView::setSearchText );
+  connect( mExpressionTreeView, &QgsExpressionTreeView::expressionItemDoubleClicked, this, &QgsExpressionBuilderWidget::insertExpressionText );
+  connect( mExpressionTreeView, &QgsExpressionTreeView::currentExpressionItemChanged, this, &QgsExpressionBuilderWidget::expressionTreeItemChanged );
+
+  mExpressionTreeMenuProvider = new ExpressionTreeMenuProvider( this );
+  mExpressionTreeView->setMenuProvider( mExpressionTreeMenuProvider );
+
   txtHelpText->setOpenExternalLinks( true );
   mValueGroupBox->hide();
 //  highlighter = new QgsExpressionHighlighter( txtExpressionString->document() );
-
-  mModel = qgis::make_unique<QStandardItemModel>();
-  mProxyModel = qgis::make_unique<QgsExpressionItemSearchProxy>();
-  mProxyModel->setDynamicSortFilter( true );
-  mProxyModel->setSourceModel( mModel.get() );
-  expressionTree->setModel( mProxyModel.get() );
-  expressionTree->setSortingEnabled( true );
-  expressionTree->sortByColumn( 0, Qt::AscendingOrder );
-
-  expressionTree->setSelectionMode( QAbstractItemView::SelectionMode::SingleSelection );
 
   // Note: must be in sync with the json help file for UserGroup
   mUserExpressionsGroupName = QgsExpression::group( QStringLiteral( "UserGroup" ) );
@@ -98,11 +95,7 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   btnImportExpressions->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionSharingImport.svg" ) ) );
   btnClearEditor->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileNew.svg" ) ) );
 
-  expressionTree->setContextMenuPolicy( Qt::CustomContextMenu );
   connect( this, &QgsExpressionBuilderWidget::expressionParsed, this, &QgsExpressionBuilderWidget::setExpressionState );
-  connect( expressionTree, &QWidget::customContextMenuRequested, this, &QgsExpressionBuilderWidget::showContextMenu );
-  connect( expressionTree->selectionModel(), &QItemSelectionModel::currentChanged,
-           this, &QgsExpressionBuilderWidget::currentChanged );
 
   connect( btnLoadAll, &QAbstractButton::pressed, this, &QgsExpressionBuilderWidget::loadAllValues );
   connect( btnLoadSample, &QAbstractButton::pressed, this, &QgsExpressionBuilderWidget::loadSampleValues );
@@ -147,9 +140,6 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   txtExpressionString->setFoldingVisible( false );
 
-  updateFunctionTree();
-  loadUserExpressions();
-
   if ( QgsPythonRunner::isValid() )
   {
     QgsPythonRunner::eval( QStringLiteral( "qgis.user.expressionspath" ), mFunctionsPath );
@@ -159,11 +149,6 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   {
     tab_2->hide();
   }
-
-  // select the first item in the function list
-  // in order to avoid a blank help widget
-  QModelIndex firstItem = mProxyModel->index( 0, 0, QModelIndex() );
-  expressionTree->setCurrentIndex( firstItem );
 
   txtExpressionString->setWrapMode( QsciScintilla::WrapWord );
   lblAutoSave->clear();
@@ -241,25 +226,33 @@ QgsExpressionBuilderWidget::~QgsExpressionBuilderWidget()
   settings.setValue( QStringLiteral( "Windows/QgsExpressionBuilderWidget/splitter" ), splitter->saveState() );
   settings.setValue( QStringLiteral( "Windows/QgsExpressionBuilderWidget/editorsplitter" ), editorSplit->saveState() );
   settings.setValue( QStringLiteral( "Windows/QgsExpressionBuilderWidget/functionsplitter" ), functionsplit->saveState() );
+  delete mExpressionTreeMenuProvider;
 }
 
 void QgsExpressionBuilderWidget::setLayer( QgsVectorLayer *layer )
 {
   mLayer = layer;
+  mExpressionTreeView->setLayer( mLayer );
 
   //TODO - remove existing layer scope from context
 
   if ( mLayer )
+  {
     mExpressionContext << QgsExpressionContextUtils::layerScope( mLayer );
+
+    txtExpressionString->setFields( mLayer->fields() );
+  }
 }
 
-void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const QModelIndex & )
+QgsVectorLayer *QgsExpressionBuilderWidget::layer() const
+{
+  return mLayer;
+}
+
+void QgsExpressionBuilderWidget::expressionTreeItemChanged( QgsExpressionItem *item )
 {
   txtSearchEditValues->clear();
 
-  // Get the item
-  QModelIndex idx = mProxyModel->mapToSource( index );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -283,7 +276,6 @@ void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const
 
   btnRemoveExpression->setEnabled( isUserExpression );
   btnEditExpression->setEnabled( isUserExpression );
-
 }
 
 void QgsExpressionBuilderWidget::btnRun_pressed()
@@ -303,10 +295,7 @@ void QgsExpressionBuilderWidget::runPythonCode( const QString &code )
     QString pythontext = code;
     QgsPythonRunner::run( pythontext );
   }
-  updateFunctionTree();
-  loadFieldNames();
-  loadRecent( mRecentKey );
-  loadUserExpressions( );
+  mExpressionTreeView->refresh();
 }
 
 void QgsExpressionBuilderWidget::saveFunctionFile( QString fileName )
@@ -414,47 +403,11 @@ void QgsExpressionBuilderWidget::loadFunctionCode( const QString &code )
   txtPython->setText( code );
 }
 
-void QgsExpressionBuilderWidget::expressionTree_doubleClicked( const QModelIndex &index )
+void QgsExpressionBuilderWidget::insertExpressionText( const QString &text )
 {
-  QModelIndex idx = mProxyModel->mapToSource( index );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
-  if ( !item )
-    return;
-
-  // Don't handle the double-click if we are on a header node.
-  if ( item->getItemType() == QgsExpressionItem::Header )
-    return;
-
   // Insert the expression text or replace selected text
-  txtExpressionString->insertText( item->getExpressionText() );
+  txtExpressionString->insertText( text );
   txtExpressionString->setFocus();
-}
-
-void QgsExpressionBuilderWidget::loadFieldNames()
-{
-  // TODO We should really return a error the user of the widget that
-  // the there is no layer set.
-  if ( !mLayer )
-    return;
-
-  loadFieldNames( mLayer->fields() );
-}
-
-
-void QgsExpressionBuilderWidget::loadFieldNames( const QgsFields &fields )
-{
-  if ( fields.isEmpty() )
-    return;
-
-  txtExpressionString->setFields( fields );
-
-  for ( int i = 0; i < fields.count(); ++i )
-  {
-    const QgsField field = fields.at( i );
-    QIcon icon = fields.iconForField( i );
-    registerItem( QStringLiteral( "Fields and Values" ), field.displayNameWithAlias(),
-                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
-  }
 }
 
 void QgsExpressionBuilderWidget::loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues )
@@ -472,18 +425,7 @@ void QgsExpressionBuilderWidget::loadFieldsAndValues( const QMap<QString, QStrin
     }
     mFieldValues.insert( it.key(), map );
   }
-  loadFieldNames( fields );
-}
-
-void QgsExpressionBuilderWidget::loadFieldsAndValues( const QMap<QString, QVariantMap> &fieldValues )
-{
-  QgsFields fields;
-  for ( auto it = fieldValues.constBegin(); it != fieldValues.constEnd(); ++it )
-  {
-    fields.append( QgsField( it.key() ) );
-  }
-  loadFieldNames( fields );
-  mFieldValues = fieldValues;
+  mExpressionTreeView->loadFieldNames( fields );
 }
 
 void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int countLimit, bool forceUsedValues )
@@ -563,50 +505,7 @@ QString QgsExpressionBuilderWidget::getFunctionHelp( QgsExpressionFunction *func
 
 }
 
-void QgsExpressionBuilderWidget::registerItem( const QString &group,
-    const QString &label,
-    const QString &expressionText,
-    const QString &helpText,
-    QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, QIcon icon, const QStringList &tags )
-{
-  QgsExpressionItem *item = new QgsExpressionItem( label, expressionText, helpText, type );
-  item->setData( label, Qt::UserRole );
-  item->setData( sortOrder, QgsExpressionItem::CUSTOM_SORT_ROLE );
-  item->setData( tags, QgsExpressionItem::SEARCH_TAGS_ROLE );
-  item->setIcon( icon );
 
-  // Look up the group and insert the new function.
-  if ( mExpressionGroups.contains( group ) )
-  {
-    QgsExpressionItem *groupNode = mExpressionGroups.value( group );
-    groupNode->appendRow( item );
-  }
-  else
-  {
-    // If the group doesn't exist yet we make it first.
-    QgsExpressionItem *newgroupNode = new QgsExpressionItem( QgsExpression::group( group ), QString(), QgsExpressionItem::Header );
-    newgroupNode->setData( group, Qt::UserRole );
-    //Recent group should always be last group
-    newgroupNode->setData( group.startsWith( QLatin1String( "Recent (" ) ) ? 2 : 1, QgsExpressionItem::CUSTOM_SORT_ROLE );
-    newgroupNode->appendRow( item );
-    newgroupNode->setBackground( QBrush( QColor( 150, 150, 150, 150 ) ) );
-    mModel->appendRow( newgroupNode );
-    mExpressionGroups.insert( group, newgroupNode );
-  }
-
-  if ( highlightedItem )
-  {
-    //insert a copy as a top level item
-    QgsExpressionItem *topLevelItem = new QgsExpressionItem( label, expressionText, helpText, type );
-    topLevelItem->setData( label, Qt::UserRole );
-    item->setData( 0, QgsExpressionItem::CUSTOM_SORT_ROLE );
-    QFont font = topLevelItem->font();
-    font.setBold( true );
-    topLevelItem->setFont( font );
-    mModel->appendRow( topLevelItem );
-  }
-
-}
 
 bool QgsExpressionBuilderWidget::isExpressionValid()
 {
@@ -615,190 +514,35 @@ bool QgsExpressionBuilderWidget::isExpressionValid()
 
 void QgsExpressionBuilderWidget::saveToRecent( const QString &collection )
 {
-  QgsSettings settings;
-  QString location = QStringLiteral( "/expressions/recent/%1" ).arg( collection );
-  QStringList expressions = settings.value( location ).toStringList();
-  expressions.removeAll( this->expressionText() );
-
-  expressions.prepend( this->expressionText() );
-
-  while ( expressions.count() > 20 )
-  {
-    expressions.pop_back();
-  }
-
-  settings.setValue( location, expressions );
-  loadRecent( collection );
+  mExpressionTreeView->saveToRecent( expressionText(), collection );
 }
 
 void QgsExpressionBuilderWidget::loadRecent( const QString &collection )
 {
-  mRecentKey = collection;
-  QString name = tr( "Recent (%1)" ).arg( collection );
-  if ( mExpressionGroups.contains( name ) )
-  {
-    QgsExpressionItem *node = mExpressionGroups.value( name );
-    node->removeRows( 0, node->rowCount() );
-  }
+  mExpressionTreeView->loadRecent( collection );
+}
 
-  QgsSettings settings;
-  const QString location = QStringLiteral( "/expressions/recent/%1" ).arg( collection );
-  const QStringList expressions = settings.value( location ).toStringList();
-  int i = 0;
-  for ( const QString &expression : expressions )
-  {
-    QString help = formatRecentExpressionHelp( expression, expression );
-    registerItem( name, expression, expression, help, QgsExpressionItem::ExpressionNode, false, i );
-    i++;
-  }
+QgsExpressionTreeView *QgsExpressionBuilderWidget::expressionTree() const
+{
+  return mExpressionTreeView;
 }
 
 // this is potentially very slow if there are thousands of user expressions, every time entire cleanup and load
 void QgsExpressionBuilderWidget::loadUserExpressions( )
 {
-  // Cleanup
-  if ( mExpressionGroups.contains( QStringLiteral( "UserGroup" ) ) )
-  {
-    QgsExpressionItem *node = mExpressionGroups.value( QStringLiteral( "UserGroup" ) );
-    node->removeRows( 0, node->rowCount() );
-  }
-
-  QgsSettings settings;
-  const QString location = QStringLiteral( "user" );
-  settings.beginGroup( location, QgsSettings::Section::Expressions );
-  QString label;
-  QString helpText;
-  QString expression;
-  int i = 0;
-  mUserExpressionLabels = settings.childGroups();
-  for ( const auto &label : qgis::as_const( mUserExpressionLabels ) )
-  {
-    settings.beginGroup( label );
-    expression = settings.value( QStringLiteral( "expression" ) ).toString();
-    helpText = formatUserExpressionHelp( label, expression, settings.value( QStringLiteral( "helpText" ) ).toString() );
-    registerItem( QStringLiteral( "UserGroup" ), label, expression, helpText, QgsExpressionItem::ExpressionNode, false, i++ );
-    settings.endGroup();
-  }
+  mExpressionTreeView->loadUserExpressions();
 }
 
 void QgsExpressionBuilderWidget::saveToUserExpressions( const QString &label, const QString expression, const QString &helpText )
 {
-  QgsSettings settings;
-  const QString location = QStringLiteral( "user" );
-  settings.beginGroup( location, QgsSettings::Section::Expressions );
-  settings.beginGroup( label );
-  settings.setValue( QStringLiteral( "expression" ), expression );
-  settings.setValue( QStringLiteral( "helpText" ), helpText );
-  loadUserExpressions( );
-  // Scroll
-  const QModelIndexList idxs { expressionTree->model()->match( expressionTree->model()->index( 0, 0 ),
-                               Qt::DisplayRole, label, 1,
-                               Qt::MatchFlag::MatchRecursive ) };
-  if ( ! idxs.isEmpty() )
-  {
-    expressionTree->scrollTo( idxs.first() );
-  }
+  mExpressionTreeView->saveToUserExpressions( label, expression, helpText );
 }
 
 void QgsExpressionBuilderWidget::removeFromUserExpressions( const QString &label )
 {
-  QgsSettings settings;
-  settings.remove( QStringLiteral( "user/%1" ).arg( label ), QgsSettings::Section::Expressions );
-  loadUserExpressions( );
+  mExpressionTreeView->removeFromUserExpressions( label );
 }
 
-void QgsExpressionBuilderWidget::loadLayers()
-{
-  if ( !mProject )
-    return;
-
-  QMap<QString, QgsMapLayer *> layers = mProject->mapLayers();
-  QMap<QString, QgsMapLayer *>::const_iterator layerIt = layers.constBegin();
-  for ( ; layerIt != layers.constEnd(); ++layerIt )
-  {
-    registerItemForAllGroups( QStringList() << tr( "Map Layers" ), layerIt.value()->name(), QStringLiteral( "'%1'" ).arg( layerIt.key() ), formatLayerHelp( layerIt.value() ) );
-  }
-}
-
-void QgsExpressionBuilderWidget::loadRelations()
-{
-  if ( !mProject )
-    return;
-
-  QMap<QString, QgsRelation> relations = mProject->relationManager()->relations();
-  QMap<QString, QgsRelation>::const_iterator relIt = relations.constBegin();
-  for ( ; relIt != relations.constEnd(); ++relIt )
-  {
-    registerItemForAllGroups( QStringList() << tr( "Relations" ), relIt->name(), QStringLiteral( "'%1'" ).arg( relIt->id() ), formatRelationHelp( relIt.value() ) );
-  }
-}
-
-void QgsExpressionBuilderWidget::updateFunctionTree()
-{
-  mModel->clear();
-  mExpressionGroups.clear();
-  // TODO Can we move this stuff to QgsExpression, like the functions?
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "+" ), QStringLiteral( " + " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "-" ), QStringLiteral( " - " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "*" ), QStringLiteral( " * " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "/" ), QStringLiteral( " / " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "%" ), QStringLiteral( " % " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "^" ), QStringLiteral( " ^ " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "=" ), QStringLiteral( " = " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "~" ), QStringLiteral( " ~ " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( ">" ), QStringLiteral( " > " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "<" ), QStringLiteral( " < " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "<>" ), QStringLiteral( " <> " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "<=" ), QStringLiteral( " <= " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( ">=" ), QStringLiteral( " >= " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "[]" ), QStringLiteral( "[ ]" ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "||" ), QStringLiteral( " || " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "IN" ), QStringLiteral( " IN " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "LIKE" ), QStringLiteral( " LIKE " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "ILIKE" ), QStringLiteral( " ILIKE " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "IS" ), QStringLiteral( " IS " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "OR" ), QStringLiteral( " OR " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "AND" ), QStringLiteral( " AND " ) );
-  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "NOT" ), QStringLiteral( " NOT " ) );
-
-  QString casestring = QStringLiteral( "CASE WHEN condition THEN result END" );
-  registerItem( QStringLiteral( "Conditionals" ), QStringLiteral( "CASE" ), casestring );
-
-  // use -1 as sort order here -- NULL should always show before the field list
-  registerItem( QStringLiteral( "Fields and Values" ), QStringLiteral( "NULL" ), QStringLiteral( "NULL" ), QString(), QgsExpressionItem::ExpressionNode, false, -1 );
-
-  // Load the functions from the QgsExpression class
-  int count = QgsExpression::functionCount();
-  for ( int i = 0; i < count; i++ )
-  {
-    QgsExpressionFunction *func = QgsExpression::Functions()[i];
-    QString name = func->name();
-    if ( name.startsWith( '_' ) ) // do not display private functions
-      continue;
-    if ( func->isDeprecated() ) // don't show deprecated functions
-      continue;
-    if ( func->isContextual() )
-    {
-      //don't show contextual functions by default - it's up the the QgsExpressionContext
-      //object to provide them if supported
-      continue;
-    }
-    if ( func->params() != 0 )
-      name += '(';
-    else if ( !name.startsWith( '$' ) )
-      name += QLatin1String( "()" );
-    // this is where the functions are being registered, including functions under "Custom"
-    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText(), QgsExpressionItem::ExpressionNode, mExpressionContext.isHighlightedFunction( func->name() ), 1, QgsExpression::tags( func->name() ) );
-  }
-
-  // load relation names
-  loadRelations();
-
-  // load layer IDs
-  loadLayers();
-
-  loadExpressionContext();
-}
 
 void QgsExpressionBuilderWidget::setGeomCalculator( const QgsDistanceArea &da )
 {
@@ -829,10 +573,8 @@ void QgsExpressionBuilderWidget::setExpectedOutputFormat( const QString &expecte
 void QgsExpressionBuilderWidget::setExpressionContext( const QgsExpressionContext &context )
 {
   mExpressionContext = context;
-  updateFunctionTree();
-  loadFieldNames();
-  loadRecent( mRecentKey );
-  loadUserExpressions( );
+  txtExpressionString->setExpressionContext( mExpressionContext );
+  mExpressionTreeView->setExpressionContext( context );
 }
 
 void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
@@ -915,108 +657,6 @@ void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
 
 }
 
-void QgsExpressionBuilderWidget::loadExpressionContext()
-{
-  txtExpressionString->setExpressionContext( mExpressionContext );
-  QStringList variableNames = mExpressionContext.filteredVariableNames();
-  const auto constVariableNames = variableNames;
-  for ( const QString &variable : constVariableNames )
-  {
-    registerItem( QStringLiteral( "Variables" ), variable, " @" + variable + ' ',
-                  formatVariableHelp( variable, mExpressionContext.description( variable ), true, mExpressionContext.variable( variable ) ),
-                  QgsExpressionItem::ExpressionNode,
-                  mExpressionContext.isHighlightedVariable( variable ) );
-  }
-
-  // Load the functions from the expression context
-  QStringList contextFunctions = mExpressionContext.functionNames();
-  const auto constContextFunctions = contextFunctions;
-  for ( const QString &functionName : constContextFunctions )
-  {
-    QgsExpressionFunction *func = mExpressionContext.function( functionName );
-    QString name = func->name();
-    if ( name.startsWith( '_' ) ) // do not display private functions
-      continue;
-    if ( func->params() != 0 )
-      name += '(';
-    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText(), QgsExpressionItem::ExpressionNode, mExpressionContext.isHighlightedFunction( func->name() ), 1, QgsExpression::tags( func->name() ) );
-  }
-}
-
-void QgsExpressionBuilderWidget::registerItemForAllGroups( const QStringList &groups, const QString &label, const QString &expressionText, const QString &helpText, QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, const QStringList &tags )
-{
-  const auto constGroups = groups;
-  for ( const QString &group : constGroups )
-  {
-    registerItem( group, label, expressionText, helpText, type, highlightedItem, sortOrder, QIcon(), tags );
-  }
-}
-
-QString QgsExpressionBuilderWidget::formatRelationHelp( const QgsRelation &relation ) const
-{
-  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-                 .arg( QCoreApplication::translate( "relation_help", "relation %1" ).arg( relation.name() ),
-                       tr( "Inserts the relation ID for the relation named '%1'." ).arg( relation.name() ) );
-
-  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-          .arg( tr( "Current value" ), relation.id() );
-
-  return text;
-}
-
-QString QgsExpressionBuilderWidget::formatLayerHelp( const QgsMapLayer *layer ) const
-{
-  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-                 .arg( QCoreApplication::translate( "layer_help", "map layer %1" ).arg( layer->name() ),
-                       tr( "Inserts the layer ID for the layer named '%1'." ).arg( layer->name() ) );
-
-  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-          .arg( tr( "Current value" ), layer->id() );
-
-  return text;
-}
-
-QString QgsExpressionBuilderWidget::formatRecentExpressionHelp( const QString &label, const QString &expression ) const
-{
-  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-                 .arg( QCoreApplication::translate( "recent_expression_help", "expression %1" ).arg( label ),
-                       QCoreApplication::translate( "recent_expression_help", "Recently used expression." ) );
-
-  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-          .arg( tr( "Expression" ), expression );
-
-  return text;
-}
-
-QString QgsExpressionBuilderWidget::formatUserExpressionHelp( const QString &label, const QString &expression, const QString &description ) const
-{
-  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-                 .arg( QCoreApplication::translate( "user_expression_help", "expression %1" ).arg( label ), description );
-
-  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
-          .arg( tr( "Expression" ), expression );
-
-  return text;
-}
-
-QString QgsExpressionBuilderWidget::formatVariableHelp( const QString &variable, const QString &description, bool showValue, const QVariant &value ) const
-{
-  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
-                 .arg( QCoreApplication::translate( "variable_help", "variable %1" ).arg( variable ), description );
-
-  if ( showValue )
-  {
-    QString valueString = !value.isValid()
-                          ? QCoreApplication::translate( "variable_help", "not set" )
-                          : QStringLiteral( "<pre>%1</pre>" ).arg( QgsExpression::formatPreviewString( value ) );
-
-    text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><p>%2</p></div>" )
-            .arg( tr( "Current value" ), valueString );
-  }
-
-  return text;
-}
-
 bool QgsExpressionBuilderWidget::parserError() const
 {
   return mParserError;
@@ -1058,7 +698,7 @@ void QgsExpressionBuilderWidget::setEvalError( bool evalError )
 
 QStandardItemModel *QgsExpressionBuilderWidget::model()
 {
-  return mModel.get();
+  return mExpressionTreeView->model();
 }
 
 QgsProject *QgsExpressionBuilderWidget::project()
@@ -1069,7 +709,7 @@ QgsProject *QgsExpressionBuilderWidget::project()
 void QgsExpressionBuilderWidget::setProject( QgsProject *project )
 {
   mProject = project;
-  updateFunctionTree();
+  mExpressionTreeView->setProject( project );
 }
 
 void QgsExpressionBuilderWidget::showEvent( QShowEvent *e )
@@ -1197,25 +837,6 @@ void QgsExpressionBuilderWidget::clearErrors()
   txtExpressionString->clearIndicatorRange( 0, 0, lastLine, txtExpressionString->text( lastLine ).length(), QgsExpression::ParserError::FunctionNamedArgsError );
 }
 
-void QgsExpressionBuilderWidget::txtSearchEdit_textChanged()
-{
-  mProxyModel->setFilterWildcard( txtSearchEdit->text() );
-  if ( txtSearchEdit->text().isEmpty() )
-  {
-    expressionTree->collapseAll();
-  }
-  else
-  {
-    expressionTree->expandAll();
-    QModelIndex index = mProxyModel->index( 0, 0 );
-    if ( mProxyModel->hasChildren( index ) )
-    {
-      QModelIndex child = mProxyModel->index( 0, 0, index );
-      expressionTree->selectionModel()->setCurrentIndex( child, QItemSelectionModel::ClearAndSelect );
-    }
-  }
-}
-
 void QgsExpressionBuilderWidget::txtSearchEditValues_textChanged()
 {
   mProxyValues->setFilterCaseSensitivity( Qt::CaseInsensitive );
@@ -1247,33 +868,9 @@ void QgsExpressionBuilderWidget::operatorButtonClicked()
   txtExpressionString->setFocus();
 }
 
-void QgsExpressionBuilderWidget::showContextMenu( QPoint pt )
-{
-  QModelIndex idx = expressionTree->indexAt( pt );
-  idx = mProxyModel->mapToSource( idx );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
-  if ( !item )
-    return;
-
-  if ( item->getItemType() == QgsExpressionItem::Field && mLayer )
-  {
-    QMenu *menu = new QMenu( this );
-    menu->addAction( tr( "Load First 10 Unique Values" ), this, SLOT( loadSampleValues() ) );
-    menu->addAction( tr( "Load All Unique Values" ), this, SLOT( loadAllValues() ) );
-
-    if ( formatterCanProvideAvailableValues( item->text() ) )
-    {
-      menu->addAction( tr( "Load First 10 Unique Used Values" ), this, SLOT( loadSampleUsedValues() ) );
-      menu->addAction( tr( "Load All Unique Used Values" ), this, SLOT( loadAllUsedValues() ) );
-    }
-    menu->popup( expressionTree->mapToGlobal( pt ) );
-  }
-}
-
 void QgsExpressionBuilderWidget::loadSampleValues()
 {
-  QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1285,8 +882,7 @@ void QgsExpressionBuilderWidget::loadSampleValues()
 
 void QgsExpressionBuilderWidget::loadAllValues()
 {
-  QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1298,8 +894,7 @@ void QgsExpressionBuilderWidget::loadAllValues()
 
 void QgsExpressionBuilderWidget::loadSampleUsedValues()
 {
-  QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1311,8 +906,7 @@ void QgsExpressionBuilderWidget::loadSampleUsedValues()
 
 void QgsExpressionBuilderWidget::loadAllUsedValues()
 {
-  QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = mExpressionTreeView->currentItem();
   // TODO We should really return a error the user of the widget that
   // the there is no layer set.
   if ( !mLayer || !item )
@@ -1357,18 +951,17 @@ void QgsExpressionBuilderWidget::autosave()
 void QgsExpressionBuilderWidget::storeCurrentUserExpression()
 {
   const QString expression { this->expressionText() };
-  QgsExpressionStoreDialog dlg { expression, expression, QString( ), mUserExpressionLabels };
+  QgsExpressionStoreDialog dlg { expression, expression, QString( ), mExpressionTreeView->userExpressionLabels() };
   if ( dlg.exec() == QDialog::DialogCode::Accepted )
   {
-    saveToUserExpressions( dlg.label(), dlg.expression(), dlg.helpText() );
+    mExpressionTreeView->saveToUserExpressions( dlg.label(), dlg.expression(), dlg.helpText() );
   }
 }
 
 void QgsExpressionBuilderWidget::editSelectedUserExpression()
 {
   // Get the item
-  QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  QgsExpressionItem *item = mExpressionTreeView->currentItem();
   if ( !item )
     return;
 
@@ -1384,16 +977,15 @@ void QgsExpressionBuilderWidget::editSelectedUserExpression()
 
   if ( dlg.exec() == QDialog::DialogCode::Accepted )
   {
-    saveToUserExpressions( dlg.label(), dlg.expression(), dlg.helpText() );
+    mExpressionTreeView->saveToUserExpressions( dlg.label(), dlg.expression(), dlg.helpText() );
   }
 }
 
 void QgsExpressionBuilderWidget::removeSelectedUserExpression()
 {
+  // Get the item
+  QgsExpressionItem *item = mExpressionTreeView->currentItem();
 
-// Get the item
-  QModelIndex idx = mProxyModel->mapToSource( expressionTree->currentIndex() );
-  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
   if ( !item )
     return;
 
@@ -1407,7 +999,7 @@ void QgsExpressionBuilderWidget::removeSelectedUserExpression()
        tr( "Do you really want to remove stored expressions '%1'?" ).arg( item->text() ),
        QMessageBox::Yes | QMessageBox::No ) )
   {
-    removeFromUserExpressions( item->text() );
+    mExpressionTreeView->removeFromUserExpressions( item->text() );
   }
 
 }
@@ -1435,7 +1027,7 @@ void QgsExpressionBuilderWidget::exportUserExpressions_pressed()
 
   settings.setValue( QStringLiteral( "lastExportExpressionsDir" ), saveFileInfo.absolutePath(), QgsSettings::App );
 
-  QJsonDocument exportJson = exportUserExpressions();
+  QJsonDocument exportJson = mExpressionTreeView->exportUserExpressions();
   QFile jsonFile( saveFileName );
 
   if ( !jsonFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
@@ -1445,49 +1037,6 @@ void QgsExpressionBuilderWidget::exportUserExpressions_pressed()
     QMessageBox::warning( this, tr( "Export user expressions" ), tr( "Error while creating the expressions file." ) );
   else
     jsonFile.close();
-}
-
-
-QJsonDocument QgsExpressionBuilderWidget::exportUserExpressions()
-{
-  const QString group = QStringLiteral( "user" );
-  QgsSettings settings;
-  QJsonArray exportList;
-  QJsonObject exportObject
-  {
-    {"qgis_version", Qgis::version()},
-    {"exported_at", QDateTime::currentDateTime().toString( Qt::ISODate )},
-    {"author", QgsApplication::userFullName()},
-    {"expressions", exportList}
-  };
-
-  settings.beginGroup( group, QgsSettings::Section::Expressions );
-
-  mUserExpressionLabels = settings.childGroups();
-
-  for ( const QString &label : qgis::as_const( mUserExpressionLabels ) )
-  {
-    settings.beginGroup( label );
-
-    const QString expression = settings.value( QStringLiteral( "expression" ) ).toString();
-    const QString helpText = settings.value( QStringLiteral( "helpText" ) ).toString();
-    const QJsonObject expressionObject
-    {
-      {"name", label},
-      {"type", "expression"},
-      {"expression", expression},
-      {"group", group},
-      {"description", helpText}
-    };
-    exportList.push_back( expressionObject );
-
-    settings.endGroup();
-  }
-
-  exportObject["expressions"] = exportList;
-  QJsonDocument exportJson = QJsonDocument( exportObject );
-
-  return exportJson;
 }
 
 void QgsExpressionBuilderWidget::importUserExpressions_pressed()
@@ -1524,199 +1073,13 @@ void QgsExpressionBuilderWidget::importUserExpressions_pressed()
     return;
   }
 
-  loadExpressionsFromJson( importJson );
+  mExpressionTreeView->loadExpressionsFromJson( importJson );
 }
 
-void QgsExpressionBuilderWidget::loadExpressionsFromJson( const QJsonDocument &expressionsDocument )
-{
-  // if the root of the json document is not an object, it means it's a wrong file
-  if ( ! expressionsDocument.isObject() )
-    return;
-
-  QJsonObject expressionsObject = expressionsDocument.object();
-
-  // validate json for manadatory fields
-  if ( ! expressionsObject["qgis_version"].isString()
-       || ! expressionsObject["exported_at"].isString()
-       || ! expressionsObject["author"].isString()
-       || ! expressionsObject["expressions"].isArray() )
-    return;
-
-  // validate versions
-  QVersionNumber qgisJsonVersion = QVersionNumber::fromString( expressionsObject["qgis_version"].toString() );
-  QVersionNumber qgisVersion = QVersionNumber::fromString( Qgis::version() );
-
-  // if the expressions are from newer version of QGIS, we ask the user to confirm
-  // they want to proceed
-  if ( qgisJsonVersion > qgisVersion )
-  {
-    QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::No;
-    switch ( QMessageBox::question( this,
-                                    tr( "QGIS Version Mismatch" ),
-                                    tr( "The imported expressions are from newer version of QGIS (%1) "
-                                        "and some of the expression might not work the current version (%2). "
-                                        "Are you sure you want to continue?" ).arg( qgisJsonVersion.toString(), qgisVersion.toString() ), buttons ) )
-    {
-      case QMessageBox::No:
-        return;
-
-      case QMessageBox::Yes:
-        break;
-
-      default:
-        break;
-    }
-  }
-
-  // we store the number of
-  QStringList skippedExpressionLabels;
-  bool isApplyToAll = false;
-  bool isOkToOverwrite = false;
-
-  QgsSettings settings;
-  settings.beginGroup( QStringLiteral( "user" ), QgsSettings::Section::Expressions );
-  mUserExpressionLabels = settings.childGroups();
-
-  for ( const QJsonValue &expressionValue : expressionsObject["expressions"].toArray() )
-  {
-    // validate the type of the array element, can be anything
-    if ( ! expressionValue.isObject() )
-    {
-      // try to stringify and put and indicator what happened
-      skippedExpressionLabels.append( expressionValue.toString() );
-      continue;
-    }
-
-    QJsonObject expressionObj = expressionValue.toObject();
-
-    // make sure the required keys are the correct types
-    if ( ! expressionObj["name"].isString()
-         || ! expressionObj["type"].isString()
-         || ! expressionObj["expression"].isString()
-         || ! expressionObj["group"].isString()
-         || ! expressionObj["description"].isString() )
-    {
-      // try to stringify and put an indicator what happened. Try to stringify the name, if fails, go with the expression.
-      if ( ! expressionObj["name"].toString().isEmpty() )
-        skippedExpressionLabels.append( expressionObj["name"].toString() );
-      else
-        skippedExpressionLabels.append( expressionObj["expression"].toString() );
-
-      continue;
-    }
-
-    // we want to import only items of type expression for now
-    if ( expressionObj["type"].toString() != QStringLiteral( "expression" ) )
-    {
-      skippedExpressionLabels.append( expressionObj["name"].toString() );
-      continue;
-    }
-
-    // we want to import only items of type expression for now
-    if ( expressionObj["group"].toString() != QStringLiteral( "user" ) )
-    {
-      skippedExpressionLabels.append( expressionObj["name"].toString() );
-      continue;
-    }
-
-    const QString label = expressionObj["name"].toString();
-    const QString expression = expressionObj["expression"].toString();
-    const QString helpText = expressionObj["description"].toString();
-
-    // make sure they have valid name
-    if ( label.contains( "\\" ) || label.contains( '/' ) )
-    {
-      skippedExpressionLabels.append( expressionObj["name"].toString() );
-      continue;
-    }
-
-    settings.beginGroup( label );
-    const QString oldExpression = settings.value( QStringLiteral( "expression" ) ).toString();
-    settings.endGroup();
-
-    // TODO would be nice to skip the cases when labels and expressions match
-    if ( mUserExpressionLabels.contains( label ) && expression != oldExpression )
-    {
-      if ( ! isApplyToAll )
-        showMessageBoxConfirmExpressionOverwrite( isApplyToAll, isOkToOverwrite, label, oldExpression, expression );
-
-      if ( isOkToOverwrite )
-        saveToUserExpressions( label, expression, helpText );
-      else
-      {
-        skippedExpressionLabels.append( label );
-        continue;
-      }
-    }
-    else
-    {
-      saveToUserExpressions( label, expression, helpText );
-    }
-  }
-
-  loadUserExpressions( );
-
-  if ( ! skippedExpressionLabels.isEmpty() )
-  {
-    QStringList skippedExpressionLabelsQuoted;
-    for ( const QString &skippedExpressionLabel : skippedExpressionLabels )
-      skippedExpressionLabelsQuoted.append( QStringLiteral( "'%1'" ).arg( skippedExpressionLabel ) );
-
-    QMessageBox::information( this,
-                              tr( "Skipped Expression Imports" ),
-                              QStringLiteral( "%1\n%2" ).arg( tr( "The following expressions have been skipped:" ),
-                                  skippedExpressionLabelsQuoted.join( ", " ) ) );
-  }
-}
-
-void QgsExpressionBuilderWidget::showMessageBoxConfirmExpressionOverwrite(
-  bool &isApplyToAll,
-  bool &isOkToOverwrite,
-  const QString &label,
-  const QString &oldExpression,
-  const QString &newExpression )
-{
-  QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll;
-  switch ( QMessageBox::question( this,
-                                  tr( "Expression Overwrite" ),
-                                  tr( "The expression with label '%1' was already defined."
-                                      "The old expression \"%2\" will be overwritten by \"%3\"."
-                                      "Are you sure you want to overwrite the expression?" ).arg( label, oldExpression, newExpression ), buttons ) )
-  {
-    case QMessageBox::NoToAll:
-      isApplyToAll = true;
-      isOkToOverwrite = false;
-      break;
-
-    case QMessageBox::No:
-      isApplyToAll = false;
-      isOkToOverwrite = false;
-      break;
-
-    case QMessageBox::YesToAll:
-      isApplyToAll = true;
-      isOkToOverwrite = true;
-      break;
-
-    case QMessageBox::Yes:
-      isApplyToAll = false;
-      isOkToOverwrite = true;
-      break;
-
-    default:
-      break;
-  }
-}
 
 const QList<QgsExpressionItem *> QgsExpressionBuilderWidget::findExpressions( const QString &label )
 {
-  QList<QgsExpressionItem *> result;
-  const QList<QStandardItem *> found { mModel->findItems( label, Qt::MatchFlag::MatchRecursive ) };
-  for ( const auto &item : qgis::as_const( found ) )
-  {
-    result.push_back( static_cast<QgsExpressionItem *>( item ) );
-  }
-  return result;
+  return mExpressionTreeView->findExpressions( label );
 }
 
 void QgsExpressionBuilderWidget::indicatorClicked( int line, int index, Qt::KeyboardModifiers state )
@@ -1770,65 +1133,22 @@ QString QgsExpressionBuilderWidget::loadFunctionHelp( QgsExpressionItem *express
   return "<head><style>" + helpStylesheet() + "</style></head><body>" + helpContents + "</body>";
 }
 
-QgsExpressionItemSearchProxy::QgsExpressionItemSearchProxy()
-{
-  setFilterCaseSensitivity( Qt::CaseInsensitive );
-}
 
-bool QgsExpressionItemSearchProxy::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
+QMenu *QgsExpressionBuilderWidget::ExpressionTreeMenuProvider::createContextMenu( QgsExpressionItem *item )
 {
-  QModelIndex index = sourceModel()->index( source_row, 0, source_parent );
-  QgsExpressionItem::ItemType itemType = QgsExpressionItem::ItemType( sourceModel()->data( index, QgsExpressionItem::ITEM_TYPE_ROLE ).toInt() );
-
-  int count = sourceModel()->rowCount( index );
-  bool matchchild = false;
-  for ( int i = 0; i < count; ++i )
+  QMenu *menu = nullptr;
+  QgsVectorLayer *layer = mExpressionBuilderWidget->layer();
+  if ( item->getItemType() == QgsExpressionItem::Field && layer )
   {
-    if ( filterAcceptsRow( i, index ) )
+    menu = new QMenu( mExpressionBuilderWidget );
+    menu->addAction( tr( "Load First 10 Unique Values" ), mExpressionBuilderWidget, &QgsExpressionBuilderWidget::loadSampleValues );
+    menu->addAction( tr( "Load All Unique Values" ), mExpressionBuilderWidget, &QgsExpressionBuilderWidget::loadAllValues );
+
+    if ( QgsFieldFormatterRegistry::formatterCanProvideAvailableValues( layer, item->text() ) )
     {
-      matchchild = true;
-      break;
+      menu->addAction( tr( "Load First 10 Unique Used Values" ), mExpressionBuilderWidget, SLOT( loadSampleUsedValues() ) );
+      menu->addAction( tr( "Load All Unique Used Values" ), mExpressionBuilderWidget, &QgsExpressionBuilderWidget::loadAllUsedValues );
     }
   }
-
-  if ( itemType == QgsExpressionItem::Header && matchchild )
-    return true;
-
-  if ( itemType == QgsExpressionItem::Header )
-    return false;
-
-  // check match of item label or tags
-  if ( QSortFilterProxyModel::filterAcceptsRow( source_row, source_parent ) )
-  {
-    return true;
-  }
-  else
-  {
-    const QStringList tags = sourceModel()->data( index, QgsExpressionItem::SEARCH_TAGS_ROLE ).toStringList();
-    for ( const QString &tag : tags )
-    {
-      if ( tag.contains( filterRegExp() ) )
-        return true;
-    }
-  }
-  return false;
-}
-
-bool QgsExpressionItemSearchProxy::lessThan( const QModelIndex &left, const QModelIndex &right ) const
-{
-  int leftSort = sourceModel()->data( left, QgsExpressionItem::CUSTOM_SORT_ROLE ).toInt();
-  int rightSort = sourceModel()->data( right,  QgsExpressionItem::CUSTOM_SORT_ROLE ).toInt();
-  if ( leftSort != rightSort )
-    return leftSort < rightSort;
-
-  QString leftString = sourceModel()->data( left, Qt::DisplayRole ).toString();
-  QString rightString = sourceModel()->data( right, Qt::DisplayRole ).toString();
-
-  //ignore $ prefixes when sorting
-  if ( leftString.startsWith( '$' ) )
-    leftString = leftString.mid( 1 );
-  if ( rightString.startsWith( '$' ) )
-    rightString = rightString.mid( 1 );
-
-  return QString::localeAwareCompare( leftString, rightString ) < 0;
+  return menu;
 }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -229,6 +229,30 @@ QgsExpressionBuilderWidget::~QgsExpressionBuilderWidget()
   delete mExpressionTreeMenuProvider;
 }
 
+void QgsExpressionBuilderWidget::init( const QgsExpressionContext &context, const QString &recentCollection, const Flags &flags )
+{
+  setExpressionContext( context );
+
+  if ( flags.testFlag( LoadRecent ) )
+    mExpressionTreeView->loadRecent( recentCollection );
+
+  if ( flags.testFlag( LoadUserExpressions ) )
+    mExpressionTreeView->loadUserExpressions();
+}
+
+void QgsExpressionBuilderWidget::initWithLayer( QgsVectorLayer *layer, const QgsExpressionContext &context, const QString &recentCollection, const Flags &flags )
+{
+  init( context, recentCollection, flags );
+  setLayer( layer );
+}
+
+void QgsExpressionBuilderWidget::initWithFields( const QgsFields &fields, const QgsExpressionContext &context, const QString &recentCollection, const Flags &flags )
+{
+  init( context, recentCollection, flags );
+  mExpressionTreeView->loadFieldNames( fields );
+}
+
+
 void QgsExpressionBuilderWidget::setLayer( QgsVectorLayer *layer )
 {
   mLayer = layer;

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -259,7 +259,7 @@ void QgsExpressionBuilderWidget::expressionTreeItemChanged( QgsExpressionItem *i
   bool isField = mLayer && item->getItemType() == QgsExpressionItem::Field;
   if ( isField )
   {
-    loadFieldValues( mFieldValues.value( item->text() ) );
+    mValuesModel->clear();
 
     cbxValuesInUse->setVisible( formatterCanProvideAvailableValues( item->text() ) );
     cbxValuesInUse->setChecked( false );
@@ -412,20 +412,8 @@ void QgsExpressionBuilderWidget::insertExpressionText( const QString &text )
 
 void QgsExpressionBuilderWidget::loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues )
 {
-  mFieldValues.clear();
-  QgsFields fields;
-  for ( auto it = fieldValues.constBegin(); it != fieldValues.constEnd(); ++it )
-  {
-    fields.append( QgsField( it.key() ) );
-    const QStringList values = it.value();
-    QVariantMap map;
-    for ( const QString &value : values )
-    {
-      map.insert( value, value );
-    }
-    mFieldValues.insert( it.key(), map );
-  }
-  mExpressionTreeView->loadFieldNames( fields );
+  Q_UNUSED( fieldValues )
+  // This is not maintained and setLayer() should be used instead.
 }
 
 void QgsExpressionBuilderWidget::fillFieldValues( const QString &fieldName, int countLimit, bool forceUsedValues )
@@ -669,17 +657,6 @@ void QgsExpressionBuilderWidget::setParserError( bool parserError )
 
   mParserError = parserError;
   emit parserErrorChanged();
-}
-
-void QgsExpressionBuilderWidget::loadFieldValues( const QVariantMap &values )
-{
-  mValuesModel->clear();
-  for ( QVariantMap::ConstIterator it = values.constBegin(); it != values.constEnd(); ++ it )
-  {
-    QStandardItem *item = new QStandardItem( it.key() );
-    item->setData( it.value() );
-    mValuesModel->appendRow( item );
-  }
 }
 
 bool QgsExpressionBuilderWidget::evalError() const
@@ -1133,6 +1110,9 @@ QString QgsExpressionBuilderWidget::loadFunctionHelp( QgsExpressionItem *express
   return "<head><style>" + helpStylesheet() + "</style></head><body>" + helpContents + "</body>";
 }
 
+
+
+// Menu provider
 
 QMenu *QgsExpressionBuilderWidget::ExpressionTreeMenuProvider::createContextMenu( QgsExpressionItem *item )
 {

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -704,7 +704,9 @@ void QgsExpressionBuilderWidget::setEvalError( bool evalError )
 
 QStandardItemModel *QgsExpressionBuilderWidget::model()
 {
+  Q_NOWARN_DEPRECATED_PUSH
   return mExpressionTreeView->model();
+  Q_NOWARN_DEPRECATED_POP
 }
 
 QgsProject *QgsExpressionBuilderWidget::project()

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -17,114 +17,22 @@
 #define QGSEXPRESSIONBUILDER_H
 
 #include <QWidget>
-#include "qgis_sip.h"
+#include <QStandardItemModel>
+#include <QSortFilterProxyModel>
+
 #include "ui_qgsexpressionbuilder.h"
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
 #include "qgsdistancearea.h"
 #include "qgsexpressioncontext.h"
 #include "qgsexpression.h"
+#include "qgsexpressiontreeview.h"
 
-#include "QStandardItemModel"
-#include "QStandardItem"
-#include "QSortFilterProxyModel"
-#include "QStringListModel"
-#include "qgis_gui.h"
 
 class QgsFields;
 class QgsExpressionHighlighter;
 class QgsRelation;
-
-/**
- * \ingroup gui
- * An expression item that can be used in the QgsExpressionBuilderWidget tree.
-  */
-class GUI_EXPORT QgsExpressionItem : public QStandardItem
-{
-  public:
-    enum ItemType
-    {
-      Header,
-      Field,
-      ExpressionNode
-    };
-
-    QgsExpressionItem( const QString &label,
-                       const QString &expressionText,
-                       const QString &helpText,
-                       QgsExpressionItem::ItemType itemType = ExpressionNode )
-      : QStandardItem( label )
-    {
-      mExpressionText = expressionText;
-      mHelpText = helpText;
-      mType = itemType;
-      setData( itemType, ITEM_TYPE_ROLE );
-    }
-
-    QgsExpressionItem( const QString &label,
-                       const QString &expressionText,
-                       QgsExpressionItem::ItemType itemType = ExpressionNode )
-      : QStandardItem( label )
-    {
-      mExpressionText = expressionText;
-      mType = itemType;
-      setData( itemType, ITEM_TYPE_ROLE );
-    }
-
-    QString getExpressionText() const { return mExpressionText; }
-
-    /**
-     * Gets the help text that is associated with this expression item.
-      *
-      * \returns The help text.
-      */
-    QString getHelpText() const { return mHelpText; }
-
-    /**
-     * Set the help text for the current item
-      *
-      * \note The help text can be set as a html string.
-      */
-    void setHelpText( const QString &helpText ) { mHelpText = helpText; }
-
-    /**
-     * Gets the type of expression item, e.g., header, field, ExpressionNode.
-      *
-      * \returns The QgsExpressionItem::ItemType
-      */
-    QgsExpressionItem::ItemType getItemType() const { return mType; }
-
-    //! Custom sort order role
-    static const int CUSTOM_SORT_ROLE = Qt::UserRole + 1;
-    //! Item type role
-    static const int ITEM_TYPE_ROLE = Qt::UserRole + 2;
-    //! Search tags role
-    static const int SEARCH_TAGS_ROLE = Qt::UserRole + 3;
-
-  private:
-    QString mExpressionText;
-    QString mHelpText;
-    QgsExpressionItem::ItemType mType;
-
-};
-
-/**
- * \ingroup gui
- * Search proxy used to filter the QgsExpressionBuilderWidget tree.
-  * The default search for a tree model only searches top level this will handle one
-  * level down
-  */
-class GUI_EXPORT QgsExpressionItemSearchProxy : public QSortFilterProxyModel
-{
-    Q_OBJECT
-
-  public:
-    QgsExpressionItemSearchProxy();
-
-    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
-
-  protected:
-
-    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
-};
 
 
 /**
@@ -145,22 +53,23 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     /**
      * Sets layer in order to get the fields and values
-      * \note this needs to be called before calling loadFieldNames().
-      */
+     * \note this needs to be called before calling loadFieldNames().
+     */
     void setLayer( QgsVectorLayer *layer );
 
     /**
-     * Loads all the field names from the layer.
-      * @remarks Should this really be public couldn't we just do this for the user?
-      */
-    void loadFieldNames();
+     * Returns the current layer or a nullptr.
+     */
+    QgsVectorLayer *layer() const;
 
-    void loadFieldNames( const QgsFields &fields );
+    //! \deprecated since QGIS 3.14 this is now done automatically
+    Q_DECL_DEPRECATED void loadFieldNames( const QgsFields &fields = QgsFields() ) {Q_UNUSED( fields )}
 
     /**
      * Loads field names and values from the specified map.
      *  \note The field values must be quoted appropriately if they are strings.
      *  \since QGIS 2.12
+     * \deprecated use setLayer() and expressionTree()->
      */
     void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues );
 
@@ -200,63 +109,51 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     /**
      * Sets the expression context for the widget. The context is used for the expression
-     * preview result and for populating the list of available functions and variables.
+     * preview result and to populate the list of available functions and variables.
      * \param context expression context
      * \see expressionContext
      * \since QGIS 2.12
      */
     void setExpressionContext( const QgsExpressionContext &context );
 
-    /**
-     * Registers a node item for the expression builder.
-      * \param group The group the item will be show in the tree view.  If the group doesn't exist it will be created.
-      * \param label The label that is show to the user for the item in the tree.
-      * \param expressionText The text that is inserted into the expression area when the user double clicks on the item.
-      * \param helpText The help text that the user will see when item is selected.
-      * \param type The type of the expression item.
-      * \param highlightedItem set to TRUE to make the item highlighted, which inserts a bold copy of the item at the top level
-      * \param sortOrder sort ranking for item
-      * \param icon custom icon to show for item
-      * \param tags tags to find function
-      */
-    void registerItem( const QString &group, const QString &label, const QString &expressionText,
-                       const QString &helpText = QString(),
-                       QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
-                       bool highlightedItem = false, int sortOrder = 1,
-                       QIcon icon = QIcon(),
-                       const QStringList &tags = QStringList() );
-
     bool isExpressionValid();
 
     /**
      * Adds the current expression to the given \a collection.
      * By default it is saved to the collection "generic".
+     * \deprecated since QGIS 3.14 use expressionTree()->saveRecent() instead
      */
-    void saveToRecent( const QString &collection = "generic" );
+    Q_DECL_DEPRECATED void saveToRecent( const QString &collection = "generic" );
 
     /**
      * Loads the recent expressions from the given \a collection.
      * By default it is loaded from the collection "generic".
+     * \deprecated since QGIS 3.14 use expressionTree()->loadRecent() instead
      */
-    void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+    Q_DECL_DEPRECATED void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+
+    QgsExpressionTreeView *expressionTree() const;
 
     /**
      * Loads the user expressions.
+     * \deprecated since QGIS 3.14 use expressionTree()->loadUserExpressions() instead
      * \since QGIS 3.12
      */
-    void loadUserExpressions( );
+    Q_DECL_DEPRECATED void loadUserExpressions();
 
     /**
      * Stores the user \a expression with given \a label and \a helpText.
+     * \deprecated since QGIS 3.14 use expressionTree()->saveToUserExpressions() instead
      * \since QGIS 3.12
      */
-    void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
+    Q_DECL_DEPRECATED void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
 
     /**
      * Removes the expression \a label from the user stored expressions.
+     * \deprecated since QGIS 3.14 use expressionTree()->removeFromUserExpressions() instead
      * \since QGIS 3.12
      */
-    void removeFromUserExpressions( const QString &label );
+    Q_DECL_DEPRECATED void removeFromUserExpressions( const QString &label );
 
     /**
      * Creates a new file in the function editor
@@ -287,8 +184,9 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * Returns a pointer to the dialog's function item model.
      * This method is exposed for testing purposes only - it should not be used to modify the model.
      * \since QGIS 3.0
+     * \deprecated since QGIS 3.14
      */
-    QStandardItemModel *model();
+    Q_DECL_DEPRECATED QStandardItemModel *model();
 
     /**
      * Returns the project currently associated with the widget.
@@ -388,31 +286,17 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void editSelectedUserExpression();
 
     /**
-     * Create the expressions JSON document storing all the user expressions to be exported.
-     * \returns the created expressions JSON file
-     * \since QGIS 3.14
-     */
-    QJsonDocument exportUserExpressions();
-
-    /**
-     * Load and permanently store the expressions from the expressions JSON document.
-     * \param expressionsDocument the parsed expressions JSON file
-     * \since QGIS 3.14
-     */
-    void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
-
-    /**
      * Returns the list of expression items matching a \a label.
      * \since QGIS 3.12
+     * \deprecated since QGIS 3.14 use expressionTree()->findExpressions instead
      */
     const QList<QgsExpressionItem *> findExpressions( const QString &label );
 
 
   private slots:
     void indicatorClicked( int line, int index, Qt::KeyboardModifiers state );
-    void showContextMenu( QPoint );
     void setExpressionState( bool state );
-    void currentChanged( const QModelIndex &index, const QModelIndex & );
+    void expressionTreeItemChanged( QgsExpressionItem *item );
     void operatorButtonClicked();
     void btnRun_pressed();
     void btnNewFile_pressed();
@@ -431,9 +315,8 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      */
     void importUserExpressions_pressed();
     void cmbFileNames_currentItemChanged( QListWidgetItem *item, QListWidgetItem *lastitem );
-    void expressionTree_doubleClicked( const QModelIndex &index );
+    void insertExpressionText( const QString &text );
     void txtExpressionString_textChanged();
-    void txtSearchEdit_textChanged();
     void txtSearchEditValues_textChanged();
     void lblPreview_linkActivated( const QString &link );
     void mValuesListView_doubleClicked( const QModelIndex &index );
@@ -469,67 +352,30 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void showEvent( QShowEvent *e ) override;
 
   private:
+    class ExpressionTreeMenuProvider : public QgsExpressionTreeView::MenuProvider
+    {
+      public:
+        ExpressionTreeMenuProvider( QgsExpressionBuilderWidget *expressionBuilderWidget )
+          : QgsExpressionTreeView::MenuProvider()
+          , mExpressionBuilderWidget( expressionBuilderWidget ) {}
+
+        QMenu *createContextMenu( QgsExpressionItem *item ) override;
+
+      private:
+        QgsExpressionBuilderWidget *mExpressionBuilderWidget;
+    };
+
     int FUNCTION_MARKER_ID = 25;
     void createErrorMarkers( QList<QgsExpression::ParserError> errors );
     void createMarkers( const QgsExpressionNode *node );
     void clearFunctionMarkers();
     void clearErrors();
     void runPythonCode( const QString &code );
-    void updateFunctionTree();
     void fillFieldValues( const QString &fieldName, int countLimit, bool forceUsedValues = false );
     bool formatterCanProvideAvailableValues( const QString &fieldName );
     QString getFunctionHelp( QgsExpressionFunction *function );
     QString loadFunctionHelp( QgsExpressionItem *functionName );
     QString helpStylesheet() const;
-
-    void loadExpressionContext();
-
-    //! Loads current project relations names/id into the expression help tree
-    void loadRelations();
-
-    //! Loads current project layer names/ids into the expression help tree
-    void loadLayers();
-
-    /**
-     * Registers a node item for the expression builder, adding multiple items when the function exists in multiple groups
-      * \param groups The groups the item will be show in the tree view.  If a group doesn't exist it will be created.
-      * \param label The label that is show to the user for the item in the tree.
-      * \param expressionText The text that is inserted into the expression area when the user double clicks on the item.
-      * \param helpText The help text that the user will see when item is selected.
-      * \param type The type of the expression item.
-      * \param highlightedItem set to TRUE to make the item highlighted, which inserts a bold copy of the item at the top level
-      * \param sortOrder sort ranking for item
-      * \param tags tags to find function
-      */
-    void registerItemForAllGroups( const QStringList &groups, const QString &label, const QString &expressionText,
-                                   const QString &helpText = QString(),
-                                   QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
-                                   bool highlightedItem = false, int sortOrder = 1, const QStringList &tags = QStringList() );
-
-    /**
-     * Returns a HTML formatted string for use as a \a relation item help.
-     */
-    QString formatRelationHelp( const QgsRelation &relation ) const;
-
-    /**
-     * Returns a HTML formatted string for use as a \a layer item help.
-     */
-    QString formatLayerHelp( const QgsMapLayer *layer ) const;
-
-    /**
-     * Returns a HTML formatted string for use as a \a recent \a expression item help.
-     */
-    QString formatRecentExpressionHelp( const QString &label, const QString &expression ) const;
-
-    /**
-     * Returns a HTML formatted string for use as a \a user \a expression item help.
-     */
-    QString formatUserExpressionHelp( const QString &label, const QString &expression, const QString &description ) const;
-
-    /**
-     * Returns a HTML formatted string for use as a \a variable item help.
-     */
-    QString formatVariableHelp( const QString &variable, const QString &description, bool showValue, const QVariant &value ) const;
 
     /**
      * Will be set to TRUE if the current expression text reported an eval error
@@ -549,37 +395,20 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     void loadFieldValues( const QVariantMap &values );
 
-    void loadFieldsAndValues( const QMap<QString, QVariantMap> &fieldValues );
-
-    /**
-     * Display a message box to ask the user what to do when an expression
-     * with the same \a label already exists. Answering "Yes" will replace
-     * the old expression with the one from the file, while "No" will keep
-     * the old expression.
-     * \param isApplyToAll whether the decision of the user should be applied to any future label collision
-     * \param isOkToOverwrite whether to overwrite the old expression with the new one in case of label collision
-     * \param label the label of the expression
-     * \param oldExpression the old expression for a given label
-     * \param newExpression the new expression for a given label
-     * \since QGIS 3.14
-     */
-    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, const QString &oldExpression, const QString &newExpression );
-
-    bool mAutoSave = true;
-    QString mFunctionsPath;
-    QgsVectorLayer *mLayer = nullptr;
-    std::unique_ptr<QStandardItemModel> mModel;
     // Will hold items with
     // * a display string that matches the represented field values
     // * custom data in Qt::UserRole + 1 that contains a ready to use expression literal ('quoted string' or NULL or a plain number )
     std::unique_ptr<QStandardItemModel> mValuesModel;
     std::unique_ptr<QSortFilterProxyModel> mProxyValues;
-    std::unique_ptr<QgsExpressionItemSearchProxy> mProxyModel;
-    QMap<QString, QgsExpressionItem *> mExpressionGroups;
+
+    ExpressionTreeMenuProvider *mExpressionTreeMenuProvider = nullptr;
+
+    bool mAutoSave = true;
+    QString mFunctionsPath;
+    QgsVectorLayer *mLayer = nullptr;
     QgsExpressionHighlighter *highlighter = nullptr;
     bool mExpressionValid = false;
     QgsDistanceArea mDa;
-    QString mRecentKey;
     QMap<QString, QVariantMap>  mFieldValues;
     QgsExpressionContext mExpressionContext;
     QPointer< QgsProject > mProject;
@@ -587,7 +416,6 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     bool mParserError = true;
     // Translated name of the user expressions group
     QString mUserExpressionsGroupName;
-    QStringList mUserExpressionLabels;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -96,17 +96,17 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QgsVectorLayer *layer() const;
 
     //! \deprecated since QGIS 3.14 this is now done automatically
-    Q_DECL_DEPRECATED void loadFieldNames() {}
+    Q_DECL_DEPRECATED void loadFieldNames() {} SIP_DEPRECATED
 
     //! \deprecated since QGIS 3.14 use epxressionTree()->loadFieldNames() instead
-    Q_DECL_DEPRECATED void loadFieldNames( const QgsFields &fields ) {mExpressionTreeView->loadFieldNames( fields );}
+    Q_DECL_DEPRECATED void loadFieldNames( const QgsFields &fields ) {mExpressionTreeView->loadFieldNames( fields );} SIP_DEPRECATED
 
     /**
      * Loads field names and values from the specified map.
      *  \since QGIS 2.12
      * \deprecated since QGIS 3.14 this will not do anything, use setLayer() instead
      */
-    void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues );
+    Q_DECL_DEPRECATED void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues ) SIP_DEPRECATED;
 
     //! Sets geometry calculator used in distance/area calculations.
     void setGeomCalculator( const QgsDistanceArea &da );
@@ -158,14 +158,14 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * By default it is saved to the collection "generic".
      * \deprecated since QGIS 3.14 use expressionTree()->saveRecent() instead
      */
-    Q_DECL_DEPRECATED void saveToRecent( const QString &collection = "generic" );
+    Q_DECL_DEPRECATED void saveToRecent( const QString &collection = "generic" ) SIP_DEPRECATED;
 
     /**
      * Loads the recent expressions from the given \a collection.
      * By default it is loaded from the collection "generic".
      * \deprecated since QGIS 3.14 use expressionTree()->loadRecent() instead
      */
-    Q_DECL_DEPRECATED void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+    Q_DECL_DEPRECATED void loadRecent( const QString &collection = QStringLiteral( "generic" ) )SIP_DEPRECATED ;
 
     QgsExpressionTreeView *expressionTree() const;
 
@@ -174,21 +174,21 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * \deprecated since QGIS 3.14 use expressionTree()->loadUserExpressions() instead
      * \since QGIS 3.12
      */
-    Q_DECL_DEPRECATED void loadUserExpressions();
+    Q_DECL_DEPRECATED void loadUserExpressions() SIP_DEPRECATED;
 
     /**
      * Stores the user \a expression with given \a label and \a helpText.
      * \deprecated since QGIS 3.14 use expressionTree()->saveToUserExpressions() instead
      * \since QGIS 3.12
      */
-    Q_DECL_DEPRECATED void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
+    Q_DECL_DEPRECATED void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText ) SIP_DEPRECATED;
 
     /**
      * Removes the expression \a label from the user stored expressions.
      * \deprecated since QGIS 3.14 use expressionTree()->removeFromUserExpressions() instead
      * \since QGIS 3.12
      */
-    Q_DECL_DEPRECATED void removeFromUserExpressions( const QString &label );
+    Q_DECL_DEPRECATED void removeFromUserExpressions( const QString &label ) SIP_DEPRECATED;
 
     /**
      * Creates a new file in the function editor
@@ -221,7 +221,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * \since QGIS 3.0
      * \deprecated since QGIS 3.14
      */
-    Q_DECL_DEPRECATED QStandardItemModel *model();
+    Q_DECL_DEPRECATED QStandardItemModel *model() SIP_DEPRECATED;
 
     /**
      * Returns the project currently associated with the widget.

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      * Loads field names and values from the specified map.
      *  \note The field values must be quoted appropriately if they are strings.
      *  \since QGIS 2.12
-     * \deprecated use setLayer() and expressionTree()->
+     * \deprecated since QGIS 3.14 this will not do anything, use setLayer() instead
      */
     void loadFieldsAndValues( const QMap<QString, QStringList> &fieldValues );
 
@@ -393,8 +393,6 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      */
     void setParserError( bool parserError );
 
-    void loadFieldValues( const QVariantMap &values );
-
     // Will hold items with
     // * a display string that matches the represented field values
     // * custom data in Qt::UserRole + 1 that contains a ready to use expression literal ('quoted string' or NULL or a plain number )
@@ -409,7 +407,6 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QgsExpressionHighlighter *highlighter = nullptr;
     bool mExpressionValid = false;
     QgsDistanceArea mDa;
-    QMap<QString, QVariantMap>  mFieldValues;
     QgsExpressionContext mExpressionContext;
     QPointer< QgsProject > mProject;
     bool mEvalError = true;

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -151,6 +151,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      */
     void setExpressionContext( const QgsExpressionContext &context );
 
+    //! Returns if the expression is valid
     bool isExpressionValid();
 
     /**
@@ -167,6 +168,10 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
      */
     Q_DECL_DEPRECATED void loadRecent( const QString &collection = QStringLiteral( "generic" ) )SIP_DEPRECATED ;
 
+    /**
+     * Returns the expression tree
+     * \since QGIS 3.14
+     */
     QgsExpressionTreeView *expressionTree() const;
 
     /**

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -46,10 +46,43 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
   public:
 
     /**
+     * Flag to determine what should be loaded
+     * \since QGIS 3.14
+     */
+    enum Flag
+    {
+      LoadNothing = 0, //!< Do not load anything
+      LoadRecent = 1 << 1, //!< Load recent expressions given the collection key
+      LoadUserExpressions = 1 << 2, //!< Load user expressions
+      LoadAll = LoadRecent | LoadUserExpressions, //!< Load everything
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+    Q_FLAG( Flag )
+
+
+    /**
      * Create a new expression builder widget with an optional parent.
      */
     QgsExpressionBuilderWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
     ~QgsExpressionBuilderWidget() override;
+
+    /**
+     * Initialize without any layer
+     * \since QGIS 3.14
+     */
+    void init( const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), const Flags &flags = LoadAll );
+
+    /**
+     * Initialize with a layer
+     * \since QGIS 3.14
+     */
+    void initWithLayer( QgsVectorLayer *layer, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), const Flags &flags = LoadAll );
+
+    /**
+     * Initialize with given fields without any layer
+     * \since QGIS 3.14
+     */
+    void initWithFields( const QgsFields &fields, const QgsExpressionContext &context = QgsExpressionContext(), const QString &recentCollection = QStringLiteral( "generic" ), const Flags &flags = LoadAll );
 
     /**
      * Sets layer in order to get the fields and values
@@ -63,11 +96,13 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QgsVectorLayer *layer() const;
 
     //! \deprecated since QGIS 3.14 this is now done automatically
-    Q_DECL_DEPRECATED void loadFieldNames( const QgsFields &fields = QgsFields() ) {Q_UNUSED( fields )}
+    Q_DECL_DEPRECATED void loadFieldNames() {}
+
+    //! \deprecated since QGIS 3.14 use epxressionTree()->loadFieldNames() instead
+    Q_DECL_DEPRECATED void loadFieldNames( const QgsFields &fields ) {mExpressionTreeView->loadFieldNames( fields );}
 
     /**
      * Loads field names and values from the specified map.
-     *  \note The field values must be quoted appropriately if they are strings.
      *  \since QGIS 2.12
      * \deprecated since QGIS 3.14 this will not do anything, use setLayer() instead
      */
@@ -366,6 +401,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     };
 
     int FUNCTION_MARKER_ID = 25;
+
     void createErrorMarkers( QList<QgsExpression::ParserError> errors );
     void createMarkers( const QgsExpressionNode *node );
     void clearFunctionMarkers();

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -408,7 +408,6 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void clearErrors();
     void runPythonCode( const QString &code );
     void fillFieldValues( const QString &fieldName, int countLimit, bool forceUsedValues = false );
-    bool formatterCanProvideAvailableValues( const QString &fieldName );
     QString getFunctionHelp( QgsExpressionFunction *function );
     QString loadFunctionHelp( QgsExpressionItem *functionName );
     QString helpStylesheet() const;

--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -223,7 +223,7 @@ void QgsExpressionSelectionDialog::done( int r )
 
 void QgsExpressionSelectionDialog::saveRecent()
 {
-  mExpressionBuilder->saveToRecent( QStringLiteral( "selection" ) );
+  mExpressionBuilder->expressionTree()->saveToRecent( mExpressionBuilder->expressionText(), QStringLiteral( "selection" ) );
 }
 
 void QgsExpressionSelectionDialog::showHelp()

--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -55,12 +55,9 @@ QgsExpressionSelectionDialog::QgsExpressionSelectionDialog( QgsVectorLayer *laye
   mButtonSelect->addAction( mActionSelectIntersect );
   mButtonSelect->setDefaultAction( mActionSelect );
 
-  mExpressionBuilder->setLayer( layer );
-  mExpressionBuilder->setExpressionText( startText );
-
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( mLayer ) );
-  mExpressionBuilder->loadRecent( QStringLiteral( "selection" ) );
-  mExpressionBuilder->setExpressionContext( context );
+  mExpressionBuilder->initWithLayer( layer, context, QStringLiteral( "selection" ) );
+  mExpressionBuilder->setExpressionText( startText );
 
   // by default, zoom to features is hidden, shown only if canvas is set
   mButtonZoomToFeatures->setVisible( false );

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -432,7 +432,7 @@ void QgsExpressionTreeView::loadFieldNames()
     node->removeRows( 0, node->rowCount() );
   }
 
-  // this can happend if fields are manually set
+  // this can happen if fields are manually set
   if ( !mLayer )
     return;
 

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -1,0 +1,852 @@
+/***************************************************************************
+    qgsexpressiontreeview.cpp
+     --------------------------------------
+    Date                 : march 2020 - quarantine day 9
+    Copyright            : (C) 2020 by Denis Rouzaud
+    Email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QMenu>
+#include <QMessageBox>
+
+#include "qgsexpressiontreeview.h"
+#include "qgis.h"
+#include "qgsfieldformatterregistry.h"
+#include "qgsvectorlayer.h"
+#include "qgsexpressioncontextutils.h"
+#include "qgssettings.h"
+#include "qgsrelationmanager.h"
+#include "qgsapplication.h"
+
+
+//! Returns a HTML formatted string for use as a \a relation item help.
+QString formatRelationHelp( const QgsRelation &relation )
+{
+  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
+                 .arg( QCoreApplication::translate( "relation_help", "relation %1" ).arg( relation.name() ),
+                       QObject::tr( "Inserts the relation ID for the relation named '%1'." ).arg( relation.name() ) );
+
+  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
+          .arg( QObject::tr( "Current value" ), relation.id() );
+
+  return text;
+}
+
+
+//! Returns a HTML formatted string for use as a \a layer item help.
+QString formatLayerHelp( const QgsMapLayer *layer )
+{
+  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
+                 .arg( QCoreApplication::translate( "layer_help", "map layer %1" ).arg( layer->name() ),
+                       QObject::tr( "Inserts the layer ID for the layer named '%1'." ).arg( layer->name() ) );
+
+  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
+          .arg( QObject::tr( "Current value" ), layer->id() );
+
+  return text;
+}
+
+//! Returns a HTML formatted string for use as a \a recent \a expression item help.
+QString formatRecentExpressionHelp( const QString &label, const QString &expression )
+{
+  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
+                 .arg( QCoreApplication::translate( "recent_expression_help", "expression %1" ).arg( label ),
+                       QCoreApplication::translate( "recent_expression_help", "Recently used expression." ) );
+
+  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
+          .arg( QObject::tr( "Expression" ), expression );
+
+  return text;
+}
+
+//! Returns a HTML formatted string for use as a \a user \a expression item help.
+QString formatUserExpressionHelp( const QString &label, const QString &expression, const QString &description )
+{
+  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
+                 .arg( QCoreApplication::translate( "user_expression_help", "expression %1" ).arg( label ), description );
+
+  text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><pre>%2</pre></div>" )
+          .arg( QObject::tr( "Expression" ), expression );
+
+  return text;
+}
+
+//! Returns a HTML formatted string for use as a \a variable item help.
+QString formatVariableHelp( const QString &variable, const QString &description, bool showValue, const QVariant &value )
+{
+  QString text = QStringLiteral( "<h3>%1</h3>\n<div class=\"description\"><p>%2</p></div>" )
+                 .arg( QCoreApplication::translate( "variable_help", "variable %1" ).arg( variable ), description );
+
+  if ( showValue )
+  {
+    QString valueString = !value.isValid()
+                          ? QCoreApplication::translate( "variable_help", "not set" )
+                          : QStringLiteral( "<pre>%1</pre>" ).arg( QgsExpression::formatPreviewString( value ) );
+
+    text += QStringLiteral( "<h4>%1</h4><div class=\"description\"><p>%2</p></div>" )
+            .arg( QObject::tr( "Current value" ), valueString );
+  }
+
+  return text;
+}
+
+
+// ****************************
+// ****************************
+// QgsExpressionTreeView
+// ****************************
+
+
+QgsExpressionTreeView::QgsExpressionTreeView( QWidget *parent )
+  : QTreeView( parent )
+  , mProject( QgsProject::instance() )
+{
+  connect( this, &QTreeView::doubleClicked, this, &QgsExpressionTreeView::onDoubleClicked );
+
+  mModel = qgis::make_unique<QStandardItemModel>();
+  mProxyModel = qgis::make_unique<QgsExpressionItemSearchProxy>();
+  mProxyModel->setDynamicSortFilter( true );
+  mProxyModel->setSourceModel( mModel.get() );
+  setModel( mProxyModel.get() );
+  setSortingEnabled( true );
+  sortByColumn( 0, Qt::AscendingOrder );
+
+  setSelectionMode( QAbstractItemView::SelectionMode::SingleSelection );
+
+  setContextMenuPolicy( Qt::CustomContextMenu );
+  connect( this, &QWidget::customContextMenuRequested, this, &QgsExpressionTreeView::showContextMenu );
+  connect( selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsExpressionTreeView::currentChanged );
+
+  updateFunctionTree();
+  loadUserExpressions();
+
+  // select the first item in the function list
+  // in order to avoid a blank help widget
+  QModelIndex firstItem = mProxyModel->index( 0, 0, QModelIndex() );
+  setCurrentIndex( firstItem );
+}
+
+void QgsExpressionTreeView::setLayer( QgsVectorLayer *layer )
+{
+  mLayer = layer;
+
+  //TODO - remove existing layer scope from context
+
+  if ( mLayer )
+    mExpressionContext << QgsExpressionContextUtils::layerScope( mLayer );
+
+  loadFieldNames();
+}
+
+void QgsExpressionTreeView::setExpressionContext( const QgsExpressionContext &context )
+{
+  mExpressionContext = context;
+  updateFunctionTree();
+  loadFieldNames();
+  loadRecent( mRecentKey );
+  loadUserExpressions( );
+}
+
+void QgsExpressionTreeView::setMenuProvider( QgsExpressionTreeView::MenuProvider *provider )
+{
+  mMenuProvider = provider;
+}
+
+void QgsExpressionTreeView::refresh()
+{
+  updateFunctionTree();
+  loadFieldNames();
+  loadRecent( mRecentKey );
+  loadUserExpressions( );
+}
+
+QgsExpressionItem *QgsExpressionTreeView::currentItem() const
+{
+  QModelIndex idx = mProxyModel->mapToSource( currentIndex() );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  return item;
+}
+
+QStandardItemModel *QgsExpressionTreeView::model()
+{
+  return mModel.get();
+}
+
+QgsProject *QgsExpressionTreeView::project()
+{
+  return mProject;
+}
+
+void QgsExpressionTreeView::setProject( QgsProject *project )
+{
+  mProject = project;
+  updateFunctionTree();
+}
+
+
+void QgsExpressionTreeView::setSearchText( const QString &text )
+{
+  mProxyModel->setFilterWildcard( text );
+  if ( text.isEmpty() )
+  {
+    collapseAll();
+  }
+  else
+  {
+    expandAll();
+    QModelIndex index = mProxyModel->index( 0, 0 );
+    if ( mProxyModel->hasChildren( index ) )
+    {
+      QModelIndex child = mProxyModel->index( 0, 0, index );
+      selectionModel()->setCurrentIndex( child, QItemSelectionModel::ClearAndSelect );
+    }
+  }
+}
+
+void QgsExpressionTreeView::onDoubleClicked( const QModelIndex &index )
+{
+  QModelIndex idx = mProxyModel->mapToSource( index );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  if ( !item )
+    return;
+
+  // Don't handle the double-click if we are on a header node.
+  if ( item->getItemType() == QgsExpressionItem::Header )
+    return;
+
+  emit expressionItemDoubleClicked( item->getExpressionText() );
+}
+
+void QgsExpressionTreeView::showContextMenu( QPoint pt )
+{
+  QModelIndex idx = indexAt( pt );
+  idx = mProxyModel->mapToSource( idx );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  if ( !item )
+    return;
+
+  if ( !mMenuProvider )
+    return;
+
+  QMenu *menu = mMenuProvider->createContextMenu( item );
+
+  if ( menu )
+    menu->popup( mapToGlobal( pt ) );
+}
+
+void QgsExpressionTreeView::currentChanged( const QModelIndex &index, const QModelIndex & )
+{
+  // Get the item
+  QModelIndex idx = mProxyModel->mapToSource( index );
+  QgsExpressionItem *item = static_cast<QgsExpressionItem *>( mModel->itemFromIndex( idx ) );
+  if ( !item )
+    return;
+
+  emit currentExpressionItemChanged( item );
+}
+
+void QgsExpressionTreeView::updateFunctionTree()
+{
+  mModel->clear();
+  mExpressionGroups.clear();
+
+  // TODO Can we move this stuff to QgsExpression, like the functions?
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "+" ), QStringLiteral( " + " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "-" ), QStringLiteral( " - " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "*" ), QStringLiteral( " * " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "/" ), QStringLiteral( " / " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "%" ), QStringLiteral( " % " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "^" ), QStringLiteral( " ^ " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "=" ), QStringLiteral( " = " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "~" ), QStringLiteral( " ~ " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( ">" ), QStringLiteral( " > " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "<" ), QStringLiteral( " < " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "<>" ), QStringLiteral( " <> " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "<=" ), QStringLiteral( " <= " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( ">=" ), QStringLiteral( " >= " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "[]" ), QStringLiteral( "[ ]" ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "||" ), QStringLiteral( " || " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "IN" ), QStringLiteral( " IN " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "LIKE" ), QStringLiteral( " LIKE " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "ILIKE" ), QStringLiteral( " ILIKE " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "IS" ), QStringLiteral( " IS " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "OR" ), QStringLiteral( " OR " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "AND" ), QStringLiteral( " AND " ) );
+  registerItem( QStringLiteral( "Operators" ), QStringLiteral( "NOT" ), QStringLiteral( " NOT " ) );
+
+  QString casestring = QStringLiteral( "CASE WHEN condition THEN result END" );
+  registerItem( QStringLiteral( "Conditionals" ), QStringLiteral( "CASE" ), casestring );
+
+  // use -1 as sort order here -- NULL should always show before the field list
+  registerItem( QStringLiteral( "Fields and Values" ), QStringLiteral( "NULL" ), QStringLiteral( "NULL" ), QString(), QgsExpressionItem::ExpressionNode, false, -1 );
+
+  // Load the functions from the QgsExpression class
+  int count = QgsExpression::functionCount();
+  for ( int i = 0; i < count; i++ )
+  {
+    QgsExpressionFunction *func = QgsExpression::Functions()[i];
+    QString name = func->name();
+    if ( name.startsWith( '_' ) ) // do not display private functions
+      continue;
+    if ( func->isDeprecated() ) // don't show deprecated functions
+      continue;
+    if ( func->isContextual() )
+    {
+      //don't show contextual functions by default - it's up the the QgsExpressionContext
+      //object to provide them if supported
+      continue;
+    }
+    if ( func->params() != 0 )
+      name += '(';
+    else if ( !name.startsWith( '$' ) )
+      name += QLatin1String( "()" );
+    // this is where the functions are being registered, including functions under "Custom"
+    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText(), QgsExpressionItem::ExpressionNode, mExpressionContext.isHighlightedFunction( func->name() ), 1, QgsExpression::tags( func->name() ) );
+  }
+
+  // load relation names
+  loadRelations();
+
+  // load layer IDs
+  loadLayers();
+
+  loadExpressionContext();
+}
+
+void QgsExpressionTreeView::registerItem( const QString &group,
+    const QString &label,
+    const QString &expressionText,
+    const QString &helpText,
+    QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, QIcon icon, const QStringList &tags )
+{
+  QgsExpressionItem *item = new QgsExpressionItem( label, expressionText, helpText, type );
+  item->setData( label, Qt::UserRole );
+  item->setData( sortOrder, QgsExpressionItem::CUSTOM_SORT_ROLE );
+  item->setData( tags, QgsExpressionItem::SEARCH_TAGS_ROLE );
+  item->setIcon( icon );
+
+  // Look up the group and insert the new function.
+  if ( mExpressionGroups.contains( group ) )
+  {
+    QgsExpressionItem *groupNode = mExpressionGroups.value( group );
+    groupNode->appendRow( item );
+  }
+  else
+  {
+    // If the group doesn't exist yet we make it first.
+    QgsExpressionItem *newgroupNode = new QgsExpressionItem( QgsExpression::group( group ), QString(), QgsExpressionItem::Header );
+    newgroupNode->setData( group, Qt::UserRole );
+    //Recent group should always be last group
+    newgroupNode->setData( group.startsWith( QLatin1String( "Recent (" ) ) ? 2 : 1, QgsExpressionItem::CUSTOM_SORT_ROLE );
+    newgroupNode->appendRow( item );
+    newgroupNode->setBackground( QBrush( QColor( 150, 150, 150, 150 ) ) );
+    mModel->appendRow( newgroupNode );
+    mExpressionGroups.insert( group, newgroupNode );
+  }
+
+  if ( highlightedItem )
+  {
+    //insert a copy as a top level item
+    QgsExpressionItem *topLevelItem = new QgsExpressionItem( label, expressionText, helpText, type );
+    topLevelItem->setData( label, Qt::UserRole );
+    item->setData( 0, QgsExpressionItem::CUSTOM_SORT_ROLE );
+    QFont font = topLevelItem->font();
+    font.setBold( true );
+    topLevelItem->setFont( font );
+    mModel->appendRow( topLevelItem );
+  }
+}
+
+void QgsExpressionTreeView::registerItemForAllGroups( const QStringList &groups, const QString &label, const QString &expressionText, const QString &helpText, QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, const QStringList &tags )
+{
+  const auto constGroups = groups;
+  for ( const QString &group : constGroups )
+  {
+    registerItem( group, label, expressionText, helpText, type, highlightedItem, sortOrder, QIcon(), tags );
+  }
+}
+
+void QgsExpressionTreeView::loadExpressionContext()
+{
+  QStringList variableNames = mExpressionContext.filteredVariableNames();
+  const auto constVariableNames = variableNames;
+  for ( const QString &variable : constVariableNames )
+  {
+    registerItem( QStringLiteral( "Variables" ), variable, " @" + variable + ' ',
+                  formatVariableHelp( variable, mExpressionContext.description( variable ), true, mExpressionContext.variable( variable ) ),
+                  QgsExpressionItem::ExpressionNode,
+                  mExpressionContext.isHighlightedVariable( variable ) );
+  }
+
+  // Load the functions from the expression context
+  QStringList contextFunctions = mExpressionContext.functionNames();
+  const auto constContextFunctions = contextFunctions;
+  for ( const QString &functionName : constContextFunctions )
+  {
+    QgsExpressionFunction *func = mExpressionContext.function( functionName );
+    QString name = func->name();
+    if ( name.startsWith( '_' ) ) // do not display private functions
+      continue;
+    if ( func->params() != 0 )
+      name += '(';
+    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText(), QgsExpressionItem::ExpressionNode, mExpressionContext.isHighlightedFunction( func->name() ), 1, QgsExpression::tags( func->name() ) );
+  }
+}
+
+void QgsExpressionTreeView::loadLayers()
+{
+  if ( !mProject )
+    return;
+
+  QMap<QString, QgsMapLayer *> layers = mProject->mapLayers();
+  QMap<QString, QgsMapLayer *>::const_iterator layerIt = layers.constBegin();
+  for ( ; layerIt != layers.constEnd(); ++layerIt )
+  {
+    registerItemForAllGroups( QStringList() << tr( "Map Layers" ), layerIt.value()->name(), QStringLiteral( "'%1'" ).arg( layerIt.key() ), formatLayerHelp( layerIt.value() ) );
+  }
+}
+
+void QgsExpressionTreeView::loadFieldNames()
+{
+  if ( mExpressionGroups.contains( QStringLiteral( "Fields and Values" ) ) )
+  {
+    QgsExpressionItem *node = mExpressionGroups.value( QStringLiteral( "Fields and Values" ) );
+    node->removeRows( 0, node->rowCount() );
+  }
+
+  if ( !mLayer )
+    return;
+
+  const QgsFields &fields = mLayer->fields();
+
+  for ( int i = 0; i < fields.count(); ++i )
+  {
+    const QgsField field = fields.at( i );
+    QIcon icon = fields.iconForField( i );
+    registerItem( QStringLiteral( "Fields and Values" ), field.displayNameWithAlias(),
+                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
+  }
+}
+
+void QgsExpressionTreeView::loadRelations()
+{
+  if ( !mProject )
+    return;
+
+  QMap<QString, QgsRelation> relations = mProject->relationManager()->relations();
+  QMap<QString, QgsRelation>::const_iterator relIt = relations.constBegin();
+  for ( ; relIt != relations.constEnd(); ++relIt )
+  {
+    registerItemForAllGroups( QStringList() << tr( "Relations" ), relIt->name(), QStringLiteral( "'%1'" ).arg( relIt->id() ), formatRelationHelp( relIt.value() ) );
+  }
+}
+
+void QgsExpressionTreeView::loadRecent( const QString &collection )
+{
+  mRecentKey = collection;
+  QString name = tr( "Recent (%1)" ).arg( collection );
+  if ( mExpressionGroups.contains( name ) )
+  {
+    QgsExpressionItem *node = mExpressionGroups.value( name );
+    node->removeRows( 0, node->rowCount() );
+  }
+
+  QgsSettings settings;
+  const QString location = QStringLiteral( "/expressions/recent/%1" ).arg( collection );
+  const QStringList expressions = settings.value( location ).toStringList();
+  int i = 0;
+  for ( const QString &expression : expressions )
+  {
+    QString help = formatRecentExpressionHelp( expression, expression );
+    registerItem( name, expression, expression, help, QgsExpressionItem::ExpressionNode, false, i );
+    i++;
+  }
+}
+
+void QgsExpressionTreeView::saveToRecent( const QString &expressionText, const QString &collection )
+{
+  QgsSettings settings;
+  QString location = QStringLiteral( "/expressions/recent/%1" ).arg( collection );
+  QStringList expressions = settings.value( location ).toStringList();
+  expressions.removeAll( expressionText );
+
+  expressions.prepend( expressionText );
+
+  while ( expressions.count() > 20 )
+  {
+    expressions.pop_back();
+  }
+
+  settings.setValue( location, expressions );
+  loadRecent( collection );
+}
+
+void QgsExpressionTreeView::saveToUserExpressions( const QString &label, const QString expression, const QString &helpText )
+{
+  QgsSettings settings;
+  const QString location = QStringLiteral( "user" );
+  settings.beginGroup( location, QgsSettings::Section::Expressions );
+  settings.beginGroup( label );
+  settings.setValue( QStringLiteral( "expression" ), expression );
+  settings.setValue( QStringLiteral( "helpText" ), helpText );
+  loadUserExpressions( );
+  // Scroll
+  const QModelIndexList idxs { mModel->match( mModel->index( 0, 0 ),
+                               Qt::DisplayRole, label, 1,
+                               Qt::MatchFlag::MatchRecursive ) };
+  if ( ! idxs.isEmpty() )
+  {
+    scrollTo( idxs.first() );
+  }
+}
+
+void QgsExpressionTreeView::removeFromUserExpressions( const QString &label )
+{
+  QgsSettings settings;
+  settings.remove( QStringLiteral( "user/%1" ).arg( label ), QgsSettings::Section::Expressions );
+  loadUserExpressions( );
+}
+
+// this is potentially very slow if there are thousands of user expressions, every time entire cleanup and load
+void QgsExpressionTreeView::loadUserExpressions( )
+{
+  // Cleanup
+  if ( mExpressionGroups.contains( QStringLiteral( "UserGroup" ) ) )
+  {
+    QgsExpressionItem *node = mExpressionGroups.value( QStringLiteral( "UserGroup" ) );
+    node->removeRows( 0, node->rowCount() );
+  }
+
+  QgsSettings settings;
+  const QString location = QStringLiteral( "user" );
+  settings.beginGroup( location, QgsSettings::Section::Expressions );
+  QString label;
+  QString helpText;
+  QString expression;
+  int i = 0;
+  mUserExpressionLabels = settings.childGroups();
+  for ( const auto &label : qgis::as_const( mUserExpressionLabels ) )
+  {
+    settings.beginGroup( label );
+    expression = settings.value( QStringLiteral( "expression" ) ).toString();
+    helpText = formatUserExpressionHelp( label, expression, settings.value( QStringLiteral( "helpText" ) ).toString() );
+    registerItem( QStringLiteral( "UserGroup" ), label, expression, helpText, QgsExpressionItem::ExpressionNode, false, i++ );
+    settings.endGroup();
+  }
+}
+
+QStringList QgsExpressionTreeView::userExpressionLabels() const
+{
+  return mUserExpressionLabels;
+}
+
+QJsonDocument QgsExpressionTreeView::exportUserExpressions()
+{
+  const QString group = QStringLiteral( "user" );
+  QgsSettings settings;
+  QJsonArray exportList;
+  QJsonObject exportObject
+  {
+    {"qgis_version", Qgis::version()},
+    {"exported_at", QDateTime::currentDateTime().toString( Qt::ISODate )},
+    {"author", QgsApplication::userFullName()},
+    {"expressions", exportList}
+  };
+
+  settings.beginGroup( group, QgsSettings::Section::Expressions );
+
+  mUserExpressionLabels = settings.childGroups();
+
+  for ( const QString &label : qgis::as_const( mUserExpressionLabels ) )
+  {
+    settings.beginGroup( label );
+
+    const QString expression = settings.value( QStringLiteral( "expression" ) ).toString();
+    const QString helpText = settings.value( QStringLiteral( "helpText" ) ).toString();
+    const QJsonObject expressionObject
+    {
+      {"name", label},
+      {"type", "expression"},
+      {"expression", expression},
+      {"group", group},
+      {"description", helpText}
+    };
+    exportList.push_back( expressionObject );
+
+    settings.endGroup();
+  }
+
+  exportObject["expressions"] = exportList;
+  QJsonDocument exportJson = QJsonDocument( exportObject );
+
+  return exportJson;
+}
+
+void QgsExpressionTreeView::loadExpressionsFromJson( const QJsonDocument &expressionsDocument )
+{
+  // if the root of the json document is not an object, it means it's a wrong file
+  if ( ! expressionsDocument.isObject() )
+    return;
+
+  QJsonObject expressionsObject = expressionsDocument.object();
+
+  // validate json for manadatory fields
+  if ( ! expressionsObject["qgis_version"].isString()
+       || ! expressionsObject["exported_at"].isString()
+       || ! expressionsObject["author"].isString()
+       || ! expressionsObject["expressions"].isArray() )
+    return;
+
+  // validate versions
+  QVersionNumber qgisJsonVersion = QVersionNumber::fromString( expressionsObject["qgis_version"].toString() );
+  QVersionNumber qgisVersion = QVersionNumber::fromString( Qgis::version() );
+
+  // if the expressions are from newer version of QGIS, we ask the user to confirm
+  // they want to proceed
+  if ( qgisJsonVersion > qgisVersion )
+  {
+    QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::No;
+    switch ( QMessageBox::question( this,
+                                    tr( "QGIS Version Mismatch" ),
+                                    tr( "The imported expressions are from newer version of QGIS (%1) "
+                                        "and some of the expression might not work the current version (%2). "
+                                        "Are you sure you want to continue?" ).arg( qgisJsonVersion.toString(), qgisVersion.toString() ), buttons ) )
+    {
+      case QMessageBox::No:
+        return;
+
+      case QMessageBox::Yes:
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  // we store the number of
+  QStringList skippedExpressionLabels;
+  bool isApplyToAll = false;
+  bool isOkToOverwrite = false;
+
+  QgsSettings settings;
+  settings.beginGroup( QStringLiteral( "user" ), QgsSettings::Section::Expressions );
+  mUserExpressionLabels = settings.childGroups();
+
+  for ( const QJsonValue &expressionValue : expressionsObject["expressions"].toArray() )
+  {
+    // validate the type of the array element, can be anything
+    if ( ! expressionValue.isObject() )
+    {
+      // try to stringify and put and indicator what happened
+      skippedExpressionLabels.append( expressionValue.toString() );
+      continue;
+    }
+
+    QJsonObject expressionObj = expressionValue.toObject();
+
+    // make sure the required keys are the correct types
+    if ( ! expressionObj["name"].isString()
+         || ! expressionObj["type"].isString()
+         || ! expressionObj["expression"].isString()
+         || ! expressionObj["group"].isString()
+         || ! expressionObj["description"].isString() )
+    {
+      // try to stringify and put an indicator what happened. Try to stringify the name, if fails, go with the expression.
+      if ( ! expressionObj["name"].toString().isEmpty() )
+        skippedExpressionLabels.append( expressionObj["name"].toString() );
+      else
+        skippedExpressionLabels.append( expressionObj["expression"].toString() );
+
+      continue;
+    }
+
+    // we want to import only items of type expression for now
+    if ( expressionObj["type"].toString() != QStringLiteral( "expression" ) )
+    {
+      skippedExpressionLabels.append( expressionObj["name"].toString() );
+      continue;
+    }
+
+    // we want to import only items of type expression for now
+    if ( expressionObj["group"].toString() != QStringLiteral( "user" ) )
+    {
+      skippedExpressionLabels.append( expressionObj["name"].toString() );
+      continue;
+    }
+
+    const QString label = expressionObj["name"].toString();
+    const QString expression = expressionObj["expression"].toString();
+    const QString helpText = expressionObj["description"].toString();
+
+    // make sure they have valid name
+    if ( label.contains( "\\" ) || label.contains( '/' ) )
+    {
+      skippedExpressionLabels.append( expressionObj["name"].toString() );
+      continue;
+    }
+
+    settings.beginGroup( label );
+    const QString oldExpression = settings.value( QStringLiteral( "expression" ) ).toString();
+    settings.endGroup();
+
+    // TODO would be nice to skip the cases when labels and expressions match
+    if ( mUserExpressionLabels.contains( label ) && expression != oldExpression )
+    {
+      if ( ! isApplyToAll )
+        showMessageBoxConfirmExpressionOverwrite( isApplyToAll, isOkToOverwrite, label, oldExpression, expression );
+
+      if ( isOkToOverwrite )
+        saveToUserExpressions( label, expression, helpText );
+      else
+      {
+        skippedExpressionLabels.append( label );
+        continue;
+      }
+    }
+    else
+    {
+      saveToUserExpressions( label, expression, helpText );
+    }
+  }
+
+  loadUserExpressions( );
+
+  if ( ! skippedExpressionLabels.isEmpty() )
+  {
+    QStringList skippedExpressionLabelsQuoted;
+    for ( const QString &skippedExpressionLabel : skippedExpressionLabels )
+      skippedExpressionLabelsQuoted.append( QStringLiteral( "'%1'" ).arg( skippedExpressionLabel ) );
+
+    QMessageBox::information( this,
+                              tr( "Skipped Expression Imports" ),
+                              QStringLiteral( "%1\n%2" ).arg( tr( "The following expressions have been skipped:" ),
+                                  skippedExpressionLabelsQuoted.join( ", " ) ) );
+  }
+}
+
+const QList<QgsExpressionItem *> QgsExpressionTreeView::findExpressions( const QString &label )
+{
+  QList<QgsExpressionItem *> result;
+  const QList<QStandardItem *> found { mModel->findItems( label, Qt::MatchFlag::MatchRecursive ) };
+  for ( const auto &item : qgis::as_const( found ) )
+  {
+    result.push_back( static_cast<QgsExpressionItem *>( item ) );
+  }
+  return result;
+}
+
+void QgsExpressionTreeView::showMessageBoxConfirmExpressionOverwrite(
+  bool &isApplyToAll,
+  bool &isOkToOverwrite,
+  const QString &label,
+  const QString &oldExpression,
+  const QString &newExpression )
+{
+  QMessageBox::StandardButtons buttons = QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll;
+  switch ( QMessageBox::question( this,
+                                  tr( "Expression Overwrite" ),
+                                  tr( "The expression with label '%1' was already defined."
+                                      "The old expression \"%2\" will be overwritten by \"%3\"."
+                                      "Are you sure you want to overwrite the expression?" ).arg( label, oldExpression, newExpression ), buttons ) )
+  {
+    case QMessageBox::NoToAll:
+      isApplyToAll = true;
+      isOkToOverwrite = false;
+      break;
+
+    case QMessageBox::No:
+      isApplyToAll = false;
+      isOkToOverwrite = false;
+      break;
+
+    case QMessageBox::YesToAll:
+      isApplyToAll = true;
+      isOkToOverwrite = true;
+      break;
+
+    case QMessageBox::Yes:
+      isApplyToAll = false;
+      isOkToOverwrite = true;
+      break;
+
+    default:
+      break;
+  }
+}
+
+
+// ****************************
+// ****************************
+// QgsExpressionItemSearchProxy
+// ****************************
+
+
+QgsExpressionItemSearchProxy::QgsExpressionItemSearchProxy()
+{
+  setFilterCaseSensitivity( Qt::CaseInsensitive );
+}
+
+bool QgsExpressionItemSearchProxy::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
+{
+  QModelIndex index = sourceModel()->index( source_row, 0, source_parent );
+  QgsExpressionItem::ItemType itemType = QgsExpressionItem::ItemType( sourceModel()->data( index, QgsExpressionItem::ITEM_TYPE_ROLE ).toInt() );
+
+  int count = sourceModel()->rowCount( index );
+  bool matchchild = false;
+  for ( int i = 0; i < count; ++i )
+  {
+    if ( filterAcceptsRow( i, index ) )
+    {
+      matchchild = true;
+      break;
+    }
+  }
+
+  if ( itemType == QgsExpressionItem::Header && matchchild )
+    return true;
+
+  if ( itemType == QgsExpressionItem::Header )
+    return false;
+
+  // check match of item label or tags
+  if ( QSortFilterProxyModel::filterAcceptsRow( source_row, source_parent ) )
+  {
+    return true;
+  }
+  else
+  {
+    const QStringList tags = sourceModel()->data( index, QgsExpressionItem::SEARCH_TAGS_ROLE ).toStringList();
+    for ( const QString &tag : tags )
+    {
+      if ( tag.contains( filterRegExp() ) )
+        return true;
+    }
+  }
+  return false;
+}
+
+bool QgsExpressionItemSearchProxy::lessThan( const QModelIndex &left, const QModelIndex &right ) const
+{
+  int leftSort = sourceModel()->data( left, QgsExpressionItem::CUSTOM_SORT_ROLE ).toInt();
+  int rightSort = sourceModel()->data( right,  QgsExpressionItem::CUSTOM_SORT_ROLE ).toInt();
+  if ( leftSort != rightSort )
+    return leftSort < rightSort;
+
+  QString leftString = sourceModel()->data( left, Qt::DisplayRole ).toString();
+  QString rightString = sourceModel()->data( right, Qt::DisplayRole ).toString();
+
+  //ignore $ prefixes when sorting
+  if ( leftString.startsWith( '$' ) )
+    leftString = leftString.mid( 1 );
+  if ( rightString.startsWith( '$' ) )
+    rightString = rightString.mid( 1 );
+
+  return QString::localeAwareCompare( leftString, rightString ) < 0;
+}

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -413,6 +413,17 @@ void QgsExpressionTreeView::loadLayers()
   }
 }
 
+void QgsExpressionTreeView::loadFieldNames( const QgsFields &fields )
+{
+  for ( int i = 0; i < fields.count(); ++i )
+  {
+    const QgsField field = fields.at( i );
+    QIcon icon = fields.iconForField( i );
+    registerItem( QStringLiteral( "Fields and Values" ), field.displayNameWithAlias(),
+                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
+  }
+}
+
 void QgsExpressionTreeView::loadFieldNames()
 {
   if ( mExpressionGroups.contains( QStringLiteral( "Fields and Values" ) ) )
@@ -421,18 +432,13 @@ void QgsExpressionTreeView::loadFieldNames()
     node->removeRows( 0, node->rowCount() );
   }
 
+  // this can happend if fields are manually set
   if ( !mLayer )
     return;
 
   const QgsFields &fields = mLayer->fields();
 
-  for ( int i = 0; i < fields.count(); ++i )
-  {
-    const QgsField field = fields.at( i );
-    QIcon icon = fields.iconForField( i );
-    registerItem( QStringLiteral( "Fields and Values" ), field.displayNameWithAlias(),
-                  " \"" + field.name() + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
-  }
+  loadFieldNames( fields );
 }
 
 void QgsExpressionTreeView::loadRelations()

--- a/src/gui/qgsexpressiontreeview.cpp
+++ b/src/gui/qgsexpressiontreeview.cpp
@@ -122,7 +122,7 @@ QgsExpressionTreeView::QgsExpressionTreeView( QWidget *parent )
 
   setContextMenuPolicy( Qt::CustomContextMenu );
   connect( this, &QWidget::customContextMenuRequested, this, &QgsExpressionTreeView::showContextMenu );
-  connect( selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsExpressionTreeView::currentChanged );
+  connect( selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsExpressionTreeView::currentItemChanged );
 
   updateFunctionTree();
   loadUserExpressions();
@@ -241,7 +241,7 @@ void QgsExpressionTreeView::showContextMenu( QPoint pt )
     menu->popup( mapToGlobal( pt ) );
 }
 
-void QgsExpressionTreeView::currentChanged( const QModelIndex &index, const QModelIndex & )
+void QgsExpressionTreeView::currentItemChanged( const QModelIndex &index, const QModelIndex & )
 {
   // Get the item
   QModelIndex idx = mProxyModel->mapToSource( index );

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -125,6 +125,7 @@ class GUI_EXPORT QgsExpressionItemSearchProxy : public QSortFilterProxyModel
 
 /**
  * \ingroup gui
+ * \class QgsExpressionTreeView
  * QgsExpressionTreeView is a tree view to list all expressions
  * functions, variables and fields that can be used in an expression.
  * \see QgsExpressionBuilderWidget
@@ -137,9 +138,9 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
 
     /**
      * \ingroup gui
+     * \class MenuProvider
      * Implementation of this interface can be implemented to allow QgsExpressionTreeView
      * instance to provide custom context menus (opened upon right-click).
-     * \since QGIS 3.14
      */
     class MenuProvider
     {

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -157,6 +157,11 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     void setLayer( QgsVectorLayer *layer );
 
     /**
+     * This allows to load fields without specifying a layer
+     */
+    void loadFieldNames( const QgsFields &fields );
+
+    /**
      * Sets the expression context for the tree view. The context is used
      * to populate the list of available functions and variables.
      * \param context expression context

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -157,7 +157,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     void setLayer( QgsVectorLayer *layer );
 
     /**
-     * This allows to load fields without specifying a layer
+     * This allows loading fields without specifying a layer
      */
     void loadFieldNames( const QgsFields &fields );
 
@@ -202,6 +202,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
      * Returns a pointer to the dialog's function item model.
      * This method is exposed for testing purposes only - it should not be used to modify the model
      * \note will be removed in QGIS 4
+     * \deprecated since QGIS 3.14
      */
     Q_DECL_DEPRECATED QStandardItemModel *model() SIP_SKIP; // TODO remove QGIS 4
 

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -136,12 +136,15 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
   public:
 
     /**
+     * \ingroup gui
      * Implementation of this interface can be implemented to allow QgsExpressionTreeView
      * instance to provide custom context menus (opened upon right-click).
+     * \since QGIS 3.14
      */
     class MenuProvider
     {
       public:
+        //! Constructor
         explicit MenuProvider() = default;
         virtual ~MenuProvider() = default;
 
@@ -149,6 +152,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
         virtual QMenu *createContextMenu( QgsExpressionItem *item ) SIP_FACTORY {Q_UNUSED( item ) return nullptr;}
     };
 
+    //! Constructor
     QgsExpressionTreeView( QWidget *parent = nullptr );
 
     /**
@@ -264,6 +268,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
     void currentExpressionItemChanged( QgsExpressionItem *item );
 
   public slots:
+    //! Sets the text to filter the expression tree
     void setSearchText( const QString &text );
 
 

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -1,0 +1,342 @@
+/***************************************************************************
+    qgsexpressiontreeview.h
+     --------------------------------------
+    Date                 : march 2020 - quarantine day 9
+    Copyright            : (C) 2020 by Denis Rouzaud
+    Email                : denis@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSEXPRESSIONTREEVIEW_H
+#define QGSEXPRESSIONTREEVIEW_H
+
+#include <QTreeView>
+#include <QStandardItemModel>
+#include <QSortFilterProxyModel>
+
+#include "qgis_gui.h"
+#include "qgis_sip.h"
+#include "qgsexpressioncontext.h"
+#include "qgsproject.h"
+
+
+class QgsVectorLayer;
+
+
+
+/**
+ * \ingroup gui
+ * An expression item that can be used in the QgsExpressionBuilderWidget tree.
+  */
+class GUI_EXPORT QgsExpressionItem : public QStandardItem
+{
+  public:
+    enum ItemType
+    {
+      Header,
+      Field,
+      ExpressionNode
+    };
+
+    QgsExpressionItem( const QString &label,
+                       const QString &expressionText,
+                       const QString &helpText,
+                       QgsExpressionItem::ItemType itemType = ExpressionNode )
+      : QStandardItem( label )
+    {
+      mExpressionText = expressionText;
+      mHelpText = helpText;
+      mType = itemType;
+      setData( itemType, ITEM_TYPE_ROLE );
+    }
+
+    QgsExpressionItem( const QString &label,
+                       const QString &expressionText,
+                       QgsExpressionItem::ItemType itemType = ExpressionNode )
+      : QStandardItem( label )
+    {
+      mExpressionText = expressionText;
+      mType = itemType;
+      setData( itemType, ITEM_TYPE_ROLE );
+    }
+
+    QString getExpressionText() const { return mExpressionText; }
+
+    /**
+     * Gets the help text that is associated with this expression item.
+      *
+      * \returns The help text.
+      */
+    QString getHelpText() const { return mHelpText; }
+
+    /**
+     * Set the help text for the current item
+      *
+      * \note The help text can be set as a html string.
+      */
+    void setHelpText( const QString &helpText ) { mHelpText = helpText; }
+
+    /**
+     * Gets the type of expression item, e.g., header, field, ExpressionNode.
+      *
+      * \returns The QgsExpressionItem::ItemType
+      */
+    QgsExpressionItem::ItemType getItemType() const { return mType; }
+
+    //! Custom sort order role
+    static const int CUSTOM_SORT_ROLE = Qt::UserRole + 1;
+    //! Item type role
+    static const int ITEM_TYPE_ROLE = Qt::UserRole + 2;
+    //! Search tags role
+    static const int SEARCH_TAGS_ROLE = Qt::UserRole + 3;
+
+  private:
+    QString mExpressionText;
+    QString mHelpText;
+    QgsExpressionItem::ItemType mType;
+};
+
+
+/**
+ * \ingroup gui
+ * Search proxy used to filter the QgsExpressionBuilderWidget tree.
+  * The default search for a tree model only searches top level this will handle one
+  * level down
+  */
+class GUI_EXPORT QgsExpressionItemSearchProxy : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+  public:
+    QgsExpressionItemSearchProxy();
+
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;
+
+  protected:
+
+    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
+};
+
+/**
+ * \ingroup gui
+ * QgsExpressionTreeView is a tree view to list all expressions
+ * functions, variables and fields that can be used in an expression.
+ * \see QgsExpressionBuilderWidget
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsExpressionTreeView : public QTreeView
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Implementation of this interface can be implemented to allow QgsExpressionTreeView
+     * instance to provide custom context menus (opened upon right-click).
+     */
+    class MenuProvider
+    {
+      public:
+        explicit MenuProvider() = default;
+        virtual ~MenuProvider() = default;
+
+        //! Returns a newly created menu instance
+        virtual QMenu *createContextMenu( QgsExpressionItem *item ) SIP_FACTORY {Q_UNUSED( item ) return nullptr;}
+    };
+
+    QgsExpressionTreeView( QWidget *parent = nullptr );
+
+    /**
+     * Sets layer in order to get the fields and values
+     */
+    void setLayer( QgsVectorLayer *layer );
+
+    /**
+     * Sets the expression context for the tree view. The context is used
+     * to populate the list of available functions and variables.
+     * \param context expression context
+     * \see expressionContext
+     */
+    void setExpressionContext( const QgsExpressionContext &context );
+
+    /**
+     * Returns the project currently associated with the widget.
+     * \see setProject()
+     */
+    QgsProject *project();
+
+    /**
+     * Sets the \a project currently associated with the widget. This
+     * controls which layers and relations and other project-specific items are shown in the widget.
+     * \see project()
+     */
+    void setProject( QgsProject *project );
+
+    /**
+     * Sets the menu provider.
+     * This does not take ownership of the provider
+     */
+    void setMenuProvider( MenuProvider *provider );
+
+    /**
+     * Refreshes the content of the tree
+     */
+    void refresh();
+
+    /**
+     * Returns the current item or a nullptr
+     */
+    QgsExpressionItem *currentItem() const;
+
+    /**
+     * Returns a pointer to the dialog's function item model.
+     * This method is exposed for testing purposes only - it should not be used to modify the model
+     * \note will be removed in QGIS 4
+     */
+    Q_DECL_DEPRECATED QStandardItemModel *model() SIP_SKIP; // TODO remove QGIS 4
+
+    /**
+     * Loads the recent expressions from the given \a collection.
+     * By default it is loaded from the collection "generic".
+     */
+    void loadRecent( const QString &collection = QStringLiteral( "generic" ) );
+
+    /**
+     * Adds the current expression to the given \a collection.
+     * By default it is saved to the collection "generic".
+     */
+    void saveToRecent( const QString &expressionText, const QString &collection = "generic" );
+
+    /**
+     * Stores the user \a expression with given \a label and \a helpText.
+     */
+    void saveToUserExpressions( const QString &label, const QString expression, const QString &helpText );
+
+    /**
+     * Removes the expression \a label from the user stored expressions.
+     */
+    void removeFromUserExpressions( const QString &label );
+
+    /**
+     * Loads the user expressions.
+     * This is done on request since it can be very slow if there are thousands of user expressions
+     */
+    void loadUserExpressions( );
+
+    /**
+     * Returns the list of expression items matching a \a label.
+     */
+    const QList<QgsExpressionItem *> findExpressions( const QString &label );
+
+    /**
+     * Returns the user expression labels
+     */
+    QStringList userExpressionLabels() const SIP_SKIP;
+
+    /**
+     * Create the expressions JSON document storing all the user expressions to be exported.
+     * \returns the created expressions JSON file
+     */
+    QJsonDocument exportUserExpressions();
+
+    /**
+     * Load and permanently store the expressions from the expressions JSON document.
+     * \param expressionsDocument the parsed expressions JSON file
+     */
+    void loadExpressionsFromJson( const QJsonDocument &expressionsDocument );
+
+  signals:
+    //! Emitted when a expression item is double clicked
+    void expressionItemDoubleClicked( const QString &text );
+
+    //! Emitter when the current expression item changed
+    void currentExpressionItemChanged( QgsExpressionItem *item );
+
+  public slots:
+    void setSearchText( const QString &text );
+
+
+  private slots:
+    void onDoubleClicked( const QModelIndex &index );
+
+    void showContextMenu( QPoint pt );
+
+    void currentChanged( const QModelIndex &index, const QModelIndex & );
+
+  private:
+    void updateFunctionTree();
+
+    /**
+     * Registers a node item for the expression builder.
+     * \param group The group the item will be show in the tree view.  If the group doesn't exist it will be created.
+     * \param label The label that is show to the user for the item in the tree.
+     * \param expressionText The text that is inserted into the expression area when the user double clicks on the item.
+     * \param helpText The help text that the user will see when item is selected.
+     * \param type The type of the expression item.
+     * \param highlightedItem set to TRUE to make the item highlighted, which inserts a bold copy of the item at the top level
+     * \param sortOrder sort ranking for item
+     * \param icon custom icon to show for item
+     * \param tags tags to find function
+     */
+    void registerItem( const QString &group, const QString &label, const QString &expressionText,
+                       const QString &helpText = QString(),
+                       QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
+                       bool highlightedItem = false, int sortOrder = 1,
+                       QIcon icon = QIcon(),
+                       const QStringList &tags = QStringList() );
+
+    /**
+     * Registers a node item for the expression builder, adding multiple items when the function exists in multiple groups
+     * \param groups The groups the item will be show in the tree view.  If a group doesn't exist it will be created.
+     * \param label The label that is show to the user for the item in the tree.
+     * \param expressionText The text that is inserted into the expression area when the user double clicks on the item.
+     * \param helpText The help text that the user will see when item is selected.
+     * \param type The type of the expression item.
+     * \param highlightedItem set to TRUE to make the item highlighted, which inserts a bold copy of the item at the top level
+     * \param sortOrder sort ranking for item
+     * \param tags tags to find function
+     */
+    void registerItemForAllGroups( const QStringList &groups, const QString &label, const QString &expressionText,
+                                   const QString &helpText = QString(),
+                                   QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
+                                   bool highlightedItem = false, int sortOrder = 1, const QStringList &tags = QStringList() );
+
+    void loadExpressionContext();
+    void loadRelations();
+    void loadLayers();
+    void loadFieldNames();
+
+    /**
+     * Display a message box to ask the user what to do when an expression
+     * with the same \a label already exists. Answering "Yes" will replace
+     * the old expression with the one from the file, while "No" will keep
+     * the old expression.
+     * \param isApplyToAll whether the decision of the user should be applied to any future label collision
+     * \param isOkToOverwrite whether to overwrite the old expression with the new one in case of label collision
+     * \param label the label of the expression
+     * \param oldExpression the old expression for a given label
+     * \param newExpression the new expression for a given label
+     */
+    void showMessageBoxConfirmExpressionOverwrite( bool &isApplyToAll, bool &isOkToOverwrite, const QString &label, const QString &oldExpression, const QString &newExpression );
+
+
+    std::unique_ptr<QStandardItemModel> mModel;
+    std::unique_ptr<QgsExpressionItemSearchProxy> mProxyModel;
+    QMap<QString, QgsExpressionItem *> mExpressionGroups;
+
+    MenuProvider *mMenuProvider = nullptr;
+
+    QgsVectorLayer *mLayer = nullptr;
+    QPointer< QgsProject > mProject;
+    QgsExpressionContext mExpressionContext;
+    QString mRecentKey;
+
+    QStringList mUserExpressionLabels;
+};
+
+#endif // QGSEXPRESSIONTREEVIEW_H

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -272,7 +272,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
 
     void showContextMenu( QPoint pt );
 
-    void currentChanged( const QModelIndex &index, const QModelIndex & );
+    void currentItemChanged( const QModelIndex &index, const QModelIndex & );
 
   private:
     void updateFunctionTree();

--- a/src/gui/qgsexpressiontreeview.h
+++ b/src/gui/qgsexpressiontreeview.h
@@ -141,6 +141,7 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
      * \class MenuProvider
      * Implementation of this interface can be implemented to allow QgsExpressionTreeView
      * instance to provide custom context menus (opened upon right-click).
+     * \since QGIS 3.14
      */
     class MenuProvider
     {
@@ -173,6 +174,13 @@ class GUI_EXPORT QgsExpressionTreeView : public QTreeView
      * \see expressionContext
      */
     void setExpressionContext( const QgsExpressionContext &context );
+
+    /**
+     * Returns the expression context for the widget. The context is used for the expression
+     * preview result and for populating the list of available functions and variables.
+     * \see setExpressionContext
+     */
+    QgsExpressionContext expressionContext() const { return mExpressionContext; }
 
     /**
      * Returns the project currently associated with the widget.

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -13,6 +13,9 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QMessageBox>
+
+
 #include "qgsfieldcalculator.h"
 #include "qgsdistancearea.h"
 #include "qgsexpression.h"
@@ -30,7 +33,6 @@
 #include "qgsexpressioncontextutils.h"
 #include "qgsvectorlayerjoinbuffer.h"
 
-#include <QMessageBox>
 
 // FTC = FieldTypeCombo
 constexpr int FTC_TYPE_ROLE_IDX = 0;
@@ -65,10 +67,6 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
 
   expContext.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "row_number" ), 1, true ) );
   expContext.setHighlightedVariables( QStringList() << QStringLiteral( "row_number" ) );
-
-  builder->setLayer( vl );
-  builder->loadFieldNames();
-  builder->setExpressionContext( expContext );
 
   populateFields();
   populateOutputFieldTypes();
@@ -151,8 +149,7 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
   mOnlyUpdateSelectedCheckBox->setEnabled( mCanChangeAttributeValue && hasselection );
   mOnlyUpdateSelectedCheckBox->setText( tr( "Only update %1 selected features" ).arg( vl->selectedFeatureCount() ) );
 
-  builder->loadRecent( QStringLiteral( "fieldcalc" ) );
-  builder->loadUserExpressions( );
+  builder->initWithLayer( vl, expContext, QStringLiteral( "fieldcalc" ) );
 
   mInfoIcon->setPixmap( style()->standardPixmap( QStyle::SP_MessageBoxInformation ) );
 

--- a/src/gui/vector/qgsfieldcalculator.cpp
+++ b/src/gui/vector/qgsfieldcalculator.cpp
@@ -161,7 +161,7 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
 
 void QgsFieldCalculator::accept()
 {
-  builder->saveToRecent( QStringLiteral( "fieldcalc" ) );
+  builder->expressionTree()->saveToRecent( builder->expressionText(), QStringLiteral( "fieldcalc" ) );
 
   if ( !mVectorLayer )
     return;

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -179,7 +179,7 @@ void QgsAfsSourceSelect::buildQuery( const QgsOwsConnection &connection, const Q
 
   //add available attributes to expression builder
   QgsExpressionBuilderWidget *w = d.expressionBuilder();
-  w->loadFieldNames( provider.fields() );
+  w->initWithFields( provider.fields() );
 
   if ( d.exec() == QDialog::Accepted )
   {

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -206,6 +206,12 @@
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
                      </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
                     </spacer>
                    </item>
                   </layout>
@@ -586,7 +592,7 @@
              <widget class="QWidget" name="layoutWidget1">
               <layout class="QGridLayout" name="gridLayout_9">
                <item row="1" column="0" colspan="2">
-                <widget class="QTreeView" name="expressionTree">
+                <widget class="QgsExpressionTreeView" name="mExpressionTreeView">
                  <property name="frameShape">
                   <enum>QFrame::StyledPanel</enum>
                  </property>
@@ -828,7 +834,7 @@ Change the name of the script and save to allow QGIS to auto load on startup.</s
                 <string/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="../../images/images.qrc">
                  <normaloff>:/images/themes/default/console/iconNewTabEditorConsole.svg</normaloff>:/images/themes/default/console/iconNewTabEditorConsole.svg</iconset>
                </property>
                <property name="iconSize">
@@ -920,7 +926,7 @@ Saved scripts are auto loaded on QGIS startup.</string>
                 <string>Save and Load Functions</string>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="../../images/images.qrc">
                  <normaloff>:/images/themes/default/mActionStart.svg</normaloff>:/images/themes/default/mActionStart.svg</iconset>
                </property>
               </widget>
@@ -969,15 +975,15 @@ Saved scripts are auto loaded on QGIS startup.</string>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCodeEditorExpression</class>
    <extends>QWidget</extends>
    <header>qgscodeeditorexpression.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsCodeEditorPython</class>
@@ -985,7 +991,15 @@ Saved scripts are auto loaded on QGIS startup.</string>
    <header>qgscodeeditorpython.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsExpressionTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgsexpressiontreeview.h</header>
+  </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR moves the code of the expression tree to a new dedicated class QgsExpressionTreeView.

This declutters the code of the expression builder.

The caching of field values was broken and can be readded later.

New init methods are added which should help a bit to start the expression builder and avoid omitting recent or user expressions.

Basically just some code moving around, but obviously a few lines are involved.