### PR TITLE
[processing] fixed detection of grass folder in Windows

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -221,7 +221,8 @@ class Grass7Utils:
                 else:
                     testfolder = os.path.join(os.path.dirname(QgsApplication.prefixPath()), 'grass')
                     if os.path.isdir(testfolder):
-                        grassfolders = sorted([f for f in os.listdir(testfolder) if f.startswith("grass-7.") and os.path.isdir(os.path.join(testfolder, f))], reverse=True, key=lambda x: [int(v) for v in x[len("grass-"):].split('.') if v != 'svn'])
+                        grassfolders = sorted([f for f in os.listdir(testfolder) if f.startswith("grass") and os.path.isdir(os.path.join(testfolder, f))], 
+                                                reverse=True, key=lambda x: [int(v) for v in x[len("grass"):] if v.isnumeric()])
                         if grassfolders:
                             folder = os.path.join(testfolder, grassfolders[0])
             elif isMac():


### PR DESCRIPTION
## Description

Looks like installation of grass in windows, both with the standalone installer and with OSGEO4W, has changed how the grass folder is named. The method that detects it fails now, and grass algorithms cannot be run from Processing.

This PR fixes it

