### PR TITLE
[joins] Disable caching if editing is enabled

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerjoininfo.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoininfo.sip.in
@@ -77,9 +77,11 @@ Returns prefix of fields from the joined layer. If ``None``, joined layer's name
 %Docstring
 Sets whether values from the joined layer should be cached in memory to speed up lookups
 %End
+
     bool isUsingMemoryCache() const;
 %Docstring
-Returns whether values from the joined layer should be cached in memory to speed up lookups
+Returns whether values from the joined layer should be cached in memory to speed up lookups.
+Will return false if upsertOnEdit is enabled.
 %End
 
     bool isDynamicFormEnabled() const;

--- a/src/core/qgsvectorlayerjoininfo.cpp
+++ b/src/core/qgsvectorlayerjoininfo.cpp
@@ -35,6 +35,19 @@ QString QgsVectorLayerJoinInfo::prefixedFieldName( const QgsField &f ) const
   return name;
 }
 
+void QgsVectorLayerJoinInfo::setUsingMemoryCache( bool enabled )
+{
+  mMemoryCache = enabled;
+}
+
+bool QgsVectorLayerJoinInfo::isUsingMemoryCache() const
+{
+  if ( mUpsertOnEdit )
+    return false;
+
+  return mMemoryCache;
+}
+
 void QgsVectorLayerJoinInfo::setEditable( bool enabled )
 {
   mEditable = enabled;

--- a/src/core/qgsvectorlayerjoininfo.h
+++ b/src/core/qgsvectorlayerjoininfo.h
@@ -65,9 +65,13 @@ class CORE_EXPORT QgsVectorLayerJoinInfo
     QString prefix() const { return mPrefix; }
 
     //! Sets whether values from the joined layer should be cached in memory to speed up lookups
-    void setUsingMemoryCache( bool enabled ) { mMemoryCache = enabled; }
-    //! Returns whether values from the joined layer should be cached in memory to speed up lookups
-    bool isUsingMemoryCache() const { return mMemoryCache; }
+    void setUsingMemoryCache( bool enabled );
+
+    /**
+     * Returns whether values from the joined layer should be cached in memory to speed up lookups.
+     * Will return false if upsertOnEdit is enabled.
+     */
+    bool isUsingMemoryCache() const;
 
     /**
      * Returns whether the form has to be dynamically updated with joined fields

--- a/src/gui/vector/qgsjoindialog.cpp
+++ b/src/gui/vector/qgsjoindialog.cpp
@@ -65,6 +65,7 @@ QgsJoinDialog::QgsJoinDialog( QgsVectorLayer *layer, QList<QgsMapLayer *> alread
   connect( mJoinLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsJoinDialog::checkDefinitionValid );
   connect( mJoinFieldComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsJoinDialog::checkDefinitionValid );
   connect( mTargetFieldComboBox, &QgsFieldComboBox::fieldChanged, this, &QgsJoinDialog::checkDefinitionValid );
+  connect( mEditableJoinLayer, &QGroupBox::toggled, this, &QgsJoinDialog::editableJoinLayerChanged );
 
   checkDefinitionValid();
 }
@@ -108,6 +109,8 @@ void QgsJoinDialog::setJoinInfo( const QgsVectorLayerJoinInfo &joinInfo )
       }
     }
   }
+
+  editableJoinLayerChanged();
 }
 
 QgsVectorLayerJoinInfo QgsJoinDialog::joinInfo() const
@@ -200,4 +203,21 @@ void QgsJoinDialog::checkDefinitionValid()
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( mJoinLayerComboBox->currentIndex() != -1
       && mJoinFieldComboBox->currentIndex() != -1
       && mTargetFieldComboBox->currentIndex() != -1 );
+}
+
+void QgsJoinDialog::editableJoinLayerChanged()
+{
+  if ( mEditableJoinLayer->isChecked() )
+  {
+    mCacheInMemoryCheckBox->setEnabled( false );
+    mCacheInMemoryCheckBox->setToolTip( tr( "Caching can not be enabled if editable join layer is enabled" ) );
+    mCacheEnabled = mCacheInMemoryCheckBox->isChecked();
+    mCacheInMemoryCheckBox->setChecked( false );
+  }
+  else
+  {
+    mCacheInMemoryCheckBox->setEnabled( true );
+    mCacheInMemoryCheckBox->setToolTip( QString() );
+    mCacheInMemoryCheckBox->setChecked( mCacheEnabled );
+  }
 }

--- a/src/gui/vector/qgsjoindialog.h
+++ b/src/gui/vector/qgsjoindialog.h
@@ -47,9 +47,14 @@ class GUI_EXPORT QgsJoinDialog: public QDialog, private Ui::QgsJoinDialogBase
 
     void checkDefinitionValid();
 
+    void editableJoinLayerChanged();
+
   private:
     //! Target layer
     QgsVectorLayer *mLayer = nullptr;
+
+    // Temporary storage for "cache" setting since the checkbox may be temporarily disabled
+    bool mCacheEnabled = false;
 };
 
 


### PR DESCRIPTION
This disables caching of joins if editing is enabled.

Gui fix for https://github.com/qgis/QGIS/issues/35403

![Peek 2020-03-27 10-58](https://user-images.githubusercontent.com/588407/77744588-1ca11200-701a-11ea-9ef7-933ea4d6aff8.gif)
