### PR TITLE
[BUG][3D] fix 3D crash with measure line

### DIFF
--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -87,6 +87,7 @@ void Qgs3DMapToolIdentify::activate()
   }
 
   mCanvas->scene()->registerPickHandler( mPickHandler.get() );
+  mIsActivate = true;
 }
 
 void Qgs3DMapToolIdentify::deactivate()
@@ -97,6 +98,7 @@ void Qgs3DMapToolIdentify::deactivate()
   }
 
   mCanvas->scene()->unregisterPickHandler( mPickHandler.get() );
+  mIsActivate = false;
 }
 
 QCursor Qgs3DMapToolIdentify::cursor() const
@@ -106,6 +108,8 @@ QCursor Qgs3DMapToolIdentify::cursor() const
 
 void Qgs3DMapToolIdentify::onMapSettingsChanged()
 {
+  if ( !mIsActivate )
+    return;
   connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolIdentify::onTerrainEntityChanged );
 }
 
@@ -153,6 +157,8 @@ void Qgs3DMapToolIdentify::onTerrainPicked( Qt3DRender::QPickEvent *event )
 
 void Qgs3DMapToolIdentify::onTerrainEntityChanged()
 {
+  if ( !mIsActivate )
+    return;
   // no need to disconnect from the previous entity: it has been destroyed
   // start listening to the new terrain entity
   if ( QgsTerrainEntity *terrainEntity = mCanvas->scene()->terrainEntity() )

--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -87,7 +87,7 @@ void Qgs3DMapToolIdentify::activate()
   }
 
   mCanvas->scene()->registerPickHandler( mPickHandler.get() );
-  mIsActivate = true;
+  mIsActive = true;
 }
 
 void Qgs3DMapToolIdentify::deactivate()
@@ -98,7 +98,7 @@ void Qgs3DMapToolIdentify::deactivate()
   }
 
   mCanvas->scene()->unregisterPickHandler( mPickHandler.get() );
-  mIsActivate = false;
+  mIsActive = false;
 }
 
 QCursor Qgs3DMapToolIdentify::cursor() const
@@ -108,7 +108,7 @@ QCursor Qgs3DMapToolIdentify::cursor() const
 
 void Qgs3DMapToolIdentify::onMapSettingsChanged()
 {
-  if ( !mIsActivate )
+  if ( !mIsActive )
     return;
   connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolIdentify::onTerrainEntityChanged );
 }
@@ -157,7 +157,7 @@ void Qgs3DMapToolIdentify::onTerrainPicked( Qt3DRender::QPickEvent *event )
 
 void Qgs3DMapToolIdentify::onTerrainEntityChanged()
 {
-  if ( !mIsActivate )
+  if ( !mIsActive )
     return;
   // no need to disconnect from the previous entity: it has been destroyed
   // start listening to the new terrain entity

--- a/src/app/3d/qgs3dmaptoolidentify.h
+++ b/src/app/3d/qgs3dmaptoolidentify.h
@@ -53,7 +53,7 @@ class Qgs3DMapToolIdentify : public Qgs3DMapTool
   private:
     std::unique_ptr<Qgs3DMapToolIdentifyPickHandler> mPickHandler;
 
-    bool mIsActivate = false;
+    bool mIsActive = false;
 
     friend class Qgs3DMapToolIdentifyPickHandler;
 };

--- a/src/app/3d/qgs3dmaptoolidentify.h
+++ b/src/app/3d/qgs3dmaptoolidentify.h
@@ -53,6 +53,8 @@ class Qgs3DMapToolIdentify : public Qgs3DMapTool
   private:
     std::unique_ptr<Qgs3DMapToolIdentifyPickHandler> mPickHandler;
 
+    bool mIsActivate = false;
+
     friend class Qgs3DMapToolIdentifyPickHandler;
 };
 

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -211,6 +211,8 @@ void Qgs3DMapToolMeasureLine::updateMeasurementLayer()
 
 void Qgs3DMapToolMeasureLine::updateSettings()
 {
+  if ( !mMeasurementLayer )
+    return;
   // Line style
   QgsLine3DSymbol *lineSymbol = new QgsLine3DSymbol;
   lineSymbol->setRenderAsSimpleLines( true );

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -124,6 +124,8 @@ QCursor Qgs3DMapToolMeasureLine::cursor() const
 
 void Qgs3DMapToolMeasureLine::onMapSettingsChanged()
 {
+  if ( !mIsAlreadyActivated )
+    return;
   connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolMeasureLine::onTerrainEntityChanged );
 
   // Update scale if the terrain vertical scale changed
@@ -137,6 +139,8 @@ void Qgs3DMapToolMeasureLine::onTerrainPicked( Qt3DRender::QPickEvent *event )
 
 void Qgs3DMapToolMeasureLine::onTerrainEntityChanged()
 {
+  if ( !mIsAlreadyActivated )
+    return;
   // no need to disconnect from the previous entity: it has been destroyed
   // start listening to the new terrain entity
   if ( QgsTerrainEntity *terrainEntity = mCanvas->scene()->terrainEntity() )

--- a/src/app/3d/qgs3dmaptoolmeasureline.cpp
+++ b/src/app/3d/qgs3dmaptoolmeasureline.cpp
@@ -175,6 +175,8 @@ void Qgs3DMapToolMeasureLine::handleClick( Qt3DRender::QPickEvent *event, const 
 
 void Qgs3DMapToolMeasureLine::updateMeasurementLayer()
 {
+  if ( !mMeasurementLayer )
+    return;
   double verticalScale = canvas()->map()->terrainVerticalScale();
   QgsLineString *line;
   if ( verticalScale != 1.0 )


### PR DESCRIPTION
Recent works on 3D measure line seems to lead to crash with mesh terrain.
Adding several guards solves the issue.
Also fix unwanted widget opening (identify and measurement) when tools are not activate.
@ismailsunni : maybe a more proper fix or do you think that does the job?

To replicate the crash:
- load a raster or mesh layer
- open a 3D map view
- open the 3D config widget
- close the 3D config widget
- click on visible entity
--> crash

With settings:
- load a raster or mesh layer
- open a 3D map view
- open in the menu : Settings->Options
- close the options window
--> crash