### PR TITLE
 FIX #19903 Greatly improve font selection UX

### DIFF
--- a/src/ui/labeling/qgslabelpropertydialogbase.ui
+++ b/src/ui/labeling/qgslabelpropertydialogbase.ui
@@ -113,11 +113,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0" colspan="3">
-           <widget class="QFontComboBox" name="mFontFamilyCmbBx">
-            <property name="editable">
-             <bool>false</bool>
-            </property>
-           </widget>
+           <widget class="QFontComboBox" name="mFontFamilyCmbBx" />
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_3">

--- a/src/ui/qgseditconditionalformatrulewidget.ui
+++ b/src/ui/qgseditconditionalformatrulewidget.ui
@@ -317,11 +317,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QFontComboBox" name="mFontFamilyCmbBx">
-          <property name="editable">
-           <bool>false</bool>
-          </property>
-         </widget>
+         <widget class="QFontComboBox" name="mFontFamilyCmbBx" />
         </item>
        </layout>
       </item>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -606,11 +606,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QFontComboBox" name="mFontFamilyComboBox">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                     </widget>
+                     <widget class="QFontComboBox" name="mFontFamilyComboBox" />
                     </item>
                     <item>
                      <widget class="QLabel" name="label_20">

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -1144,9 +1144,6 @@
                          </item>
                          <item row="1" column="1">
                           <widget class="QFontComboBox" name="mFontFamilyCmbBx">
-                           <property name="editable">
-                            <bool>false</bool>
-                           </property>
                            <property name="sizeAdjustPolicy">
                             <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
                            </property>


### PR DESCRIPTION
Trying to select a font on a system with thousands of installed fonts is huge pain under Linux. It causes the whole interface to freeze and does not allow searching without opening the huge list of fonts. On the gifs below the pause is caused by the font dropdown itself, it is not me. Also there is a little flash, which also feels buggy.
In addition, the font selector was inconsistent between different interfaces, now it is always an editable combobox.
Final note - in case of invalid font name, the widget uses the last selected one.
|before|after|
|------|-----|
|![old](https://user-images.githubusercontent.com/2820439/77802884-82c27f00-7084-11ea-8ac8-1b900de1b3b0.gif)|![new](https://user-images.githubusercontent.com/2820439/77802887-848c4280-7084-11ea-8005-53020b4ebdcb.gif)|

