### PR TITLE
[locator] Prefer exact match

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -134,6 +134,7 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
         QgsExpressionContext context;
         std::unique_ptr<QgsVectorLayerFeatureSource> featureSource;
         QgsFeatureRequest request;
+        QgsFeatureRequest exactMatchRequest;
         QString layerName;
         QString layerId;
         QIcon layerIcon;


### PR DESCRIPTION
This tackles issue #35418 . When a search string is entered for the "all layers locator filter" it will perform two searches: priority goes to exact matches, non-exact matches are also listed but lower in the results.

Fix https://github.com/qgis/QGIS/issues/35418

![Peek 2020-03-28 14-35](https://user-images.githubusercontent.com/588407/77824282-d2935b80-7101-11ea-979b-f86fd6c74c55.gif)
