### PR TITLE
Network logger - more functionality

### DIFF
--- a/src/app/devtools/networklogger/qgsnetworklogger.cpp
+++ b/src/app/devtools/networklogger/qgsnetworklogger.cpp
@@ -206,6 +206,11 @@ void QgsNetworkLogger::removeRows( const QList<int> &rows )
   }
 }
 
+QgsNetworkLoggerRootNode *QgsNetworkLogger::rootGroup()
+{
+  return mRootNode.get();
+}
+
 int QgsNetworkLogger::rowCount( const QModelIndex &parent ) const
 {
   QgsNetworkLoggerNode *n = index2node( parent );

--- a/src/app/devtools/networklogger/qgsnetworklogger.h
+++ b/src/app/devtools/networklogger/qgsnetworklogger.h
@@ -81,6 +81,11 @@ class QgsNetworkLogger : public QAbstractItemModel
     */
     void removeRows( const QList< int > &rows );
 
+    /**
+     * Returns the root node of the log.
+     */
+    QgsNetworkLoggerRootNode *rootGroup();
+
     static constexpr int MAX_LOGGED_REQUESTS = 1000;
 
   public slots:

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.cpp
@@ -257,6 +257,13 @@ QList<QAction *> QgsNetworkLoggerRequestGroup::actions( QObject *parent )
   } );
   res << openUrlAction;
 
+  QAction *copyUrlAction = new QAction( QObject::tr( "Copy URL" ), parent );
+  QObject::connect( copyUrlAction, &QAction::triggered, openUrlAction, [ = ]
+  {
+    QApplication::clipboard()->setText( mUrl.url() );
+  } );
+  res << copyUrlAction;
+
   QAction *copyAsCurlAction = new QAction( QObject::tr( "Copy As cURL" ), parent );
   QObject::connect( copyAsCurlAction, &QAction::triggered, copyAsCurlAction, [ = ]
   {

--- a/src/app/devtools/networklogger/qgsnetworkloggernode.h
+++ b/src/app/devtools/networklogger/qgsnetworkloggernode.h
@@ -69,6 +69,11 @@ class QgsNetworkLoggerNode
      */
     virtual QList< QAction * > actions( QObject *parent );
 
+    /**
+     * Converts the node's contents to a variant.
+     */
+    virtual QVariant toVariant() const;
+
   protected:
 
     QgsNetworkLoggerNode();
@@ -114,6 +119,7 @@ class QgsNetworkLoggerGroup : public QgsNetworkLoggerNode
 
     int childCount() const override final { return mChildren.size(); }
     QVariant data( int role = Qt::DisplayRole ) const override;
+    QVariant toVariant() const override;
 
   protected:
 
@@ -151,6 +157,16 @@ class QgsNetworkLoggerValueNode : public QgsNetworkLoggerNode
      */
     QgsNetworkLoggerValueNode( const QString &key, const QString &value, const QColor &color = QColor() );
 
+    /**
+     * Returns the node's key.
+     */
+    QString key() const { return mKey; }
+
+    /**
+     * Returns the node's value.
+     */
+    QString value() const { return mValue; }
+
     QVariant data( int role = Qt::DisplayRole ) const override final;
     int childCount() const override final { return 0; }
 
@@ -179,8 +195,13 @@ class QgsNetworkLoggerRootNode final : public QgsNetworkLoggerGroup
      * Removes a \a row from the root group.
      */
     void removeRow( int row );
+
+    QVariant toVariant() const override;
 };
 
+class QgsNetworkLoggerRequestDetailsGroup;
+class QgsNetworkLoggerReplyGroup;
+class QgsNetworkLoggerSslErrorGroup;
 
 /**
  * \ingroup app
@@ -229,6 +250,7 @@ class QgsNetworkLoggerRequestGroup final : public QgsNetworkLoggerGroup
     QgsNetworkLoggerRequestGroup( const QgsNetworkRequestParameters &request );
     QVariant data( int role = Qt::DisplayRole ) const override;
     QList< QAction * > actions( QObject *parent ) override final;
+    QVariant toVariant() const override;
 
     /**
      * Returns the request's status.
@@ -293,7 +315,14 @@ class QgsNetworkLoggerRequestGroup final : public QgsNetworkLoggerGroup
     Status mStatus = Status::Pending;
     bool mHasSslErrors = false;
     QList< QPair< QString, QString > > mHeaders;
+    QgsNetworkLoggerRequestDetailsGroup *mDetailsGroup = nullptr;
+    QgsNetworkLoggerReplyGroup *mReplyGroup = nullptr;
+    QgsNetworkLoggerSslErrorGroup *mSslErrorsGroup = nullptr;
 };
+
+class QgsNetworkLoggerRequestQueryGroup;
+class QgsNetworkLoggerRequestHeadersGroup;
+class QgsNetworkLoggerPostContentGroup;
 
 /**
  * \ingroup app
@@ -329,7 +358,13 @@ class QgsNetworkLoggerRequestDetailsGroup final : public QgsNetworkLoggerGroup
      * specified \a request details.
      */
     QgsNetworkLoggerRequestDetailsGroup( const QgsNetworkRequestParameters &request );
+    QVariant toVariant() const override;
 
+  private:
+
+    QgsNetworkLoggerRequestQueryGroup *mQueryGroup = nullptr;
+    QgsNetworkLoggerRequestHeadersGroup *mRequestHeaders = nullptr;
+    QgsNetworkLoggerPostContentGroup *mPostContent = nullptr;
 };
 
 
@@ -407,6 +442,8 @@ class QgsNetworkLoggerPostContentGroup final : public QgsNetworkLoggerGroup
     QgsNetworkLoggerPostContentGroup( const QgsNetworkRequestParameters &parameters );
 };
 
+class QgsNetworkLoggerReplyHeadersGroup;
+
 /**
  * \ingroup app
  * \class QgsNetworkLoggerReplyGroup
@@ -432,6 +469,11 @@ class QgsNetworkLoggerReplyGroup final : public QgsNetworkLoggerGroup
      * specified \a reply details.
      */
     QgsNetworkLoggerReplyGroup( const QgsNetworkReplyContent &reply );
+    QVariant toVariant() const override;
+
+  private:
+
+    QgsNetworkLoggerReplyHeadersGroup *mReplyHeaders = nullptr;
 
 };
 

--- a/src/ui/qgsnetworkloggerpanelbase.ui
+++ b/src/ui/qgsnetworkloggerpanelbase.ui
@@ -41,6 +41,8 @@
      <addaction name="mActionClear"/>
      <addaction name="mActionShowSuccessful"/>
      <addaction name="mActionShowTimeouts"/>
+     <addaction name="separator"/>
+     <addaction name="mActionSaveLog"/>
     </widget>
    </item>
    <item>
@@ -101,6 +103,15 @@
    </property>
    <property name="text">
     <string>Show Timeouts</string>
+   </property>
+  </action>
+  <action name="mActionSaveLog">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Save Log…</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Adds some more useful tools to the network logger:
- copy URL
- copy request as JSON
- save log to file (after a big warning to users that the log may contain sensitive information and should be treated as confidential)