### PR TITLE
[layers-panel] Changes to layer mark in layer tree view

### DIFF
--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -64,7 +64,7 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
   connect( this, &QTreeView::collapsed, this, &QgsLayerTreeView::updateExpandedStateToNode );
   connect( this, &QTreeView::expanded, this, &QgsLayerTreeView::updateExpandedStateToNode );
 
-  connect( this->horizontalScrollBar(), &QScrollBar::valueChanged, this, &QgsLayerTreeView::onHorizontalScroll );
+  connect( horizontalScrollBar(), &QScrollBar::valueChanged, this, &QgsLayerTreeView::onHorizontalScroll );
 }
 
 QgsLayerTreeView::~QgsLayerTreeView()

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -27,6 +27,7 @@
 #include <QMenu>
 #include <QContextMenuEvent>
 #include <QHeaderView>
+#include <QScrollBar>
 
 #include "qgslayertreeviewindicator.h"
 #include "qgslayertreeviewitemdelegate.h"
@@ -62,6 +63,8 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
 
   connect( this, &QTreeView::collapsed, this, &QgsLayerTreeView::updateExpandedStateToNode );
   connect( this, &QTreeView::expanded, this, &QgsLayerTreeView::updateExpandedStateToNode );
+
+  connect( this->horizontalScrollBar(), &QScrollBar::valueChanged, this, &QgsLayerTreeView::onHorizontalScroll );
 }
 
 QgsLayerTreeView::~QgsLayerTreeView()
@@ -554,4 +557,10 @@ void QgsLayerTreeView::resizeEvent( QResizeEvent *event )
   // viewport, which allows indicators to become active again.
   header()->setMinimumSectionSize( viewport()->width() );
   QTreeView::resizeEvent( event );
+}
+
+void QgsLayerTreeView::onHorizontalScroll( int value )
+{
+  Q_UNUSED( value )
+  viewport()->update();
 }

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -237,6 +237,8 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
 
   private slots:
     void onCustomPropertyChanged( QgsLayerTreeNode *node, const QString &key );
+    //! Handles updating the viewport to avoid flicker
+    void onHorizontalScroll( int value );
 
   protected:
     //! helper class with default actions. Lazily initialized.

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
@@ -81,26 +81,29 @@ void QgsLayerTreeViewItemDelegate::paint( QPainter *painter, const QStyleOptionV
   QStyleOptionViewItem opt = option;
   initStyleOption( &opt, index );
 
-  QRect tRect = mLayerTreeView->style()->subElementRect( QStyle::SE_ItemViewItemText, &opt, mLayerTreeView );
-  int tPadding = tRect.height() / 10;
-
-  // Draw layer context menu mark
-  QRect mRect( mLayerTreeView->viewport()->rect().right() - mLayerTreeView->layerMarkWidth(), tRect.top() + tPadding, mLayerTreeView->layerMarkWidth(), tRect.height() - tPadding * 2 );
-  QBrush pb = painter->brush();
-  QPen pp = painter->pen();
-  painter->setPen( QPen( Qt::NoPen ) );
-  QBrush b = QBrush( opt.palette.mid() );
-  QColor bc = b.color();
-  // mix mid color with base color for a less dominant, yet still opaque, version of the color
   const QColor baseColor = opt.palette.base().color();
-  bc.setRed( static_cast< int >( bc.red() * 0.3 + baseColor.red() * 0.7 ) );
-  bc.setGreen( static_cast< int >( bc.green() * 0.3 + baseColor.green() * 0.7 ) );
-  bc.setBlue( static_cast< int >( bc.blue() * 0.3 + baseColor.blue() * 0.7 ) );
-  b.setColor( bc );
-  painter->setBrush( b );
-  painter->drawRect( mRect );
-  painter->setBrush( pb );
-  painter->setPen( pp );
+  QRect tRect = mLayerTreeView->style()->subElementRect( QStyle::SE_ItemViewItemText, &opt, mLayerTreeView );
+
+  const bool shouldShowLayerMark = tRect.left() < 0;  // Layer/group node icon not visible anymore?
+  if ( shouldShowLayerMark )
+  {
+    int tPadding = tRect.height() / 10;
+    QRect mRect( mLayerTreeView->viewport()->rect().right() - mLayerTreeView->layerMarkWidth(), tRect.top() + tPadding, mLayerTreeView->layerMarkWidth(), tRect.height() - tPadding * 2 );
+    QBrush pb = painter->brush();
+    QPen pp = painter->pen();
+    painter->setPen( QPen( Qt::NoPen ) );
+    QBrush b = QBrush( opt.palette.mid() );
+    QColor bc = b.color();
+    // mix mid color with base color for a less dominant, yet still opaque, version of the color
+    bc.setRed( static_cast< int >( bc.red() * 0.3 + baseColor.red() * 0.7 ) );
+    bc.setGreen( static_cast< int >( bc.green() * 0.3 + baseColor.green() * 0.7 ) );
+    bc.setBlue( static_cast< int >( bc.blue() * 0.3 + baseColor.blue() * 0.7 ) );
+    b.setColor( bc );
+    painter->setBrush( b );
+    painter->drawRect( mRect );
+    painter->setBrush( pb );
+    painter->setPen( pp );
+  }
 
   const QList<QgsLayerTreeViewIndicator *> indicators = mLayerTreeView->indicators( node );
   if ( indicators.isEmpty() )


### PR DESCRIPTION
## Description

PR to suggest 2 changes to layer mark in layers panel:

1. Update the viewport when scrolling horizontally to avoid the flicker.

2. Avoid showing the layer mark always and instead show it only when a layer/group icon is not visible anymore. 

**Before / After** 

![before](https://user-images.githubusercontent.com/652785/77923917-b100b400-7268-11ea-9bd2-3b15d608b5a3.gif)      ..........          ![after](https://user-images.githubusercontent.com/652785/79343988-ce827e80-7ef4-11ea-9f41-26f6142ccf8f.gif)

**Before:** 
![image](https://user-images.githubusercontent.com/652785/77984495-56eb0780-72d7-11ea-880d-4bab1a5900e5.png) 

**After:**
![image](https://user-images.githubusercontent.com/652785/77984566-826df200-72d7-11ea-8752-5fb02c3f7f91.png)



There are other options for suggestion number 2, like showing the layer mark: 
 
2.1 only when the horizontal scroll value is greater than the minimum (0); or
2.2 only when the layer/group text (including feature count) is not visible anymore. This one is a bit trickier!



Fix #32029