### PR TITLE
Add "protoc" as a build dependency to support MVT vector tiles

### DIFF
--- a/.docker/qgis3-build-deps.dockerfile
+++ b/.docker/qgis3-build-deps.dockerfile
@@ -64,6 +64,7 @@ RUN  apt-get update \
     pkg-config \
     poppler-utils \
     postgresql-client \
+    protobuf-compiler \
     pyqt5-dev \
     pyqt5-dev-tools \
     pyqt5.qsci-dev \


### PR DESCRIPTION
It turns out it is not a good idea to keep generated files from protobuf compiler (protoc) in the repository because different versions of generated cpp/h files may not be compatible with different versions of runtime library. So we will use "protoc" tool to generate the files during build time for the source .proto file - like this one: https://github.com/mapbox/vector-tile-spec/blob/master/2.1/vector_tile.proto