### PR TITLE
Hide reference time input for one temporal dimension wms layers 

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1263,8 +1263,18 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
       mEndStaticDateTimeEdit->setDateTime( QDateTime::fromString( parts.at( 1 ), Qt::ISODateWithMs ) );
     }
 
+    const QString referenceTimeExent = uri.param( QStringLiteral( "referenceTimeDimensionExtent" ) );
+
+    mReferenceTime->setEnabled( !referenceTimeExent.isEmpty() );
+    mReferenceDateTimeEdit->setVisible( !referenceTimeExent.isEmpty() );
+
+    QString referenceTimeLabelText = referenceTimeExent.isEmpty() ?
+                                     tr( "There is no reference time in the layer's capabilities." ) : QString();
+    mReferenceTimeLabel->setText( referenceTimeLabelText );
+
     const QString referenceTime = uri.param( QStringLiteral( "reference_time" ) );
-    if ( !referenceTime.isEmpty() )
+
+    if ( !referenceTime.isEmpty() && !referenceTimeExent.isEmpty() )
     {
       if ( referenceTime.contains( '/' ) )
       {

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1263,18 +1263,18 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
       mEndStaticDateTimeEdit->setDateTime( QDateTime::fromString( parts.at( 1 ), Qt::ISODateWithMs ) );
     }
 
-    const QString referenceTimeExent = uri.param( QStringLiteral( "referenceTimeDimensionExtent" ) );
+    const QString referenceTimeExtent = uri.param( QStringLiteral( "referenceTimeDimensionExtent" ) );
 
-    mReferenceTime->setEnabled( !referenceTimeExent.isEmpty() );
-    mReferenceDateTimeEdit->setVisible( !referenceTimeExent.isEmpty() );
+    mReferenceTime->setEnabled( !referenceTimeExtent.isEmpty() );
+    mReferenceDateTimeEdit->setVisible( !referenceTimeExtent.isEmpty() );
 
-    QString referenceTimeLabelText = referenceTimeExent.isEmpty() ?
+    QString referenceTimeLabelText = referenceTimeExtent.isEmpty() ?
                                      tr( "There is no reference time in the layer's capabilities." ) : QString();
     mReferenceTimeLabel->setText( referenceTimeLabelText );
 
     const QString referenceTime = uri.param( QStringLiteral( "reference_time" ) );
 
-    if ( !referenceTime.isEmpty() && !referenceTimeExent.isEmpty() )
+    if ( !referenceTime.isEmpty() && !referenceTimeExtent.isEmpty() )
     {
       if ( referenceTime.contains( '/' ) )
       {

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -302,8 +302,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>643</width>
-                <height>679</height>
+                <width>634</width>
+                <height>680</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -482,7 +482,7 @@ border-radius: 2px;</string>
                       <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
                        <property name="dateTime">
                         <datetime>
-                         <hour>22</hour>
+                         <hour>21</hour>
                          <minute>20</minute>
                          <second>36</second>
                          <year>2020</year>
@@ -505,6 +505,13 @@ border-radius: 2px;</string>
                        </property>
                        <property name="timeSpec">
                         <enum>Qt::UTC</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QLabel" name="mReferenceTimeLabel">
+                       <property name="text">
+                        <string/>
                        </property>
                       </widget>
                      </item>
@@ -597,8 +604,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>512</width>
-                <height>524</height>
+                <width>550</width>
+                <height>514</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -1197,8 +1204,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>341</width>
-                <height>474</height>
+                <width>359</width>
+                <height>467</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1551,7 +1558,7 @@ border-radius: 2px;</string>
                 <x>0</x>
                 <y>0</y>
                 <width>98</width>
-                <height>46</height>
+                <height>45</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1768,8 +1775,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>579</width>
-                <height>209</height>
+                <width>631</width>
+                <height>205</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1838,7 +1845,7 @@ border-radius: 2px;</string>
                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                      </widget>
@@ -1998,8 +2005,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>337</width>
-                <height>684</height>
+                <width>364</width>
+                <height>667</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_12">
@@ -2582,8 +2589,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>mBackgroundLayerCheckBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
This PR disables the reference time input in the raster layer properties source tab, when the wms layer does not have reference time in it's capabilities.