### PR TITLE
Add missing temporal properties from wmst layers when using data source manager

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1027,7 +1027,7 @@ void QgsWMSSourceSelect::collectDimensions( QStringList &layers, QgsDataSourceUr
 {
   for ( const QgsWmsLayerProperty layerProperty : mLayerProperties )
   {
-    if ( layerProperty.name == layers.join( QStringLiteral( "," ) ) )
+    if ( layerProperty.name == layers.join( ',' ) )
     {
       // Check for layer dimensions
       for ( const QgsWmsDimensionProperty &dimension : qgis::as_const( layerProperty.dimensions ) )
@@ -1037,7 +1037,7 @@ void QgsWMSSourceSelect::collectDimensions( QStringList &layers, QgsDataSourceUr
              dimension.name == QLatin1String( "reference_time" ) )
         {
           QString name = dimension.name == QLatin1String( "time" ) ?
-                         QString( "timeDimensionExtent" ) : QString( "referenceTimeDimensionExtent" );
+                         QStringLiteral( "timeDimensionExtent" ) : QStringLiteral( "referenceTimeDimensionExtent" );
 
           if ( !( uri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) ) )
             uri.setParam( QLatin1String( "type" ), QLatin1String( "wmst" ) );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -277,6 +277,7 @@ void QgsWMSSourceSelect::clear()
 bool QgsWMSSourceSelect::populateLayerList( const QgsWmsCapabilities &capabilities )
 {
   const QVector<QgsWmsLayerProperty> layers = capabilities.supportedLayers();
+  mLayerProperties = layers;
 
   bool first = true;
   QSet<QString> alreadyAddedLabels;
@@ -515,6 +516,8 @@ void QgsWMSSourceSelect::addButtonClicked()
     collectSelectedLayers( layers, styles, titles );
     crs = mCRS;
     format = mFormats[ mImageFormatGroup->checkedId()].format;
+
+    collectDimensions( layers, uri );
   }
   else
   {
@@ -1017,6 +1020,39 @@ void QgsWMSSourceSelect::collectSelectedLayers( QStringList &layers, QStringList
     layers << mLayerOrderTreeWidget->topLevelItem( i )->text( 0 );
     styles << mLayerOrderTreeWidget->topLevelItem( i )->text( 1 );
     titles << mLayerOrderTreeWidget->topLevelItem( i )->text( 2 );
+  }
+}
+
+void QgsWMSSourceSelect::collectDimensions( QStringList &layers, QgsDataSourceUri &uri )
+{
+  for ( const QgsWmsLayerProperty layerProperty : mLayerProperties )
+  {
+    if ( layerProperty.name == layers.join( QStringLiteral( "," ) ) )
+    {
+      // Check for layer dimensions
+      for ( const QgsWmsDimensionProperty &dimension : qgis::as_const( layerProperty.dimensions ) )
+      {
+        // add temporal dimensions only
+        if ( dimension.name == QLatin1String( "time" ) ||
+             dimension.name == QLatin1String( "reference_time" ) )
+        {
+          QString name = dimension.name == QLatin1String( "time" ) ?
+                         QString( "timeDimensionExtent" ) : QString( "referenceTimeDimensionExtent" );
+
+          if ( !( uri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) ) )
+            uri.setParam( QLatin1String( "type" ), QLatin1String( "wmst" ) );
+          uri.setParam( name, dimension.extent );
+        }
+      }
+
+      // WMS-T defaults settings
+      if ( uri.param( QLatin1String( "type" ) ) == QLatin1String( "wmst" ) )
+      {
+        uri.setParam( QLatin1String( "temporalSource" ), QLatin1String( "provider" ) );
+        uri.setParam( QLatin1String( "enableTime" ), QLatin1String( "yes" ) );
+      }
+
+    }
   }
 }
 

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -178,12 +178,22 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
     void enableLayersForCrs( QTreeWidgetItem *item );
 
     void collectSelectedLayers( QStringList &layers, QStringList &styles, QStringList &titles );
+
+    /**
+     * Collects the available dimensions from the WMS layers and adds them
+     * to the passed \a uri.
+     */
+    void collectDimensions( QStringList &layers, QgsDataSourceUri &uri );
+
     QString selectedImageEncoding();
 
     QList<QTreeWidgetItem *> mCurrentSelection;
     QTableWidgetItem *mCurrentTileset = nullptr;
 
     QList<QgsWmtsTileLayer> mTileLayers;
+
+    //! Stores all the layers properties from the service capabilities.
+    QVector<QgsWmsLayerProperty> mLayerProperties;
 
   private slots:
     void btnSearch_clicked();


### PR DESCRIPTION
Enables temporal properties and temporal capabilities for the wmst layers which has been added to the layers panel by using the data source manager.

Example
![added_missing_wmst_temporal_properties](https://user-images.githubusercontent.com/2663775/77969152-c241d300-72f1-11ea-9176-99e03c2feca2.gif)
