### PR TITLE
Add "Save Log to File" algorithm for models 

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -48,6 +48,7 @@ Abstract base class for processing algorithms.
       FlagKnownIssues,
       FlagCustomException,
       FlagPruneModelBranchesBasedOnAlgorithmResults,
+      FlagSkipGenericModelLogging,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -27,6 +27,14 @@ it to users via the GUI.
 %End
   public:
 
+    QgsProcessingFeedback( bool logFeedback = true );
+%Docstring
+Constructor for QgsProcessingFeedback.
+
+If ``logFeedback`` is ``True``, then all feedback received will be directed
+to :py:class:`QgsMessageLog`.
+%End
+
     virtual void setProgressText( const QString &text );
 %Docstring
 Sets a progress report text string. This can be used in conjunction with
@@ -98,6 +106,24 @@ report the output from executing an external command or subprocess.
 Pushes a summary of the QGIS (and underlying library) version information to the log.
 
 .. versionadded:: 3.4.7
+%End
+
+    QString htmlLog() const;
+%Docstring
+Returns the HTML formatted contents of the log, which contains all messages pushed to the feedback object.
+
+.. seealso:: :py:func:`textLog`
+
+.. versionadded:: 3.14
+%End
+
+    QString textLog() const;
+%Docstring
+Returns the plain text contents of the log, which contains all messages pushed to the feedback object.
+
+.. seealso:: :py:func:`htmlLog`
+
+.. versionadded:: 3.14
 %End
 
 };

--- a/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingfeedback.sip.in
@@ -108,7 +108,7 @@ Pushes a summary of the QGIS (and underlying library) version information to the
 .. versionadded:: 3.4.7
 %End
 
-    QString htmlLog() const;
+    virtual QString htmlLog() const;
 %Docstring
 Returns the HTML formatted contents of the log, which contains all messages pushed to the feedback object.
 
@@ -117,7 +117,7 @@ Returns the HTML formatted contents of the log, which contains all messages push
 .. versionadded:: 3.14
 %End
 
-    QString textLog() const;
+    virtual QString textLog() const;
 %Docstring
 Returns the plain text contents of the log, which contains all messages pushed to the feedback object.
 
@@ -172,6 +172,9 @@ to scale the current progress to account for progress through the overall proces
 
     virtual void pushConsoleInfo( const QString &info );
 
+    virtual QString htmlLog() const;
+
+    virtual QString textLog() const;
 
 };
 

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -131,6 +131,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmreverselinedirection.cpp
   processing/qgsalgorithmrotate.cpp
   processing/qgsalgorithmruggedness.cpp
+  processing/qgsalgorithmsavelog.cpp
   processing/qgsalgorithmsaveselectedfeatures.cpp
   processing/qgsalgorithmsegmentize.cpp
   processing/qgsalgorithmserviceareafromlayer.cpp

--- a/src/analysis/processing/qgsalgorithmsavelog.cpp
+++ b/src/analysis/processing/qgsalgorithmsavelog.cpp
@@ -1,0 +1,93 @@
+/***************************************************************************
+                         qgsalgorithmsavelog.cpp
+                         ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmsavelog.h"
+
+///@cond PRIVATE
+
+QString QgsSaveLogToFileAlgorithm::name() const
+{
+  return QStringLiteral( "savelog" );
+}
+
+QgsProcessingAlgorithm::Flags QgsSaveLogToFileAlgorithm::flags() const
+{
+  return QgsProcessingAlgorithm::flags() | FlagHideFromToolbox | FlagSkipGenericModelLogging;
+}
+
+QString QgsSaveLogToFileAlgorithm::displayName() const
+{
+  return QObject::tr( "Save log to file" );
+}
+
+QStringList QgsSaveLogToFileAlgorithm::tags() const
+{
+  return QObject::tr( "record,messages,logged" ).split( ',' );
+}
+
+QString QgsSaveLogToFileAlgorithm::group() const
+{
+  return QObject::tr( "Modeler tools" );
+}
+
+QString QgsSaveLogToFileAlgorithm::groupId() const
+{
+  return QStringLiteral( "modelertools" );
+}
+
+QString QgsSaveLogToFileAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm saves the model's execution log to a file.\n"
+                      "Optionally, the log can be saved in a HTML formatted version." );
+}
+
+QString QgsSaveLogToFileAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Saves the model's log contents to a file." );
+}
+
+QgsSaveLogToFileAlgorithm *QgsSaveLogToFileAlgorithm::createInstance() const
+{
+  return new QgsSaveLogToFileAlgorithm();
+}
+
+void QgsSaveLogToFileAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Log file" ), QObject::tr( "Text files (*.txt);;HTML files (*.html *.HTML)" ) ) );
+  addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "USE_HTML" ), QObject::tr( "Use HTML formatting" ), false ) );
+}
+
+QVariantMap QgsSaveLogToFileAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  const QString file = parameterAsFile( parameters, QStringLiteral( "OUTPUT" ), context );
+  const bool useHtml = parameterAsBool( parameters, QStringLiteral( "USE_HTML" ), context );
+  if ( !file.isEmpty() )
+  {
+    QFile exportFile( file );
+    if ( !exportFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
+    {
+      throw QgsProcessingException( QObject::tr( "Could not save log to file %1" ).arg( file ) );
+    }
+    QTextStream fout( &exportFile );
+    fout << ( useHtml ? feedback->htmlLog() : feedback->textLog() );
+  }
+  QVariantMap res;
+  res.insert( QStringLiteral( "OUTPUT" ), file );
+  return res;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmsavelog.h
+++ b/src/analysis/processing/qgsalgorithmsavelog.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+                         qgsalgorithmsavelog.h
+                         ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMSAVELOG_H
+#define QGSALGORITHMSAVELOG_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
+
+///@cond PRIVATE
+
+/**
+ * Native save log to file algorithm.
+ */
+class QgsSaveLogToFileAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+    QgsSaveLogToFileAlgorithm() = default;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+    Flags flags() const override;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QgsSaveLogToFileAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback * ) override;
+
+};
+
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMSAVELOG_H

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -125,6 +125,7 @@
 #include "qgsalgorithmreverselinedirection.h"
 #include "qgsalgorithmrotate.h"
 #include "qgsalgorithmruggedness.h"
+#include "qgsalgorithmsavelog.h"
 #include "qgsalgorithmsaveselectedfeatures.h"
 #include "qgsalgorithmsegmentize.h"
 #include "qgsalgorithmserviceareafromlayer.h"
@@ -331,6 +332,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsReverseLineDirectionAlgorithm() );
   addAlgorithm( new QgsRotateFeaturesAlgorithm() );
   addAlgorithm( new QgsRuggednessAlgorithm() );
+  addAlgorithm( new QgsSaveLogToFileAlgorithm() );
   addAlgorithm( new QgsSaveSelectedFeatures() );
   addAlgorithm( new QgsSegmentizeByMaximumAngleAlgorithm() );
   addAlgorithm( new QgsSegmentizeByMaximumDistanceAlgorithm() );

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -78,6 +78,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagKnownIssues = 1 << 9, //!< Algorithm has known issues
       FlagCustomException = 1 << 10, //!< Algorithm raises custom exception notices, don't use the standard ones
       FlagPruneModelBranchesBasedOnAlgorithmResults = 1 << 11, //!< Algorithm results will cause remaining model branches to be pruned based on the results of running the algorithm
+      FlagSkipGenericModelLogging = 1 << 12, //!< When running as part of a model, the generic algorithm setup and results logging should be skipped
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -26,33 +26,59 @@
 #include <proj_api.h>
 #endif
 
+QgsProcessingFeedback::QgsProcessingFeedback( bool logFeedback )
+  : mLogFeedback( logFeedback )
+{
+
+}
+
 void QgsProcessingFeedback::setProgressText( const QString & )
 {
 }
 
 void QgsProcessingFeedback::reportError( const QString &error, bool )
 {
-  QgsMessageLog::logMessage( error, tr( "Processing" ), Qgis::Critical );
+  if ( mLogFeedback )
+    QgsMessageLog::logMessage( error, tr( "Processing" ), Qgis::Critical );
+
+  mHtmlLog.append( QStringLiteral( "<span style=\"color:red\">%1</span><br/>" ).arg( error.toHtmlEscaped() ).replace( '\n', QStringLiteral( "<br>" ) ) );
+  mTextLog.append( error + '\n' );
 }
 
 void QgsProcessingFeedback::pushInfo( const QString &info )
 {
-  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+  if ( mLogFeedback )
+    QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+
+  mHtmlLog.append( info.toHtmlEscaped().replace( '\n', QStringLiteral( "<br>" ) ) + QStringLiteral( "<br/>" ) );
+  mTextLog.append( info + '\n' );
 }
 
 void QgsProcessingFeedback::pushCommandInfo( const QString &info )
 {
-  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+  if ( mLogFeedback )
+    QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+
+  mHtmlLog.append( QStringLiteral( "<code>%1</code><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QStringLiteral( "<br>" ) ) ) );
+  mTextLog.append( info + '\n' );
 }
 
 void QgsProcessingFeedback::pushDebugInfo( const QString &info )
 {
-  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+  if ( mLogFeedback )
+    QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+
+  mHtmlLog.append( QStringLiteral( "<span style=\"color:#777\">%1</span><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QStringLiteral( "<br>" ) ) ) );
+  mTextLog.append( info + '\n' );
 }
 
 void QgsProcessingFeedback::pushConsoleInfo( const QString &info )
 {
-  QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+  if ( mLogFeedback )
+    QgsMessageLog::logMessage( info, tr( "Processing" ), Qgis::Info );
+
+  mHtmlLog.append( QStringLiteral( "<code style=\"color:#777\">%1</code><br/>" ).arg( info.toHtmlEscaped().replace( '\n', QStringLiteral( "<br>" ) ) ) );
+  mTextLog.append( info + '\n' );
 }
 
 void QgsProcessingFeedback::pushVersionInfo( const QgsProcessingProvider *provider )

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -104,6 +104,16 @@ void QgsProcessingFeedback::pushVersionInfo( const QgsProcessingProvider *provid
   }
 }
 
+QString QgsProcessingFeedback::htmlLog() const
+{
+  return mHtmlLog;
+}
+
+QString QgsProcessingFeedback::textLog() const
+{
+  return mTextLog;
+}
+
 
 QgsProcessingMultiStepFeedback::QgsProcessingMultiStepFeedback( int childAlgorithmCount, QgsProcessingFeedback *feedback )
   : mChildSteps( childAlgorithmCount )
@@ -147,6 +157,16 @@ void QgsProcessingMultiStepFeedback::pushDebugInfo( const QString &info )
 void QgsProcessingMultiStepFeedback::pushConsoleInfo( const QString &info )
 {
   mFeedback->pushConsoleInfo( info );
+}
+
+QString QgsProcessingMultiStepFeedback::htmlLog() const
+{
+  return mFeedback->htmlLog();
+}
+
+QString QgsProcessingMultiStepFeedback::textLog() const
+{
+  return mFeedback->textLog();
 }
 
 void QgsProcessingMultiStepFeedback::updateOverallProgress( double progress )

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -113,7 +113,7 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \see textLog()
      * \since QGIS 3.14
      */
-    QString htmlLog() const { return mHtmlLog; }
+    virtual QString htmlLog() const;
 
     /**
      * Returns the plain text contents of the log, which contains all messages pushed to the feedback object.
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \see htmlLog()
      * \since QGIS 3.14
      */
-    QString textLog() const { return mTextLog; }
+    virtual QString textLog() const;
 
   private:
     bool mLogFeedback = true;
@@ -168,7 +168,8 @@ class CORE_EXPORT QgsProcessingMultiStepFeedback : public QgsProcessingFeedback
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;
     void pushConsoleInfo( const QString &info ) override;
-
+    QString htmlLog() const override;
+    QString textLog() const override;
   private slots:
 
     void updateOverallProgress( double progress );

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -41,6 +41,14 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
   public:
 
     /**
+     * Constructor for QgsProcessingFeedback.
+     *
+     * If \a logFeedback is TRUE, then all feedback received will be directed
+     * to QgsMessageLog.
+     */
+    QgsProcessingFeedback( bool logFeedback = true );
+
+    /**
      * Sets a progress report text string. This can be used in conjunction with
      * setProgress() to provide detailed progress reports, such as "Transformed
      * 4 of 5 layers".
@@ -98,6 +106,27 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
      * \since QGIS 3.4.7
      */
     void pushVersionInfo( const QgsProcessingProvider *provider = nullptr );
+
+    /**
+     * Returns the HTML formatted contents of the log, which contains all messages pushed to the feedback object.
+     *
+     * \see textLog()
+     * \since QGIS 3.14
+     */
+    QString htmlLog() const { return mHtmlLog; }
+
+    /**
+     * Returns the plain text contents of the log, which contains all messages pushed to the feedback object.
+     *
+     * \see htmlLog()
+     * \since QGIS 3.14
+     */
+    QString textLog() const { return mTextLog; }
+
+  private:
+    bool mLogFeedback = true;
+    QString mHtmlLog;
+    QString mTextLog;
 
 };
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -35,33 +35,43 @@
 
 ///@cond NOT_STABLE
 
+QgsProcessingAlgorithmDialogFeedback::QgsProcessingAlgorithmDialogFeedback()
+  : QgsProcessingFeedback( false )
+{}
+
 void QgsProcessingAlgorithmDialogFeedback::setProgressText( const QString &text )
 {
+  QgsProcessingFeedback::setProgressText( text );
   emit progressTextChanged( text );
 }
 
 void QgsProcessingAlgorithmDialogFeedback::reportError( const QString &error, bool fatalError )
 {
+  QgsProcessingFeedback::reportError( error, fatalError );
   emit errorReported( error, fatalError );
 }
 
 void QgsProcessingAlgorithmDialogFeedback::pushInfo( const QString &info )
 {
+  QgsProcessingFeedback::pushInfo( info );
   emit infoPushed( info );
 }
 
 void QgsProcessingAlgorithmDialogFeedback::pushCommandInfo( const QString &info )
 {
+  QgsProcessingFeedback::pushCommandInfo( info );
   emit commandInfoPushed( info );
 }
 
 void QgsProcessingAlgorithmDialogFeedback::pushDebugInfo( const QString &info )
 {
+  QgsProcessingFeedback::pushDebugInfo( info );
   emit debugInfoPushed( info );
 }
 
 void QgsProcessingAlgorithmDialogFeedback::pushConsoleInfo( const QString &info )
 {
+  QgsProcessingFeedback::pushConsoleInfo( info );
   emit consoleInfoPushed( info );
 }
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -49,7 +49,7 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
     /**
      * Constructor for QgsProcessingAlgorithmDialogFeedback.
      */
-    QgsProcessingAlgorithmDialogFeedback() = default;
+    QgsProcessingAlgorithmDialogFeedback();
 
   signals:
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -521,6 +521,7 @@ class TestQgsProcessing: public QObject
     void encodeDecodeUriProvider();
     void normalizeLayerSource();
     void context();
+    void feedback();
     void mapLayers();
     void mapLayerFromStore();
     void mapLayerFromString();
@@ -1054,6 +1055,19 @@ void TestQgsProcessing::context()
   id = v2->id();
   delete v2;
   QVERIFY( !context2.temporaryLayerStore()->mapLayer( id ) );
+}
+
+void TestQgsProcessing::feedback()
+{
+  QgsProcessingFeedback f;
+  f.pushInfo( QStringLiteral( "info" ) );
+  f.reportError( QStringLiteral( "error" ) );
+  f.pushDebugInfo( QStringLiteral( "debug" ) );
+  f.pushCommandInfo( QStringLiteral( "command" ) );
+  f.pushConsoleInfo( QStringLiteral( "console" ) );
+
+  QCOMPARE( f.htmlLog(), QStringLiteral( "info<br/><span style=\"color:red\">error</span><br/><span style=\"color:#777\">debug</span><br/><code>command</code><br/><code style=\"color:#777\">console</code><br/>" ) );
+  QCOMPARE( f.textLog(), QStringLiteral( "info\nerror\ndebug\ncommand\nconsole\n" ) );
 }
 
 void TestQgsProcessing::mapLayers()

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -2400,7 +2400,7 @@ void TestQgsProcessingAlgs::saveLog()
   QVERIFY( !results.value( QStringLiteral( "OUTPUT" ) ).toString().isEmpty() );
   QFile file( results.value( QStringLiteral( "OUTPUT" ) ).toString() );
   QVERIFY( file.open( QFile::ReadOnly  | QIODevice::Text ) );
-  QCOMPARE( file.readAll(), QStringLiteral( "test\n" ) );
+  QCOMPARE( QString( file.readAll() ), QStringLiteral( "test\n" ) );
 
   parameters.insert( QStringLiteral( "USE_HTML" ), true );
   results = alg->run( parameters, *context, &feedback, &ok );
@@ -2408,7 +2408,7 @@ void TestQgsProcessingAlgs::saveLog()
   QVERIFY( !results.value( QStringLiteral( "OUTPUT" ) ).toString().isEmpty() );
   QFile file2( results.value( QStringLiteral( "OUTPUT" ) ).toString() );
   QVERIFY( file2.open( QFile::ReadOnly  | QIODevice::Text ) );
-  QCOMPARE( file2.readAll(), QStringLiteral( "<span style=\"color:red\">test</span><br/>" ) );
+  QCOMPARE( QString( file2.readAll() ), QStringLiteral( "<span style=\"color:red\">test</span><br/>" ) );
 }
 
 QGSTEST_MAIN( TestQgsProcessingAlgs )


### PR DESCRIPTION
This algorithm saves the contents of the execution log (right up to the point in the model at which the 'save log' algorithm executes) to a file.

It can be used to automatically store the debugging log when running models for later reference and transparency.

Refs NRCan Contract#3000707093