### PR TITLE
Processing: show input and output values for children after running model through designer

### DIFF
--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -389,6 +389,11 @@ Ownership of ``child`` is transferred to the item.
     virtual bool canDeleteComponent();
 
 
+    void setResults( const QVariantMap &results );
+%Docstring
+Sets the results obtained for this child algorithm for the last model execution through the dialog.
+%End
+
   protected:
 
     virtual QColor fillColor( State state ) const;

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -394,6 +394,11 @@ Ownership of ``child`` is transferred to the item.
 Sets the results obtained for this child algorithm for the last model execution through the dialog.
 %End
 
+    void setInputs( const QVariantMap &inputs );
+%Docstring
+Sets the inputs used for this child algorithm for the last model execution through the dialog.
+%End
+
   protected:
 
     virtual QColor fillColor( State state ) const;

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -102,6 +102,11 @@ Returns ``False`` if the cancel option was selected
 Sets the results of child algorithms for the last run of the model through the designer window.
 %End
 
+    void setLastRunChildAlgorithmInputs( const QVariantMap &inputs );
+%Docstring
+Sets the inputs for child algorithms for the last run of the model through the designer window.
+%End
+
 };
 
 

--- a/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodeldesignerdialog.sip.in
@@ -97,6 +97,11 @@ Checks if there are unsaved changes in the model, and if so, prompts the user to
 Returns ``False`` if the cancel option was selected
 %End
 
+    void setLastRunChildAlgorithmResults( const QVariantMap &results );
+%Docstring
+Sets the results of child algorithms for the last run of the model through the designer window.
+%End
+
 };
 
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -114,6 +114,11 @@ not correctly emit signals to allow the scene's model to update.
 Clears any selected items and sets ``item`` as the current selection.
 %End
 
+    void setChildAlgorithmResults( const QVariantMap &results );
+%Docstring
+Sets the results for child algorithms for the last model execution.
+%End
+
   signals:
 
     void rebuildRequired();
@@ -147,7 +152,7 @@ If ``None``, no item is selected.
 Creates a new graphic item for a model parameter.
 %End
 
-    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelChildAlgorithm *child ) const  /Factory/;
+    virtual QgsModelChildAlgorithmGraphicItem *createChildAlgGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelChildAlgorithm *child ) const  /Factory/;
 %Docstring
 Creates a new graphic item for a model child algorithm.
 %End

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -119,6 +119,11 @@ Clears any selected items and sets ``item`` as the current selection.
 Sets the results for child algorithms for the last model execution.
 %End
 
+    void setChildAlgorithmInputs( const QVariantMap &inputs );
+%Docstring
+Sets the inputs for child algorithms for the last model execution.
+%End
+
   signals:
 
     void rebuildRequired();

--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -301,6 +301,15 @@ Formats an input ``string`` for display in the log tab.
 .. versionadded:: 3.0.1
 %End
 
+  signals:
+
+    void algorithmFinished( bool successful, const QVariantMap &result );
+%Docstring
+Emitted whenever an algorithm has finished executing in the dialog.
+
+.. versionadded:: 3.14
+%End
+
   protected slots:
 
     virtual void finished( bool successful, const QVariantMap &result, QgsProcessingContext &context, QgsProcessingFeedback *feedback );

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -342,6 +342,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
         self.setExecuted(True)
         self.setResults(result)
         self.setInfo(self.tr('Algorithm \'{0}\' finished').format(self.algorithm().displayName()), escapeHtml=False)
+        self.algorithmFinished.emit(successful, result)
 
         if not in_place and not keepOpen:
             self.close()

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -258,7 +258,8 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     if ok:
                         self.feedback.pushInfo(self.tr('Execution completed in {0:0.2f} seconds').format(time.time() - start_time))
                         self.feedback.pushInfo(self.tr('Results:'))
-                        self.feedback.pushCommandInfo(pformat(results))
+                        r = {k: v for k, v in results.items() if k not in ('CHILD_RESULTS', 'CHILD_INPUTS')}
+                        self.feedback.pushCommandInfo(pformat(r))
                     else:
                         self.feedback.reportError(
                             self.tr('Execution failed after {0:0.2f} seconds').format(time.time() - start_time))

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -120,8 +120,12 @@ class ModelerDialog(QgsModelDesignerDialog):
                 duration=5)
             return
 
+        def on_finished(successful, results):
+            self.setLastRunChildAlgorithmResults(dlg.results()['CHILD_RESULTS'])
+
         dlg = AlgorithmDialog(self.model().create(), parent=self)
         dlg.setParameters(self.model().designerParameterValues())
+        dlg.algorithmFinished.connect(on_finished)
         dlg.exec_()
 
         if dlg.wasExecuted():

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -122,6 +122,7 @@ class ModelerDialog(QgsModelDesignerDialog):
 
         def on_finished(successful, results):
             self.setLastRunChildAlgorithmResults(dlg.results()['CHILD_RESULTS'])
+            self.setLastRunChildAlgorithmInputs(dlg.results()['CHILD_INPUTS'])
 
         dlg = AlgorithmDialog(self.model().create(), parent=self)
         dlg.setParameters(self.model().designerParameterValues())

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -400,6 +400,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
     feedback->pushDebugInfo( QObject::tr( "Model processed OK. Executed %1 algorithms total in %2 s." ).arg( executed.count() ).arg( totalTime.elapsed() / 1000.0 ) );
 
   mResults = finalResults;
+  mResults.insert( QStringLiteral( "CHILD_RESULTS" ), childResults );
   return mResults;
 }
 

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -253,6 +253,8 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
   QgsExpressionContext baseContext = createExpressionContext( parameters, context );
 
   QVariantMap childResults;
+  QVariantMap childInputs;
+
   QVariantMap finalResults;
   QSet< QString > executed;
   bool executedAlg = true;
@@ -296,6 +298,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
       if ( feedback )
         feedback->setProgressText( QObject::tr( "Running %1 [%2/%3]" ).arg( child.description() ).arg( executed.count() + 1 ).arg( toExecute.count() ) );
 
+      childInputs.insert( childId, childParams );
       QStringList params;
       for ( auto childParamIt = childParams.constBegin(); childParamIt != childParams.constEnd(); ++childParamIt )
       {
@@ -401,6 +404,7 @@ QVariantMap QgsProcessingModelAlgorithm::processAlgorithm( const QVariantMap &pa
 
   mResults = finalResults;
   mResults.insert( QStringLiteral( "CHILD_RESULTS" ), childResults );
+  mResults.insert( QStringLiteral( "CHILD_INPUTS" ), childInputs );
   return mResults;
 }
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -954,7 +954,11 @@ QString QgsModelChildAlgorithmGraphicItem::linkPointText( Qt::Edge edge, int ind
           return param->flags() & QgsProcessingParameterDefinition::FlagHidden || param->isDestination();
         } ), params.end() );
 
-        return truncatedTextForItem( params.at( index )->description() );
+
+        QString title = params.at( index )->description();
+        if ( !mInputs.value( params.at( index )->name() ).toString().isEmpty() )
+          title +=  QStringLiteral( ": %1" ).arg( mInputs.value( params.at( index )->name() ).toString() );
+        return truncatedTextForItem( title );
       }
 
       case Qt::LeftEdge:
@@ -989,6 +993,16 @@ void QgsModelChildAlgorithmGraphicItem::setResults( const QVariantMap &results )
     return;
 
   mResults = results;
+  update();
+  emit updateArrowPaths();
+}
+
+void QgsModelChildAlgorithmGraphicItem::setInputs( const QVariantMap &inputs )
+{
+  if ( mInputs == inputs )
+    return;
+
+  mInputs = inputs;
   update();
   emit updateArrowPaths();
 }

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -936,7 +936,15 @@ QString QgsModelChildAlgorithmGraphicItem::linkPointText( Qt::Edge edge, int ind
     switch ( edge )
     {
       case Qt::BottomEdge:
-        return truncatedTextForItem( child->algorithm()->outputDefinitions().at( index )->description() );
+      {
+        const QgsProcessingOutputDefinition *output = child->algorithm()->outputDefinitions().at( index );
+        QString title = output->description();
+        if ( mResults.contains( output->name() ) )
+        {
+          title += QStringLiteral( ": %1" ).arg( mResults.value( output->name() ).toString() );
+        }
+        return truncatedTextForItem( title );
+      }
 
       case Qt::TopEdge:
       {
@@ -973,6 +981,16 @@ bool QgsModelChildAlgorithmGraphicItem::canDeleteComponent()
     return model()->dependentChildAlgorithms( child->childId() ).empty();
   }
   return false;
+}
+
+void QgsModelChildAlgorithmGraphicItem::setResults( const QVariantMap &results )
+{
+  if ( mResults == results )
+    return;
+
+  mResults = results;
+  update();
+  emit updateArrowPaths();
 }
 
 void QgsModelChildAlgorithmGraphicItem::deleteComponent()

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -452,6 +452,11 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
     void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
     bool canDeleteComponent() override;
 
+    /**
+     * Sets the results obtained for this child algorithm for the last model execution through the dialog.
+     */
+    void setResults( const QVariantMap &results );
+
   protected:
 
     QColor fillColor( State state ) const override;
@@ -475,6 +480,7 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
   private:
     QPicture mPicture;
     QPixmap mPixmap;
+    QVariantMap mResults;
 };
 
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -457,6 +457,11 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
      */
     void setResults( const QVariantMap &results );
 
+    /**
+     * Sets the inputs used for this child algorithm for the last model execution through the dialog.
+     */
+    void setInputs( const QVariantMap &inputs );
+
   protected:
 
     QColor fillColor( State state ) const override;
@@ -481,6 +486,7 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
     QPicture mPicture;
     QPixmap mPixmap;
     QVariantMap mResults;
+    QVariantMap mInputs;
 };
 
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -445,6 +445,13 @@ void QgsModelDesignerDialog::setLastRunChildAlgorithmResults( const QVariantMap 
     mScene->setChildAlgorithmResults( mChildResults );
 }
 
+void QgsModelDesignerDialog::setLastRunChildAlgorithmInputs( const QVariantMap &inputs )
+{
+  mChildInputs = inputs;
+  if ( mScene )
+    mScene->setChildAlgorithmInputs( mChildInputs );
+}
+
 void QgsModelDesignerDialog::zoomIn()
 {
   mView->setTransformationAnchor( QGraphicsView::NoAnchor );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -437,6 +437,11 @@ bool QgsModelDesignerDialog::checkForUnsavedChanges()
   }
 }
 
+void QgsModelDesignerDialog::setLastRunChildAlgorithmResults( const QVariantMap &results )
+{
+  mChildResults = results;
+}
+
 void QgsModelDesignerDialog::zoomIn()
 {
   mView->setTransformationAnchor( QGraphicsView::NoAnchor );

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -356,6 +356,7 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
 
   mScene = scene;
   mScene->setParent( this );
+  mScene->setChildAlgorithmResults( mChildResults );
 
   mView->setModelScene( mScene );
 
@@ -440,6 +441,8 @@ bool QgsModelDesignerDialog::checkForUnsavedChanges()
 void QgsModelDesignerDialog::setLastRunChildAlgorithmResults( const QVariantMap &results )
 {
   mChildResults = results;
+  if ( mScene )
+    mScene->setChildAlgorithmResults( mChildResults );
 }
 
 void QgsModelDesignerDialog::zoomIn()

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -120,6 +120,11 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
      */
     bool checkForUnsavedChanges();
 
+    /**
+     * Sets the results of child algorithms for the last run of the model through the designer window.
+     */
+    void setLastRunChildAlgorithmResults( const QVariantMap &results );
+
   private slots:
     void zoomIn();
     void zoomOut();
@@ -163,6 +168,8 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QString mTitle;
 
     int mBlockRepaints = 0;
+
+    QVariantMap mChildResults;
 
     bool isDirty() const;
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -125,6 +125,11 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
      */
     void setLastRunChildAlgorithmResults( const QVariantMap &results );
 
+    /**
+     * Sets the inputs for child algorithms for the last run of the model through the designer window.
+     */
+    void setLastRunChildAlgorithmInputs( const QVariantMap &inputs );
+
   private slots:
     void zoomIn();
     void zoomOut();
@@ -170,6 +175,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     int mBlockRepaints = 0;
 
     QVariantMap mChildResults;
+    QVariantMap mChildInputs;
 
     bool isDirty() const;
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -104,6 +104,7 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
     addItem( item );
     item->setPos( it.value().position().x(), it.value().position().y() );
     item->setResults( mChildResults.value( it.value().childId() ).toMap() );
+    item->setInputs( mChildInputs.value( it.value().childId() ).toMap() );
     mChildAlgorithmItems.insert( it.value().childId(), item );
     connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
     connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
@@ -275,6 +276,19 @@ void QgsModelGraphicsScene::setChildAlgorithmResults( const QVariantMap &results
     if ( QgsModelChildAlgorithmGraphicItem *item = mChildAlgorithmItems.value( it.key() ) )
     {
       item->setResults( it.value().toMap() );
+    }
+  }
+}
+
+void QgsModelGraphicsScene::setChildAlgorithmInputs( const QVariantMap &inputs )
+{
+  mChildInputs = inputs;
+
+  for ( auto it = mChildInputs.constBegin(); it != mChildInputs.constEnd(); ++it )
+  {
+    if ( QgsModelChildAlgorithmGraphicItem *item = mChildAlgorithmItems.value( it.key() ) )
+    {
+      item->setInputs( it.value().toMap() );
     }
   }
 }

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -130,6 +130,11 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     void setChildAlgorithmResults( const QVariantMap &results );
 
+    /**
+     * Sets the inputs for child algorithms for the last model execution.
+     */
+    void setChildAlgorithmInputs( const QVariantMap &inputs );
+
   signals:
 
     /**
@@ -198,6 +203,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     QMap< QString, QgsModelChildAlgorithmGraphicItem * > mChildAlgorithmItems;
     QMap< QString, QMap< QString, QgsModelComponentGraphicItem * > > mOutputItems;
     QVariantMap mChildResults;
+    QVariantMap mChildInputs;
 
 };
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -28,6 +28,7 @@ class QgsProcessingModelChildAlgorithm;
 class QgsProcessingModelOutput;
 class QgsProcessingModelComponent;
 class QgsProcessingModelComment;
+class QgsModelChildAlgorithmGraphicItem;
 
 ///@cond NOT_STABLE
 
@@ -124,6 +125,11 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     */
     void setSelectedItem( QgsModelComponentGraphicItem *item );
 
+    /**
+     * Sets the results for child algorithms for the last model execution.
+     */
+    void setChildAlgorithmResults( const QVariantMap &results );
+
   signals:
 
     /**
@@ -160,7 +166,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     /**
      * Creates a new graphic item for a model child algorithm.
      */
-    virtual QgsModelComponentGraphicItem *createChildAlgGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelChildAlgorithm *child ) const  SIP_FACTORY;
+    virtual QgsModelChildAlgorithmGraphicItem *createChildAlgGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelChildAlgorithm *child ) const  SIP_FACTORY;
 
     /**
      * Creates a new graphic item for a model output.
@@ -189,8 +195,9 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     Flags mFlags = nullptr;
 
     QMap< QString, QgsModelComponentGraphicItem * > mParameterItems;
-    QMap< QString, QgsModelComponentGraphicItem * > mChildAlgorithmItems;
+    QMap< QString, QgsModelChildAlgorithmGraphicItem * > mChildAlgorithmItems;
     QMap< QString, QMap< QString, QgsModelComponentGraphicItem * > > mOutputItems;
+    QVariantMap mChildResults;
 
 };
 

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -343,6 +343,15 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      */
     static QString formatStringForLog( const QString &string );
 
+  signals:
+
+    /**
+     * Emitted whenever an algorithm has finished executing in the dialog.
+     *
+     * \since QGIS 3.14
+     */
+    void algorithmFinished( bool successful, const QVariantMap &result );
+
   protected slots:
 
     /**


### PR DESCRIPTION
A picture explains this best! After running the algorithm through the designer, you now see the values calculated for the inputs and outputs for each child algorithm:

![image](https://user-images.githubusercontent.com/1829991/77991113-5d749000-7366-11ea-986c-652f6e2229e7.png)

This is very useful for debugging models -- you can see a much clearer visual picture of the flow of values through the model.

Refs NRCan Contract#3000707093