### PR TITLE
[FEATURE] Add import content from clipboard for fixed table items

### DIFF
--- a/python/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
+++ b/python/gui/auto_generated/tableeditor/qgstableeditordialog.sip.in
@@ -37,6 +37,16 @@ Sets the ``contents`` to show in the editor widget.
 .. seealso:: :py:func:`tableContents`
 %End
 
+
+    bool setTableContentsFromClipboard();
+%Docstring
+Parses the clipboard text into contents to show in the editor widget.
+
+:return: ``True`` if the clipboard was successfully parsed
+
+.. seealso:: :py:func:`tableContents`
+%End
+
     QgsTableContents tableContents() const;
 %Docstring
 Returns the current contents of the editor widget table.

--- a/src/gui/layout/qgslayoutmanualtablewidget.cpp
+++ b/src/gui/layout/qgslayoutmanualtablewidget.cpp
@@ -188,7 +188,7 @@ void QgsLayoutManualTableWidget::setTableContents()
     for ( double width : columnWidths )
     {
       mEditorDialog->setTableColumnWidth( col, width );
-      headers << mTable->headers().value( col )->heading();
+      headers << ( mTable->headers().size() > col ? mTable->headers().value( col )->heading() : QVariant() );
       col++;
     }
     mEditorDialog->setTableHeaders( headers );

--- a/src/gui/tableeditor/qgstableeditordialog.h
+++ b/src/gui/tableeditor/qgstableeditordialog.h
@@ -55,6 +55,15 @@ class GUI_EXPORT QgsTableEditorDialog : public QMainWindow, private Ui::QgsTable
     void setTableContents( const QgsTableContents &contents );
 
     /**
+     * Parses the clipboard text into contents to show in the editor widget.
+     * \returns TRUE if the clipboard was successfully parsed
+     *
+     * \see tableContents()
+     */
+
+    bool setTableContentsFromClipboard();
+
+    /**
      * Returns the current contents of the editor widget table.
      *
      * \see setTableContents()

--- a/src/ui/qgstableeditorbase.ui
+++ b/src/ui/qgstableeditorbase.ui
@@ -100,6 +100,8 @@
     <property name="title">
      <string>File</string>
     </property>
+    <addaction name="mActionImportFromClipboard"/>
+    <addaction name="separator"/>
     <addaction name="mActionClose"/>
    </widget>
    <addaction name="menuFile"/>
@@ -159,6 +161,11 @@
   <action name="mActionSelectColumn">
    <property name="text">
     <string>Select Column</string>
+   </property>
+  </action>
+  <action name="mActionImportFromClipboard">
+   <property name="text">
+    <string>Import Content from Clipboard</string>
    </property>
   </action>
   <action name="mActionClose">


### PR DESCRIPTION
## Description

Fixed table items are great, the editor is fantastic, but it's been lacking a way to import content. This PR implements a rudimentary import content from clipboard function:
![Peek 2020-03-31 12-03](https://user-images.githubusercontent.com/1728657/77991304-ad932880-734d-11ea-8e5a-40b2b28e66b0.gif)

I was in need of such a feature for some work I'm doing, hope it'll help others too.