### PR TITLE
Update on match modes for WMS-T layers static temporal range

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovidertemporalcapabilities.sip.in
@@ -38,6 +38,8 @@ The ``enabled`` argument specifies whether the data provider has temporal capabi
       MatchUsingWholeRange,
       MatchExactUsingStartOfRange,
       MatchExactUsingEndOfRange,
+      FindClosestMatchToStartOfRange,
+      FindClosestMatchToEndOfRange
     };
 
     IntervalHandlingMethod intervalHandlingMethod() const;

--- a/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
+++ b/src/core/raster/qgsrasterdataprovidertemporalcapabilities.h
@@ -53,8 +53,10 @@ class CORE_EXPORT QgsRasterDataProviderTemporalCapabilities : public QgsDataProv
       MatchUsingWholeRange, //!< Use an exact match to the whole temporal range
       MatchExactUsingStartOfRange, //!< Match the start of the temporal range to a corresponding layer or band, and only use exact matching results
       MatchExactUsingEndOfRange, //!< Match the end of the temporal range to a corresponding layer or band, and only use exact matching results
+      FindClosestMatchToStartOfRange, //! Match the start of the temporal range to the least previous closest datetime.
+      FindClosestMatchToEndOfRange //! Match the end of the temporal range to the least previous closest datetime.
     };
-    // TODO -- add other methods, like "FindClosestMatchToStartOfRange", "FindClosestMatchToEndOfRange", etc
+    // TODO -- add other methods
 
     /**
      * Returns the desired method to use when resolving a temporal interval to matching

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -246,7 +246,10 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
     }
   }
   else if ( mPipe->provider()->temporalCapabilities() )
+  {
     mPipe->provider()->temporalCapabilities()->setRequestedTemporalRange( QgsDateTimeRange() );
+    mPipe->provider()->temporalCapabilities()->setIntervalHandlingMethod( layer->temporalProperties()->intervalHandlingMethod() );
+  }
 }
 
 QgsRasterLayerRenderer::~QgsRasterLayerRenderer()

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1281,8 +1281,8 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
     mFetchModeComboBox->addItem( tr( "Use Whole Temporal Range" ), QgsRasterDataProviderTemporalCapabilities::MatchUsingWholeRange );
     mFetchModeComboBox->addItem( tr( "Match to Start of Range" ), QgsRasterDataProviderTemporalCapabilities::MatchExactUsingStartOfRange );
     mFetchModeComboBox->addItem( tr( "Match to End of Range" ), QgsRasterDataProviderTemporalCapabilities::MatchExactUsingEndOfRange );
-    mFetchModeComboBox->addItem( tr( "Previous Closest to Start of Range" ), QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToStartOfRange );
-    mFetchModeComboBox->addItem( tr( "Previous Closest to End of Range" ), QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToEndOfRange );
+    mFetchModeComboBox->addItem( tr( "Closest Match to Start of Range" ), QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToStartOfRange );
+    mFetchModeComboBox->addItem( tr( "Closest Match to End of Range" ), QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToEndOfRange );
     mFetchModeComboBox->setCurrentIndex( mFetchModeComboBox->findData( mRasterLayer->temporalProperties()->intervalHandlingMethod() ) );
 
     const QString temporalSource = uri.param( QStringLiteral( "temporalSource" ) );

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1222,15 +1222,6 @@ void QgsRasterLayerProperties::updateSourceStaticTime()
 
 void QgsRasterLayerProperties::setSourceStaticTimeState()
 {
-  QLocale locale;
-
-  mStartStaticDateTimeEdit->setDisplayFormat(
-    locale.dateTimeFormat( QLocale::ShortFormat ) );
-  mEndStaticDateTimeEdit->setDisplayFormat(
-    locale.dateTimeFormat( QLocale::ShortFormat ) );
-  mReferenceDateTimeEdit->setDisplayFormat(
-    locale.dateTimeFormat( QLocale::ShortFormat ) );
-
   if ( mRasterLayer->dataProvider() && mRasterLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() )
   {
     const QgsDateTimeRange availableProviderRange = mRasterLayer->dataProvider()->temporalCapabilities()->availableTemporalRange();
@@ -1290,6 +1281,8 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
     mFetchModeComboBox->addItem( tr( "Use Whole Temporal Range" ), QgsRasterDataProviderTemporalCapabilities::MatchUsingWholeRange );
     mFetchModeComboBox->addItem( tr( "Match to Start of Range" ), QgsRasterDataProviderTemporalCapabilities::MatchExactUsingStartOfRange );
     mFetchModeComboBox->addItem( tr( "Match to End of Range" ), QgsRasterDataProviderTemporalCapabilities::MatchExactUsingEndOfRange );
+    mFetchModeComboBox->addItem( tr( "Previous Closest to Start of Range" ), QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToStartOfRange );
+    mFetchModeComboBox->addItem( tr( "Previous Closest to End of Range" ), QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToEndOfRange );
     mFetchModeComboBox->setCurrentIndex( mFetchModeComboBox->findData( mRasterLayer->temporalProperties()->intervalHandlingMethod() ) );
 
     const QString temporalSource = uri.param( QStringLiteral( "temporalSource" ) );

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -335,10 +335,10 @@ QDateTime QgsWmsSettings::addTime( QDateTime dateTime, QgsWmstResolution resolut
   return resultDateTime;
 }
 
-QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime )
+QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime ) const
 {
   QDateTime closest = dateTime;
-  long long min = LLONG_MAX;
+  long long min = std::numeric_limits<long long>::max();
 
   if ( !dateTime.isValid() || mDateTimes.contains( dateTime ) )
     return closest;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -295,6 +295,7 @@ QList<QDateTime> QgsWmsSettings::dateTimesFromExtent( QgsWmstDimensionExtent dim
       {
         QDateTime first = QDateTime( pair.dates.dateTimes.at( 0 ) );
         QDateTime last = QDateTime( pair.dates.dateTimes.at( 1 ) );
+        dates.append( first );
 
         while ( first < last )
         {
@@ -332,6 +333,37 @@ QDateTime QgsWmsSettings::addTime( QDateTime dateTime, QgsWmstResolution resolut
     resultDateTime = resultDateTime.addSecs( resolution.seconds );
 
   return resultDateTime;
+}
+
+QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime )
+{
+  QDateTime closest = dateTime;
+  long long min = LLONG_MAX;
+
+  if ( !dateTime.isValid() || mDateTimes.contains( dateTime ) )
+    return closest;
+
+  for ( QDateTime current : mDateTimes )
+  {
+    if ( !current.isValid() )
+      continue;
+
+    long long difference = dateTime.secsTo( current );
+
+    // The datetimes list is sorted, if difference is increasing or
+    // it is above zero means search is now looking for greater than
+    // datetimes then search will have to stop.
+    if ( difference > 0 || std::abs( difference ) > min )
+      break;
+
+    if ( std::abs( difference ) < min )
+    {
+      min = std::abs( difference );
+      closest = current;
+    }
+  }
+
+  return closest;
 }
 
 QgsWmstResolution QgsWmsSettings::parseWmstResolution( QString item )
@@ -416,10 +448,10 @@ QgsWmstResolution QgsWmsSettings::parseWmstResolution( QString item )
 
 QDateTime QgsWmsSettings::parseWmstDateTimes( QString item )
 {
-  // Standard item will have YYYY-MM-DDThh:mm:ss.SSSZ
+  // Standard item will have YYYY-MM-DDTHH:mm:ss.SSSZ
   //  format a Qt::ISODateWithMs
 
-  QString format = "YYYY-MM-DDThh:mm:ss.SSSZ";
+  QString format = "YYYY-MM-DDTHH:mm:ss.SSSZ";
 
   // Check if it does not have time part
   if ( !item.contains( 'T' ) )

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -791,7 +791,7 @@ class QgsWmsSettings
      *
      * Returns the passed \a dateTime if it is found in the available datetimes.
      */
-    QDateTime findLeastClosestDateTime( QDateTime dateTime );
+    QDateTime findLeastClosestDateTime( QDateTime dateTime ) const;
 
   protected:
     QgsWmsParserSettings    mParserSettings;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -785,6 +785,14 @@ class QgsWmsSettings
 
     QDateTime addTime( QDateTime dateTime, QgsWmstResolution resolution );
 
+    /**
+     * Finds the least closest datetime from list of available datetimes
+     * with the given \a dateTime.
+     *
+     * Returns the passed \a dateTime if it is found in the available datetimes.
+     */
+    QDateTime findLeastClosestDateTime( QDateTime dateTime );
+
   protected:
     QgsWmsParserSettings    mParserSettings;
 

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -302,8 +302,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>634</width>
-                <height>680</height>
+                <width>643</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -356,7 +356,7 @@ border-radius: 2px;</string>
                 </layout>
                </item>
                <item>
-                <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+                <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
                  <property name="focusPolicy">
                   <enum>Qt::StrongFocus</enum>
                  </property>
@@ -419,16 +419,6 @@ border-radius: 2px;</string>
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="1" colspan="2">
-                      <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
-                       <property name="displayFormat">
-                        <string>M/d/yyyy h:mm:ss AP</string>
-                       </property>
-                       <property name="timeSpec">
-                        <enum>Qt::UTC</enum>
-                       </property>
-                      </widget>
-                     </item>
                      <item row="0" column="0">
                       <widget class="QLabel" name="label_13">
                        <property name="text">
@@ -439,10 +429,13 @@ border-radius: 2px;</string>
                      <item row="1" column="1" colspan="2">
                       <widget class="QgsDateTimeEdit" name="mEndStaticDateTimeEdit">
                        <property name="displayFormat">
-                        <string>M/d/yyyy h:mm:ss AP</string>
+                        <string>M/d/yyyy H:mm:ss AP</string>
                        </property>
                        <property name="timeSpec">
                         <enum>Qt::UTC</enum>
+                       </property>
+                       <property name="allowNull">
+                        <bool>false</bool>
                        </property>
                       </widget>
                      </item>
@@ -457,6 +450,32 @@ border-radius: 2px;</string>
                       <widget class="QCheckBox" name="mDisableTime">
                        <property name="text">
                         <string>Use dates only</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1" colspan="2">
+                      <widget class="QgsDateTimeEdit" name="mStartStaticDateTimeEdit">
+                       <property name="dateTime">
+                        <datetime>
+                         <hour>8</hour>
+                         <minute>3</minute>
+                         <second>57</second>
+                         <year>2020</year>
+                         <month>4</month>
+                         <day>30</day>
+                        </datetime>
+                       </property>
+                       <property name="currentSection">
+                        <enum>QDateTimeEdit::DaySection</enum>
+                       </property>
+                       <property name="displayFormat">
+                        <string>M/d/yyyy H:mm:ss AP</string>
+                       </property>
+                       <property name="timeSpec">
+                        <enum>Qt::UTC</enum>
+                       </property>
+                       <property name="allowNull">
+                        <bool>false</bool>
                        </property>
                       </widget>
                      </item>
@@ -482,7 +501,7 @@ border-radius: 2px;</string>
                       <widget class="QgsDateTimeEdit" name="mReferenceDateTimeEdit">
                        <property name="dateTime">
                         <datetime>
-                         <hour>21</hour>
+                         <hour>19</hour>
                          <minute>20</minute>
                          <second>36</second>
                          <year>2020</year>
@@ -501,10 +520,16 @@ border-radius: 2px;</string>
                         <enum>QDateTimeEdit::MonthSection</enum>
                        </property>
                        <property name="displayFormat">
-                        <string>M/d/yyyy h:mm:ss AP</string>
+                        <string>M/d/yyyy H:mm:ss AP</string>
+                       </property>
+                       <property name="calendarPopup">
+                        <bool>false</bool>
                        </property>
                        <property name="timeSpec">
                         <enum>Qt::UTC</enum>
+                       </property>
+                       <property name="allowNull">
+                        <bool>false</bool>
                        </property>
                       </widget>
                      </item>
@@ -604,8 +629,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>550</width>
-                <height>514</height>
+                <width>515</width>
+                <height>506</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -632,7 +657,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Band Rendering</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_14">
@@ -677,13 +702,13 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Color Rendering</string>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_2">
@@ -979,13 +1004,13 @@ border-radius: 2px;</string>
                  <property name="checkable">
                   <bool>false</bool>
                  </property>
-                 <property name="collapsed" stdset="0">
+                 <property name="collapsed">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rasterstyle</string>
                  </property>
-                 <property name="saveCollapsedState" stdset="0">
+                 <property name="saveCollapsedState">
                   <bool>true</bool>
                  </property>
                  <layout class="QHBoxLayout" name="horizontalLayout">
@@ -1204,8 +1229,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>359</width>
-                <height>467</height>
+                <width>343</width>
+                <height>476</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1226,12 +1251,12 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Global Opacity</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rastertransp</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_13">
                   <item row="0" column="0">
-                   <widget class="QgsOpacityWidget" name="mOpacityWidget" native="true">
+                   <widget class="QgsOpacityWidget" name="mOpacityWidget">
                     <property name="focusPolicy">
                      <enum>Qt::StrongFocus</enum>
                     </property>
@@ -1245,7 +1270,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>No Data Value</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rastertransp</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_11">
@@ -1317,7 +1342,7 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Custom Transparency Options</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rastertransp</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_3">
@@ -1557,8 +1582,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
-                <height>45</height>
+                <width>86</width>
+                <height>44</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1620,7 +1645,7 @@ border-radius: 2px;</string>
              <property name="checked">
               <bool>false</bool>
              </property>
-             <property name="syncGroup" stdset="0">
+             <property name="syncGroup">
               <string notr="true">rastergeneral</string>
              </property>
              <layout class="QGridLayout" name="_5">
@@ -1640,7 +1665,7 @@ border-radius: 2px;</string>
                <number>6</number>
               </property>
               <item row="0" column="0" colspan="2">
-               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
+               <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
                 <property name="toolTip">
                  <string/>
                 </property>
@@ -1775,8 +1800,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>631</width>
-                <height>205</height>
+                <width>579</width>
+                <height>201</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2005,8 +2030,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>364</width>
-                <height>667</height>
+                <width>370</width>
+                <height>650</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_12">
@@ -2027,7 +2052,7 @@ p, li { white-space: pre-wrap; }
                  <property name="title">
                   <string>Description</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">rastermeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_5">
@@ -2163,7 +2188,7 @@ p, li { white-space: pre-wrap; }
                  <property name="title">
                   <string>Attribution</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
@@ -2209,7 +2234,7 @@ p, li { white-space: pre-wrap; }
                  <property name="title">
                   <string>MetadataUrl</string>
                  </property>
-                 <property name="syncGroup" stdset="0">
+                 <property name="syncGroup">
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_9">
@@ -2457,22 +2482,6 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsScrollArea</class>
-   <extends>QScrollArea</extends>
-   <header>qgsscrollarea.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsDateTimeEdit</class>
-   <extends>QDateTimeEdit</extends>
-   <header>qgsdatetimeedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
@@ -2483,6 +2492,16 @@ p, li { white-space: pre-wrap; }
    <extends>QToolButton</extends>
    <header>qgscolorbutton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>qgsdatetimeedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QgsOpacityWidget</class>
@@ -2505,6 +2524,12 @@ p, li { white-space: pre-wrap; }
    <class>QgsScaleRangeWidget</class>
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>qgsscrollarea.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>


### PR DESCRIPTION
Added two match modes in the time slice option in the static temporal range group found in raster layer temporal properties.

The "Previous Closest To Start Range" set the start of temporal range to the previous closest date time in the available temporal capabilities only if the requested temporal range is not found in the 
available temporal capabilities, while the "Previous Closest To End Range" mode does the same but using the end of the requested temporal range.


![Update_on_match_modes](https://user-images.githubusercontent.com/2663775/78025121-21d7c700-7362-11ea-993b-cc5ededa0121.png)
