### PR TITLE
Port output parameter wrappers to new API

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
@@ -30,6 +30,7 @@ Source for the value of a parameter for a child algorithm within a model.
       StaticValue,
       Expression,
       ExpressionText,
+      ModelOutput,
     };
 
     QgsProcessingModelChildParameterSource();

--- a/python/gui/auto_generated/processing/models/qgsmodelarrowitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelarrowitem.sip.in
@@ -28,8 +28,8 @@ A link arrow item for use in the model designer.
 %End
   public:
 
-    QgsModelArrowItem( QgsModelComponentGraphicItem *startItem, Qt::Edge startEdge, int startIndex,
-                       QgsModelComponentGraphicItem *endItem, Qt::Edge endEdge, int endIndex );
+    QgsModelArrowItem( QgsModelComponentGraphicItem *startItem, Qt::Edge startEdge, int startIndex, bool startIsOutgoing,
+                       QgsModelComponentGraphicItem *endItem, Qt::Edge endEdge, int endIndex, bool endIsIncoming );
 %Docstring
 Constructor for QgsModelArrowItem, with the specified ``parent`` item.
 

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -159,7 +159,7 @@ Returns the number of link points associated with the component on the specified
 Returns the text to use for the link point with the specified ``index`` on the specified ``edge``.
 %End
 
-    QPointF linkPoint( Qt::Edge edge, int index ) const;
+    QPointF linkPoint( Qt::Edge edge, int index, bool incoming ) const;
 %Docstring
 Returns the location of the link point with the specified ``index`` on the specified ``edge``.
 %End

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -91,7 +91,7 @@ from QgsProcessing.SourceType.
     void setExpressionHelpText( const QString &text );
 %Docstring
 Set the expected expression format ``text``, which is shown in the expression builder dialog for the widget
-when in the "pre-calculated" expression mode. This is purely a text format and no expression validation is made
+when in the "pre-calculated" ex  pression mode. This is purely a text format and no expression validation is made
 against it.
 %End
 
@@ -119,6 +119,39 @@ Sets the current ``value`` for the parameter.
 Sets the current ``values`` for the parameter.
 
 .. seealso:: :py:func:`value`
+
+.. versionadded:: 3.14
+%End
+
+    void setToModelOutput( const QString &value );
+%Docstring
+Sets the widget to a model output, for destination parameters only.
+
+.. seealso:: :py:func:`isModelOutput`
+
+.. seealso:: :py:func:`modelOutputName`
+
+.. versionadded:: 3.14
+%End
+
+    bool isModelOutput() const;
+%Docstring
+Returns ``True`` if the widget is set to the model output mode.
+
+.. seealso:: :py:func:`setToModelOutput`
+
+.. seealso:: :py:func:`modelOutputName`
+
+.. versionadded:: 3.14
+%End
+
+    QString modelOutputName() const;
+%Docstring
+Returns the model output name, if isModelOutput() is ``True``.
+
+.. seealso:: :py:func:`setToModelOutput`
+
+.. seealso:: :py:func:`isModelOutput`
 
 .. versionadded:: 3.14
 %End

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -91,7 +91,7 @@ from QgsProcessing.SourceType.
     void setExpressionHelpText( const QString &text );
 %Docstring
 Set the expected expression format ``text``, which is shown in the expression builder dialog for the widget
-when in the "pre-calculated" ex  pression mode. This is purely a text format and no expression validation is made
+when in the "pre-calculated" expression mode. This is purely a text format and no expression validation is made
 against it.
 %End
 

--- a/python/gui/auto_generated/processing/qgsprocessingoutputdestinationwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingoutputdestinationwidget.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsProcessingLayerOutputDestinationWidget : QWidget
 {
 %Docstring
@@ -52,6 +51,16 @@ Returns the widgets current value.
 Sets the ``context`` in which the widget is shown, e.g., the
 parent model algorithm, a linked map canvas, and other relevant information which allows the widget
 to fine-tune its behavior.
+%End
+
+    void addOpenAfterRunningOption();
+%Docstring
+Adds the "Open output file after running" option to the widget.
+%End
+
+    bool openAfterRunning() const;
+%Docstring
+Returns ``True`` if the widget has the "Open output file after running" option checked.
 %End
 
   signals:

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -304,6 +304,11 @@ Returns the current value of the parameter.
 .. seealso:: :py:func:`setParameterValue`
 %End
 
+    virtual QVariantMap customProperties() const;
+%Docstring
+Returns any custom properties set by the wrapper.
+%End
+
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 %Docstring
 Registers a Processing context ``generator`` class that will be used to retrieve

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
@@ -100,9 +100,6 @@ class GdalParametersPanel(ParametersPanel):
             for c in w.findChildren(QWidget):
                 self.connectWidgetChangedSignals(c)
 
-        for output_widget in self.outputWidgets.values():
-            self.connectWidgetChangedSignals(output_widget)
-
     def connectWidgetChangedSignals(self, w):
         if isinstance(w, QLineEdit):
             w.textChanged.connect(self.parametersHaveChanged)

--- a/python/plugins/processing/algs/qgis/CheckValidity.py
+++ b/python/plugins/processing/algs/qgis/CheckValidity.py
@@ -96,13 +96,13 @@ class CheckValidity(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterBoolean(self.IGNORE_RING_SELF_INTERSECTION,
                                                         self.tr('Ignore ring self intersections'), defaultValue=False))
 
-        self.addParameter(QgsProcessingParameterFeatureSink(self.VALID_OUTPUT, self.tr('Valid output'), QgsProcessing.TypeVectorAnyGeometry, '', True))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.VALID_OUTPUT, self.tr('Valid output'), QgsProcessing.TypeVectorAnyGeometry, None, True))
         self.addOutput(QgsProcessingOutputNumber(self.VALID_COUNT, self.tr('Count of valid features')))
 
-        self.addParameter(QgsProcessingParameterFeatureSink(self.INVALID_OUTPUT, self.tr('Invalid output'), QgsProcessing.TypeVectorAnyGeometry, '', True))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.INVALID_OUTPUT, self.tr('Invalid output'), QgsProcessing.TypeVectorAnyGeometry, None, True))
         self.addOutput(QgsProcessingOutputNumber(self.INVALID_COUNT, self.tr('Count of invalid features')))
 
-        self.addParameter(QgsProcessingParameterFeatureSink(self.ERROR_OUTPUT, self.tr('Error output'), QgsProcessing.TypeVectorAnyGeometry, '', True))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.ERROR_OUTPUT, self.tr('Error output'), QgsProcessing.TypeVectorAnyGeometry, None, True))
         self.addOutput(QgsProcessingOutputNumber(self.ERROR_COUNT, self.tr('Count of errors')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/UniqueValues.py
+++ b/python/plugins/processing/algs/qgis/UniqueValues.py
@@ -79,7 +79,7 @@ class UniqueValues(QgisAlgorithm):
                                                       self.tr('Target field(s)'),
                                                       parentLayerParameterName=self.INPUT, type=QgsProcessingParameterField.Any, allowMultiple=True))
 
-        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Unique values'), optional=True, defaultValue=''))
+        self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Unique values'), optional=True, defaultValue=None))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT_HTML_FILE, self.tr('HTML report'), self.tr('HTML files (*.html)'), None, True))
         self.addOutput(QgsProcessingOutputNumber(self.TOTAL_VALUES, self.tr('Total unique values')))

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -47,6 +47,7 @@ from qgis.core import (Qgis,
                        QgsProcessingFeatureSourceDefinition)
 from qgis.gui import (QgsGui,
                       QgsMessageBar,
+                      QgsProcessingLayerOutputDestinationWidget,
                       QgsProcessingAlgorithmDialogBase)
 from qgis.utils import iface
 
@@ -155,16 +156,17 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     parameters[param.name()] = 'memory:'
                     continue
 
-                dest_project = None
-                if not param.flags() & QgsProcessingParameterDefinition.FlagHidden and \
-                        isinstance(param, (QgsProcessingParameterRasterDestination,
-                                           QgsProcessingParameterFeatureSink,
-                                           QgsProcessingParameterVectorDestination)):
-                    if self.mainWidget().checkBoxes[param.name()].isChecked():
-                        dest_project = QgsProject.instance()
+                try:
+                    wrapper = self.mainWidget().wrappers[param.name()]
+                except KeyError:
+                    continue
 
-                widget = self.mainWidget().outputWidgets[param.name()]
-                value = widget.value()
+                widget = wrapper.wrappedWidget()
+                value = wrapper.parameterValue()
+
+                dest_project = None
+                if wrapper.customProperties().get('OPEN_AFTER_RUNNING'):
+                    dest_project = QgsProject.instance()
 
                 if value and isinstance(value, QgsProcessingOutputLayerDefinition):
                     value.destinationProject = dest_project

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -121,8 +121,8 @@ class ModelerDialog(QgsModelDesignerDialog):
             return
 
         def on_finished(successful, results):
-            self.setLastRunChildAlgorithmResults(dlg.results()['CHILD_RESULTS'])
-            self.setLastRunChildAlgorithmInputs(dlg.results()['CHILD_INPUTS'])
+            self.setLastRunChildAlgorithmResults(dlg.results().get('CHILD_RESULTS', {}))
+            self.setLastRunChildAlgorithmInputs(dlg.results().get('CHILD_INPUTS', {}))
 
         dlg = AlgorithmDialog(self.model().create(), parent=self)
         dlg.setParameters(self.model().designerParameterValues())

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -521,7 +521,6 @@ class ModelerParametersWidget(QWidget):
         self.commentEdit.selectAll()
 
     def setupUi(self):
-        self.checkBoxes = {}
         self.showAdvanced = False
         self.wrappers = {}
         self.valueItems = {}

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -136,6 +136,9 @@ QVariantMap QgsProcessingModelAlgorithm::parametersForChildAlgorithm( const QgsP
           expressionText = QgsExpression::replaceExpressionText( source.expressionText(), &expressionContext );
           break;
         }
+
+        case QgsProcessingModelChildParameterSource::ModelOutput:
+          break;
       }
     }
 
@@ -856,6 +859,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
       case QgsProcessingModelChildParameterSource::Expression:
       case QgsProcessingModelChildParameterSource::ExpressionText:
       case QgsProcessingModelChildParameterSource::StaticValue:
+      case QgsProcessingModelChildParameterSource::ModelOutput:
         continue;
     };
     variables.insert( safeName( name ), VariableDefinition( value, source, description ) );
@@ -901,6 +905,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
       case QgsProcessingModelChildParameterSource::Expression:
       case QgsProcessingModelChildParameterSource::ExpressionText:
       case QgsProcessingModelChildParameterSource::StaticValue:
+      case QgsProcessingModelChildParameterSource::ModelOutput:
         continue;
 
     };
@@ -959,6 +964,7 @@ QMap<QString, QgsProcessingModelAlgorithm::VariableDefinition> QgsProcessingMode
       case QgsProcessingModelChildParameterSource::Expression:
       case QgsProcessingModelChildParameterSource::ExpressionText:
       case QgsProcessingModelChildParameterSource::StaticValue:
+      case QgsProcessingModelChildParameterSource::ModelOutput:
         continue;
 
     };

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.cpp
@@ -39,6 +39,8 @@ bool QgsProcessingModelChildParameterSource::operator==( const QgsProcessingMode
       return mExpression == other.mExpression;
     case ExpressionText:
       return mExpressionText == other.mExpressionText;
+    case ModelOutput:
+      return true;
   }
   return false;
 }
@@ -120,6 +122,9 @@ QVariant QgsProcessingModelChildParameterSource::toVariant() const
     case ExpressionText:
       map.insert( QStringLiteral( "expression_text" ), mExpressionText );
       break;
+
+    case ModelOutput:
+      break;
   }
   return map;
 }
@@ -148,6 +153,9 @@ bool QgsProcessingModelChildParameterSource::loadVariant( const QVariantMap &map
 
     case ExpressionText:
       mExpressionText = map.value( QStringLiteral( "expression_text" ) ).toString();
+      break;
+
+    case ModelOutput:
       break;
   }
   return true;
@@ -179,6 +187,9 @@ QString QgsProcessingModelChildParameterSource::asPythonCode( const QgsProcessin
 
     case ExpressionText:
       return mExpressionText;
+
+    case ModelOutput:
+      return QString();
   }
   return QString();
 }
@@ -222,6 +233,9 @@ QString QgsProcessingModelChildParameterSource::friendlyIdentifier( QgsProcessin
 
     case ExpressionText:
       return mExpressionText;
+
+    case ModelOutput:
+      return QString();
   }
   return QString();
 }

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.h
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.h
@@ -43,6 +43,7 @@ class CORE_EXPORT QgsProcessingModelChildParameterSource
       StaticValue, //!< Parameter value is a static value
       Expression, //!< Parameter value is taken from an expression, evaluated just before the algorithm runs
       ExpressionText, //!< Parameter value is taken from a text with expressions, evaluated just before the algorithm runs
+      ModelOutput, //!< Parameter value is linked to an output parameter for the model
     };
 
     /**

--- a/src/gui/processing/models/qgsmodelarrowitem.h
+++ b/src/gui/processing/models/qgsmodelarrowitem.h
@@ -43,8 +43,8 @@ class GUI_EXPORT QgsModelArrowItem : public QObject, public QGraphicsPathItem
      * The arrow will link \a startItem to \a endItem, joining the specified \a startEdge and \a startIndex
      * to \a endEdge and \a endIndex.
      */
-    QgsModelArrowItem( QgsModelComponentGraphicItem *startItem, Qt::Edge startEdge, int startIndex,
-                       QgsModelComponentGraphicItem *endItem, Qt::Edge endEdge, int endIndex );
+    QgsModelArrowItem( QgsModelComponentGraphicItem *startItem, Qt::Edge startEdge, int startIndex, bool startIsOutgoing,
+                       QgsModelComponentGraphicItem *endItem, Qt::Edge endEdge, int endIndex, bool endIsIncoming );
 
     /**
      * Constructor for QgsModelArrowItem, with the specified \a parent item.
@@ -88,15 +88,17 @@ class GUI_EXPORT QgsModelArrowItem : public QObject, public QGraphicsPathItem
 
   private:
 
-    QPointF bezierPointForCurve( const QPointF &point, Qt::Edge edge ) const;
+    QPointF bezierPointForCurve( const QPointF &point, Qt::Edge edge, bool incoming ) const;
 
     QgsModelComponentGraphicItem *mStartItem = nullptr;
     Qt::Edge mStartEdge = Qt::LeftEdge;
     int mStartIndex = -1;
+    bool mStartIsOutgoing = true;
 
     QgsModelComponentGraphicItem *mEndItem = nullptr;
     Qt::Edge mEndEdge = Qt::LeftEdge;
     int mEndIndex = -1;
+    bool mEndIsIncoming = false;
 
     QList< QPointF > mNodePoints;
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -498,12 +498,12 @@ void QgsModelComponentGraphicItem::updateButtonPositions()
 
   if ( mExpandTopButton )
   {
-    QPointF pt = linkPoint( Qt::TopEdge, -1 );
+    QPointF pt = linkPoint( Qt::TopEdge, -1, true );
     mExpandTopButton->setPosition( QPointF( 0, pt.y() ) );
   }
   if ( mExpandBottomButton )
   {
-    QPointF pt = linkPoint( Qt::BottomEdge, -1 );
+    QPointF pt = linkPoint( Qt::BottomEdge, -1, false );
     mExpandBottomButton->setPosition( QPointF( 0, pt.y() ) );
   }
 }
@@ -584,7 +584,7 @@ QString QgsModelComponentGraphicItem::linkPointText( Qt::Edge, int ) const
   return QString();
 }
 
-QPointF QgsModelComponentGraphicItem::linkPoint( Qt::Edge edge, int index ) const
+QPointF QgsModelComponentGraphicItem::linkPoint( Qt::Edge edge, int index, bool incoming ) const
 {
   switch ( edge )
   {
@@ -592,6 +592,11 @@ QPointF QgsModelComponentGraphicItem::linkPoint( Qt::Edge edge, int index ) cons
     {
       if ( linkPointCount( Qt::BottomEdge ) )
       {
+        double offsetX = 25;
+        if ( mComponent->linksCollapsed( Qt::BottomEdge ) )
+        {
+          offsetX = 17;
+        }
         const int pointIndex = !mComponent->linksCollapsed( Qt::BottomEdge ) ? index : -1;
         const QString text = truncatedTextForItem( linkPointText( Qt::BottomEdge, index ) );
         QFontMetricsF fm( mFont );
@@ -599,7 +604,9 @@ QPointF QgsModelComponentGraphicItem::linkPoint( Qt::Edge edge, int index ) cons
         const double h = fm.height() * 1.2 * ( pointIndex + 1 ) + fm.height() / 2.0;
         const double y = h + itemSize().height() / 2.0 + 5;
         const double x = !mComponent->linksCollapsed( Qt::BottomEdge ) ? ( -itemSize().width() / 2 + 33 + w + 5 ) : 10;
-        return QPointF( x, y );
+        return QPointF( incoming ? -itemSize().width() / 2 + offsetX
+                        :  x,
+                        y );
       }
       break;
     }
@@ -616,9 +623,13 @@ QPointF QgsModelComponentGraphicItem::linkPoint( Qt::Edge edge, int index ) cons
           offsetX = 17;
         }
         QFontMetricsF fm( mFont );
+        const QString text = truncatedTextForItem( linkPointText( Qt::TopEdge, index ) );
+        const double w = fm.boundingRect( text ).width();
         double h = -( fm.height() * 1.2 ) * ( paramIndex + 2 ) - fm.height() / 2.0 + 8;
         h = h - itemSize().height() / 2.0;
-        return QPointF( -itemSize().width() / 2 + offsetX, h );
+        return QPointF( incoming ? -itemSize().width() / 2 + offsetX
+                        : ( !mComponent->linksCollapsed( Qt::TopEdge ) ? ( -itemSize().width() / 2 + 33 + w + 5 ) : 10 ),
+                        h );
       }
       break;
     }

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -209,7 +209,7 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     /**
      * Returns the location of the link point with the specified \a index on the specified \a edge.
      */
-    QPointF linkPoint( Qt::Edge edge, int index ) const;
+    QPointF linkPoint( Qt::Edge edge, int index, bool incoming ) const;
 
     /**
      * Returns the best link point to use for a link originating at a specified \a other item.

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -136,14 +136,15 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
   // arrows linking child algorithms
   for ( auto it = childAlgs.constBegin(); it != childAlgs.constEnd(); ++it )
   {
-    int idx = 0;
+    int topIdx = 0;
+    int bottomIdx = 0;
     if ( !it.value().algorithm() )
       continue;
 
     const QgsProcessingParameterDefinitions parameters = it.value().algorithm()->parameterDefinitions();
     for ( const QgsProcessingParameterDefinition *parameter : parameters )
     {
-      if ( !parameter->isDestination() && !( parameter->flags() & QgsProcessingParameterDefinition::FlagHidden ) )
+      if ( !( parameter->flags() & QgsProcessingParameterDefinition::FlagHidden ) )
       {
         QList< QgsProcessingModelChildParameterSource > sources;
         if ( it.value().parameterSources().contains( parameter->name() ) )
@@ -155,14 +156,21 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
           {
             QgsModelArrowItem *arrow = nullptr;
             if ( link.linkIndex == -1 )
-              arrow = new QgsModelArrowItem( link.item, mChildAlgorithmItems.value( it.value().childId() ), Qt::TopEdge, idx );
+              arrow = new QgsModelArrowItem( link.item, mChildAlgorithmItems.value( it.value().childId() ), parameter->isDestination() ? Qt::BottomEdge : Qt::TopEdge, parameter->isDestination() ? bottomIdx : topIdx );
             else
-              arrow = new QgsModelArrowItem( link.item, link.edge, link.linkIndex, mChildAlgorithmItems.value( it.value().childId() ), Qt::TopEdge, idx );
+              arrow = new QgsModelArrowItem( link.item, link.edge, link.linkIndex, true,
+                                             mChildAlgorithmItems.value( it.value().childId() ),
+                                             parameter->isDestination() ? Qt::BottomEdge : Qt::TopEdge,
+                                             parameter->isDestination() ? bottomIdx : topIdx,
+                                             true );
             addItem( arrow );
           }
         }
       }
-      idx += 1;
+      if ( parameter->isDestination() )
+        bottomIdx++;
+      else
+        topIdx++;
     }
     const QStringList dependencies = it.value().dependencies();
     for ( const QString &depend : dependencies )

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -395,6 +395,7 @@ QList<QgsModelGraphicsScene::LinkSource> QgsModelGraphicsScene::linkSourcesForPa
 
       case QgsProcessingModelChildParameterSource::StaticValue:
       case QgsProcessingModelChildParameterSource::ExpressionText:
+      case QgsProcessingModelChildParameterSource::ModelOutput:
         break;
     }
   }

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -58,6 +58,11 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingMeshLayerWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingBandWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingMultipleLayerWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingFeatureSinkWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingVectorDestinationWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingRasterDestinationWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingFileDestinationWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingFolderDestinationWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingmaplayercombobox.cpp
+++ b/src/gui/processing/qgsprocessingmaplayercombobox.cpp
@@ -50,11 +50,6 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
   layout->addWidget( mCombo );
   layout->setAlignment( mCombo, Qt::AlignTop );
 
-  mSelectButton = new QToolButton();
-  mSelectButton->setText( QString( QChar( 0x2026 ) ) );
-  mSelectButton->setToolTip( tr( "Select input" ) );
-  layout->addWidget( mSelectButton );
-  layout->setAlignment( mSelectButton, Qt::AlignTop );
   int iconSize = QgsGuiUtils::scaleIconSize( 24 );
   if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() && type == QgsProcessingGui::Standard )
   {
@@ -86,7 +81,15 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
     connect( mSettingsButton, &QToolButton::clicked, this, &QgsProcessingMapLayerComboBox::showSourceOptions );
     layout->addWidget( mSettingsButton );
     layout->setAlignment( mSettingsButton, Qt::AlignTop );
+  }
 
+  mSelectButton = new QToolButton();
+  mSelectButton->setText( QString( QChar( 0x2026 ) ) );
+  mSelectButton->setToolTip( tr( "Select input" ) );
+  layout->addWidget( mSelectButton );
+  layout->setAlignment( mSelectButton, Qt::AlignTop );
+  if ( mParameter->type() == QgsProcessingParameterFeatureSource::typeName() )
+  {
     mFeatureSourceMenu = new QMenu( this );
     QAction *selectFromFileAction = new QAction( tr( "Select File…" ), mFeatureSourceMenu );
     connect( selectFromFileAction, &QAction::triggered, this, &QgsProcessingMapLayerComboBox::selectFromFile );
@@ -94,7 +97,6 @@ QgsProcessingMapLayerComboBox::QgsProcessingMapLayerComboBox( const QgsProcessin
     QAction *browseForLayerAction = new QAction( tr( "Browse for Layer…" ), mFeatureSourceMenu );
     connect( browseForLayerAction, &QAction::triggered, this, &QgsProcessingMapLayerComboBox::browseForLayer );
     mFeatureSourceMenu->addAction( browseForLayerAction );
-
     mSelectButton->setMenu( mFeatureSourceMenu );
     mSelectButton->setPopupMode( QToolButton::InstantPopup );
   }

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -32,6 +32,7 @@ class QgsExpressionLineEdit;
 class QgsProcessingModelAlgorithm;
 class QgsProcessingParameterWidgetContext;
 class QgsProcessingContextGenerator;
+class QgsFilterLineEdit;
 
 class QLabel;
 class QToolButton;
@@ -117,7 +118,7 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
 
     /**
      * Set the expected expression format \a text, which is shown in the expression builder dialog for the widget
-     * when in the "pre-calculated" expression mode. This is purely a text format and no expression validation is made
+     * when in the "pre-calculated" ex  pression mode. This is purely a text format and no expression validation is made
      * against it.
      */
     void setExpressionHelpText( const QString &text );
@@ -150,6 +151,33 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
     void setWidgetValue( const QList< QgsProcessingModelChildParameterSource > &values );
 
     /**
+     * Sets the widget to a model output, for destination parameters only.
+     *
+     * \see isModelOutput()
+     * \see modelOutputName()
+     * \since QGIS 3.14
+     */
+    void setToModelOutput( const QString &value );
+
+    /**
+     * Returns TRUE if the widget is set to the model output mode.
+     *
+     * \see setToModelOutput()
+     * \see modelOutputName()
+     * \since QGIS 3.14
+     */
+    bool isModelOutput() const;
+
+    /**
+     * Returns the model output name, if isModelOutput() is TRUE.
+     *
+     * \see setToModelOutput()
+     * \see isModelOutput()
+     * \since QGIS 3.14
+     */
+    QString modelOutputName() const;
+
+    /**
      * Returns the current value of the parameter.
      *
      * \see setWidgetValue()
@@ -179,6 +207,7 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
       Expression = 1,
       ModelParameter = 2,
       ChildOutput = 3,
+      ModelOutput = 4,
     };
 
     SourceType currentSourceType() const;
@@ -206,6 +235,7 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
     QgsExpressionLineEdit *mExpressionWidget = nullptr;
     QComboBox *mModelInputCombo = nullptr;
     QComboBox *mChildOutputCombo = nullptr;
+    QgsFilterLineEdit *mModelOutputName = nullptr;
 
     friend class TestProcessingGui;
 };

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -118,7 +118,7 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
 
     /**
      * Set the expected expression format \a text, which is shown in the expression builder dialog for the widget
-     * when in the "pre-calculated" ex  pression mode. This is purely a text format and no expression validation is made
+     * when in the "pre-calculated" expression mode. This is purely a text format and no expression validation is made
      * against it.
      */
     void setExpressionHelpText( const QString &text );

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.cpp
@@ -26,6 +26,7 @@
 #include <QMenu>
 #include <QFileDialog>
 #include <QInputDialog>
+#include <QCheckBox>
 
 ///@cond NOT_STABLE
 
@@ -184,6 +185,26 @@ QVariant QgsProcessingLayerOutputDestinationWidget::value() const
 void QgsProcessingLayerOutputDestinationWidget::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
 {
   mBrowserModel = context.browserModel();
+}
+
+void QgsProcessingLayerOutputDestinationWidget::addOpenAfterRunningOption()
+{
+  mOpenAfterRunningCheck = new QCheckBox( tr( "Open output file after running algorithm" ) );
+  mOpenAfterRunningCheck->setChecked( !outputIsSkipped() );
+  mOpenAfterRunningCheck->setEnabled( !outputIsSkipped() );
+  gridLayout->addWidget( mOpenAfterRunningCheck, 1, 0, 1, 2 );
+
+  connect( this, &QgsProcessingLayerOutputDestinationWidget::skipOutputChanged, this, [ = ]( bool skipped )
+  {
+    bool enabled = !skipped;
+    mOpenAfterRunningCheck->setEnabled( enabled );
+    mOpenAfterRunningCheck->setChecked( enabled );
+  } );
+}
+
+bool QgsProcessingLayerOutputDestinationWidget::openAfterRunning() const
+{
+  return mOpenAfterRunningCheck && mOpenAfterRunningCheck->isChecked();
 }
 
 void QgsProcessingLayerOutputDestinationWidget::menuAboutToShow()

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.h
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.h
@@ -24,7 +24,7 @@
 
 class QgsProcessingDestinationParameter;
 class QgsBrowserGuiModel;
-
+class QCheckBox;
 ///@cond NOT_STABLE
 
 /**
@@ -66,6 +66,16 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
      */
     void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
 
+    /**
+     * Adds the "Open output file after running" option to the widget.
+     */
+    void addOpenAfterRunningOption();
+
+    /**
+     * Returns TRUE if the widget has the "Open output file after running" option checked.
+     */
+    bool openAfterRunning() const;
+
   signals:
 
     /**
@@ -106,6 +116,7 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
     bool mDefaultSelection = false;
     QString mEncoding;
     QgsBrowserGuiModel *mBrowserModel = nullptr;
+    QCheckBox *mOpenAfterRunningCheck = nullptr;
 
     friend class TestProcessingGui;
 };

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -23,7 +23,7 @@
 #include "qgsexpressioncontext.h"
 #include "models/qgsprocessingmodelalgorithm.h"
 #include "qgsexpressioncontextutils.h"
-
+#include "qgsprocessingwidgetwrapperimpl.h"
 #include <QLabel>
 #include <QHBoxLayout>
 
@@ -151,7 +151,11 @@ QWidget *QgsAbstractProcessingParameterWidgetWrapper::createWrappedWidget( QgsPr
     wrappedWidget->setLayout( hLayout );
   }
 
-  setWidgetValue( mParameterDefinition->defaultValue(), context );
+  if ( !dynamic_cast<const QgsProcessingDestinationParameter * >( mParameterDefinition ) )
+  {
+    // an exception -- output widgets handle this themselves
+    setWidgetValue( mParameterDefinition->defaultValue(), context );
+  }
 
   return wrappedWidget;
 }
@@ -201,6 +205,11 @@ QVariant QgsAbstractProcessingParameterWidgetWrapper::parameterValue() const
     return mPropertyButton->toProperty();
   else
     return widgetValue();
+}
+
+QVariantMap QgsAbstractProcessingParameterWidgetWrapper::customProperties() const
+{
+  return QVariantMap();
 }
 
 void QgsAbstractProcessingParameterWidgetWrapper::registerProcessingContextGenerator( QgsProcessingContextGenerator *generator )

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -345,6 +345,11 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
     QVariant parameterValue() const;
 
     /**
+     * Returns any custom properties set by the wrapper.
+     */
+    virtual QVariantMap customProperties() const;
+
+    /**
      * Registers a Processing context \a generator class that will be used to retrieve
      * a Processing context for the wrapper when required.
      */

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -5891,6 +5891,7 @@ QWidget *QgsProcessingOutputWidgetWrapper::createWidget()
   switch ( type() )
   {
     case QgsProcessingGui::Standard:
+    case QgsProcessingGui::Modeler:
     {
       mOutputWidget = new QgsProcessingLayerOutputDestinationWidget( destParam, false );
       mOutputWidget->setToolTip( parameterDefinition()->toolTip() );
@@ -5903,16 +5904,15 @@ QWidget *QgsProcessingOutputWidgetWrapper::createWidget()
         emit widgetValueHasChanged( this );
       } );
 
-      if ( destParam->type() == QgsProcessingParameterRasterDestination::typeName() ||
-           destParam->type() == QgsProcessingParameterFeatureSink::typeName() ||
-           destParam->type() == QgsProcessingParameterVectorDestination::typeName() )
+      if ( type() == QgsProcessingGui::Standard
+           && ( destParam->type() == QgsProcessingParameterRasterDestination::typeName() ||
+                destParam->type() == QgsProcessingParameterFeatureSink::typeName() ||
+                destParam->type() == QgsProcessingParameterVectorDestination::typeName() ) )
         mOutputWidget->addOpenAfterRunningOption();
 
       return mOutputWidget;
     }
     case QgsProcessingGui::Batch:
-      break;
-    case QgsProcessingGui::Modeler:
       break;
   }
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -63,6 +63,7 @@ class QgsProcessingEnumModelerWidget;
 class QgsProcessingMatrixModelerWidget;
 class QgsProcessingMapLayerComboBox;
 class QgsRasterBandComboBox;
+class QgsProcessingLayerOutputDestinationWidget;
 
 ///@cond PRIVATE
 
@@ -1782,6 +1783,126 @@ class GUI_EXPORT QgsProcessingMultipleLayerWidgetWrapper : public QgsAbstractPro
     friend class TestProcessingGui;
 };
 
+
+class GUI_EXPORT QgsProcessingOutputWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingOutputWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                      QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+    QVariantMap customProperties() const override;
+
+    QStringList compatibleParameterTypes() const override;
+
+    QStringList compatibleOutputTypes() const override;
+
+  private:
+
+    QgsProcessingLayerOutputDestinationWidget *mOutputWidget = nullptr;
+    int mBlockSignals = 0;
+
+    friend class TestProcessingGui;
+};
+
+
+class GUI_EXPORT QgsProcessingFeatureSinkWidgetWrapper : public QgsProcessingOutputWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingFeatureSinkWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                           QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+  protected:
+    QString modelerExpressionFormatString() const override;
+
+};
+
+class GUI_EXPORT QgsProcessingVectorDestinationWidgetWrapper : public QgsProcessingOutputWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingVectorDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+        QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+  protected:
+    QString modelerExpressionFormatString() const override;
+
+};
+
+class GUI_EXPORT QgsProcessingRasterDestinationWidgetWrapper : public QgsProcessingOutputWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingRasterDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+        QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+  protected:
+    QString modelerExpressionFormatString() const override;
+
+};
+
+class GUI_EXPORT QgsProcessingFileDestinationWidgetWrapper : public QgsProcessingOutputWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingFileDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+        QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+  protected:
+    QString modelerExpressionFormatString() const override;
+
+};
+
+class GUI_EXPORT QgsProcessingFolderDestinationWidgetWrapper : public QgsProcessingOutputWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingFolderDestinationWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+        QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+  protected:
+    QString modelerExpressionFormatString() const override;
+
+};
 
 ///@endcond PRIVATE
 

--- a/src/ui/processing/qgsprocessingdestinationwidgetbase.ui
+++ b/src/ui/processing/qgsprocessingdestinationwidgetbase.ui
@@ -13,10 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -29,7 +26,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
+   <item row="0" column="0">
     <widget class="QgsHighlightableLineEdit" name="leText">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -39,7 +36,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="0" column="1">
     <widget class="QToolButton" name="mSelectButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9216,6 +9216,23 @@ void TestQgsProcessing::modelExecution()
   QCOMPARE( outDef.sink.staticValue().toString(), QStringLiteral( "memory:" ) );
   QCOMPARE( params.count(), 3 ); // don't want FAIL_OUTPUT set!
 
+  // a child with an static output value
+  QgsProcessingModelChildAlgorithm alg2c4;
+  alg2c4.setChildId( "cx4" );
+  alg2c4.setAlgorithmId( "native:extractbyexpression" );
+  alg2c4.addParameterSources( "OUTPUT", QgsProcessingModelChildParameterSources() << QgsProcessingModelChildParameterSource::fromStaticValue( "STATIC" ) );
+  model2.addChildAlgorithm( alg2c4 );
+  params = model2.parametersForChildAlgorithm( model2.childAlgorithm( "cx4" ), modelInputs, childResults, expContext );
+  QCOMPARE( params.value( "OUTPUT" ).toString(), QStringLiteral( "STATIC" ) );
+  model2.removeChildAlgorithm( "cx4" );
+  // expression based output value
+  alg2c4.addParameterSources( "OUTPUT", QgsProcessingModelChildParameterSources() << QgsProcessingModelChildParameterSource::fromExpression( "'A' || 'B'" ) );
+  model2.addChildAlgorithm( alg2c4 );
+  params = model2.parametersForChildAlgorithm( model2.childAlgorithm( "cx4" ), modelInputs, childResults, expContext );
+  QCOMPARE( params.value( "OUTPUT" ).toString(), QStringLiteral( "AB" ) );
+  model2.removeChildAlgorithm( "cx4" );
+
+
   variables = model2.variablesForChildAlgorithm( "cx3", context );
   QCOMPARE( variables.count(), 16 );
   QCOMPARE( variables.value( "DIST" ).source.source(), QgsProcessingModelChildParameterSource::ModelParameter );


### PR DESCRIPTION
(includes https://github.com/qgis/QGIS/pull/35472)

Ports the output parameter wrappers (sinks, vector, raster, file and folder destinations) to the new c++ API for dialog and modeler. 

This allows a range of new possibilities, including:
- models with static outputs for child algorithms, e.g. always saving a child algorithm's output to a geopackage or postgres layer
- models with expression based output values for child algorithms, e.g. generating an automatic file name based on today's date and saving outputs to that file

![Peek 2020-03-31 22-55](https://user-images.githubusercontent.com/1829991/78028688-bbbf6400-73a2-11ea-9b7f-a7d81133d321.gif)


Refs NRCan Contract#3000707093