### PR TITLE
Install jinja and pygments python3 modules in qgis docker

### DIFF
--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -1,7 +1,7 @@
 
 # see https://docs.docker.com/docker-cloud/builds/advanced/
 # using ARG in FROM requires min v17.05.0-ce
-ARG DOCKER_TAG=latest
+ARG DOCKER_TAG=release-3_10
 
 FROM  qgis/qgis3-build-deps:${DOCKER_TAG} AS BUILDER
 MAINTAINER Denis Rouzaud <denis@opengis.ch>

--- a/.docker/qgis.dockerfile
+++ b/.docker/qgis.dockerfile
@@ -82,3 +82,7 @@ WORKDIR /
 
 # Run supervisor
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+
+# Install python modules required to load automatically loaded
+# python plugins
+RUN pip3 install jinja2 pygments


### PR DESCRIPTION
They are needed for default-enabled MetaSearch plugin.
Fixes #35480