### PR TITLE
Uncheck save in project cb when pg < 9.5

### DIFF
--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -211,6 +211,7 @@ void QgsPgNewConnection::testConnection()
     if ( conn->pgVersion() < 90500 )
     {
       cb_projectsInDatabase->setEnabled( false );
+      cb_projectsInDatabase->setChecked( false );
       cb_projectsInDatabase->setToolTip( tr( "Saving projects in databases not available for PostgreSQL databases earlier than 9.5" ) );
     }
     else


### PR DESCRIPTION
Actually a continuation from PR #30977 that properly fixes #28966 and fixes #35485 by unchecking the checkbox in the UI, not just disabling it
