### PR TITLE
Allow creation of group boxes in models 

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsProcessingModelAlgorithm : QgsProcessingAlgorithm
 {
 %Docstring

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsProcessingModelAlgorithm : QgsProcessingAlgorithm
 {
 %Docstring
@@ -281,6 +282,37 @@ this name a new component will be added to the model and returned.
 Updates the model's parameter definitions to include all relevant destination
 parameters as required by child algorithm ModelOutputs.
 Must be called whenever child algorithm ModelOutputs are altered.
+%End
+
+    void addGroupBox( const QgsProcessingModelGroupBox &groupBox );
+%Docstring
+Adds a new group ``box`` to the model.
+
+If an existing group box with the same uuid already exists then its definition will be replaced.
+
+.. seealso:: :py:func:`groupBoxes`
+
+.. versionadded:: 3.14
+%End
+
+    QList< QgsProcessingModelGroupBox > groupBoxes() const;
+%Docstring
+Returns a list of the group boxes within the model.
+
+.. seealso:: :py:func:`addGroupBox`
+
+.. versionadded:: 3.14
+%End
+
+    void removeGroupBox( const QString &uuid );
+%Docstring
+Removes the group box with matching ``uuid`` from the model.
+
+.. seealso:: :py:func:`addGroupBox`
+
+.. seealso:: :py:func:`groupBoxes`
+
+.. versionadded:: 3.14
 %End
 
     bool toFile( const QString &path ) const;

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelcomponent.sip.in
@@ -72,6 +72,27 @@ Sets the ``size`` of the model component within the graphical modeler.
 .. versionadded:: 3.14
 %End
 
+    QColor color() const;
+%Docstring
+Returns the color of the model component within the graphical modeler.
+
+An invalid color indicates that the default color for the component should be used.
+
+.. seealso:: :py:func:`setColor`
+
+.. versionadded:: 3.14
+%End
+
+    void setColor( const QColor &color );
+%Docstring
+Sets the ``color`` of the model component within the graphical modeler. An invalid ``color``
+indicates that the default color for the component should be used.
+
+.. seealso:: :py:func:`color`
+
+.. versionadded:: 3.14
+%End
+
     bool linksCollapsed( Qt::Edge edge ) const;
 %Docstring
 Returns ``True`` if the link points for the specified ``edge`` should be shown collapsed or not.

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelgroupbox.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelgroupbox.sip.in
@@ -1,0 +1,62 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/processing/models/qgsprocessingmodelgroupbox.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsProcessingModelGroupBox : QgsProcessingModelComponent
+{
+%Docstring
+Represents a group box in a model.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingmodelgroupbox.h"
+%End
+  public:
+
+    QgsProcessingModelGroupBox( const QString &description = QString() );
+%Docstring
+Constructor for QgsProcessingModelGroupBox with the specified ``description``.
+%End
+
+    virtual QgsProcessingModelGroupBox *clone() const /Factory/;
+
+
+    QVariant toVariant() const;
+%Docstring
+Saves this group box to a QVariant.
+
+.. seealso:: :py:func:`loadVariant`
+%End
+
+    bool loadVariant( const QVariantMap &map );
+%Docstring
+Loads this group box from a QVariantMap.
+
+.. seealso:: :py:func:`toVariant`
+%End
+
+    QString uuid() const;
+%Docstring
+Returns the unique ID associated with this group box.
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/processing/models/qgsprocessingmodelgroupbox.h              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -428,6 +428,7 @@
 %Include auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip
 %Include auto_generated/processing/models/qgsprocessingmodelcomment.sip
 %Include auto_generated/processing/models/qgsprocessingmodelcomponent.sip
+%Include auto_generated/processing/models/qgsprocessingmodelgroupbox.sip
 %Include auto_generated/processing/models/qgsprocessingmodeloutput.sip
 %Include auto_generated/processing/models/qgsprocessingmodelparameter.sip
 %Include auto_generated/processing/qgsprocessing.sip

--- a/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelcomponentgraphicitem.sip.in
@@ -278,6 +278,11 @@ Returns the label text color for the item for the specified ``state``.
 Returns the stroke style to use while rendering the outline of the item.
 %End
 
+    virtual Qt::Alignment titleAlignment() const;
+%Docstring
+Returns the title alignment
+%End
+
     virtual QPicture iconPicture() const;
 %Docstring
 Returns a QPicture version of the item's icon, if available.
@@ -535,6 +540,64 @@ Ownership of ``output`` is transferred to the item.
     virtual void editComponent();
 
 };
+
+
+class QgsModelGroupBoxGraphicItem : QgsModelComponentGraphicItem
+{
+%Docstring
+A graphic item representing a group box in the model designer.
+
+.. warning::
+
+   Not stable API
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsmodelcomponentgraphicitem.h"
+%End
+  public:
+
+    QgsModelGroupBoxGraphicItem( QgsProcessingModelGroupBox *box /Transfer/,
+                                 QgsProcessingModelAlgorithm *model,
+                                 QGraphicsItem *parent /TransferThis/ );
+%Docstring
+Constructor for QgsModelGroupBoxGraphicItem for the specified group ``box``, with the specified ``parent`` item.
+
+The ``model`` argument specifies the associated processing model. Ownership of ``model`` is not transferred, and
+it must exist for the lifetime of this object.
+
+Ownership of ``output`` is transferred to the item.
+%End
+    ~QgsModelGroupBoxGraphicItem();
+    virtual void contextMenuEvent( QGraphicsSceneContextMenuEvent *event );
+
+    virtual bool canDeleteComponent();
+
+  protected:
+
+    virtual QColor fillColor( State state ) const;
+
+    virtual QColor strokeColor( State state ) const;
+
+    virtual QColor textColor( State state ) const;
+
+    virtual Qt::PenStyle strokeStyle( State state ) const;
+
+    virtual Qt::Alignment titleAlignment() const;
+
+    virtual void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size );
+
+
+  protected slots:
+
+    virtual void deleteComponent();
+
+    virtual void editComponent();
+
+};
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -29,6 +29,7 @@ QGraphicsScene subclass representing the model designer.
 
     enum ZValues
     {
+      GroupBox,
       ArrowLink,
       ModelComponent,
       MouseHandles,
@@ -173,6 +174,10 @@ Creates a new graphic item for a model output.
 Creates a new graphic item for a model comment.
 %End
 
+    QgsModelComponentGraphicItem *createGroupBoxGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelGroupBox *box ) const /Factory/;
+%Docstring
+Creates a new graphic item for a model group box.
+%End
 
 };
 

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -97,6 +97,11 @@ Returns list of selected component items.
 Returns the topmost component item at a specified ``position``.
 %End
 
+    QgsModelComponentGraphicItem *groupBoxItem( const QString &uuid );
+%Docstring
+Returns the graphic item corresponding to the specified group box ``uuid``.
+%End
+
     void selectAll();
 %Docstring
 Selects all the components in the scene.

--- a/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingparameterdefinitionwidget.sip.in
@@ -160,6 +160,24 @@ Returns the comments for the parameter.
 .. versionadded:: 3.14
 %End
 
+    void setCommentColor( const QColor &color );
+%Docstring
+Sets the color for the comments for the parameter.
+
+.. seealso:: :py:func:`commentColor`
+
+.. versionadded:: 3.14
+%End
+
+    QColor commentColor() const;
+%Docstring
+Returns the color for the comments for the parameter.
+
+.. seealso:: :py:func:`setCommentColor`
+
+.. versionadded:: 3.14
+%End
+
     void switchToCommentTab();
 %Docstring
 Switches the dialog to the comments tab.

--- a/python/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorbutton.sip.in
@@ -210,11 +210,12 @@ Sets the string to use for the "no color" option in the button's drop-down menu.
    dialog
 %End
 
-    void setShowNull( bool showNull );
+    void setShowNull( bool showNull, const QString &nullString = QString() );
 %Docstring
 Sets whether a set to null (clear) option is shown in the button's drop-down menu.
 
 :param showNull: set to ``True`` to show a null option
+:param nullString: translated string to use for the null option. If not set, a default "Clear Color" string will be used.
 
 .. seealso:: :py:func:`showNull`
 

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -205,7 +205,7 @@ class ModelerDialog(QgsModelDesignerDialog):
 
         showComments = QgsSettings().value("/Processing/Modeler/ShowComments", True, bool)
         if not showComments:
-            self.scene.setFlag(QgsModelGraphicsScene.FlagHideComments)
+            scene.setFlag(QgsModelGraphicsScene.FlagHideComments)
 
         context = createContext()
         scene.createItems(self.model(), context)

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -63,17 +63,20 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
     def edit(self, edit_comment=False):
         existing_param = self.model().parameterDefinition(self.component().parameterName())
         comment = self.component().comment().description()
+        comment_color = self.component().comment().color()
         new_param = None
         if ModelerParameterDefinitionDialog.use_legacy_dialog(param=existing_param):
             # boo, old api
             dlg = ModelerParameterDefinitionDialog(self.model(),
                                                    param=existing_param)
             dlg.setComments(comment)
+            dlg.setCommentColor(comment_color)
             if edit_comment:
                 dlg.switchToCommentTab()
             if dlg.exec_():
                 new_param = dlg.param
                 comment = dlg.comments()
+                comment_color = dlg.commentColor()
         else:
             # yay, use new API!
             context = createContext()
@@ -84,12 +87,14 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
                                                          definition=existing_param,
                                                          algorithm=self.model())
             dlg.setComments(comment)
+            dlg.setCommentColor(comment_color)
             if edit_comment:
                 dlg.switchToCommentTab()
 
             if dlg.exec_():
                 new_param = dlg.createParameter(existing_param.name())
                 comment = dlg.comments()
+                comment_color = dlg.commentColor()
 
         if new_param is not None:
             self.aboutToChange.emit(self.tr('Edit {}').format(new_param.description()))
@@ -97,6 +102,7 @@ class ModelerInputGraphicItem(QgsModelParameterGraphicItem):
             self.component().setParameterName(new_param.name())
             self.component().setDescription(new_param.name())
             self.component().comment().setDescription(comment)
+            self.component().comment().setColor(comment_color)
             self.model().addModelParameter(new_param, self.component())
             self.setLabel(new_param.description())
             self.requestModelRepaint.emit()
@@ -125,6 +131,7 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
         dlg = ModelerParametersDialog(elemAlg, self.model(), self.component().childId(),
                                       self.component().configuration())
         dlg.setComments(self.component().comment().description())
+        dlg.setCommentColor(self.component().comment().color())
         if edit_comment:
             dlg.switchToCommentTab()
         if dlg.exec_():
@@ -160,6 +167,7 @@ class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):
         dlg = ModelerParameterDefinitionDialog(self.model(),
                                                param=self.model().parameterDefinition(param_name))
         dlg.setComments(self.component().comment().description())
+        dlg.setCommentColor(self.component().comment().color())
         if edit_comment:
             dlg.switchToCommentTab()
 
@@ -169,6 +177,7 @@ class ModelerOutputGraphicItem(QgsModelOutputGraphicItem):
             model_output.setDefaultValue(dlg.param.defaultValue())
             model_output.setMandatory(not (dlg.param.flags() & QgsProcessingParameterDefinition.FlagOptional))
             model_output.comment().setDescription(dlg.comments())
+            model_output.comment().setColor(dlg.commentColor())
             self.aboutToChange.emit(self.tr('Edit {}').format(model_output.description()))
             self.model().updateDestinationParameters()
             self.requestModelRepaint.emit()

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -27,6 +27,7 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import (QDialog, QDialogButtonBox, QLabel, QLineEdit,
                                  QFrame, QPushButton, QSizePolicy, QVBoxLayout,
                                  QHBoxLayout, QWidget, QTabWidget, QTextEdit)
+from qgis.PyQt.QtGui import QColor
 
 from qgis.core import (Qgis,
                        QgsProject,
@@ -50,7 +51,8 @@ from qgis.gui import (QgsGui,
                       QgsProcessingModelerParameterWidget,
                       QgsProcessingParameterWidgetContext,
                       QgsPanelWidget,
-                      QgsPanelWidgetStack)
+                      QgsPanelWidgetStack,
+                      QgsColorButton)
 from qgis.utils import iface
 
 from processing.gui.wrappers import WidgetWrapperFactory
@@ -100,6 +102,12 @@ class ModelerParametersDialog(QDialog):
 
     def comments(self):
         return self.widget.comments()
+
+    def setCommentColor(self, color):
+        self.widget.setCommentColor(color)
+
+    def commentColor(self):
+        return self.widget.commentColor()
 
     def switchToCommentTab(self):
         self.widget.switchToCommentTab()
@@ -534,7 +542,18 @@ class ModelerParametersWidget(QWidget):
         self.commentLayout = QVBoxLayout()
         self.commentEdit = QTextEdit()
         self.commentEdit.setAcceptRichText(False)
-        self.commentLayout.addWidget(self.commentEdit)
+        self.commentLayout.addWidget(self.commentEdit, 1)
+
+        hl = QHBoxLayout()
+        hl.setContentsMargins(0, 0, 0, 0)
+        hl.addWidget(QLabel(self.tr('Color')))
+        self.comment_color_button = QgsColorButton()
+        self.comment_color_button.setAllowOpacity(True)
+        self.comment_color_button.setWindowTitle(self.tr('Comment Color'))
+        self.comment_color_button.setShowNull(True, self.tr('Default'))
+        hl.addWidget(self.comment_color_button)
+        self.commentLayout.addLayout(hl)
+
         w2 = QWidget()
         w2.setLayout(self.commentLayout)
         self.tab.addTab(w2, self.tr('Comments'))
@@ -546,6 +565,15 @@ class ModelerParametersWidget(QWidget):
 
     def comments(self):
         return self.commentEdit.toPlainText()
+
+    def setCommentColor(self, color):
+        if color.isValid():
+            self.comment_color_button.setColor(color)
+        else:
+            self.comment_color_button.setToNull()
+
+    def commentColor(self):
+        return self.comment_color_button.color() if not self.comment_color_button.isNull() else QColor()
 
     def getAvailableDependencies(self):
         return self.widget.getAvailableDependencies()
@@ -566,4 +594,5 @@ class ModelerParametersWidget(QWidget):
         alg = self.widget.createAlgorithm()
         if alg:
             alg.comment().setDescription(self.comments())
+            alg.comment().setColor(self.commentColor())
         return alg

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -155,6 +155,7 @@ SET(QGIS_CORE_SRCS
   processing/models/qgsprocessingmodelchildparametersource.cpp
   processing/models/qgsprocessingmodelcomment.cpp
   processing/models/qgsprocessingmodelcomponent.cpp
+  processing/models/qgsprocessingmodelgroupbox.cpp
   processing/models/qgsprocessingmodelparameter.cpp
   processing/models/qgsprocessingmodeloutput.cpp
 
@@ -1197,6 +1198,7 @@ SET(QGIS_CORE_HDRS
   processing/models/qgsprocessingmodelchildparametersource.h
   processing/models/qgsprocessingmodelcomment.h
   processing/models/qgsprocessingmodelcomponent.h
+  processing/models/qgsprocessingmodelgroupbox.h
   processing/models/qgsprocessingmodeloutput.h
   processing/models/qgsprocessingmodelparameter.h
   processing/qgsprocessing.h

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -25,6 +25,8 @@
 #include "qgsprocessingmodelparameter.h"
 #include "qgsprocessingmodelchildparametersource.h"
 
+class QgsProcessingModelGroupBox;
+
 ///@cond NOT_STABLE
 
 /**
@@ -242,6 +244,33 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     void updateDestinationParameters();
 
     /**
+     * Adds a new group \a box to the model.
+     *
+     * If an existing group box with the same uuid already exists then its definition will be replaced.
+     *
+     * \see groupBoxes()
+     * \since QGIS 3.14
+     */
+    void addGroupBox( const QgsProcessingModelGroupBox &groupBox );
+
+    /**
+     * Returns a list of the group boxes within the model.
+     *
+     * \see addGroupBox()
+     * \since QGIS 3.14
+     */
+    QList< QgsProcessingModelGroupBox > groupBoxes() const;
+
+    /**
+     * Removes the group box with matching \a uuid from the model.
+     *
+     * \see addGroupBox()
+     * \see groupBoxes()
+     * \since QGIS 3.14
+     */
+    void removeGroupBox( const QString &uuid );
+
+    /**
      * Writes the model to a file, at the specified \a path.
      * \see fromFile()
      */
@@ -451,6 +480,8 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QVariantMap mVariables;
 
     QVariantMap mDesignerParameterValues;
+
+    QMap< QString, QgsProcessingModelGroupBox > mGroupBoxes;
 
     void dependsOnChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;
     void dependentChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -24,8 +24,7 @@
 #include "qgsprocessingalgorithm.h"
 #include "qgsprocessingmodelparameter.h"
 #include "qgsprocessingmodelchildparametersource.h"
-
-class QgsProcessingModelGroupBox;
+#include "qgsprocessingmodelgroupbox.h"
 
 ///@cond NOT_STABLE
 

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -68,7 +68,10 @@ void QgsProcessingModelChildAlgorithm::copyNonDefinitionPropertiesFromModel( Qgs
   for ( auto it = mModelOutputs.begin(); it != mModelOutputs.end(); ++it )
   {
     if ( !existingChild.modelOutputs().value( it.key() ).position().isNull() )
+    {
       it.value().setPosition( existingChild.modelOutputs().value( it.key() ).position() );
+      it.value().setSize( existingChild.modelOutputs().value( it.key() ).size() );
+    }
     else
       it.value().setPosition( position() + QPointF( size().width(), ( i + 1.5 ) * size().height() ) );
 
@@ -79,6 +82,7 @@ void QgsProcessingModelChildAlgorithm::copyNonDefinitionPropertiesFromModel( Qgs
         comment->setDescription( existingComment->description() );
         comment->setSize( existingComment->size() );
         comment->setPosition( existingComment->position() );
+        comment->setColor( existingComment->color() );
       }
     }
     i++;

--- a/src/core/processing/models/qgsprocessingmodelcomponent.cpp
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsprocessingmodelcomponent.h"
 #include "qgsprocessingmodelcomment.h"
+#include "qgssymbollayerutils.h"
 
 ///@cond NOT_STABLE
 
@@ -52,6 +53,16 @@ QSizeF QgsProcessingModelComponent::size() const
 void QgsProcessingModelComponent::setSize( QSizeF size )
 {
   mSize = size;
+}
+
+QColor QgsProcessingModelComponent::color() const
+{
+  return mColor;
+}
+
+void QgsProcessingModelComponent::setColor( const QColor &color )
+{
+  mColor = color;
 }
 
 bool QgsProcessingModelComponent::linksCollapsed( Qt::Edge edge ) const
@@ -103,6 +114,7 @@ void QgsProcessingModelComponent::saveCommonProperties( QVariantMap &map ) const
   map.insert( QStringLiteral( "component_height" ), mSize.height() );
   map.insert( QStringLiteral( "parameters_collapsed" ), mTopEdgeLinksCollapsed );
   map.insert( QStringLiteral( "outputs_collapsed" ), mBottomEdgeLinksCollapsed );
+  map.insert( QStringLiteral( "color" ), mColor.isValid() ? QgsSymbolLayerUtils::encodeColor( mColor ) : QString() );
   if ( comment() )
     map.insert( QStringLiteral( "comment" ), comment()->toVariant() );
 }
@@ -116,6 +128,7 @@ void QgsProcessingModelComponent::restoreCommonProperties( const QVariantMap &ma
   mDescription = map.value( QStringLiteral( "component_description" ) ).toString();
   mSize.setWidth( map.value( QStringLiteral( "component_width" ), QString::number( DEFAULT_COMPONENT_WIDTH ) ).toDouble() );
   mSize.setHeight( map.value( QStringLiteral( "component_height" ), QString::number( DEFAULT_COMPONENT_HEIGHT ) ).toDouble() );
+  mColor = map.value( QStringLiteral( "color" ) ).toString().isEmpty() ? QColor() : QgsSymbolLayerUtils::decodeColor( map.value( QStringLiteral( "color" ) ).toString() );
   mTopEdgeLinksCollapsed = map.value( QStringLiteral( "parameters_collapsed" ) ).toBool();
   mBottomEdgeLinksCollapsed = map.value( QStringLiteral( "outputs_collapsed" ) ).toBool();
   if ( comment() )

--- a/src/core/processing/models/qgsprocessingmodelcomponent.h
+++ b/src/core/processing/models/qgsprocessingmodelcomponent.h
@@ -22,6 +22,7 @@
 #include "qgis.h"
 #include <QPointF>
 #include <QSizeF>
+#include <QColor>
 
 class QgsProcessingModelComment;
 
@@ -75,6 +76,25 @@ class CORE_EXPORT QgsProcessingModelComponent
      * \since QGIS 3.14
      */
     void setSize( QSizeF size );
+
+    /**
+     * Returns the color of the model component within the graphical modeler.
+     *
+     * An invalid color indicates that the default color for the component should be used.
+     *
+     * \see setColor()
+     * \since QGIS 3.14
+     */
+    QColor color() const;
+
+    /**
+     * Sets the \a color of the model component within the graphical modeler. An invalid \a color
+     * indicates that the default color for the component should be used.
+     *
+     * \see color()
+     * \since QGIS 3.14
+     */
+    void setColor( const QColor &color );
 
     /**
      * Returns TRUE if the link points for the specified \a edge should be shown collapsed or not.
@@ -158,6 +178,7 @@ class CORE_EXPORT QgsProcessingModelComponent
     QString mDescription;
 
     QSizeF mSize = QSizeF( DEFAULT_COMPONENT_WIDTH, DEFAULT_COMPONENT_HEIGHT );
+    QColor mColor;
 
     bool mTopEdgeLinksCollapsed = true;
     bool mBottomEdgeLinksCollapsed = true;

--- a/src/core/processing/models/qgsprocessingmodelgroupbox.cpp
+++ b/src/core/processing/models/qgsprocessingmodelgroupbox.cpp
@@ -23,7 +23,7 @@ QgsProcessingModelGroupBox::QgsProcessingModelGroupBox( const QString &descripti
   : QgsProcessingModelComponent( description )
   , mUuid( QUuid::createUuid().toString() )
 {
-  setSize( QSizeF( 100, 60 ) );
+  setSize( QSizeF( 400, 360 ) );
 }
 
 QgsProcessingModelGroupBox *QgsProcessingModelGroupBox::clone() const

--- a/src/core/processing/models/qgsprocessingmodelgroupbox.cpp
+++ b/src/core/processing/models/qgsprocessingmodelgroupbox.cpp
@@ -21,6 +21,7 @@
 
 QgsProcessingModelGroupBox::QgsProcessingModelGroupBox( const QString &description )
   : QgsProcessingModelComponent( description )
+  , mUuid( QUuid::createUuid().toString() )
 {
   setSize( QSizeF( 100, 60 ) );
 }
@@ -33,6 +34,7 @@ QgsProcessingModelGroupBox *QgsProcessingModelGroupBox::clone() const
 QVariant QgsProcessingModelGroupBox::toVariant() const
 {
   QVariantMap map;
+  map.insert( QStringLiteral( "uuid" ), mUuid );
   saveCommonProperties( map );
   return map;
 }
@@ -40,7 +42,13 @@ QVariant QgsProcessingModelGroupBox::toVariant() const
 bool QgsProcessingModelGroupBox::loadVariant( const QVariantMap &map )
 {
   restoreCommonProperties( map );
+  mUuid = map.value( QStringLiteral( "uuid" ) ).toString();
   return true;
+}
+
+QString QgsProcessingModelGroupBox::uuid() const
+{
+  return mUuid;
 }
 
 

--- a/src/core/processing/models/qgsprocessingmodelgroupbox.cpp
+++ b/src/core/processing/models/qgsprocessingmodelgroupbox.cpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+                         qgsprocessingmodelgroupbox.cpp
+                         --------------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingmodelgroupbox.h"
+
+///@cond NOT_STABLE
+
+QgsProcessingModelGroupBox::QgsProcessingModelGroupBox( const QString &description )
+  : QgsProcessingModelComponent( description )
+{
+  setSize( QSizeF( 100, 60 ) );
+}
+
+QgsProcessingModelGroupBox *QgsProcessingModelGroupBox::clone() const
+{
+  return new QgsProcessingModelGroupBox( *this );
+}
+
+QVariant QgsProcessingModelGroupBox::toVariant() const
+{
+  QVariantMap map;
+  saveCommonProperties( map );
+  return map;
+}
+
+bool QgsProcessingModelGroupBox::loadVariant( const QVariantMap &map )
+{
+  restoreCommonProperties( map );
+  return true;
+}
+
+
+///@endcond

--- a/src/core/processing/models/qgsprocessingmodelgroupbox.h
+++ b/src/core/processing/models/qgsprocessingmodelgroupbox.h
@@ -52,6 +52,15 @@ class CORE_EXPORT QgsProcessingModelGroupBox : public QgsProcessingModelComponen
      * \see toVariant()
      */
     bool loadVariant( const QVariantMap &map );
+
+    /**
+     * Returns the unique ID associated with this group box.
+     */
+    QString uuid() const;
+
+  private:
+
+    QString mUuid;
 };
 
 ///@endcond

--- a/src/core/processing/models/qgsprocessingmodelgroupbox.h
+++ b/src/core/processing/models/qgsprocessingmodelgroupbox.h
@@ -1,0 +1,59 @@
+/***************************************************************************
+                         qgsprocessingmodelgroupbox.h
+                         --------------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGMODELGROUPBOX_H
+#define QGSPROCESSINGMODELGROUPBOX_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsprocessingmodelcomponent.h"
+#include "qgsprocessingparameters.h"
+
+///@cond NOT_STABLE
+
+/**
+ * Represents a group box in a model.
+ * \ingroup core
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsProcessingModelGroupBox : public QgsProcessingModelComponent
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingModelGroupBox with the specified \a description.
+     */
+    QgsProcessingModelGroupBox( const QString &description = QString() );
+
+    QgsProcessingModelGroupBox *clone() const override SIP_FACTORY;
+
+    /**
+     * Saves this group box to a QVariant.
+     * \see loadVariant()
+     */
+    QVariant toVariant() const;
+
+    /**
+     * Loads this group box from a QVariantMap.
+     * \see toVariant()
+     */
+    bool loadVariant( const QVariantMap &map );
+};
+
+///@endcond
+
+#endif // QGSPROCESSINGMODELGROUPBOX_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -291,6 +291,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelgraphicitem.cpp
   processing/models/qgsmodelgraphicsscene.cpp
   processing/models/qgsmodelgraphicsview.cpp
+  processing/models/qgsmodelgroupboxdefinitionwidget.cpp
   processing/models/qgsmodelsnapper.cpp
   processing/models/qgsmodelundocommand.cpp
   processing/models/qgsmodelviewmouseevent.cpp
@@ -984,6 +985,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelgraphicitem.h
   processing/models/qgsmodelgraphicsscene.h
   processing/models/qgsmodelgraphicsview.h
+  processing/models/qgsmodelgroupboxdefinitionwidget.h
   processing/models/qgsmodelsnapper.h
   processing/models/qgsmodelundocommand.h
   processing/models/qgsmodelviewmouseevent.h

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -318,8 +318,33 @@ bool QgsModelComponentGraphicItem::contains( const QPointF &point ) const
 void QgsModelComponentGraphicItem::paint( QPainter *painter, const QStyleOptionGraphicsItem *, QWidget * )
 {
   const QRectF rect = itemRect();
-  QColor color = fillColor( state() );
-  QColor stroke = strokeColor( state() );
+  QColor color;
+  QColor stroke;
+  QColor foreColor;
+  if ( mComponent->color().isValid() )
+  {
+    color = mComponent->color();
+    switch ( state() )
+    {
+      case Selected:
+        color = color.darker( 110 );
+        break;
+      case Hover:
+        color = color.darker( 105 );
+        break;
+
+      case Normal:
+        break;
+    }
+    stroke = color.darker( 110 );
+    foreColor = color.lightness() > 150 ? QColor( 0, 0, 0 ) : QColor( 255, 255, 255 );
+  }
+  else
+  {
+    color = fillColor( state() );
+    stroke = strokeColor( state() );
+    foreColor = textColor( state() );
+  }
 
   QPen strokePen = QPen( stroke, 0 ) ; // 0 width "cosmetic" pen
   strokePen.setStyle( strokeStyle( state() ) );
@@ -327,7 +352,7 @@ void QgsModelComponentGraphicItem::paint( QPainter *painter, const QStyleOptionG
   painter->setBrush( QBrush( color, Qt::SolidPattern ) );
   painter->drawRect( rect );
   painter->setFont( font() );
-  painter->setPen( QPen( textColor( state() ) ) );
+  painter->setPen( QPen( foreColor ) );
 
   QString text;
 

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -33,6 +33,7 @@ class QgsModelDesignerFlatButtonGraphicItem;
 class QgsModelDesignerFoldButtonGraphicItem;
 class QgsModelGraphicsView;
 class QgsModelViewMouseEvent;
+class QgsProcessingModelGroupBox;
 
 ///@cond NOT_STABLE
 
@@ -324,6 +325,11 @@ class GUI_EXPORT QgsModelComponentGraphicItem : public QGraphicsObject
     virtual Qt::PenStyle strokeStyle( State state ) const;
 
     /**
+     * Returns the title alignment
+     */
+    virtual Qt::Alignment titleAlignment() const;
+
+    /**
      * Returns a QPicture version of the item's icon, if available.
      */
     virtual QPicture iconPicture() const;
@@ -583,6 +589,52 @@ class GUI_EXPORT QgsModelCommentGraphicItem : public QgsModelComponentGraphicIte
 
 
 };
+
+
+/**
+ * \ingroup gui
+ * \brief A graphic item representing a group box in the model designer.
+ * \warning Not stable API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelGroupBoxGraphicItem : public QgsModelComponentGraphicItem
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelGroupBoxGraphicItem for the specified group \a box, with the specified \a parent item.
+     *
+     * The \a model argument specifies the associated processing model. Ownership of \a model is not transferred, and
+     * it must exist for the lifetime of this object.
+     *
+     * Ownership of \a output is transferred to the item.
+     */
+    QgsModelGroupBoxGraphicItem( QgsProcessingModelGroupBox *box SIP_TRANSFER,
+                                 QgsProcessingModelAlgorithm *model,
+                                 QGraphicsItem *parent SIP_TRANSFERTHIS );
+    ~QgsModelGroupBoxGraphicItem() override;
+    void contextMenuEvent( QGraphicsSceneContextMenuEvent *event ) override;
+    bool canDeleteComponent() override;
+  protected:
+
+    QColor fillColor( State state ) const override;
+    QColor strokeColor( State state ) const override;
+    QColor textColor( State state ) const override;
+    Qt::PenStyle strokeStyle( State state ) const override;
+    Qt::Alignment titleAlignment() const override;
+    void updateStoredComponentPosition( const QPointF &pos, const QSizeF &size ) override;
+
+  protected slots:
+
+    void deleteComponent() override;
+    void editComponent() override;
+  private:
+
+
+};
+
 ///@endcond
 
 #endif // QGSMODELCOMPONENTGRAPHICITEM_H

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -162,6 +162,9 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   mToolbar->insertAction( mActionZoomIn, mRedoAction );
   mToolbar->insertSeparator( mActionZoomIn );
 
+  mGroupMenu = new QMenu( tr( "Zoom To" ), this );
+  mMenuView->insertMenu( mActionZoomIn, mGroupMenu );
+  connect( mGroupMenu, &QMenu::aboutToShow, this, &QgsModelDesignerDialog::populateZoomToMenu );
 
   QgsProcessingToolboxProxyModel::Filters filters = QgsProcessingToolboxProxyModel::FilterModeler;
   if ( settings.value( QStringLiteral( "Processing/Configuration/SHOW_ALGORITHMS_KNOWN_ISSUES" ), false ).toBool() )
@@ -705,6 +708,23 @@ void QgsModelDesignerDialog::deleteSelected()
 
   mBlockRepaints = false;
   repaintModel();
+}
+
+void QgsModelDesignerDialog::populateZoomToMenu()
+{
+  mGroupMenu->clear();
+  for ( const QgsProcessingModelGroupBox &box : model()->groupBoxes() )
+  {
+    if ( QgsModelComponentGraphicItem *item = mScene->groupBoxItem( box.uuid() ) )
+    {
+      QAction *zoomAction = new QAction( box.description(), mGroupMenu );
+      connect( zoomAction, &QAction::triggered, this, [ = ]
+      {
+        mView->centerOn( item );
+      } );
+      mGroupMenu->addAction( zoomAction );
+    }
+  }
 }
 
 bool QgsModelDesignerDialog::isDirty() const

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -270,7 +270,18 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
     mIgnoreUndoStackChanges--;
   } );
 
+  connect( mActionAddGroupBox, &QAction::triggered, this, [ = ]
+  {
+    const QPointF viewCenter = mView->mapToScene( mView->viewport()->rect().center() );
+    QgsProcessingModelGroupBox group;
+    group.setPosition( viewCenter );
+    group.setDescription( tr( "New Group" ) );
 
+    beginUndoCommand( tr( "Add Group Box" ) );
+    model()->addGroupBox( group );
+    repaintModel();
+    endUndoCommand();
+  } );
   updateWindowTitle();
 }
 
@@ -632,6 +643,10 @@ void QgsModelDesignerDialog::deleteSelected()
     if ( dynamic_cast< QgsModelCommentGraphicItem *>( p1 ) )
       return true;
     else if ( dynamic_cast< QgsModelCommentGraphicItem *>( p2 ) )
+      return false;
+    else if ( dynamic_cast< QgsModelGroupBoxGraphicItem *>( p1 ) )
+      return true;
+    else if ( dynamic_cast< QgsModelGroupBoxGraphicItem *>( p2 ) )
       return false;
     else if ( dynamic_cast< QgsModelOutputGraphicItem *>( p1 ) )
       return true;

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -27,6 +27,7 @@
 #include "qgsmodelviewtoolselect.h"
 #include "qgsmodelgraphicsscene.h"
 #include "qgsmodelcomponentgraphicitem.h"
+#include "processing/models/qgsprocessingmodelgroupbox.h"
 
 #include <QShortcut>
 #include <QDesktopWidget>

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -142,6 +142,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void toggleComments( bool show );
     void updateWindowTitle();
     void deleteSelected();
+    void populateZoomToMenu();
 
   private:
 
@@ -166,6 +167,8 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     QAction *mRedoAction = nullptr;
     QUndoView *mUndoView = nullptr;
     QgsDockWidget *mUndoDock = nullptr;
+
+    QMenu *mGroupMenu = nullptr;
 
     int mBlockUndoCommands = 0;
     int mIgnoreUndoStackChanges = 0;

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -165,8 +165,6 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
       connect( item, &QgsModelComponentGraphicItem::aboutToChange, this, &QgsModelGraphicsScene::componentAboutToChange );
 
-      addCommentItemForComponent( model, outputIt.value(), item );
-
       QPointF pos = outputIt.value().position();
       int idx = -1;
       int i = 0;
@@ -188,6 +186,8 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
       item->setPos( pos );
       outputItems.insert( outputIt.key(), item );
       addItem( new QgsModelArrowItem( mChildAlgorithmItems[it.value().childId()], Qt::BottomEdge, idx, item ) );
+
+      addCommentItemForComponent( model, outputIt.value(), item );
     }
     mOutputItems.insert( it.value().childId(), outputItems );
   }

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -73,12 +73,13 @@ void QgsModelGraphicsScene::createItems( QgsProcessingModelAlgorithm *model, Qgs
 {
   // model group boxes
   const QList<QgsProcessingModelGroupBox> boxes = model->groupBoxes();
+  mGroupBoxItems.clear();
   for ( const QgsProcessingModelGroupBox &box : boxes )
   {
-    // TODO z order!
     QgsModelComponentGraphicItem *item = createGroupBoxGraphicItem( model, box.clone() );
     addItem( item );
     item->setPos( box.position().x(), box.position().y() );
+    mGroupBoxItems.insert( box.uuid(), item );
     connect( item, &QgsModelComponentGraphicItem::requestModelRepaint, this, &QgsModelGraphicsScene::rebuildRequired );
     connect( item, &QgsModelComponentGraphicItem::changed, this, &QgsModelGraphicsScene::componentChanged );
     connect( item, &QgsModelComponentGraphicItem::aboutToChange, this, &QgsModelGraphicsScene::componentAboutToChange );
@@ -241,6 +242,11 @@ QgsModelComponentGraphicItem *QgsModelGraphicsScene::componentItemAt( QPointF po
     }
   }
   return nullptr;
+}
+
+QgsModelComponentGraphicItem *QgsModelGraphicsScene::groupBoxItem( const QString &uuid )
+{
+  return mGroupBoxItems.value( uuid );
 }
 
 void QgsModelGraphicsScene::selectAll()

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -29,6 +29,7 @@ class QgsProcessingModelOutput;
 class QgsProcessingModelComponent;
 class QgsProcessingModelComment;
 class QgsModelChildAlgorithmGraphicItem;
+class QgsProcessingModelGroupBox;
 
 ///@cond NOT_STABLE
 
@@ -47,8 +48,9 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     //! Z values for scene items
     enum ZValues
     {
-      ArrowLink = 0, //!< An arrow linking model items
-      ModelComponent = 1, //!< Model components (e.g. algorithms, inputs and outputs)
+      GroupBox = 0, //!< A logical group box
+      ArrowLink = 1, //!< An arrow linking model items
+      ModelComponent = 2, //!< Model components (e.g. algorithms, inputs and outputs)
       MouseHandles = 99, //!< Mouse handles
       RubberBand = 100, //!< Rubber band item
       ZSnapIndicator = 101, //!< Z-value for snapping indicator
@@ -184,6 +186,10 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     virtual QgsModelComponentGraphicItem *createCommentGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelComment *comment,
         QgsModelComponentGraphicItem *parentItem ) const SIP_FACTORY;
 
+    /**
+     * Creates a new graphic item for a model group box.
+     */
+    QgsModelComponentGraphicItem *createGroupBoxGraphicItem( QgsProcessingModelAlgorithm *model, QgsProcessingModelGroupBox *box ) const SIP_FACTORY;
 
   private:
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -110,6 +110,11 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     QgsModelComponentGraphicItem *componentItemAt( QPointF position ) const;
 
     /**
+     * Returns the graphic item corresponding to the specified group box \a uuid.
+     */
+    QgsModelComponentGraphicItem *groupBoxItem( const QString &uuid );
+
+    /**
      * Selects all the components in the scene.
      */
     void selectAll();
@@ -208,6 +213,7 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     QMap< QString, QgsModelComponentGraphicItem * > mParameterItems;
     QMap< QString, QgsModelChildAlgorithmGraphicItem * > mChildAlgorithmItems;
     QMap< QString, QMap< QString, QgsModelComponentGraphicItem * > > mOutputItems;
+    QMap< QString, QgsModelComponentGraphicItem * > mGroupBoxItems;
     QVariantMap mChildResults;
     QVariantMap mChildInputs;
 

--- a/src/gui/processing/models/qgsmodelgroupboxdefinitionwidget.cpp
+++ b/src/gui/processing/models/qgsmodelgroupboxdefinitionwidget.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+                         qgsmodelgroupboxdefinitionwidget.cpp
+                         ------------------------------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgsmodelgroupboxdefinitionwidget.h"
+
+#include "qgscolorbutton.h"
+#include "qgsgui.h"
+#include <QVBoxLayout>
+#include <QTextEdit>
+#include <QDialogButtonBox>
+#include <QLabel>
+
+QgsModelGroupBoxDefinitionDialog::QgsModelGroupBoxDefinitionDialog( const QgsProcessingModelGroupBox &box,
+    QWidget *parent )
+  : QDialog( parent )
+  , mBox( box )
+{
+  QVBoxLayout *commentLayout = new QVBoxLayout();
+  commentLayout->addWidget( new QLabel( tr( "Title" ) ) );
+  mCommentEdit = new QTextEdit();
+  mCommentEdit->setAcceptRichText( false );
+  mCommentEdit->setText( box.description() );
+  commentLayout->addWidget( mCommentEdit, 1 );
+
+  QHBoxLayout *hl = new QHBoxLayout();
+  hl->setContentsMargins( 0, 0, 0, 0 );
+  hl->addWidget( new QLabel( tr( "Color" ) ) );
+  mCommentColorButton = new QgsColorButton();
+  mCommentColorButton->setAllowOpacity( true );
+  mCommentColorButton->setWindowTitle( tr( "Comment Color" ) );
+  mCommentColorButton->setShowNull( true, tr( "Default" ) );
+
+  if ( box.color().isValid() )
+    mCommentColorButton->setColor( box.color() );
+  else
+    mCommentColorButton->setToNull();
+
+  hl->addWidget( mCommentColorButton );
+  commentLayout->addLayout( hl );
+
+  QDialogButtonBox *bbox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok );
+  connect( bbox, &QDialogButtonBox::accepted, this, &QgsModelGroupBoxDefinitionDialog::accept );
+  connect( bbox, &QDialogButtonBox::rejected, this, &QgsModelGroupBoxDefinitionDialog::reject );
+
+  commentLayout->addWidget( bbox );
+  setLayout( commentLayout );
+  setWindowTitle( tr( "Group Box Properties" ) );
+  setObjectName( QStringLiteral( "QgsModelGroupBoxDefinitionWidget" ) );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mCommentEdit->setFocus();
+  mCommentEdit->selectAll();
+}
+
+QgsProcessingModelGroupBox QgsModelGroupBoxDefinitionDialog::groupBox() const
+{
+  QgsProcessingModelGroupBox box = mBox;
+  box.setColor( mCommentColorButton->isNull() ? QColor() : mCommentColorButton->color() );
+  box.setDescription( mCommentEdit->toPlainText() );
+  return box;
+}
+

--- a/src/gui/processing/models/qgsmodelgroupboxdefinitionwidget.h
+++ b/src/gui/processing/models/qgsmodelgroupboxdefinitionwidget.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+                         qgsmodelgroupboxdefinitionwidget.h
+                         ----------------------------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef QGSPROCESSINGGROUPBBOXDEFINITIONWIDGET_H
+#define QGSPROCESSINGGROUPBBOXDEFINITIONWIDGET_H
+
+#include <QWidget>
+#include <QDialog>
+#include "processing/models/qgsprocessingmodelgroupbox.h"
+#include "qgis_gui.h"
+
+#define SIP_NO_FILE
+
+class QLineEdit;
+class QCheckBox;
+class QTabWidget;
+class QTextEdit;
+class QgsColorButton;
+class QgsProcessingModelGroupBox;
+
+
+/**
+ * A widget which allow users to specify the properties of a model group box.
+ *
+ * \ingroup gui
+ * \note Not available in Python bindings.
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelGroupBoxDefinitionDialog: public QDialog
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Constructor for QgsModelGroupBoxDefinitionWidget, for the specified group \a box.
+     */
+    QgsModelGroupBoxDefinitionDialog( const QgsProcessingModelGroupBox &box,
+                                      QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Returns a new instance of the group box, using the current settings defined in the dialog.
+     */
+    QgsProcessingModelGroupBox groupBox() const;
+
+  private:
+
+    QTextEdit *mCommentEdit = nullptr;
+    QgsColorButton *mCommentColorButton = nullptr;
+    QgsProcessingModelGroupBox mBox;
+
+};
+
+
+#endif // QGSPROCESSINGGROUPBBOXDEFINITIONWIDGET_H

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.cpp
@@ -22,6 +22,7 @@
 #include "qgsapplication.h"
 #include "qgsprocessingregistry.h"
 #include "qgsprocessingparametertype.h"
+#include "qgscolorbutton.h"
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -145,7 +146,18 @@ QgsProcessingParameterDefinitionDialog::QgsProcessingParameterDefinitionDialog( 
   QVBoxLayout *commentLayout = new QVBoxLayout();
   mCommentEdit = new QTextEdit();
   mCommentEdit->setAcceptRichText( false );
-  commentLayout->addWidget( mCommentEdit );
+  commentLayout->addWidget( mCommentEdit, 1 );
+
+  QHBoxLayout *hl = new QHBoxLayout();
+  hl->setContentsMargins( 0, 0, 0, 0 );
+  hl->addWidget( new QLabel( tr( "Color" ) ) );
+  mCommentColorButton = new QgsColorButton();
+  mCommentColorButton->setAllowOpacity( true );
+  mCommentColorButton->setWindowTitle( tr( "Comment Color" ) );
+  mCommentColorButton->setShowNull( true, tr( "Default" ) );
+  hl->addWidget( mCommentColorButton );
+  commentLayout->addLayout( hl );
+
   QWidget *w2 = new QWidget();
   w2->setLayout( commentLayout );
   mTabWidget->addTab( w2, tr( "Comments" ) );
@@ -176,6 +188,19 @@ void QgsProcessingParameterDefinitionDialog::setComments( const QString &comment
 QString QgsProcessingParameterDefinitionDialog::comments() const
 {
   return mCommentEdit->toPlainText();
+}
+
+void QgsProcessingParameterDefinitionDialog::setCommentColor( const QColor &color )
+{
+  if ( color.isValid() )
+    mCommentColorButton->setColor( color );
+  else
+    mCommentColorButton->setToNull();
+}
+
+QColor QgsProcessingParameterDefinitionDialog::commentColor() const
+{
+  return !mCommentColorButton->isNull() ? mCommentColorButton->color() : QColor();
 }
 
 void QgsProcessingParameterDefinitionDialog::switchToCommentTab()

--- a/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
+++ b/src/gui/processing/qgsprocessingparameterdefinitionwidget.h
@@ -31,6 +31,7 @@ class QLineEdit;
 class QCheckBox;
 class QTabWidget;
 class QTextEdit;
+class QgsColorButton;
 
 /**
  * Abstract base class for widgets which allow users to specify the properties of a
@@ -184,6 +185,20 @@ class GUI_EXPORT QgsProcessingParameterDefinitionDialog: public QDialog
     QString comments() const;
 
     /**
+     * Sets the color for the comments for the parameter.
+     * \see commentColor()
+     * \since QGIS 3.14
+     */
+    void setCommentColor( const QColor &color );
+
+    /**
+     * Returns the color for the comments for the parameter.
+     * \see setCommentColor()
+     * \since QGIS 3.14
+     */
+    QColor commentColor() const;
+
+    /**
      * Switches the dialog to the comments tab.
      */
     void switchToCommentTab();
@@ -195,6 +210,7 @@ class GUI_EXPORT QgsProcessingParameterDefinitionDialog: public QDialog
 
     QTabWidget *mTabWidget = nullptr;
     QTextEdit *mCommentEdit = nullptr;
+    QgsColorButton *mCommentColorButton = nullptr;
     QgsProcessingParameterDefinitionWidget *mWidget = nullptr;
 
 };

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -508,7 +508,7 @@ void QgsColorButton::prepareMenu()
   {
     if ( mShowNull )
     {
-      QAction *nullAction = new QAction( tr( "Clear Color" ), this );
+      QAction *nullAction = new QAction( mNullColorString.isEmpty() ? tr( "Clear Color" ) : mNullColorString, this );
       nullAction->setIcon( createMenuIcon( Qt::transparent, false ) );
       mMenu->addAction( nullAction );
       connect( nullAction, &QAction::triggered, this, &QgsColorButton::setToNull );
@@ -825,9 +825,10 @@ void QgsColorButton::setDefaultColor( const QColor &color )
   mDefaultColor = color;
 }
 
-void QgsColorButton::setShowNull( bool showNull )
+void QgsColorButton::setShowNull( bool showNull, const QString &nullString )
 {
   mShowNull = showNull;
+  mNullColorString = nullString;
 }
 
 bool QgsColorButton::showNull() const

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -202,11 +202,12 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     /**
      * Sets whether a set to null (clear) option is shown in the button's drop-down menu.
      * \param showNull set to TRUE to show a null option
+     * \param nullString translated string to use for the null option. If not set, a default "Clear Color" string will be used.
      * \see showNull()
      * \see isNull()
      * \since QGIS 2.16
      */
-    void setShowNull( bool showNull );
+    void setShowNull( bool showNull, const QString &nullString = QString() );
 
     /**
      * Returns whether the set to null (clear) option is shown in the button's drop-down menu.
@@ -481,6 +482,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     bool mShowNoColorOption = false;
     QString mNoColorString;
     bool mShowNull = false;
+    QString mNullColorString;
 
     QPoint mDragStartPosition;
     bool mPickingColor = false;

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -70,7 +70,7 @@
     <addaction name="separator"/>
     <addaction name="mActionClose"/>
    </widget>
-   <widget class="QMenu" name="menu_View">
+   <widget class="QMenu" name="mMenuView">
     <property name="title">
      <string>&amp;View</string>
     </property>
@@ -96,7 +96,7 @@
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
-   <addaction name="menu_View"/>
+   <addaction name="mMenuView"/>
   </widget>
   <widget class="QToolBar" name="mToolbar">
    <property name="windowTitle">

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -92,6 +92,7 @@
     <addaction name="separator"/>
     <addaction name="mActionDeleteComponents"/>
     <addaction name="separator"/>
+    <addaction name="mActionAddGroupBox"/>
    </widget>
    <addaction name="menu_Model"/>
    <addaction name="mMenuEdit"/>
@@ -639,6 +640,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+A</string>
+   </property>
+  </action>
+  <action name="mActionAddGroupBox">
+   <property name="text">
+    <string>Add Group Box</string>
    </property>
   </action>
  </widget>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8266,16 +8266,20 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( comment.position(), QPointF( 11, 14 ) );
   comment.setDescription( QStringLiteral( "a comment" ) );
   QCOMPARE( comment.description(), QStringLiteral( "a comment" ) );
+  comment.setColor( QColor( 123, 45, 67 ) );
+  QCOMPARE( comment.color(), QColor( 123, 45, 67 ) );
   std::unique_ptr< QgsProcessingModelComment > commentClone( comment.clone() );
   QCOMPARE( commentClone->toVariant(), comment.toVariant() );
   QCOMPARE( commentClone->size(), QSizeF( 9, 8 ) );
   QCOMPARE( commentClone->position(), QPointF( 11, 14 ) );
   QCOMPARE( commentClone->description(), QStringLiteral( "a comment" ) );
+  QCOMPARE( commentClone->color(), QColor( 123, 45, 67 ) );
   QgsProcessingModelComment comment2;
   comment2.loadVariant( comment.toVariant().toMap() );
   QCOMPARE( comment2.size(), QSizeF( 9, 8 ) );
   QCOMPARE( comment2.position(), QPointF( 11, 14 ) );
   QCOMPARE( comment2.description(), QStringLiteral( "a comment" ) );
+  QCOMPARE( comment2.color(), QColor( 123, 45, 67 ) );
 
   QMap< QString, QString > friendlyOutputNames;
   QgsProcessingModelChildAlgorithm child( QStringLiteral( "some_id" ) );
@@ -8463,6 +8467,21 @@ void TestQgsProcessing::modelerAlgorithm()
   a2.setDescription( QStringLiteral( "alg2" ) );
   a2.setPosition( QPointF( 112, 131 ) );
   a2.setSize( QSizeF( 44, 55 ) );
+  a2.comment()->setSize( QSizeF( 111, 222 ) );
+  a2.comment()->setPosition( QPointF( 113, 114 ) );
+  a2.comment()->setDescription( QStringLiteral( "c" ) );
+  a2.comment()->setColor( QColor( 255, 254, 253 ) );
+  QgsProcessingModelOutput oo;
+  oo.setPosition( QPointF( 312, 331 ) );
+  oo.setSize( QSizeF( 344, 355 ) );
+  oo.comment()->setSize( QSizeF( 311, 322 ) );
+  oo.comment()->setPosition( QPointF( 313, 314 ) );
+  oo.comment()->setDescription( QStringLiteral( "c3" ) );
+  oo.comment()->setColor( QColor( 155, 14, 353 ) );
+  QMap< QString, QgsProcessingModelOutput > a2Outs;
+  a2Outs.insert( QStringLiteral( "out1" ), oo );
+  a2.setModelOutputs( a2Outs );
+
   algs.insert( QStringLiteral( "a" ), a1 );
   algs.insert( QStringLiteral( "b" ), a2 );
   alg.setChildAlgorithms( algs );
@@ -8473,10 +8492,28 @@ void TestQgsProcessing::modelerAlgorithm()
   QgsProcessingModelChildAlgorithm a2other;
   a2other.setChildId( QStringLiteral( "b" ) );
   a2other.setDescription( QStringLiteral( "alg2 other" ) );
+  QgsProcessingModelOutput oo2;
+  QMap< QString, QgsProcessingModelOutput > a2Outs2;
+  a2Outs2.insert( QStringLiteral( "out1" ), oo2 );
+  a2other.setModelOutputs( a2Outs2 );
+
   a2other.copyNonDefinitionPropertiesFromModel( &alg );
   QCOMPARE( a2other.description(), QStringLiteral( "alg2 other" ) );
   QCOMPARE( a2other.position(), QPointF( 112, 131 ) );
   QCOMPARE( a2other.size(), QSizeF( 44, 55 ) );
+  QCOMPARE( a2other.comment()->size(), QSizeF( 111, 222 ) );
+  QCOMPARE( a2other.comment()->position(), QPointF( 113, 114 ) );
+  // should not be copied
+  QCOMPARE( a2other.comment()->description(), QString() );
+  QVERIFY( !a2other.comment()->color().isValid() );
+
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).position(), QPointF( 312, 331 ) );
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).size(), QSizeF( 344, 355 ) );
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).comment()->size(), QSizeF( 311, 322 ) );
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).comment()->position(), QPointF( 313, 314 ) );
+  // should be copied for outputs
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).comment()->description(), QStringLiteral( "c3" ) );
+  QCOMPARE( a2other.modelOutput( QStringLiteral( "out1" ) ).comment()->color(), QColor( 155, 14, 353 ) );
 
   QgsProcessingModelChildAlgorithm a3;
   a3.setChildId( QStringLiteral( "c" ) );

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -40,6 +40,7 @@
 #include "qgsprocessingmaplayercombobox.h"
 #include "qgsnativealgorithms.h"
 #include "processing/models/qgsprocessingmodelalgorithm.h"
+#include "processing/models/qgsprocessingmodelgroupbox.h"
 #include "qgsxmlutils.h"
 #include "qgspropertyoverridebutton.h"
 #include "qgsprojectionselectionwidget.h"


### PR DESCRIPTION
Adds MORE nice stuff to the model designer... when will the goodness stop?!? :stuck_out_tongue: 

This one:

- Adds the ability to customise the color of individual comments in a model
- Allows creation of "Group Boxes" in models, which are a visual indicator of logically linked model components (e.g. 'Data Preparation Steps', 'NDVI Calculation Steps', ... etc). Users can customise the color and title for group boxes.
- Allows navigation direct to group boxes from the View menu, aiding navigation of complex models.

![Peek 2020-04-01 11-41](https://user-images.githubusercontent.com/1829991/78090538-bba87e00-740d-11ea-9476-144163d8f1ca.gif)



Refs NRCan Contract#3000707093