### PR TITLE
followup commit d2360da : fix rendering of vertical lines on multiline header

### DIFF
--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -1271,7 +1271,7 @@ void QgsLayoutTable::drawVerticalGridLines( QPainter *painter, const QMap<int, d
   double tableHeight = 0;
   if ( hasHeader )
   {
-    tableHeight += ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 ) + mCellMargin * 2 + QgsLayoutUtils::fontAscentMM( mHeaderFont );
+    tableHeight += ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 ) + mCellMargin * 2 + mMaxRowHeightMap[0];
   }
   tableHeight += ( mShowGrid && mHorizontalGrid ? mGridStrokeWidth : 0 );
   double headerHeight = tableHeight;


### PR DESCRIPTION
## Description

A small fix to make sure layout table items draw vertical lines of proper length when headers are multiline / wrapped.