### PR TITLE
Set a better size adjustment policy for our map layer combo box widget

### DIFF
--- a/src/gui/qgsmaplayercombobox.cpp
+++ b/src/gui/qgsmaplayercombobox.cpp
@@ -29,6 +29,8 @@ QgsMapLayerComboBox::QgsMapLayerComboBox( QWidget *parent )
   connect( mProxyModel, &QAbstractItemModel::rowsInserted, this, &QgsMapLayerComboBox::rowsChanged );
   connect( mProxyModel, &QAbstractItemModel::rowsRemoved, this, &QgsMapLayerComboBox::rowsChanged );
 
+  setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
+
   setAcceptDrops( true );
 }
 


### PR DESCRIPTION
## Description

By default, Qt combo boxes aren't allowed to get smaller than the largest item text width, which can create overly wide areas.

Among other things, this translates into very wide processing algorithm panels when a map layer parameter is present and a given project has a very long layer name.

This PR updates the sizing adjustment policy of our map layer combo box widget to allow for smaller-than-widest-text resizing.
 