### PR TITLE
Fix sip __hash__ for QgsActionScope

### DIFF
--- a/python/core/auto_generated/qgsactionscope.sip.in
+++ b/python/core/auto_generated/qgsactionscope.sip.in
@@ -36,6 +36,9 @@ form.</dd>
 #include "qgsactionscope.h"
 %End
   public:
+%TypeCode
+#include <QHash>
+%End
 
     explicit QgsActionScope();
 %Docstring
@@ -109,6 +112,10 @@ in here, they are extracted automatically from the expressionContextScope().
 Returns if this scope is valid.
 
 .. versionadded:: 3.0
+%End
+    long __hash__();
+%MethodCode
+    sipRes = qHash( *sipCpp );
 %End
 
 };

--- a/src/core/qgsactionscope.h
+++ b/src/core/qgsactionscope.h
@@ -46,6 +46,11 @@
 class CORE_EXPORT QgsActionScope
 {
   public:
+#ifdef SIP_RUN
+    % TypeCode
+#include <QHash>
+    % End
+#endif
 
     /**
      * Creates a new invalid action scope.
@@ -117,6 +122,12 @@ class CORE_EXPORT QgsActionScope
      * \since QGIS 3.0
      */
     bool isValid() const;
+#ifdef SIP_RUN
+    long __hash__();
+    % MethodCode
+    sipRes = qHash( *sipCpp );
+    % End
+#endif
 
   private:
     QString mId;


### PR DESCRIPTION
to allow use in actionScopeRegistry
Fixes #29225

`QgsApplication.actionScopeRegistry().actionScopes()` was not working because it returns a set.

This requires the `__hash__` method on the set class contained in  the set (`QgsActionScope`) to be implemented in Python. 

This PR implements that function to allow sets of `QgsActionScope`
