### PR TITLE
Don't raise ballpark transform warnings when reprojecting layer extent for rendering

### DIFF
--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -126,6 +126,11 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
 {
   bool split = false;
 
+  // we can safely use ballpark transforms without bothering the user here -- at the likely scale of layer extents there
+  // won't be an appreciable difference, and we aren't actually transforming any rendered points here anyway (just the layer extent)
+  QgsCoordinateTransform approxTransform = ct;
+  approxTransform.setBallparkTransformsAreAppropriate( true );
+
   try
   {
 #ifdef QGISDEBUG
@@ -140,13 +145,13 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
 
     if ( ml->crs().isGeographic() )
     {
-      if ( ml->type() == QgsMapLayerType::VectorLayer && !ct.destinationCrs().isGeographic() )
+      if ( ml->type() == QgsMapLayerType::VectorLayer && !approxTransform.destinationCrs().isGeographic() )
       {
         // if we transform from a projected coordinate system check
         // check if transforming back roughly returns the input
         // extend - otherwise render the world.
-        QgsRectangle extent1 = ct.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
-        QgsRectangle extent2 = ct.transformBoundingBox( extent1, QgsCoordinateTransform::ForwardTransform );
+        QgsRectangle extent1 = approxTransform.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
+        QgsRectangle extent2 = approxTransform.transformBoundingBox( extent1, QgsCoordinateTransform::ForwardTransform );
 
         QgsDebugMsgLevel( QStringLiteral( "\n0:%1 %2x%3\n1:%4\n2:%5 %6x%7 (w:%8 h:%9)" )
                           .arg( extent.toString() ).arg( extent.width() ).arg( extent.height() )
@@ -172,16 +177,16 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
       else
       {
         // Note: ll = lower left point
-        QgsPointXY ll = ct.transform( extent.xMinimum(), extent.yMinimum(),
-                                      QgsCoordinateTransform::ReverseTransform );
+        QgsPointXY ll = approxTransform.transform( extent.xMinimum(), extent.yMinimum(),
+                        QgsCoordinateTransform::ReverseTransform );
 
         //   and ur = upper right point
-        QgsPointXY ur = ct.transform( extent.xMaximum(), extent.yMaximum(),
-                                      QgsCoordinateTransform::ReverseTransform );
+        QgsPointXY ur = approxTransform.transform( extent.xMaximum(), extent.yMaximum(),
+                        QgsCoordinateTransform::ReverseTransform );
 
         QgsDebugMsgLevel( QStringLiteral( "in:%1 (ll:%2 ur:%3)" ).arg( extent.toString(), ll.toString(), ur.toString() ), 4 );
 
-        extent = ct.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
+        extent = approxTransform.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
 
         QgsDebugMsgLevel( QStringLiteral( "out:%1 (w:%2 h:%3)" ).arg( extent.toString() ).arg( extent.width() ).arg( extent.height() ), 4 );
 
@@ -205,7 +210,7 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
     }
     else // can't cross 180
     {
-      if ( ct.destinationCrs().isGeographic() &&
+      if ( approxTransform.destinationCrs().isGeographic() &&
            ( extent.xMinimum() <= -180 || extent.xMaximum() >= 180 ||
              extent.yMinimum() <= -90 || extent.yMaximum() >= 90 ) )
         // Use unlimited rectangle because otherwise we may end up transforming wrong coordinates.
@@ -214,7 +219,7 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
         // but this seems like a safer choice.
         extent = QgsRectangle( std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max() );
       else
-        extent = ct.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
+        extent = approxTransform.transformBoundingBox( extent, QgsCoordinateTransform::ReverseTransform );
     }
   }
   catch ( QgsCsException &cse )


### PR DESCRIPTION
We can safely use ballpark transforms without bothering the user here -- at the likely scale of layer extents there won't be an appreciable difference, and we aren't actually transforming any rendered points here anyway (just the layer extent)

Fixes #34983
