### PR TITLE
Show a menu next to scale widget buttons, to allow setting the widget directly to a scale from a print layout map

### DIFF
--- a/src/gui/qgsscalewidget.h
+++ b/src/gui/qgsscalewidget.h
@@ -184,10 +184,15 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
      */
     void scaleChanged( double scale );
 
+  private slots:
+
+    void menuAboutToShow();
+
   private:
     QgsScaleComboBox *mScaleComboBox = nullptr;
     QToolButton *mCurrentScaleButton = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
+    QMenu *mMenu = nullptr;
     bool mShowCurrentScaleButton = false;
 };
 


### PR DESCRIPTION
A screencast says a thousand words:

![Peek 2020-04-02 10-31](https://user-images.githubusercontent.com/1829991/78198825-34bada80-74cd-11ea-803a-90afea085b38.gif)
