### PR TITLE
Vector tile layer - part 2 (browser)

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -118,6 +118,7 @@ IF(WITH_APIDOC)
       ${CMAKE_SOURCE_DIR}/src/gui/processing/models
       ${CMAKE_SOURCE_DIR}/src/gui/raster
       ${CMAKE_SOURCE_DIR}/src/gui/symbology
+      ${CMAKE_SOURCE_DIR}/src/gui/vectortile
       ${CMAKE_SOURCE_DIR}/src/analysis
       ${CMAKE_SOURCE_DIR}/src/analysis/mesh
       ${CMAKE_SOURCE_DIR}/src/analysis/interpolation

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -380,8 +380,5 @@
 %Include auto_generated/symbology/qgsvectorfieldsymbollayerwidget.sip
 %Include auto_generated/tableeditor/qgstableeditordialog.sip
 %Include auto_generated/tableeditor/qgstableeditorwidget.sip
-%Include auto_generated/vectortile/qgsvectortileconnectiondialog.sip
-%Include auto_generated/vectortile/qgsvectortiledataitemguiprovider.sip
-%Include auto_generated/vectortile/qgsvectortileproviderguimetadata.sip
 %Include auto_generated/editorwidgets/qgsqmlwidgetwrapper.sip
 %Include auto_generated/qgsadvanceddigitizingcanvasitem.sip

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -380,5 +380,8 @@
 %Include auto_generated/symbology/qgsvectorfieldsymbollayerwidget.sip
 %Include auto_generated/tableeditor/qgstableeditordialog.sip
 %Include auto_generated/tableeditor/qgstableeditorwidget.sip
+%Include auto_generated/vectortile/qgsvectortileconnectiondialog.sip
+%Include auto_generated/vectortile/qgsvectortiledataitemguiprovider.sip
+%Include auto_generated/vectortile/qgsvectortileproviderguimetadata.sip
 %Include auto_generated/editorwidgets/qgsqmlwidgetwrapper.sip
 %Include auto_generated/qgsadvanceddigitizingcanvasitem.sip

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -336,6 +336,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerproperties.h"
 #include "qgsvectorlayerdigitizingproperties.h"
+#include "qgsvectortilelayer.h"
 #include "qgsmapthemes.h"
 #include "qgsmessagelogviewer.h"
 #include "qgsdataitem.h"
@@ -2010,6 +2011,11 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
     else if ( u.layerType == QLatin1String( "mesh" ) )
     {
       QgsMeshLayer *layer = new QgsMeshLayer( uri, u.name, u.providerKey );
+      addMapLayer( layer );
+    }
+    else if ( u.layerType == QLatin1String( "vector-tile" ) )
+    {
+      QgsVectorTileLayer *layer = new QgsVectorTileLayer( uri, u.name );
       addMapLayer( layer );
     }
     else if ( u.layerType == QLatin1String( "plugin" ) )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -641,10 +641,13 @@ SET(QGIS_CORE_SRCS
   validity/qgsvaliditycheckregistry.cpp
 
   vectortile/qgsvectortilebasicrenderer.cpp
+  vectortile/qgsvectortileconnection.cpp
+  vectortile/qgsvectortiledataitems.cpp
   vectortile/qgsvectortilelayer.cpp
   vectortile/qgsvectortilelayerrenderer.cpp
   vectortile/qgsvectortileloader.cpp
   vectortile/qgsvectortilemvtdecoder.cpp
+  vectortile/qgsvectortileprovidermetadata.cpp
   vectortile/qgsvectortileutils.cpp
 
   ${CMAKE_CURRENT_BINARY_DIR}/qgsexpression_texts.cpp
@@ -1338,10 +1341,13 @@ SET(QGIS_CORE_HDRS
   validity/qgsvaliditycheckregistry.h
 
   vectortile/qgsvectortilebasicrenderer.h
+  vectortile/qgsvectortileconnection.h
+  vectortile/qgsvectortiledataitems.h
   vectortile/qgsvectortilelayer.h
   vectortile/qgsvectortilelayerrenderer.h
   vectortile/qgsvectortileloader.h
   vectortile/qgsvectortilemvtdecoder.h
+  vectortile/qgsvectortileprovidermetadata.h
   vectortile/qgsvectortilerenderer.h
   vectortile/qgsvectortileutils.h
 )

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -30,6 +30,7 @@
 #include "qgsmessagelog.h"
 #include "qgsprovidermetadata.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectortileprovidermetadata.h"
 #include "qgsproject.h"
 #include "providers/memory/qgsmemoryprovider.h"
 #include "providers/gdal/qgsgdalprovider.h"
@@ -106,7 +107,6 @@ QgsProviderRegistry::QgsProviderRegistry( const QString &pluginPath )
   init();
 }
 
-
 void QgsProviderRegistry::init()
 {
   // add static providers
@@ -116,6 +116,8 @@ void QgsProviderRegistry::init()
   Q_NOWARN_DEPRECATED_POP
   mProviders[ QgsGdalProvider::providerKey() ] = new QgsGdalProviderMetadata();
   mProviders[ QgsOgrProvider::providerKey() ] = new QgsOgrProviderMetadata();
+  QgsProviderMetadata *vt = new QgsVectorTileProviderMetadata();
+  mProviders[ vt->key() ] = vt;
 #ifdef HAVE_STATIC_PROVIDERS
   mProviders[ QgsWmsProvider::providerKey() ] = new QgsWmsProviderMetadata();
   mProviders[ QgsPostgresProvider::providerKey() ] = new QgsPostgresProviderMetadata();

--- a/src/core/vectortile/qgsvectortileconnection.cpp
+++ b/src/core/vectortile/qgsvectortileconnection.cpp
@@ -1,0 +1,74 @@
+/***************************************************************************
+    qgsvectortileconnection.cpp
+    ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortileconnection.h"
+
+#include "qgslogger.h"
+#include "qgsdatasourceuri.h"
+#include "qgssettings.h"
+
+///@cond PRIVATE
+
+QString QgsVectorTileConnection::encodedUri() const
+{
+  QgsDataSourceUri uri;
+  uri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  uri.setParam( QStringLiteral( "url" ), url );
+  if ( zMin != -1 )
+    uri.setParam( QStringLiteral( "zmin" ), QString::number( zMin ) );
+  if ( zMax != -1 )
+    uri.setParam( QStringLiteral( "zmax" ), QString::number( zMax ) );
+  return uri.encodedUri();
+}
+
+QStringList QgsVectorTileConnectionUtils::connectionList()
+{
+  QgsSettings settings;
+  settings.beginGroup( QStringLiteral( "qgis/connections-vector-tile" ) );
+  QStringList connList = settings.childGroups();
+
+  return connList;
+}
+
+QgsVectorTileConnection QgsVectorTileConnectionUtils::connection( const QString &name )
+{
+  QgsSettings settings;
+  settings.beginGroup( "qgis/connections-vector-tile/" + name );
+
+  QgsVectorTileConnection conn;
+  conn.name = name;
+  conn.url = settings.value( QStringLiteral( "url" ) ).toString();
+  conn.zMin = settings.value( QStringLiteral( "zmin" ), -1 ).toInt();
+  conn.zMax = settings.value( QStringLiteral( "zmax" ), -1 ).toInt();
+  return conn;
+}
+
+void QgsVectorTileConnectionUtils::deleteConnection( const QString &name )
+{
+  QgsSettings settings;
+  settings.remove( "qgis/connections-vector-tile/" + name );
+}
+
+void QgsVectorTileConnectionUtils::addConnection( const QgsVectorTileConnection &conn )
+{
+  QgsSettings settings;
+
+  settings.beginGroup( "qgis/connections-vector-tile/" + conn.name );
+  settings.setValue( QStringLiteral( "url" ), conn.url );
+  settings.setValue( QStringLiteral( "zmin" ), conn.zMin );
+  settings.setValue( QStringLiteral( "zmax" ), conn.zMax );
+}
+
+///@endcond

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+    qgsvectortileconnection.h
+    ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILECONNECTION_H
+#define QGSVECTORTILECONNECTION_H
+
+#include "qgis_core.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+#include <QStringList>
+
+struct QgsVectorTileConnection
+{
+  QString name;
+  QString url;
+  int zMin = -1;
+  int zMax = -1;
+
+  QString encodedUri() const;
+};
+
+//! Utility class for handling list of connections to vector tile layers
+class CORE_EXPORT QgsVectorTileConnectionUtils
+{
+  public:
+    //! Returns list of existing connections, unless the hidden ones
+    static QStringList connectionList();
+
+    //! Returns connection details
+    static QgsVectorTileConnection connection( const QString &name );
+
+    //! Removes a connection from the list
+    static void deleteConnection( const QString &name );
+
+    //! Adds a new connection to the list
+    static void addConnection( const QgsVectorTileConnection &conn );
+};
+
+///@endcond
+
+#endif // QGSVECTORTILECONNECTION_H

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderCo
     //! Decodes connection string to a data structure
     static Data decodedUri( const QString &uri );
 
-    //! Returns connection data encoded as a string containg URI for QgsVectorTileLayer
+    //! Returns connection data encoded as a string containing URI for QgsVectorTileLayer
     static QString encodedLayerUri( const Data &conn );
 
     //! Returns list of existing connections, unless the hidden ones

--- a/src/core/vectortile/qgsvectortileconnection.h
+++ b/src/core/vectortile/qgsvectortileconnection.h
@@ -23,31 +23,42 @@
 
 #include <QStringList>
 
-struct QgsVectorTileConnection
-{
-  QString name;
-  QString url;
-  int zMin = -1;
-  int zMax = -1;
+#include "qgsabstractproviderconnection.h"
 
-  QString encodedUri() const;
-};
-
-//! Utility class for handling list of connections to vector tile layers
-class CORE_EXPORT QgsVectorTileConnectionUtils
+class CORE_EXPORT QgsVectorTileProviderConnection : public QgsAbstractProviderConnection
 {
+
   public:
+    QgsVectorTileProviderConnection( const QString &name );
+    QgsVectorTileProviderConnection( const QString &uri, const QVariantMap &configuration );
+
+    virtual void store( const QString &name ) const override;
+    virtual void remove( const QString &name ) const override;
+
+    //! Represents decoded data of a connection
+    struct Data
+    {
+      QString url;
+      int zMin = -1;
+      int zMax = -1;
+    };
+
+    //! Returns connection data encoded as a string
+    static QString encodedUri( const Data &conn );
+    //! Decodes connection string to a data structure
+    static Data decodedUri( const QString &uri );
+
+    //! Returns connection data encoded as a string containg URI for QgsVectorTileLayer
+    static QString encodedLayerUri( const Data &conn );
+
     //! Returns list of existing connections, unless the hidden ones
     static QStringList connectionList();
-
     //! Returns connection details
-    static QgsVectorTileConnection connection( const QString &name );
-
+    static Data connection( const QString &name );
     //! Removes a connection from the list
     static void deleteConnection( const QString &name );
-
     //! Adds a new connection to the list
-    static void addConnection( const QgsVectorTileConnection &conn );
+    static void addConnection( const QString &name, Data conn );
 };
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortiledataitems.cpp
+++ b/src/core/vectortile/qgsvectortiledataitems.cpp
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgsvectortiledataitems.cpp
+    ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsvectortiledataitems.h"
+
+#include "qgssettings.h"
+#include "qgsvectortileconnection.h"
+
+///@cond PRIVATE
+
+QgsVectorTileRootItem::QgsVectorTileRootItem( QgsDataItem *parent, QString name, QString path )
+  : QgsDataCollectionItem( parent, name, path, QStringLiteral( "vectortile" ) )
+{
+  mCapabilities |= Fast;
+  mIconName = QStringLiteral( "mIconWms.svg" );
+  populate();
+}
+
+QVector<QgsDataItem *> QgsVectorTileRootItem::createChildren()
+{
+  QVector<QgsDataItem *> connections;
+  const auto connectionList = QgsVectorTileConnectionUtils::connectionList();
+  for ( const QString &connName : connectionList )
+  {
+    QgsVectorTileConnection connection( QgsVectorTileConnectionUtils::connection( connName ) );
+    QgsDataItem *conn = new QgsVectorTileLayerItem( this, connName, mPath + '/' + connName, connection.encodedUri() );
+    connections.append( conn );
+  }
+  return connections;
+}
+
+
+// ---------------------------------------------------------------------------
+
+
+QgsVectorTileLayerItem::QgsVectorTileLayerItem( QgsDataItem *parent, QString name, QString path, const QString &encodedUri )
+  : QgsLayerItem( parent, name, path, encodedUri, QgsLayerItem::VectorTile, QString() )
+{
+  setState( Populated );
+}
+
+
+// ---------------------------------------------------------------------------
+
+QString QgsVectorTileDataItemProvider::name()
+{
+  return QStringLiteral( "Vector Tiles" );
+}
+
+QString QgsVectorTileDataItemProvider::dataProviderKey() const
+{
+  return QStringLiteral( "vectortile" );
+}
+
+int QgsVectorTileDataItemProvider::capabilities() const
+{
+  return QgsDataProvider::Net;
+}
+
+QgsDataItem *QgsVectorTileDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
+{
+  if ( path.isEmpty() )
+    return new QgsVectorTileRootItem( parentItem, QStringLiteral( "Vector Tiles" ), QStringLiteral( "vectortile:" ) );
+  return nullptr;
+}
+
+///@endcond

--- a/src/core/vectortile/qgsvectortiledataitems.cpp
+++ b/src/core/vectortile/qgsvectortiledataitems.cpp
@@ -30,11 +30,11 @@ QgsVectorTileRootItem::QgsVectorTileRootItem( QgsDataItem *parent, QString name,
 QVector<QgsDataItem *> QgsVectorTileRootItem::createChildren()
 {
   QVector<QgsDataItem *> connections;
-  const auto connectionList = QgsVectorTileConnectionUtils::connectionList();
+  const auto connectionList = QgsVectorTileProviderConnection::connectionList();
   for ( const QString &connName : connectionList )
   {
-    QgsVectorTileConnection connection( QgsVectorTileConnectionUtils::connection( connName ) );
-    QgsDataItem *conn = new QgsVectorTileLayerItem( this, connName, mPath + '/' + connName, connection.encodedUri() );
+    QString uri = QgsVectorTileProviderConnection::encodedLayerUri( QgsVectorTileProviderConnection::connection( connName ) );
+    QgsDataItem *conn = new QgsVectorTileLayerItem( this, connName, mPath + '/' + connName, uri );
     connections.append( conn );
   }
   return connections;

--- a/src/core/vectortile/qgsvectortiledataitems.h
+++ b/src/core/vectortile/qgsvectortiledataitems.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+    qgsvectortiledataitems.h
+    ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSVECTORTILEDATAITEMS_H
+#define QGSVECTORTILEDATAITEMS_H
+
+#include "qgsdataitem.h"
+#include "qgsdataitemprovider.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+//! Root item for XYZ tile layers
+class CORE_EXPORT QgsVectorTileRootItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileRootItem( QgsDataItem *parent, QString name, QString path );
+
+    QVector<QgsDataItem *> createChildren() override;
+
+    QVariant sortKey() const override { return 8; }
+
+};
+
+//! Item implementation for XYZ tile layers
+class CORE_EXPORT QgsVectorTileLayerItem : public QgsLayerItem
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileLayerItem( QgsDataItem *parent, QString name, QString path, const QString &encodedUri );
+
+};
+
+
+//! Provider for XYZ root data item
+class QgsVectorTileDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    QString name() override;
+    QString dataProviderKey() const override;
+    int capabilities() const override;
+
+    QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
+};
+
+///@endcond
+
+#endif // QGSVECTORTILEDATAITEMS_H

--- a/src/core/vectortile/qgsvectortilelayer.cpp
+++ b/src/core/vectortile/qgsvectortilelayer.cpp
@@ -67,7 +67,9 @@ QgsVectorTileLayer::QgsVectorTileLayer( const QString &uri, const QString &baseN
     QgsDebugMsgLevel( QStringLiteral( "zoom range: %1 - %2" ).arg( mSourceMinZoom ).arg( mSourceMaxZoom ), 2 );
 
     QgsRectangle r = reader.extent();
-    // TODO: reproject to EPSG:3857
+    QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ),
+                               QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ), transformContext() );
+    r = ct.transformBoundingBox( r );
     setExtent( r );
   }
   else

--- a/src/core/vectortile/qgsvectortileprovidermetadata.cpp
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+  qgsvectortileprovidermetadata.cpp
+  --------------------------------------
+  Date                 : March 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortileprovidermetadata.h"
+
+#include "qgsvectortiledataitems.h"
+
+///@cond PRIVATE
+
+#define PROVIDER_KEY QStringLiteral( "vectortile" )
+#define PROVIDER_DESCRIPTION QStringLiteral( "Vector tile provider" )
+
+QgsVectorTileProviderMetadata::QgsVectorTileProviderMetadata()
+  : QgsProviderMetadata( PROVIDER_KEY, PROVIDER_DESCRIPTION )
+{
+}
+
+QList<QgsDataItemProvider *> QgsVectorTileProviderMetadata::dataItemProviders() const
+{
+  QList< QgsDataItemProvider * > providers;
+  providers << new QgsVectorTileDataItemProvider;
+  return providers;
+}
+
+//QString QgsVectorTileProviderMetadata::staticKey()
+//{
+//  return PROVIDER_KEY;
+//}
+
+///@endcond

--- a/src/core/vectortile/qgsvectortileprovidermetadata.cpp
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.cpp
@@ -34,9 +34,4 @@ QList<QgsDataItemProvider *> QgsVectorTileProviderMetadata::dataItemProviders() 
   return providers;
 }
 
-//QString QgsVectorTileProviderMetadata::staticKey()
-//{
-//  return PROVIDER_KEY;
-//}
-
 ///@endcond

--- a/src/core/vectortile/qgsvectortileprovidermetadata.cpp
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsvectortileprovidermetadata.h"
 
+#include "qgsvectortileconnection.h"
 #include "qgsvectortiledataitems.h"
 
 ///@cond PRIVATE
@@ -32,6 +33,26 @@ QList<QgsDataItemProvider *> QgsVectorTileProviderMetadata::dataItemProviders() 
   QList< QgsDataItemProvider * > providers;
   providers << new QgsVectorTileDataItemProvider;
   return providers;
+}
+
+QMap<QString, QgsAbstractProviderConnection *> QgsVectorTileProviderMetadata::connections( bool cached )
+{
+  return connectionsProtected<QgsVectorTileProviderConnection, QgsVectorTileProviderConnection>( cached );
+}
+
+QgsAbstractProviderConnection *QgsVectorTileProviderMetadata::createConnection( const QString &name )
+{
+  return new QgsVectorTileProviderConnection( name );
+}
+
+void QgsVectorTileProviderMetadata::deleteConnection( const QString &name )
+{
+  deleteConnectionProtected<QgsVectorTileProviderConnection>( name );
+}
+
+void QgsVectorTileProviderMetadata::saveConnection( const QgsAbstractProviderConnection *connection, const QString &name )
+{
+  saveConnectionProtected( connection, name );
 }
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortileprovidermetadata.h
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+  qgsvectortileprovidermetadata.h
+  --------------------------------------
+  Date                 : March 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEPROVIDERMETADATA_H
+#define QGSVECTORTILEPROVIDERMETADATA_H
+
+
+#include "qgsprovidermetadata.h"
+
+///@cond PRIVATE
+#define SIP_NO_FILE
+
+/**
+ * This metadata class does not support creation of provider instances, because
+ * vector tile layer currently does not have a concept of data providers. This class
+ * is only used to create data item provider (for browser integration).
+ */
+class QgsVectorTileProviderMetadata : public QgsProviderMetadata
+{
+  public:
+    QgsVectorTileProviderMetadata();
+    QList< QgsDataItemProvider * > dataItemProviders() const override;
+
+    //static QString staticKey();
+};
+
+///@endcond
+
+#endif // QGSVECTORTILEPROVIDERMETADATA_H

--- a/src/core/vectortile/qgsvectortileprovidermetadata.h
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.h
@@ -33,7 +33,6 @@ class QgsVectorTileProviderMetadata : public QgsProviderMetadata
     QgsVectorTileProviderMetadata();
     QList< QgsDataItemProvider * > dataItemProviders() const override;
 
-    //static QString staticKey();
 };
 
 ///@endcond

--- a/src/core/vectortile/qgsvectortileprovidermetadata.h
+++ b/src/core/vectortile/qgsvectortileprovidermetadata.h
@@ -33,6 +33,13 @@ class QgsVectorTileProviderMetadata : public QgsProviderMetadata
     QgsVectorTileProviderMetadata();
     QList< QgsDataItemProvider * > dataItemProviders() const override;
 
+    // handling of stored connections
+
+    QMap<QString, QgsAbstractProviderConnection *> connections( bool cached ) override;
+    QgsAbstractProviderConnection *createConnection( const QString &name ) override;
+    void deleteConnection( const QString &name ) override;
+    void saveConnection( const QgsAbstractProviderConnection *connection, const QString &name ) override;
+
 };
 
 ///@endcond

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -320,6 +320,10 @@ SET(QGIS_GUI_SRCS
   tableeditor/qgstableeditorformattingwidget.cpp
   tableeditor/qgstableeditorwidget.cpp
 
+  vectortile/qgsvectortileconnectiondialog.cpp
+  vectortile/qgsvectortiledataitemguiprovider.cpp
+  vectortile/qgsvectortileproviderguimetadata.cpp
+
   qgisinterface.cpp
   qgsactionmenu.cpp
   qgsaddattrdialog.cpp
@@ -1079,6 +1083,10 @@ SET(QGIS_GUI_HDRS
   tableeditor/qgstableeditorformattingwidget.h
   tableeditor/qgstableeditorwidget.h
 
+  vectortile/qgsvectortileconnectiondialog.h
+  vectortile/qgsvectortiledataitemguiprovider.h
+  vectortile/qgsvectortileproviderguimetadata.h
+
   qgsbrowserdockwidget_p.h
 )
 
@@ -1194,6 +1202,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/gui/providers/ogr
   ${CMAKE_SOURCE_DIR}/src/gui/raster
   ${CMAKE_SOURCE_DIR}/src/gui/vector
+  ${CMAKE_SOURCE_DIR}/src/gui/vectortile
   ${CMAKE_SOURCE_DIR}/src/gui/tableeditor
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/annotations

--- a/src/gui/qgsproviderguiregistry.cpp
+++ b/src/gui/qgsproviderguiregistry.cpp
@@ -24,6 +24,7 @@
 #include "qgslogger.h"
 #include "qgsgdalguiprovider.h"
 #include "qgsogrguiprovider.h"
+#include "qgsvectortileproviderguimetadata.h"
 
 #ifdef HAVE_STATIC_PROVIDERS
 #include "qgswmsprovidergui.h"
@@ -65,6 +66,9 @@ void QgsProviderGuiRegistry::loadStaticProviders( )
 
   QgsProviderGuiMetadata *ogr = new QgsOgrGuiProviderMetadata();
   mProviders[ ogr->key() ] = ogr;
+
+  QgsProviderGuiMetadata *vt = new QgsVectorTileProviderGuiMetadata();
+  mProviders[ vt->key() ] = vt;
 
 #ifdef HAVE_STATIC_PROVIDERS
   QgsProviderGuiMetadata *wms = new QgsWmsProviderGuiMetadata();

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -1,0 +1,62 @@
+/***************************************************************************
+    qgsvectortileconnectiondialog.cpp
+    ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortileconnectiondialog.h"
+#include "qgsvectortileconnection.h"
+#include "qgsgui.h"
+#include <QMessageBox>
+
+QgsVectorTileConnectionDialog::QgsVectorTileConnectionDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setupUi( this );
+  QgsGui::enableAutoGeometryRestore( this );
+
+  // Behavior for min and max zoom checkbox
+  connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
+  connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
+}
+
+void QgsVectorTileConnectionDialog::setConnection( const QgsVectorTileConnection &conn )
+{
+  mEditName->setText( conn.name );
+  mEditUrl->setText( conn.url );
+  mCheckBoxZMin->setChecked( conn.zMin != -1 );
+  mSpinZMin->setValue( conn.zMin != -1 ? conn.zMin : 0 );
+  mCheckBoxZMax->setChecked( conn.zMax != -1 );
+  mSpinZMax->setValue( conn.zMax != -1 ? conn.zMax : 14 );
+}
+
+QgsVectorTileConnection QgsVectorTileConnectionDialog::connection() const
+{
+  QgsVectorTileConnection conn;
+  conn.name = mEditName->text();
+  conn.url = mEditUrl->text();
+  if ( mCheckBoxZMin->isChecked() )
+    conn.zMin = mSpinZMin->value();
+  if ( mCheckBoxZMax->isChecked() )
+    conn.zMax = mSpinZMax->value();
+  return conn;
+}
+
+void QgsVectorTileConnectionDialog::accept()
+{
+  if ( mCheckBoxZMin->isChecked() && mCheckBoxZMax->isChecked() && mSpinZMax->value() < mSpinZMin->value() )
+  {
+    QMessageBox::warning( this, tr( "Connection Properties" ), tr( "The maximum zoom level (%1) cannot be lower than the minimum zoom level (%2)." ).arg( mSpinZMax->value() ).arg( mSpinZMin->value() ) );
+    return;
+  }
+  QDialog::accept();
+}

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -31,9 +31,11 @@ QgsVectorTileConnectionDialog::QgsVectorTileConnectionDialog( QWidget *parent )
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
 }
 
-void QgsVectorTileConnectionDialog::setConnection( const QgsVectorTileConnection &conn )
+void QgsVectorTileConnectionDialog::setConnection( const QString &name, const QString &uri )
 {
-  mEditName->setText( conn.name );
+  mEditName->setText( name );
+
+  QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( uri );
   mEditUrl->setText( conn.url );
   mCheckBoxZMin->setChecked( conn.zMin != -1 );
   mSpinZMin->setValue( conn.zMin != -1 ? conn.zMin : 0 );
@@ -41,16 +43,20 @@ void QgsVectorTileConnectionDialog::setConnection( const QgsVectorTileConnection
   mSpinZMax->setValue( conn.zMax != -1 ? conn.zMax : 14 );
 }
 
-QgsVectorTileConnection QgsVectorTileConnectionDialog::connection() const
+QString QgsVectorTileConnectionDialog::connectionUri() const
 {
-  QgsVectorTileConnection conn;
-  conn.name = mEditName->text();
+  QgsVectorTileProviderConnection::Data conn;
   conn.url = mEditUrl->text();
   if ( mCheckBoxZMin->isChecked() )
     conn.zMin = mSpinZMin->value();
   if ( mCheckBoxZMax->isChecked() )
     conn.zMax = mSpinZMax->value();
-  return conn;
+  return QgsVectorTileProviderConnection::encodedUri( conn );
+}
+
+QString QgsVectorTileConnectionDialog::connectionName() const
+{
+  return mEditName->text();
 }
 
 void QgsVectorTileConnectionDialog::accept()

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -18,6 +18,8 @@
 #include "qgsgui.h"
 #include <QMessageBox>
 
+///@cond PRIVATE
+
 QgsVectorTileConnectionDialog::QgsVectorTileConnectionDialog( QWidget *parent )
   : QDialog( parent )
 {
@@ -60,3 +62,5 @@ void QgsVectorTileConnectionDialog::accept()
   }
   QDialog::accept();
 }
+
+///@endcond

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+    qgsvectortileconnectiondialog.h
+    ---------------------
+    begin                : March 2020
+    copyright            : (C) 2020 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILECONNECTIONDIALOG_H
+#define QGSVECTORTILECONNECTIONDIALOG_H
+
+#include <QDialog>
+
+#include "ui_qgsvectortileconnectiondialog.h"
+
+
+struct QgsVectorTileConnection;
+
+
+class QgsVectorTileConnectionDialog : public QDialog, public Ui::QgsVectorTileConnectionDialog
+{
+    Q_OBJECT
+  public:
+    explicit QgsVectorTileConnectionDialog( QWidget *parent = nullptr );
+
+    void setConnection( const QgsVectorTileConnection &conn );
+
+    QgsVectorTileConnection connection() const;
+
+    void accept() override;
+
+  private:
+
+    QString mBaseKey;
+    QString mCredentialsBaseKey;
+};
+
+#endif // QGSVECTORTILECONNECTIONDIALOG_H

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.h
@@ -24,18 +24,16 @@
 #include "ui_qgsvectortileconnectiondialog.h"
 
 
-struct QgsVectorTileConnection;
-
-
 class QgsVectorTileConnectionDialog : public QDialog, public Ui::QgsVectorTileConnectionDialog
 {
     Q_OBJECT
   public:
     explicit QgsVectorTileConnectionDialog( QWidget *parent = nullptr );
 
-    void setConnection( const QgsVectorTileConnection &conn );
+    void setConnection( const QString &name, const QString &uri );
 
-    QgsVectorTileConnection connection() const;
+    QString connectionUri() const;
+    QString connectionName() const;
 
     void accept() override;
 

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.h
@@ -16,6 +16,9 @@
 #ifndef QGSVECTORTILECONNECTIONDIALOG_H
 #define QGSVECTORTILECONNECTIONDIALOG_H
 
+///@cond PRIVATE
+#define SIP_NO_FILE
+
 #include <QDialog>
 
 #include "ui_qgsvectortileconnectiondialog.h"
@@ -41,5 +44,7 @@ class QgsVectorTileConnectionDialog : public QDialog, public Ui::QgsVectorTileCo
     QString mBaseKey;
     QString mCredentialsBaseKey;
 };
+
+///@endcond
 
 #endif // QGSVECTORTILECONNECTIONDIALOG_H

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -1,0 +1,108 @@
+/***************************************************************************
+  qgsvectortiledataitemguiprovider.cpp
+  --------------------------------------
+  Date                 : March 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortiledataitemguiprovider.h"
+
+#include "qgsvectortiledataitems.h"
+#include "qgsvectortileconnectiondialog.h"
+#include "qgsvectortileconnection.h"
+#include "qgsmanageconnectionsdialog.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+
+void QgsVectorTileDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
+{
+  if ( QgsVectorTileLayerItem *layerItem = qobject_cast< QgsVectorTileLayerItem * >( item ) )
+  {
+    QAction *actionEdit = new QAction( tr( "Edit…" ), this );
+    connect( actionEdit, &QAction::triggered, this, [layerItem] { editConnection( layerItem ); } );
+    menu->addAction( actionEdit );
+
+    QAction *actionDelete = new QAction( tr( "Delete" ), this );
+    connect( actionDelete, &QAction::triggered, this, [layerItem] { deleteConnection( layerItem ); } );
+    menu->addAction( actionDelete );
+  }
+
+  if ( QgsVectorTileRootItem *rootItem = qobject_cast< QgsVectorTileRootItem * >( item ) )
+  {
+    QAction *actionNew = new QAction( tr( "New Connection…" ), this );
+    connect( actionNew, &QAction::triggered, this, [rootItem] { newConnection( rootItem ); } );
+    menu->addAction( actionNew );
+
+    QAction *actionSaveXyzTilesServers = new QAction( tr( "Save Connections…" ), this );
+    connect( actionSaveXyzTilesServers, &QAction::triggered, this, [] { saveXyzTilesServers(); } );
+    menu->addAction( actionSaveXyzTilesServers );
+
+    QAction *actionLoadXyzTilesServers = new QAction( tr( "Load Connections…" ), this );
+    connect( actionLoadXyzTilesServers, &QAction::triggered, this, [rootItem] { loadXyzTilesServers( rootItem ); } );
+    menu->addAction( actionLoadXyzTilesServers );
+  }
+}
+
+void QgsVectorTileDataItemGuiProvider::editConnection( QgsDataItem *item )
+{
+  QgsVectorTileConnectionDialog dlg;
+  dlg.setConnection( QgsVectorTileConnectionUtils::connection( item->name() ) );
+  if ( !dlg.exec() )
+    return;
+
+  QgsVectorTileConnectionUtils::deleteConnection( item->name() );
+  QgsVectorTileConnectionUtils::addConnection( dlg.connection() );
+
+  item->parent()->refreshConnections();
+}
+
+void QgsVectorTileDataItemGuiProvider::deleteConnection( QgsDataItem *item )
+{
+  if ( QMessageBox::question( nullptr, tr( "Delete Connection" ), tr( "Are you sure you want to delete the connection “%1”?" ).arg( item->name() ),
+                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
+    return;
+
+  QgsVectorTileConnectionUtils::deleteConnection( item->name() );
+
+  item->parent()->refreshConnections();
+}
+
+void QgsVectorTileDataItemGuiProvider::newConnection( QgsDataItem *item )
+{
+  QgsVectorTileConnectionDialog dlg;
+  if ( !dlg.exec() )
+    return;
+
+  QgsVectorTileConnectionUtils::addConnection( dlg.connection() );
+  item->refreshConnections();
+}
+
+void QgsVectorTileDataItemGuiProvider::saveXyzTilesServers()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::XyzTiles );
+  dlg.exec();
+}
+
+void QgsVectorTileDataItemGuiProvider::loadXyzTilesServers( QgsDataItem *item )
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *.XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::XyzTiles, fileName );
+  dlg.exec();
+  item->refreshConnections();
+}

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -57,12 +57,14 @@ void QgsVectorTileDataItemGuiProvider::populateContextMenu( QgsDataItem *item, Q
 void QgsVectorTileDataItemGuiProvider::editConnection( QgsDataItem *item )
 {
   QgsVectorTileConnectionDialog dlg;
-  dlg.setConnection( QgsVectorTileConnectionUtils::connection( item->name() ) );
+  QString uri = QgsVectorTileProviderConnection::encodedUri( QgsVectorTileProviderConnection::connection( item->name() ) );
+  dlg.setConnection( item->name(), uri );
   if ( !dlg.exec() )
     return;
 
-  QgsVectorTileConnectionUtils::deleteConnection( item->name() );
-  QgsVectorTileConnectionUtils::addConnection( dlg.connection() );
+  QgsVectorTileProviderConnection::deleteConnection( item->name() );
+  QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( dlg.connectionUri() );
+  QgsVectorTileProviderConnection::addConnection( dlg.connectionName(), conn );
 
   item->parent()->refreshConnections();
 }
@@ -73,7 +75,7 @@ void QgsVectorTileDataItemGuiProvider::deleteConnection( QgsDataItem *item )
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) != QMessageBox::Yes )
     return;
 
-  QgsVectorTileConnectionUtils::deleteConnection( item->name() );
+  QgsVectorTileProviderConnection::deleteConnection( item->name() );
 
   item->parent()->refreshConnections();
 }
@@ -84,7 +86,9 @@ void QgsVectorTileDataItemGuiProvider::newConnection( QgsDataItem *item )
   if ( !dlg.exec() )
     return;
 
-  QgsVectorTileConnectionUtils::addConnection( dlg.connection() );
+  QgsVectorTileProviderConnection::Data conn = QgsVectorTileProviderConnection::decodedUri( dlg.connectionUri() );
+  QgsVectorTileProviderConnection::addConnection( dlg.connectionName(), conn );
+
   item->refreshConnections();
 }
 

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.cpp
@@ -23,6 +23,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
+///@cond PRIVATE
 
 void QgsVectorTileDataItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
 {
@@ -106,3 +107,5 @@ void QgsVectorTileDataItemGuiProvider::loadXyzTilesServers( QgsDataItem *item )
   dlg.exec();
   item->refreshConnections();
 }
+
+///@endcond

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
@@ -1,0 +1,42 @@
+/***************************************************************************
+  qgsvectortiledataitemguiprovider.h
+  --------------------------------------
+  Date                 : March 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEDATAITEMGUIPROVIDER_H
+#define QGSVECTORTILEDATAITEMGUIPROVIDER_H
+
+#include "qgsdataitemguiprovider.h"
+
+
+class QgsVectorTileDataItemGuiProvider : public QObject, public QgsDataItemGuiProvider
+{
+    Q_OBJECT
+  public:
+
+    QString name() override { return QStringLiteral( "Vector Tiles" ); }
+
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+
+  private:
+    static void editConnection( QgsDataItem *item );
+    static void deleteConnection( QgsDataItem *item );
+    static void newConnection( QgsDataItem *item );
+    static void saveXyzTilesServers();
+    static void loadXyzTilesServers( QgsDataItem *item );
+
+};
+
+
+#endif // QGSVECTORTILEDATAITEMGUIPROVIDER_H

--- a/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
+++ b/src/gui/vectortile/qgsvectortiledataitemguiprovider.h
@@ -16,6 +16,9 @@
 #ifndef QGSVECTORTILEDATAITEMGUIPROVIDER_H
 #define QGSVECTORTILEDATAITEMGUIPROVIDER_H
 
+///@cond PRIVATE
+#define SIP_NO_FILE
+
 #include "qgsdataitemguiprovider.h"
 
 
@@ -38,5 +41,6 @@ class QgsVectorTileDataItemGuiProvider : public QObject, public QgsDataItemGuiPr
 
 };
 
+///@endcond
 
 #endif // QGSVECTORTILEDATAITEMGUIPROVIDER_H

--- a/src/gui/vectortile/qgsvectortileproviderguimetadata.cpp
+++ b/src/gui/vectortile/qgsvectortileproviderguimetadata.cpp
@@ -1,0 +1,30 @@
+/***************************************************************************
+  qgsvectortileproviderguimetadata.cpp
+  --------------------------------------
+  Date                 : March 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectortileproviderguimetadata.h"
+
+#include "qgsvectortiledataitemguiprovider.h"
+
+
+QgsVectorTileProviderGuiMetadata::QgsVectorTileProviderGuiMetadata()
+  : QgsProviderGuiMetadata( QStringLiteral( "vectortile" ) )
+{
+}
+
+QList<QgsDataItemGuiProvider *> QgsVectorTileProviderGuiMetadata::dataItemGuiProviders()
+{
+  return QList<QgsDataItemGuiProvider *>()
+         << new QgsVectorTileDataItemGuiProvider;
+}

--- a/src/gui/vectortile/qgsvectortileproviderguimetadata.cpp
+++ b/src/gui/vectortile/qgsvectortileproviderguimetadata.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsvectortiledataitemguiprovider.h"
 
+///@cond PRIVATE
 
 QgsVectorTileProviderGuiMetadata::QgsVectorTileProviderGuiMetadata()
   : QgsProviderGuiMetadata( QStringLiteral( "vectortile" ) )
@@ -28,3 +29,5 @@ QList<QgsDataItemGuiProvider *> QgsVectorTileProviderGuiMetadata::dataItemGuiPro
   return QList<QgsDataItemGuiProvider *>()
          << new QgsVectorTileDataItemGuiProvider;
 }
+
+///@endcond

--- a/src/gui/vectortile/qgsvectortileproviderguimetadata.h
+++ b/src/gui/vectortile/qgsvectortileproviderguimetadata.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+  qgsvectortileproviderguimetadata.h
+  --------------------------------------
+  Date                 : March 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORTILEPROVIDERGUIMETADATA_H
+#define QGSVECTORTILEPROVIDERGUIMETADATA_H
+
+#include <QList>
+#include <QMainWindow>
+
+#include "qgsproviderguimetadata.h"
+
+class QgsVectorTileProviderGuiMetadata: public QgsProviderGuiMetadata
+{
+  public:
+    QgsVectorTileProviderGuiMetadata();
+
+    QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
+
+};
+
+#endif // QGSVECTORTILEPROVIDERGUIMETADATA_H

--- a/src/gui/vectortile/qgsvectortileproviderguimetadata.h
+++ b/src/gui/vectortile/qgsvectortileproviderguimetadata.h
@@ -16,6 +16,9 @@
 #ifndef QGSVECTORTILEPROVIDERGUIMETADATA_H
 #define QGSVECTORTILEPROVIDERGUIMETADATA_H
 
+///@cond PRIVATE
+#define SIP_NO_FILE
+
 #include <QList>
 #include <QMainWindow>
 
@@ -29,5 +32,7 @@ class QgsVectorTileProviderGuiMetadata: public QgsProviderGuiMetadata
     QList<QgsDataItemGuiProvider *> dataItemGuiProviders() override;
 
 };
+
+///@endcond
 
 #endif // QGSVECTORTILEPROVIDERGUIMETADATA_H

--- a/src/ui/qgsvectortileconnectiondialog.ui
+++ b/src/ui/qgsvectortileconnectiondialog.ui
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorTileConnectionDialog</class>
+ <widget class="QDialog" name="QgsVectorTileConnectionDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>659</width>
+    <height>506</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Vector Tiles Connection</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="mGroupBox">
+     <property name="title">
+      <string>Connection Details</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="7" column="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>URL</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QSpinBox" name="mSpinZMax">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="value">
+         <number>14</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mEditName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="mEditUrl">
+        <property name="toolTip">
+         <string>URL of the connection, {x}, {y}, and {z} will be replaced with actual values. Use {-y} for inverted y axis.</string>
+        </property>
+        <property name="placeholderText">
+         <string>http://example.com/{z}/{x}/{y}.png</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCheckBoxZMax">
+        <property name="text">
+         <string>Max. Zoom Level</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCheckBoxZMin">
+        <property name="text">
+         <string>Min. Zoom Level</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QSpinBox" name="mSpinZMin">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>mEditName</tabstop>
+  <tabstop>mEditUrl</tabstop>
+  <tabstop>mCheckBoxZMin</tabstop>
+  <tabstop>mSpinZMin</tabstop>
+  <tabstop>mCheckBoxZMax</tabstop>
+  <tabstop>mSpinZMax</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsVectorTileConnectionDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>381</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsVectorTileConnectionDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>292</x>
+     <y>387</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tests/src/python/test_qgsproviderregistry.py
+++ b/tests/src/python/test_qgsproviderregistry.py
@@ -51,7 +51,7 @@ class TestQgsProviderRegistry(unittest.TestCase):
         """
         providers = QgsProviderRegistry.instance().providerList()
         for p in providers:
-            if p == 'geonode':
+            if p == 'geonode' or p == 'vectortile':
                 continue
 
             self.assertTrue(QgsProviderRegistry.instance().createProvider(p, ''))


### PR DESCRIPTION
Continued work on vector tile layer implementation.

This piece of work adds browser integration: there is a new root item "Vector Tiles" which lists connections defined by the user. Right-clicking it, one can add new connections in a GUI similarly to how it works with raster XYZ tiles.

It is also possible to drag'n'drop MBTiles file to QGIS - if it contains vector tiles, it will be loaded correctly. Similarly, if a MBTiles file in browser will be correctly recognized as a vector tiles or raster tiles file.

See the QEP: qgis/QGIS-Enhancement-Proposals#162

![image](https://user-images.githubusercontent.com/193367/78267786-a31c8e80-7507-11ea-9497-930272290670.png)

![image](https://user-images.githubusercontent.com/193367/78267999-e8d95700-7507-11ea-86ab-00e8eb32f888.png)


## Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/