### PR TITLE
Added move to bottom in layertreeview context menu

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -210,6 +210,13 @@ children.
 .. versionadded:: 3.0
 %End
 
+    int depth() const;
+%Docstring
+Returns the depth of this node, i.e. the number of it's ancestors
+
+.. versionadded:: 3.14
+%End
+
     bool isExpanded() const;
 %Docstring
 Returns whether the node should be shown as expanded or collapsed in GUI

--- a/python/core/auto_generated/layertree/qgslayertreenode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreenode.sip.in
@@ -212,7 +212,7 @@ children.
 
     int depth() const;
 %Docstring
-Returns the depth of this node, i.e. the number of it's ancestors
+Returns the depth of this node, i.e. the number of its ancestors
 
 .. versionadded:: 3.14
 %End

--- a/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -81,6 +81,14 @@ Action to zoom to selected features of a vector layer
 
 .. versionadded:: 3.2
 %End
+
+    QAction *actionMoveToBottom( QObject *parent = 0 ) /Factory/;
+%Docstring
+
+.. seealso:: :py:func:`moveToBottom`
+
+.. versionadded:: 3.14
+%End
     QAction *actionGroupSelected( QObject *parent = 0 ) /Factory/;
 
     QAction *actionMutuallyExclusiveGroup( QObject *parent = 0 ) /Factory/;
@@ -139,6 +147,14 @@ Moves selected layer(s) and/or group(s) to the top of the layer panel
 or the top of the group if the layer/group is placed within a group.
 
 .. versionadded:: 3.2
+%End
+
+    void moveToBottom();
+%Docstring
+Moves selected layer(s) and/or group(s) to the bottom of the layer panel
+or the bottom of the group if the layer/group is placed within a group.
+
+.. versionadded:: 3.14
 %End
     void groupSelected();
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -117,6 +117,11 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( actions->actionMoveToTop( menu ) );
       }
 
+      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == idx.model()->rowCount() - 1 ) )
+      {
+        menu->addAction( actions->actionMoveToBottom( menu ) );
+      }
+
       menu->addSeparator();
 
       if ( mView->selectedNodes( true ).count() >= 2 )
@@ -202,6 +207,11 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
       {
         menu->addAction( actions->actionMoveToTop( menu ) );
+      }
+
+      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == idx.model()->rowCount() - 1 ) )
+      {
+        menu->addAction( actions->actionMoveToBottom( menu ) );
       }
 
       QAction *checkAll = actions->actionCheckAndAllParents( menu );

--- a/src/core/layertree/qgslayertreenode.cpp
+++ b/src/core/layertree/qgslayertreenode.cpp
@@ -155,6 +155,18 @@ QList<QgsMapLayer *> QgsLayerTreeNode::checkedLayers() const
   return layers;
 }
 
+int QgsLayerTreeNode::depth() const
+{
+  int depth = 0;
+  QgsLayerTreeNode *node = mParent;
+  while ( node )
+  {
+    node = node->parent();
+    ++depth;
+  }
+  return depth;
+}
+
 void QgsLayerTreeNode::setExpanded( bool expanded )
 {
   if ( mExpanded == expanded )

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -208,6 +208,12 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
      */
     QList< QgsMapLayer * > checkedLayers() const;
 
+    /**
+     * Returns the depth of this node, i.e. the number of it's ancestors
+     * \since QGIS 3.14
+     */
+    int depth() const;
+
     //! Returns whether the node should be shown as expanded or collapsed in GUI
     bool isExpanded() const;
     //! Sets whether the node should be shown as expanded or collapsed in GUI

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -209,7 +209,7 @@ class CORE_EXPORT QgsLayerTreeNode : public QObject
     QList< QgsMapLayer * > checkedLayers() const;
 
     /**
-     * Returns the depth of this node, i.e. the number of it's ancestors
+     * Returns the depth of this node, i.e. the number of its ancestors
      * \since QGIS 3.14
      */
     int depth() const;

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -437,17 +437,18 @@ void QgsLayerTreeViewDefaultActions::moveOutOfGroup()
 void QgsLayerTreeViewDefaultActions::moveToTop()
 {
   QList< QgsLayerTreeNode * >  selectedNodes = mView->selectedNodes();
-  // sort the nodes by depth first to avoid moving a group before it's contents
+  std::reverse( selectedNodes.begin(), selectedNodes.end() );
+  // sort the nodes by depth first to avoid moving a group before its contents
   std::stable_sort( selectedNodes.begin(), selectedNodes.end(), []( const QgsLayerTreeNode * a, const QgsLayerTreeNode * b )
   {
-    return a->depth() < b->depth();
+    return a->depth() > b->depth();
   } );
-  for ( auto it = selectedNodes.rbegin(); it < selectedNodes.rend(); ++it )
+  for ( QgsLayerTreeNode *n : qgis::as_const( selectedNodes ) )
   {
-    QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( ( *it )->parent() );
-    QgsLayerTreeNode *clonedNode = ( *it )->clone();
+    QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( n->parent() );
+    QgsLayerTreeNode *clonedNode = n->clone();
     parentGroup->insertChildNode( 0, clonedNode );
-    parentGroup->removeChildNode( ( *it ) );
+    parentGroup->removeChildNode( n );
   }
 }
 
@@ -455,7 +456,7 @@ void QgsLayerTreeViewDefaultActions::moveToTop()
 void QgsLayerTreeViewDefaultActions::moveToBottom()
 {
   QList< QgsLayerTreeNode * > selectedNodes = mView->selectedNodes();
-  // sort the nodes by depth first to avoid moving a group before it's contents
+  // sort the nodes by depth first to avoid moving a group before its contents
   std::stable_sort( selectedNodes.begin(), selectedNodes.end(), []( const QgsLayerTreeNode * a, const QgsLayerTreeNode * b )
   {
     return a->depth() > b->depth();

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -138,6 +138,13 @@ QAction *QgsLayerTreeViewDefaultActions::actionMoveToTop( QObject *parent )
   return a;
 }
 
+QAction *QgsLayerTreeViewDefaultActions::actionMoveToBottom( QObject *parent )
+{
+  QAction *a = new QAction( tr( "Move to &Bottom" ), parent );
+  connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::moveToBottom );
+  return a;
+}
+
 QAction *QgsLayerTreeViewDefaultActions::actionGroupSelected( QObject *parent )
 {
   QAction *a = new QAction( tr( "&Group Selected" ), parent );
@@ -429,26 +436,39 @@ void QgsLayerTreeViewDefaultActions::moveOutOfGroup()
 
 void QgsLayerTreeViewDefaultActions::moveToTop()
 {
-  QHash <QgsLayerTreeGroup *, int> groupInsertIdx;
-  int insertIdx;
-  const QList< QgsLayerTreeNode * >  selectedNodes = mView->selectedNodes();
-  for ( QgsLayerTreeNode *n : selectedNodes )
+  QList< QgsLayerTreeNode * >  selectedNodes = mView->selectedNodes();
+  // sort the nodes by depth first to avoid moving a group before it's contents
+  std::stable_sort( selectedNodes.begin(), selectedNodes.end(), []( const QgsLayerTreeNode * a, const QgsLayerTreeNode * b )
+  {
+    return a->depth() < b->depth();
+  } );
+  for ( auto it = selectedNodes.rbegin(); it < selectedNodes.rend(); ++it )
+  {
+    QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( ( *it )->parent() );
+    QgsLayerTreeNode *clonedNode = ( *it )->clone();
+    parentGroup->insertChildNode( 0, clonedNode );
+    parentGroup->removeChildNode( ( *it ) );
+  }
+}
+
+
+void QgsLayerTreeViewDefaultActions::moveToBottom()
+{
+  QList< QgsLayerTreeNode * > selectedNodes = mView->selectedNodes();
+  // sort the nodes by depth first to avoid moving a group before it's contents
+  std::stable_sort( selectedNodes.begin(), selectedNodes.end(), []( const QgsLayerTreeNode * a, const QgsLayerTreeNode * b )
+  {
+    return a->depth() > b->depth();
+  } );
+  for ( QgsLayerTreeNode *n : qgis::as_const( selectedNodes ) )
   {
     QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( n->parent() );
     QgsLayerTreeNode *clonedNode = n->clone();
-    if ( groupInsertIdx.contains( parentGroup ) )
-    {
-      insertIdx = groupInsertIdx.value( parentGroup );
-    }
-    else
-    {
-      insertIdx = 0;
-    }
-    parentGroup->insertChildNode( insertIdx, clonedNode );
+    parentGroup->insertChildNode( -1, clonedNode );
     parentGroup->removeChildNode( n );
-    groupInsertIdx.insert( parentGroup, insertIdx + 1 );
   }
 }
+
 
 void QgsLayerTreeViewDefaultActions::groupSelected()
 {

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -82,6 +82,12 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      * \since QGIS 3.2
      */
     QAction *actionMoveToTop( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * \see moveToBottom()
+     * \since QGIS 3.14
+     */
+    QAction *actionMoveToBottom( QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionGroupSelected( QObject *parent = nullptr ) SIP_FACTORY;
 
     /**
@@ -133,6 +139,13 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      * \since QGIS 3.2
      */
     void moveToTop();
+
+    /**
+     * Moves selected layer(s) and/or group(s) to the bottom of the layer panel
+     * or the bottom of the group if the layer/group is placed within a group.
+     * \since QGIS 3.14
+     */
+    void moveToBottom();
     void groupSelected();
 
     /**

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -55,6 +55,7 @@ class TestQgsLayerTree : public QObject
     void testUtilsCollectMapLayers();
     void testUtilsCountMapLayers();
     void testSymbolText();
+    void testNodeDepth();
 
   private:
 
@@ -764,6 +765,39 @@ void TestQgsLayerTree::testSymbolText()
   delete root;
 }
 
+void TestQgsLayerTree::testNodeDepth()
+{
+  QCOMPARE( mRoot->depth(), 0 );
+  QgsLayerTreeNode *secondGroup = mRoot->children()[1];
+  QCOMPARE( secondGroup->depth(), 1 );
+
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+
+  QgsLayerTreeLayer *n = new QgsLayerTreeLayer( vl->id(), vl->name() );
+  mRoot->addChildNode( n );
+  QCOMPARE( n->depth(), 1 );
+
+  QgsLayerTreeGroup *g1 = mRoot->addGroup( QStringLiteral( "g1" ) );
+  QCOMPARE( g1->depth(), 1 );
+  QgsLayerTreeLayer *n1 = n->clone();
+  g1->addChildNode( n1 );
+  QCOMPARE( n1->depth(), 2 );
+  QgsLayerTreeGroup *g2 = g1->addGroup( QStringLiteral( "g2" ) );
+  QCOMPARE( g2->depth(), 2 );
+  QgsLayerTreeLayer *n2 = n->clone();
+  g2->addChildNode( n2 );
+  QCOMPARE( n2->depth(), 3 );
+  QgsLayerTreeGroup *g3 = g2->addGroup( QStringLiteral( "g3" ) );
+  QCOMPARE( g3->depth(), 3 );
+  QgsLayerTreeLayer *n3 = n->clone();
+  g3->addChildNode( n3 );
+  QCOMPARE( n3->depth(), 4 );
+
+  mRoot->removeChildNode( n );
+  mRoot->removeChildNode( g1 );
+  delete vl;
+}
 
 QGSTEST_MAIN( TestQgsLayerTree )
 #include "testqgslayertree.moc"

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -211,6 +211,148 @@ class TestQgsLayerTreeView(unittest.TestCase):
             groupname + '-' + self.layer4.name(),
         ])
 
+    def testMoveToTopActionLayerAndGroup(self):
+        """Test move to top action for a group and it's layer simultaneously"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().addGroup("embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+        ])
+
+        selectionMode = view.selectionMode()
+        view.setSelectionMode(QgsLayerTreeView.MultiSelection)
+        nodeLayerIndex = self.model.node2index(group)
+        view.setCurrentIndex(nodeLayerIndex)
+        view.setCurrentLayer(self.layer5)
+        view.setSelectionMode(selectionMode)
+        movetotop = actions.actionMoveToTop()
+        movetotop.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            groupname,
+            groupname + '-' + self.layer5.name(),
+            groupname + '-' + self.layer4.name(),
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+        ])
+
+    def testMoveToBottomActionLayer(self):
+        """Test move to bottom action on layer"""
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.project.layerTreeRoot().layerOrder(), [self.layer, self.layer2, self.layer3])
+        view.setCurrentLayer(self.layer)
+        movetobottom = actions.actionMoveToBottom()
+        movetobottom.trigger()
+        self.assertEqual(self.project.layerTreeRoot().layerOrder(), [self.layer2, self.layer3, self.layer])
+
+    def testMoveToBottomActionGroup(self):
+        """Test move to bottom action on group"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().insertGroup(0, "embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+        ])
+
+        nodeLayerIndex = self.model.node2index(group)
+        view.setCurrentIndex(nodeLayerIndex)
+        movetobottom = actions.actionMoveToBottom()
+        movetobottom.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+        ])
+
+    def testMoveToBottomActionEmbeddedGroup(self):
+        """Test move to bottom action on embeddedgroup layer"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().addGroup("embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+        ])
+
+        view.setCurrentLayer(self.layer4)
+        movetobottom = actions.actionMoveToBottom()
+        movetobottom.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer5.name(),
+            groupname + '-' + self.layer4.name(),
+        ])
+
+    def testMoveToBottomActionLayerAndGroup(self):
+        """Test move to top action for a group and it's layer simultaneously"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().insertGroup(0, "embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+        ])
+
+        selectionMode = view.selectionMode()
+        view.setSelectionMode(QgsLayerTreeView.MultiSelection)
+        nodeLayerIndex = self.model.node2index(group)
+        view.setCurrentIndex(nodeLayerIndex)
+        view.setCurrentLayer(self.layer4)
+        view.setSelectionMode(selectionMode)
+        movetobottom = actions.actionMoveToBottom()
+        movetobottom.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer5.name(),
+            groupname + '-' + self.layer4.name(),
+        ])
+
     def testSetLayerVisible(self):
         view = QgsLayerTreeView()
         view.setModel(self.model)


### PR DESCRIPTION
## Description
Moving around layers on big projects was made easier with *Move to top* but still one had to move manually his basemaps to the bottom of the layer list, a cumbersome task in big layer trees. This PR adds a *Move to bottom* option on the layer tree context menu that works in the same way as Move to top.

Also fixes #35530 
<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
