### PR TITLE
Flag another transform as ballpark appropriate

### DIFF
--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -459,6 +459,7 @@ QgsRectangle QgsMapSettings::outputExtentToLayerExtent( const QgsMapLayer *layer
   try
   {
     QgsCoordinateTransform ct = layerTransform( layer );
+    ct.setBallparkTransformsAreAppropriate( true );
     if ( ct.isValid() )
     {
       QgsDebugMsgLevel( QStringLiteral( "sourceCrs = %1" ).arg( ct.sourceCrs().authid() ), 3 );


### PR DESCRIPTION
Avoids some more unnecessary ballpark transform warnings