### PR TITLE
Fix proj search paths are incorrectly set and missing the local profile proj folder

### DIFF
--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -592,6 +592,8 @@ class CORE_EXPORT QgsTaskManager : public QObject
       QgsTaskRunnableWrapper *runnable = nullptr;
     };
 
+    bool mInitialized = false;
+
     mutable QMutex *mTaskMutex;
 
     QMap< long, TaskInfo > mTasks;


### PR DESCRIPTION
This is a stupid stupid situation, but because of the mess which is QGIS application initialization we have to be very careful that nothing creates a QgsCoordinateReferenceSystem or 
qgsCoordinateTransform object between the QgsApplication construction and the call to qgsApplication::init with the correct profile path.

The QgsApplication constructor creates the members object which contains singleton-ish things, and this CANNOT POSSIBLY be moved out of the constructor. And since it's apparently impossible to know the correct profile path at time of QgsApplication construction, we are left with the only
option of ensuring that NOTHING in the QgsApplication members creates QgsCoordinateReferenceSystem or QgsCoordinateTransform objects (because if they
do, then the proj search paths can't correctly be set to the actual profile path -- because until QgsApplication::init is called we don't know what the profile path is)

Long story short: QgsTaskManager constructor was connecting to the QgsProject instance, forcing early construction of QgsProject and a QgsCoordinateReferenceSystem object as a result. F̶i̶x̶ gross hack around this by deferring the connection until a task is actually created, by which time we e̶x̶p̶e̶c̶t̶ hope that the call to QgsApplication::init has occurred...

This is all l̶o̶v̶e̶l̶y̶ a pile of s***, and needs to be re-thought for QGIS 4.0

Likely fixes https://github.com/qgis/QGIS/issues/35212, because I suspect that the grid IS already installed, it's just incorrectly stating that it's not...