### PR TITLE
Filter out field with readonly in the widget. Fix #34331

### DIFF
--- a/python/core/auto_generated/qgsfieldmodel.sip.in
+++ b/python/core/auto_generated/qgsfieldmodel.sip.in
@@ -38,6 +38,7 @@ It can be associated with a QgsMapLayerModel to dynamically display a layer and 
       IsEmptyRole,
       EditorWidgetType,
       JoinedFieldIsEditable,
+      FieldIsWidgetEditable,
     };
 
     explicit QgsFieldModel( QObject *parent /TransferThis/ = 0 );

--- a/src/core/qgsfieldmodel.cpp
+++ b/src/core/qgsfieldmodel.cpp
@@ -387,6 +387,12 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       return QVariant();
     }
 
+    case FieldIsWidgetEditable:
+    {
+      return !( mLayer->editFormConfig().readOnly( index.row() - fieldOffset ) );
+    }
+
+
     case Qt::DisplayRole:
     case Qt::EditRole:
     case Qt::ToolTipRole:

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -57,6 +57,7 @@ class CORE_EXPORT QgsFieldModel : public QAbstractItemModel
       IsEmptyRole = Qt::UserRole + 8, //!< Return if the index corresponds to the empty value
       EditorWidgetType = Qt::UserRole + 9, //!< Editor widget type
       JoinedFieldIsEditable = Qt::UserRole + 10, //!< TRUE if a joined field is editable (returns QVariant if not a joined field)
+      FieldIsWidgetEditable = Qt::UserRole + 11, //!< TRUE if a is editable from the widget
     };
 
     /**

--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -41,6 +41,11 @@ bool QgsFieldProxyModel::isReadOnly( const QModelIndex &index ) const
     return true;
   }
 
+  if ( !sourceModel()->data( index, QgsFieldModel::FieldIsWidgetEditable ).toBool() )
+  {
+    return true;
+  }
+
   QgsFields::FieldOrigin origin = static_cast< QgsFields::FieldOrigin >( originVariant.toInt() );
   switch ( origin )
   {

--- a/src/core/qgsfieldproxymodel.cpp
+++ b/src/core/qgsfieldproxymodel.cpp
@@ -41,11 +41,6 @@ bool QgsFieldProxyModel::isReadOnly( const QModelIndex &index ) const
     return true;
   }
 
-  if ( !sourceModel()->data( index, QgsFieldModel::FieldIsWidgetEditable ).toBool() )
-  {
-    return true;
-  }
-
   QgsFields::FieldOrigin origin = static_cast< QgsFields::FieldOrigin >( originVariant.toInt() );
   switch ( origin )
   {
@@ -67,8 +62,18 @@ bool QgsFieldProxyModel::isReadOnly( const QModelIndex &index ) const
 
     case QgsFields::OriginEdit:
     case QgsFields::OriginProvider:
-      //not read only
-      return false;
+    {
+      if ( !sourceModel()->data( index, QgsFieldModel::FieldIsWidgetEditable ).toBool() )
+      {
+        return true;
+      }
+      else
+      {
+        //not read only
+        return false;
+      }
+    }
+
   }
   return false; // avoid warnings
 }

--- a/tests/src/python/test_qgsfieldmodel.py
+++ b/tests/src/python/test_qgsfieldmodel.py
@@ -349,6 +349,26 @@ class TestQgsFieldModel(unittest.TestCase):
         self.assertEqual(proxy_m.rowCount(), 1)
         self.assertEqual(proxy_m.data(proxy_m.index(0, 0)), 'id_a')
 
+    def testFieldIsWidgetEditableRole(self):
+        l, m = create_model()
+        self.assertTrue(m.data(m.indexFromName('fldtxt'), QgsFieldModel.FieldIsWidgetEditable))
+        self.assertTrue(m.data(m.indexFromName('fldint'), QgsFieldModel.FieldIsWidgetEditable))
+        self.assertFalse(m.data(m.indexFromName('an expression'), QgsFieldModel.FieldIsWidgetEditable))
+        self.assertFalse(m.data(m.indexFromName(None), QgsFieldModel.FieldIsWidgetEditable))
+        m.setAllowExpression(True)
+        m.setExpression('an expression')
+        self.assertTrue(m.data(m.indexFromName('an expression'), QgsFieldModel.FieldIsWidgetEditable))
+        m.setAllowEmptyFieldName(True)
+        self.assertTrue(m.data(m.indexFromName(None), QgsFieldModel.FieldIsWidgetEditable))
+
+        editFormConfig = l.editFormConfig()
+        idx = l.fields().indexOf('fldtxt')
+        # Make fldtxt readOnly
+        editFormConfig.setReadOnly(idx, True)
+        l.setEditFormConfig(editFormConfig)
+        # It's read only, so the widget is NOT editable
+        self.assertFalse(m.data(m.indexFromName('fldtxt'), QgsFieldModel.FieldIsWidgetEditable))
+
     def testFieldTooltip(self):
         f = QgsField('my_string', QVariant.String, 'string')
         self.assertEqual(QgsFieldModel.fieldToolTip(f), "<b>my_string</b><br><font style='font-family:monospace; white-space: nowrap;'>string NULL</font>")


### PR DESCRIPTION
## Description

I made another flag to make a field that is not editable through widget not showing up in the attribute table to prevent it gets updated. Example:
field `nama` is not editable
![Selection_360](https://user-images.githubusercontent.com/1421861/78355378-e0d3f280-75ad-11ea-8a95-cde3ff76716b.jpg)
field `nama` is not showing up in the combo box.
![ gedung :: Features Total: 1, Filtered: 1, Selected: 0_361](https://user-images.githubusercontent.com/1421861/78355371-dfa2c580-75ad-11ea-83dc-0b745b32145a.jpg)

