### PR TITLE
Defer mask source widget population (fixes #34942)

### DIFF
--- a/src/gui/qgsmaskingwidget.cpp
+++ b/src/gui/qgsmaskingwidget.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include <QSet>
+#include <QCheckBox>
 
 #include "qgsmaskingwidget.h"
 #include "qgsmasksourceselectionwidget.h"
@@ -41,6 +42,14 @@ QgsMaskingWidget::QgsMaskingWidget( QWidget *parent ) :
   connect( mMaskSourcesWidget, &QgsMaskSourceSelectionWidget::changed, this, [&]()
   {
     emit widgetChanged();
+  } );
+
+  connect( mEditMaskSettingsGroup, &QGroupBox::toggled, this, [&]( bool on )
+  {
+    if ( on && mLayer )
+    {
+      populate();
+    }
   } );
 }
 
@@ -133,8 +142,16 @@ QList<QPair<QgsSymbolLayerId, QList<QgsSymbolLayerReference>>> symbolLayerMasks(
 void QgsMaskingWidget::setLayer( QgsVectorLayer *layer )
 {
   mLayer = layer;
+  if ( mEditMaskSettingsGroup->isChecked() )
+  {
+    populate();
+  }
+}
+
+void QgsMaskingWidget::populate()
+{
   mMaskSourcesWidget->update();
-  mMaskTargetsWidget->setLayer( layer );
+  mMaskTargetsWidget->setLayer( mLayer );
 
   // collect masks and filter on those which have the current layer as destination
   QSet<QgsSymbolLayerId> maskedSymbolLayers;

--- a/src/gui/qgsmaskingwidget.h
+++ b/src/gui/qgsmaskingwidget.h
@@ -48,7 +48,9 @@ class GUI_EXPORT QgsMaskingWidget: public QgsPanelWidget, private Ui::QgsMasking
     void widgetChanged();
 
   private:
-    QgsVectorLayer *mLayer;
+    QgsVectorLayer *mLayer = nullptr;
+    //! Populate the mask source and target widgets
+    void populate();
 };
 
 #endif

--- a/src/gui/qgsmasksourceselectionwidget.cpp
+++ b/src/gui/qgsmasksourceselectionwidget.cpp
@@ -63,6 +63,7 @@ QgsMaskSourceSelectionWidget::QgsMaskSourceSelectionWidget( QWidget *parent )
 
   // place the tree in a layout
   QVBoxLayout *vbox = new QVBoxLayout();
+  vbox->setContentsMargins( 0, 0, 0, 0 );
   vbox->addWidget( mTree );
 
   setLayout( vbox );

--- a/src/gui/qgssymbollayerselectionwidget.cpp
+++ b/src/gui/qgssymbollayerselectionwidget.cpp
@@ -37,6 +37,7 @@ QgsSymbolLayerSelectionWidget::QgsSymbolLayerSelectionWidget( QWidget *parent )
 
   // place the tree in a layout
   QVBoxLayout *vbox = new QVBoxLayout();
+  vbox->setContentsMargins( 0, 0, 0, 0 );
   vbox->addWidget( mTree );
 
   setLayout( vbox );

--- a/src/ui/qgsmaskingwidgetbase.ui
+++ b/src/ui/qgsmaskingwidgetbase.ui
@@ -6,51 +6,54 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>637</width>
-    <height>409</height>
+    <width>863</width>
+    <height>461</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>0</number>
-   </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Masked symbol layers</string>
+    <widget class="QGroupBox" name="mEditMaskSettingsGroup">
+     <property name="title">
+      <string>Edit mask settings</string>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QgsSymbolLayerSelectionWidget" name="mMaskTargetsWidget" native="true"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Mask sources</string>
+     <property name="checkable">
+      <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QgsMaskSourceSelectionWidget" name="mMaskSourcesWidget" native="true">
-     <property name="enabled">
+     <property name="checked">
       <bool>false</bool>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Masked symbol layers</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsSymbolLayerSelectionWidget" name="mMaskTargetsWidget" native="true"/>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Mask sources</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QgsMaskSourceSelectionWidget" name="mMaskSourcesWidget" native="true">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## Description

Defer the loading of masking widgets (mask sources and targets) in the layer properties.

They are loaded only on explicit user request, when the user ticks a checkbox.

![Capture d’écran de 2020-04-03 16-22-53](https://user-images.githubusercontent.com/1618556/78371181-e4747300-75c7-11ea-9571-32fb39885504.png)

Should fix #34942 

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
