### PR TITLE
ctrl-k should not perform a new search in locator

### DIFF
--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -144,18 +144,19 @@ void QgsLocatorWidget::setMapCanvas( QgsMapCanvas *canvas )
 
 void QgsLocatorWidget::search( const QString &string )
 {
+  window()->activateWindow(); // window must also be active - otherwise floating docks can steal keystrokes
   if ( string.isEmpty() )
   {
+    mLineEdit->setFocus();
     mLineEdit->selectAll();
   }
   else
   {
+    scheduleDelayedPopup();
+    mLineEdit->setFocus();
     mLineEdit->setText( string );
+    performSearch();
   }
-  window()->activateWindow(); // window must also be active - otherwise floating docks can steal keystrokes
-  scheduleDelayedPopup();
-  mLineEdit->setFocus();
-  performSearch();
 }
 
 void QgsLocatorWidget::invalidateResults()


### PR DESCRIPTION
## Description
We want ctrl-k to have the same effect as clicking the locator widget with the mouse.
#35119 only tackled half the problem by keeping the last locator string. We also don't want to perform a new search with the same string, rather than just popup the previous search results. 
That way the last selected result is still selected!

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
