### PR TITLE
Set time of the temporal controller widget

### DIFF
--- a/src/gui/qgstemporalcontrollerwidget.h
+++ b/src/gui/qgstemporalcontrollerwidget.h
@@ -68,6 +68,8 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
 
     int mBlockSettingUpdates = 0;
 
+    bool mHasTemporalLayersLoaded = false;
+
   private slots:
 
     /**
@@ -107,6 +109,9 @@ class GUI_EXPORT QgsTemporalControllerWidget : public QgsPanelWidget, private Ui
     void updateFrameDuration();
 
     void setWidgetStateFromProject();
+
+    void onLayersAdded();
+    void onProjectCleared();
 };
 
 #endif // QGSTEMPORALCONTROLLERWIDGET_H


### PR DESCRIPTION
This PR purposes a way to handle time when a temporal layer is loaded for the first time in a project.
Not sure it is the better way to do this, but it permits to start discussion about and every suggestion is of course welcomed.
The principle is :
Sets the time of the temporal controller widget accordingly with layer time extent (or project time extent) when loading temporal layer for the first time.
Set the time of the temporal controller to current date when the project is cleared.