### PR TITLE
Update on temporal dates input display formats

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -236,7 +236,9 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
 
   // Set time settings input
   QgsDateTimeRange range = QgsProject::instance()->timeSettings()->temporalRange();
-  QLocale locale;
+
+  mStartDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mEndDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
   mStartDateTimeEdit->setDateTime( range.begin() );
   mEndDateTimeEdit->setDateTime( range.end() );

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -63,10 +63,9 @@ QgsTemporalControllerWidget::QgsTemporalControllerWidget( QWidget *parent )
 
   if ( QgsProject::instance()->timeSettings() )
     range = QgsProject::instance()->timeSettings()->temporalRange();
-  QLocale locale;
 
-  mStartDateTime->setDisplayFormat( locale.dateTimeFormat( QLocale::ShortFormat ) );
-  mEndDateTime->setDisplayFormat( locale.dateTimeFormat( QLocale::ShortFormat ) );
+  mStartDateTime->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  mEndDateTime->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
   if ( range.begin().isValid() && range.end().isValid() )
   {
@@ -158,10 +157,9 @@ void QgsTemporalControllerWidget::updateSlider( const QgsDateTimeRange &range )
 
 void QgsTemporalControllerWidget::updateRangeLabel( const QgsDateTimeRange &range )
 {
-  QLocale locale;
   mCurrentRangeLabel->setText( tr( "%1 to %2" ).arg(
-                                 range.begin().toString( locale.dateTimeFormat( QLocale::NarrowFormat ) ),
-                                 range.end().toString( locale.dateTimeFormat( QLocale::NarrowFormat ) ) ) );
+                                 range.begin().toString( "yyyy-MM-dd HH:mm:ss" ),
+                                 range.end().toString( "yyyy-MM-dd HH:mm:ss" ) ) );
 }
 
 QgsTemporalController *QgsTemporalControllerWidget::temporalController()

--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1231,6 +1231,10 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
     const QString uriString = mRasterLayer->dataProvider()->dataSourceUri() ;
     uri.setEncodedUri( uriString );
 
+    mStartStaticDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+    mEndStaticDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+    mReferenceDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+
     // setup maximum extents for widgets, based on provider's capabilities
     if ( availableProviderRange.begin().isValid() && availableProviderRange.end().isValid() )
     {
@@ -1310,16 +1314,13 @@ void QgsRasterLayerProperties::passProjectTemporalRange_toggled( bool checked )
   if ( checked )
   {
     QgsDateTimeRange range;
-    QLocale locale;
     if ( QgsProject::instance()->timeSettings() )
       range = QgsProject::instance()->timeSettings()->temporalRange();
 
     if ( range.begin().isValid() && range.end().isValid() )
       mLabel->setText( tr( "Project temporal range is set from %1 to %2" ).arg(
-                         range.begin().toString(
-                           locale.dateTimeFormat( QLocale::ShortFormat ) ),
-                         range.end().toString(
-                           locale.dateTimeFormat( QLocale::ShortFormat ) )
+                         range.begin().toString( "yyyy-MM-dd HH:mm:ss" ),
+                         range.end().toString( "yyyy-MM-dd HH:mm:ss" )
                        ) );
     else
       mLabel->setText( tr( "Project temporal range is not valid, can't use it here" ) );

--- a/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
+++ b/src/gui/raster/qgsrasterlayertemporalpropertieswidget.cpp
@@ -36,12 +36,9 @@ QgsRasterLayerTemporalPropertiesWidget::QgsRasterLayerTemporalPropertiesWidget( 
 
 void QgsRasterLayerTemporalPropertiesWidget::init()
 {
-  QLocale locale;
-  mStartTemporalDateTimeEdit->setDisplayFormat(
-    locale.dateTimeFormat( QLocale::ShortFormat ) );
+  mStartTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
-  mEndTemporalDateTimeEdit->setDisplayFormat(
-    locale.dateTimeFormat( QLocale::ShortFormat ) );
+  mEndTemporalDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
 
   mTemporalGroupBox->setChecked( mLayer->temporalProperties()->isActive() );
   switch ( mLayer->temporalProperties()->mode() )

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -451,7 +451,7 @@ QDateTime QgsWmsSettings::parseWmstDateTimes( QString item )
   // Standard item will have YYYY-MM-DDTHH:mm:ss.SSSZ
   //  format a Qt::ISODateWithMs
 
-  QString format = "YYYY-MM-DDTHH:mm:ss.SSSZ";
+  QString format = "yyyy-MM-ddTHH:mm:ss.SSSZ";
 
   // Check if it does not have time part
   if ( !item.contains( 'T' ) )

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1082,7 +1082,7 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
 void QgsWmsProvider::addWmstParameters( QUrlQuery &query )
 {
   QgsDateTimeRange range = temporalCapabilities()->requestedTemporalRange();
-  QString format = "yyyy-MM-ddThh:mm:ssZ";
+  QString format = "yyyy-MM-ddTHH:mm:ssZ";
   QgsDataSourceUri uri;
   uri.setEncodedUri( dataSourceUri() );
 


### PR DESCRIPTION
Changed the display format used in all temporal UI components date times inputs to a ISO Date subset of the standard ( "yyyy-MM-dd HH:mm:ss" ).