### PR TITLE
allow resampling method for default mesh vector dataset

### DIFF
--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -82,23 +82,20 @@ void QgsMeshLayer::setDefaultRendererSettings()
   for ( int i = 0; i < mDataProvider->datasetGroupCount(); ++i )
   {
     QgsMeshDatasetGroupMetadata meta = mDataProvider->datasetGroupMetadata( i );
-    if ( meta.isScalar() )
+    QgsMeshRendererScalarSettings scalarSettings = mRendererSettings.scalarSettings( i );
+    switch ( meta.dataType() )
     {
-      QgsMeshRendererScalarSettings scalarSettings = mRendererSettings.scalarSettings( i );
-      switch ( meta.dataType() )
-      {
-        case QgsMeshDatasetGroupMetadata::DataOnFaces:
-        case QgsMeshDatasetGroupMetadata::DataOnVolumes: // data on volumes are averaged to 2D data on faces
-          scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
-          break;
-        case QgsMeshDatasetGroupMetadata::DataOnVertices:
-          scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
-          break;
-        case QgsMeshDatasetGroupMetadata::DataOnEdges:
-          break;
-      }
-      mRendererSettings.setScalarSettings( i, scalarSettings );
+      case QgsMeshDatasetGroupMetadata::DataOnFaces:
+      case QgsMeshDatasetGroupMetadata::DataOnVolumes: // data on volumes are averaged to 2D data on faces
+        scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::NeighbourAverage );
+        break;
+      case QgsMeshDatasetGroupMetadata::DataOnVertices:
+        scalarSettings.setDataResamplingMethod( QgsMeshRendererScalarSettings::None );
+        break;
+      case QgsMeshDatasetGroupMetadata::DataOnEdges:
+        break;
     }
+    mRendererSettings.setScalarSettings( i, scalarSettings );
   }
 
 }


### PR DESCRIPTION
In the PR #35264, the vector dataset type are excluded when setting default resampling method. That was a mistake and this PR fixes this.