### PR TITLE
Allow plugins to register custom "Project Open" handlers

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1157,11 +1157,11 @@ Unregister a previously registered tool factory from the development/debugging t
 
     virtual void registerCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 %Docstring
-Register a new custom drop handler.
+Register a new custom drop ``handler``.
 
 .. note::
 
-   Ownership of the factory is not transferred, and the factory must
+   Ownership of ``handler`` is not transferred, and the handler must
    be unregistered when plugin is unloaded.
 
 .. seealso:: :py:class:`QgsCustomDropHandler`
@@ -1173,7 +1173,7 @@ Register a new custom drop handler.
 
     virtual void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 %Docstring
-Unregister a previously registered custom drop handler.
+Unregister a previously registered custom drop ``handler``.
 
 .. seealso:: :py:class:`QgsCustomDropHandler`
 
@@ -1182,13 +1182,40 @@ Unregister a previously registered custom drop handler.
 .. versionadded:: 3.0
 %End
 
+    virtual void registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) = 0;
+%Docstring
+Register a new custom project open ``handler``.
+
+.. note::
+
+   Ownership of ``handler`` is not transferred, and the handler must
+   be unregistered when plugin is unloaded.
+
+.. seealso:: :py:class:`QgsCustomProjectOpenHandler`
+
+.. seealso:: :py:func:`unregisterCustomProjectOpenHandler`
+
+.. versionadded:: 3.14
+%End
+
+    virtual void unregisterCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) = 0;
+%Docstring
+Unregister a previously registered custom project open ``handler``.
+
+.. seealso:: :py:class:`QgsCustomDropHandler`
+
+.. seealso:: :py:func:`registerCustomProjectOpenHandler`
+
+.. versionadded:: 3.14
+%End
+
     virtual void registerCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler ) = 0;
 %Docstring
 Register a new custom drop ``handler`` for layout windows.
 
 .. note::
 
-   Ownership of the factory is not transferred, and the factory must
+   Ownership of ``handler`` is not transferred, and the handler must
    be unregistered when plugin is unloaded.
 
 .. seealso:: :py:class:`QgsLayoutCustomDropHandler`

--- a/python/gui/auto_generated/qgscustomprojectopenhandler.sip.in
+++ b/python/gui/auto_generated/qgscustomprojectopenhandler.sip.in
@@ -1,0 +1,58 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscustomprojectopenhandler.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsCustomProjectOpenHandler : QObject
+{
+%Docstring
+Abstract base class that may be implemented to handle new project file types within
+the QGIS application.
+
+This interface allows extending the QGIS interface by adding support for opening additional
+(non QGS/QGZ) project files, e.g. allowing plugins to add support for opening other
+vendor project formats (such as ArcGIS MXD documents or MapInfo WOR workspaces).
+
+Handler implementations should indicate the file types they support via their filters()
+implementation, and then implement handleProjectOpen() to open the associated files.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgscustomprojectopenhandler.h"
+%End
+  public:
+
+    virtual bool handleProjectOpen( const QString &file ) = 0;
+%Docstring
+Called when the specified project ``file`` has been opened within QGIS. If ``True``
+is returned, then the handler has accepted this file and it should not
+be further processed (e.g. by other QgsCustomProjectOpenHandler).
+
+It it is the subclasses' responsiblity to ignore file types it cannot handle
+by returning ``False`` for these.
+
+The base class implementation does nothing.
+%End
+
+    virtual QStringList filters() const = 0;
+%Docstring
+Returns file filters associated with this handler, e.g. "MXD Documents (*.mxd)", "MapInfo Workspaces (*.wor)".
+
+Each individual filter should be reflected as one entry in the returned list.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscustomprojectopenhandler.h                                *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgscustomprojectopenhandler.sip.in
+++ b/python/gui/auto_generated/qgscustomprojectopenhandler.sip.in
@@ -35,7 +35,7 @@ Called when the specified project ``file`` has been opened within QGIS. If ``Tru
 is returned, then the handler has accepted this file and it should not
 be further processed (e.g. by other QgsCustomProjectOpenHandler).
 
-It it is the subclasses' responsiblity to ignore file types it cannot handle
+It it is the subclasses' responsibility to ignore file types it cannot handle
 by returning ``False`` for these.
 
 The base class implementation does nothing.

--- a/python/gui/auto_generated/qgscustomprojectopenhandler.sip.in
+++ b/python/gui/auto_generated/qgscustomprojectopenhandler.sip.in
@@ -47,6 +47,18 @@ Returns file filters associated with this handler, e.g. "MXD Documents (*.mxd)",
 
 Each individual filter should be reflected as one entry in the returned list.
 %End
+
+    virtual bool createDocumentThumbnailAfterOpen() const;
+%Docstring
+Returns ``True`` if a document thumbnail should automatically be created after opening the project.
+
+The default behavior is to return ``False``.
+%End
+
+    virtual QIcon icon() const;
+%Docstring
+Returns a custom icon used to represent this handler.
+%End
 };
 
 /************************************************************************

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -54,6 +54,7 @@
 %Include auto_generated/qgscredentialdialog.sip
 %Include auto_generated/qgscurveeditorwidget.sip
 %Include auto_generated/qgscustomdrophandler.sip
+%Include auto_generated/qgscustomprojectopenhandler.sip
 %Include auto_generated/qgsdatabaseschemacombobox.sip
 %Include auto_generated/qgsdatabasetablecombobox.sip
 %Include auto_generated/qgsdataitemguiprovider.sip

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -50,6 +50,7 @@ class QgsComposerManager;
 class QgsContrastEnhancement;
 class QgsCoordinateReferenceSystem;
 class QgsCustomDropHandler;
+class QgsCustomProjectOpenHandler;
 class QgsCustomLayerOrderWidget;
 class QgsDockWidget;
 class QgsDoubleSpinBox;
@@ -700,6 +701,22 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Unregister a previously registered custom drop handler.
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler );
+
+    /**
+     * Register a new custom project open \a handler.
+     * \note Ownership of \a handler is not transferred, and the handler must
+     *       be unregistered when plugin is unloaded.
+     * \see QgsCustomProjectOpenHandler
+     * \see unregisterCustomProjectOpenHandler()
+     */
+    void registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler );
+
+    /**
+     * Unregister a previously registered custom project open \a handler.
+     * \see QgsCustomDropHandler
+     * \see registerCustomProjectOpenHandler()
+     */
+    void unregisterCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler );
 
     //! Returns a list of registered custom drop handlers.
     QVector<QPointer<QgsCustomDropHandler >> customDropHandlers() const;
@@ -2399,6 +2416,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QList<QgsDevToolWidgetFactory * > mDevToolFactories;
 
     QVector<QPointer<QgsCustomDropHandler>> mCustomDropHandlers;
+    QVector<QPointer<QgsCustomProjectOpenHandler>> mCustomProjectOpenHandlers;
     QVector<QPointer<QgsLayoutCustomDropHandler>> mCustomLayoutDropHandlers;
 
     QgsLayoutCustomDropHandler *mLayoutQptDropHandler = nullptr;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1863,7 +1863,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void activeLayerChanged( QgsMapLayer *layer );
 
   private:
-    void createPreviewImage( const QString &path );
+    void createPreviewImage( const QString &path, const QIcon &overlayIcon = QIcon() );
     void startProfile( const QString &name );
     void endProfile();
     void functionProfile( void ( QgisApp::*fnc )(), QgisApp *instance, const QString &name );
@@ -1918,8 +1918,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * instance simultaneously results in data loss.
      *
      * \param savePreviewImage Set to false when the preview image should not be saved. E.g. project load.
+     * \param iconOverlay optional icon to overlay when saving a preview image
      */
-    void saveRecentProjectPath( bool savePreviewImage = true );
+    void saveRecentProjectPath( bool savePreviewImage = true, const QIcon &iconOverlay = QIcon() );
     //! Save recent projects list to settings
     void saveRecentProjects();
     //! Update project menu with the current list of recently accessed projects

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -566,6 +566,16 @@ void QgisAppInterface::unregisterCustomDropHandler( QgsCustomDropHandler *handle
   qgis->unregisterCustomDropHandler( handler );
 }
 
+void QgisAppInterface::registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler )
+{
+  qgis->registerCustomProjectOpenHandler( handler );
+}
+
+void QgisAppInterface::unregisterCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler )
+{
+  qgis->unregisterCustomProjectOpenHandler( handler );
+}
+
 QMenu *QgisAppInterface::projectMenu() { return qgis->projectMenu(); }
 QMenu *QgisAppInterface::editMenu() { return qgis->editMenu(); }
 QMenu *QgisAppInterface::viewMenu() { return qgis->viewMenu(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -147,6 +147,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) override;
     void registerCustomDropHandler( QgsCustomDropHandler *handler ) override;
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) override;
+    void registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) override;
+    void unregisterCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) override;
     void registerCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler ) override;
     void unregisterCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler ) override;
     QMenu *projectMenu() override;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -370,6 +370,7 @@ SET(QGIS_GUI_SRCS
   qgscoordinateoperationwidget.cpp
   qgscredentialdialog.cpp
   qgscustomdrophandler.cpp
+  qgscustomprojectopenhandler.cpp
   qgscurveeditorwidget.cpp
   qgsdatabaseschemacombobox.cpp
   qgsdatabasetablecombobox.cpp
@@ -592,6 +593,7 @@ SET(QGIS_GUI_HDRS
   qgscredentialdialog.h
   qgscurveeditorwidget.h
   qgscustomdrophandler.h
+  qgscustomprojectopenhandler.h
   qgsdatabaseschemacombobox.h
   qgsdatabasetablecombobox.h
   qgsdataitemguiprovider.h

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -39,6 +39,7 @@ class QWidget;
 class QgsAdvancedDigitizingDockWidget;
 class QgsAttributeDialog;
 class QgsCustomDropHandler;
+class QgsCustomProjectOpenHandler;
 class QgsLayoutCustomDropHandler;
 class QgsFeature;
 class QgsLayerTreeMapCanvasBridge;
@@ -957,8 +958,8 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void unregisterDevToolWidgetFactory( QgsDevToolWidgetFactory *factory ) = 0;
 
     /**
-     * Register a new custom drop handler.
-     * \note Ownership of the factory is not transferred, and the factory must
+     * Register a new custom drop \a handler.
+     * \note Ownership of \a handler is not transferred, and the handler must
      *       be unregistered when plugin is unloaded.
      * \see QgsCustomDropHandler
      * \see unregisterCustomDropHandler()
@@ -967,7 +968,7 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void registerCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 
     /**
-     * Unregister a previously registered custom drop handler.
+     * Unregister a previously registered custom drop \a handler.
      * \see QgsCustomDropHandler
      * \see registerCustomDropHandler()
      * \since QGIS 3.0
@@ -975,8 +976,26 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) = 0;
 
     /**
+     * Register a new custom project open \a handler.
+     * \note Ownership of \a handler is not transferred, and the handler must
+     *       be unregistered when plugin is unloaded.
+     * \see QgsCustomProjectOpenHandler
+     * \see unregisterCustomProjectOpenHandler()
+     * \since QGIS 3.14
+     */
+    virtual void registerCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) = 0;
+
+    /**
+     * Unregister a previously registered custom project open \a handler.
+     * \see QgsCustomDropHandler
+     * \see registerCustomProjectOpenHandler()
+     * \since QGIS 3.14
+     */
+    virtual void unregisterCustomProjectOpenHandler( QgsCustomProjectOpenHandler *handler ) = 0;
+
+    /**
      * Register a new custom drop \a handler for layout windows.
-     * \note Ownership of the factory is not transferred, and the factory must
+     * \note Ownership of \a handler is not transferred, and the handler must
      *       be unregistered when plugin is unloaded.
      * \see QgsLayoutCustomDropHandler
      * \see unregisterCustomLayoutDropHandler()

--- a/src/gui/qgscustomprojectopenhandler.cpp
+++ b/src/gui/qgscustomprojectopenhandler.cpp
@@ -1,0 +1,16 @@
+/***************************************************************************
+    qgscustomprojectopenhandler.h
+    ---------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscustomprojectopenhandler.h"

--- a/src/gui/qgscustomprojectopenhandler.cpp
+++ b/src/gui/qgscustomprojectopenhandler.cpp
@@ -14,3 +14,14 @@
  ***************************************************************************/
 
 #include "qgscustomprojectopenhandler.h"
+#include <QIcon>
+
+bool QgsCustomProjectOpenHandler::createDocumentThumbnailAfterOpen() const
+{
+  return false;
+}
+
+QIcon QgsCustomProjectOpenHandler::icon() const
+{
+  return QIcon();
+}

--- a/src/gui/qgscustomprojectopenhandler.h
+++ b/src/gui/qgscustomprojectopenhandler.h
@@ -58,6 +58,18 @@ class GUI_EXPORT QgsCustomProjectOpenHandler : public QObject
      * Each individual filter should be reflected as one entry in the returned list.
      */
     virtual QStringList filters() const = 0;
+
+    /**
+     * Returns TRUE if a document thumbnail should automatically be created after opening the project.
+     *
+     * The default behavior is to return FALSE.
+     */
+    virtual bool createDocumentThumbnailAfterOpen() const;
+
+    /**
+     * Returns a custom icon used to represent this handler.
+     */
+    virtual QIcon icon() const;
 };
 
 #endif // QgsCustomProjectOpenHandler_H

--- a/src/gui/qgscustomprojectopenhandler.h
+++ b/src/gui/qgscustomprojectopenhandler.h
@@ -45,7 +45,7 @@ class GUI_EXPORT QgsCustomProjectOpenHandler : public QObject
      * is returned, then the handler has accepted this file and it should not
      * be further processed (e.g. by other QgsCustomProjectOpenHandler).
      *
-     * It it is the subclasses' responsiblity to ignore file types it cannot handle
+     * It it is the subclasses' responsibility to ignore file types it cannot handle
      * by returning FALSE for these.
      *
      * The base class implementation does nothing.

--- a/src/gui/qgscustomprojectopenhandler.h
+++ b/src/gui/qgscustomprojectopenhandler.h
@@ -1,0 +1,63 @@
+/***************************************************************************
+    qgscustomprojectopenhandler.h
+    ---------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCUSTOMPROJECTOPENHANDLER_H
+#define QGSCUSTOMPROJECTOPENHANDLER_H
+
+#include "qgis_gui.h"
+#include <QStringList>
+#include <QObject>
+
+/**
+ * \ingroup gui
+ * Abstract base class that may be implemented to handle new project file types within
+ * the QGIS application.
+ *
+ * This interface allows extending the QGIS interface by adding support for opening additional
+ * (non QGS/QGZ) project files, e.g. allowing plugins to add support for opening other
+ * vendor project formats (such as ArcGIS MXD documents or MapInfo WOR workspaces).
+ *
+ * Handler implementations should indicate the file types they support via their filters()
+ * implementation, and then implement handleProjectOpen() to open the associated files.
+ *
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsCustomProjectOpenHandler : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Called when the specified project \a file has been opened within QGIS. If TRUE
+     * is returned, then the handler has accepted this file and it should not
+     * be further processed (e.g. by other QgsCustomProjectOpenHandler).
+     *
+     * It it is the subclasses' responsiblity to ignore file types it cannot handle
+     * by returning FALSE for these.
+     *
+     * The base class implementation does nothing.
+     */
+    virtual bool handleProjectOpen( const QString &file ) = 0;
+
+    /**
+     * Returns file filters associated with this handler, e.g. "MXD Documents (*.mxd)", "MapInfo Workspaces (*.wor)".
+     *
+     * Each individual filter should be reflected as one entry in the returned list.
+     */
+    virtual QStringList filters() const = 0;
+};
+
+#endif // QgsCustomProjectOpenHandler_H


### PR DESCRIPTION
These allow plugins to extend the "Open Project" dialog by adding in support for new file filters, which appear in the formats drop down list alongside the existing "QGS Projects" entry.

Custom project open handlers then get first chance at loading project files.

This allows plugins to extend QGIS support by adding integrated support for opening projects from non QGS/QGZ formats, e.g. allowing users to open ArcGIS MXD documents or MapInfo WOR Workspaces direct from the project open dialog.

These non-native projects are also added to the recent projects list and welcome screen, giving them a truly first-class experience within QGIS.

Sponsored by SLYR

![Peek 2020-04-06 10-47](https://user-images.githubusercontent.com/1829991/78514331-1833e080-77f4-11ea-9c8d-a5e9ead7dc1a.gif)
