### PR TITLE
[ui] Set a sensible minimum height to saved symbol list widget

### DIFF
--- a/src/gui/qgsstyleitemslistwidget.cpp
+++ b/src/gui/qgsstyleitemslistwidget.cpp
@@ -86,6 +86,7 @@ QgsStyleItemsListWidget::QgsStyleItemsListWidget( QWidget *parent )
   double treeIconSize = Qgis::UI_SCALE_FACTOR * fontMetrics().horizontalAdvance( 'X' ) * 2;
 #endif
   mSymbolTreeView->setIconSize( QSize( static_cast< int >( treeIconSize ), static_cast< int >( treeIconSize ) ) );
+  mSymbolTreeView->setMinimumHeight( mSymbolTreeView->fontMetrics().height() * 6 );
 
   viewSymbols->setSelectionBehavior( QAbstractItemView::SelectRows );
   mSymbolTreeView->setSelectionMode( viewSymbols->selectionMode() );


### PR DESCRIPTION
## Description

This PR fixes the following impractical mini-height widget:
![Screenshot from 2020-04-06 11-30-39](https://user-images.githubusercontent.com/1728657/78523606-8af48a00-77fb-11ea-8a1a-8a71304ac6f6.png)
