### PR TITLE
[temporal] Never assume a layer has temporal properties, it crashes

### DIFF
--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -158,7 +158,10 @@ void QgsTemporalControllerWidget::onLayersAdded()
   {
     QVector<QgsMapLayer *> layers = QgsProject::instance()->layers<QgsMapLayer *>();
     for ( QgsMapLayer *layer : layers )
-      mHasTemporalLayersLoaded |= layer->temporalProperties()->isActive();
+    {
+      if ( layer->temporalProperties() )
+        mHasTemporalLayersLoaded |= layer->temporalProperties()->isActive();
+    }
 
     if ( mHasTemporalLayersLoaded )
       setDatesToProjectTime();


### PR DESCRIPTION
## Description

Follow up to commit 2ca80dd -- long story short: temporal properties aren't a certainty, don't treat those as such.