### PR TITLE
[vector] Fix bogus assert when adding polygons with topological edit toggled on

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -34,6 +34,7 @@
 #include "qgisapp.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsrubberband.h"
+
 #include <QSettings>
 
 QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas *canvas, CaptureMode mode )
@@ -91,7 +92,7 @@ void QgsMapToolAddFeature::digitized( const QgsFeature &f )
     if ( topologicalEditing )
     {
       QList<QgsPointLocator::Match> sm = snappingMatches();
-      Q_ASSERT( f.geometry().constGet()->vertexCount() == sm.size() );
+      Q_ASSERT( f.geometry().constGet()->vertexCount() == ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry ? sm.size() + 1 : sm.size() ) );
       for ( int i = 0; i < sm.size() ; ++i )
       {
         if ( sm.at( i ).layer() )


### PR DESCRIPTION
## Description

Jumping from one crash to another.

QGIS crashes due to a bogus assert in the add feature tool while adding polygons when the topological editing is toggled on. This PR fixes that.
