### PR TITLE
 [vector] Fix bogus assert when adding polygons with topological edit toggled on

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -91,7 +91,7 @@ void QgsMapToolAddFeature::digitized( const QgsFeature &f )
     if ( topologicalEditing )
     {
       QList<QgsPointLocator::Match> sm = snappingMatches();
-      Q_ASSERT( f.geometry().constGet()->vertexCount() == sm.size() );
+      Q_ASSERT( f.geometry().constGet()->vertexCount() == ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry ? sm.size() + 1 : sm.size() ) );
       for ( int i = 0; i < sm.size() ; ++i )
       {
         if ( sm.at( i ).layer() )


### PR DESCRIPTION
## Description

Themes failed to offer a visual hint of whether a given tool button, when checked, was disabled or not. This backported commit addresses that.