### PR TITLE
[ui] Disable advanced config toolbar button when snapping disabled

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -430,6 +430,10 @@ void QgsSnappingWidget::toggleSnappingWidgets( bool enabled )
   mTypeButton->setEnabled( enabled );
   mToleranceSpinBox->setEnabled( enabled );
   mUnitsComboBox->setEnabled( enabled );
+  if ( mEditAdvancedConfigAction )
+  {
+    mEditAdvancedConfigAction->setEnabled( enabled );
+  }
   if ( mAdvancedConfigWidget )
   {
     mAdvancedConfigWidget->setEnabled( enabled );


### PR DESCRIPTION
## Description

The advanced config toolbar button wasn't disabled when snapping was:
![Screenshot from 2020-04-06 12-38-20](https://user-images.githubusercontent.com/1728657/78528243-1c1e2d80-7809-11ea-8ef9-3669b0ae6e92.png)

The PR fixes that.