### PR TITLE
API for allowing processing sinks to append to existing tables, with remapping

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1542,7 +1542,32 @@ Exports the geometry to a GeoJSON string.
 %End
 
 
-    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const /Factory/;
+    QVector< QgsGeometry > coerceToType( QgsWkbTypes::Type type ) const;
+%Docstring
+Attempts to coerce this geometry into the specified destination ``type``.
+
+This method will do anything possible to force the current geometry into the specified type. E.g.
+- lines or polygons will be converted to points by return either a single multipoint geometry or multiple
+single point geometries.
+- polygons will be converted to lines by extracting their exterior and interior rings, returning
+either a multilinestring or multiple single line strings as dictated by ``type``.
+- lines will be converted to polygon rings if ``type`` is a polygon type
+- curved geometries will be segmented if ``type`` is non-curved.
+- multi geometries will be converted to a list of single geometries
+- single geometries will be upgraded to multi geometries
+- z or m values will be added or dropped as required.
+
+.. note::
+
+   This method is much stricter than convertToType(), as it considers the exact WKB type
+   of geometries instead of the geometry family (point/line/polygon), and tries more exhaustively
+   to coerce geometries to the desired ``type``. It also correctly maintains curves and z/m values
+   wherever appropriate.
+
+.. versionadded:: 3.14
+%End
+
+    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const;
 %Docstring
 Try to convert the geometry to the requested type
 
@@ -1550,6 +1575,12 @@ Try to convert the geometry to the requested type
 :param destMultipart: determines if the output geometry will be multipart or not
 
 :return: the converted geometry or ``None`` if the conversion fails.
+
+.. note::
+
+   The coerceToType() method applies much stricter and more exhaustive attempts to convert
+   between geometry types, and is recommended instead of this method. This method force drops
+   curves and any z or m values present in the geometry.
 
 .. versionadded:: 2.2
 %End

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -143,6 +143,39 @@ to automatically load the resulting sink/layer after completing processing.
 
     QVariantMap createOptions;
 
+    bool useRemapping() const;
+%Docstring
+Returns ``True`` if the output uses a remapping definition.
+
+.. seealso:: :py:func:`remappingDefinition`
+
+.. versionadded:: 3.14
+%End
+
+    QgsRemappingSinkDefinition remappingDefinition() const;
+%Docstring
+Returns the output remapping definition, if useRemapping() is ``True``.
+
+.. seealso:: :py:func:`useRemapping`
+
+.. seealso:: :py:func:`setRemappingDefinition`
+
+.. versionadded:: 3.14
+%End
+
+    void setRemappingDefinition( const QgsRemappingSinkDefinition &definition );
+%Docstring
+Sets the remapping ``definition`` to use when adding features to the output layer.
+
+Calling this method will set useRemapping() to ``True``.
+
+.. seealso:: :py:func:`remappingDefinition`
+
+.. seealso:: :py:func:`useRemapping`
+
+.. versionadded:: 3.14
+%End
+
     QVariant toVariant() const;
 %Docstring
 Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
@@ -166,6 +199,7 @@ You can use QgsXmlUtils.readVariant to load it from an XML document.
     operator QVariant() const;
 
     bool operator==( const QgsProcessingOutputLayerDefinition &other ) const;
+    bool operator!=( const QgsProcessingOutputLayerDefinition &other ) const;
 
 };
 

--- a/python/core/auto_generated/qgsfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsfeaturesink.sip.in
@@ -77,41 +77,6 @@ QFlags<QgsFeatureSink::Flag> operator|(QgsFeatureSink::Flag f1, QFlags<QgsFeatur
 
 
 
-class QgsProxyFeatureSink : QgsFeatureSink
-{
-%Docstring
-A simple feature sink which proxies feature addition on to another feature sink.
-
-This class is designed to allow factory methods which always return new QgsFeatureSink
-objects. Since it is not always possible to create an entirely new QgsFeatureSink
-(e.g. if the feature sink is a layer's data provider), a new :py:class:`QgsProxyFeatureSink`
-can instead be returned which forwards features on to the destination sink. The
-proxy sink can be safely deleted without affecting the destination sink.
-
-.. versionadded:: 3.0
-%End
-
-%TypeHeaderCode
-#include "qgsfeaturesink.h"
-%End
-  public:
-
-    QgsProxyFeatureSink( QgsFeatureSink *sink );
-%Docstring
-Constructs a new QgsProxyFeatureSink which forwards features onto a destination ``sink``.
-%End
-    virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 );
-    virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 );
-    virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
-
-    QgsFeatureSink *destinationSink();
-%Docstring
-Returns the destination QgsFeatureSink which the proxy will forward features to.
-%End
-
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/qgsproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsproxyfeaturesink.sip.in
@@ -1,0 +1,58 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsproxyfeaturesink.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsProxyFeatureSink : QgsFeatureSink
+{
+%Docstring
+A simple feature sink which proxies feature addition on to another feature sink.
+
+This class is designed to allow factory methods which always return new QgsFeatureSink
+objects. Since it is not always possible to create an entirely new QgsFeatureSink
+(e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
+can instead be returned which forwards features on to the destination sink. The
+proxy sink can be safely deleted without affecting the destination sink.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsproxyfeaturesink.h"
+%End
+  public:
+
+    QgsProxyFeatureSink( QgsFeatureSink *sink );
+%Docstring
+Constructs a new QgsProxyFeatureSink which forwards features onto a destination ``sink``.
+%End
+    virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 );
+    virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 );
+    virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
+
+    QgsFeatureSink *destinationSink();
+%Docstring
+Returns the destination QgsFeatureSink which the proxy will forward features to.
+%End
+
+};
+
+
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsproxyfeaturesink.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -1,0 +1,170 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsremappingproxyfeaturesink.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsRemappingSinkDefinition
+{
+%Docstring
+Defines the parameters used to remap features when creating a QgsRemappingProxyFeatureSink.
+
+The definition includes parameters required to correctly map incoming features to the structure
+of the destination sink, e.g. information about how to create output field values and how to transform
+geometries to match the destination CRS.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsremappingproxyfeaturesink.h"
+%End
+  public:
+
+    QMap< QString, QgsProperty > fieldMap() const;
+%Docstring
+Returns the field mapping, which defines how to map the values from incoming features to destination
+field values.
+
+Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+mapping or use of QgsExpression expressions to transform values to the destination field.
+
+.. seealso:: :py:func:`setFieldMap`
+
+.. seealso:: :py:func:`addMappedField`
+%End
+
+    void setFieldMap( const QMap< QString, QgsProperty > &map );
+%Docstring
+Sets the field mapping, which defines how to map the values from incoming features to destination
+field values.
+
+Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+mapping or use of QgsExpression expressions to transform values to the destination field.
+
+.. seealso:: :py:func:`fieldMap`
+
+.. seealso:: :py:func:`addMappedField`
+%End
+
+    void addMappedField( const QString &destinationField, const QgsProperty &property );
+%Docstring
+Adds a mapping for a destination field.
+
+Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+mapping or use of QgsExpression expressions to transform values to the destination field.
+
+.. seealso:: :py:func:`setFieldMap`
+
+.. seealso:: :py:func:`fieldMap`
+%End
+
+    QgsCoordinateTransform transform() const;
+%Docstring
+Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`setTransform`
+%End
+
+    void setTransform( const QgsCoordinateTransform &transform );
+%Docstring
+Sets the ``transform`` used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`transform`
+%End
+
+    QgsWkbTypes::Type destinationWkbType() const;
+%Docstring
+Returns the WKB geometry type for the destination.
+
+.. seealso:: :py:func:`setDestinationWkbType`
+%End
+
+    void setDestinationWkbType( QgsWkbTypes::Type type );
+%Docstring
+Sets the WKB geometry ``type`` for the destination.
+
+.. seealso:: :py:func:`setDestinationWkbType`
+%End
+
+    QgsFields destinationFields() const;
+%Docstring
+Returns the fields for the destination sink.
+
+.. seealso:: :py:func:`setDestinationFields`
+%End
+
+    void setDestinationFields( const QgsFields &fields );
+%Docstring
+Sets the ``fields`` for the destination sink.
+
+.. seealso:: :py:func:`destinationFields`
+%End
+
+};
+
+
+class QgsRemappingProxyFeatureSink : QgsFeatureSink
+{
+%Docstring
+A QgsFeatureSink which proxies incoming features to a destination feature sink, after applying
+transformations and field value mappings.
+
+This sink allows for transformation of incoming features to match the requirements of storing
+in an existing destination layer, e.g. by reprojecting the features to the destination's CRS
+and by coercing geometries to the format required by the destination sink.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsremappingproxyfeaturesink.h"
+%End
+  public:
+
+    QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
+%Docstring
+Constructor for QgsRemappingProxyFeatureSink, using the specified ``mappingDefinition``
+to manipulate features before sending them to the destination ``sink``.
+%End
+
+    void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression ``context`` to use when evaluating mapped field values.
+%End
+
+    QgsFeatureList remapFeature( const QgsFeature &feature ) const;
+%Docstring
+Remaps a ``feature`` to a set of features compatible with the destination sink.
+%End
+
+    virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 );
+
+    virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 );
+
+    virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
+
+
+    QgsFeatureSink *destinationSink();
+%Docstring
+Returns the destination QgsFeatureSink which the proxy will forward features to.
+%End
+
+};
+
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsremappingproxyfeaturesink.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -64,18 +64,32 @@ mapping or use of QgsExpression expressions to transform values to the destinati
 .. seealso:: :py:func:`fieldMap`
 %End
 
-    QgsCoordinateTransform transform() const;
+    QgsCoordinateReferenceSystem sourceCrs() const;
 %Docstring
-Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+Returns the source CRS used for reprojecting incoming features to the sink's destination CRS.
 
-.. seealso:: :py:func:`setTransform`
+.. seealso:: :py:func:`setSourceCrs`
 %End
 
-    void setTransform( const QgsCoordinateTransform &transform );
+    void setSourceCrs( const QgsCoordinateReferenceSystem &source );
 %Docstring
-Sets the ``transform`` used for reprojecting incoming features to the sink's destination CRS.
+Sets the ``source`` crs used for reprojecting incoming features to the sink's destination CRS.
 
-.. seealso:: :py:func:`transform`
+.. seealso:: :py:func:`sourceCrs`
+%End
+
+    QgsCoordinateReferenceSystem destinationCrs() const;
+%Docstring
+Returns the destination CRS used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`setDestinationCrs`
+%End
+
+    void setDestinationCrs( const QgsCoordinateReferenceSystem &destination );
+%Docstring
+Sets the ``destination`` crs used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`destinationCrs`
 %End
 
     QgsWkbTypes::Type destinationWkbType() const;
@@ -106,7 +120,28 @@ Sets the ``fields`` for the destination sink.
 .. seealso:: :py:func:`destinationFields`
 %End
 
+    QVariant toVariant() const;
+%Docstring
+Saves this remapping definition to a QVariantMap, wrapped in a QVariant.
+You can use QgsXmlUtils.writeVariant to save it to an XML document.
+
+.. seealso:: :py:func:`loadVariant`
+%End
+
+    bool loadVariant( const QVariantMap &map );
+%Docstring
+Loads this remapping definition from a QVariantMap, wrapped in a QVariant.
+You can use QgsXmlUtils.readVariant to load it from an XML document.
+
+.. seealso:: :py:func:`toVariant`
+%End
+
+    bool operator==( const QgsRemappingSinkDefinition &other ) const;
+    bool operator!=( const QgsRemappingSinkDefinition &other ) const;
+
 };
+
+
 
 
 class QgsRemappingProxyFeatureSink : QgsFeatureSink
@@ -136,6 +171,11 @@ to manipulate features before sending them to the destination ``sink``.
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring
 Sets the expression ``context`` to use when evaluating mapped field values.
+%End
+
+    void setTransformContext( const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the transform ``context`` to use when reprojecting features.
 %End
 
     QgsFeatureList remapFeature( const QgsFeature &feature ) const;

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -162,11 +162,14 @@ and by coercing geometries to the format required by the destination sink.
 %End
   public:
 
+
     QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
 %Docstring
 Constructor for QgsRemappingProxyFeatureSink, using the specified ``mappingDefinition``
 to manipulate features before sending them to the destination ``sink``.
 %End
+
+    ~QgsRemappingProxyFeatureSink();
 
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -175,6 +175,7 @@
 %Include auto_generated/qgsreadwritelocker.sip
 %Include auto_generated/qgsrelation.sip
 %Include auto_generated/qgsrelationcontext.sip
+%Include auto_generated/qgsremappingproxyfeaturesink.sip
 %Include auto_generated/qgsrelationmanager.sip
 %Include auto_generated/qgsrenderchecker.sip
 %Include auto_generated/qgsrendercontext.sip

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -167,6 +167,7 @@
 %Include auto_generated/qgsproviderconnectionmodel.sip
 %Include auto_generated/qgsprovidermetadata.sip
 %Include auto_generated/qgsproviderregistry.sip
+%Include auto_generated/qgsproxyfeaturesink.sip
 %Include auto_generated/qgsproxyprogresstask.sip
 %Include auto_generated/qgspythonrunner.sip
 %Include auto_generated/qgsrange.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -360,6 +360,7 @@ SET(QGIS_CORE_SRCS
   qgsproviderconnectionmodel.cpp
   qgsprovidermetadata.cpp
   qgsproviderregistry.cpp
+  qgsproxyfeaturesink.cpp
   qgsproxyprogresstask.cpp
   qgspythonrunner.cpp
   qgsreadwritecontext.cpp
@@ -900,6 +901,7 @@ SET(QGIS_CORE_HDRS
   qgsproviderconnectionmodel.h
   qgsprovidermetadata.h
   qgsproviderregistry.h
+  qgsproxyfeaturesink.h
   qgsproxyprogresstask.h
   qgspythonrunner.h
   qgsrange.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -369,6 +369,7 @@ SET(QGIS_CORE_SRCS
   qgsrelationcontext.cpp
   qgsweakrelation.cpp
   qgsrelationmanager.cpp
+  qgsremappingproxyfeaturesink.cpp
   qgsrenderchecker.cpp
   qgsrendercontext.cpp
   qgsrunprocess.cpp
@@ -909,6 +910,7 @@ SET(QGIS_CORE_HDRS
   qgsreadwritelocker.h
   qgsrelation.h
   qgsrelationcontext.h
+  qgsremappingproxyfeaturesink.h
   qgsweakrelation.h
   qgsrelationmanager.h
   qgsrenderchecker.h

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1313,9 +1313,17 @@ json QgsGeometry::asJsonObject( int precision ) const
 QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type ) const
 {
   QVector< QgsGeometry > res;
-  if ( wkbType() == type )
+  if ( isNull() )
+    return res;
+
+  if ( wkbType() == type || type == QgsWkbTypes::Unknown )
   {
     res << *this;
+    return res;
+  }
+
+  if ( type == QgsWkbTypes::NoGeometry )
+  {
     return res;
   }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1310,6 +1310,121 @@ json QgsGeometry::asJsonObject( int precision ) const
 
 }
 
+QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type ) const
+{
+  QVector< QgsGeometry > res;
+  if ( wkbType() == type )
+  {
+    res << *this;
+    return res;
+  }
+
+  QgsGeometry newGeom = *this;
+
+  // Curved -> straight
+  if ( !QgsWkbTypes::isCurvedType( type ) && QgsWkbTypes::isCurvedType( newGeom.wkbType() ) )
+  {
+    newGeom = QgsGeometry( d->geometry.get()->segmentize() );
+  }
+
+  // polygon -> line
+  if ( QgsWkbTypes::geometryType( type ) == QgsWkbTypes::LineGeometry &&
+       newGeom.type() == QgsWkbTypes::PolygonGeometry )
+  {
+    // boundary gives us a (multi)line string of exterior + interior rings
+    newGeom = QgsGeometry( newGeom.constGet()->boundary() );
+  }
+  // line -> polygon
+  if ( QgsWkbTypes::geometryType( type ) == QgsWkbTypes::PolygonGeometry &&
+       newGeom.type() == QgsWkbTypes::LineGeometry )
+  {
+    std::unique_ptr< QgsGeometryCollection > gc( QgsGeometryFactory::createCollectionOfType( type ) );
+    const QgsGeometry source = newGeom;
+    for ( auto part = source.const_parts_begin(); part != source.const_parts_end(); ++part )
+    {
+      std::unique_ptr< QgsAbstractGeometry > exterior( ( *part )->clone() );
+      if ( QgsCurve *curve = qgsgeometry_cast< QgsCurve * >( exterior.get() ) )
+      {
+        if ( QgsWkbTypes::isCurvedType( type ) )
+        {
+          std::unique_ptr< QgsCurvePolygon > cp = qgis::make_unique< QgsCurvePolygon >();
+          cp->setExteriorRing( curve );
+          exterior.release();
+          gc->addGeometry( cp.release() );
+        }
+        else
+        {
+          std::unique_ptr< QgsPolygon > p = qgis::make_unique< QgsPolygon  >();
+          p->setExteriorRing( qgsgeometry_cast< QgsLineString * >( curve ) );
+          exterior.release();
+          gc->addGeometry( p.release() );
+        }
+      }
+    }
+    newGeom = QgsGeometry( std::move( gc ) );
+  }
+
+  // line/polygon -> points
+  if ( QgsWkbTypes::geometryType( type ) == QgsWkbTypes::PointGeometry &&
+       ( newGeom.type() == QgsWkbTypes::LineGeometry ||
+         newGeom.type() == QgsWkbTypes::PolygonGeometry ) )
+  {
+    // lines/polygons to a point layer, extract all vertices
+    std::unique_ptr< QgsMultiPoint > mp = qgis::make_unique< QgsMultiPoint >();
+    const QgsGeometry source = newGeom;
+    QSet< QgsPoint > added;
+    for ( auto vertex = source.vertices_begin(); vertex != source.vertices_end(); ++vertex )
+    {
+      if ( added.contains( *vertex ) )
+        continue; // avoid duplicate points, e.g. start/end of rings
+      mp->addGeometry( ( *vertex ).clone() );
+      added.insert( *vertex );
+    }
+    newGeom = QgsGeometry( std::move( mp ) );
+  }
+
+  // Single -> multi
+  if ( QgsWkbTypes::isMultiType( type ) && ! newGeom.isMultipart( ) )
+  {
+    newGeom.convertToMultiType();
+  }
+  // Drop Z/M
+  if ( newGeom.constGet()->is3D() && ! QgsWkbTypes::hasZ( type ) )
+  {
+    newGeom.get()->dropZValue();
+  }
+  if ( newGeom.constGet()->isMeasure() && ! QgsWkbTypes::hasM( type ) )
+  {
+    newGeom.get()->dropMValue();
+  }
+  // Add Z/M back, set to 0
+  if ( ! newGeom.constGet()->is3D() && QgsWkbTypes::hasZ( type ) )
+  {
+    newGeom.get()->addZValue( 0.0 );
+  }
+  if ( ! newGeom.constGet()->isMeasure() && QgsWkbTypes::hasM( type ) )
+  {
+    newGeom.get()->addMValue( 0.0 );
+  }
+
+  // Multi -> single
+  if ( ! QgsWkbTypes::isMultiType( type ) && newGeom.isMultipart( ) )
+  {
+    const QgsGeometryCollection *parts( static_cast< const QgsGeometryCollection * >( newGeom.constGet() ) );
+    QgsAttributeMap attrMap;
+    res.reserve( parts->partCount() );
+    for ( int i = 0; i < parts->partCount( ); i++ )
+    {
+      res << QgsGeometry( parts->geometryN( i )->clone() );
+    }
+  }
+  else
+  {
+    res << newGeom;
+  }
+  return res;
+}
+
 QgsGeometry QgsGeometry::convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart ) const
 {
   switch ( destType )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1568,13 +1568,41 @@ class CORE_EXPORT QgsGeometry
     virtual json asJsonObject( int precision = 17 ) const SIP_SKIP;
 
     /**
+     * Attempts to coerce this geometry into the specified destination \a type.
+     *
+     * This method will do anything possible to force the current geometry into the specified type. E.g.
+     * - lines or polygons will be converted to points by return either a single multipoint geometry or multiple
+     * single point geometries.
+     * - polygons will be converted to lines by extracting their exterior and interior rings, returning
+     * either a multilinestring or multiple single line strings as dictated by \a type.
+     * - lines will be converted to polygon rings if \a type is a polygon type
+     * - curved geometries will be segmented if \a type is non-curved.
+     * - multi geometries will be converted to a list of single geometries
+     * - single geometries will be upgraded to multi geometries
+     * - z or m values will be added or dropped as required.
+     *
+     * \note This method is much stricter than convertToType(), as it considers the exact WKB type
+     * of geometries instead of the geometry family (point/line/polygon), and tries more exhaustively
+     * to coerce geometries to the desired \a type. It also correctly maintains curves and z/m values
+     * wherever appropriate.
+     *
+     * \since QGIS 3.14
+     */
+    QVector< QgsGeometry > coerceToType( QgsWkbTypes::Type type ) const;
+
+    /**
      * Try to convert the geometry to the requested type
      * \param destType the geometry type to be converted to
      * \param destMultipart determines if the output geometry will be multipart or not
      * \returns the converted geometry or NULLPTR if the conversion fails.
+     *
+     * \note The coerceToType() method applies much stricter and more exhaustive attempts to convert
+     * between geometry types, and is recommended instead of this method. This method force drops
+     * curves and any z or m values present in the geometry.
+     *
      * \since QGIS 2.2
      */
-    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const SIP_FACTORY;
+    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const;
 
     /* Accessor functions for getting geometry data */
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -61,11 +61,23 @@ bool QgsProcessingFeatureSourceDefinition::loadVariant( const QVariantMap &map )
 }
 
 
+//
+// QgsProcessingOutputLayerDefinition
+//
+
+void QgsProcessingOutputLayerDefinition::setRemappingDefinition( const QgsRemappingSinkDefinition &definition )
+{
+  mUseRemapping = true;
+  mRemappingDefinition = definition;
+}
+
 QVariant QgsProcessingOutputLayerDefinition::toVariant() const
 {
   QVariantMap map;
   map.insert( QStringLiteral( "sink" ), sink.toVariant() );
   map.insert( QStringLiteral( "create_options" ), createOptions );
+  if ( mUseRemapping )
+    map.insert( QStringLiteral( "remapping" ), QVariant::fromValue( mRemappingDefinition ) );
   return map;
 }
 
@@ -73,12 +85,27 @@ bool QgsProcessingOutputLayerDefinition::loadVariant( const QVariantMap &map )
 {
   sink.loadVariant( map.value( QStringLiteral( "sink" ) ) );
   createOptions = map.value( QStringLiteral( "create_options" ) ).toMap();
+  if ( map.contains( QStringLiteral( "remapping" ) ) )
+  {
+    mUseRemapping = true;
+    mRemappingDefinition = map.value( QStringLiteral( "remapping" ) ).value< QgsRemappingSinkDefinition >();
+  }
+  else
+  {
+    mUseRemapping = false;
+  }
   return true;
 }
 
 bool QgsProcessingOutputLayerDefinition::operator==( const QgsProcessingOutputLayerDefinition &other ) const
 {
-  return sink == other.sink && destinationProject == other.destinationProject && destinationName == other.destinationName && createOptions == other.createOptions;
+  return sink == other.sink && destinationProject == other.destinationProject && destinationName == other.destinationName && createOptions == other.createOptions
+         && mUseRemapping == other.mUseRemapping && mRemappingDefinition == other.mRemappingDefinition;
+}
+
+bool QgsProcessingOutputLayerDefinition::operator!=( const QgsProcessingOutputLayerDefinition &other ) const
+{
+  return !( *this == other );
 }
 
 bool QgsProcessingParameters::isDynamic( const QVariantMap &parameters, const QString &name )

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -579,6 +579,8 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   QgsProject *destinationProject = nullptr;
   QString destName;
   QVariantMap createOptions;
+  QgsRemappingSinkDefinition remapDefinition;
+  bool useRemapDefinition = false;
   if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
@@ -588,6 +590,11 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
 
     val = fromVar.sink;
     destName = fromVar.destinationName;
+    if ( fromVar.useRemapping() )
+    {
+      useRemapDefinition = true;
+      remapDefinition = fromVar.remappingDefinition();
+    }
   }
 
   QString dest;
@@ -622,7 +629,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   if ( dest.isEmpty() )
     return nullptr;
 
-  std::unique_ptr< QgsFeatureSink > sink( QgsProcessingUtils::createFeatureSink( dest, context, fields, geometryType, crs, createOptions, sinkFlags ) );
+  std::unique_ptr< QgsFeatureSink > sink( QgsProcessingUtils::createFeatureSink( dest, context, fields, geometryType, crs, createOptions, sinkFlags, useRemapDefinition ? &remapDefinition : nullptr ) );
   destinationIdentifier = dest;
 
   if ( destinationProject )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -26,6 +26,7 @@
 #include "qgsfeaturesource.h"
 #include "qgsprocessingutils.h"
 #include "qgsfilefiltergenerator.h"
+#include "qgsremappingproxyfeaturesink.h"
 #include <QMap>
 #include <limits>
 
@@ -245,6 +246,35 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     QVariantMap createOptions;
 
     /**
+     * Returns TRUE if the output uses a remapping definition.
+     *
+     * \see remappingDefinition()
+     * \since QGIS 3.14
+     */
+    bool useRemapping() const { return mUseRemapping; }
+
+    /**
+     * Returns the output remapping definition, if useRemapping() is TRUE.
+     *
+     * \see useRemapping()
+     * \see setRemappingDefinition()
+     * \since QGIS 3.14
+     */
+    QgsRemappingSinkDefinition remappingDefinition() const { return mRemappingDefinition; }
+
+    /**
+     * Sets the remapping \a definition to use when adding features to the output layer.
+     *
+     * Calling this method will set useRemapping() to TRUE.
+     *
+     * \see remappingDefinition()
+     * \see useRemapping()
+     *
+     * \since QGIS 3.14
+     */
+    void setRemappingDefinition( const QgsRemappingSinkDefinition &definition );
+
+    /**
      * Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
      * You can use QgsXmlUtils::writeVariant to save it to an XML document.
      * \see loadVariant()
@@ -267,6 +297,12 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     }
 
     bool operator==( const QgsProcessingOutputLayerDefinition &other ) const;
+    bool operator!=( const QgsProcessingOutputLayerDefinition &other ) const;
+
+  private:
+
+    bool mUseRemapping = false;
+    QgsRemappingSinkDefinition mRemappingDefinition;
 
 };
 

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -27,6 +27,7 @@
 #include "qgsfeaturesink.h"
 #include "qgsfeaturesource.h"
 #include "qgsproxyfeaturesink.h"
+#include "qgsremappingproxyfeaturesink.h"
 
 class QgsMeshLayer;
 class QgsProject;
@@ -222,7 +223,8 @@ class CORE_EXPORT QgsProcessingUtils
         QgsWkbTypes::Type geometryType,
         const QgsCoordinateReferenceSystem &crs,
         const QVariantMap &createOptions = QVariantMap(),
-        QgsFeatureSink::SinkFlags sinkFlags = nullptr ) SIP_FACTORY;
+        QgsFeatureSink::SinkFlags sinkFlags = nullptr,
+        QgsRemappingSinkDefinition *remappingDefinition = nullptr ) SIP_FACTORY;
 #endif
 
     /**

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -26,6 +26,7 @@
 #include "qgsprocessing.h"
 #include "qgsfeaturesink.h"
 #include "qgsfeaturesource.h"
+#include "qgsproxyfeaturesink.h"
 
 class QgsMeshLayer;
 class QgsProject;

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -61,6 +61,7 @@
 #include "qgsbookmarkmanager.h"
 #include "qgsstylemodel.h"
 #include "qgsconnectionregistry.h"
+#include "qgsremappingproxyfeaturesink.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -230,6 +231,7 @@ void QgsApplication::init( QString profileFolder )
   qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
   qRegisterMetaType<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
   qRegisterMetaTypeStreamOperators<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
+  qRegisterMetaType<QgsRemappingSinkDefinition>( "QgsRemappingSinkDefinition" );
 
   ( void ) resolvePkgPath();
 

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -102,42 +102,6 @@ class CORE_EXPORT QgsFeatureSink
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureSink::Flags )
 
-
-/**
- * \class QgsProxyFeatureSink
- * \ingroup core
- * A simple feature sink which proxies feature addition on to another feature sink.
- *
- * This class is designed to allow factory methods which always return new QgsFeatureSink
- * objects. Since it is not always possible to create an entirely new QgsFeatureSink
- * (e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
- * can instead be returned which forwards features on to the destination sink. The
- * proxy sink can be safely deleted without affecting the destination sink.
- *
- * \since QGIS 3.0
- */
-class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
-{
-  public:
-
-    /**
-     * Constructs a new QgsProxyFeatureSink which forwards features onto a destination \a sink.
-     */
-    QgsProxyFeatureSink( QgsFeatureSink *sink );
-    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeature( feature, flags ); }
-    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( features, flags ); }
-    bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( iterator, flags ); }
-
-    /**
-     * Returns the destination QgsFeatureSink which the proxy will forward features to.
-     */
-    QgsFeatureSink *destinationSink() { return mSink; }
-
-  private:
-
-    QgsFeatureSink *mSink = nullptr;
-};
-
 Q_DECLARE_METATYPE( QgsFeatureSink * )
 
 #endif // QGSFEATURESINK_H

--- a/src/core/qgsproxyfeaturesink.cpp
+++ b/src/core/qgsproxyfeaturesink.cpp
@@ -1,8 +1,8 @@
 /***************************************************************************
-                         qgsfeaturesink.cpp
-                         ------------------
-    begin                : April 2017
-    copyright            : (C) 2017 by Nyall Dawson
+                         qgsproxyfeaturesink.cpp
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
     email                : nyall dot dawson at gmail dot com
  ***************************************************************************/
 
@@ -15,30 +15,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsfeaturestore.h"
+#include "qgsproxyfeaturesink.h"
 
-bool QgsFeatureSink::addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags )
-{
-  QgsFeatureList features;
-  features << feature;
-  bool result = addFeatures( features, flags );
 
-  if ( !( flags & FastInsert ) )
-  {
-    // need to update the passed feature reference to the updated copy from the features list
-    feature = features.at( 0 );
-  }
-  return result;
-}
-
-bool QgsFeatureSink::addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags )
-{
-  QgsFeature f;
-  bool result = true;
-  while ( iterator.nextFeature( f ) )
-  {
-    result = result && addFeature( f, flags );
-  }
-  return result;
-}
-
+QgsProxyFeatureSink::QgsProxyFeatureSink( QgsFeatureSink *sink )
+  : mSink( sink )
+{}

--- a/src/core/qgsproxyfeaturesink.h
+++ b/src/core/qgsproxyfeaturesink.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+                         qgsproxyfeaturesink.h
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROXYFEATURESINK_H
+#define QGSPROXYFEATURESINK_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsfeaturesink.h"
+
+
+/**
+ * \class QgsProxyFeatureSink
+ * \ingroup core
+ * A simple feature sink which proxies feature addition on to another feature sink.
+ *
+ * This class is designed to allow factory methods which always return new QgsFeatureSink
+ * objects. Since it is not always possible to create an entirely new QgsFeatureSink
+ * (e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
+ * can instead be returned which forwards features on to the destination sink. The
+ * proxy sink can be safely deleted without affecting the destination sink.
+ *
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
+{
+  public:
+
+    /**
+     * Constructs a new QgsProxyFeatureSink which forwards features onto a destination \a sink.
+     */
+    QgsProxyFeatureSink( QgsFeatureSink *sink );
+    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeature( feature, flags ); }
+    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( features, flags ); }
+    bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( iterator, flags ); }
+
+    /**
+     * Returns the destination QgsFeatureSink which the proxy will forward features to.
+     */
+    QgsFeatureSink *destinationSink() { return mSink; }
+
+  private:
+
+    QgsFeatureSink *mSink = nullptr;
+};
+
+
+#endif // QGSPROXYFEATURESINK_H
+
+
+
+

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -18,11 +18,18 @@
 #include "qgsremappingproxyfeaturesink.h"
 #include "qgslogger.h"
 
-QgsRemappingProxyFeatureSink::QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink )
+QgsRemappingProxyFeatureSink::QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink, bool ownsSink )
   : QgsFeatureSink()
   , mDefinition( mappingDefinition )
   , mSink( sink )
+  , mOwnsSink( ownsSink )
 {}
+
+QgsRemappingProxyFeatureSink::~QgsRemappingProxyFeatureSink()
+{
+  if ( mOwnsSink )
+    delete mSink;
+}
 
 void QgsRemappingProxyFeatureSink::setExpressionContext( const QgsExpressionContext &context )
 {
@@ -39,6 +46,7 @@ QgsFeatureList QgsRemappingProxyFeatureSink::remapFeature( const QgsFeature &fea
   QgsFeatureList res;
 
   mContext.setFeature( feature );
+  mContext.setFields( feature.fields() );
 
   // remap fields first
   QgsFeature f;

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -1,0 +1,119 @@
+/***************************************************************************
+                         qgsremappingproxyfeaturesink.cpp
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsremappingproxyfeaturesink.h"
+#include "qgslogger.h"
+
+QgsRemappingProxyFeatureSink::QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink )
+  : QgsFeatureSink()
+  , mDefinition( mappingDefinition )
+  , mSink( sink )
+{}
+
+void QgsRemappingProxyFeatureSink::setExpressionContext( const QgsExpressionContext &context )
+{
+  mContext = context;
+}
+
+QgsFeatureList QgsRemappingProxyFeatureSink::remapFeature( const QgsFeature &feature ) const
+{
+  QgsFeatureList res;
+
+  mContext.setFeature( feature );
+
+  // remap fields first
+  QgsFeature f;
+  f.setFields( mDefinition.destinationFields(), true );
+  QgsAttributes attributes;
+  const QMap< QString, QgsProperty > fieldMap = mDefinition.fieldMap();
+  for ( const QgsField &field : mDefinition.destinationFields() )
+  {
+    if ( fieldMap.contains( field.name() ) )
+    {
+      attributes.append( fieldMap.value( field.name() ).value( mContext ) );
+    }
+    else
+    {
+      attributes.append( QVariant() );
+    }
+  }
+  f.setAttributes( attributes );
+
+  // make geometries compatible, and reproject if necessary
+  if ( feature.hasGeometry() )
+  {
+    const QVector< QgsGeometry > geometries = feature.geometry().coerceToType( mDefinition.destinationWkbType() );
+    if ( !geometries.isEmpty() )
+    {
+      res.reserve( geometries.size() );
+      for ( const QgsGeometry &geometry : geometries )
+      {
+        QgsFeature featurePart = f;
+
+        QgsGeometry reproject = geometry;
+        try
+        {
+          reproject.transform( mDefinition.transform() );
+          featurePart.setGeometry( reproject );
+        }
+        catch ( QgsCsException & )
+        {
+          QgsLogger::warning( QObject::tr( "Error reprojecting feature geometry" ) );
+          featurePart.clearGeometry();
+        }
+        res << featurePart;
+      }
+    }
+    else
+    {
+      f.clearGeometry();
+      res << f;
+    }
+  }
+  else
+  {
+    res << f;
+  }
+  return res;
+}
+
+bool QgsRemappingProxyFeatureSink::addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags )
+{
+  QgsFeatureList features = remapFeature( feature );
+  return mSink->addFeatures( features, flags );
+}
+
+bool QgsRemappingProxyFeatureSink::addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags )
+{
+  bool res = true;
+  for ( QgsFeature &f : features )
+  {
+    res = addFeature( f, flags ) && res;
+  }
+  return res;
+}
+
+bool QgsRemappingProxyFeatureSink::addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags )
+{
+  QgsFeature f;
+  bool res = true;
+  while ( iterator.nextFeature( f ) )
+  {
+    res = addFeature( f, flags ) && res;
+  }
+  return res;
+}

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -46,7 +46,6 @@ QgsFeatureList QgsRemappingProxyFeatureSink::remapFeature( const QgsFeature &fea
   QgsFeatureList res;
 
   mContext.setFeature( feature );
-  mContext.setFields( feature.fields() );
 
   // remap fields first
   QgsFeature f;

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -179,11 +179,27 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
 {
   public:
 
+#ifndef SIP_RUN
+
+    /**
+     * Constructor for QgsRemappingProxyFeatureSink, using the specified \a mappingDefinition
+     * to manipulate features before sending them to the destination \a sink.
+     *
+     * Ownership of \a sink is dictated by \a ownsSink. If \a ownsSink is FALSE,
+     * ownership is not transferred, and callers must ensure that \a sink exists for the lifetime of this object.
+     * If \a ownsSink is TRUE, then this object will take ownership of \a sink.
+     */
+    QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink, bool ownsSink = false );
+#else
+
     /**
      * Constructor for QgsRemappingProxyFeatureSink, using the specified \a mappingDefinition
      * to manipulate features before sending them to the destination \a sink.
      */
     QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
+#endif
+
+    ~QgsRemappingProxyFeatureSink() override;
 
     /**
      * Sets the expression \a context to use when evaluating mapped field values.
@@ -215,6 +231,7 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
     QgsCoordinateTransform mTransform;
     QgsFeatureSink *mSink = nullptr;
     mutable QgsExpressionContext mContext;
+    bool mOwnsSink = false;
 };
 
 #endif // QGSREMAPPINGPROXYFEATURESINK_H

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -1,0 +1,183 @@
+/***************************************************************************
+                         qgsremappingproxyfeaturesink.h
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSREMAPPINGPROXYFEATURESINK_H
+#define QGSREMAPPINGPROXYFEATURESINK_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsfeaturesink.h"
+#include "qgsproperty.h"
+
+/**
+ * \class QgsRemappingSinkDefinition
+ * \ingroup core
+ * Defines the parameters used to remap features when creating a QgsRemappingProxyFeatureSink.
+ *
+ * The definition includes parameters required to correctly map incoming features to the structure
+ * of the destination sink, e.g. information about how to create output field values and how to transform
+ * geometries to match the destination CRS.
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsRemappingSinkDefinition
+{
+  public:
+
+    /**
+     * Returns the field mapping, which defines how to map the values from incoming features to destination
+     * field values.
+     *
+     * Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+     * mapping or use of QgsExpression expressions to transform values to the destination field.
+     *
+     * \see setFieldMap()
+     * \see addMappedField()
+     */
+    QMap< QString, QgsProperty > fieldMap() const { return mFieldMap; }
+
+    /**
+     * Sets the field mapping, which defines how to map the values from incoming features to destination
+     * field values.
+     *
+     * Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+     * mapping or use of QgsExpression expressions to transform values to the destination field.
+     *
+     * \see fieldMap()
+     * \see addMappedField()
+     */
+    void setFieldMap( const QMap< QString, QgsProperty > &map ) { mFieldMap = map; }
+
+    /**
+     * Adds a mapping for a destination field.
+     *
+     * Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+     * mapping or use of QgsExpression expressions to transform values to the destination field.
+     *
+     * \see setFieldMap()
+     * \see fieldMap()
+     */
+    void addMappedField( const QString &destinationField, const QgsProperty &property ) { mFieldMap.insert( destinationField, property ); }
+
+    /**
+     * Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see setTransform()
+     */
+    QgsCoordinateTransform transform() const { return mTransform; }
+
+    /**
+     * Sets the \a transform used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see transform()
+     */
+    void setTransform( const QgsCoordinateTransform &transform )  { mTransform = transform; }
+
+    /**
+     * Returns the WKB geometry type for the destination.
+     *
+     * \see setDestinationWkbType()
+     */
+    QgsWkbTypes::Type destinationWkbType() const { return mDestinationWkbType; }
+
+    /**
+     * Sets the WKB geometry \a type for the destination.
+     *
+     * \see setDestinationWkbType()
+     */
+    void setDestinationWkbType( QgsWkbTypes::Type type ) { mDestinationWkbType = type; }
+
+    /**
+     * Returns the fields for the destination sink.
+     *
+     * \see setDestinationFields()
+     */
+    QgsFields destinationFields() const { return mDestinationFields; }
+
+    /**
+     * Sets the \a fields for the destination sink.
+     *
+     * \see destinationFields()
+     */
+    void setDestinationFields( const QgsFields &fields ) { mDestinationFields = fields; }
+
+  private:
+
+    QMap< QString, QgsProperty > mFieldMap;
+
+    QgsCoordinateTransform mTransform;
+
+    QgsWkbTypes::Type mDestinationWkbType = QgsWkbTypes::Unknown;
+
+    QgsFields mDestinationFields;
+
+};
+
+
+/**
+ * \class QgsRemappingProxyFeatureSink
+ * \ingroup core
+ * A QgsFeatureSink which proxies incoming features to a destination feature sink, after applying
+ * transformations and field value mappings.
+ *
+ * This sink allows for transformation of incoming features to match the requirements of storing
+ * in an existing destination layer, e.g. by reprojecting the features to the destination's CRS
+ * and by coercing geometries to the format required by the destination sink.
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
+{
+  public:
+
+    /**
+     * Constructor for QgsRemappingProxyFeatureSink, using the specified \a mappingDefinition
+     * to manipulate features before sending them to the destination \a sink.
+     */
+    QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
+
+    /**
+     * Sets the expression \a context to use when evaluating mapped field values.
+     */
+    void setExpressionContext( const QgsExpressionContext &context );
+
+    /**
+     * Remaps a \a feature to a set of features compatible with the destination sink.
+     */
+    QgsFeatureList remapFeature( const QgsFeature &feature ) const;
+
+    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override;
+    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override;
+    bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override;
+
+    /**
+     * Returns the destination QgsFeatureSink which the proxy will forward features to.
+     */
+    QgsFeatureSink *destinationSink() { return mSink; }
+
+  private:
+
+    QgsRemappingSinkDefinition mDefinition;
+    QgsFeatureSink *mSink = nullptr;
+    mutable QgsExpressionContext mContext;
+};
+
+#endif // QGSREMAPPINGPROXYFEATURESINK_H
+
+
+
+

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -74,18 +74,32 @@ class CORE_EXPORT QgsRemappingSinkDefinition
     void addMappedField( const QString &destinationField, const QgsProperty &property ) { mFieldMap.insert( destinationField, property ); }
 
     /**
-     * Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+     * Returns the source CRS used for reprojecting incoming features to the sink's destination CRS.
      *
-     * \see setTransform()
+     * \see setSourceCrs()
      */
-    QgsCoordinateTransform transform() const { return mTransform; }
+    QgsCoordinateReferenceSystem sourceCrs() const { return mSourceCrs; }
 
     /**
-     * Sets the \a transform used for reprojecting incoming features to the sink's destination CRS.
+     * Sets the \a source crs used for reprojecting incoming features to the sink's destination CRS.
      *
-     * \see transform()
+     * \see sourceCrs()
      */
-    void setTransform( const QgsCoordinateTransform &transform )  { mTransform = transform; }
+    void setSourceCrs( const QgsCoordinateReferenceSystem &source ) { mSourceCrs = source; }
+
+    /**
+     * Returns the destination CRS used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see setDestinationCrs()
+     */
+    QgsCoordinateReferenceSystem destinationCrs() const { return mDestinationCrs; }
+
+    /**
+     * Sets the \a destination crs used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see destinationCrs()
+     */
+    void setDestinationCrs( const QgsCoordinateReferenceSystem &destination ) { mDestinationCrs = destination; }
 
     /**
      * Returns the WKB geometry type for the destination.
@@ -115,17 +129,38 @@ class CORE_EXPORT QgsRemappingSinkDefinition
      */
     void setDestinationFields( const QgsFields &fields ) { mDestinationFields = fields; }
 
+    /**
+     * Saves this remapping definition to a QVariantMap, wrapped in a QVariant.
+     * You can use QgsXmlUtils::writeVariant to save it to an XML document.
+     * \see loadVariant()
+     */
+    QVariant toVariant() const;
+
+    /**
+     * Loads this remapping definition from a QVariantMap, wrapped in a QVariant.
+     * You can use QgsXmlUtils::readVariant to load it from an XML document.
+     * \see toVariant()
+     */
+    bool loadVariant( const QVariantMap &map );
+
+    bool operator==( const QgsRemappingSinkDefinition &other ) const;
+    bool operator!=( const QgsRemappingSinkDefinition &other ) const;
+
   private:
 
     QMap< QString, QgsProperty > mFieldMap;
 
-    QgsCoordinateTransform mTransform;
+    QgsCoordinateReferenceSystem mSourceCrs;
+    QgsCoordinateReferenceSystem mDestinationCrs;
 
     QgsWkbTypes::Type mDestinationWkbType = QgsWkbTypes::Unknown;
 
     QgsFields mDestinationFields;
 
 };
+
+Q_DECLARE_METATYPE( QgsRemappingSinkDefinition )
+
 
 
 /**
@@ -156,6 +191,11 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
     void setExpressionContext( const QgsExpressionContext &context );
 
     /**
+     * Sets the transform \a context to use when reprojecting features.
+     */
+    void setTransformContext( const QgsCoordinateTransformContext &context );
+
+    /**
      * Remaps a \a feature to a set of features compatible with the destination sink.
      */
     QgsFeatureList remapFeature( const QgsFeature &feature ) const;
@@ -172,6 +212,7 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
   private:
 
     QgsRemappingSinkDefinition mDefinition;
+    QgsCoordinateTransform mTransform;
     QgsFeatureSink *mSink = nullptr;
     mutable QgsExpressionContext mContext;
 };

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -21,6 +21,7 @@
 #include "qgsproperty.h"
 #include "qgssymbollayerutils.h"
 #include "qgsprocessingparameters.h"
+#include "qgsremappingproxyfeaturesink.h"
 
 QgsUnitTypes::DistanceUnit QgsXmlUtils::readMapUnits( const QDomElement &element )
 {
@@ -228,6 +229,13 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingFeatureSourceDefinition" ) );
         break;
       }
+      else if ( value.canConvert< QgsRemappingSinkDefinition >() )
+      {
+        QDomElement valueElement = writeVariant( value.value< QgsRemappingSinkDefinition >().toVariant(), doc );
+        element.appendChild( valueElement );
+        element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsRemappingSinkDefinition" ) );
+        break;
+      }
       Q_ASSERT_X( false, "QgsXmlUtils::writeVariant", QStringLiteral( "unsupported user variant type %1" ).arg( QMetaType::typeName( value.userType() ) ).toLocal8Bit() );
       break;
     }
@@ -375,6 +383,18 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
 
     if ( res.loadVariant( QgsXmlUtils::readVariant( values.at( 0 ).toElement() ).toMap() ) )
       return res;
+
+    return QVariant();
+  }
+  else if ( type == QLatin1String( "QgsRemappingSinkDefinition" ) )
+  {
+    QgsRemappingSinkDefinition res;
+    const QDomNodeList values = element.childNodes();
+    if ( values.isEmpty() )
+      return QVariant();
+
+    if ( res.loadVariant( QgsXmlUtils::readVariant( values.at( 0 ).toElement() ).toMap() ) )
+      return QVariant::fromValue( res );
 
     return QVariant();
   }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -7946,8 +7946,15 @@ void TestQgsProcessing::processingFeatureSink()
   QString sinkString( QStringLiteral( "test.shp" ) );
   QgsProject p;
   QgsProcessingOutputLayerDefinition fs( sinkString, &p );
+  QgsRemappingSinkDefinition remap;
+  QVERIFY( !fs.useRemapping() );
+  remap.setDestinationWkbType( QgsWkbTypes::Point );
+  fs.setRemappingDefinition( remap );
+  QVERIFY( fs.useRemapping() );
+
   QCOMPARE( fs.sink.staticValue().toString(), sinkString );
   QCOMPARE( fs.destinationProject, &p );
+  QCOMPARE( fs.remappingDefinition().destinationWkbType(), QgsWkbTypes::Point );
 
   // test storing QgsProcessingFeatureSink in variant and retrieving
   QVariant fsInVariant = QVariant::fromValue( fs );
@@ -7956,6 +7963,7 @@ void TestQgsProcessing::processingFeatureSink()
   QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( fsInVariant );
   QCOMPARE( fromVar.sink.staticValue().toString(), sinkString );
   QCOMPARE( fromVar.destinationProject, &p );
+  QCOMPARE( fromVar.remappingDefinition().destinationWkbType(), QgsWkbTypes::Point );
 
   // test evaluating parameter as sink
   QgsProcessingContext context;

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -18,9 +18,15 @@ from qgis.core import (QgsXmlUtils,
                        QgsCoordinateReferenceSystem,
                        QgsProcessingOutputLayerDefinition,
                        QgsProcessingFeatureSourceDefinition,
+                       QgsRemappingSinkDefinition,
+                       QgsWkbTypes,
+                       QgsCoordinateTransform,
+                       QgsFields,
+                       QgsField,
+                       QgsProject,
                        NULL)
 
-from qgis.PyQt.QtCore import QDateTime, QDate, QTime
+from qgis.PyQt.QtCore import QDateTime, QDate, QTime, QVariant
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.QtGui import QColor
 
@@ -277,6 +283,32 @@ class TestQgsXmlUtils(unittest.TestCase):
         c = QgsXmlUtils.readVariant(elem)
         self.assertEqual(c.sink.staticValue(), 'my sink')
         self.assertEqual(c.createOptions, {'opt': 1, 'opt2': 2})
+
+    def testRemappingDefinition(self):
+        fields = QgsFields()
+        fields.append(QgsField('fldtxt', QVariant.String))
+        fields.append(QgsField('fldint', QVariant.Int))
+        fields.append(QgsField('fldtxt2', QVariant.String))
+
+        mapping_def = QgsRemappingSinkDefinition()
+        mapping_def.setDestinationWkbType(QgsWkbTypes.Point)
+        mapping_def.setSourceCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
+        mapping_def.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3857'))
+        mapping_def.setDestinationFields(fields)
+        mapping_def.addMappedField('fldtxt2', QgsProperty.fromField('fld1'))
+        mapping_def.addMappedField('fldint', QgsProperty.fromExpression('@myval * fldint'))
+
+        doc = QDomDocument("properties")
+        elem = QgsXmlUtils.writeVariant(mapping_def, doc)
+        c = QgsXmlUtils.readVariant(elem)
+
+        self.assertEqual(c.destinationWkbType(), QgsWkbTypes.Point)
+        self.assertEqual(c.sourceCrs().authid(), 'EPSG:4326')
+        self.assertEqual(c.destinationCrs().authid(), 'EPSG:3857')
+        self.assertEqual(c.destinationFields()[0].name(), 'fldtxt')
+        self.assertEqual(c.destinationFields()[1].name(), 'fldint')
+        self.assertEqual(c.fieldMap()['fldtxt2'].field(), 'fld1')
+        self.assertEqual(c.fieldMap()['fldint'].expressionString(), '@myval * fldint')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds all the backend API pieces required to allow feature sinks in processing to append to an existing data file.

Features are remapped according to a QgsRemappingSinkDefinition, allowing the features to be silently reprojected, have their geometry coerced into compatible types, and for fields to be mapped (using QgsProperty values) to match the destination geometry and field structures.

(The remaining part here will be exposing this to GUI)

Refs NRCan Contract#3000707093