### PR TITLE
Vector tile layer - part 3 (basic styling)

### DIFF
--- a/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
+++ b/python/core/auto_generated/vectortile/qgsvectortilebasicrenderer.sip.in
@@ -173,6 +173,14 @@ Sets list of styles of the renderer
 %Docstring
 Returns list of styles of the renderer
 %End
+    void setStyle( int index, const QgsVectorTileBasicRendererStyle &style );
+%Docstring
+Updates style definition at the paricular index of the list (the index must be in interval [0,N-1] otherwise this function does nothing)
+%End
+    QgsVectorTileBasicRendererStyle style( int index ) const;
+%Docstring
+Returns style definition at the particular index
+%End
 
     static QList<QgsVectorTileBasicRendererStyle> simpleStyle(
       const QColor &polygonFillColor, const QColor &polygonStrokeColor, double polygonStrokeWidth,

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -430,6 +430,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/gui/layertree
   ${CMAKE_SOURCE_DIR}/src/gui/locator
   ${CMAKE_SOURCE_DIR}/src/gui/vector
+  ${CMAKE_SOURCE_DIR}/src/gui/vectortile
   ${CMAKE_SOURCE_DIR}/src/plugins
   ${CMAKE_SOURCE_DIR}/src/python
   ${CMAKE_SOURCE_DIR}/src/native

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -35,6 +35,8 @@
 #include "qgsmaplayer.h"
 #include "qgsstyle.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectortilelayer.h"
+#include "qgsvectortilebasicrendererwidget.h"
 #include "qgsmeshlayer.h"
 #include "qgsproject.h"
 #include "qgsundowidget.h"
@@ -227,7 +229,11 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
 
     case QgsMapLayerType::VectorTileLayer:
     {
-      // TODO
+      QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
+      symbolItem->setData( Qt::UserRole, Symbology );
+      symbolItem->setToolTip( tr( "Symbology" ) );
+      mOptionsListWidget->addItem( symbolItem );
+
       break;
     }
 
@@ -608,7 +614,20 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
 
       case QgsMapLayerType::VectorTileLayer:
       {
-        // TODO
+        QgsVectorTileLayer *vtLayer = qobject_cast<QgsVectorTileLayer *>( mCurrentLayer );
+        switch ( row )
+        {
+          case 0: // Style
+          {
+            mVectorTileStyleWidget = new QgsVectorTileBasicRendererWidget( vtLayer, mMapCanvas, mMessageBar, mWidgetStack );
+            mVectorTileStyleWidget->setDockMode( true );
+            connect( mVectorTileStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            mWidgetStack->setMainPanel( mVectorTileStyleWidget );
+            break;
+          }
+          default:
+            break;
+        }
         break;
       }
 

--- a/src/app/qgslayerstylingwidget.h
+++ b/src/app/qgslayerstylingwidget.h
@@ -44,6 +44,7 @@ class QgsMapLayerStyleManagerWidget;
 class QgsVectorLayer3DRendererWidget;
 class QgsMeshLayer3DRendererWidget;
 class QgsMessageBar;
+class QgsVectorTileBasicRendererWidget;
 
 class APP_EXPORT QgsLayerStyleManagerWidgetFactory : public QgsMapLayerConfigWidgetFactory
 {
@@ -149,6 +150,7 @@ class APP_EXPORT QgsLayerStylingWidget : public QWidget, private Ui::QgsLayerSty
 #endif
     QgsRendererRasterPropertiesWidget *mRasterStyleWidget = nullptr;
     QgsRendererMeshPropertiesWidget *mMeshStyleWidget = nullptr;
+    QgsVectorTileBasicRendererWidget *mVectorTileStyleWidget = nullptr;
     QList<QgsMapLayerConfigWidgetFactory *> mPageFactories;
     QMap<int, QgsMapLayerConfigWidgetFactory *> mUserPages;
     QgsLayerStyleManagerWidgetFactory *mStyleManagerFactory = nullptr;

--- a/src/core/vectortile/qgsvectortilebasicrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.cpp
@@ -89,7 +89,7 @@ void QgsVectorTileBasicRendererStyle::readXml( const QDomElement &elem, const Qg
   if ( !symbolsElem.isNull() )
   {
     QgsSymbolMap symbolMap = QgsSymbolLayerUtils::loadSymbols( symbolsElem, context );
-    if ( !symbolMap.contains( QStringLiteral( "0" ) ) )
+    if ( symbolMap.contains( QStringLiteral( "0" ) ) )
     {
       mSymbol.reset( symbolMap.take( QStringLiteral( "0" ) ) );
     }
@@ -219,6 +219,7 @@ void QgsVectorTileBasicRenderer::readXml( const QDomElement &elem, const QgsRead
     QgsVectorTileBasicRendererStyle layerStyle;
     layerStyle.readXml( elemStyle, context );
     mStyles.append( layerStyle );
+    elemStyle = elemStyle.nextSiblingElement( QStringLiteral( "style" ) );
   }
 }
 

--- a/src/core/vectortile/qgsvectortilebasicrenderer.h
+++ b/src/core/vectortile/qgsvectortilebasicrenderer.h
@@ -142,6 +142,10 @@ class CORE_EXPORT QgsVectorTileBasicRenderer : public QgsVectorTileRenderer
     void setStyles( const QList<QgsVectorTileBasicRendererStyle> &styles );
     //! Returns list of styles of the renderer
     QList<QgsVectorTileBasicRendererStyle> styles() const;
+    //! Updates style definition at the paricular index of the list (the index must be in interval [0,N-1] otherwise this function does nothing)
+    void setStyle( int index, const QgsVectorTileBasicRendererStyle &style ) { mStyles[index] = style; }
+    //! Returns style definition at the particular index
+    QgsVectorTileBasicRendererStyle style( int index ) const { return mStyles[index]; }
 
     //! Returns a list of styles to render all layers with the given fill/stroke colors, stroke widths and marker sizes
     static QList<QgsVectorTileBasicRendererStyle> simpleStyle(

--- a/src/core/vectortile/qgsvectortilelayer.h
+++ b/src/core/vectortile/qgsvectortilelayer.h
@@ -138,6 +138,9 @@ class CORE_EXPORT QgsVectorTileLayer : public QgsMapLayer
     bool isTileBorderRenderingEnabled() const { return mTileBorderRendering; }
 
   private:
+    bool loadDataSource();
+
+  private:
     //! Type of the data source
     QString mSourceType;
     //! URL/Path of the data source

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -321,6 +321,7 @@ SET(QGIS_GUI_SRCS
   tableeditor/qgstableeditorformattingwidget.cpp
   tableeditor/qgstableeditorwidget.cpp
 
+  vectortile/qgsvectortilebasicrendererwidget.cpp
   vectortile/qgsvectortileconnectiondialog.cpp
   vectortile/qgsvectortiledataitemguiprovider.cpp
   vectortile/qgsvectortileproviderguimetadata.cpp
@@ -1089,6 +1090,7 @@ SET(QGIS_GUI_HDRS
   tableeditor/qgstableeditorformattingwidget.h
   tableeditor/qgstableeditorwidget.h
 
+  vectortile/qgsvectortilebasicrendererwidget.h
   vectortile/qgsvectortileconnectiondialog.h
   vectortile/qgsvectortiledataitemguiprovider.h
   vectortile/qgsvectortileproviderguimetadata.h

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgsvectortilebasicrendererwidget.cpp
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "qgsvectortilebasicrendererwidget.h"
 
 #include "qgsguiutils.h"
@@ -10,6 +25,8 @@
 #include <QAbstractListModel>
 #include <QInputDialog>
 
+
+///@cond PRIVATE
 
 class QgsVectorTileBasicRendererListModel : public QAbstractListModel
 {
@@ -446,3 +463,5 @@ void QgsVectorTileBasicRendererWidget::removeStyle()
   // make sure that the selection is gone
   viewStyles->selectionModel()->clear();
 }
+
+///@endcond

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -24,6 +24,7 @@
 
 #include <QAbstractListModel>
 #include <QInputDialog>
+#include <QMenu>
 
 
 ///@cond PRIVATE
@@ -340,7 +341,12 @@ QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTil
   mModel = new QgsVectorTileBasicRendererListModel( mRenderer.get(), viewStyles );
   viewStyles->setModel( mModel );
 
-  connect( btnAddRule, &QPushButton::clicked, this, &QgsVectorTileBasicRendererWidget::addStyle );
+  QMenu *menuAddRule = new QMenu( btnAddRule );
+  menuAddRule->addAction( tr( "Marker" ), this, [this] { addStyle( QgsWkbTypes::PointGeometry ); } );
+  menuAddRule->addAction( tr( "Line" ), this, [this] { addStyle( QgsWkbTypes::LineGeometry ); } );
+  menuAddRule->addAction( tr( "Fill" ), this, [this] { addStyle( QgsWkbTypes::PolygonGeometry ); } );
+  btnAddRule->setMenu( menuAddRule );
+
   connect( btnEditRule, &QPushButton::clicked, this, &QgsVectorTileBasicRendererWidget::editStyle );
   connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicRendererWidget::removeStyle );
 
@@ -358,25 +364,8 @@ void QgsVectorTileBasicRendererWidget::apply()
   mVTLayer->setRenderer( mRenderer->clone() );
 }
 
-void QgsVectorTileBasicRendererWidget::addStyle()
+void QgsVectorTileBasicRendererWidget::addStyle( QgsWkbTypes::GeometryType geomType )
 {
-  QStringList lst;
-  lst << tr( "Marker" ) << tr( "Line" ) << tr( "Fill" );
-  QString type = QInputDialog::getItem( this, tr( "Add style" ), tr( "Please choose symbol type" ), lst, 0, false );
-  if ( type.isEmpty() )
-    return;
-  int index = lst.indexOf( type );
-
-  QgsWkbTypes::GeometryType geomType;
-  if ( index == 0 )
-    geomType = QgsWkbTypes::PointGeometry;
-  else if ( index == 1 )
-    geomType = QgsWkbTypes::LineGeometry;
-  else if ( index == 2 )
-    geomType = QgsWkbTypes::PolygonGeometry;
-  else
-    return;
-
   QgsVectorTileBasicRendererStyle style( QString(), QString(), geomType );
   style.setSymbol( QgsSymbol::defaultSymbol( geomType ) );
 

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.cpp
@@ -1,0 +1,448 @@
+#include "qgsvectortilebasicrendererwidget.h"
+
+#include "qgsguiutils.h"
+#include "qgssymbollayerutils.h"
+#include "qgsvectortilebasicrenderer.h"
+#include "qgsvectortilelayer.h"
+#include "qgssymbolselectordialog.h"
+#include "qgsstyle.h"
+
+#include <QAbstractListModel>
+#include <QInputDialog>
+
+
+class QgsVectorTileBasicRendererListModel : public QAbstractListModel
+{
+  public:
+    QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent = nullptr );
+
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
+    int columnCount( const QModelIndex &parent = QModelIndex() ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role = Qt::DisplayRole ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+    bool removeRows( int row, int count, const QModelIndex &parent = QModelIndex() ) override;
+
+    void insertStyle( int row, const QgsVectorTileBasicRendererStyle &style );
+
+    // drag'n'drop support
+    Qt::DropActions supportedDropActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData( const QModelIndexList &indexes ) const override;
+    bool dropMimeData( const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent ) override;
+
+  private:
+    QgsVectorTileBasicRenderer *mRenderer = nullptr;
+};
+
+
+QgsVectorTileBasicRendererListModel::QgsVectorTileBasicRendererListModel( QgsVectorTileBasicRenderer *r, QObject *parent )
+  : QAbstractListModel( parent )
+  , mRenderer( r )
+{
+}
+
+int QgsVectorTileBasicRendererListModel::rowCount( const QModelIndex &parent ) const
+{
+  if ( parent.isValid() )
+    return 0;
+
+  return mRenderer->styles().count();
+}
+
+int QgsVectorTileBasicRendererListModel::columnCount( const QModelIndex & ) const
+{
+  return 5;
+}
+
+QVariant QgsVectorTileBasicRendererListModel::data( const QModelIndex &index, int role ) const
+{
+  if ( index.row() < 0 || index.row() >= mRenderer->styles().count() )
+    return QVariant();
+
+  const QList<QgsVectorTileBasicRendererStyle> styles = mRenderer->styles();
+  const QgsVectorTileBasicRendererStyle &style = styles[index.row()];
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    {
+      if ( index.column() == 0 )
+        return style.styleName();
+      else if ( index.column() == 1 )
+        return style.layerName().isEmpty() ? tr( "(all layers)" ) : style.layerName();
+      else if ( index.column() == 2 )
+        return style.minZoomLevel() >= 0 ? style.minZoomLevel() : QVariant();
+      else if ( index.column() == 3 )
+        return style.maxZoomLevel() >= 0 ? style.maxZoomLevel() : QVariant();
+      else if ( index.column() == 4 )
+        return style.filterExpression().isEmpty() ? tr( "(no filter)" ) : style.filterExpression();
+
+      break;
+    }
+
+    case Qt::EditRole:
+    {
+      if ( index.column() == 0 )
+        return style.styleName();
+      else if ( index.column() == 1 )
+        return style.layerName();
+      else if ( index.column() == 2 )
+        return style.minZoomLevel();
+      else if ( index.column() == 3 )
+        return style.maxZoomLevel();
+      else if ( index.column() == 4 )
+        return style.filterExpression();
+
+      break;
+    }
+
+    case Qt::DecorationRole:
+    {
+      if ( index.column() == 0 && style.symbol() )
+      {
+        const int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+        return QgsSymbolLayerUtils::symbolPreviewIcon( style.symbol(), QSize( iconSize, iconSize ) );
+      }
+      break;
+    }
+
+    case Qt::CheckStateRole:
+    {
+      if ( index.column() != 0 )
+        return QVariant();
+      return style.isEnabled() ? Qt::Checked : Qt::Unchecked;
+    }
+
+  }
+  return QVariant();
+}
+
+QVariant QgsVectorTileBasicRendererListModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 5 )
+  {
+    QStringList lst;
+    lst << tr( "Label" ) << tr( "Layer" ) << tr( "Min. zoom" ) << tr( "Max. zoom" ) << tr( "Filter" );
+    return lst[section];
+  }
+
+  return QVariant();
+}
+
+Qt::ItemFlags QgsVectorTileBasicRendererListModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::ItemIsDropEnabled;
+
+  Qt::ItemFlag checkable = ( index.column() == 0 ? Qt::ItemIsUserCheckable : Qt::NoItemFlags );
+
+  return Qt::ItemIsEnabled | Qt::ItemIsSelectable |
+         Qt::ItemIsEditable | checkable |
+         Qt::ItemIsDragEnabled;
+}
+
+bool QgsVectorTileBasicRendererListModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( !index.isValid() )
+    return false;
+
+  QgsVectorTileBasicRendererStyle style = mRenderer->style( index.row() );
+
+  if ( role == Qt::CheckStateRole )
+  {
+    style.setEnabled( value.toInt() == Qt::Checked );
+    mRenderer->setStyle( index.row(), style );
+    emit dataChanged( index, index );
+    return true;
+  }
+
+  if ( role == Qt::EditRole )
+  {
+    if ( index.column() == 0 )
+      style.setStyleName( value.toString() );
+    else if ( index.column() == 1 )
+      style.setLayerName( value.toString() );
+    else if ( index.column() == 2 )
+      style.setMinZoomLevel( value.toInt() );
+    else if ( index.column() == 3 )
+      style.setMaxZoomLevel( value.toInt() );
+    else if ( index.column() == 4 )
+      style.setFilterExpression( value.toString() );
+
+    mRenderer->setStyle( index.row(), style );
+    emit dataChanged( index, index );
+    return true;
+  }
+
+  return false;
+}
+
+bool QgsVectorTileBasicRendererListModel::removeRows( int row, int count, const QModelIndex &parent )
+{
+  QList<QgsVectorTileBasicRendererStyle> styles = mRenderer->styles();
+
+  if ( row < 0 || row >= styles.count() )
+    return false;
+
+  beginRemoveRows( parent, row, row + count - 1 );
+
+  for ( int i = 0; i < count; i++ )
+  {
+    if ( row < styles.count() )
+    {
+      styles.removeAt( row );
+    }
+  }
+
+  mRenderer->setStyles( styles );
+
+  endRemoveRows();
+  return true;
+}
+
+void QgsVectorTileBasicRendererListModel::insertStyle( int row, const QgsVectorTileBasicRendererStyle &style )
+{
+  beginInsertRows( QModelIndex(), row, row );
+
+  QList<QgsVectorTileBasicRendererStyle> styles = mRenderer->styles();
+  styles.insert( row, style );
+  mRenderer->setStyles( styles );
+
+  endInsertRows();
+}
+
+Qt::DropActions QgsVectorTileBasicRendererListModel::supportedDropActions() const
+{
+  return Qt::MoveAction;
+}
+
+QStringList QgsVectorTileBasicRendererListModel::mimeTypes() const
+{
+  QStringList types;
+  types << QStringLiteral( "application/vnd.text.list" );
+  return types;
+}
+
+QMimeData *QgsVectorTileBasicRendererListModel::mimeData( const QModelIndexList &indexes ) const
+{
+  QMimeData *mimeData = new QMimeData();
+  QByteArray encodedData;
+
+  QDataStream stream( &encodedData, QIODevice::WriteOnly );
+
+  const auto constIndexes = indexes;
+  for ( const QModelIndex &index : constIndexes )
+  {
+    // each item consists of several columns - let's add it with just first one
+    if ( !index.isValid() || index.column() != 0 )
+      continue;
+
+    QgsVectorTileBasicRendererStyle style = mRenderer->style( index.row() );
+
+    QDomDocument doc;
+    QDomElement rootElem = doc.createElement( QStringLiteral( "vector_tile_basic_renderer_style_mime" ) );
+    style.writeXml( rootElem, QgsReadWriteContext() );
+    doc.appendChild( rootElem );
+
+    stream << doc.toString( -1 );
+  }
+
+  mimeData->setData( QStringLiteral( "application/vnd.text.list" ), encodedData );
+  return mimeData;
+}
+
+bool QgsVectorTileBasicRendererListModel::dropMimeData( const QMimeData *data,
+    Qt::DropAction action, int row, int column, const QModelIndex &parent )
+{
+  Q_UNUSED( column )
+
+  if ( action == Qt::IgnoreAction )
+    return true;
+
+  if ( !data->hasFormat( QStringLiteral( "application/vnd.text.list" ) ) )
+    return false;
+
+  if ( parent.column() > 0 )
+    return false;
+
+  QByteArray encodedData = data->data( QStringLiteral( "application/vnd.text.list" ) );
+  QDataStream stream( &encodedData, QIODevice::ReadOnly );
+  int rows = 0;
+
+  if ( row == -1 )
+  {
+    // the item was dropped at a parent - we may decide where to put the items - let's append them
+    row = rowCount( parent );
+  }
+
+  while ( !stream.atEnd() )
+  {
+    QString text;
+    stream >> text;
+
+    QDomDocument doc;
+    if ( !doc.setContent( text ) )
+      continue;
+    QDomElement rootElem = doc.documentElement();
+    if ( rootElem.tagName() != QLatin1String( "vector_tile_basic_renderer_style_mime" ) )
+      continue;
+
+    QgsVectorTileBasicRendererStyle style;
+    style.readXml( rootElem, QgsReadWriteContext() );
+
+    insertStyle( row + rows, style );
+    ++rows;
+  }
+  return true;
+}
+
+
+//
+
+
+QgsVectorTileBasicRendererWidget::QgsVectorTileBasicRendererWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent )
+  : QgsMapLayerConfigWidget( layer, canvas, parent )
+  , mVTLayer( layer )
+  , mMessageBar( messageBar )
+{
+  setupUi( this );
+  layout()->setContentsMargins( 0, 0, 0, 0 );
+
+  if ( layer->renderer() && layer->renderer()->type() == QStringLiteral( "basic" ) )
+  {
+    mRenderer.reset( static_cast<QgsVectorTileBasicRenderer *>( layer->renderer()->clone() ) );
+  }
+  else
+  {
+    mRenderer.reset( new QgsVectorTileBasicRenderer() );
+  }
+
+  mModel = new QgsVectorTileBasicRendererListModel( mRenderer.get(), viewStyles );
+  viewStyles->setModel( mModel );
+
+  connect( btnAddRule, &QPushButton::clicked, this, &QgsVectorTileBasicRendererWidget::addStyle );
+  connect( btnEditRule, &QPushButton::clicked, this, &QgsVectorTileBasicRendererWidget::editStyle );
+  connect( btnRemoveRule, &QAbstractButton::clicked, this, &QgsVectorTileBasicRendererWidget::removeStyle );
+
+  connect( viewStyles, &QAbstractItemView::doubleClicked, this, &QgsVectorTileBasicRendererWidget::editStyleAtIndex );
+
+  connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsPanelWidget::widgetChanged );
+  connect( mModel, &QAbstractItemModel::rowsInserted, this, &QgsPanelWidget::widgetChanged );
+  connect( mModel, &QAbstractItemModel::rowsRemoved, this, &QgsPanelWidget::widgetChanged );
+}
+
+QgsVectorTileBasicRendererWidget::~QgsVectorTileBasicRendererWidget() = default;
+
+void QgsVectorTileBasicRendererWidget::apply()
+{
+  mVTLayer->setRenderer( mRenderer->clone() );
+}
+
+void QgsVectorTileBasicRendererWidget::addStyle()
+{
+  QStringList lst;
+  lst << tr( "Marker" ) << tr( "Line" ) << tr( "Fill" );
+  QString type = QInputDialog::getItem( this, tr( "Add style" ), tr( "Please choose symbol type" ), lst, 0, false );
+  if ( type.isEmpty() )
+    return;
+  int index = lst.indexOf( type );
+
+  QgsWkbTypes::GeometryType geomType;
+  if ( index == 0 )
+    geomType = QgsWkbTypes::PointGeometry;
+  else if ( index == 1 )
+    geomType = QgsWkbTypes::LineGeometry;
+  else if ( index == 2 )
+    geomType = QgsWkbTypes::PolygonGeometry;
+  else
+    return;
+
+  QgsVectorTileBasicRendererStyle style( QString(), QString(), geomType );
+  style.setSymbol( QgsSymbol::defaultSymbol( geomType ) );
+
+  int rows = mModel->rowCount();
+  mModel->insertStyle( rows, style );
+  viewStyles->selectionModel()->setCurrentIndex( mModel->index( rows, 0 ), QItemSelectionModel::ClearAndSelect );
+}
+
+void QgsVectorTileBasicRendererWidget::editStyle()
+{
+  editStyleAtIndex( viewStyles->selectionModel()->currentIndex() );
+}
+
+void QgsVectorTileBasicRendererWidget::editStyleAtIndex( const QModelIndex &index )
+{
+  QgsVectorTileBasicRendererStyle style = mRenderer->style( index.row() );
+
+  if ( !style.symbol() )
+    return;
+
+  std::unique_ptr< QgsSymbol > symbol( style.symbol()->clone() );
+
+  QgsSymbolWidgetContext context;
+  context.setMapCanvas( mMapCanvas );
+  context.setMessageBar( mMessageBar );
+
+  QgsVectorLayer *vectorLayer = nullptr;  // TODO: have a temporary vector layer with sub-layer's fields?
+
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( panel && panel->dockMode() )
+  {
+    QgsSymbolSelectorWidget *dlg = new QgsSymbolSelectorWidget( symbol.release(), QgsStyle::defaultStyle(), vectorLayer, panel );
+    dlg->setContext( context );
+    dlg->setPanelTitle( style.styleName() );
+    connect( dlg, &QgsPanelWidget::widgetChanged, this, &QgsVectorTileBasicRendererWidget::updateSymbolsFromWidget );
+    connect( dlg, &QgsPanelWidget::panelAccepted, this, &QgsVectorTileBasicRendererWidget::cleanUpSymbolSelector );
+    openPanel( dlg );
+  }
+  else
+  {
+    QgsSymbolSelectorDialog dlg( symbol.get(), QgsStyle::defaultStyle(), vectorLayer, panel );
+    dlg.setContext( context );
+    if ( !dlg.exec() || !symbol )
+    {
+      return;
+    }
+
+    style.setSymbol( symbol.release() );
+    mRenderer->setStyle( index.row(), style );
+    emit widgetChanged();
+  }
+}
+
+void QgsVectorTileBasicRendererWidget::updateSymbolsFromWidget()
+{
+  int index = viewStyles->selectionModel()->currentIndex().row();
+  QgsVectorTileBasicRendererStyle style = mRenderer->style( index );
+
+  QgsSymbolSelectorWidget *dlg = qobject_cast<QgsSymbolSelectorWidget *>( sender() );
+  style.setSymbol( dlg->symbol()->clone() );
+
+  mRenderer->setStyle( index, style );
+  emit widgetChanged();
+}
+
+void QgsVectorTileBasicRendererWidget::cleanUpSymbolSelector( QgsPanelWidget *container )
+{
+  QgsSymbolSelectorWidget *dlg = qobject_cast<QgsSymbolSelectorWidget *>( container );
+  if ( !dlg )
+    return;
+
+  delete dlg->symbol();
+}
+
+void QgsVectorTileBasicRendererWidget::removeStyle()
+{
+  QItemSelection sel = viewStyles->selectionModel()->selection();
+  const auto constSel = sel;
+  for ( const QItemSelectionRange &range : constSel )
+  {
+    if ( range.isValid() )
+      mModel->removeRows( range.top(), range.bottom() - range.top() + 1, range.parent() );
+  }
+  // make sure that the selection is gone
+  viewStyles->selectionModel()->clear();
+}

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -20,6 +20,8 @@
 
 #include "ui_qgsvectortilebasicrendererwidget.h"
 
+#include "qgswkbtypes.h"
+
 #include <memory>
 
 ///@cond PRIVATE
@@ -49,7 +51,7 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     void apply() override;
 
   private slots:
-    void addStyle();
+    void addStyle( QgsWkbTypes::GeometryType geomType );
     void editStyle();
     void editStyleAtIndex( const QModelIndex &index );
     void removeStyle();

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -1,0 +1,51 @@
+#ifndef QGSVECTORTILEBASICRENDERERWIDGET_H
+#define QGSVECTORTILEBASICRENDERERWIDGET_H
+
+#include "qgsmaplayerconfigwidget.h"
+
+#include "ui_qgsvectortilebasicrendererwidget.h"
+
+#include <memory>
+
+#define SIP_NO_FILE
+
+class QgsVectorTileBasicRenderer;
+class QgsVectorTileBasicRendererListModel;
+class QgsVectorTileLayer;
+class QgsMapCanvas;
+class QgsMessageBar;
+
+/**
+ * \ingroup gui
+ * Styling widget for basic renderer of vector tile layer
+ *
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidget, private Ui::QgsVectorTileBasicRendererWidget
+{
+    Q_OBJECT
+  public:
+    QgsVectorTileBasicRendererWidget( QgsVectorTileLayer *layer, QgsMapCanvas *canvas, QgsMessageBar *messageBar, QWidget *parent = nullptr );
+    ~QgsVectorTileBasicRendererWidget() override;
+
+  public slots:
+    //! Applies the settings made in the dialog
+    void apply() override;
+
+  private slots:
+    void addStyle();
+    void editStyle();
+    void editStyleAtIndex( const QModelIndex &index );
+    void removeStyle();
+
+    void updateSymbolsFromWidget();
+    void cleanUpSymbolSelector( QgsPanelWidget *container );
+
+  private:
+    QgsVectorTileLayer *mVTLayer = nullptr;
+    std::unique_ptr<QgsVectorTileBasicRenderer> mRenderer;
+    QgsVectorTileBasicRendererListModel *mModel = nullptr;
+    QgsMessageBar *mMessageBar = nullptr;
+};
+
+#endif // QGSVECTORTILEBASICRENDERERWIDGET_H

--- a/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
+++ b/src/gui/vectortile/qgsvectortilebasicrendererwidget.h
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgsvectortilebasicrendererwidget.h
+  --------------------------------------
+  Date                 : April 2020
+  Copyright            : (C) 2020 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGSVECTORTILEBASICRENDERERWIDGET_H
 #define QGSVECTORTILEBASICRENDERERWIDGET_H
 
@@ -7,6 +22,7 @@
 
 #include <memory>
 
+///@cond PRIVATE
 #define SIP_NO_FILE
 
 class QgsVectorTileBasicRenderer;
@@ -47,5 +63,7 @@ class GUI_EXPORT QgsVectorTileBasicRendererWidget : public QgsMapLayerConfigWidg
     QgsVectorTileBasicRendererListModel *mModel = nullptr;
     QgsMessageBar *mMessageBar = nullptr;
 };
+
+///@endcond
 
 #endif // QGSVECTORTILEBASICRENDERERWIDGET_H

--- a/src/ui/qgsvectortilebasicrendererwidget.ui
+++ b/src/ui/qgsvectortilebasicrendererwidget.ui
@@ -36,7 +36,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="btnAddRule">
+      <widget class="QToolButton" name="btnAddRule">
        <property name="toolTip">
         <string>Add rule</string>
        </property>
@@ -46,6 +46,9 @@
        <property name="icon">
         <iconset resource="../../images/images.qrc">
          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
        </property>
       </widget>
      </item>

--- a/src/ui/qgsvectortilebasicrendererwidget.ui
+++ b/src/ui/qgsvectortilebasicrendererwidget.ui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsVectorTileBasicRendererWidget</class>
+ <widget class="QWidget" name="QgsVectorTileBasicRendererWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>557</width>
+    <height>424</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTreeView" name="viewStyles">
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+     </property>
+     <property name="dragEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="btnAddRule">
+       <property name="toolTip">
+        <string>Add rule</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRemoveRule">
+       <property name="toolTip">
+        <string>Remove selected rules</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnEditRule">
+       <property name="toolTip">
+        <string>Edit current rule</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyEdit.svg</normaloff>:/images/themes/default/symbologyEdit.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
Continued work on vector tile layer implementation.

This adds styling panel integration for configuration of the "basic" renderer: one can set symbol, sub-layer name, min/max zoom levels and filter expression. So far it is pretty rudimentary, without data-defined symbol properties, list of sub-layers, expression builder... but at least something to start with :)

See the QEP: qgis/QGIS-Enhancement-Proposals#162

![image(2)](https://user-images.githubusercontent.com/193367/78533058-925e6800-77e8-11ea-983f-5bdaacd3c18f.png)

# Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/