### PR TITLE
[vector] Remove problematic topological editing related assert when adding features

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -92,7 +92,6 @@ void QgsMapToolAddFeature::digitized( const QgsFeature &f )
     if ( topologicalEditing )
     {
       QList<QgsPointLocator::Match> sm = snappingMatches();
-      Q_ASSERT( f.geometry().constGet()->vertexCount() == ( vlayer->geometryType() == QgsWkbTypes::PolygonGeometry ? sm.size() + 1 : sm.size() ) );
       for ( int i = 0; i < sm.size() ; ++i )
       {
         if ( sm.at( i ).layer() )


### PR DESCRIPTION
## Description

So it turns out there are more scenarios where the assert check is bogus. Other than a newly-created polygon having nb of vertices entered + 1 as its final nb of geometry vertices, the count also doesn't match when a newly added polygon as clipped when [x] avoid overlap is active.

The more I've gotten to familiarize myself with the code here, the more I think this assert should simply go away. 

@m-kuhn , all good?  