### PR TITLE
update temporal extent of temporal navigation object

### DIFF
--- a/src/core/qgstemporalnavigationobject.cpp
+++ b/src/core/qgstemporalnavigationobject.cpp
@@ -90,7 +90,13 @@ QgsDateTimeRange QgsTemporalNavigationObject::dateTimeRangeForFrameNumber( long 
 void QgsTemporalNavigationObject::setTemporalExtents( const QgsDateTimeRange &temporalExtents )
 {
   mTemporalExtents = temporalExtents;
+  int currentFrameNmber = mCurrentFrameNumber;
   setCurrentFrameNumber( 0 );
+
+  //Force to emit signal if the current frame number doesn't change
+  if ( currentFrameNmber == mCurrentFrameNumber )
+    emit updateTemporalRange( dateTimeRangeForFrameNumber( 0 ) );
+
 }
 
 QgsDateTimeRange QgsTemporalNavigationObject::temporalExtents() const

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -173,6 +173,7 @@ void QgsTemporalControllerWidget::onProjectCleared()
   mHasTemporalLayersLoaded = false;
   mStartDateTime->setDateTime( QDateTime( QDate::currentDate(), QTime( 0, 0, 0, Qt::UTC ) ) );
   mEndDateTime->setDateTime( mStartDateTime->dateTime() );
+  updateTemporalExtent();
 }
 
 void QgsTemporalControllerWidget::updateSlider( const QgsDateTimeRange &range )
@@ -230,6 +231,7 @@ void QgsTemporalControllerWidget::setDatesToProjectTime()
   {
     mStartDateTime->setDateTime( range.begin() );
     mEndDateTime->setDateTime( range.end() );
+    updateTemporalExtent();
   }
 }
 

--- a/tests/src/core/testqgstemporalnavigationobject.cpp
+++ b/tests/src/core/testqgstemporalnavigationobject.cpp
@@ -147,6 +147,7 @@ void TestQgsTemporalNavigationObject::frameSettings()
                              QDateTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) )
                            );
   navigationObject->setTemporalExtents( range );
+  QCOMPARE( temporalRangeSignal.count(), 1 );
 
   navigationObject->setFrameDuration( QgsInterval( 1, QgsUnitTypes::TemporalHours ) );
   QCOMPARE( navigationObject->frameDuration(), QgsInterval( 1, QgsUnitTypes::TemporalHours ) );
@@ -156,7 +157,7 @@ void TestQgsTemporalNavigationObject::frameSettings()
 
   navigationObject->setCurrentFrameNumber( 1 );
   QCOMPARE( navigationObject->currentFrameNumber(), 1 );
-  QCOMPARE( temporalRangeSignal.count(), 1 );
+  QCOMPARE( temporalRangeSignal.count(), 2 );
 
   navigationObject->setFramesPerSecond( 1 );
   QCOMPARE( navigationObject->framesPerSecond(), 1.0 );


### PR DESCRIPTION
This PR allows the temporal navigation object to be updated with new temporal extent when the temporal extent of the controller widget change.