### PR TITLE
Allow appending processing results to existing layers 

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1542,7 +1542,32 @@ Exports the geometry to a GeoJSON string.
 %End
 
 
-    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const /Factory/;
+    QVector< QgsGeometry > coerceToType( QgsWkbTypes::Type type ) const;
+%Docstring
+Attempts to coerce this geometry into the specified destination ``type``.
+
+This method will do anything possible to force the current geometry into the specified type. E.g.
+- lines or polygons will be converted to points by return either a single multipoint geometry or multiple
+single point geometries.
+- polygons will be converted to lines by extracting their exterior and interior rings, returning
+either a multilinestring or multiple single line strings as dictated by ``type``.
+- lines will be converted to polygon rings if ``type`` is a polygon type
+- curved geometries will be segmented if ``type`` is non-curved.
+- multi geometries will be converted to a list of single geometries
+- single geometries will be upgraded to multi geometries
+- z or m values will be added or dropped as required.
+
+.. note::
+
+   This method is much stricter than convertToType(), as it considers the exact WKB type
+   of geometries instead of the geometry family (point/line/polygon), and tries more exhaustively
+   to coerce geometries to the desired ``type``. It also correctly maintains curves and z/m values
+   wherever appropriate.
+
+.. versionadded:: 3.14
+%End
+
+    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const;
 %Docstring
 Try to convert the geometry to the requested type
 
@@ -1550,6 +1575,12 @@ Try to convert the geometry to the requested type
 :param destMultipart: determines if the output geometry will be multipart or not
 
 :return: the converted geometry or ``None`` if the conversion fails.
+
+.. note::
+
+   The coerceToType() method applies much stricter and more exhaustive attempts to convert
+   between geometry types, and is recommended instead of this method. This method force drops
+   curves and any z or m values present in the geometry.
 
 .. versionadded:: 2.2
 %End

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -1191,6 +1191,11 @@ Read the source from ``parameters`` and ``context`` and set it
 .. versionadded:: 3.4
 %End
 
+     virtual QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
+        const QVariantMap &parameters,
+        QgsProcessingContext &context,
+        const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const;
+
 };
 
 

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -298,6 +298,43 @@ manner.
 Returns ``True`` if this algorithm generates HTML outputs.
 %End
 
+    enum PropertyAvailability
+    {
+      NotAvailable,
+      Available,
+    };
+
+    struct VectorProperties
+    {
+      QgsFields fields;
+
+      QgsWkbTypes::Type wkbType;
+
+      QgsCoordinateReferenceSystem crs;
+
+      QgsProcessingAlgorithm::PropertyAvailability availability;
+    };
+
+    virtual QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
+        const QVariantMap &parameters,
+        QgsProcessingContext &context,
+        const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const;
+%Docstring
+Returns the vector properties which will be used for the ``sink`` with matching name.
+
+The ``parameters`` argument specifies the values of all parameters which would be used to generate
+the sink. These can be used alongside the provided ``context`` in order to pre-evaluate inputs
+when required in order to determine the sink's properties.
+
+The ``sourceProperties`` map will contain the vector properties of the various sources used
+as inputs to the algorithm. These will only be available in certain circumstances (e.g. when the
+algorithm is used within a model), so implementations will need to be adaptable to circumstances
+when either ``sourceParameters`` is empty or ``parameters`` is empty, and use whatever information
+is passed in order to make a best guess determination of the output properties.
+
+.. versionadded:: 3.14
+%End
+
     QVariantMap run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok /Out/ = 0, const QVariantMap &configuration = QVariantMap() ) const;
 %Docstring
 Executes the algorithm using the specified ``parameters``. This method internally

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -2869,7 +2869,7 @@ A parameter which represents the destination feature sink for features created b
   public:
 
     QgsProcessingParameterFeatureSink( const QString &name, const QString &description = QString(), QgsProcessing::SourceType type = QgsProcessing::TypeVectorAnyGeometry, const QVariant &defaultValue = QVariant(),
-                                       bool optional = false, bool createByDefault = true );
+                                       bool optional = false, bool createByDefault = true, bool supportsAppend = false );
 %Docstring
 Constructor for QgsProcessingParameterFeatureSink.
 
@@ -2926,6 +2926,30 @@ cannot be reliably determined in advance, this method will default to returning 
 Sets the layer ``type`` for the sinks associated with the parameter.
 
 .. seealso:: :py:func:`dataType`
+%End
+
+    bool supportsAppend() const;
+%Docstring
+Returns ``True`` if the sink supports appending features to an existing table.
+
+A sink only supports appending if the algorithm implements QgsProcessingAlgorithm.sinkProperties for the sink parameter.
+
+.. seealso:: :py:func:`setSupportsAppend`
+
+.. versionadded:: 3.14
+%End
+
+    void setSupportsAppend( bool supportsAppend );
+%Docstring
+Sets whether the sink supports appending features to an existing table.
+
+.. warning::
+
+   A sink only supports appending if the algorithm implements QgsProcessingAlgorithm.sinkProperties for the sink parameter.
+
+.. seealso:: :py:func:`supportsAppend`
+
+.. versionadded:: 3.14
 %End
 
     virtual QVariantMap toVariantMap() const;

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -143,6 +143,39 @@ to automatically load the resulting sink/layer after completing processing.
 
     QVariantMap createOptions;
 
+    bool useRemapping() const;
+%Docstring
+Returns ``True`` if the output uses a remapping definition.
+
+.. seealso:: :py:func:`remappingDefinition`
+
+.. versionadded:: 3.14
+%End
+
+    QgsRemappingSinkDefinition remappingDefinition() const;
+%Docstring
+Returns the output remapping definition, if useRemapping() is ``True``.
+
+.. seealso:: :py:func:`useRemapping`
+
+.. seealso:: :py:func:`setRemappingDefinition`
+
+.. versionadded:: 3.14
+%End
+
+    void setRemappingDefinition( const QgsRemappingSinkDefinition &definition );
+%Docstring
+Sets the remapping ``definition`` to use when adding features to the output layer.
+
+Calling this method will set useRemapping() to ``True``.
+
+.. seealso:: :py:func:`remappingDefinition`
+
+.. seealso:: :py:func:`useRemapping`
+
+.. versionadded:: 3.14
+%End
+
     QVariant toVariant() const;
 %Docstring
 Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
@@ -166,6 +199,7 @@ You can use QgsXmlUtils.readVariant to load it from an XML document.
     operator QVariant() const;
 
     bool operator==( const QgsProcessingOutputLayerDefinition &other ) const;
+    bool operator!=( const QgsProcessingOutputLayerDefinition &other ) const;
 
 };
 

--- a/python/core/auto_generated/qgsfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsfeaturesink.sip.in
@@ -77,41 +77,6 @@ QFlags<QgsFeatureSink::Flag> operator|(QgsFeatureSink::Flag f1, QFlags<QgsFeatur
 
 
 
-class QgsProxyFeatureSink : QgsFeatureSink
-{
-%Docstring
-A simple feature sink which proxies feature addition on to another feature sink.
-
-This class is designed to allow factory methods which always return new QgsFeatureSink
-objects. Since it is not always possible to create an entirely new QgsFeatureSink
-(e.g. if the feature sink is a layer's data provider), a new :py:class:`QgsProxyFeatureSink`
-can instead be returned which forwards features on to the destination sink. The
-proxy sink can be safely deleted without affecting the destination sink.
-
-.. versionadded:: 3.0
-%End
-
-%TypeHeaderCode
-#include "qgsfeaturesink.h"
-%End
-  public:
-
-    QgsProxyFeatureSink( QgsFeatureSink *sink );
-%Docstring
-Constructs a new QgsProxyFeatureSink which forwards features onto a destination ``sink``.
-%End
-    virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 );
-    virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 );
-    virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
-
-    QgsFeatureSink *destinationSink();
-%Docstring
-Returns the destination QgsFeatureSink which the proxy will forward features to.
-%End
-
-};
-
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/core/auto_generated/qgsproperty.sip.in
+++ b/python/core/auto_generated/qgsproperty.sip.in
@@ -491,6 +491,39 @@ be called in non-performance critical code.
 
     operator QVariant() const;
 
+
+    SIP_PYOBJECT __repr__();
+%MethodCode
+    QString typeString;
+    QString definitionString;
+    switch ( sipCpp->propertyType() )
+    {
+      case QgsProperty::StaticProperty:
+        typeString = QStringLiteral( "static" );
+        definitionString = sipCpp->staticValue().toString();
+        break;
+
+      case QgsProperty::FieldBasedProperty:
+        typeString = QStringLiteral( "field" );
+        definitionString = sipCpp->field();
+        break;
+
+      case QgsProperty::ExpressionBasedProperty:
+        typeString = QStringLiteral( "expression" );
+        definitionString = sipCpp->expressionString();
+        break;
+
+      case QgsProperty::InvalidProperty:
+        typeString = QStringLiteral( "invalid" );
+        break;
+    }
+
+    QString str = QStringLiteral( "<QgsProperty: %1%2%3>" ).arg( !sipCpp->isActive() && sipCpp->propertyType() != QgsProperty::InvalidProperty ? QStringLiteral( "INACTIVE " ) : QString(),
+                  typeString,
+                  definitionString.isEmpty() ? QString() : QStringLiteral( " (%1)" ).arg( definitionString ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+%End
+
 };
 
 

--- a/python/core/auto_generated/qgsproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsproxyfeaturesink.sip.in
@@ -1,0 +1,58 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsproxyfeaturesink.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsProxyFeatureSink : QgsFeatureSink
+{
+%Docstring
+A simple feature sink which proxies feature addition on to another feature sink.
+
+This class is designed to allow factory methods which always return new QgsFeatureSink
+objects. Since it is not always possible to create an entirely new QgsFeatureSink
+(e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
+can instead be returned which forwards features on to the destination sink. The
+proxy sink can be safely deleted without affecting the destination sink.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsproxyfeaturesink.h"
+%End
+  public:
+
+    QgsProxyFeatureSink( QgsFeatureSink *sink );
+%Docstring
+Constructs a new QgsProxyFeatureSink which forwards features onto a destination ``sink``.
+%End
+    virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 );
+    virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 );
+    virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
+
+    QgsFeatureSink *destinationSink();
+%Docstring
+Returns the destination QgsFeatureSink which the proxy will forward features to.
+%End
+
+};
+
+
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsproxyfeaturesink.h                                       *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -1,0 +1,170 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsremappingproxyfeaturesink.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsRemappingSinkDefinition
+{
+%Docstring
+Defines the parameters used to remap features when creating a QgsRemappingProxyFeatureSink.
+
+The definition includes parameters required to correctly map incoming features to the structure
+of the destination sink, e.g. information about how to create output field values and how to transform
+geometries to match the destination CRS.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsremappingproxyfeaturesink.h"
+%End
+  public:
+
+    QMap< QString, QgsProperty > fieldMap() const;
+%Docstring
+Returns the field mapping, which defines how to map the values from incoming features to destination
+field values.
+
+Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+mapping or use of QgsExpression expressions to transform values to the destination field.
+
+.. seealso:: :py:func:`setFieldMap`
+
+.. seealso:: :py:func:`addMappedField`
+%End
+
+    void setFieldMap( const QMap< QString, QgsProperty > &map );
+%Docstring
+Sets the field mapping, which defines how to map the values from incoming features to destination
+field values.
+
+Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+mapping or use of QgsExpression expressions to transform values to the destination field.
+
+.. seealso:: :py:func:`fieldMap`
+
+.. seealso:: :py:func:`addMappedField`
+%End
+
+    void addMappedField( const QString &destinationField, const QgsProperty &property );
+%Docstring
+Adds a mapping for a destination field.
+
+Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+mapping or use of QgsExpression expressions to transform values to the destination field.
+
+.. seealso:: :py:func:`setFieldMap`
+
+.. seealso:: :py:func:`fieldMap`
+%End
+
+    QgsCoordinateTransform transform() const;
+%Docstring
+Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`setTransform`
+%End
+
+    void setTransform( const QgsCoordinateTransform &transform );
+%Docstring
+Sets the ``transform`` used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`transform`
+%End
+
+    QgsWkbTypes::Type destinationWkbType() const;
+%Docstring
+Returns the WKB geometry type for the destination.
+
+.. seealso:: :py:func:`setDestinationWkbType`
+%End
+
+    void setDestinationWkbType( QgsWkbTypes::Type type );
+%Docstring
+Sets the WKB geometry ``type`` for the destination.
+
+.. seealso:: :py:func:`setDestinationWkbType`
+%End
+
+    QgsFields destinationFields() const;
+%Docstring
+Returns the fields for the destination sink.
+
+.. seealso:: :py:func:`setDestinationFields`
+%End
+
+    void setDestinationFields( const QgsFields &fields );
+%Docstring
+Sets the ``fields`` for the destination sink.
+
+.. seealso:: :py:func:`destinationFields`
+%End
+
+};
+
+
+class QgsRemappingProxyFeatureSink : QgsFeatureSink
+{
+%Docstring
+A QgsFeatureSink which proxies incoming features to a destination feature sink, after applying
+transformations and field value mappings.
+
+This sink allows for transformation of incoming features to match the requirements of storing
+in an existing destination layer, e.g. by reprojecting the features to the destination's CRS
+and by coercing geometries to the format required by the destination sink.
+
+.. versionadded:: 3.14
+%End
+
+%TypeHeaderCode
+#include "qgsremappingproxyfeaturesink.h"
+%End
+  public:
+
+    QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
+%Docstring
+Constructor for QgsRemappingProxyFeatureSink, using the specified ``mappingDefinition``
+to manipulate features before sending them to the destination ``sink``.
+%End
+
+    void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Sets the expression ``context`` to use when evaluating mapped field values.
+%End
+
+    QgsFeatureList remapFeature( const QgsFeature &feature ) const;
+%Docstring
+Remaps a ``feature`` to a set of features compatible with the destination sink.
+%End
+
+    virtual bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 );
+
+    virtual bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 );
+
+    virtual bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = 0 );
+
+
+    QgsFeatureSink *destinationSink();
+%Docstring
+Returns the destination QgsFeatureSink which the proxy will forward features to.
+%End
+
+};
+
+
+
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsremappingproxyfeaturesink.h                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -64,18 +64,32 @@ mapping or use of QgsExpression expressions to transform values to the destinati
 .. seealso:: :py:func:`fieldMap`
 %End
 
-    QgsCoordinateTransform transform() const;
+    QgsCoordinateReferenceSystem sourceCrs() const;
 %Docstring
-Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+Returns the source CRS used for reprojecting incoming features to the sink's destination CRS.
 
-.. seealso:: :py:func:`setTransform`
+.. seealso:: :py:func:`setSourceCrs`
 %End
 
-    void setTransform( const QgsCoordinateTransform &transform );
+    void setSourceCrs( const QgsCoordinateReferenceSystem &source );
 %Docstring
-Sets the ``transform`` used for reprojecting incoming features to the sink's destination CRS.
+Sets the ``source`` crs used for reprojecting incoming features to the sink's destination CRS.
 
-.. seealso:: :py:func:`transform`
+.. seealso:: :py:func:`sourceCrs`
+%End
+
+    QgsCoordinateReferenceSystem destinationCrs() const;
+%Docstring
+Returns the destination CRS used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`setDestinationCrs`
+%End
+
+    void setDestinationCrs( const QgsCoordinateReferenceSystem &destination );
+%Docstring
+Sets the ``destination`` crs used for reprojecting incoming features to the sink's destination CRS.
+
+.. seealso:: :py:func:`destinationCrs`
 %End
 
     QgsWkbTypes::Type destinationWkbType() const;
@@ -106,7 +120,28 @@ Sets the ``fields`` for the destination sink.
 .. seealso:: :py:func:`destinationFields`
 %End
 
+    QVariant toVariant() const;
+%Docstring
+Saves this remapping definition to a QVariantMap, wrapped in a QVariant.
+You can use QgsXmlUtils.writeVariant to save it to an XML document.
+
+.. seealso:: :py:func:`loadVariant`
+%End
+
+    bool loadVariant( const QVariantMap &map );
+%Docstring
+Loads this remapping definition from a QVariantMap, wrapped in a QVariant.
+You can use QgsXmlUtils.readVariant to load it from an XML document.
+
+.. seealso:: :py:func:`toVariant`
+%End
+
+    bool operator==( const QgsRemappingSinkDefinition &other ) const;
+    bool operator!=( const QgsRemappingSinkDefinition &other ) const;
+
 };
+
+
 
 
 class QgsRemappingProxyFeatureSink : QgsFeatureSink
@@ -136,6 +171,11 @@ to manipulate features before sending them to the destination ``sink``.
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring
 Sets the expression ``context`` to use when evaluating mapped field values.
+%End
+
+    void setTransformContext( const QgsCoordinateTransformContext &context );
+%Docstring
+Sets the transform ``context`` to use when reprojecting features.
 %End
 
     QgsFeatureList remapFeature( const QgsFeature &feature ) const;

--- a/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
+++ b/python/core/auto_generated/qgsremappingproxyfeaturesink.sip.in
@@ -162,11 +162,14 @@ and by coercing geometries to the format required by the destination sink.
 %End
   public:
 
+
     QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
 %Docstring
 Constructor for QgsRemappingProxyFeatureSink, using the specified ``mappingDefinition``
 to manipulate features before sending them to the destination ``sink``.
 %End
+
+    ~QgsRemappingProxyFeatureSink();
 
     void setExpressionContext( const QgsExpressionContext &context );
 %Docstring

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -175,6 +175,7 @@
 %Include auto_generated/qgsreadwritelocker.sip
 %Include auto_generated/qgsrelation.sip
 %Include auto_generated/qgsrelationcontext.sip
+%Include auto_generated/qgsremappingproxyfeaturesink.sip
 %Include auto_generated/qgsrelationmanager.sip
 %Include auto_generated/qgsrenderchecker.sip
 %Include auto_generated/qgsrendercontext.sip

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -167,6 +167,7 @@
 %Include auto_generated/qgsproviderconnectionmodel.sip
 %Include auto_generated/qgsprovidermetadata.sip
 %Include auto_generated/qgsproviderregistry.sip
+%Include auto_generated/qgsproxyfeaturesink.sip
 %Include auto_generated/qgsproxyprogresstask.sip
 %Include auto_generated/qgspythonrunner.sip
 %Include auto_generated/qgsrange.sip

--- a/python/gui/auto_generated/processing/qgsprocessingparameterswidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingparameterswidget.sip.in
@@ -10,7 +10,7 @@
 
 
 
-class QgsProcessingParametersWidget : QgsPanelWidget
+class QgsProcessingParametersWidget : QgsPanelWidget, QgsProcessingParametersGenerator
 {
 %Docstring
 A widget which allows users to select the value for the parameters for an algorithm.

--- a/python/gui/auto_generated/qgsfieldmappingmodel.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingmodel.sip.in
@@ -81,6 +81,21 @@ Returns a list of source fields
 Returns a list of Field objects representing the current status of the model
 %End
 
+    QMap< QString, QgsProperty > fieldPropertyMap() const;
+%Docstring
+Returns a map of destination field name to QgsProperty definition for field value,
+representing the current status of the model.
+
+.. seealso:: :py:func:`setFieldPropertyMap`
+%End
+
+    void setFieldPropertyMap( const QMap< QString, QgsProperty > &map );
+%Docstring
+Sets a map of destination field name to QgsProperty definition for field value.
+
+.. seealso:: :py:func:`fieldPropertyMap`
+%End
+
     void appendField( const QgsField &field, const QString &expression = QString() );
 %Docstring
 Appends a new ``field`` to the model, with an optional ``expression``

--- a/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldmappingwidget.sip.in
@@ -55,6 +55,21 @@ Returns the underlying mapping model
 Returns a list of Field objects representing the current status of the underlying mapping model
 %End
 
+    QMap< QString, QgsProperty > fieldPropertyMap() const;
+%Docstring
+Returns a map of destination field name to QgsProperty definition for field value,
+representing the current status of the widget.
+
+.. seealso:: :py:func:`setFieldPropertyMap`
+%End
+
+    void setFieldPropertyMap( const QMap< QString, QgsProperty > &map );
+%Docstring
+Sets a map of destination field name to QgsProperty definition for field value.
+
+.. seealso:: :py:func:`fieldPropertyMap`
+%End
+
     QItemSelectionModel *selectionModel();
 %Docstring
 Returns the selection model

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -43,7 +43,7 @@ from processing.gui.AlgorithmDialogBase import AlgorithmDialogBase
 from processing.tools.dataobjects import createContext
 
 
-class ParametersPanel(QgsProcessingParametersWidget, QgsProcessingParametersGenerator):
+class ParametersPanel(QgsProcessingParametersWidget):
 
     def __init__(self, parent, alg, in_place=False):
         super().__init__(alg, parent)

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -179,6 +179,36 @@ QgsProcessingAlgorithm::Flags QgsBufferAlgorithm::flags() const
   return f;
 }
 
+QgsProcessingAlgorithm::VectorProperties QgsBufferAlgorithm::sinkProperties( const QString &sink, const QVariantMap &parameters, QgsProcessingContext &context, const QMap<QString, QgsProcessingAlgorithm::VectorProperties> &sourceProperties ) const
+{
+  QgsProcessingAlgorithm::VectorProperties result;
+  if ( sink == QStringLiteral( "OUTPUT" ) )
+  {
+    if ( sourceProperties.value( QStringLiteral( "INPUT" ) ).availability == QgsProcessingAlgorithm::Available )
+    {
+      const VectorProperties inputProps = sourceProperties.value( QStringLiteral( "INPUT" ) );
+      result.fields = inputProps.fields;
+      result.crs = inputProps.crs;
+      result.wkbType = QgsWkbTypes::MultiPolygon;
+      result.availability = Available;
+      return result;
+    }
+    else
+    {
+      std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+      if ( source )
+      {
+        result.fields = source->fields();
+        result.crs = source->sourceCrs();
+        result.wkbType = QgsWkbTypes::MultiPolygon;
+        result.availability = Available;
+        return result;
+      }
+    }
+  }
+  return result;
+}
+
 bool QgsBufferAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
 {
   const QgsVectorLayer *vlayer = qobject_cast< const QgsVectorLayer * >( layer );

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -62,7 +62,7 @@ void QgsBufferAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MITER_LIMIT" ), QObject::tr( "Miter limit" ), QgsProcessingParameterNumber::Double, 2, false, 1 ) );
 
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "DISSOLVE" ), QObject::tr( "Dissolve result" ), false ) );
-  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Buffered" ), QgsProcessing::TypeVectorPolygon ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Buffered" ), QgsProcessing::TypeVectorPolygon, QVariant(), false, true, true ) );
 }
 
 QString QgsBufferAlgorithm::shortHelpString() const

--- a/src/analysis/processing/qgsalgorithmbuffer.h
+++ b/src/analysis/processing/qgsalgorithmbuffer.h
@@ -48,6 +48,10 @@ class QgsBufferAlgorithm : public QgsProcessingAlgorithm
     bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
     QgsProcessingAlgorithm::Flags flags() const override;
 
+    QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
+        const QVariantMap &parameters,
+        QgsProcessingContext &context,
+        const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const override;
 
   protected:
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -360,6 +360,7 @@ SET(QGIS_CORE_SRCS
   qgsproviderconnectionmodel.cpp
   qgsprovidermetadata.cpp
   qgsproviderregistry.cpp
+  qgsproxyfeaturesink.cpp
   qgsproxyprogresstask.cpp
   qgspythonrunner.cpp
   qgsreadwritecontext.cpp
@@ -901,6 +902,7 @@ SET(QGIS_CORE_HDRS
   qgsproviderconnectionmodel.h
   qgsprovidermetadata.h
   qgsproviderregistry.h
+  qgsproxyfeaturesink.h
   qgsproxyprogresstask.h
   qgspythonrunner.h
   qgsrange.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -369,6 +369,7 @@ SET(QGIS_CORE_SRCS
   qgsrelationcontext.cpp
   qgsweakrelation.cpp
   qgsrelationmanager.cpp
+  qgsremappingproxyfeaturesink.cpp
   qgsrenderchecker.cpp
   qgsrendercontext.cpp
   qgsrunprocess.cpp
@@ -910,6 +911,7 @@ SET(QGIS_CORE_HDRS
   qgsreadwritelocker.h
   qgsrelation.h
   qgsrelationcontext.h
+  qgsremappingproxyfeaturesink.h
   qgsweakrelation.h
   qgsrelationmanager.h
   qgsrenderchecker.h

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1313,9 +1313,17 @@ json QgsGeometry::asJsonObject( int precision ) const
 QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type ) const
 {
   QVector< QgsGeometry > res;
-  if ( wkbType() == type )
+  if ( isNull() )
+    return res;
+
+  if ( wkbType() == type || type == QgsWkbTypes::Unknown )
   {
     res << *this;
+    return res;
+  }
+
+  if ( type == QgsWkbTypes::NoGeometry )
+  {
     return res;
   }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1310,6 +1310,121 @@ json QgsGeometry::asJsonObject( int precision ) const
 
 }
 
+QVector<QgsGeometry> QgsGeometry::coerceToType( const QgsWkbTypes::Type type ) const
+{
+  QVector< QgsGeometry > res;
+  if ( wkbType() == type )
+  {
+    res << *this;
+    return res;
+  }
+
+  QgsGeometry newGeom = *this;
+
+  // Curved -> straight
+  if ( !QgsWkbTypes::isCurvedType( type ) && QgsWkbTypes::isCurvedType( newGeom.wkbType() ) )
+  {
+    newGeom = QgsGeometry( d->geometry.get()->segmentize() );
+  }
+
+  // polygon -> line
+  if ( QgsWkbTypes::geometryType( type ) == QgsWkbTypes::LineGeometry &&
+       newGeom.type() == QgsWkbTypes::PolygonGeometry )
+  {
+    // boundary gives us a (multi)line string of exterior + interior rings
+    newGeom = QgsGeometry( newGeom.constGet()->boundary() );
+  }
+  // line -> polygon
+  if ( QgsWkbTypes::geometryType( type ) == QgsWkbTypes::PolygonGeometry &&
+       newGeom.type() == QgsWkbTypes::LineGeometry )
+  {
+    std::unique_ptr< QgsGeometryCollection > gc( QgsGeometryFactory::createCollectionOfType( type ) );
+    const QgsGeometry source = newGeom;
+    for ( auto part = source.const_parts_begin(); part != source.const_parts_end(); ++part )
+    {
+      std::unique_ptr< QgsAbstractGeometry > exterior( ( *part )->clone() );
+      if ( QgsCurve *curve = qgsgeometry_cast< QgsCurve * >( exterior.get() ) )
+      {
+        if ( QgsWkbTypes::isCurvedType( type ) )
+        {
+          std::unique_ptr< QgsCurvePolygon > cp = qgis::make_unique< QgsCurvePolygon >();
+          cp->setExteriorRing( curve );
+          exterior.release();
+          gc->addGeometry( cp.release() );
+        }
+        else
+        {
+          std::unique_ptr< QgsPolygon > p = qgis::make_unique< QgsPolygon  >();
+          p->setExteriorRing( qgsgeometry_cast< QgsLineString * >( curve ) );
+          exterior.release();
+          gc->addGeometry( p.release() );
+        }
+      }
+    }
+    newGeom = QgsGeometry( std::move( gc ) );
+  }
+
+  // line/polygon -> points
+  if ( QgsWkbTypes::geometryType( type ) == QgsWkbTypes::PointGeometry &&
+       ( newGeom.type() == QgsWkbTypes::LineGeometry ||
+         newGeom.type() == QgsWkbTypes::PolygonGeometry ) )
+  {
+    // lines/polygons to a point layer, extract all vertices
+    std::unique_ptr< QgsMultiPoint > mp = qgis::make_unique< QgsMultiPoint >();
+    const QgsGeometry source = newGeom;
+    QSet< QgsPoint > added;
+    for ( auto vertex = source.vertices_begin(); vertex != source.vertices_end(); ++vertex )
+    {
+      if ( added.contains( *vertex ) )
+        continue; // avoid duplicate points, e.g. start/end of rings
+      mp->addGeometry( ( *vertex ).clone() );
+      added.insert( *vertex );
+    }
+    newGeom = QgsGeometry( std::move( mp ) );
+  }
+
+  // Single -> multi
+  if ( QgsWkbTypes::isMultiType( type ) && ! newGeom.isMultipart( ) )
+  {
+    newGeom.convertToMultiType();
+  }
+  // Drop Z/M
+  if ( newGeom.constGet()->is3D() && ! QgsWkbTypes::hasZ( type ) )
+  {
+    newGeom.get()->dropZValue();
+  }
+  if ( newGeom.constGet()->isMeasure() && ! QgsWkbTypes::hasM( type ) )
+  {
+    newGeom.get()->dropMValue();
+  }
+  // Add Z/M back, set to 0
+  if ( ! newGeom.constGet()->is3D() && QgsWkbTypes::hasZ( type ) )
+  {
+    newGeom.get()->addZValue( 0.0 );
+  }
+  if ( ! newGeom.constGet()->isMeasure() && QgsWkbTypes::hasM( type ) )
+  {
+    newGeom.get()->addMValue( 0.0 );
+  }
+
+  // Multi -> single
+  if ( ! QgsWkbTypes::isMultiType( type ) && newGeom.isMultipart( ) )
+  {
+    const QgsGeometryCollection *parts( static_cast< const QgsGeometryCollection * >( newGeom.constGet() ) );
+    QgsAttributeMap attrMap;
+    res.reserve( parts->partCount() );
+    for ( int i = 0; i < parts->partCount( ); i++ )
+    {
+      res << QgsGeometry( parts->geometryN( i )->clone() );
+    }
+  }
+  else
+  {
+    res << newGeom;
+  }
+  return res;
+}
+
 QgsGeometry QgsGeometry::convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart ) const
 {
   switch ( destType )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1568,13 +1568,41 @@ class CORE_EXPORT QgsGeometry
     virtual json asJsonObject( int precision = 17 ) const SIP_SKIP;
 
     /**
+     * Attempts to coerce this geometry into the specified destination \a type.
+     *
+     * This method will do anything possible to force the current geometry into the specified type. E.g.
+     * - lines or polygons will be converted to points by return either a single multipoint geometry or multiple
+     * single point geometries.
+     * - polygons will be converted to lines by extracting their exterior and interior rings, returning
+     * either a multilinestring or multiple single line strings as dictated by \a type.
+     * - lines will be converted to polygon rings if \a type is a polygon type
+     * - curved geometries will be segmented if \a type is non-curved.
+     * - multi geometries will be converted to a list of single geometries
+     * - single geometries will be upgraded to multi geometries
+     * - z or m values will be added or dropped as required.
+     *
+     * \note This method is much stricter than convertToType(), as it considers the exact WKB type
+     * of geometries instead of the geometry family (point/line/polygon), and tries more exhaustively
+     * to coerce geometries to the desired \a type. It also correctly maintains curves and z/m values
+     * wherever appropriate.
+     *
+     * \since QGIS 3.14
+     */
+    QVector< QgsGeometry > coerceToType( QgsWkbTypes::Type type ) const;
+
+    /**
      * Try to convert the geometry to the requested type
      * \param destType the geometry type to be converted to
      * \param destMultipart determines if the output geometry will be multipart or not
      * \returns the converted geometry or NULLPTR if the conversion fails.
+     *
+     * \note The coerceToType() method applies much stricter and more exhaustive attempts to convert
+     * between geometry types, and is recommended instead of this method. This method force drops
+     * curves and any z or m values present in the geometry.
+     *
      * \since QGIS 2.2
      */
-    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const SIP_FACTORY;
+    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const;
 
     /* Accessor functions for getting geometry data */
 

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -418,6 +418,11 @@ bool QgsProcessingAlgorithm::hasHtmlOutputs() const
   return false;
 }
 
+QgsProcessingAlgorithm::VectorProperties QgsProcessingAlgorithm::sinkProperties( const QString &, const QVariantMap &, QgsProcessingContext &, const QMap<QString, QgsProcessingAlgorithm::VectorProperties> & ) const
+{
+  return VectorProperties();
+}
+
 QVariantMap QgsProcessingAlgorithm::run( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback, bool *ok, const QVariantMap &configuration ) const
 {
   std::unique_ptr< QgsProcessingAlgorithm > alg( create( configuration ) );

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -875,7 +875,7 @@ void QgsProcessingFeatureBasedAlgorithm::initAlgorithm( const QVariantMap &confi
 {
   addParameter( new QgsProcessingParameterFeatureSource( inputParameterName(), inputParameterDescription(), inputLayerTypes() ) );
   initParameters( config );
-  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), outputName(), outputLayerType() ) );
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), outputName(), outputLayerType(), QVariant(), false, true, true ) );
 }
 
 QString QgsProcessingFeatureBasedAlgorithm::inputParameterName() const

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -1031,3 +1031,34 @@ void QgsProcessingFeatureBasedAlgorithm::prepareSource( const QVariantMap &param
   }
 }
 
+
+QgsProcessingAlgorithm::VectorProperties QgsProcessingFeatureBasedAlgorithm::sinkProperties( const QString &sink, const QVariantMap &parameters, QgsProcessingContext &context, const QMap<QString, QgsProcessingAlgorithm::VectorProperties> &sourceProperties ) const
+{
+  QgsProcessingAlgorithm::VectorProperties result;
+  if ( sink == QStringLiteral( "OUTPUT" ) )
+  {
+    if ( sourceProperties.value( QStringLiteral( "INPUT" ) ).availability == QgsProcessingAlgorithm::Available )
+    {
+      const VectorProperties inputProps = sourceProperties.value( QStringLiteral( "INPUT" ) );
+      result.fields = outputFields( inputProps.fields );
+      result.crs = outputCrs( inputProps.crs );
+      result.wkbType = outputWkbType( inputProps.wkbType );
+      result.availability = Available;
+      return result;
+    }
+    else
+    {
+      std::unique_ptr< QgsProcessingFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
+      if ( source )
+      {
+        result.fields = outputFields( source->fields() );
+        result.crs = outputCrs( source->sourceCrs() );
+        result.wkbType = outputWkbType( source->wkbType() );
+        result.availability = Available;
+        return result;
+      }
+    }
+  }
+  return result;
+}
+

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -1199,6 +1199,11 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      */
     void prepareSource( const QVariantMap &parameters, QgsProcessingContext &context );
 
+    QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
+        const QVariantMap &parameters,
+        QgsProcessingContext &context,
+        const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const override;
+
   private:
 
     std::unique_ptr< QgsProcessingFeatureSource > mSource;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -316,6 +316,56 @@ class CORE_EXPORT QgsProcessingAlgorithm
     bool hasHtmlOutputs() const;
 
     /**
+     * Property availability, used for QgsProcessingAlgorithm::VectorProperties
+     * in order to determine if properties are available or not
+     */
+    enum PropertyAvailability
+    {
+      NotAvailable, //!< Properties are not available
+      Available, //!< Properties are available
+    };
+
+    /**
+     * Properties of a vector source or sink used in an algorithm.
+     *
+     * \since QGIS 3.14
+     */
+    struct VectorProperties
+    {
+      //! Fields
+      QgsFields fields;
+
+      //! Geometry (WKB) type
+      QgsWkbTypes::Type wkbType = QgsWkbTypes::Unknown;
+
+      //! Coordinate Reference System
+      QgsCoordinateReferenceSystem crs;
+
+      //! Availability of the properties. By default properties are not available.
+      QgsProcessingAlgorithm::PropertyAvailability availability = QgsProcessingAlgorithm::NotAvailable;
+    };
+
+    /**
+     * Returns the vector properties which will be used for the \a sink with matching name.
+     *
+     * The \a parameters argument specifies the values of all parameters which would be used to generate
+     * the sink. These can be used alongside the provided \a context in order to pre-evaluate inputs
+     * when required in order to determine the sink's properties.
+     *
+     * The \a sourceProperties map will contain the vector properties of the various sources used
+     * as inputs to the algorithm. These will only be available in certain circumstances (e.g. when the
+     * algorithm is used within a model), so implementations will need to be adaptable to circumstances
+     * when either \a sourceParameters is empty or \a parameters is empty, and use whatever information
+     * is passed in order to make a best guess determination of the output properties.
+     *
+     * \since QGIS 3.14
+     */
+    virtual QgsProcessingAlgorithm::VectorProperties sinkProperties( const QString &sink,
+        const QVariantMap &parameters,
+        QgsProcessingContext &context,
+        const QMap< QString, QgsProcessingAlgorithm::VectorProperties > &sourceProperties ) const;
+
+    /**
      * Executes the algorithm using the specified \a parameters. This method internally
      * creates a copy of the algorithm before running it, so it is safe to call
      * on algorithms directly retrieved from QgsProcessingRegistry and QgsProcessingProvider.

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -4904,9 +4904,10 @@ QgsProcessingParameterFeatureSource *QgsProcessingParameterFeatureSource::fromSc
   return new QgsProcessingParameterFeatureSource( name, description, types, def, isOptional );
 }
 
-QgsProcessingParameterFeatureSink::QgsProcessingParameterFeatureSink( const QString &name, const QString &description, QgsProcessing::SourceType type, const QVariant &defaultValue, bool optional, bool createByDefault )
+QgsProcessingParameterFeatureSink::QgsProcessingParameterFeatureSink( const QString &name, const QString &description, QgsProcessing::SourceType type, const QVariant &defaultValue, bool optional, bool createByDefault, bool supportsAppend )
   : QgsProcessingDestinationParameter( name, description, defaultValue, optional, createByDefault )
   , mDataType( type )
+  , mSupportsAppend( supportsAppend )
 {
 }
 
@@ -5047,6 +5048,8 @@ QString QgsProcessingParameterFeatureSink::asPythonString( const QgsProcessing::
       code += QStringLiteral( ", type=QgsProcessing.%1" ).arg( QgsProcessing::sourceTypeToString( mDataType ) );
 
       code += QStringLiteral( ", createByDefault=%1" ).arg( createByDefault() ? QStringLiteral( "True" ) : QStringLiteral( "False" ) );
+      if ( mSupportsAppend )
+        code += QStringLiteral( ", supportsAppend=True" );
 
       QgsProcessingContext c;
       code += QStringLiteral( ", defaultValue=%1)" ).arg( valueAsPythonString( mDefault, c ) );
@@ -5124,6 +5127,7 @@ QVariantMap QgsProcessingParameterFeatureSink::toVariantMap() const
 {
   QVariantMap map = QgsProcessingDestinationParameter::toVariantMap();
   map.insert( QStringLiteral( "data_type" ), mDataType );
+  map.insert( QStringLiteral( "supports_append" ), mSupportsAppend );
   return map;
 }
 
@@ -5131,6 +5135,7 @@ bool QgsProcessingParameterFeatureSink::fromVariantMap( const QVariantMap &map )
 {
   QgsProcessingDestinationParameter::fromVariantMap( map );
   mDataType = static_cast< QgsProcessing::SourceType >( map.value( QStringLiteral( "data_type" ) ).toInt() );
+  mSupportsAppend = map.value( QStringLiteral( "supports_append" ), false ).toBool();
   return true;
 }
 
@@ -5168,6 +5173,16 @@ QgsProcessingParameterFeatureSink *QgsProcessingParameterFeatureSink::fromScript
   }
 
   return new QgsProcessingParameterFeatureSink( name, description, type, definition, isOptional );
+}
+
+bool QgsProcessingParameterFeatureSink::supportsAppend() const
+{
+  return mSupportsAppend;
+}
+
+void QgsProcessingParameterFeatureSink::setSupportsAppend( bool supportsAppend )
+{
+  mSupportsAppend = supportsAppend;
 }
 
 QgsProcessingParameterRasterDestination::QgsProcessingParameterRasterDestination( const QString &name, const QString &description, const QVariant &defaultValue, bool optional, bool createByDefault )

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -61,11 +61,23 @@ bool QgsProcessingFeatureSourceDefinition::loadVariant( const QVariantMap &map )
 }
 
 
+//
+// QgsProcessingOutputLayerDefinition
+//
+
+void QgsProcessingOutputLayerDefinition::setRemappingDefinition( const QgsRemappingSinkDefinition &definition )
+{
+  mUseRemapping = true;
+  mRemappingDefinition = definition;
+}
+
 QVariant QgsProcessingOutputLayerDefinition::toVariant() const
 {
   QVariantMap map;
   map.insert( QStringLiteral( "sink" ), sink.toVariant() );
   map.insert( QStringLiteral( "create_options" ), createOptions );
+  if ( mUseRemapping )
+    map.insert( QStringLiteral( "remapping" ), QVariant::fromValue( mRemappingDefinition ) );
   return map;
 }
 
@@ -73,12 +85,27 @@ bool QgsProcessingOutputLayerDefinition::loadVariant( const QVariantMap &map )
 {
   sink.loadVariant( map.value( QStringLiteral( "sink" ) ) );
   createOptions = map.value( QStringLiteral( "create_options" ) ).toMap();
+  if ( map.contains( QStringLiteral( "remapping" ) ) )
+  {
+    mUseRemapping = true;
+    mRemappingDefinition = map.value( QStringLiteral( "remapping" ) ).value< QgsRemappingSinkDefinition >();
+  }
+  else
+  {
+    mUseRemapping = false;
+  }
   return true;
 }
 
 bool QgsProcessingOutputLayerDefinition::operator==( const QgsProcessingOutputLayerDefinition &other ) const
 {
-  return sink == other.sink && destinationProject == other.destinationProject && destinationName == other.destinationName && createOptions == other.createOptions;
+  return sink == other.sink && destinationProject == other.destinationProject && destinationName == other.destinationName && createOptions == other.createOptions
+         && mUseRemapping == other.mUseRemapping && mRemappingDefinition == other.mRemappingDefinition;
+}
+
+bool QgsProcessingOutputLayerDefinition::operator!=( const QgsProcessingOutputLayerDefinition &other ) const
+{
+  return !( *this == other );
 }
 
 bool QgsProcessingParameters::isDynamic( const QVariantMap &parameters, const QString &name )

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -579,6 +579,8 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   QgsProject *destinationProject = nullptr;
   QString destName;
   QVariantMap createOptions;
+  QgsRemappingSinkDefinition remapDefinition;
+  bool useRemapDefinition = false;
   if ( val.canConvert<QgsProcessingOutputLayerDefinition>() )
   {
     // input is a QgsProcessingOutputLayerDefinition - get extra properties from it
@@ -588,6 +590,11 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
 
     val = fromVar.sink;
     destName = fromVar.destinationName;
+    if ( fromVar.useRemapping() )
+    {
+      useRemapDefinition = true;
+      remapDefinition = fromVar.remappingDefinition();
+    }
   }
 
   QString dest;
@@ -622,7 +629,7 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   if ( dest.isEmpty() )
     return nullptr;
 
-  std::unique_ptr< QgsFeatureSink > sink( QgsProcessingUtils::createFeatureSink( dest, context, fields, geometryType, crs, createOptions, sinkFlags ) );
+  std::unique_ptr< QgsFeatureSink > sink( QgsProcessingUtils::createFeatureSink( dest, context, fields, geometryType, crs, createOptions, sinkFlags, useRemapDefinition ? &remapDefinition : nullptr ) );
   destinationIdentifier = dest;
 
   if ( destinationProject )

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -26,6 +26,7 @@
 #include "qgsfeaturesource.h"
 #include "qgsprocessingutils.h"
 #include "qgsfilefiltergenerator.h"
+#include "qgsremappingproxyfeaturesink.h"
 #include <QMap>
 #include <limits>
 
@@ -245,6 +246,35 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     QVariantMap createOptions;
 
     /**
+     * Returns TRUE if the output uses a remapping definition.
+     *
+     * \see remappingDefinition()
+     * \since QGIS 3.14
+     */
+    bool useRemapping() const { return mUseRemapping; }
+
+    /**
+     * Returns the output remapping definition, if useRemapping() is TRUE.
+     *
+     * \see useRemapping()
+     * \see setRemappingDefinition()
+     * \since QGIS 3.14
+     */
+    QgsRemappingSinkDefinition remappingDefinition() const { return mRemappingDefinition; }
+
+    /**
+     * Sets the remapping \a definition to use when adding features to the output layer.
+     *
+     * Calling this method will set useRemapping() to TRUE.
+     *
+     * \see remappingDefinition()
+     * \see useRemapping()
+     *
+     * \since QGIS 3.14
+     */
+    void setRemappingDefinition( const QgsRemappingSinkDefinition &definition );
+
+    /**
      * Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
      * You can use QgsXmlUtils::writeVariant to save it to an XML document.
      * \see loadVariant()
@@ -267,6 +297,12 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     }
 
     bool operator==( const QgsProcessingOutputLayerDefinition &other ) const;
+    bool operator!=( const QgsProcessingOutputLayerDefinition &other ) const;
+
+  private:
+
+    bool mUseRemapping = false;
+    QgsRemappingSinkDefinition mRemappingDefinition;
 
 };
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -2763,7 +2763,7 @@ class CORE_EXPORT QgsProcessingParameterFeatureSink : public QgsProcessingDestin
      * output will not be created by default.
      */
     QgsProcessingParameterFeatureSink( const QString &name, const QString &description = QString(), QgsProcessing::SourceType type = QgsProcessing::TypeVectorAnyGeometry, const QVariant &defaultValue = QVariant(),
-                                       bool optional = false, bool createByDefault = true );
+                                       bool optional = false, bool createByDefault = true, bool supportsAppend = false );
 
     /**
      * Returns the type name for the parameter class.
@@ -2804,6 +2804,26 @@ class CORE_EXPORT QgsProcessingParameterFeatureSink : public QgsProcessingDestin
      */
     void setDataType( QgsProcessing::SourceType type );
 
+    /**
+     * Returns TRUE if the sink supports appending features to an existing table.
+     *
+     * A sink only supports appending if the algorithm implements QgsProcessingAlgorithm::sinkProperties for the sink parameter.
+     *
+     * \see setSupportsAppend()
+     * \since QGIS 3.14
+     */
+    bool supportsAppend() const;
+
+    /**
+     * Sets whether the sink supports appending features to an existing table.
+     *
+     * \warning A sink only supports appending if the algorithm implements QgsProcessingAlgorithm::sinkProperties for the sink parameter.
+     *
+     * \see supportsAppend()
+     * \since QGIS 3.14
+     */
+    void setSupportsAppend( bool supportsAppend );
+
     QVariantMap toVariantMap() const override;
     bool fromVariantMap( const QVariantMap &map ) override;
     QString generateTemporaryDestination() const override;
@@ -2816,6 +2836,7 @@ class CORE_EXPORT QgsProcessingParameterFeatureSink : public QgsProcessingDestin
   private:
 
     QgsProcessing::SourceType mDataType = QgsProcessing::TypeVectorAnyGeometry;
+    bool mSupportsAppend = false;
 };
 
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -719,7 +719,7 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
     bool useWriter = false;
     parseDestinationString( destination, providerKey, uri, layerName, format, options, useWriter, extension );
 
-    QgsFields newFields = remappingDefinition ? remappingDefinition->destinationFields() : fields;
+    QgsFields newFields = fields;
     if ( useWriter && providerKey == QLatin1String( "ogr" ) )
     {
       // use QgsVectorFileWriter for OGR destinations instead of QgsVectorLayerImport, as that allows
@@ -740,6 +740,8 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
         {
           remappingDefinition->setDestinationWkbType( vl->wkbType() );
           remappingDefinition->setDestinationCrs( vl->crs() );
+          newFields = vl->fields();
+          remappingDefinition->setDestinationFields( newFields );
         }
         context.expressionContext().setFields( fields );
       }
@@ -781,6 +783,7 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
         {
           remappingDefinition->setDestinationWkbType( layer->wkbType() );
           remappingDefinition->setDestinationCrs( layer->crs() );
+          remappingDefinition->setDestinationFields( layer->fields() );
         }
 
         std::unique_ptr< QgsRemappingProxyFeatureSink > remapSink = qgis::make_unique< QgsRemappingProxyFeatureSink >( *remappingDefinition, layer->dataProvider(), false );

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -27,6 +27,7 @@
 #include "qgsfeaturesink.h"
 #include "qgsfeaturesource.h"
 #include "qgsproxyfeaturesink.h"
+#include "qgsremappingproxyfeaturesink.h"
 
 class QgsMeshLayer;
 class QgsProject;
@@ -222,7 +223,8 @@ class CORE_EXPORT QgsProcessingUtils
         QgsWkbTypes::Type geometryType,
         const QgsCoordinateReferenceSystem &crs,
         const QVariantMap &createOptions = QVariantMap(),
-        QgsFeatureSink::SinkFlags sinkFlags = nullptr ) SIP_FACTORY;
+        QgsFeatureSink::SinkFlags sinkFlags = nullptr,
+        QgsRemappingSinkDefinition *remappingDefinition = nullptr ) SIP_FACTORY;
 #endif
 
     /**

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -26,6 +26,7 @@
 #include "qgsprocessing.h"
 #include "qgsfeaturesink.h"
 #include "qgsfeaturesource.h"
+#include "qgsproxyfeaturesink.h"
 
 class QgsMeshLayer;
 class QgsProject;

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -61,6 +61,7 @@
 #include "qgsbookmarkmanager.h"
 #include "qgsstylemodel.h"
 #include "qgsconnectionregistry.h"
+#include "qgsremappingproxyfeaturesink.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -230,6 +231,7 @@ void QgsApplication::init( QString profileFolder )
   qRegisterMetaType<QgsRectangle>( "QgsRectangle" );
   qRegisterMetaType<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
   qRegisterMetaTypeStreamOperators<QgsProcessingModelChildParameterSource>( "QgsProcessingModelChildParameterSource" );
+  qRegisterMetaType<QgsRemappingSinkDefinition>( "QgsRemappingSinkDefinition" );
 
   ( void ) resolvePkgPath();
 

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -102,42 +102,6 @@ class CORE_EXPORT QgsFeatureSink
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureSink::Flags )
 
-
-/**
- * \class QgsProxyFeatureSink
- * \ingroup core
- * A simple feature sink which proxies feature addition on to another feature sink.
- *
- * This class is designed to allow factory methods which always return new QgsFeatureSink
- * objects. Since it is not always possible to create an entirely new QgsFeatureSink
- * (e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
- * can instead be returned which forwards features on to the destination sink. The
- * proxy sink can be safely deleted without affecting the destination sink.
- *
- * \since QGIS 3.0
- */
-class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
-{
-  public:
-
-    /**
-     * Constructs a new QgsProxyFeatureSink which forwards features onto a destination \a sink.
-     */
-    QgsProxyFeatureSink( QgsFeatureSink *sink );
-    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeature( feature, flags ); }
-    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( features, flags ); }
-    bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( iterator, flags ); }
-
-    /**
-     * Returns the destination QgsFeatureSink which the proxy will forward features to.
-     */
-    QgsFeatureSink *destinationSink() { return mSink; }
-
-  private:
-
-    QgsFeatureSink *mSink = nullptr;
-};
-
 Q_DECLARE_METATYPE( QgsFeatureSink * )
 
 #endif // QGSFEATURESINK_H

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -489,6 +489,41 @@ class CORE_EXPORT QgsProperty
       return QVariant::fromValue( *this );
     }
 
+
+#ifdef SIP_RUN
+    SIP_PYOBJECT __repr__();
+    % MethodCode
+    QString typeString;
+    QString definitionString;
+    switch ( sipCpp->propertyType() )
+    {
+      case QgsProperty::StaticProperty:
+        typeString = QStringLiteral( "static" );
+        definitionString = sipCpp->staticValue().toString();
+        break;
+
+      case QgsProperty::FieldBasedProperty:
+        typeString = QStringLiteral( "field" );
+        definitionString = sipCpp->field();
+        break;
+
+      case QgsProperty::ExpressionBasedProperty:
+        typeString = QStringLiteral( "expression" );
+        definitionString = sipCpp->expressionString();
+        break;
+
+      case QgsProperty::InvalidProperty:
+        typeString = QStringLiteral( "invalid" );
+        break;
+    }
+
+    QString str = QStringLiteral( "<QgsProperty: %1%2%3>" ).arg( !sipCpp->isActive() && sipCpp->propertyType() != QgsProperty::InvalidProperty ? QStringLiteral( "INACTIVE " ) : QString(),
+                  typeString,
+                  definitionString.isEmpty() ? QString() : QStringLiteral( " (%1)" ).arg( definitionString ) );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
+    % End
+#endif
+
   private:
 
     mutable QExplicitlySharedDataPointer<QgsPropertyPrivate> d;

--- a/src/core/qgsproxyfeaturesink.cpp
+++ b/src/core/qgsproxyfeaturesink.cpp
@@ -1,8 +1,8 @@
 /***************************************************************************
-                         qgsfeaturesink.cpp
-                         ------------------
-    begin                : April 2017
-    copyright            : (C) 2017 by Nyall Dawson
+                         qgsproxyfeaturesink.cpp
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
     email                : nyall dot dawson at gmail dot com
  ***************************************************************************/
 
@@ -15,30 +15,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsfeaturestore.h"
+#include "qgsproxyfeaturesink.h"
 
-bool QgsFeatureSink::addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags )
-{
-  QgsFeatureList features;
-  features << feature;
-  bool result = addFeatures( features, flags );
 
-  if ( !( flags & FastInsert ) )
-  {
-    // need to update the passed feature reference to the updated copy from the features list
-    feature = features.at( 0 );
-  }
-  return result;
-}
-
-bool QgsFeatureSink::addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags )
-{
-  QgsFeature f;
-  bool result = true;
-  while ( iterator.nextFeature( f ) )
-  {
-    result = result && addFeature( f, flags );
-  }
-  return result;
-}
-
+QgsProxyFeatureSink::QgsProxyFeatureSink( QgsFeatureSink *sink )
+  : mSink( sink )
+{}

--- a/src/core/qgsproxyfeaturesink.h
+++ b/src/core/qgsproxyfeaturesink.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+                         qgsproxyfeaturesink.h
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROXYFEATURESINK_H
+#define QGSPROXYFEATURESINK_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsfeaturesink.h"
+
+
+/**
+ * \class QgsProxyFeatureSink
+ * \ingroup core
+ * A simple feature sink which proxies feature addition on to another feature sink.
+ *
+ * This class is designed to allow factory methods which always return new QgsFeatureSink
+ * objects. Since it is not always possible to create an entirely new QgsFeatureSink
+ * (e.g. if the feature sink is a layer's data provider), a new QgsProxyFeatureSink
+ * can instead be returned which forwards features on to the destination sink. The
+ * proxy sink can be safely deleted without affecting the destination sink.
+ *
+ * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsProxyFeatureSink : public QgsFeatureSink
+{
+  public:
+
+    /**
+     * Constructs a new QgsProxyFeatureSink which forwards features onto a destination \a sink.
+     */
+    QgsProxyFeatureSink( QgsFeatureSink *sink );
+    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeature( feature, flags ); }
+    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( features, flags ); }
+    bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override { return mSink->addFeatures( iterator, flags ); }
+
+    /**
+     * Returns the destination QgsFeatureSink which the proxy will forward features to.
+     */
+    QgsFeatureSink *destinationSink() { return mSink; }
+
+  private:
+
+    QgsFeatureSink *mSink = nullptr;
+};
+
+
+#endif // QGSPROXYFEATURESINK_H
+
+
+
+

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -18,11 +18,18 @@
 #include "qgsremappingproxyfeaturesink.h"
 #include "qgslogger.h"
 
-QgsRemappingProxyFeatureSink::QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink )
+QgsRemappingProxyFeatureSink::QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink, bool ownsSink )
   : QgsFeatureSink()
   , mDefinition( mappingDefinition )
   , mSink( sink )
+  , mOwnsSink( ownsSink )
 {}
+
+QgsRemappingProxyFeatureSink::~QgsRemappingProxyFeatureSink()
+{
+  if ( mOwnsSink )
+    delete mSink;
+}
 
 void QgsRemappingProxyFeatureSink::setExpressionContext( const QgsExpressionContext &context )
 {
@@ -39,6 +46,7 @@ QgsFeatureList QgsRemappingProxyFeatureSink::remapFeature( const QgsFeature &fea
   QgsFeatureList res;
 
   mContext.setFeature( feature );
+  mContext.setFields( feature.fields() );
 
   // remap fields first
   QgsFeature f;

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -1,0 +1,119 @@
+/***************************************************************************
+                         qgsremappingproxyfeaturesink.cpp
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsremappingproxyfeaturesink.h"
+#include "qgslogger.h"
+
+QgsRemappingProxyFeatureSink::QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink )
+  : QgsFeatureSink()
+  , mDefinition( mappingDefinition )
+  , mSink( sink )
+{}
+
+void QgsRemappingProxyFeatureSink::setExpressionContext( const QgsExpressionContext &context )
+{
+  mContext = context;
+}
+
+QgsFeatureList QgsRemappingProxyFeatureSink::remapFeature( const QgsFeature &feature ) const
+{
+  QgsFeatureList res;
+
+  mContext.setFeature( feature );
+
+  // remap fields first
+  QgsFeature f;
+  f.setFields( mDefinition.destinationFields(), true );
+  QgsAttributes attributes;
+  const QMap< QString, QgsProperty > fieldMap = mDefinition.fieldMap();
+  for ( const QgsField &field : mDefinition.destinationFields() )
+  {
+    if ( fieldMap.contains( field.name() ) )
+    {
+      attributes.append( fieldMap.value( field.name() ).value( mContext ) );
+    }
+    else
+    {
+      attributes.append( QVariant() );
+    }
+  }
+  f.setAttributes( attributes );
+
+  // make geometries compatible, and reproject if necessary
+  if ( feature.hasGeometry() )
+  {
+    const QVector< QgsGeometry > geometries = feature.geometry().coerceToType( mDefinition.destinationWkbType() );
+    if ( !geometries.isEmpty() )
+    {
+      res.reserve( geometries.size() );
+      for ( const QgsGeometry &geometry : geometries )
+      {
+        QgsFeature featurePart = f;
+
+        QgsGeometry reproject = geometry;
+        try
+        {
+          reproject.transform( mDefinition.transform() );
+          featurePart.setGeometry( reproject );
+        }
+        catch ( QgsCsException & )
+        {
+          QgsLogger::warning( QObject::tr( "Error reprojecting feature geometry" ) );
+          featurePart.clearGeometry();
+        }
+        res << featurePart;
+      }
+    }
+    else
+    {
+      f.clearGeometry();
+      res << f;
+    }
+  }
+  else
+  {
+    res << f;
+  }
+  return res;
+}
+
+bool QgsRemappingProxyFeatureSink::addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags )
+{
+  QgsFeatureList features = remapFeature( feature );
+  return mSink->addFeatures( features, flags );
+}
+
+bool QgsRemappingProxyFeatureSink::addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags )
+{
+  bool res = true;
+  for ( QgsFeature &f : features )
+  {
+    res = addFeature( f, flags ) && res;
+  }
+  return res;
+}
+
+bool QgsRemappingProxyFeatureSink::addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags )
+{
+  QgsFeature f;
+  bool res = true;
+  while ( iterator.nextFeature( f ) )
+  {
+    res = addFeature( f, flags ) && res;
+  }
+  return res;
+}

--- a/src/core/qgsremappingproxyfeaturesink.cpp
+++ b/src/core/qgsremappingproxyfeaturesink.cpp
@@ -46,7 +46,6 @@ QgsFeatureList QgsRemappingProxyFeatureSink::remapFeature( const QgsFeature &fea
   QgsFeatureList res;
 
   mContext.setFeature( feature );
-  mContext.setFields( feature.fields() );
 
   // remap fields first
   QgsFeature f;

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -179,11 +179,27 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
 {
   public:
 
+#ifndef SIP_RUN
+
+    /**
+     * Constructor for QgsRemappingProxyFeatureSink, using the specified \a mappingDefinition
+     * to manipulate features before sending them to the destination \a sink.
+     *
+     * Ownership of \a sink is dictated by \a ownsSink. If \a ownsSink is FALSE,
+     * ownership is not transferred, and callers must ensure that \a sink exists for the lifetime of this object.
+     * If \a ownsSink is TRUE, then this object will take ownership of \a sink.
+     */
+    QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink, bool ownsSink = false );
+#else
+
     /**
      * Constructor for QgsRemappingProxyFeatureSink, using the specified \a mappingDefinition
      * to manipulate features before sending them to the destination \a sink.
      */
     QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
+#endif
+
+    ~QgsRemappingProxyFeatureSink() override;
 
     /**
      * Sets the expression \a context to use when evaluating mapped field values.
@@ -215,6 +231,7 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
     QgsCoordinateTransform mTransform;
     QgsFeatureSink *mSink = nullptr;
     mutable QgsExpressionContext mContext;
+    bool mOwnsSink = false;
 };
 
 #endif // QGSREMAPPINGPROXYFEATURESINK_H

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -1,0 +1,183 @@
+/***************************************************************************
+                         qgsremappingproxyfeaturesink.h
+                         ----------------------
+    begin                : April 2020
+    copyright            : (C) 2020 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSREMAPPINGPROXYFEATURESINK_H
+#define QGSREMAPPINGPROXYFEATURESINK_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsfeaturesink.h"
+#include "qgsproperty.h"
+
+/**
+ * \class QgsRemappingSinkDefinition
+ * \ingroup core
+ * Defines the parameters used to remap features when creating a QgsRemappingProxyFeatureSink.
+ *
+ * The definition includes parameters required to correctly map incoming features to the structure
+ * of the destination sink, e.g. information about how to create output field values and how to transform
+ * geometries to match the destination CRS.
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsRemappingSinkDefinition
+{
+  public:
+
+    /**
+     * Returns the field mapping, which defines how to map the values from incoming features to destination
+     * field values.
+     *
+     * Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+     * mapping or use of QgsExpression expressions to transform values to the destination field.
+     *
+     * \see setFieldMap()
+     * \see addMappedField()
+     */
+    QMap< QString, QgsProperty > fieldMap() const { return mFieldMap; }
+
+    /**
+     * Sets the field mapping, which defines how to map the values from incoming features to destination
+     * field values.
+     *
+     * Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+     * mapping or use of QgsExpression expressions to transform values to the destination field.
+     *
+     * \see fieldMap()
+     * \see addMappedField()
+     */
+    void setFieldMap( const QMap< QString, QgsProperty > &map ) { mFieldMap = map; }
+
+    /**
+     * Adds a mapping for a destination field.
+     *
+     * Field values are mapped using a QgsProperty source object, which allows either direct field value to field value
+     * mapping or use of QgsExpression expressions to transform values to the destination field.
+     *
+     * \see setFieldMap()
+     * \see fieldMap()
+     */
+    void addMappedField( const QString &destinationField, const QgsProperty &property ) { mFieldMap.insert( destinationField, property ); }
+
+    /**
+     * Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see setTransform()
+     */
+    QgsCoordinateTransform transform() const { return mTransform; }
+
+    /**
+     * Sets the \a transform used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see transform()
+     */
+    void setTransform( const QgsCoordinateTransform &transform )  { mTransform = transform; }
+
+    /**
+     * Returns the WKB geometry type for the destination.
+     *
+     * \see setDestinationWkbType()
+     */
+    QgsWkbTypes::Type destinationWkbType() const { return mDestinationWkbType; }
+
+    /**
+     * Sets the WKB geometry \a type for the destination.
+     *
+     * \see setDestinationWkbType()
+     */
+    void setDestinationWkbType( QgsWkbTypes::Type type ) { mDestinationWkbType = type; }
+
+    /**
+     * Returns the fields for the destination sink.
+     *
+     * \see setDestinationFields()
+     */
+    QgsFields destinationFields() const { return mDestinationFields; }
+
+    /**
+     * Sets the \a fields for the destination sink.
+     *
+     * \see destinationFields()
+     */
+    void setDestinationFields( const QgsFields &fields ) { mDestinationFields = fields; }
+
+  private:
+
+    QMap< QString, QgsProperty > mFieldMap;
+
+    QgsCoordinateTransform mTransform;
+
+    QgsWkbTypes::Type mDestinationWkbType = QgsWkbTypes::Unknown;
+
+    QgsFields mDestinationFields;
+
+};
+
+
+/**
+ * \class QgsRemappingProxyFeatureSink
+ * \ingroup core
+ * A QgsFeatureSink which proxies incoming features to a destination feature sink, after applying
+ * transformations and field value mappings.
+ *
+ * This sink allows for transformation of incoming features to match the requirements of storing
+ * in an existing destination layer, e.g. by reprojecting the features to the destination's CRS
+ * and by coercing geometries to the format required by the destination sink.
+ *
+ * \since QGIS 3.14
+ */
+class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
+{
+  public:
+
+    /**
+     * Constructor for QgsRemappingProxyFeatureSink, using the specified \a mappingDefinition
+     * to manipulate features before sending them to the destination \a sink.
+     */
+    QgsRemappingProxyFeatureSink( const QgsRemappingSinkDefinition &mappingDefinition, QgsFeatureSink *sink );
+
+    /**
+     * Sets the expression \a context to use when evaluating mapped field values.
+     */
+    void setExpressionContext( const QgsExpressionContext &context );
+
+    /**
+     * Remaps a \a feature to a set of features compatible with the destination sink.
+     */
+    QgsFeatureList remapFeature( const QgsFeature &feature ) const;
+
+    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override;
+    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override;
+    bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override;
+
+    /**
+     * Returns the destination QgsFeatureSink which the proxy will forward features to.
+     */
+    QgsFeatureSink *destinationSink() { return mSink; }
+
+  private:
+
+    QgsRemappingSinkDefinition mDefinition;
+    QgsFeatureSink *mSink = nullptr;
+    mutable QgsExpressionContext mContext;
+};
+
+#endif // QGSREMAPPINGPROXYFEATURESINK_H
+
+
+
+

--- a/src/core/qgsremappingproxyfeaturesink.h
+++ b/src/core/qgsremappingproxyfeaturesink.h
@@ -74,18 +74,32 @@ class CORE_EXPORT QgsRemappingSinkDefinition
     void addMappedField( const QString &destinationField, const QgsProperty &property ) { mFieldMap.insert( destinationField, property ); }
 
     /**
-     * Returns the transform used for reprojecting incoming features to the sink's destination CRS.
+     * Returns the source CRS used for reprojecting incoming features to the sink's destination CRS.
      *
-     * \see setTransform()
+     * \see setSourceCrs()
      */
-    QgsCoordinateTransform transform() const { return mTransform; }
+    QgsCoordinateReferenceSystem sourceCrs() const { return mSourceCrs; }
 
     /**
-     * Sets the \a transform used for reprojecting incoming features to the sink's destination CRS.
+     * Sets the \a source crs used for reprojecting incoming features to the sink's destination CRS.
      *
-     * \see transform()
+     * \see sourceCrs()
      */
-    void setTransform( const QgsCoordinateTransform &transform )  { mTransform = transform; }
+    void setSourceCrs( const QgsCoordinateReferenceSystem &source ) { mSourceCrs = source; }
+
+    /**
+     * Returns the destination CRS used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see setDestinationCrs()
+     */
+    QgsCoordinateReferenceSystem destinationCrs() const { return mDestinationCrs; }
+
+    /**
+     * Sets the \a destination crs used for reprojecting incoming features to the sink's destination CRS.
+     *
+     * \see destinationCrs()
+     */
+    void setDestinationCrs( const QgsCoordinateReferenceSystem &destination ) { mDestinationCrs = destination; }
 
     /**
      * Returns the WKB geometry type for the destination.
@@ -115,17 +129,38 @@ class CORE_EXPORT QgsRemappingSinkDefinition
      */
     void setDestinationFields( const QgsFields &fields ) { mDestinationFields = fields; }
 
+    /**
+     * Saves this remapping definition to a QVariantMap, wrapped in a QVariant.
+     * You can use QgsXmlUtils::writeVariant to save it to an XML document.
+     * \see loadVariant()
+     */
+    QVariant toVariant() const;
+
+    /**
+     * Loads this remapping definition from a QVariantMap, wrapped in a QVariant.
+     * You can use QgsXmlUtils::readVariant to load it from an XML document.
+     * \see toVariant()
+     */
+    bool loadVariant( const QVariantMap &map );
+
+    bool operator==( const QgsRemappingSinkDefinition &other ) const;
+    bool operator!=( const QgsRemappingSinkDefinition &other ) const;
+
   private:
 
     QMap< QString, QgsProperty > mFieldMap;
 
-    QgsCoordinateTransform mTransform;
+    QgsCoordinateReferenceSystem mSourceCrs;
+    QgsCoordinateReferenceSystem mDestinationCrs;
 
     QgsWkbTypes::Type mDestinationWkbType = QgsWkbTypes::Unknown;
 
     QgsFields mDestinationFields;
 
 };
+
+Q_DECLARE_METATYPE( QgsRemappingSinkDefinition )
+
 
 
 /**
@@ -156,6 +191,11 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
     void setExpressionContext( const QgsExpressionContext &context );
 
     /**
+     * Sets the transform \a context to use when reprojecting features.
+     */
+    void setTransformContext( const QgsCoordinateTransformContext &context );
+
+    /**
      * Remaps a \a feature to a set of features compatible with the destination sink.
      */
     QgsFeatureList remapFeature( const QgsFeature &feature ) const;
@@ -172,6 +212,7 @@ class CORE_EXPORT QgsRemappingProxyFeatureSink : public QgsFeatureSink
   private:
 
     QgsRemappingSinkDefinition mDefinition;
+    QgsCoordinateTransform mTransform;
     QgsFeatureSink *mSink = nullptr;
     mutable QgsExpressionContext mContext;
 };

--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -21,6 +21,7 @@
 #include "qgsproperty.h"
 #include "qgssymbollayerutils.h"
 #include "qgsprocessingparameters.h"
+#include "qgsremappingproxyfeaturesink.h"
 
 QgsUnitTypes::DistanceUnit QgsXmlUtils::readMapUnits( const QDomElement &element )
 {
@@ -228,6 +229,13 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
         element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsProcessingFeatureSourceDefinition" ) );
         break;
       }
+      else if ( value.canConvert< QgsRemappingSinkDefinition >() )
+      {
+        QDomElement valueElement = writeVariant( value.value< QgsRemappingSinkDefinition >().toVariant(), doc );
+        element.appendChild( valueElement );
+        element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "QgsRemappingSinkDefinition" ) );
+        break;
+      }
       Q_ASSERT_X( false, "QgsXmlUtils::writeVariant", QStringLiteral( "unsupported user variant type %1" ).arg( QMetaType::typeName( value.userType() ) ).toLocal8Bit() );
       break;
     }
@@ -375,6 +383,18 @@ QVariant QgsXmlUtils::readVariant( const QDomElement &element )
 
     if ( res.loadVariant( QgsXmlUtils::readVariant( values.at( 0 ).toElement() ).toMap() ) )
       return res;
+
+    return QVariant();
+  }
+  else if ( type == QLatin1String( "QgsRemappingSinkDefinition" ) )
+  {
+    QgsRemappingSinkDefinition res;
+    const QDomNodeList values = element.childNodes();
+    if ( values.isEmpty() )
+      return QVariant();
+
+    if ( res.loadVariant( QgsXmlUtils::readVariant( values.at( 0 ).toElement() ).toMap() ) )
+      return QVariant::fromValue( res );
 
     return QVariant();
   }

--- a/src/gui/processing/qgsprocessingoutputdestinationwidget.h
+++ b/src/gui/processing/qgsprocessingoutputdestinationwidget.h
@@ -20,6 +20,7 @@
 #include "qgis_gui.h"
 #include "ui_qgsprocessingdestinationwidgetbase.h"
 #include "qgsprocessingwidgetwrapper.h"
+#include "qgsprocessingcontext.h"
 #include <QWidget>
 
 class QgsProcessingDestinationParameter;
@@ -115,10 +116,13 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
     void selectFile();
     void saveToGeopackage();
     void saveToDatabase();
+    void appendToLayer();
     void selectEncoding();
     void textChanged( const QString &text );
 
   private:
+
+    void setAppendDestination( const QString &uri, const QgsFields &destFields );
 
     QString mimeDataToPath( const QMimeData *data );
 
@@ -131,6 +135,9 @@ class GUI_EXPORT QgsProcessingLayerOutputDestinationWidget : public QWidget, pri
     QString mEncoding;
     QgsBrowserGuiModel *mBrowserModel = nullptr;
     QCheckBox *mOpenAfterRunningCheck = nullptr;
+
+    QgsRemappingSinkDefinition mRemapDefinition;
+    bool mUseRemapping = false;
 
     QgsProcessingContext *mContext = nullptr;
 

--- a/src/gui/processing/qgsprocessingparameterswidget.h
+++ b/src/gui/processing/qgsprocessingparameterswidget.h
@@ -20,6 +20,7 @@
 #include "qgis_gui.h"
 #include "ui_qgsprocessingparameterswidgetbase.h"
 #include <QWidget>
+#include "qgsprocessingwidgetwrapper.h"
 
 class QgsProcessingAlgorithm;
 class QgsProcessingParameterDefinition;
@@ -32,7 +33,7 @@ class QgsProcessingParameterDefinition;
  * \note Not stable API
  * \since QGIS 3.14
  */
-class GUI_EXPORT QgsProcessingParametersWidget : public QgsPanelWidget, private Ui::QgsProcessingParametersWidgetBase
+class GUI_EXPORT QgsProcessingParametersWidget : public QgsPanelWidget, public QgsProcessingParametersGenerator, private Ui::QgsProcessingParametersWidgetBase
 {
     Q_OBJECT
 

--- a/src/gui/qgsfieldmappingmodel.h
+++ b/src/gui/qgsfieldmappingmodel.h
@@ -22,6 +22,7 @@
 #include "qgsfields.h"
 #include "qgsexpressioncontextgenerator.h"
 #include "qgsfieldconstraints.h"
+#include "qgsproperty.h"
 #include "qgis_gui.h"
 
 
@@ -96,6 +97,21 @@ class GUI_EXPORT QgsFieldMappingModel: public QAbstractTableModel
 
     //! Returns a list of Field objects representing the current status of the model
     QList<QgsFieldMappingModel::Field> mapping() const;
+
+    /**
+     * Returns a map of destination field name to QgsProperty definition for field value,
+     * representing the current status of the model.
+     *
+     * \see setFieldPropertyMap()
+     */
+    QMap< QString, QgsProperty > fieldPropertyMap() const;
+
+    /**
+     * Sets a map of destination field name to QgsProperty definition for field value.
+     *
+     * \see fieldPropertyMap()
+     */
+    void setFieldPropertyMap( const QMap< QString, QgsProperty > &map );
 
     //! Appends a new \a field to the model, with an optional \a expression
     void appendField( const QgsField &field, const QString &expression = QString() );

--- a/src/gui/qgsfieldmappingwidget.cpp
+++ b/src/gui/qgsfieldmappingwidget.cpp
@@ -67,6 +67,16 @@ QList<QgsFieldMappingModel::Field> QgsFieldMappingWidget::mapping() const
   return model()->mapping();
 }
 
+QMap<QString, QgsProperty> QgsFieldMappingWidget::fieldPropertyMap() const
+{
+  return model()->fieldPropertyMap();
+}
+
+void QgsFieldMappingWidget::setFieldPropertyMap( const QMap<QString, QgsProperty> &map )
+{
+  model()->setFieldPropertyMap( map );
+}
+
 QItemSelectionModel *QgsFieldMappingWidget::selectionModel()
 {
   return mTableView->selectionModel();

--- a/src/gui/qgsfieldmappingwidget.h
+++ b/src/gui/qgsfieldmappingwidget.h
@@ -61,6 +61,21 @@ class GUI_EXPORT QgsFieldMappingWidget : public QgsPanelWidget, private Ui::QgsF
     //! Returns a list of Field objects representing the current status of the underlying mapping model
     QList<QgsFieldMappingModel::Field> mapping() const;
 
+    /**
+     * Returns a map of destination field name to QgsProperty definition for field value,
+     * representing the current status of the widget.
+     *
+     * \see setFieldPropertyMap()
+     */
+    QMap< QString, QgsProperty > fieldPropertyMap() const;
+
+    /**
+     * Sets a map of destination field name to QgsProperty definition for field value.
+     *
+     * \see fieldPropertyMap()
+     */
+    void setFieldPropertyMap( const QMap< QString, QgsProperty > &map );
+
     //! Returns the selection model
     QItemSelectionModel *selectionModel();
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -7946,8 +7946,15 @@ void TestQgsProcessing::processingFeatureSink()
   QString sinkString( QStringLiteral( "test.shp" ) );
   QgsProject p;
   QgsProcessingOutputLayerDefinition fs( sinkString, &p );
+  QgsRemappingSinkDefinition remap;
+  QVERIFY( !fs.useRemapping() );
+  remap.setDestinationWkbType( QgsWkbTypes::Point );
+  fs.setRemappingDefinition( remap );
+  QVERIFY( fs.useRemapping() );
+
   QCOMPARE( fs.sink.staticValue().toString(), sinkString );
   QCOMPARE( fs.destinationProject, &p );
+  QCOMPARE( fs.remappingDefinition().destinationWkbType(), QgsWkbTypes::Point );
 
   // test storing QgsProcessingFeatureSink in variant and retrieving
   QVariant fsInVariant = QVariant::fromValue( fs );
@@ -7956,6 +7963,7 @@ void TestQgsProcessing::processingFeatureSink()
   QgsProcessingOutputLayerDefinition fromVar = qvariant_cast<QgsProcessingOutputLayerDefinition>( fsInVariant );
   QCOMPARE( fromVar.sink.staticValue().toString(), sinkString );
   QCOMPARE( fromVar.destinationProject, &p );
+  QCOMPARE( fromVar.remappingDefinition().destinationWkbType(), QgsWkbTypes::Point );
 
   // test evaluating parameter as sink
   QgsProcessingContext context;

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -8023,7 +8023,7 @@ void TestQgsProcessing::processingFeatureSink()
   context.setProject( &p );
 
   // first using static string definition
-  std::unique_ptr< QgsProcessingParameterDefinition > def( new QgsProcessingParameterFeatureSink( QStringLiteral( "layer" ) ) );
+  std::unique_ptr< QgsProcessingParameterFeatureSink > def( new QgsProcessingParameterFeatureSink( QStringLiteral( "layer" ) ) );
   QVariantMap params;
   params.insert( QStringLiteral( "layer" ), QgsProcessingOutputLayerDefinition( "memory:test", nullptr ) );
   QString dest;
@@ -8091,6 +8091,22 @@ void TestQgsProcessing::processingFeatureSink()
   params.insert( QStringLiteral( "layer" ), QVariant() );
   sink.reset( QgsProcessingParameters::parameterAsSink( def.get(), params, QgsFields(), QgsWkbTypes::Point, QgsCoordinateReferenceSystem( "EPSG:3113" ), context, dest ) );
   QVERIFY( sink.get() );
+
+  // appendable
+  def->setSupportsAppend( true );
+  QVERIFY( def->supportsAppend() );
+  QString pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterFeatureSink('layer', '', optional=True, type=QgsProcessing.TypeMapLayer, createByDefault=True, supportsAppend=True, defaultValue='memory:defaultlayer')" ) );
+
+  QVariantMap val = def->toVariantMap();
+  QgsProcessingParameterFeatureSink fromMap( "x" );
+  QVERIFY( fromMap.fromVariantMap( val ) );
+  QVERIFY( fromMap.supportsAppend() );
+
+  def->setSupportsAppend( false );
+  QVERIFY( !def->supportsAppend() );
+  pythonCode = def->asPythonString();
+  QCOMPARE( pythonCode, QStringLiteral( "QgsProcessingParameterFeatureSink('layer', '', optional=True, type=QgsProcessing.TypeMapLayer, createByDefault=True, defaultValue='memory:defaultlayer')" ) );
 }
 
 void TestQgsProcessing::algorithmScope()
@@ -9370,7 +9386,7 @@ void TestQgsProcessing::modelExecution()
                               "    param = QgsProcessingParameterCrs('CRS', '', defaultValue=QgsCoordinateReferenceSystem('EPSG:28355'))\n"
                               "    param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)\n"
                               "    self.addParameter(param)\n"
-                              "    self.addParameter(QgsProcessingParameterFeatureSink('MyModelOutput', 'my model output', type=QgsProcessing.TypeVectorPolygon, createByDefault=True, defaultValue=None))\n"
+                              "    self.addParameter(QgsProcessingParameterFeatureSink('MyModelOutput', 'my model output', type=QgsProcessing.TypeVectorPolygon, createByDefault=True, supportsAppend=True, defaultValue=None))\n"
                               "    self.addParameter(QgsProcessingParameterFeatureSink('cx3:MY_OUT', '', type=QgsProcessing.TypeVectorAnyGeometry, createByDefault=True, defaultValue=None))\n"
                               "\n"
                               "  def processAlgorithm(self, parameters, context, model_feedback):\n"

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -7349,6 +7349,28 @@ void TestProcessingGui::testOutputDefinitionWidget()
   panel3.setValue( QgsProcessing::TEMPORARY_OUTPUT );
   QCOMPARE( skipSpy3.count(), 3 );
   QCOMPARE( changedSpy3.count(), 3 );
+
+  // with remapping
+  def = QgsProcessingOutputLayerDefinition( QStringLiteral( "test.shp" ) );
+  QgsRemappingSinkDefinition remap;
+  QMap< QString, QgsProperty > fieldMap;
+  fieldMap.insert( QStringLiteral( "field1" ), QgsProperty::fromField( QStringLiteral( "source1" ) ) );
+  fieldMap.insert( QStringLiteral( "field2" ), QgsProperty::fromExpression( QStringLiteral( "source || source2" ) ) );
+  remap.setFieldMap( fieldMap );
+  def.setRemappingDefinition( remap );
+
+  panel3.setValue( def );
+  v = panel3.value();
+  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QVERIFY( v.value< QgsProcessingOutputLayerDefinition>().useRemapping() );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().size(), 2 );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().value( QStringLiteral( "field1" ) ), QgsProperty::fromField( QStringLiteral( "source1" ) ) );
+  QCOMPARE( v.value< QgsProcessingOutputLayerDefinition>().remappingDefinition().fieldMap().value( QStringLiteral( "field2" ) ), QgsProperty::fromExpression( QStringLiteral( "source || source2" ) ) );
+
+  panel3.setValue( QStringLiteral( "other.shp" ) );
+  v = panel3.value();
+  QVERIFY( v.canConvert< QgsProcessingOutputLayerDefinition>() );
+  QVERIFY( !v.value< QgsProcessingOutputLayerDefinition>().useRemapping() );
 }
 
 void TestProcessingGui::testOutputDefinitionWidgetVectorOut()

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -18,7 +18,7 @@ from qgis.core import QgsGeometry, QgsPoint, QgsPointXY, QgsCircle, QgsCircularS
     QgsCurvePolygon, QgsEllipse, QgsLineString, QgsMultiCurve, QgsRectangle, QgsExpression, QgsField, QgsError,\
     QgsMimeDataUtils, QgsVector, QgsVector3D, QgsVectorLayer, QgsReferencedPointXY, QgsReferencedRectangle,\
     QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject, QgsClassificationRange, QgsBookmark, \
-    QgsLayoutMeasurement, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes, QgsConditionalStyle, QgsTableCell
+    QgsLayoutMeasurement, QgsLayoutPoint, QgsLayoutSize, QgsUnitTypes, QgsConditionalStyle, QgsTableCell, QgsProperty
 
 start_app()
 
@@ -224,6 +224,22 @@ class TestPython__repr__(unittest.TestCase):
         self.assertEqual(b.__repr__(), "<QgsTableCell: test>")
         b.setContent(5)
         self.assertEqual(b.__repr__(), "<QgsTableCell: 5>")
+
+    def testQgsProperty(self):
+        p = QgsProperty.fromValue(5)
+        self.assertEqual(p.__repr__(), '<QgsProperty: static (5)>')
+        p = QgsProperty.fromField('my_field')
+        self.assertEqual(p.__repr__(), '<QgsProperty: field (my_field)>')
+        p = QgsProperty.fromExpression('5*5 || \'a\'')
+        self.assertEqual(p.__repr__(), '<QgsProperty: expression (5*5 || \'a\')>')
+        p = QgsProperty.fromValue(5, False)
+        self.assertEqual(p.__repr__(), '<QgsProperty: INACTIVE static (5)>')
+        p = QgsProperty.fromField('my_field', False)
+        self.assertEqual(p.__repr__(), '<QgsProperty: INACTIVE field (my_field)>')
+        p = QgsProperty.fromExpression('5*5 || \'a\'', False)
+        self.assertEqual(p.__repr__(), '<QgsProperty: INACTIVE expression (5*5 || \'a\')>')
+        p = QgsProperty()
+        self.assertEqual(p.__repr__(), '<QgsProperty: invalid>')
 
 
 if __name__ == "__main__":

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -18,9 +18,15 @@ from qgis.core import (QgsXmlUtils,
                        QgsCoordinateReferenceSystem,
                        QgsProcessingOutputLayerDefinition,
                        QgsProcessingFeatureSourceDefinition,
+                       QgsRemappingSinkDefinition,
+                       QgsWkbTypes,
+                       QgsCoordinateTransform,
+                       QgsFields,
+                       QgsField,
+                       QgsProject,
                        NULL)
 
-from qgis.PyQt.QtCore import QDateTime, QDate, QTime
+from qgis.PyQt.QtCore import QDateTime, QDate, QTime, QVariant
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.QtGui import QColor
 
@@ -277,6 +283,32 @@ class TestQgsXmlUtils(unittest.TestCase):
         c = QgsXmlUtils.readVariant(elem)
         self.assertEqual(c.sink.staticValue(), 'my sink')
         self.assertEqual(c.createOptions, {'opt': 1, 'opt2': 2})
+
+    def testRemappingDefinition(self):
+        fields = QgsFields()
+        fields.append(QgsField('fldtxt', QVariant.String))
+        fields.append(QgsField('fldint', QVariant.Int))
+        fields.append(QgsField('fldtxt2', QVariant.String))
+
+        mapping_def = QgsRemappingSinkDefinition()
+        mapping_def.setDestinationWkbType(QgsWkbTypes.Point)
+        mapping_def.setSourceCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
+        mapping_def.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3857'))
+        mapping_def.setDestinationFields(fields)
+        mapping_def.addMappedField('fldtxt2', QgsProperty.fromField('fld1'))
+        mapping_def.addMappedField('fldint', QgsProperty.fromExpression('@myval * fldint'))
+
+        doc = QDomDocument("properties")
+        elem = QgsXmlUtils.writeVariant(mapping_def, doc)
+        c = QgsXmlUtils.readVariant(elem)
+
+        self.assertEqual(c.destinationWkbType(), QgsWkbTypes.Point)
+        self.assertEqual(c.sourceCrs().authid(), 'EPSG:4326')
+        self.assertEqual(c.destinationCrs().authid(), 'EPSG:3857')
+        self.assertEqual(c.destinationFields()[0].name(), 'fldtxt')
+        self.assertEqual(c.destinationFields()[1].name(), 'fldint')
+        self.assertEqual(c.fieldMap()['fldtxt2'].field(), 'fld1')
+        self.assertEqual(c.fieldMap()['fldint'].expressionString(), '@myval * fldint')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
(includes https://github.com/qgis/QGIS/pull/35620)

Support needs to be enabled on an algorithm by algorithm basis, but it's currently enabled for ALL feature based algorithm subclasses + the buffer algorithm. I'll add more following merge of this PR.

When appending results, users are given a field mapping panel choice to allow them to manually set how fields are mapped to the destination layer's fields:

![Peek 2020-04-07 14-47](https://user-images.githubusercontent.com/1829991/78631098-b9976100-78de-11ea-8f18-f7c7473e0945.gif)

Refs NRCan Contract#3000707093