### PR TITLE
[snapping] Fix broken version detection which leads to broken reading of snapping type flags

### DIFF
--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -372,7 +372,7 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
     if ( versionElem.hasAttribute( QStringLiteral( "version" ) ) )
     {
       version = versionElem.attribute( QStringLiteral( "version" ) );
-      QRegularExpression re( "([\\d]*)\\.([\\d]*)" );
+      QRegularExpression re( "([\\d]+)\\.([\\d]+)" );
       QRegularExpressionMatch match = re.match( version );
       if ( match.hasMatch() )
       {

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -372,7 +372,7 @@ void QgsSnappingConfig::readProject( const QDomDocument &doc )
     if ( versionElem.hasAttribute( QStringLiteral( "version" ) ) )
     {
       version = versionElem.attribute( QStringLiteral( "version" ) );
-      QRegularExpression re( "(\\d).(\\d)" );
+      QRegularExpression re( "([\\d]*)\\.([\\d]*)" );
       QRegularExpressionMatch match = re.match( version );
       if ( match.hasMatch() )
       {


### PR DESCRIPTION
## Description

The regular expression used to extract the project file's version was wrong, and made it impossible to properly restore snapping type flags. This PR fixes that.

Were snapping flags adding in 3.12 or only master? Not sure this needs backporting.