### PR TITLE
Enable per-pixel horizontal scrolling on attribute table

### DIFF
--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -56,6 +56,8 @@ QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
   setSortingEnabled( true ); // At this point no data is in the model yet, so actually nothing is sorted.
   horizontalHeader()->setSortIndicatorShown( false ); // So hide the indicator to avoid confusion.
 
+  setHorizontalScrollMode( QAbstractItemView::ScrollPerPixel );
+
   verticalHeader()->viewport()->installEventFilter( this );
 
   connect( verticalHeader(), &QHeaderView::sectionPressed, this, [ = ]( int row ) { selectRow( row, true ); } );


### PR DESCRIPTION
Instead of the previous per-cell scrolling mode, which is very frustrating to work with when you have wide columns (e.g. columns wider than the the attribute table window)
