### PR TITLE
Forms: expression controlled aliases (labels)

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
@@ -21,14 +21,16 @@ The time in a mesh layer is defined by :
 - each dataset is associated with a relative times
 - time extent is defined by the first time and the last time of all dataset
 
-Reference time :          AT
-Dataset 1 time            o-----RT------RT-----RT-----------RT
-Dataset 2 time            o---------RT------RT--------RT
-Dataset 3 time            o------------------------------RT-------RT----------RT
-Time extent of layer      o-----<--------------------------------------------->
+.. code-block:: unparsed
 
-AT : absolute time (QDateTime)
-RT : relative time (qint64)
+     Reference time :          AT
+     Dataset 1 time            o-----RT------RT-----RT-----------RT
+     Dataset 2 time            o---------RT------RT--------RT
+     Dataset 3 time            o------------------------------RT-------RT----------RT
+     Time extent of layer      o-----<--------------------------------------------->
+
+     AT : absolute time (QDateTime)
+     RT : relative time (qint64)
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -15,7 +15,7 @@ class QgsAttributeEditorElement /Abstract/
 This is an abstract base class for any elements of a drag and drop form.
 
 This can either be a container which will be represented on the screen
-as a tab widget or ca collapsible group box. Or it can be a field which will
+as a tab widget or a collapsible group box. Or it can be a field which will
 then be represented based on the QgsEditorWidget type and configuration.
 Or it can be a relation and embed the form of several children of another
 layer.
@@ -112,40 +112,6 @@ Controls if this element should be labeled with a title (field, relation or grou
 Controls if this element should be labeled with a title (field, relation or groupname).
 
 .. versionadded:: 2.18
-%End
-
-    QString labelExpression() const;
-%Docstring
-Returns the (possibly empty or inactive) label expression.
-
-.. seealso:: :py:func:`labelExpressionIsActive`
-
-.. versionadded:: 3.14
-%End
-
-    void setLabelExpression( const QString &labelExpression );
-%Docstring
-Sets the label expression override for the field to ``labelExpression``.
-If the override is not active or it is set to an empty string the field label will be taken from
-the label alias if set or from the field name otherwise.
-
-.. seealso:: :py:func:`setLabelExpressionIsActive`
-
-.. versionadded:: 3.14
-%End
-
-    bool labelExpressionIsActive() const;
-%Docstring
-Returns the status of the label expression override.
-
-.. versionadded:: 3.14
-%End
-
-    void setLabelExpressionIsActive( bool labelExpressionIsActive );
-%Docstring
-Sets the status of a label expression override to ``labelExpressionIsActive``.
-
-.. versionadded:: 3.14
 %End
 
   protected:

--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -116,16 +116,34 @@ Controls if this element should be labeled with a title (field, relation or grou
 
     QString labelExpression() const;
 %Docstring
-Returns the (possibly empty) label expression
+Returns the (possibly empty or inactive) label expression.
+
+.. seealso:: :py:func:`labelExpressionIsActive`
 
 .. versionadded:: 3.14
 %End
 
     void setLabelExpression( const QString &labelExpression );
 %Docstring
-Sets the label expression for the field to ``labelExpression``.
-If set to an empty string the field label will be taken from
+Sets the label expression override for the field to ``labelExpression``.
+If the override is not active or it is set to an empty string the field label will be taken from
 the label alias if set or from the field name otherwise.
+
+.. seealso:: :py:func:`setLabelExpressionIsActive`
+
+.. versionadded:: 3.14
+%End
+
+    bool labelExpressionIsActive() const;
+%Docstring
+Returns the status of the label expression override.
+
+.. versionadded:: 3.14
+%End
+
+    void setLabelExpressionIsActive( bool labelExpressionIsActive );
+%Docstring
+Sets the status of a label expression override to ``labelExpressionIsActive``.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -114,6 +114,20 @@ Controls if this element should be labeled with a title (field, relation or grou
 .. versionadded:: 2.18
 %End
 
+    QString labelExpression() const;
+%Docstring
+Returns the (possibly empty) label expression
+
+.. versionadded:: 3.14
+%End
+
+    void setLabelExpression( const QString &labelExpression );
+%Docstring
+Sets the label expression to ``labelExpression``
+
+.. versionadded:: 3.14
+%End
+
   protected:
 
 };

--- a/python/core/auto_generated/qgsattributeeditorelement.sip.in
+++ b/python/core/auto_generated/qgsattributeeditorelement.sip.in
@@ -123,7 +123,9 @@ Returns the (possibly empty) label expression
 
     void setLabelExpression( const QString &labelExpression );
 %Docstring
-Sets the label expression to ``labelExpression``
+Sets the label expression for the field to ``labelExpression``.
+If set to an empty string the field label will be taken from
+the label alias if set or from the field name otherwise.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/qgseditformconfig.sip.in
@@ -191,6 +191,19 @@ on the left hand side.
 Labeling on top leaves more horizontal space for the widget itself.
 %End
 
+    QString labelExpression( int idx ) const;
+%Docstring
+Returns the (possibly empty) expression for the label, to be evaluated in the form context.
+
+.. versionadded:: 3.14
+%End
+
+    void setLabelExpression( int idx, const QString &labelExpression );
+%Docstring
+Set the label expression to ``labelExpression``, to be evaluated in the form context.
+
+.. versionadded:: 3.14
+%End
 
 
     QString initFunction() const;

--- a/python/core/auto_generated/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/qgseditformconfig.sip.in
@@ -67,6 +67,13 @@ Constructor for TabData
       CodeSourceEnvironment
     };
 
+    enum DataDefinedProperty
+    {
+      NoProperty,
+      AllProperties,
+      Alias,
+    };
+
     QgsEditFormConfig( const QgsEditFormConfig &o );
 %Docstring
 Copy constructor
@@ -191,33 +198,6 @@ on the left hand side.
 Labeling on top leaves more horizontal space for the widget itself.
 %End
 
-    QString labelExpression( const QString &fieldName ) const;
-%Docstring
-Returns the (possibly empty or inactive) expression for the label of ``fieldName``, to be evaluated in the form context.
-
-.. note::
-
-   The returned expression might not be active.
-
-.. seealso:: :py:func:`labelExpressionIsActive`
-
-.. versionadded:: 3.14
-%End
-
-    bool labelExpressionIsActive( const QString &fieldName ) const;
-%Docstring
-Returns true if the label expression for the label of ``fieldName`` is active and it is not empty.
-
-.. versionadded:: 3.14
-%End
-
-    void setLabelExpression( const QString &fieldName, const QString &labelExpression, bool isActive );
-%Docstring
-Set the label expression for ``fieldName`` to ``labelExpression`` and the active state to ``isActive``,
-to be evaluated in the form context.
-
-.. versionadded:: 3.14
-%End
 
 
     QString initFunction() const;
@@ -302,6 +282,28 @@ Deserialize drag and drop designer elements.
     explicit QgsEditFormConfig();
 %Docstring
 Create a new edit form config. Normally invoked by :py:class:`QgsVectorLayer`
+%End
+
+    void setDataDefinedFieldProperties( const QString &fieldName, const QgsPropertyCollection &properties );
+%Docstring
+Set data defined properties for ``fieldName`` to ``properties``
+
+.. versionadded:: 4.14
+%End
+
+    QgsPropertyCollection dataDefinedFieldProperties( const QString &fieldName ) const;
+%Docstring
+Returns data defined properties for ``fieldName``
+
+.. versionadded:: 4.14
+%End
+
+
+    static const QgsPropertiesDefinition &propertyDefinitions();
+%Docstring
+Returns data defined property definitions.
+
+.. versionadded:: 4.14
 %End
 
 };

--- a/python/core/auto_generated/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/qgseditformconfig.sip.in
@@ -213,16 +213,8 @@ Returns true if the label expression for the label of ``fieldName`` is active an
 
     void setLabelExpression( const QString &fieldName, const QString &labelExpression, bool isActive );
 %Docstring
-Set the label expression for ``fieldName`` to ``labelExpression``, to be evaluated in the form context.
-
-.. seealso:: :py:func:`setLabelExpressionIsActive`
-
-.. versionadded:: 3.14
-%End
-
-    void setLabelExpressionIsActive( const QString &fieldName, bool isActive );
-%Docstring
-Set the label expression active state for ``fieldName`` to ``isActive``
+Set the label expression for ``fieldName`` to ``labelExpression`` and the active state to ``isActive``,
+to be evaluated in the form context.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/qgseditformconfig.sip.in
@@ -193,14 +193,36 @@ Labeling on top leaves more horizontal space for the widget itself.
 
     QString labelExpression( const QString &fieldName ) const;
 %Docstring
-Returns the (possibly empty) expression for the label of ``fieldName``, to be evaluated in the form context.
+Returns the (possibly empty or inactive) expression for the label of ``fieldName``, to be evaluated in the form context.
+
+.. note::
+
+   The returned expression might not be active.
+
+.. seealso:: :py:func:`labelExpressionIsActive`
 
 .. versionadded:: 3.14
 %End
 
-    void setLabelExpression( const QString &fieldName, const QString &labelExpression );
+    bool labelExpressionIsActive( const QString &fieldName ) const;
+%Docstring
+Returns true if the label expression for the label of ``fieldName`` is active and it is not empty.
+
+.. versionadded:: 3.14
+%End
+
+    void setLabelExpression( const QString &fieldName, const QString &labelExpression, bool isActive );
 %Docstring
 Set the label expression for ``fieldName`` to ``labelExpression``, to be evaluated in the form context.
+
+.. seealso:: :py:func:`setLabelExpressionIsActive`
+
+.. versionadded:: 3.14
+%End
+
+    void setLabelExpressionIsActive( const QString &fieldName, bool isActive );
+%Docstring
+Set the label expression active state for ``fieldName`` to ``isActive``
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/qgseditformconfig.sip.in
@@ -191,16 +191,16 @@ on the left hand side.
 Labeling on top leaves more horizontal space for the widget itself.
 %End
 
-    QString labelExpression( int idx ) const;
+    QString labelExpression( const QString &fieldName ) const;
 %Docstring
-Returns the (possibly empty) expression for the label, to be evaluated in the form context.
+Returns the (possibly empty) expression for the label of ``fieldName``, to be evaluated in the form context.
 
 .. versionadded:: 3.14
 %End
 
-    void setLabelExpression( int idx, const QString &labelExpression );
+    void setLabelExpression( const QString &fieldName, const QString &labelExpression );
 %Docstring
-Set the label expression to ``labelExpression``, to be evaluated in the form context.
+Set the label expression for ``fieldName`` to ``labelExpression``, to be evaluated in the form context.
 
 .. versionadded:: 3.14
 %End

--- a/python/core/auto_generated/qgseditformconfig.sip.in
+++ b/python/core/auto_generated/qgseditformconfig.sip.in
@@ -288,14 +288,14 @@ Create a new edit form config. Normally invoked by :py:class:`QgsVectorLayer`
 %Docstring
 Set data defined properties for ``fieldName`` to ``properties``
 
-.. versionadded:: 4.14
+.. versionadded:: 3.14
 %End
 
     QgsPropertyCollection dataDefinedFieldProperties( const QString &fieldName ) const;
 %Docstring
 Returns data defined properties for ``fieldName``
 
-.. versionadded:: 4.14
+.. versionadded:: 3.14
 %End
 
 
@@ -303,7 +303,7 @@ Returns data defined properties for ``fieldName``
 %Docstring
 Returns data defined property definitions.
 
-.. versionadded:: 4.14
+.. versionadded:: 3.14
 %End
 
 };

--- a/src/core/expression/qgsexpressioncontextutils.cpp
+++ b/src/core/expression/qgsexpressioncontextutils.cpp
@@ -132,6 +132,11 @@ class GetCurrentFormFieldValue : public QgsScopedExpressionFunction
       return new GetCurrentFormFieldValue( );
     }
 
+    bool isStatic( const QgsExpressionNodeFunction *, QgsExpression *, const QgsExpressionContext * ) const override
+    {
+      return false;
+    };
+
 };
 
 class GetCurrentParentFormFieldValue : public QgsScopedExpressionFunction
@@ -156,6 +161,11 @@ class GetCurrentParentFormFieldValue : public QgsScopedExpressionFunction
     {
       return new GetCurrentParentFormFieldValue( );
     }
+
+    bool isStatic( const QgsExpressionNodeFunction *, QgsExpression *, const QgsExpressionContext * ) const override
+    {
+      return false;
+    };
 
 };
 

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -16,6 +16,7 @@
 #include "qgsattributeeditorelement.h"
 #include "qgsrelationmanager.h"
 
+
 void QgsAttributeEditorContainer::addChildElement( QgsAttributeEditorElement *widget )
 {
   mChildren.append( widget );
@@ -115,7 +116,6 @@ QDomElement QgsAttributeEditorElement::toDomElement( QDomDocument &doc ) const
   QDomElement elem = doc.createElement( typeIdentifier() );
   elem.setAttribute( QStringLiteral( "name" ), mName );
   elem.setAttribute( QStringLiteral( "showLabel" ), mShowLabel );
-
   saveConfiguration( elem );
   return elem;
 }
@@ -128,26 +128,6 @@ bool QgsAttributeEditorElement::showLabel() const
 void QgsAttributeEditorElement::setShowLabel( bool showLabel )
 {
   mShowLabel = showLabel;
-}
-
-QString QgsAttributeEditorElement::labelExpression() const
-{
-  return mLabelExpression;
-}
-
-void QgsAttributeEditorElement::setLabelExpression( const QString &labelExpression )
-{
-  mLabelExpression = labelExpression;
-}
-
-bool QgsAttributeEditorElement::labelExpressionIsActive() const
-{
-  return mLabelExpressionIsActive;
-}
-
-void QgsAttributeEditorElement::setLabelExpressionIsActive( bool labelExpressionIsActive )
-{
-  mLabelExpressionIsActive = labelExpressionIsActive;
 }
 
 void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem ) const

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -130,6 +130,16 @@ void QgsAttributeEditorElement::setShowLabel( bool showLabel )
   mShowLabel = showLabel;
 }
 
+QString QgsAttributeEditorElement::labelExpression() const
+{
+  return mLabelExpression;
+}
+
+void QgsAttributeEditorElement::setLabelExpression( const QString &labelExpression )
+{
+  mLabelExpression = labelExpression;
+}
+
 void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem ) const
 {
   elem.setAttribute( QStringLiteral( "relation" ), mRelation.id() );

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -140,6 +140,16 @@ void QgsAttributeEditorElement::setLabelExpression( const QString &labelExpressi
   mLabelExpression = labelExpression;
 }
 
+bool QgsAttributeEditorElement::labelExpressionIsActive() const
+{
+  return mLabelExpressionIsActive;
+}
+
+void QgsAttributeEditorElement::setLabelExpressionIsActive( bool labelExpressionIsActive )
+{
+  mLabelExpressionIsActive = labelExpressionIsActive;
+}
+
 void QgsAttributeEditorRelation::saveConfiguration( QDomElement &elem ) const
 {
   elem.setAttribute( QStringLiteral( "relation" ), mRelation.id() );

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -134,24 +134,39 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
     void setShowLabel( bool showLabel );
 
     /**
-     * Returns the (possibly empty) label expression
+     * Returns the (possibly empty or inactive) label expression.
+     * \see labelExpressionIsActive()
      * \since QGIS 3.14
      */
     QString labelExpression() const;
 
     /**
-     * Sets the label expression for the field to \a labelExpression.
-     * If set to an empty string the field label will be taken from
+     * Sets the label expression override for the field to \a labelExpression.
+     * If the override is not active or it is set to an empty string the field label will be taken from
      * the label alias if set or from the field name otherwise.
+     * \see setLabelExpressionIsActive
      * \since QGIS 3.14
      */
     void setLabelExpression( const QString &labelExpression );
+
+    /**
+     * Returns the status of the label expression override.
+     * \since QGIS 3.14
+     */
+    bool labelExpressionIsActive() const;
+
+    /**
+     * Sets the status of a label expression override to \a labelExpressionIsActive.
+     * \since QGIS 3.14
+     */
+    void setLabelExpressionIsActive( bool labelExpressionIsActive );
 
   protected:
 #ifndef SIP_RUN
     AttributeEditorType mType;
     QString mName;
     QString mLabelExpression;
+    bool mLabelExpressionIsActive;
     QgsAttributeEditorElement *mParent = nullptr;
     bool mShowLabel;
 #endif

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -138,7 +138,6 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
 #ifndef SIP_RUN
     AttributeEditorType mType;
     QString mName;
-    //QgsPropertyCollection mDataDefinedProperties;
     QgsAttributeEditorElement *mParent = nullptr;
     bool mShowLabel;
 #endif

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -129,7 +129,6 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
 
     /**
      * Controls if this element should be labeled with a title (field, relation or groupname).
-     *
      * \since QGIS 2.18
      */
     void setShowLabel( bool showLabel );
@@ -141,7 +140,9 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
     QString labelExpression() const;
 
     /**
-     * Sets the label expression to \a labelExpression
+     * Sets the label expression for the field to \a labelExpression.
+     * If set to an empty string the field label will be taken from
+     * the label alias if set or from the field name otherwise.
      * \since QGIS 3.14
      */
     void setLabelExpression( const QString &labelExpression );

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -134,10 +134,23 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      */
     void setShowLabel( bool showLabel );
 
+    /**
+     * Returns the (possibly empty) label expression
+     * \since QGIS 3.14
+     */
+    QString labelExpression() const;
+
+    /**
+     * Sets the label expression to \a labelExpression
+     * \since QGIS 3.14
+     */
+    void setLabelExpression( const QString &labelExpression );
+
   protected:
 #ifndef SIP_RUN
     AttributeEditorType mType;
     QString mName;
+    QString mLabelExpression;
     QgsAttributeEditorElement *mParent = nullptr;
     bool mShowLabel;
 #endif

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -19,6 +19,7 @@
 #include "qgis_core.h"
 #include "qgsrelation.h"
 #include "qgsoptionalexpression.h"
+#include "qgspropertycollection.h"
 #include <QColor>
 
 class QgsRelationManager;
@@ -28,7 +29,7 @@ class QgsRelationManager;
  * This is an abstract base class for any elements of a drag and drop form.
  *
  * This can either be a container which will be represented on the screen
- * as a tab widget or ca collapsible group box. Or it can be a field which will
+ * as a tab widget or a collapsible group box. Or it can be a field which will
  * then be represented based on the QgsEditorWidget type and configuration.
  * Or it can be a relation and embed the form of several children of another
  * layer.
@@ -133,40 +134,11 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      */
     void setShowLabel( bool showLabel );
 
-    /**
-     * Returns the (possibly empty or inactive) label expression.
-     * \see labelExpressionIsActive()
-     * \since QGIS 3.14
-     */
-    QString labelExpression() const;
-
-    /**
-     * Sets the label expression override for the field to \a labelExpression.
-     * If the override is not active or it is set to an empty string the field label will be taken from
-     * the label alias if set or from the field name otherwise.
-     * \see setLabelExpressionIsActive
-     * \since QGIS 3.14
-     */
-    void setLabelExpression( const QString &labelExpression );
-
-    /**
-     * Returns the status of the label expression override.
-     * \since QGIS 3.14
-     */
-    bool labelExpressionIsActive() const;
-
-    /**
-     * Sets the status of a label expression override to \a labelExpressionIsActive.
-     * \since QGIS 3.14
-     */
-    void setLabelExpressionIsActive( bool labelExpressionIsActive );
-
   protected:
 #ifndef SIP_RUN
     AttributeEditorType mType;
     QString mName;
-    QString mLabelExpression;
-    bool mLabelExpressionIsActive;
+    //QgsPropertyCollection mDataDefinedProperties;
     QgsAttributeEditorElement *mParent = nullptr;
     bool mShowLabel;
 #endif
@@ -187,6 +159,7 @@ class CORE_EXPORT QgsAttributeEditorElement SIP_ABSTRACT
      * \since QGIS 2.18
      */
     virtual QString typeIdentifier() const = 0;
+
 };
 
 

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -639,8 +639,7 @@ QgsAttributeEditorElement *QgsEditFormConfig::attributeEditorElementFromDomEleme
       newElement->setShowLabel( elem.attribute( QStringLiteral( "showLabel" ) ).toInt() );
     else
       newElement->setShowLabel( true );
-    if ( elem.hasAttribute( QStringLiteral( "labelExpression" ) ) )
-      newElement->setLabelExpression( elem.attribute( QStringLiteral( "labelExpression" ) ) );
+    newElement->setLabelExpression( labelExpression( newElement->name() ) );
   }
 
   return newElement;

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -211,20 +211,20 @@ void QgsEditFormConfig::setLabelOnTop( int idx, bool onTop )
   }
 }
 
-QString QgsEditFormConfig::labelExpression( int idx ) const
+QString QgsEditFormConfig::labelExpression( const QString &fieldName ) const
 {
-  if ( idx >= 0 && idx < d->mFields.count() )
-    return d->mLabelExpressions.value( d->mFields.at( idx ).name(), QString() );
+  if ( d->mFields.indexOf( fieldName ) != -1 )
+    return d->mLabelExpressions.value( fieldName, QString() );
   else
     return QString();
 }
 
-void QgsEditFormConfig::setLabelExpression( int idx, const QString &labelExpression )
+void QgsEditFormConfig::setLabelExpression( const QString &fieldName, const QString &labelExpression )
 {
-  if ( idx >= 0 && idx < d->mFields.count() )
+  if ( d->mFields.indexOf( fieldName ) != -1 )
   {
     d.detach();
-    d->mLabelExpressions[ d->mFields.at( idx ).name() ] = labelExpression;
+    d->mLabelExpressions[ fieldName ] = labelExpression;
   }
 }
 

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -208,7 +208,7 @@ class CORE_EXPORT QgsEditFormConfig
      * If this returns TRUE, the widget at the given index will receive its label on the previous line
      * while if it returns FALSE, the widget will receive its label on the left hand side.
      * Labeling on top leaves more horizontal space for the widget itself.
-     **/
+     */
     bool labelOnTop( int idx ) const;
 
     /**
@@ -216,20 +216,20 @@ class CORE_EXPORT QgsEditFormConfig
      * the previous line while if it is set to FALSE, the widget will receive its label
      * on the left hand side.
      * Labeling on top leaves more horizontal space for the widget itself.
-     **/
+     */
     void setLabelOnTop( int idx, bool onTop );
 
     /**
-     * Returns the (possibly empty) expression for the label, to be evaluated in the form context.
+     * Returns the (possibly empty) expression for the label of \a fieldName, to be evaluated in the form context.
      * \since QGIS 3.14
-     **/
-    QString labelExpression( int idx ) const;
+     */
+    QString labelExpression( const QString &fieldName ) const;
 
     /**
-     * Set the label expression to \a labelExpression, to be evaluated in the form context.
+     * Set the label expression for \a fieldName to \a labelExpression, to be evaluated in the form context.
      * \since QGIS 3.14
-     **/
-    void setLabelExpression( int idx, const QString &labelExpression );
+     */
+    void setLabelExpression( const QString &fieldName, const QString &labelExpression );
 
     // Python form init function stuff
 

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -219,6 +219,17 @@ class CORE_EXPORT QgsEditFormConfig
      **/
     void setLabelOnTop( int idx, bool onTop );
 
+    /**
+     * Returns the (possibly empty) expression for the label, to be evaluated in the form context.
+     * \since QGIS 3.14
+     **/
+    QString labelExpression( int idx ) const;
+
+    /**
+     * Set the label expression to \a labelExpression, to be evaluated in the form context.
+     * \since QGIS 3.14
+     **/
+    void setLabelExpression( int idx, const QString &labelExpression );
 
     // Python form init function stuff
 

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -220,16 +220,31 @@ class CORE_EXPORT QgsEditFormConfig
     void setLabelOnTop( int idx, bool onTop );
 
     /**
-     * Returns the (possibly empty) expression for the label of \a fieldName, to be evaluated in the form context.
+     * Returns the (possibly empty or inactive) expression for the label of \a fieldName, to be evaluated in the form context.
+     * \note The returned expression might not be active.
+     * \see labelExpressionIsActive()
      * \since QGIS 3.14
      */
     QString labelExpression( const QString &fieldName ) const;
 
     /**
-     * Set the label expression for \a fieldName to \a labelExpression, to be evaluated in the form context.
+     * Returns true if the label expression for the label of \a fieldName is active and it is not empty.
      * \since QGIS 3.14
      */
-    void setLabelExpression( const QString &fieldName, const QString &labelExpression );
+    bool labelExpressionIsActive( const QString &fieldName ) const;
+
+    /**
+     * Set the label expression for \a fieldName to \a labelExpression, to be evaluated in the form context.
+     * \see setLabelExpressionIsActive() to control its status
+     * \since QGIS 3.14
+     */
+    void setLabelExpression( const QString &fieldName, const QString &labelExpression, bool isActive );
+
+    /**
+     * Set the label expression active state for \a fieldName to \a isActive
+     * \since QGIS 3.14
+     */
+    void setLabelExpressionIsActive( const QString &fieldName, bool isActive );
 
     // Python form init function stuff
 

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -317,20 +317,20 @@ class CORE_EXPORT QgsEditFormConfig
 
     /**
      * Set data defined properties for \a fieldName to \a properties
-     * \since QGIS 4.14
+     * \since QGIS 3.14
      */
     void setDataDefinedFieldProperties( const QString &fieldName, const QgsPropertyCollection &properties );
 
     /**
      * Returns data defined properties for \a fieldName
-     * \since QGIS 4.14
+     * \since QGIS 3.14
      */
     QgsPropertyCollection dataDefinedFieldProperties( const QString &fieldName ) const;
 
 
     /**
      * Returns data defined property definitions.
-     * \since QGIS 4.14
+     * \since QGIS 3.14
      */
     static const QgsPropertiesDefinition &propertyDefinitions();
 

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -234,17 +234,11 @@ class CORE_EXPORT QgsEditFormConfig
     bool labelExpressionIsActive( const QString &fieldName ) const;
 
     /**
-     * Set the label expression for \a fieldName to \a labelExpression, to be evaluated in the form context.
-     * \see setLabelExpressionIsActive() to control its status
+     * Set the label expression for \a fieldName to \a labelExpression and the active state to \a isActive,
+     * to be evaluated in the form context.
      * \since QGIS 3.14
      */
     void setLabelExpression( const QString &fieldName, const QString &labelExpression, bool isActive );
-
-    /**
-     * Set the label expression active state for \a fieldName to \a isActive
-     * \since QGIS 3.14
-     */
-    void setLabelExpressionIsActive( const QString &fieldName, bool isActive );
 
     // Python form init function stuff
 

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -100,6 +100,20 @@ class CORE_EXPORT QgsEditFormConfig
     Q_ENUM( PythonInitCodeSource )
 
     /**
+     * Data defined properties.
+     * Form data defined overrides are stored in a property collection
+     * and they can be retrieved using the indexes specified in this
+     * enum.
+     * \since QGIS 3.14
+     */
+    enum DataDefinedProperty
+    {
+      NoProperty = 0, //!< No property
+      AllProperties = 1, //!< All properties for item
+      Alias = 2, //!< Alias
+    };
+
+    /**
      * Copy constructor
      *
      * \since QGIS 3.0
@@ -219,26 +233,6 @@ class CORE_EXPORT QgsEditFormConfig
      */
     void setLabelOnTop( int idx, bool onTop );
 
-    /**
-     * Returns the (possibly empty or inactive) expression for the label of \a fieldName, to be evaluated in the form context.
-     * \note The returned expression might not be active.
-     * \see labelExpressionIsActive()
-     * \since QGIS 3.14
-     */
-    QString labelExpression( const QString &fieldName ) const;
-
-    /**
-     * Returns true if the label expression for the label of \a fieldName is active and it is not empty.
-     * \since QGIS 3.14
-     */
-    bool labelExpressionIsActive( const QString &fieldName ) const;
-
-    /**
-     * Set the label expression for \a fieldName to \a labelExpression and the active state to \a isActive,
-     * to be evaluated in the form context.
-     * \since QGIS 3.14
-     */
-    void setLabelExpression( const QString &fieldName, const QString &labelExpression, bool isActive );
 
     // Python form init function stuff
 
@@ -320,6 +314,25 @@ class CORE_EXPORT QgsEditFormConfig
      * Create a new edit form config. Normally invoked by QgsVectorLayer
      */
     explicit QgsEditFormConfig();
+
+    /**
+     * Set data defined properties for \a fieldName to \a properties
+     * \since QGIS 4.14
+     */
+    void setDataDefinedFieldProperties( const QString &fieldName, const QgsPropertyCollection &properties );
+
+    /**
+     * Returns data defined properties for \a fieldName
+     * \since QGIS 4.14
+     */
+    QgsPropertyCollection dataDefinedFieldProperties( const QString &fieldName ) const;
+
+
+    /**
+     * Returns data defined property definitions.
+     * \since QGIS 4.14
+     */
+    static const QgsPropertiesDefinition &propertyDefinitions();
 
   private:
 

--- a/src/core/qgseditformconfig_p.h
+++ b/src/core/qgseditformconfig_p.h
@@ -36,6 +36,7 @@ class QgsEditFormConfigPrivate : public QSharedData
       , mConfiguredRootContainer( o.mConfiguredRootContainer )
       , mFieldEditables( o.mFieldEditables )
       , mLabelOnTop( o.mLabelOnTop )
+      , mLabelExpressions( o.mLabelExpressions )
       , mWidgetConfigs( o.mWidgetConfigs )
       , mEditorLayout( o.mEditorLayout )
       , mUiFormPath( o.mUiFormPath )
@@ -59,6 +60,7 @@ class QgsEditFormConfigPrivate : public QSharedData
 
     QMap< QString, bool> mFieldEditables;
     QMap< QString, bool> mLabelOnTop;
+    QMap< QString, QString> mLabelExpressions;
 
     QMap<QString, QVariantMap > mWidgetConfigs;
 

--- a/src/core/qgseditformconfig_p.h
+++ b/src/core/qgseditformconfig_p.h
@@ -60,7 +60,7 @@ class QgsEditFormConfigPrivate : public QSharedData
 
     QMap< QString, bool> mFieldEditables;
     QMap< QString, bool> mLabelOnTop;
-    QMap< QString, QString> mLabelExpressions;
+    QMap< QString, QPair<QString, bool>> mLabelExpressions;
 
     QMap<QString, QVariantMap > mWidgetConfigs;
 

--- a/src/core/qgseditformconfig_p.h
+++ b/src/core/qgseditformconfig_p.h
@@ -17,7 +17,6 @@
 #define QGSEDITFORMCONFIG_P_H
 
 #include <QMap>
-
 #include "qgsfields.h"
 #include "qgseditformconfig.h"
 
@@ -36,7 +35,7 @@ class QgsEditFormConfigPrivate : public QSharedData
       , mConfiguredRootContainer( o.mConfiguredRootContainer )
       , mFieldEditables( o.mFieldEditables )
       , mLabelOnTop( o.mLabelOnTop )
-      , mLabelExpressions( o.mLabelExpressions )
+      , mDataDefinedFieldProperties( o.mDataDefinedFieldProperties )
       , mWidgetConfigs( o.mWidgetConfigs )
       , mEditorLayout( o.mEditorLayout )
       , mUiFormPath( o.mUiFormPath )
@@ -52,6 +51,20 @@ class QgsEditFormConfigPrivate : public QSharedData
       delete mInvisibleRootContainer;
     }
 
+    static QgsPropertiesDefinition &propertyDefinitions()
+    {
+      static QgsPropertiesDefinition sPropertyDefinitions
+      {
+        {
+          QgsEditFormConfig::DataDefinedProperty::Alias,
+          QgsPropertyDefinition( "dataDefinedAlias",
+                                 QObject::tr( "Alias" ),
+                                 QgsPropertyDefinition::String )
+        },
+      };
+      return sPropertyDefinitions;
+    };
+
     //! The invisible root container for attribute editors in the drag and drop designer
     QgsAttributeEditorContainer *mInvisibleRootContainer = nullptr;
 
@@ -60,7 +73,7 @@ class QgsEditFormConfigPrivate : public QSharedData
 
     QMap< QString, bool> mFieldEditables;
     QMap< QString, bool> mLabelOnTop;
-    QMap< QString, QPair<QString, bool>> mLabelExpressions;
+    QMap< QString, QgsPropertyCollection> mDataDefinedFieldProperties;
 
     QMap<QString, QVariantMap > mWidgetConfigs;
 
@@ -82,7 +95,9 @@ class QgsEditFormConfigPrivate : public QSharedData
     QgsEditFormConfig::FeatureFormSuppress mSuppressForm = QgsEditFormConfig::FeatureFormSuppress::SuppressDefault;
 
     QgsFields mFields;
+
 };
+
 
 /// @endcond
 

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -73,8 +73,12 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   mExpressionWidget->registerExpressionContextGenerator( this );
   mExpressionWidget->setLayer( mLayer );
 
-  mAliasExpression->registerExpressionContextGenerator( this );
-  mAliasExpression->setLayer( mLayer );
+  mAliasExpressionProperty = QgsProperty::fromExpression( QString() );
+  mAliasExpressionButton->registerExpressionContextGenerator( this );
+  connect( mAliasExpressionButton, &QgsPropertyOverrideButton::changed, this, [ = ]
+  {
+    mAliasExpressionProperty = mAliasExpressionButton->toProperty();
+  } );
 
   connect( mExpressionWidget, &QgsExpressionLineEdit::expressionChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
   connect( mUniqueCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )
@@ -358,14 +362,21 @@ QString QgsAttributeTypeDialog::alias() const
   return mAlias->text();
 }
 
-void QgsAttributeTypeDialog::setAliasExpression( const QString &aliasExpression )
+void QgsAttributeTypeDialog::setAliasExpression( const QString &aliasExpression, bool isActive )
 {
-  mAliasExpression->setExpression( aliasExpression );
+  mAliasExpressionProperty.setExpressionString( aliasExpression );
+  mAliasExpressionProperty.setActive( isActive );
+  mAliasExpressionButton->setToProperty( mAliasExpressionProperty );
 }
 
 QString QgsAttributeTypeDialog::aliasExpression() const
 {
-  return mAliasExpression->expression();
+  return mAliasExpressionProperty.asExpression();
+}
+
+bool QgsAttributeTypeDialog::aliasExpressionIsActive() const
+{
+  return mAliasExpressionProperty.isActive();
 }
 
 void QgsAttributeTypeDialog::setComment( const QString &comment )

--- a/src/gui/attributeformconfig/qgsattributetypedialog.cpp
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.cpp
@@ -73,6 +73,9 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   mExpressionWidget->registerExpressionContextGenerator( this );
   mExpressionWidget->setLayer( mLayer );
 
+  mAliasExpression->registerExpressionContextGenerator( this );
+  mAliasExpression->setLayer( mLayer );
+
   connect( mExpressionWidget, &QgsExpressionLineEdit::expressionChanged, this, &QgsAttributeTypeDialog::defaultExpressionChanged );
   connect( mUniqueCheckBox, &QCheckBox::toggled, this, [ = ]( bool checked )
   {
@@ -92,6 +95,8 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
 
   constraintExpressionWidget->setAllowEmptyFieldName( true );
   constraintExpressionWidget->setLayer( vl );
+
+  // TODO: mAliasExpression->registerExpressionContextGenerator( ... );
 }
 
 QgsAttributeTypeDialog::~QgsAttributeTypeDialog()
@@ -303,7 +308,13 @@ QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const
       << QgsExpressionContextUtils::globalScope()
       << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
       << QgsExpressionContextUtils::layerScope( mLayer )
+      << QgsExpressionContextUtils::formScope( QgsFeature( mLayer->fields() ) )
       << QgsExpressionContextUtils::mapToolCaptureScope( QList<QgsPointLocator::Match>() );
+
+  context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) );
+  context.setHighlightedVariables( QStringList() << QStringLiteral( "current_geometry" )
+                                   << QStringLiteral( "current_feature" )
+                                   << QStringLiteral( "form_mode" ) );
 
   return context;
 }
@@ -339,12 +350,22 @@ void QgsAttributeTypeDialog::setFieldEditable( bool editable )
 
 void QgsAttributeTypeDialog::setAlias( const QString &alias )
 {
-  leAlias->setText( alias );
+  mAlias->setText( alias );
 }
 
 QString QgsAttributeTypeDialog::alias() const
 {
-  return leAlias->text();
+  return mAlias->text();
+}
+
+void QgsAttributeTypeDialog::setAliasExpression( const QString &aliasExpression )
+{
+  mAliasExpression->setExpression( aliasExpression );
+}
+
+QString QgsAttributeTypeDialog::aliasExpression() const
+{
+  return mAliasExpression->expression();
 }
 
 void QgsAttributeTypeDialog::setComment( const QString &comment )

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -77,16 +77,22 @@ class GUI_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
     QString alias() const;
 
     /**
-     * Sets expression for for label alias
+     * Sets expression for the label alias override to \a aliasExpression and its active state to \a isActive.
      * \since QGIS 3.14
      */
-    void setAliasExpression( const QString &aliasExpression );
+    void setAliasExpression( const QString &aliasExpression, bool isActive );
 
     /**
      * Returns the expression for the label alias
      * \since QGIS 3.14
      */
     QString aliasExpression() const;
+
+    /**
+     * Returns TRUE if the expression override for the label alias is active.
+     * \since QGIS 3.14
+     */
+    bool aliasExpressionIsActive() const;
 
     /**
      * Setter for label comment
@@ -233,6 +239,8 @@ class GUI_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
 
     //! Cached configuration dialog (lazy loaded)
     QMap< QString, QgsEditorConfigWidget * > mEditorConfigWidgets;
+
+    QgsProperty mAliasExpressionProperty;
 
     QStandardItem *currentItem() const;
 

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -77,22 +77,16 @@ class GUI_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
     QString alias() const;
 
     /**
-     * Sets expression for the label alias override to \a aliasExpression and its active state to \a isActive.
+     * Sets the data defined properties to \a properties.
      * \since QGIS 3.14
      */
-    void setAliasExpression( const QString &aliasExpression, bool isActive );
+    void setDataDefinedProperties( const QgsPropertyCollection &properties );
 
     /**
-     * Returns the expression for the label alias
+     * Returns the data defined properties.
      * \since QGIS 3.14
      */
-    QString aliasExpression() const;
-
-    /**
-     * Returns TRUE if the expression override for the label alias is active.
-     * \since QGIS 3.14
-     */
-    bool aliasExpressionIsActive() const;
+    QgsPropertyCollection dataDefinedProperties() const;
 
     /**
      * Setter for label comment
@@ -221,6 +215,7 @@ class GUI_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
     bool applyDefaultValueOnUpdate() const;
     void setApplyDefaultValueOnUpdate( bool applyDefaultValueOnUpdate );
 
+
   private slots:
 
     /**
@@ -240,11 +235,11 @@ class GUI_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
     //! Cached configuration dialog (lazy loaded)
     QMap< QString, QgsEditorConfigWidget * > mEditorConfigWidgets;
 
-    QgsProperty mAliasExpressionProperty;
-
     QStandardItem *currentItem() const;
 
     QgsFeature mPreviewFeature;
+
+    QgsPropertyCollection mDataDefinedProperties;
 };
 
 #endif

--- a/src/gui/attributeformconfig/qgsattributetypedialog.h
+++ b/src/gui/attributeformconfig/qgsattributetypedialog.h
@@ -77,6 +77,18 @@ class GUI_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
     QString alias() const;
 
     /**
+     * Sets expression for for label alias
+     * \since QGIS 3.14
+     */
+    void setAliasExpression( const QString &aliasExpression );
+
+    /**
+     * Returns the expression for the label alias
+     * \since QGIS 3.14
+     */
+    QString aliasExpression() const;
+
+    /**
      * Setter for label comment
      */
     void setComment( const QString &comment );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1529,7 +1529,7 @@ void QgsAttributeForm::init()
       QString labelText = fieldName;
       labelText.replace( '&', QStringLiteral( "&&" ) ); // need to escape '&' or they'll be replace by _ in the label text
 
-      const QString labelExpression { mLayer->editFormConfig().labelExpression( idx ) };
+      const QString labelExpression { mLayer->editFormConfig().labelExpression( field.name() ) };
       const QgsEditorWidgetSetup widgetSetup = QgsGui::editorWidgetRegistry()->findBest( mLayer, field.name() );
 
       if ( widgetSetup.type() == QLatin1String( "Hidden" ) )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1474,7 +1474,7 @@ void QgsAttributeForm::init()
           layout->addWidget( widgetInfo.widget, row, column++ );
         }
 
-        if ( ! widgetInfo.labelExpression.isEmpty() )
+        if ( ! widgetInfo.labelExpression.isEmpty() && widgetInfo.labelExpressionIsActive )
         {
           mExpressionLabels[ label ] = QgsExpression( widgetInfo.labelExpression );
         }
@@ -1532,6 +1532,7 @@ void QgsAttributeForm::init()
       labelText.replace( '&', QStringLiteral( "&&" ) ); // need to escape '&' or they'll be replace by _ in the label text
 
       const QString labelExpression { mLayer->editFormConfig().labelExpression( field.name() ) };
+      const bool labelExpressionIsActive { mLayer->editFormConfig().labelExpressionIsActive( field.name() ) };
       const QgsEditorWidgetSetup widgetSetup = QgsGui::editorWidgetRegistry()->findBest( mLayer, field.name() );
 
       if ( widgetSetup.type() == QLatin1String( "Hidden" ) )
@@ -1545,7 +1546,7 @@ void QgsAttributeForm::init()
       QSvgWidget *i = new QSvgWidget();
       i->setFixedSize( 18, 18 );
 
-      if ( ! labelExpression.isEmpty() )
+      if ( ! labelExpression.isEmpty() && labelExpressionIsActive )
       {
         mExpressionLabels[ label ] = QgsExpression( labelExpression );
       }
@@ -2089,6 +2090,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
 
   newWidgetInfo.showLabel = widgetDef->showLabel();
   newWidgetInfo.labelExpression = widgetDef->labelExpression();
+  newWidgetInfo.labelExpressionIsActive = widgetDef->labelExpressionIsActive();
 
   return newWidgetInfo;
 }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -2102,16 +2102,7 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
   }
 
   newWidgetInfo.showLabel = widgetDef->showLabel();
-  // THIS IS NEVER HIT!
-  /*
-  const QgsPropertyCollection properties { widgetDef->dataDefinedProperties() };
-  if ( properties.hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
-  {
-    const QgsProperty labelProperty { properties.property( QgsEditFormConfig::DataDefinedProperty::Alias ) };
-    newWidgetInfo.labelExpression = labelProperty.asExpression() ;
-    newWidgetInfo.labelExpressionIsActive = labelProperty.isActive() ;
-  }
-  */
+
   return newWidgetInfo;
 }
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1470,13 +1470,15 @@ void QgsAttributeForm::init()
         }
         else
         {
-          if ( ! widgetInfo.labelExpression.isEmpty() )
-          {
-            mExpressionLabels[ label ] = QgsExpression( widgetInfo.labelExpression );
-          }
           layout->addWidget( label, row, column++ );
           layout->addWidget( widgetInfo.widget, row, column++ );
         }
+
+        if ( ! widgetInfo.labelExpression.isEmpty() )
+        {
+          mExpressionLabels[ label ] = QgsExpression( widgetInfo.labelExpression );
+        }
+
       }
 
       if ( column >= columnCount * 2 )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1009,20 +1009,21 @@ void QgsAttributeForm::updateConstraint( const QgsFeature &ft, QgsEditorWidgetWr
 
 void QgsAttributeForm::updateLabels()
 {
-  if ( ! mExpressionLabels.isEmpty() )
+  if ( ! mLabelDataDefinedProperties.isEmpty() )
   {
     QgsFeature currentFeature;
     if ( currentFormFeature( currentFeature ) )
     {
       mExpressionContext << QgsExpressionContextUtils::formScope( currentFeature, mContext.attributeFormModeString() );
       mExpressionContext.setFields( mLayer->fields() );
-      for ( auto it = mExpressionLabels.constBegin() ; it != mExpressionLabels.constEnd(); ++it )
+      for ( auto it = mLabelDataDefinedProperties.constBegin() ; it != mLabelDataDefinedProperties.constEnd(); ++it )
       {
         QLabel *label { it.key() };
-        QgsExpression exp { it.value() };
-        if ( exp.prepare( &mExpressionContext ) && ! exp.hasParserError() )
+        bool ok;
+        const QString value { it->valueAsString( mExpressionContext, QString(), &ok ) };
+        if ( ok && ! value.isEmpty() )
         {
-          label->setText( exp.evaluate( &mExpressionContext ).toString() );
+          label->setText( value );
         }
       }
     }
@@ -1482,10 +1483,9 @@ void QgsAttributeForm::init()
           if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
           {
             const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Alias ) };
-            const QString labelExpression { property.asExpression() };
-            if ( ! labelExpression.isEmpty() && property.isActive() )
+            if ( property.isActive() && ! property.expressionString().isEmpty() )
             {
-              mExpressionLabels[ label ] = QgsExpression( labelExpression );
+              mLabelDataDefinedProperties[ label ] = property;
             }
           }
         }
@@ -1557,10 +1557,9 @@ void QgsAttributeForm::init()
       if ( mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).hasProperty( QgsEditFormConfig::DataDefinedProperty::Alias ) )
       {
         const QgsProperty property { mLayer->editFormConfig().dataDefinedFieldProperties( fieldName ).property( QgsEditFormConfig::DataDefinedProperty::Alias ) };
-        const QString labelExpression { property.asExpression() };
-        if ( ! labelExpression.isEmpty() && property.isActive() )
+        if ( property.isActive() && ! property.expressionString().isEmpty() )
         {
-          mExpressionLabels[ label ] = QgsExpression( labelExpression );
+          mLabelDataDefinedProperties[ label ] = property;
         }
       }
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -351,8 +351,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     {
       QWidget *widget = nullptr;
       QString labelText;
-      QString labelExpression;
-      bool labelExpressionIsActive;
       QString toolTip;
       QString hint;
       bool labelOnTop = false;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -414,7 +414,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QList< QgsAttributeFormWidget *> mFormWidgets;
     QgsExpressionContext mExpressionContext;
     QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
-    QMap<QLabel *, QgsExpression> mExpressionLabels;
+    QMap<QLabel *, QgsProperty> mLabelDataDefinedProperties;
     bool mValuesInitialized = false;
     bool mDirty = false;
     bool mIsSettingFeature = false;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -351,6 +351,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     {
       QWidget *widget = nullptr;
       QString labelText;
+      QString labelExpression;
       QString toolTip;
       QString hint;
       bool labelOnTop = false;
@@ -392,6 +393,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateConstraints( QgsEditorWidgetWrapper *w );
     void updateContainersVisibility();
     void updateConstraint( const QgsFeature &ft, QgsEditorWidgetWrapper *eww );
+    void updateLabels();
     bool currentFormFeature( QgsFeature &feature );
     bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions );
     QList<QgsEditorWidgetWrapper *> constraintDependencies( QgsEditorWidgetWrapper *w );
@@ -413,6 +415,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QList< QgsAttributeFormWidget *> mFormWidgets;
     QgsExpressionContext mExpressionContext;
     QMap<const QgsVectorLayerJoinInfo *, QgsFeature> mJoinedFeatures;
+    QMap<QLabel *, QgsExpression> mExpressionLabels;
     bool mValuesInitialized = false;
     bool mDirty = false;
     bool mIsSettingFeature = false;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -352,6 +352,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
       QWidget *widget = nullptr;
       QString labelText;
       QString labelExpression;
+      bool labelExpressionIsActive;
       QString toolTip;
       QString hint;
       bool labelOnTop = false;

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -846,7 +846,8 @@ void QgsAttributesFormProperties::apply()
     QTreeWidgetItem *fieldItem = fieldContainer->child( i );
     FieldConfig cfg = fieldItem->data( 0, FieldConfigRole ).value<FieldConfig>();
 
-    int idx = mLayer->fields().indexOf( fieldItem->data( 0, FieldNameRole ).toString() );
+    const QString fieldName { fieldItem->data( 0, FieldNameRole ).toString() };
+    int idx = mLayer->fields().indexOf( fieldName );
 
     //continue in case field does not exist anymore
     if ( idx < 0 )
@@ -854,7 +855,7 @@ void QgsAttributesFormProperties::apply()
 
     editFormConfig.setReadOnly( idx, !cfg.mEditable );
     editFormConfig.setLabelOnTop( idx, cfg.mLabelOnTop );
-    editFormConfig.setLabelExpression( idx, cfg.mAliasExpression );
+    editFormConfig.setLabelExpression( fieldName, cfg.mAliasExpression );
     mLayer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
 
     QgsFieldConstraints constraints = cfg.mFieldConstraints;
@@ -935,7 +936,7 @@ void QgsAttributesFormProperties::apply()
 QgsAttributesFormProperties::FieldConfig::FieldConfig( QgsVectorLayer *layer, int idx )
 {
   mAlias = layer->fields().at( idx ).alias();
-  mAliasExpression = layer->editFormConfig().labelExpression( idx );
+  mAliasExpression = layer->editFormConfig().labelExpression( layer->fields().field( idx ).name() );
   mComment = layer->fields().at( idx ).comment();
   mEditable = !layer->editFormConfig().readOnly( idx );
   mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -893,18 +893,6 @@ void QgsAttributesFormProperties::apply()
   {
     QTreeWidgetItem *tabItem = mFormLayoutTree->invisibleRootItem()->child( t );
     QgsAttributeEditorElement *editorElement { createAttributeEditorWidget( tabItem, nullptr, false ) };
-    /*
-    // Store data defined field properties
-    if ( editorElement->type() == QgsAttributeEditorElement::AttributeEditorType::AeTypeField )
-    {
-      const QgsAttributeEditorField *fieldElement { static_cast<QgsAttributeEditorField *>( editorElement ) };
-      const QString fieldName { mLayer->fields().at( fieldElement->idx() ).name() };
-      if ( editFormConfig.dataDefinedFieldProperties( fieldName ).count() > 0 )
-      {
-        editorElement->setDataDefinedProperties( editFormConfig.dataDefinedFieldProperties( fieldName ) );
-      }
-    }
-    */
     editFormConfig.addTab( editorElement );
   }
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -243,6 +243,7 @@ void QgsAttributesFormProperties::loadAttributeTypeDialog()
   QgsFieldConstraints constraints = cfg.mFieldConstraints;
 
   mAttributeTypeDialog->setAlias( cfg.mAlias );
+  mAttributeTypeDialog->setAliasExpression( cfg.mAliasExpression );
   mAttributeTypeDialog->setComment( cfg.mComment );
   mAttributeTypeDialog->setFieldEditable( cfg.mEditable );
   mAttributeTypeDialog->setLabelOnTop( cfg.mLabelOnTop );
@@ -289,6 +290,7 @@ void QgsAttributesFormProperties::storeAttributeTypeDialog()
   cfg.mEditable = mAttributeTypeDialog->fieldEditable();
   cfg.mLabelOnTop = mAttributeTypeDialog->labelOnTop();
   cfg.mAlias = mAttributeTypeDialog->alias();
+  cfg.mAliasExpression = mAttributeTypeDialog->aliasExpression();
 
   QgsFieldConstraints constraints;
   if ( mAttributeTypeDialog->notNull() )
@@ -462,6 +464,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelExpression( widgetDef->labelExpression() );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -471,6 +474,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelExpression( widgetDef->labelExpression() );
       RelationEditorConfiguration relEdConfig;
       relEdConfig.showLinkButton = relationEditor->showLinkButton();
       relEdConfig.showUnlinkButton = relationEditor->showUnlinkButton();
@@ -489,6 +493,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       if ( !container )
         break;
 
+      itemData.setLabelExpression( widgetDef->labelExpression() );
       itemData.setColumnCount( container->columnCount() );
       itemData.setShowAsGroupBox( container->isGroupBox() );
       itemData.setBackgroundColor( container->backgroundColor() );
@@ -508,6 +513,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorQmlElement *qmlElementEditor = static_cast<const QgsAttributeEditorQmlElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::QmlWidget, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelExpression( widgetDef->labelExpression() );
       QmlElementEditorConfiguration qmlEdConfig;
       qmlEdConfig.qmlCode = qmlElementEditor->qmlCode();
       itemData.setQmlElementEditorConfiguration( qmlEdConfig );
@@ -520,6 +526,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorHtmlElement *htmlElementEditor = static_cast<const QgsAttributeEditorHtmlElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::HtmlWidget, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
+      itemData.setLabelExpression( widgetDef->labelExpression() );
       HtmlElementEditorConfiguration htmlEdConfig;
       htmlEdConfig.htmlCode = htmlElementEditor->htmlCode();
       itemData.setHtmlElementEditorConfiguration( htmlEdConfig );
@@ -533,6 +540,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       break;
     }
   }
+
   return newWidget;
 }
 
@@ -750,6 +758,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
   }
 
   widgetDef->setShowLabel( itemData.showLabel() );
+  widgetDef->setLabelExpression( itemData.labelExpression() );
 
   return widgetDef;
 }
@@ -845,6 +854,7 @@ void QgsAttributesFormProperties::apply()
 
     editFormConfig.setReadOnly( idx, !cfg.mEditable );
     editFormConfig.setLabelOnTop( idx, cfg.mLabelOnTop );
+    editFormConfig.setLabelExpression( idx, cfg.mAliasExpression );
     mLayer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
 
     QgsFieldConstraints constraints = cfg.mFieldConstraints;
@@ -925,6 +935,7 @@ void QgsAttributesFormProperties::apply()
 QgsAttributesFormProperties::FieldConfig::FieldConfig( QgsVectorLayer *layer, int idx )
 {
   mAlias = layer->fields().at( idx ).alias();
+  mAliasExpression = layer->editFormConfig().labelExpression( idx );
   mComment = layer->fields().at( idx ).comment();
   mEditable = !layer->editFormConfig().readOnly( idx );
   mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin
@@ -1599,5 +1610,15 @@ QColor QgsAttributesFormProperties::DnDTreeItemData::backgroundColor() const
 void QgsAttributesFormProperties::DnDTreeItemData::setBackgroundColor( const QColor &backgroundColor )
 {
   mBackgroundColor = backgroundColor;
+}
+
+QString QgsAttributesFormProperties::DnDTreeItemData::labelExpression() const
+{
+  return mLabelExpression;
+}
+
+void QgsAttributesFormProperties::DnDTreeItemData::setLabelExpression( const QString &labelExpression )
+{
+  mLabelExpression = labelExpression;
 }
 

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -243,7 +243,7 @@ void QgsAttributesFormProperties::loadAttributeTypeDialog()
   QgsFieldConstraints constraints = cfg.mFieldConstraints;
 
   mAttributeTypeDialog->setAlias( cfg.mAlias );
-  mAttributeTypeDialog->setAliasExpression( cfg.mAliasExpression );
+  mAttributeTypeDialog->setAliasExpression( cfg.mAliasExpression, cfg.mAliasExpressionIsActive );
   mAttributeTypeDialog->setComment( cfg.mComment );
   mAttributeTypeDialog->setFieldEditable( cfg.mEditable );
   mAttributeTypeDialog->setLabelOnTop( cfg.mLabelOnTop );
@@ -291,6 +291,7 @@ void QgsAttributesFormProperties::storeAttributeTypeDialog()
   cfg.mLabelOnTop = mAttributeTypeDialog->labelOnTop();
   cfg.mAlias = mAttributeTypeDialog->alias();
   cfg.mAliasExpression = mAttributeTypeDialog->aliasExpression();
+  cfg.mAliasExpressionIsActive = mAttributeTypeDialog->aliasExpressionIsActive();
 
   QgsFieldConstraints constraints;
   if ( mAttributeTypeDialog->notNull() )
@@ -699,6 +700,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
       int idx = mLayer->fields().lookupField( itemData.name() );
       widgetDef = new QgsAttributeEditorField( itemData.name(), idx, parent );
       widgetDef->setLabelExpression( mAttributeTypeDialog->aliasExpression() );
+      widgetDef->setLabelExpressionIsActive( mAttributeTypeDialog->aliasExpressionIsActive() );
       break;
     }
 
@@ -850,7 +852,7 @@ void QgsAttributesFormProperties::apply()
 
     editFormConfig.setReadOnly( idx, !cfg.mEditable );
     editFormConfig.setLabelOnTop( idx, cfg.mLabelOnTop );
-    editFormConfig.setLabelExpression( fieldName, cfg.mAliasExpression );
+    editFormConfig.setLabelExpression( fieldName, cfg.mAliasExpression, cfg.mAliasExpressionIsActive );
     mLayer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
 
     QgsFieldConstraints constraints = cfg.mFieldConstraints;
@@ -932,6 +934,7 @@ QgsAttributesFormProperties::FieldConfig::FieldConfig( QgsVectorLayer *layer, in
 {
   mAlias = layer->fields().at( idx ).alias();
   mAliasExpression = layer->editFormConfig().labelExpression( layer->fields().field( idx ).name() );
+  mAliasExpressionIsActive = layer->editFormConfig().labelExpressionIsActive( layer->fields().field( idx ).name() );
   mComment = layer->fields().at( idx ).comment();
   mEditable = !layer->editFormConfig().readOnly( idx );
   mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin

--- a/src/gui/vector/qgsattributesformproperties.cpp
+++ b/src/gui/vector/qgsattributesformproperties.cpp
@@ -464,7 +464,6 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     {
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
-      itemData.setLabelExpression( widgetDef->labelExpression() );
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -474,7 +473,6 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name() );
       itemData.setShowLabel( widgetDef->showLabel() );
-      itemData.setLabelExpression( widgetDef->labelExpression() );
       RelationEditorConfiguration relEdConfig;
       relEdConfig.showLinkButton = relationEditor->showLinkButton();
       relEdConfig.showUnlinkButton = relationEditor->showUnlinkButton();
@@ -493,7 +491,6 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       if ( !container )
         break;
 
-      itemData.setLabelExpression( widgetDef->labelExpression() );
       itemData.setColumnCount( container->columnCount() );
       itemData.setShowAsGroupBox( container->isGroupBox() );
       itemData.setBackgroundColor( container->backgroundColor() );
@@ -513,7 +510,6 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorQmlElement *qmlElementEditor = static_cast<const QgsAttributeEditorQmlElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::QmlWidget, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
-      itemData.setLabelExpression( widgetDef->labelExpression() );
       QmlElementEditorConfiguration qmlEdConfig;
       qmlEdConfig.qmlCode = qmlElementEditor->qmlCode();
       itemData.setQmlElementEditorConfiguration( qmlEdConfig );
@@ -526,7 +522,6 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
       const QgsAttributeEditorHtmlElement *htmlElementEditor = static_cast<const QgsAttributeEditorHtmlElement *>( widgetDef );
       DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::HtmlWidget, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
-      itemData.setLabelExpression( widgetDef->labelExpression() );
       HtmlElementEditorConfiguration htmlEdConfig;
       htmlEdConfig.htmlCode = htmlElementEditor->htmlCode();
       itemData.setHtmlElementEditorConfiguration( htmlEdConfig );
@@ -703,6 +698,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
     {
       int idx = mLayer->fields().lookupField( itemData.name() );
       widgetDef = new QgsAttributeEditorField( itemData.name(), idx, parent );
+      widgetDef->setLabelExpression( mAttributeTypeDialog->aliasExpression() );
       break;
     }
 
@@ -758,7 +754,6 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
   }
 
   widgetDef->setShowLabel( itemData.showLabel() );
-  widgetDef->setLabelExpression( itemData.labelExpression() );
 
   return widgetDef;
 }
@@ -1611,15 +1606,5 @@ QColor QgsAttributesFormProperties::DnDTreeItemData::backgroundColor() const
 void QgsAttributesFormProperties::DnDTreeItemData::setBackgroundColor( const QColor &backgroundColor )
 {
   mBackgroundColor = backgroundColor;
-}
-
-QString QgsAttributesFormProperties::DnDTreeItemData::labelExpression() const
-{
-  return mLabelExpression;
-}
-
-void QgsAttributesFormProperties::DnDTreeItemData::setLabelExpression( const QString &labelExpression )
-{
-  mLabelExpression = labelExpression;
 }
 

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -173,8 +173,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
       QString mEditorWidgetType;
       QMap<QString, QVariant> mEditorWidgetConfig;
       QString mAlias;
-      QString mAliasExpression;
-      bool mAliasExpressionIsActive;
+      QgsPropertyCollection mDataDefinedProperties;
       QString mComment;
 
       operator QVariant();

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -100,11 +100,10 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
         //do we need that
         DnDTreeItemData() = default;
 
-        DnDTreeItemData( Type type, const QString &name, const QString &displayName, const QColor &backgroundColor = QColor(), const QString &labelExpression = QString() )
+        DnDTreeItemData( Type type, const QString &name, const QString &displayName, const QColor &backgroundColor = QColor() )
           : mType( type )
           , mName( name )
           , mDisplayName( displayName )
-          , mLabelExpression( labelExpression )
           , mBackgroundColor( backgroundColor )
         {}
 
@@ -143,14 +142,10 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
         QColor backgroundColor() const;
         void setBackgroundColor( const QColor &backgroundColor );
 
-        QString labelExpression() const;
-        void setLabelExpression( const QString &labelExpression );
-
       private:
         Type mType = Field;
         QString mName;
         QString mDisplayName;
-        QString mLabelExpression;
         int mColumnCount = 1;
         bool mShowAsGroupBox = false;
         bool mShowLabel = true;

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -100,10 +100,11 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
         //do we need that
         DnDTreeItemData() = default;
 
-        DnDTreeItemData( Type type, const QString &name, const QString &displayName, const QColor &backgroundColor = QColor() )
+        DnDTreeItemData( Type type, const QString &name, const QString &displayName, const QColor &backgroundColor = QColor(), const QString &labelExpression = QString() )
           : mType( type )
           , mName( name )
           , mDisplayName( displayName )
+          , mLabelExpression( labelExpression )
           , mBackgroundColor( backgroundColor )
         {}
 
@@ -142,11 +143,14 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
         QColor backgroundColor() const;
         void setBackgroundColor( const QColor &backgroundColor );
 
+        QString labelExpression() const;
+        void setLabelExpression( const QString &labelExpression );
+
       private:
         Type mType = Field;
         QString mName;
         QString mDisplayName;
-
+        QString mLabelExpression;
         int mColumnCount = 1;
         bool mShowAsGroupBox = false;
         bool mShowLabel = true;
@@ -174,6 +178,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
       QString mEditorWidgetType;
       QMap<QString, QVariant> mEditorWidgetConfig;
       QString mAlias;
+      QString mAliasExpression;
       QString mComment;
 
       operator QVariant();

--- a/src/gui/vector/qgsattributesformproperties.h
+++ b/src/gui/vector/qgsattributesformproperties.h
@@ -174,6 +174,7 @@ class GUI_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
       QMap<QString, QVariant> mEditorWidgetConfig;
       QString mAlias;
       QString mAliasExpression;
+      bool mAliasExpressionIsActive;
       QString mComment;
 
       operator QVariant();

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -20,38 +20,34 @@
       <string>General</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Alias</string>
+      <item row="1" column="2">
+       <widget class="QgsExpressionLineEdit" name="mAliasExpression" native="true">
+        <property name="toolTip">
+         <string>The expression will be evaluated in the form context </string>
+        </property>
+        <property name="text" stdset="0">
+         <string/>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="labelOnTopCheckBox">
+        <property name="text">
+         <string>Label on top</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Comment</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QLineEdit" name="leAlias">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="laComment">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QCheckBox" name="isFieldEditableCheckBox">
         <property name="text">
          <string>Editable</string>
@@ -62,14 +58,31 @@
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QCheckBox" name="labelOnTopCheckBox">
+       <widget class="QLabel" name="laComment">
         <property name="text">
-         <string>Label on top</string>
+         <string/>
         </property>
-        <property name="checked">
-         <bool>false</bool>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Alias expression</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Alias</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="mAlias"/>
       </item>
      </layout>
     </widget>
@@ -184,7 +197,7 @@
      <property name="title">
       <string>Defaults</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
       <item row="4" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
@@ -235,7 +248,7 @@
          <item>
           <widget class="QLabel" name="label_7">
            <property name="text">
-            <string>Using fields in a default value expression only works if "Apply default value on update" is checked.</string>
+            <string>Using fields in a default value expression only works if &quot;Apply default value on update&quot; is checked.</string>
            </property>
           </widget>
          </item>
@@ -291,7 +304,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>leAlias</tabstop>
+  <tabstop>mAliasExpression</tabstop>
   <tabstop>isFieldEditableCheckBox</tabstop>
   <tabstop>labelOnTopCheckBox</tabstop>
   <tabstop>mWidgetTypeComboBox</tabstop>
@@ -305,6 +318,7 @@
   <tabstop>mExpressionWidget</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>

--- a/src/ui/attributeformconfig/qgsattributetypeedit.ui
+++ b/src/ui/attributeformconfig/qgsattributetypeedit.ui
@@ -21,56 +21,12 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="2">
-       <widget class="QgsExpressionLineEdit" name="mAliasExpression" native="true">
-        <property name="toolTip">
-         <string>The expression will be evaluated in the form context </string>
-        </property>
-        <property name="text" stdset="0">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QCheckBox" name="labelOnTopCheckBox">
-        <property name="text">
-         <string>Label on top</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Comment</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="isFieldEditableCheckBox">
-        <property name="text">
-         <string>Editable</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
        <widget class="QLabel" name="laComment">
         <property name="text">
          <string/>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Alias expression</string>
         </property>
        </widget>
       </item>
@@ -81,8 +37,42 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="isFieldEditableCheckBox">
+        <property name="text">
+         <string>Editable</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="labelOnTopCheckBox">
+        <property name="text">
+         <string>Label on top</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="2">
        <widget class="QLineEdit" name="mAlias"/>
+      </item>
+      <item row="0" column="3">
+       <widget class="QgsPropertyOverrideButton" name="mAliasExpressionButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Comment</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -302,9 +292,13 @@
    <header>qgsexpressionlineedit.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mAliasExpression</tabstop>
   <tabstop>isFieldEditableCheckBox</tabstop>
   <tabstop>labelOnTopCheckBox</tabstop>
   <tabstop>mWidgetTypeComboBox</tabstop>


### PR DESCRIPTION
## Allow form labels (aliases) to be evaluated in the form context

![image](https://user-images.githubusercontent.com/142164/78998144-46912300-7b48-11ea-9fbf-232d11fbeff6.png)

It needs some code cleanup and testing, but the functionality is there:


![qgis-label-expressions](https://user-images.githubusercontent.com/142164/78904645-26486200-7a7d-11ea-84b0-b9e96c0c9797.gif)


Funded by: **ARPA Piemonte**