### PR TITLE
AttribueForm: No python init when no custom UI

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1709,9 +1709,10 @@ void QgsAttributeForm::initPython()
   cleanPython();
 
   // Init Python, if init function is not empty and the combo indicates
-  // the source for the function code
+  // the source for the function code and the customUi should be used
   if ( !mLayer->editFormConfig().initFunction().isEmpty()
-       && mLayer->editFormConfig().initCodeSource() != QgsEditFormConfig::CodeSourceNone )
+       && mLayer->editFormConfig().initCodeSource() != QgsEditFormConfig::CodeSourceNone 
+       && mContext.allowCustomUi())
   {
 
     QString initFunction = mLayer->editFormConfig().initFunction();

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1712,7 +1712,7 @@ void QgsAttributeForm::initPython()
   // the source for the function code and the customUi should be used
   if ( !mLayer->editFormConfig().initFunction().isEmpty()
        && mLayer->editFormConfig().initCodeSource() != QgsEditFormConfig::CodeSourceNone 
-       && mContext.allowCustomUi())
+       && mContext.allowCustomUi() )
   {
 
     QString initFunction = mLayer->editFormConfig().initFunction();


### PR DESCRIPTION
I have an issue when using the multi edition tool: despite the fact that the custom UI is not used (expected) the python custom form code is executed resulting in errors because I always use python initialization for my custom UIs (which is not found in this case obviously).

I don't see a usecase where python init form code should be executed if no custom UI is loaded.

As a result, I submit this change.

