### PR TITLE
Improve QGIS Server WMS GetCapabilities output

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayertemporalproperties.sip.in
@@ -21,14 +21,16 @@ The time in a mesh layer is defined by :
 - each dataset is associated with a relative times
 - time extent is defined by the first time and the last time of all dataset
 
-Reference time :          AT
-Dataset 1 time            o-----RT------RT-----RT-----------RT
-Dataset 2 time            o---------RT------RT--------RT
-Dataset 3 time            o------------------------------RT-------RT----------RT
-Time extent of layer      o-----<--------------------------------------------->
+.. code-block:: unparsed
 
-AT : absolute time (QDateTime)
-RT : relative time (qint64)
+     Reference time :          AT
+     Dataset 1 time            o-----RT------RT-----RT-----------RT
+     Dataset 2 time            o---------RT------RT--------RT
+     Dataset 3 time            o------------------------------RT-------RT----------RT
+     Time extent of layer      o-----<--------------------------------------------->
+
+     AT : absolute time (QDateTime)
+     RT : relative time (qint64)
 
 .. versionadded:: 3.14
 %End

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -128,7 +128,7 @@ namespace QgsWms
         }
         else if ( QSTR_COMPARE( req, "GetSchemaExtension" ) )
         {
-          writeGetSchemaExtension( mServerIface, version, request, response );
+          writeGetSchemaExtension( response );
         }
         else if ( QSTR_COMPARE( req, "GetStyle" ) )
         {

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -844,6 +844,7 @@ namespace QgsWms
       layerParentElem.appendChild( layerParentAbstElem );
     }
 
+    /*
     // Root Layer name
     QString rootLayerName = QgsServerProjectUtils::wmsRootName( *project );
     if ( rootLayerName.isEmpty() && !project->title().isEmpty() )
@@ -861,6 +862,7 @@ namespace QgsWms
 
     // Keyword list
     addKeywordListElement( project, doc, layerParentElem );
+    */
 
     // Root Layer tree name
     if ( projectSettings )
@@ -1433,7 +1435,15 @@ namespace QgsWms
       QDomElement crsElement = doc.createElement( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" );
       QDomText crsTextNode = doc.createTextNode( crsText );
       crsElement.appendChild( crsTextNode );
-      layerElement.insertAfter( crsElement, precedingElement );
+      if ( !precedingElement.isNull() )
+      {
+        layerElement.insertAfter( crsElement, precedingElement );
+      }
+      else
+      {
+        QDomElement first = layerElement.firstChild().toElement();
+        layerElement.insertBefore( crsElement, first );
+      }
     }
 
     void appendLayerBoundingBoxes( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &lExtent,

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -265,14 +265,26 @@ namespace QgsWms
     nameElem.appendChild( nameText );
     serviceElem.appendChild( nameElem );
 
+    QDomText titleText;
     QString title = QgsServerProjectUtils::owsServiceTitle( *project );
+    QDomElement titleElem = doc.createElement( QStringLiteral( "Title" ) );
     if ( !title.isEmpty() )
     {
-      QDomElement titleElem = doc.createElement( QStringLiteral( "Title" ) );
-      QDomText titleText = doc.createTextNode( title );
-      titleElem.appendChild( titleText );
-      serviceElem.appendChild( titleElem );
+      titleText = doc.createTextNode( title );
     }
+    else
+    {
+      if ( !project->title().isEmpty() )
+      {
+        titleText = doc.createTextNode( project->title() );
+      }
+      else
+      {
+        titleText = doc.createTextNode( QStringLiteral( "untitled" ) );
+      }
+    }
+    titleElem.appendChild( titleText );
+    serviceElem.appendChild( titleElem );
 
     QString abstract = QgsServerProjectUtils::owsServiceAbstract( *project );
     if ( !abstract.isEmpty() )
@@ -312,36 +324,45 @@ namespace QgsWms
 
       //Contact person primary
       if ( !contactPerson.isEmpty() ||
-           !contactOrganization.isEmpty() ||
-           !contactPosition.isEmpty() )
+           !contactOrganization.isEmpty() )
       {
         QDomElement contactPersonPrimaryElem = doc.createElement( QStringLiteral( "ContactPersonPrimary" ) );
 
+        QDomText contactPersonText;
         if ( !contactPerson.isEmpty() )
         {
-          QDomElement contactPersonElem = doc.createElement( QStringLiteral( "ContactPerson" ) );
-          QDomText contactPersonText = doc.createTextNode( contactPerson );
-          contactPersonElem.appendChild( contactPersonText );
-          contactPersonPrimaryElem.appendChild( contactPersonElem );
+          contactPersonText = doc.createTextNode( contactPerson );
         }
+        else
+        {
+          contactPersonText = doc.createTextNode( QStringLiteral( "unknown" ) );
+        }
+        QDomElement contactPersonElem = doc.createElement( QStringLiteral( "ContactPerson" ) );
+        contactPersonElem.appendChild( contactPersonText );
+        contactPersonPrimaryElem.appendChild( contactPersonElem );
 
+        QDomText contactOrganizationText;
         if ( !contactOrganization.isEmpty() )
         {
-          QDomElement contactOrganizationElem = doc.createElement( QStringLiteral( "ContactOrganization" ) );
-          QDomText contactOrganizationText = doc.createTextNode( contactOrganization );
-          contactOrganizationElem.appendChild( contactOrganizationText );
-          contactPersonPrimaryElem.appendChild( contactOrganizationElem );
+          contactOrganizationText = doc.createTextNode( contactOrganization );
         }
-
-        if ( !contactPosition.isEmpty() )
+        else
         {
-          QDomElement contactPositionElem = doc.createElement( QStringLiteral( "ContactPosition" ) );
-          QDomText contactPositionText = doc.createTextNode( contactPosition );
-          contactPositionElem.appendChild( contactPositionText );
-          contactPersonPrimaryElem.appendChild( contactPositionElem );
+          contactOrganizationText = doc.createTextNode( QStringLiteral( "unknown" ) );
         }
+        QDomElement contactOrganizationElem = doc.createElement( QStringLiteral( "ContactOrganization" ) );
+        contactOrganizationElem.appendChild( contactOrganizationText );
+        contactPersonPrimaryElem.appendChild( contactOrganizationElem );
 
         contactInfoElem.appendChild( contactPersonPrimaryElem );
+      }
+
+      if ( !contactPosition.isEmpty() )
+      {
+        QDomElement contactPositionElem = doc.createElement( QStringLiteral( "ContactPosition" ) );
+        QDomText contactPositionText = doc.createTextNode( contactPosition );
+        contactPositionElem.appendChild( contactPositionText );
+        contactInfoElem.appendChild( contactPositionElem );
       }
 
       if ( !contactPhone.isEmpty() )

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -829,22 +829,6 @@ namespace QgsWms
 
     QDomElement layerParentElem = doc.createElement( QStringLiteral( "Layer" ) );
 
-    if ( !project->title().isEmpty() )
-    {
-      // Root Layer title
-      QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
-      QDomText layerParentTitleText = doc.createTextNode( project->title() );
-      layerParentTitleElem.appendChild( layerParentTitleText );
-      layerParentElem.appendChild( layerParentTitleElem );
-
-      // Root Layer abstract
-      QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
-      QDomText layerParentAbstText = doc.createTextNode( project->title() );
-      layerParentAbstElem.appendChild( layerParentAbstText );
-      layerParentElem.appendChild( layerParentAbstElem );
-    }
-
-    /*
     // Root Layer name
     QString rootLayerName = QgsServerProjectUtils::wmsRootName( *project );
     if ( rootLayerName.isEmpty() && !project->title().isEmpty() )
@@ -860,9 +844,23 @@ namespace QgsWms
       layerParentElem.appendChild( layerParentNameElem );
     }
 
+    if ( !project->title().isEmpty() )
+    {
+      // Root Layer title
+      QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
+      QDomText layerParentTitleText = doc.createTextNode( project->title() );
+      layerParentTitleElem.appendChild( layerParentTitleText );
+      layerParentElem.appendChild( layerParentTitleElem );
+
+      // Root Layer abstract
+      QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
+      QDomText layerParentAbstText = doc.createTextNode( project->title() );
+      layerParentAbstElem.appendChild( layerParentAbstText );
+      layerParentElem.appendChild( layerParentAbstElem );
+    }
+
     // Keyword list
     addKeywordListElement( project, doc, layerParentElem );
-    */
 
     // Root Layer tree name
     if ( projectSettings )
@@ -1397,7 +1395,8 @@ namespace QgsWms
       //insert the CRS elements after the title element to be in accordance with the WMS 1.3 specification
       QDomElement titleElement = layerElement.firstChildElement( QStringLiteral( "Title" ) );
       QDomElement abstractElement = layerElement.firstChildElement( QStringLiteral( "Abstract" ) );
-      QDomElement CRSPrecedingElement = abstractElement.isNull() ? titleElement : abstractElement; //last element before the CRS elements
+      QDomElement keywordListElement = layerElement.firstChildElement( QStringLiteral( "KeywordList" ) );
+      QDomElement CRSPrecedingElement = !keywordListElement.isNull() ? keywordListElement : !abstractElement.isNull() ? abstractElement : titleElement;
 
       if ( CRSPrecedingElement.isNull() )
       {
@@ -1435,15 +1434,7 @@ namespace QgsWms
       QDomElement crsElement = doc.createElement( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS" );
       QDomText crsTextNode = doc.createTextNode( crsText );
       crsElement.appendChild( crsTextNode );
-      if ( !precedingElement.isNull() )
-      {
-        layerElement.insertAfter( crsElement, precedingElement );
-      }
-      else
-      {
-        QDomElement first = layerElement.firstChild().toElement();
-        layerElement.insertBefore( crsElement, first );
-      }
+      layerElement.insertAfter( crsElement, precedingElement );
     }
 
     void appendLayerBoundingBoxes( QDomDocument &doc, QDomElement &layerElem, const QgsRectangle &lExtent,

--- a/src/server/services/wms/qgswmsgetschemaextension.cpp
+++ b/src/server/services/wms/qgswmsgetschemaextension.cpp
@@ -24,62 +24,48 @@
 
 #include <QDir>
 #include <QFileInfo>
+#include <QTextStream>
 
 namespace QgsWms
 {
 
+//    void writeGetSchemaExtension( QgsServerInterface *serverIface, const QString &version,
+//                                  const QgsServerRequest &request, QgsServerResponse &response )
+//    {
+//      QDomDocument doc = getSchemaExtension( serverIface, version, request );
+//      response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
+//      response.write( doc.toByteArray() );
+//    }
+
   void writeGetSchemaExtension( QgsServerInterface *serverIface, const QString &version,
                                 const QgsServerRequest &request, QgsServerResponse &response )
   {
-    QDomDocument doc = getSchemaExtension( serverIface, version, request );
-    response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
-    response.write( doc.toByteArray() );
-  }
-
-  QDomDocument getSchemaExtension( QgsServerInterface *serverIface, const QString &version,
-                                   const QgsServerRequest & )
-  {
-    Q_UNUSED( version )
-    Q_UNUSED( serverIface )
-
-    QDomDocument xsdDoc;
-
     QDir resourcesDir = QFileInfo( QgsApplication::serverResourcesPath() ).absoluteDir();
     QFileInfo xsdFileInfo( resourcesDir, QStringLiteral( "schemaExtension.xsd" ) );
+    QString schema_str = QStringLiteral( "<?xml version='1.0'?>" );
 
     if ( !xsdFileInfo.exists() )
     {
       QgsMessageLog::logMessage( QStringLiteral( "Error, xsd file 'schemaExtension.xsd' does not exist" ),
                                  QStringLiteral( "Server" ), Qgis::Critical );
-      return xsdDoc;
     }
-
-    QString xsdFilePath = xsdFileInfo.absoluteFilePath();
-    QFile xsdFile( xsdFilePath );
-    if ( !xsdFile.exists() )
+    else
     {
-      QgsMessageLog::logMessage( QStringLiteral( "Error, xsd file 'schemaExtension.xsd' does not exist" ),
-                                 QStringLiteral( "Server" ), Qgis::Critical );
-      return xsdDoc;
+      QFile file( xsdFileInfo.absoluteFilePath() );
+      if ( file.open( QFile::ReadOnly | QFile::Text ) )
+      {
+        QTextStream in( &file );
+        schema_str = in.readAll();
+        file.close();
+      }
+      else
+      {
+        QgsMessageLog::logMessage( QStringLiteral( "Error, xsd file 'schemaExtension.xsd' not readable" ),
+                                   QStringLiteral( "Server" ), Qgis::Critical );
+      }
     }
-
-    if ( !xsdFile.open( QIODevice::ReadOnly ) )
-    {
-      QgsMessageLog::logMessage( QStringLiteral( "Error, cannot open xsd file 'schemaExtension.xsd' does not exist" ),
-                                 QStringLiteral( "Server" ), Qgis::Critical );
-      return xsdDoc;
-    }
-
-    QString errorMsg;
-    int line, column;
-    if ( !xsdDoc.setContent( &xsdFile, true, &errorMsg, &line, &column ) )
-    {
-      QgsMessageLog::logMessage( QStringLiteral( "Error parsing file 'schemaExtension.xsd" ) +
-                                 QStringLiteral( "': parse error %1 at row %2, column %3" ).arg( errorMsg ).arg( line ).arg( column ),
-                                 QStringLiteral( "Server" ), Qgis::Critical );
-    }
-
-    return xsdDoc;
+    response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
+    response.write( schema_str );
   }
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetschemaextension.cpp
+++ b/src/server/services/wms/qgswmsgetschemaextension.cpp
@@ -29,16 +29,7 @@
 namespace QgsWms
 {
 
-//    void writeGetSchemaExtension( QgsServerInterface *serverIface, const QString &version,
-//                                  const QgsServerRequest &request, QgsServerResponse &response )
-//    {
-//      QDomDocument doc = getSchemaExtension( serverIface, version, request );
-//      response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
-//      response.write( doc.toByteArray() );
-//    }
-
-  void writeGetSchemaExtension( QgsServerInterface *serverIface, const QString &version,
-                                const QgsServerRequest &request, QgsServerResponse &response )
+  void writeGetSchemaExtension( QgsServerResponse &response )
   {
     QDir resourcesDir = QFileInfo( QgsApplication::serverResourcesPath() ).absoluteDir();
     QFileInfo xsdFileInfo( resourcesDir, QStringLiteral( "schemaExtension.xsd" ) );

--- a/src/server/services/wms/qgswmsgetschemaextension.h
+++ b/src/server/services/wms/qgswmsgetschemaextension.h
@@ -25,16 +25,7 @@ namespace QgsWms
   /**
    * Output GetSchemaExtension response
    */
-  void writeGetSchemaExtension( QgsServerInterface *serverIface, const QString &version,
-                                const QgsServerRequest &request, QgsServerResponse &response );
-
-
-  /**
-   * Returns the schemaExtension for WMS 1.3.0 capabilities
-   */
-  QDomDocument getSchemaExtension( QgsServerInterface *serverIface, const QString &version,
-                                   const QgsServerRequest &request );
-
+  void writeGetSchemaExtension( QgsServerResponse &response );
 
 } // namespace QgsWms
 

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -102,8 +102,12 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <Abstract>QGIS Test Project</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -115,10 +115,6 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
-   <Name>QGIS Test Project</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <Layer queryable="1">
     <Name>layer_with_short_name</Name>
     <Title>A Layer with a short name</Title>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -15,8 +15,8 @@ Content-Type: text/xml; charset=utf-8
    <ContactPersonPrimary>
     <ContactPerson>Alessandro Pasotti</ContactPerson>
     <ContactOrganization>QGIS dev team</ContactOrganization>
-    <ContactPosition>originator</ContactPosition>
    </ContactPersonPrimary>
+   <ContactPosition>originator</ContactPosition>
    <ContactElectronicMailAddress>elpaso@itopen.it</ContactElectronicMailAddress>
   </ContactInformation>
   <Fees>conditions unknown</Fees>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -123,8 +123,12 @@ Content-Type: text/xml; charset=utf-8
    </inspire_common:ResponseLanguage>
   </inspire_vs:ExtendedCapabilities>
   <Layer queryable="1">
+   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <Abstract>QGIS Test Project</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -136,10 +136,6 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
-   <Name>QGIS Test Project</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <Layer queryable="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -136,10 +136,6 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
-   <Name>QGIS Test Project</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <TreeName>QGIS Test Project</TreeName>
    <Layer geometryType="Point" queryable="1" displayField="id" visible="1" opacity="1" expanded="1">
     <Name>layer_with_short_name</Name>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -123,8 +123,12 @@ Content-Type: text/xml; charset=utf-8
    <WFSLayer name="testlayer èé"/>
   </WFSLayers>
   <Layer>
+   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <Abstract>QGIS Test Project</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -136,10 +136,6 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
-   <Name>QGIS Test Project</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <TreeName>QGIS Test Project</TreeName>
    <Layer geometryType="Point" queryable="1" displayField="id" visible="1" opacity="1" expanded="1">
     <Name>layer_with_short_name</Name>

--- a/tests/testdata/qgis_server/getprojectsettings_opacity.txt
+++ b/tests/testdata/qgis_server/getprojectsettings_opacity.txt
@@ -123,8 +123,12 @@ Content-Type: text/xml; charset=utf-8
    <WFSLayer name="testlayer èé"/>
   </WFSLayers>
   <Layer>
+   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <Abstract>QGIS Test Project</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/getschemaextension.txt
+++ b/tests/testdata/qgis_server/getschemaextension.txt
@@ -1,9 +1,9 @@
 *****
 Content-Type: text/xml; charset=utf-8
 
-<?xml version='1.0' encoding='UTF-8'?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.qgis.org/wms" elementFormDefault="qualified" version="1.0.0">
- <import xmlns="http://www.w3.org/2001/XMLSchema" namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd"/>
- <element xmlns="http://www.w3.org/2001/XMLSchema" name="GetPrint" substitutionGroup="wms:_ExtendedOperation" type="wms:OperationType"/>
- <element xmlns="http://www.w3.org/2001/XMLSchema" name="GetStyles" substitutionGroup="wms:_ExtendedOperation" type="wms:OperationType"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wms="http://www.opengis.net/wms" xmlns:qgs="http://www.qgis.org/wms" targetNamespace="http://www.qgis.org/wms" elementFormDefault="qualified" version="1.0.0">
+  <import namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd"/>
+  <element name="GetPrint" type="wms:OperationType" substitutionGroup="wms:_ExtendedOperation" />
+  <element name="GetStyles" type="wms:OperationType" substitutionGroup="wms:_ExtendedOperation" />
 </schema>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -110,10 +110,6 @@ Content-Type: text/xml; charset=utf-8
    <LatLonBoundingBox maxy="44.901599" maxx="8.204165" miny="44.901236" minx="8.203154"/>
    <BoundingBox maxy="5606043.446" SRS="EPSG:3857" maxx="913283.462" miny="5605986.581" minx="913170.942"/>
    <BoundingBox maxy="44.901599" SRS="EPSG:4326" maxx="8.204165" miny="44.901236" minx="8.203154"/>
-   <Name>QGIS Test Project</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <Layer queryable="1">
     <Name>layer_with_short_name</Name>
     <Title>A Layer with a short name</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_1_1.txt
@@ -102,8 +102,12 @@ Content-Type: text/xml; charset=utf-8
    <Format>application/vnd.ogc.se_xml</Format>
   </Exception>
   <Layer queryable="1">
+   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <Abstract>QGIS Test Project</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <SRS>CRS:84</SRS>
    <SRS>EPSG:4326</SRS>
    <SRS>EPSG:3857</SRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -102,8 +102,12 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <Name>QGIS Test Project</Name>
    <Title>QGIS Test Project</Title>
    <Abstract>QGIS Test Project</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_1_3_0.txt
@@ -115,10 +115,6 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox maxy="5606043.446" maxx="913283.462" miny="5605986.581" CRS="EPSG:3857" minx="913170.942"/>
    <BoundingBox maxy="8.204165" maxx="44.901599" miny="8.203154" CRS="EPSG:4326" minx="44.901236"/>
-   <Name>QGIS Test Project</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <Layer queryable="1">
     <Name>layer_with_short_name</Name>
     <Title>A Layer with a short name</Title>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -5,6 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms https://www.qgis.org/?SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
  <Service>
   <Name>WMS</Name>
+  <Title>untitled</Title>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -94,9 +94,6 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:3857</CRS>
    <CRS>EPSG:4326</CRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_layer.txt
@@ -94,6 +94,9 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:3857</CRS>
    <CRS>EPSG:4326</CRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -5,6 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_empty_spatial_layer.qgz&amp;SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
  <Service>
   <Name>WMS</Name>
+  <Title>untitled</Title>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -94,9 +94,6 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_empty_spatial_layer.txt
@@ -94,6 +94,9 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -5,6 +5,7 @@ Content-Type: text/xml; charset=utf-8
 <WMS_Capabilities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qgs="http://www.qgis.org/wms" xmlns="http://www.opengis.net/wms" xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd http://www.qgis.org/wms https://www.qgis.org/?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_without_title.qgs&amp;SERVICE=WMS&amp;REQUEST=GetSchemaExtension" version="1.3.0" xmlns:sld="http://www.opengis.net/sld">
  <Service>
   <Name>WMS</Name>
+  <Title>untitled</Title>
   <KeywordList>
    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
   </KeywordList>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -96,9 +96,6 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
+++ b/tests/testdata/qgis_server/wms_getcapabilities_without_title.txt
@@ -96,6 +96,9 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization SupportSLD="1" RemoteWCS="0" UserLayer="0" InlineFeature="0" RemoteWFS="0" UserStyle="1"/>
   <Layer queryable="1">
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:4326</CRS>
    <CRS>EPSG:3857</CRS>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -103,8 +103,12 @@ Content-Type: text/xml; charset=utf-8
   </Exception>
   <sld:UserDefinedSymbolization UserStyle="1" RemoteWFS="0" RemoteWCS="0" InlineFeature="0" UserLayer="0" SupportSLD="1"/>
   <Layer queryable="1">
+   <Name>QGIS Server WMS Dimensions</Name>
    <Title>QGIS Server WMS Dimensions</Title>
    <Abstract>QGIS Server WMS Dimensions</Abstract>
+   <KeywordList>
+    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
+   </KeywordList>
    <CRS>CRS:84</CRS>
    <CRS>EPSG:3857</CRS>
    <CRS>EPSG:4326</CRS>

--- a/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
+++ b/tests/testdata/qgis_server_accesscontrol/results/getcapabilities_wms_dimension.txt
@@ -116,10 +116,6 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox miny="-174.766579" maxy="177.930822" minx="-69.957839" maxx="84.307877" CRS="EPSG:4326"/>
    <BoundingBox miny="-11055007" maxy="19143773" minx="-20609694" maxx="20961936" CRS="EPSG:3857"/>
-   <Name>QGIS Server WMS Dimensions</Name>
-   <KeywordList>
-    <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
-   </KeywordList>
    <Layer queryable="1">
     <Name>Contours</Name>
     <Title>Contours</Title>


### PR DESCRIPTION
## Description

This PR improves QGIS Server WMS GetCapabilities output.

Fixes #35696, #35701, #35717 and #35710

It also fixes the output when only one of `<ContactPerson>` or `<ContactOrganization>` is filled. If one is filled, both should be written to parent `<ContactPersonPrimary>`.

## Decisions

### If the title is missing

If Project → Properties → QGIS Server → Service Capabilities → Title is not filled by the user, there is no OWS Title. If this is the case, we use the project's title (Project → General → Project title). Only if project's title is not set, we use '<Title>untitled</Title>'.

### If the Person or Organization is missing

If both are missing from Project → Properties → QGIS Server → Service Capabilities , there is no problem. 
But if one of them is defined, we need both filled to create a valid `<ContactPersonPrimary>`. The other uses the _unknown_ default, like:
```xml
 <Service>
  <Name>WMS</Name>
  <Title>Antivirus</Title>
  <KeywordList>
   <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
  </KeywordList>
  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http:" xlink:type="simple"/>
  <ContactInformation>
   <ContactPersonPrimary>
    <ContactPerson>Gustavo</ContactPerson>
    <ContactOrganization>unknown</ContactOrganization>
   </ContactPersonPrimary>
   <ContactPosition>Treinee</ContactPosition>
  </ContactInformation>
  <Fees>conditions unknown</Fees>
  <AccessConstraints>None</AccessConstraints>
 </Service>
```


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
