### PR TITLE
Don't prompt to cancel the news feed task on shutdown

### DIFF
--- a/python/core/auto_generated/qgsnetworkcontentfetchertask.sip.in
+++ b/python/core/auto_generated/qgsnetworkcontentfetchertask.sip.in
@@ -34,7 +34,7 @@ without danger of the task being first removed by the QgsTaskManager.
 %End
   public:
 
-    QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg = QString() );
+    QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg = QString(), QgsTask::Flags flags = QgsTask::CanCancel );
 %Docstring
 Constructor for a QgsNetworkContentFetcherTask which fetches
 the specified ``url``.
@@ -42,7 +42,7 @@ the specified ``url``.
 Optionally, authentication configuration can be set via the ``authcfg`` argument.
 %End
 
-    QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg = QString() );
+    QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg = QString(), QgsTask::Flags flags = QgsTask::CanCancel );
 %Docstring
 Constructor for a QgsNetworkContentFetcherTask which fetches
 the specified network ``request``.

--- a/python/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/core/auto_generated/qgstaskmanager.sip.in
@@ -47,6 +47,7 @@ clean up and terminate at the earliest possible convenience.
     enum Flag
     {
       CanCancel,
+      CancelWithoutPrompt,
       AllFlags,
     };
     typedef QFlags<QgsTask::Flag> Flags;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6067,20 +6067,31 @@ void QgisApp::fileExit()
   if ( QgsApplication::taskManager()->countActiveTasks() > 0 )
   {
     QStringList tasks;
-    const auto constActiveTasks = QgsApplication::taskManager()->activeTasks();
-    for ( QgsTask *task : constActiveTasks )
+    const QList< QgsTask * > activeTasks = QgsApplication::taskManager()->activeTasks();
+    for ( QgsTask *task : activeTasks )
     {
+      if ( task->flags() & QgsTask::CancelWithoutPrompt )
+        continue;
+
       tasks << tr( " • %1" ).arg( task->description() );
     }
 
-    // active tasks
-    if ( QMessageBox::question( this, tr( "Active Tasks" ),
-                                tr( "The following tasks are currently running in the background:\n\n%1\n\nDo you want to try canceling these active tasks?" ).arg( tasks.join( QStringLiteral( "\n" ) ) ),
-                                QMessageBox::Yes | QMessageBox::No ) == QMessageBox::Yes )
+    // prompt if any tasks which require user confirmation remain, otherwise just cancel them directly and continue with shutdown.
+    if ( tasks.empty() )
     {
+      // all tasks can be silently terminated without warning
       QgsApplication::taskManager()->cancelAll();
     }
-    return;
+    else
+    {
+      if ( QMessageBox::question( this, tr( "Active Tasks" ),
+                                  tr( "The following tasks are currently running in the background:\n\n%1\n\nDo you want to try canceling these active tasks?" ).arg( tasks.join( QStringLiteral( "\n" ) ) ),
+                                  QMessageBox::Yes | QMessageBox::No ) == QMessageBox::Yes )
+      {
+        QgsApplication::taskManager()->cancelAll();
+      }
+      return;
+    }
   }
 
   QgsCanvasRefreshBlocker refreshBlocker;

--- a/src/core/qgsnetworkcontentfetchertask.cpp
+++ b/src/core/qgsnetworkcontentfetchertask.cpp
@@ -19,12 +19,12 @@
 #include "qgsnetworkcontentfetchertask.h"
 #include "qgsnetworkcontentfetcher.h"
 
-QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg, Flags flags )
+QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg, QgsTask::Flags flags )
   : QgsNetworkContentFetcherTask( QNetworkRequest( url ), authcfg, flags )
 {
 }
 
-QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg, Flags flags )
+QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg, QgsTask::Flags flags )
   : QgsTask( tr( "Fetching %1" ).arg( request.url().toString() ), flags )
   , mRequest( request )
   , mAuthcfg( authcfg )

--- a/src/core/qgsnetworkcontentfetchertask.cpp
+++ b/src/core/qgsnetworkcontentfetchertask.cpp
@@ -19,13 +19,13 @@
 #include "qgsnetworkcontentfetchertask.h"
 #include "qgsnetworkcontentfetcher.h"
 
-QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg )
-  : QgsNetworkContentFetcherTask( QNetworkRequest( url ), authcfg )
+QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg, Flags flags )
+  : QgsNetworkContentFetcherTask( QNetworkRequest( url ), authcfg, flags )
 {
 }
 
-QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg )
-  : QgsTask( tr( "Fetching %1" ).arg( request.url().toString() ) )
+QgsNetworkContentFetcherTask::QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg, Flags flags )
+  : QgsTask( tr( "Fetching %1" ).arg( request.url().toString() ), flags )
   , mRequest( request )
   , mAuthcfg( authcfg )
 {

--- a/src/core/qgsnetworkcontentfetchertask.h
+++ b/src/core/qgsnetworkcontentfetchertask.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsNetworkContentFetcherTask : public QgsTask
      *
      * Optionally, authentication configuration can be set via the \a authcfg argument.
      */
-    QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg = QString() );
+    QgsNetworkContentFetcherTask( const QUrl &url, const QString &authcfg = QString(), QgsTask::Flags flags = QgsTask::CanCancel );
 
     /**
      * Constructor for a QgsNetworkContentFetcherTask which fetches
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsNetworkContentFetcherTask : public QgsTask
      *
      * Optionally, authentication configuration can be set via the \a authcfg argument.
      */
-    QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg = QString() );
+    QgsNetworkContentFetcherTask( const QNetworkRequest &request, const QString &authcfg = QString(), QgsTask::Flags flags = QgsTask::CanCancel );
 
     ~QgsNetworkContentFetcherTask() override;
 

--- a/src/core/qgsnewsfeedparser.cpp
+++ b/src/core/qgsnewsfeedparser.cpp
@@ -140,7 +140,8 @@ void QgsNewsFeedParser::fetch()
 
   mFetchStartTime = QDateTime::currentDateTimeUtc().toSecsSinceEpoch();
 
-  QgsNetworkContentFetcherTask *task = new QgsNetworkContentFetcherTask( req, mAuthCfg );
+  // allow canceling the news fetching without prompts -- it's not crucial if this gets finished or not
+  QgsNetworkContentFetcherTask *task = new QgsNetworkContentFetcherTask( req, mAuthCfg, QgsTask::CanCancel | QgsTask::CancelWithoutPrompt );
   task->setDescription( tr( "Fetching News Feed" ) );
   connect( task, &QgsNetworkContentFetcherTask::fetched, this, [this, task]
   {

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -70,6 +70,7 @@ class CORE_EXPORT QgsTask : public QObject
     enum Flag
     {
       CanCancel = 1 << 1, //!< Task can be canceled
+      CancelWithoutPrompt = 1 << 2, //!< Task can be canceled without any users prompts, e.g. when closing a project or QGIS.
       AllFlags = CanCancel, //!< Task supports all flags
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -621,6 +621,9 @@ QgsTaskManagerStatusBarWidget::QgsTaskManagerStatusBarWidget( QgsTaskManager *ma
   connect( manager, &QgsTaskManager::allTasksFinished, this, &QgsTaskManagerStatusBarWidget::allFinished );
   connect( manager, &QgsTaskManager::finalTaskProgressChanged, this, &QgsTaskManagerStatusBarWidget::overallProgressChanged );
   connect( manager, &QgsTaskManager::countActiveTasksChanged, this, &QgsTaskManagerStatusBarWidget::countActiveTasksChanged );
+
+  if ( manager->countActiveTasks() )
+    showButton();
 }
 
 QSize QgsTaskManagerStatusBarWidget::sizeHint() const


### PR DESCRIPTION
If it hasn't completed, just cancel it immediately without prompting users -- it's not essential that it completes and the prompt is just annoying for this task.