### PR TITLE
Increase default bin size for raster histograms

### DIFF
--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -208,7 +208,7 @@ void QgsColorRampShader::classifyColorRamp( const int classes, const int band, c
 
       double cut1 = std::numeric_limits<double>::quiet_NaN();
       double cut2 = std::numeric_limits<double>::quiet_NaN();
-      int sampleSize = 250000;
+      const int sampleSize = 250000;
 
       // set min and max from histogram, used later to calculate number of decimals to display
       input->cumulativeCut( band, 0.0, 1.0, min, max, extent, sampleSize );

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -347,9 +347,12 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram,
     }
     else
     {
-      // There is no best default value, to display something reasonable in histogram chart, binCount should be small, OTOH, to get precise data for cumulative cut, the number should be big. Because it is easier to define fixed lower value for the chart, we calc optimum binCount for higher resolution (to avoid calculating that where histogram() is used. In any any case, it does not make sense to use more than width*height;
-      myBinCount = histogram.width * histogram.height;
-      if ( myBinCount > 1000 )  myBinCount = 1000;
+      // There is no best default value, to display something reasonable in histogram chart,
+      // binCount should be small, OTOH, to get precise data for cumulative cut, the number should be big.
+      // Because it is easier to define fixed lower value for the chart, we calc optimum binCount
+      // for higher resolution (to avoid calculating that where histogram() is used. In any any case,
+      // it does not make sense to use more than width*height;
+      myBinCount = std::min( 2000, histogram.width * histogram.height );
 
       // for Int16/Int32 make sure bin count <= actual range, because there is no sense in having
       // bins at fractional values


### PR DESCRIPTION
Fixes #35465 
but it is still an arbitrary value,
better approaches would require to calculate other
dispersion indexes and they seem impractical (inefficient)
in this case.
