### PR TITLE
Update on WMS-T static temporal range options state

### DIFF
--- a/src/gui/raster/qgsrasterlayerproperties.cpp
+++ b/src/gui/raster/qgsrasterlayerproperties.cpp
@@ -1293,9 +1293,9 @@ void QgsRasterLayerProperties::setSourceStaticTimeState()
     const QString enableTime = uri.param( QStringLiteral( "enableTime" ) );
 
     if ( temporalSource == QLatin1String( "provider" ) )
-      mStaticTemporalRange->setChecked( true );
+      mStaticTemporalRange->setChecked( !time.isEmpty() );
     else if ( temporalSource == QLatin1String( "project" ) )
-      mProjectTemporalRange->setChecked( true );
+      mProjectTemporalRange->setChecked( !time.isEmpty() );
 
     mDisableTime->setChecked( enableTime == QLatin1String( "no" ) );
   }


### PR DESCRIPTION
This PR updates the source tab state when the WMS-T layer is loaded at the first time, the static temporal range inputs options will all be unchecked.