### PR TITLE
De-emphasise SAGA results when searching in toolbox

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingprovider.sip.in
@@ -24,6 +24,13 @@ to a common area of analysis.
 %End
   public:
 
+    enum Flag
+    {
+      FlagDeemphasiseSearchResults,
+    };
+    typedef QFlags<QgsProcessingProvider::Flag> Flags;
+
+
     QgsProcessingProvider( QObject *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsProcessingProvider.
@@ -44,6 +51,14 @@ Returns an icon for the provider.
 Returns a path to an SVG version of the provider's icon.
 
 .. seealso:: :py:func:`icon`
+%End
+
+    virtual Flags flags() const;
+%Docstring
+Returns the flags indicating how and when the provider operates and should be exposed to users.
+Default is no flags.
+
+.. versionadded:: 3.14
 %End
 
     virtual QString id() const = 0;
@@ -283,6 +298,9 @@ Adds an ``algorithm`` to the provider. Ownership of the algorithm is transferred
   private:
     QgsProcessingProvider( const QgsProcessingProvider &other );
 };
+
+QFlags<QgsProcessingProvider::Flag> operator|(QgsProcessingProvider::Flag f1, QFlags<QgsProcessingProvider::Flag> f2);
+
 
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
@@ -256,6 +256,7 @@ of this model.
       RoleAlgorithmName,
       RoleAlgorithmShortDescription,
       RoleAlgorithmTags,
+      RoleProviderFlags,
     };
 
     QgsProcessingToolboxModel( QObject *parent /TransferThis/ = 0, QgsProcessingRegistry *registry = 0,
@@ -446,6 +447,8 @@ Returns the current filter string, if set.
     virtual bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const;
 
     virtual bool lessThan( const QModelIndex &left, const QModelIndex &right ) const;
+
+    virtual QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const;
 
 
 };

--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -146,6 +146,11 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
     def supportedOutputTableExtensions(self):
         return ['dbf']
 
+    def flags(self):
+        # push users towards alternative algorithms instead, SAGA algorithms should only be used by experienced
+        # users who understand and can workaround the frequent issues encountered here
+        return QgsProcessingProvider.FlagDeemphasiseSearchResults
+
     def supportsNonFileBasedOutput(self):
         """
         SAGA Provider doesn't support non file based outputs

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -41,6 +41,11 @@ QString QgsProcessingProvider::svgIconPath() const
   return QgsApplication::iconPath( QStringLiteral( "processingAlgorithm.svg" ) );
 }
 
+QgsProcessingProvider::Flags QgsProcessingProvider::flags() const
+{
+  return nullptr;
+}
+
 QString QgsProcessingProvider::helpId() const
 {
   return QString();

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -38,6 +38,16 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
   public:
 
     /**
+     * Flags indicating how and when an provider operates and should be exposed to users
+     * \since QGIS 3.14
+     */
+    enum Flag
+    {
+      FlagDeemphasiseSearchResults = 1 << 1, //!< Algorithms should be de-emphasised in the search results when searching for algorithms. Use for low-priority providers or those with substantial known issues.
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    /**
      * Constructor for QgsProcessingProvider.
      */
     QgsProcessingProvider( QObject *parent SIP_TRANSFERTHIS = nullptr );
@@ -60,6 +70,13 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * \see icon()
      */
     virtual QString svgIconPath() const;
+
+    /**
+     * Returns the flags indicating how and when the provider operates and should be exposed to users.
+     * Default is no flags.
+     * \since QGIS 3.14
+     */
+    virtual Flags flags() const;
 
     /**
      * Returns the unique provider id, used for identifying the provider. This string
@@ -280,6 +297,8 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
     QgsProcessingProvider( const QgsProcessingProvider &other );
 #endif
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingProvider::Flags )
 
 #endif // QGSPROCESSINGPROVIDER_H
 

--- a/src/gui/processing/qgsprocessingtoolboxmodel.h
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.h
@@ -286,6 +286,7 @@ class GUI_EXPORT QgsProcessingToolboxModel : public QAbstractItemModel
       RoleAlgorithmName, //!< Untranslated algorithm name, for algorithm nodes
       RoleAlgorithmShortDescription, //!< Short algorithm description, for algorithm nodes
       RoleAlgorithmTags, //!< List of algorithm tags, for algorithm nodes
+      RoleProviderFlags, //!< Returns the node's provider flags
     };
 
     /**
@@ -493,6 +494,7 @@ class GUI_EXPORT QgsProcessingToolboxProxyModel: public QSortFilterProxyModel
 
     bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
     bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 
   private:
 


### PR DESCRIPTION
This change "dims" the results from the SAGA provider when a search
is made in the toolbox, to visually push users towards picking alternative
algorithms instead.

The Processing implementation of SAGA algorithms are a constant source
of critical bugs for users, causing incorrect analysis results. There's
zero community interest in actively maintaining this provider, so we
need to take steps to push users to stop picking these algorithms
wherever alternative (QGIS/GRASS/GDAL based) equivalents exist.

And for 4.0, seriously re-consider dropping this provider from the
out of the box install. We are causing more harm then good by offering
it to users.
