### PR TITLE
fix handling of checked items in checkable combobox (fix #28658)

### DIFF
--- a/src/gui/qgscheckablecombobox.cpp
+++ b/src/gui/qgscheckablecombobox.cpp
@@ -52,10 +52,10 @@ bool QgsCheckableItemModel::setData( const QModelIndex &index, const QVariant &v
 
   if ( ok && role == Qt::CheckStateRole )
   {
-    emit dataChanged( index, index );
-    emit itemCheckStateChanged();
+    emit itemCheckStateChanged( index );
   }
 
+  emit dataChanged( index, index );
   return ok;
 }
 
@@ -94,12 +94,9 @@ QgsCheckableComboBox::QgsCheckableComboBox( QWidget *parent )
   view()->setContextMenuPolicy( Qt::CustomContextMenu );
   connect( view(), &QAbstractItemView::customContextMenuRequested, this, &QgsCheckableComboBox::showContextMenu );
 
-  QgsCheckableItemModel *myModel = qobject_cast<QgsCheckableItemModel *>( model() );
-  connect( myModel, &QgsCheckableItemModel::itemCheckStateChanged, this, &QgsCheckableComboBox::updateCheckedItems );
-  connect( model(), &QStandardItemModel::rowsInserted, this, [ = ]( const QModelIndex &, int, int ) { updateCheckedItems(); } );
-  connect( model(), &QStandardItemModel::rowsRemoved, this, [ = ]( const QModelIndex &, int, int ) { updateCheckedItems(); } );
-
-  connect( this, static_cast< void ( QComboBox::* )( int ) >( &QComboBox::activated ), this, &QgsCheckableComboBox::toggleItemCheckState );
+  connect( model(), &QStandardItemModel::rowsInserted, this, [ = ]( const QModelIndex &, int, int ) { updateDisplayText(); } );
+  connect( model(), &QStandardItemModel::rowsRemoved, this, [ = ]( const QModelIndex &, int, int ) { updateDisplayText(); } );
+  connect( model(), &QStandardItemModel::dataChanged, this, [ = ]( const QModelIndex &, const QModelIndex &, const QVector< int > & ) { updateDisplayText(); } );
 }
 
 QString QgsCheckableComboBox::separator() const
@@ -230,15 +227,25 @@ bool QgsCheckableComboBox::eventFilter( QObject *object, QEvent *event )
        && object == view()->viewport() )
   {
     mSkipHide = true;
-  }
 
-  if ( event->type() == QEvent::MouseButtonRelease )
-  {
-    if ( static_cast<QMouseEvent *>( event )->button() == Qt::RightButton )
+    if ( event->type() == QEvent::MouseButtonRelease && static_cast<QMouseEvent *>( event )->button() == Qt::RightButton )
     {
       return true;
     }
+
+    if ( event->type() == QEvent::MouseButtonRelease )
+    {
+      QModelIndex index = view()->indexAt( static_cast<QMouseEvent *>( event )->pos() );
+      if ( index.isValid() )
+      {
+        QgsCheckableItemModel *myModel = qobject_cast<QgsCheckableItemModel *>( model() );
+        QStandardItem *item = myModel->itemFromIndex( index );
+        item->checkState() == Qt::Checked ? item->setCheckState( Qt::Unchecked ) : item->setCheckState( Qt::Checked );
+      }
+      return true;
+    }
   }
+
   return QComboBox::eventFilter( object, event );
 }
 
@@ -250,6 +257,7 @@ void QgsCheckableComboBox::setCheckedItems( const QStringList &items )
     const int index = findText( text );
     setItemCheckState( index, index != -1 ? Qt::Checked : Qt::Unchecked );
   }
+  updateCheckedItems();
 }
 
 void QgsCheckableComboBox::resizeEvent( QResizeEvent *event )
@@ -283,4 +291,3 @@ void QgsCheckableComboBox::updateDisplayText()
   text = fontMetrics.elidedText( text, Qt::ElideRight, rect.width() );
   setEditText( text );
 }
-

--- a/src/gui/qgscheckablecombobox.cpp
+++ b/src/gui/qgscheckablecombobox.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgscheckablecombobox.h"
+#include "qgsapplication.h"
 
 #include <QEvent>
 #include <QMouseEvent>
@@ -82,6 +83,9 @@ QgsCheckableComboBox::QgsCheckableComboBox( QWidget *parent )
 
   QLineEdit *lineEdit = new QLineEdit( this );
   lineEdit->setReadOnly( true );
+  QPalette pal = qApp->palette();
+  pal.setBrush( QPalette::Base, pal.button() );
+  lineEdit->setPalette( pal );
   setLineEdit( lineEdit );
 
   mContextMenu = new QMenu( this );

--- a/src/gui/qgscheckablecombobox.h
+++ b/src/gui/qgscheckablecombobox.h
@@ -77,9 +77,9 @@ class QgsCheckableItemModel : public QStandardItemModel
   signals:
 
     /**
-     * Emitted whenever the items checkstate has changed.
+     * Emitted whenever the item's checkstate has changed.
      */
-    void itemCheckStateChanged();
+    void itemCheckStateChanged( const QModelIndex &index );
 };
 
 


### PR DESCRIPTION
## Description
Improve handling of toggling item state in the checkable combobox, so single checked item does not become unchecked. Fixes #28658.