### PR TITLE
Revert usage of QGIS native raster API in KDE as it causes issues

### DIFF
--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -16,12 +16,15 @@
 #ifndef QGSKDE_H
 #define QGSKDE_H
 
+#include "qgsrectangle.h"
 #include "qgsogrutils.h"
 #include <QString>
 
+// GDAL includes
+#include <gdal.h>
+#include <cpl_string.h>
+#include <cpl_conv.h>
 #include "qgis_analysis.h"
-#include "qgsrectangle.h"
-#include "qgsrasterdataprovider.h"
 
 class QgsFeatureSource;
 class QgsFeature;
@@ -165,8 +168,11 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
 
     int mBufferSize;
 
-    QgsRasterDataProvider *mProvider = nullptr;
+    gdal::dataset_unique_ptr mDatasetH;
+    GDALRasterBandH mRasterBandH;
 
+    //! Creates a new raster layer and initializes it to the no data value
+    bool createEmptyLayer( GDALDriverH driver, const QgsRectangle &bounds, int rows, int columns ) const;
     int radiusSizeInPixels( double radius ) const;
 
 #ifdef SIP_RUN


### PR DESCRIPTION
This reverts commits 3e63d65f89021de9c346cdf902a5119340521856 and 82559322d168a8eea44b4f11e4debff657cecf3f. Fixes #34958.