### PR TITLE
Vector tile layer - part 5 (identify tool)

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -40,6 +40,7 @@ after selecting a point, performs the identification:
       VectorLayer,
       RasterLayer,
       MeshLayer,
+      VectorTileLayer,
       AllLayers
     };
     typedef QFlags<QgsMapToolIdentify::Type> LayerType;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14185,7 +14185,65 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer *layer )
       break;
 
     case QgsMapLayerType::VectorTileLayer:
-      // TODO
+      mActionLocalHistogramStretch->setEnabled( false );
+      mActionFullHistogramStretch->setEnabled( false );
+      mActionLocalCumulativeCutStretch->setEnabled( false );
+      mActionFullCumulativeCutStretch->setEnabled( false );
+      mActionIncreaseBrightness->setEnabled( false );
+      mActionDecreaseBrightness->setEnabled( false );
+      mActionIncreaseContrast->setEnabled( false );
+      mActionDecreaseContrast->setEnabled( false );
+      mActionLayerSubsetString->setEnabled( false );
+      mActionFeatureAction->setEnabled( false );
+      mActionSelectFeatures->setEnabled( false );
+      mActionSelectPolygon->setEnabled( false );
+      mActionSelectFreehand->setEnabled( false );
+      mActionSelectRadius->setEnabled( false );
+      mActionZoomActualSize->setEnabled( false );
+      mActionZoomToLayer->setEnabled( true );
+      mActionZoomToSelected->setEnabled( false );
+      mActionOpenTable->setEnabled( false );
+      mActionSelectAll->setEnabled( false );
+      mActionReselect->setEnabled( false );
+      mActionInvertSelection->setEnabled( false );
+      mActionSelectByExpression->setEnabled( false );
+      mActionSelectByForm->setEnabled( false );
+      mActionOpenFieldCalc->setEnabled( false );
+      mActionToggleEditing->setEnabled( false );
+      mActionToggleEditing->setChecked( false );
+      mActionSaveLayerEdits->setEnabled( false );
+      mUndoDock->widget()->setEnabled( false );
+      mActionUndo->setEnabled( false );
+      mActionRedo->setEnabled( false );
+      mActionSaveLayerDefinition->setEnabled( true );
+      mActionLayerSaveAs->setEnabled( false );
+      mActionAddFeature->setEnabled( false );
+      mActionCircularStringCurvePoint->setEnabled( false );
+      mActionCircularStringRadius->setEnabled( false );
+      mActionDeleteSelected->setEnabled( false );
+      mActionAddRing->setEnabled( false );
+      mActionFillRing->setEnabled( false );
+      mActionAddPart->setEnabled( false );
+      mActionVertexTool->setEnabled( false );
+      mActionVertexToolActiveLayer->setEnabled( false );
+      mActionMoveFeature->setEnabled( false );
+      mActionMoveFeatureCopy->setEnabled( false );
+      mActionRotateFeature->setEnabled( false );
+      mActionOffsetCurve->setEnabled( false );
+      mActionCopyFeatures->setEnabled( false );
+      mActionCutFeatures->setEnabled( false );
+      mActionPasteFeatures->setEnabled( false );
+      mActionRotatePointSymbols->setEnabled( false );
+      mActionOffsetPointSymbol->setEnabled( false );
+      mActionDeletePart->setEnabled( false );
+      mActionDeleteRing->setEnabled( false );
+      mActionSimplifyFeature->setEnabled( false );
+      mActionReshapeFeatures->setEnabled( false );
+      mActionSplitFeatures->setEnabled( false );
+      mActionSplitParts->setEnabled( false );
+      mActionLabeling->setEnabled( false );
+      mActionDiagramProperties->setEnabled( false );
+      mActionIdentify->setEnabled( true );
       break;
 
     case QgsMapLayerType::PluginLayer:

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -156,6 +156,16 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
                      const QMap< QString, QString > &attributes,
                      const QMap< QString, QString > &derivedAttributes );
 
+    /**
+     * Adds results from vector tile layer
+     * \since QGIS 3.14
+     */
+    void addFeature( QgsVectorTileLayer *layer,
+                     const QString &label,
+                     const QgsFields &fields,
+                     const QgsFeature &feature,
+                     const QMap< QString, QString > &derivedAttributes );
+
     //! Adds feature from identify results
     void addFeature( const QgsMapToolIdentify::IdentifyResult &result );
 
@@ -275,6 +285,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QgsVectorLayer *vectorLayer( QTreeWidgetItem *item );
     QgsRasterLayer *rasterLayer( QTreeWidgetItem *item );
     QgsMeshLayer *meshLayer( QTreeWidgetItem *item );
+    QgsVectorTileLayer *vectorTileLayer( QTreeWidgetItem *item );
     QTreeWidgetItem *featureItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QObject *layer );

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -28,6 +28,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsreadwritecontext.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectortilelayer.h"
 #include "qgsapplication.h"
 
 bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage )
@@ -292,6 +293,10 @@ QList<QgsMapLayer *> QgsLayerDefinition::loadLayerDefinitionLayers( QDomDocument
     else if ( type == QLatin1String( "raster" ) )
     {
       layer = new QgsRasterLayer;
+    }
+    else if ( type == QLatin1String( "vector-tile" ) )
+    {
+      layer = new QgsVectorTileLayer;
     }
     else if ( type == QLatin1String( "plugin" ) )
     {

--- a/src/core/vectortile/qgsvectortilemvtdecoder.cpp
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.cpp
@@ -48,6 +48,10 @@ inline bool _isExteriorRing( const QVector<QgsPoint> &pts )
 }
 
 
+QgsVectorTileMVTDecoder::QgsVectorTileMVTDecoder() = default;
+
+QgsVectorTileMVTDecoder::~QgsVectorTileMVTDecoder() = default;
+
 bool QgsVectorTileMVTDecoder::decode( QgsTileXYZ tileID, const QByteArray &rawTileData )
 {
   if ( !tile.ParseFromArray( rawTileData.constData(), rawTileData.count() ) )

--- a/src/core/vectortile/qgsvectortilemvtdecoder.h
+++ b/src/core/vectortile/qgsvectortilemvtdecoder.h
@@ -33,9 +33,11 @@ class QgsFeature;
  *
  * \since QGIS 3.14
  */
-class QgsVectorTileMVTDecoder
+class CORE_EXPORT QgsVectorTileMVTDecoder
 {
   public:
+    QgsVectorTileMVTDecoder();
+    ~QgsVectorTileMVTDecoder();
 
     //! Tries to decode raw tile data, returns true on success
     bool decode( QgsTileXYZ tileID, const QByteArray &rawTileData );

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -51,7 +51,9 @@ QPolygon QgsVectorTileUtils::tilePolygon( QgsTileXYZ id, const QgsCoordinateTran
 QgsFields QgsVectorTileUtils::makeQgisFields( QSet<QString> flds )
 {
   QgsFields fields;
-  for ( QString fieldName : flds )
+  QStringList fieldsSorted = flds.toList();
+  std::sort( fieldsSorted.begin(), fieldsSorted.end() );
+  for ( QString fieldName : qgis::as_const( fieldsSorted ) )
   {
     fields.append( QgsField( fieldName, QVariant::String ) );
   }

--- a/src/core/vectortile/qgsvectortileutils.cpp
+++ b/src/core/vectortile/qgsvectortileutils.cpp
@@ -53,7 +53,7 @@ QgsFields QgsVectorTileUtils::makeQgisFields( QSet<QString> flds )
   QgsFields fields;
   QStringList fieldsSorted = flds.toList();
   std::sort( fieldsSorted.begin(), fieldsSorted.end() );
-  for ( QString fieldName : qgis::as_const( fieldsSorted ) )
+  for ( const QString &fieldName : qgis::as_const( fieldsSorted ) )
   {
     fields.append( QgsField( fieldName, QVariant::String ) );
   }

--- a/src/core/vectortile/qgsvectortileutils.h
+++ b/src/core/vectortile/qgsvectortileutils.h
@@ -16,6 +16,8 @@
 #ifndef QGSVECTORTILEUTILS_H
 #define QGSVECTORTILEUTILS_H
 
+#include "qgis_core.h"
+
 #define SIP_NO_FILE
 
 #include <QSet>
@@ -40,7 +42,7 @@ class QgsVectorTileLayer;
  *
  * \since QGIS 3.14
  */
-class QgsVectorTileUtils
+class CORE_EXPORT QgsVectorTileUtils
 {
   public:
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -329,11 +329,11 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
 
   if ( !layer->isInScaleRange( mCanvas->mapSettings().scale() ) )
   {
-    QgsDebugMsg( QStringLiteral( "Out of scale limits" ) );
+    QgsDebugMsgLevel( QStringLiteral( "Out of scale limits" ), 2 );
     return false;
   }
 
-  QApplication::setOverrideCursor( Qt::WaitCursor );
+  QgsTemporaryCursorOverride waitCursor( Qt::WaitCursor );
 
   QMap< QString, QString > commonDerivedAttributes;
 
@@ -403,14 +403,16 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
           continue;  // failed to decode
 
         QMap<QString, QgsFields> perLayerFields;
-        for ( QString layerName : decoder.layers() )
+        const QStringList layerNames = decoder.layers();
+        for ( const QString &layerName : layerNames )
         {
           QSet<QString> fieldNames = QSet<QString>::fromList( decoder.layerFieldNames( layerName ) );
           perLayerFields[layerName] = QgsVectorTileUtils::makeQgisFields( fieldNames );
         }
 
         const QgsVectorTileFeatures features = decoder.layerFeatures( perLayerFields, QgsCoordinateTransform() );
-        for ( QString layerName : features.keys() )
+        const QStringList featuresLayerNames = features.keys();
+        for ( const QString &layerName : featuresLayerNames )
         {
           const QgsFields fFields = perLayerFields[layerName];
           const QVector<QgsFeature> &layerFeatures = features[layerName];
@@ -438,7 +440,6 @@ bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::Iden
     QgsDebugMsg( QStringLiteral( "Caught CRS exception %1" ).arg( cse.what() ) );
   }
 
-  QApplication::restoreOverrideCursor();
   return featureCount > 0;
 }
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -35,8 +35,12 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectortilelayer.h"
+#include "qgsvectortilemvtdecoder.h"
+#include "qgsvectortileutils.h"
 #include "qgsproject.h"
 #include "qgsrenderer.h"
+#include "qgstiles.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeometrycollection.h"
 #include "qgscurve.h"
@@ -220,6 +224,10 @@ bool QgsMapToolIdentify::identifyLayer( QList<IdentifyResult> *results, QgsMapLa
   {
     return identifyMeshLayer( results, qobject_cast<QgsMeshLayer *>( layer ), geometry );
   }
+  else if ( layer->type() == QgsMapLayerType::VectorTileLayer && layerType.testFlag( VectorTileLayer ) )
+  {
+    return identifyVectorTileLayer( results, qobject_cast<QgsVectorTileLayer *>( layer ), geometry );
+  }
   else
   {
     return false;
@@ -312,6 +320,126 @@ bool QgsMapToolIdentify::identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyRe
     }
   }
   return true;
+}
+
+bool QgsMapToolIdentify::identifyVectorTileLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorTileLayer *layer, const QgsGeometry &geometry )
+{
+  if ( !layer || !layer->isSpatial() )
+    return false;
+
+  if ( !layer->isInScaleRange( mCanvas->mapSettings().scale() ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Out of scale limits" ) );
+    return false;
+  }
+
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+
+  QMap< QString, QString > commonDerivedAttributes;
+
+  QgsGeometry selectionGeom = geometry;
+  bool isPointOrRectangle;
+  QgsPointXY point;
+  bool isSingleClick = selectionGeom.type() == QgsWkbTypes::PointGeometry;
+  if ( isSingleClick )
+  {
+    isPointOrRectangle = true;
+    point = selectionGeom.asPoint();
+
+    commonDerivedAttributes = derivedAttributesForPoint( QgsPoint( point ) );
+  }
+  else
+  {
+    // we have a polygon - maybe it is a rectangle - in such case we can avoid costly insterestion tests later
+    isPointOrRectangle = QgsGeometry::fromRect( selectionGeom.boundingBox() ).isGeosEqual( selectionGeom );
+  }
+
+  int featureCount = 0;
+
+  QgsFeatureList featureList;
+  std::unique_ptr<QgsGeometryEngine> selectionGeomPrepared;
+
+  // toLayerCoordinates will throw an exception for an 'invalid' point.
+  // For example, if you project a world map onto a globe using EPSG 2163
+  // and then click somewhere off the globe, an exception will be thrown.
+  try
+  {
+    QgsRectangle r;
+    if ( isSingleClick )
+    {
+      double sr = mOverrideCanvasSearchRadius < 0 ? searchRadiusMU( mCanvas ) : mOverrideCanvasSearchRadius;
+      r = toLayerCoordinates( layer, QgsRectangle( point.x() - sr, point.y() - sr, point.x() + sr, point.y() + sr ) );
+    }
+    else
+    {
+      r = toLayerCoordinates( layer, selectionGeom.boundingBox() );
+
+      if ( !isPointOrRectangle )
+      {
+        QgsCoordinateTransform ct( mCanvas->mapSettings().destinationCrs(), layer->crs(), mCanvas->mapSettings().transformContext() );
+        if ( ct.isValid() )
+          selectionGeom.transform( ct );
+
+        // use prepared geometry for faster intersection test
+        selectionGeomPrepared.reset( QgsGeometry::createGeometryEngine( selectionGeom.constGet() ) );
+      }
+    }
+
+    int tileZoom = QgsVectorTileUtils::scaleToZoomLevel( mCanvas->scale(), layer->sourceMinZoom(), layer->sourceMaxZoom() );
+    QgsTileMatrix tileMatrix = QgsTileMatrix::fromWebMercator( tileZoom );
+    QgsTileRange tileRange = tileMatrix.tileRangeFromExtent( r );
+
+    for ( int row = tileRange.startRow(); row <= tileRange.endRow(); ++row )
+    {
+      for ( int col = tileRange.startColumn(); col <= tileRange.endColumn(); ++col )
+      {
+        QgsTileXYZ tileID( col, row, tileZoom );
+        QByteArray data = layer->getRawTile( tileID );
+        if ( data.isEmpty() )
+          continue;  // failed to get data
+
+        QgsVectorTileMVTDecoder decoder;
+        if ( !decoder.decode( tileID, data ) )
+          continue;  // failed to decode
+
+        QMap<QString, QgsFields> perLayerFields;
+        for ( QString layerName : decoder.layers() )
+        {
+          QSet<QString> fieldNames = QSet<QString>::fromList( decoder.layerFieldNames( layerName ) );
+          perLayerFields[layerName] = QgsVectorTileUtils::makeQgisFields( fieldNames );
+        }
+
+        const QgsVectorTileFeatures features = decoder.layerFeatures( perLayerFields, QgsCoordinateTransform() );
+        for ( QString layerName : features.keys() )
+        {
+          const QgsFields fFields = perLayerFields[layerName];
+          const QVector<QgsFeature> &layerFeatures = features[layerName];
+          for ( const QgsFeature &f : layerFeatures )
+          {
+            if ( f.geometry().intersects( r ) && ( !selectionGeomPrepared || selectionGeomPrepared->intersects( f.geometry().constGet() ) ) )
+            {
+              QMap< QString, QString > derivedAttributes = commonDerivedAttributes;
+              derivedAttributes.insert( tr( "Feature ID" ), FID_TO_STRING( f.id() ) );
+
+              results->append( IdentifyResult( qobject_cast<QgsMapLayer *>( layer ), layerName, fFields, f, derivedAttributes ) );
+
+              featureCount++;
+            }
+          }
+        }
+      }
+    }
+
+  }
+  catch ( QgsCsException &cse )
+  {
+    Q_UNUSED( cse )
+    // catch exception for 'invalid' point and proceed with no features found
+    QgsDebugMsg( QStringLiteral( "Caught CRS exception %1" ).arg( cse.what() ) );
+  }
+
+  QApplication::restoreOverrideCursor();
+  return featureCount > 0;
 }
 
 QMap<QString, QString> QgsMapToolIdentify::derivedAttributesForPoint( const QgsPoint &point )

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -28,6 +28,7 @@
 
 class QgsRasterLayer;
 class QgsVectorLayer;
+class QgsVectorTileLayer;
 class QgsMapLayer;
 class QgsMapCanvas;
 class QgsMeshLayer;
@@ -64,7 +65,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
       VectorLayer = 1,
       RasterLayer = 2,
       MeshLayer = 4, //!< \since QGIS 3.6
-      AllLayers = VectorLayer | RasterLayer | MeshLayer
+      VectorTileLayer = 8,  //!< \since QGIS 3.14
+      AllLayers = VectorLayer | RasterLayer | MeshLayer | VectorTileLayer
     };
     Q_DECLARE_FLAGS( LayerType, Type )
     Q_FLAG( LayerType )
@@ -206,6 +208,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
     bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsGeometry &geometry );
     bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsGeometry &geometry );
+    bool identifyVectorTileLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorTileLayer *layer, const QgsGeometry &geometry );
 
     /**
      * Desired units for distance display.

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -19,6 +19,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/core/effects
   ${CMAKE_SOURCE_DIR}/src/core/validity
+  ${CMAKE_SOURCE_DIR}/src/core/vectortile
   ${CMAKE_SOURCE_DIR}/src/ui
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -679,9 +679,10 @@ void TestQgsMapToolIdentifyAction::identifyMesh()
 void TestQgsMapToolIdentifyAction::identifyVectorTile()
 {
   //create a temporary layer
+  QString vtPath = QStringLiteral( TEST_DATA_DIR ) + QStringLiteral( "/vector_tile/{z}-{x}-{y}.pbf" );
   QgsDataSourceUri dsUri;
   dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
-  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "file://%1/vector_tile/{z}-{x}-{y}.pbf" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+  dsUri.setParam( QStringLiteral( "url" ), QUrl::fromLocalFile( vtPath ).toString() );
   QgsVectorTileLayer *tempLayer = new QgsVectorTileLayer( dsUri.encodedUri(), QStringLiteral( "testlayer" ) );
   QVERIFY( tempLayer->isValid() );
 

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -21,6 +21,7 @@
 #include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgsvectordataprovider.h"
+#include "qgsvectortilelayer.h"
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsmeshlayer.h"
@@ -56,6 +57,7 @@ class TestQgsMapToolIdentifyAction : public QObject
     void identifyRasterFloat32(); // test pixel identification and decimal precision
     void identifyRasterFloat64(); // test pixel identification and decimal precision
     void identifyMesh(); // test identification for mesh layer
+    void identifyVectorTile();  // test identification for vector tile layer
     void identifyInvalidPolygons(); // test selecting invalid polygons
     void clickxy(); // test if clicked_x and clicked_y variables are propagated
     void closestPoint();
@@ -70,6 +72,7 @@ class TestQgsMapToolIdentifyAction : public QObject
     QString testIdentifyRaster( QgsRasterLayer *layer, double xGeoref, double yGeoref );
     QList<QgsMapToolIdentify::IdentifyResult> testIdentifyVector( QgsVectorLayer *layer, double xGeoref, double yGeoref );
     QList<QgsMapToolIdentify::IdentifyResult> testIdentifyMesh( QgsMeshLayer *layer, double xGeoref, double yGeoref );
+    QList<QgsMapToolIdentify::IdentifyResult> testIdentifyVectorTile( QgsVectorTileLayer *layer, double xGeoref, double yGeoref );
 
     // Release return with delete []
     unsigned char *
@@ -540,6 +543,16 @@ TestQgsMapToolIdentifyAction::testIdentifyVector( QgsVectorLayer *layer, double 
   return result;
 }
 
+// private
+QList<QgsMapToolIdentify::IdentifyResult>
+TestQgsMapToolIdentifyAction::testIdentifyVectorTile( QgsVectorTileLayer *layer, double xGeoref, double yGeoref )
+{
+  std::unique_ptr< QgsMapToolIdentifyAction > action( new QgsMapToolIdentifyAction( canvas ) );
+  QgsPointXY mapPoint = canvas->getCoordinateTransform()->transform( xGeoref, yGeoref );
+  QList<QgsMapToolIdentify::IdentifyResult> result = action->identify( mapPoint.x(), mapPoint.y(), QList<QgsMapLayer *>() << layer );
+  return result;
+}
+
 void TestQgsMapToolIdentifyAction::identifyRasterFloat32()
 {
   //create a temporary layer
@@ -661,6 +674,33 @@ void TestQgsMapToolIdentifyAction::identifyMesh()
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector Magnitude" )], QStringLiteral( "3" ) );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector x-component" )], QStringLiteral( "1.8" ) );
   QCOMPARE( results[0].mAttributes[ QStringLiteral( "Vector y-component" )], QStringLiteral( "2.4" ) );
+}
+
+void TestQgsMapToolIdentifyAction::identifyVectorTile()
+{
+  //create a temporary layer
+  QgsDataSourceUri dsUri;
+  dsUri.setParam( QStringLiteral( "type" ), QStringLiteral( "xyz" ) );
+  dsUri.setParam( QStringLiteral( "url" ), QStringLiteral( "file://%1/vector_tile/{z}-{x}-{y}.pbf" ).arg( QStringLiteral( TEST_DATA_DIR ) ) );
+  QgsVectorTileLayer *tempLayer = new QgsVectorTileLayer( dsUri.encodedUri(), QStringLiteral( "testlayer" ) );
+  QVERIFY( tempLayer->isValid() );
+
+  QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:3857" ) );
+  canvas->setDestinationCrs( srs );
+  canvas->setExtent( tempLayer->extent() );
+  canvas->setLayers( QList<QgsMapLayer *>() << tempLayer );
+  canvas->setCurrentLayer( tempLayer );
+
+  QList<QgsMapToolIdentify::IdentifyResult> results;
+  results = testIdentifyVectorTile( tempLayer, 15186127, -2974969 );
+  QCOMPARE( results.size(), 1 );
+  QCOMPARE( results[0].mLayer, tempLayer );
+  QCOMPARE( results[0].mLabel, QStringLiteral( "place" ) );
+  QCOMPARE( results[0].mFeature.geometry().wkbType(), QgsWkbTypes::Point );
+  QCOMPARE( results[0].mFeature.attribute( QStringLiteral( "class" ) ).toString(), QStringLiteral( "country" ) );
+  QCOMPARE( results[0].mFeature.attribute( QStringLiteral( "name" ) ).toString(), QStringLiteral( "Australia" ) );
+
+  delete tempLayer;
 }
 
 void TestQgsMapToolIdentifyAction::identifyInvalidPolygons()

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -696,13 +696,12 @@ void TestQgsMapToolIdentifyAction::identifyVectorTile()
   QList<QgsMapToolIdentify::IdentifyResult> results;
   results = testIdentifyVectorTile( tempLayer, 15186127, -2974969 );
   QCOMPARE( results.size(), 1 );
-#if 0
   QCOMPARE( results[0].mLayer, tempLayer );
   QCOMPARE( results[0].mLabel, QStringLiteral( "place" ) );
   QCOMPARE( results[0].mFeature.geometry().wkbType(), QgsWkbTypes::Point );
   QCOMPARE( results[0].mFeature.attribute( QStringLiteral( "class" ) ).toString(), QStringLiteral( "country" ) );
   QCOMPARE( results[0].mFeature.attribute( QStringLiteral( "name" ) ).toString(), QStringLiteral( "Australia" ) );
-#endif
+
   delete tempLayer;
 }
 

--- a/tests/src/app/testqgsmaptoolidentifyaction.cpp
+++ b/tests/src/app/testqgsmaptoolidentifyaction.cpp
@@ -688,18 +688,20 @@ void TestQgsMapToolIdentifyAction::identifyVectorTile()
   QgsCoordinateReferenceSystem srs( QStringLiteral( "EPSG:3857" ) );
   canvas->setDestinationCrs( srs );
   canvas->setExtent( tempLayer->extent() );
+  canvas->resize( 512, 512 );
   canvas->setLayers( QList<QgsMapLayer *>() << tempLayer );
   canvas->setCurrentLayer( tempLayer );
 
   QList<QgsMapToolIdentify::IdentifyResult> results;
   results = testIdentifyVectorTile( tempLayer, 15186127, -2974969 );
   QCOMPARE( results.size(), 1 );
+#if 0
   QCOMPARE( results[0].mLayer, tempLayer );
   QCOMPARE( results[0].mLabel, QStringLiteral( "place" ) );
   QCOMPARE( results[0].mFeature.geometry().wkbType(), QgsWkbTypes::Point );
   QCOMPARE( results[0].mFeature.attribute( QStringLiteral( "class" ) ).toString(), QStringLiteral( "country" ) );
   QCOMPARE( results[0].mFeature.attribute( QStringLiteral( "name" ) ).toString(), QStringLiteral( "Australia" ) );
-
+#endif
   delete tempLayer;
 }
 


### PR DESCRIPTION
Continued work on vector tile layer implementation.

This piece adds support for identify map tool, so it is now possible to inspect attributes of features in vector tiles.

See the QEP: qgis/QGIS-Enhancement-Proposals#162

![image](https://user-images.githubusercontent.com/193367/79157425-d3501100-7dd4-11ea-8395-5c8ff1dce449.png)

## Thanks

Huge thanks to all funders who have contributed to the crowdfunding and made this possible :clap: :clap: :clap:
https://www.lutraconsulting.co.uk/blog/2020/04/02/vectortiles-donors/