### PR TITLE
Improved WMS-T matching modes logic in temporal range updates 

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -279,38 +279,14 @@ QgsWmstDimensionExtent QgsWmsSettings::parseTemporalExtent( QString extent )
   return dimensionExtent;
 }
 
-QList<QDateTime> QgsWmsSettings::dateTimesFromExtent( QgsWmstDimensionExtent dimensionExtent )
+void QgsWmsSettings::setTimeDimensionExtent( QgsWmstDimensionExtent timeDimensionExtent )
 {
-  QList<QDateTime> dates;
+  mTimeDimensionExtent = timeDimensionExtent;
+}
 
-  for ( QgsWmstExtentPair pair : dimensionExtent.datesResolutionList )
-  {
-    if ( !pair.dates.dateTimes.isEmpty() )
-    {
-      if ( pair.dates.dateTimes.size() < 2 )
-        dates.append( pair.dates.dateTimes.at( 0 ) );
-      else
-      {
-        QDateTime first = QDateTime( pair.dates.dateTimes.at( 0 ) );
-        QDateTime last = QDateTime( pair.dates.dateTimes.at( 1 ) );
-        dates.append( first );
-
-        while ( first < last )
-        {
-          if ( pair.resolution.active() )
-            first = addTime( first, pair.resolution );
-          else
-            break;
-
-          if ( first <= last )
-            dates.append( first );
-        }
-      }
-    }
-  }
-
-  return dates;
-
+QgsWmstDimensionExtent QgsWmsSettings::timeDimensionExtent() const
+{
+  return mTimeDimensionExtent;
 }
 
 QDateTime QgsWmsSettings::addTime( QDateTime dateTime, QgsWmstResolution resolution )

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -98,8 +98,6 @@ bool QgsWmsSettings::parseUri( const QString &uriString )
     else
       mFixedRange = QgsDateTimeRange();
 
-    mDateTimes = dateTimesFromExtent( mTimeDimensionExtent );
-
     if ( uri.param( QStringLiteral( "referenceTimeDimensionExtent" ) ) != QString() )
     {
       QString referenceExtent = uri.param( QStringLiteral( "referenceTimeDimensionExtent" ) );
@@ -335,32 +333,36 @@ QDateTime QgsWmsSettings::addTime( QDateTime dateTime, QgsWmstResolution resolut
   return resultDateTime;
 }
 
-QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime ) const
+QDateTime QgsWmsSettings::findLeastClosestDateTime( QDateTime dateTime, bool dateOnly ) const
 {
   QDateTime closest = dateTime;
-  long long min = std::numeric_limits<long long>::max();
 
-  if ( !dateTime.isValid() || mDateTimes.contains( dateTime ) )
-    return closest;
+  long long seconds;
 
-  for ( QDateTime current : mDateTimes )
+  if ( dateOnly )
+    seconds = QDateTime::fromString( closest.date().toString() ).toSecsSinceEpoch();
+  else
+    seconds = closest.toSecsSinceEpoch();
+
+  for ( QgsWmstExtentPair pair : mTimeDimensionExtent.datesResolutionList )
   {
-    if ( !current.isValid() )
+    if ( pair.dates.dateTimes.size() < 2 )
       continue;
 
-    long long difference = dateTime.secsTo( current );
+    long long startSeconds = pair.dates.dateTimes.at( 0 ).toSecsSinceEpoch();
+    long long endSeconds = pair.dates.dateTimes.at( 1 ).toSecsSinceEpoch();
 
-    // The datetimes list is sorted, if difference is increasing or
-    // it is above zero means search is now looking for greater than
-    // datetimes then search will have to stop.
-    if ( difference > 0 || std::abs( difference ) > min )
+    // if out of bounds
+    if ( seconds < startSeconds || seconds > endSeconds )
+      continue;
+    if ( seconds == endSeconds )
       break;
 
-    if ( std::abs( difference ) < min )
-    {
-      min = std::abs( difference );
-      closest = current;
-    }
+    long long resolutionSeconds = pair.resolution.interval();
+    long long step = std::floor( ( seconds - startSeconds ) / resolutionSeconds );
+    long long resultSeconds = startSeconds + ( step * resolutionSeconds );
+
+    closest.setSecsSinceEpoch( resultSeconds );
   }
 
   return closest;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -27,6 +27,7 @@
 #include "qgsrasteriterator.h"
 #include "qgsapplication.h"
 #include "qgsdataprovider.h"
+#include "qgsinterval.h"
 
 
 class QNetworkReply;
@@ -405,6 +406,26 @@ struct QgsWmstResolution
   int hour = -1;
   int minutes = -1;
   int seconds = -1;
+
+  long long interval()
+  {
+    long long secs = 0.0;
+
+    if ( year != -1 )
+      secs += year * QgsInterval::YEARS ;
+    if ( month != -1 )
+      secs += month * QgsInterval::MONTHS;
+    if ( day != -1 )
+      secs += day * QgsInterval::DAY;
+    if ( hour != -1 )
+      secs += hour * QgsInterval::HOUR;
+    if ( minutes != -1 )
+      secs += minutes * QgsInterval::MINUTE;
+    if ( seconds != -1 )
+      secs += seconds;
+
+    return secs;
+  }
 
   bool active()
   {
@@ -786,12 +807,13 @@ class QgsWmsSettings
     QDateTime addTime( QDateTime dateTime, QgsWmstResolution resolution );
 
     /**
-     * Finds the least closest datetime from list of available datetimes
+     * Finds the least closest datetime from list of available dimension temporal ranges
      * with the given \a dateTime.
      *
-     * Returns the passed \a dateTime if it is found in the available datetimes.
+     * \note It works with wms-t capabilities that provide time dimension with temporal ranges only.
+     *
      */
-    QDateTime findLeastClosestDateTime( QDateTime dateTime ) const;
+    QDateTime findLeastClosestDateTime( QDateTime dateTime, bool dateOnly = false ) const;
 
   protected:
     QgsWmsParserSettings    mParserSettings;
@@ -815,9 +837,6 @@ class QgsWmsSettings
 
     //! Fixed reference temporal range for the data provider
     QgsDateTimeRange mFixedReferenceRange;
-
-    //! List of all available datetimes.
-    QList<QDateTime> mDateTimes;
 
     //! Stores WMS-T time dimension extent dates
     QgsWmstDimensionExtent mTimeDimensionExtent;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -789,6 +789,22 @@ class QgsWmsSettings
     QgsWmstDimensionExtent parseTemporalExtent( QString extent );
 
     /**
+     * Sets the dimension extent property
+     *
+     * \see timeDimensionExtent()
+     * \since 3.14
+     */
+    void setTimeDimensionExtent( QgsWmstDimensionExtent timeDimensionExtent );
+
+    /**
+     * Returns the dimension extent property.
+     *
+     * \see setTimeDimensionExtent()
+     * \since 3.14
+     */
+    QgsWmstDimensionExtent timeDimensionExtent() const;
+
+    /**
      * Parse the given string item into a resolution structure.
      *
      * \since 3.14
@@ -802,8 +818,11 @@ class QgsWmsSettings
      */
     QDateTime parseWmstDateTimes( QString item );
 
-    QList<QDateTime> dateTimesFromExtent( QgsWmstDimensionExtent dimensionExtent );
-
+    /**
+     * Returns the datetime with the sum of passed \a dateTime and the \a resolution time.
+     *
+     * \since 3.14
+     */
     QDateTime addTime( QDateTime dateTime, QgsWmstResolution resolution );
 
     /**
@@ -812,6 +831,7 @@ class QgsWmsSettings
      *
      * \note It works with wms-t capabilities that provide time dimension with temporal ranges only.
      *
+     * \since 3.14
      */
     QDateTime findLeastClosestDateTime( QDateTime dateTime, bool dateOnly = false ) const;
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -1082,8 +1082,10 @@ QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle &viewExtent, int pi
 void QgsWmsProvider::addWmstParameters( QUrlQuery &query )
 {
   QgsDateTimeRange range = temporalCapabilities()->requestedTemporalRange();
+
   QString format { QStringLiteral( "yyyy-MM-ddThh:mm:ssZ" ) };
   QgsDataSourceUri uri { dataSourceUri() };
+  bool dateOnly = false;
 
   if ( range.isInfinite() )
   {
@@ -1101,7 +1103,10 @@ void QgsWmsProvider::addWmstParameters( QUrlQuery &query )
   }
 
   if ( uri.param( QStringLiteral( "enableTime" ) ) == QLatin1String( "no" ) )
+  {
     format = "yyyy-MM-dd";
+    dateOnly = true;
+  }
 
   if ( range.begin().isValid() && range.end().isValid() )
   {
@@ -1117,14 +1122,14 @@ void QgsWmsProvider::addWmstParameters( QUrlQuery &query )
         break;
       case QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToStartOfRange:
       {
-        QDateTime dateTimeStart = mSettings.findLeastClosestDateTime( range.begin() );
+        QDateTime dateTimeStart = mSettings.findLeastClosestDateTime( range.begin(), dateOnly );
         range = QgsDateTimeRange( dateTimeStart, dateTimeStart );
         break;
       }
 
       case QgsRasterDataProviderTemporalCapabilities::FindClosestMatchToEndOfRange:
       {
-        QDateTime dateTimeEnd = mSettings.findLeastClosestDateTime( range.end() );
+        QDateTime dateTimeEnd = mSettings.findLeastClosestDateTime( range.end(), dateOnly );
         range = QgsDateTimeRange( dateTimeEnd, dateTimeEnd );
         break;
       }

--- a/tests/src/providers/testqgswmscapabilities.cpp
+++ b/tests/src/providers/testqgswmscapabilities.cpp
@@ -106,6 +106,54 @@ class TestQgsWmsCapabilities: public QObject
         QgsWmstResolution resolution = settings.parseWmstResolution( resolutionText );
         QCOMPARE( resolution.text(), resolutionText );
       }
+
+      QgsWmstDimensionExtent extent = settings.parseTemporalExtent( QStringLiteral( "2020-01-02T00:00:00.000Z/2020-01-09T00:00:00.000Z/P1D" ) );
+      settings.setTimeDimensionExtent( extent );
+
+      QDateTime start = QDateTime( QDate( 2020, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC );
+      QDateTime end = QDateTime( QDate( 2020, 1, 9 ), QTime( 0, 0, 0 ), Qt::UTC );
+
+      QgsWmstResolution res;
+      res.day = 1;
+      QgsWmstResolution extentResolution = extent.datesResolutionList.at( 0 ).resolution;
+
+      QCOMPARE( extent.datesResolutionList.at( 0 ).dates.dateTimes.at( 0 ), start );
+      QCOMPARE( extent.datesResolutionList.at( 0 ).dates.dateTimes.at( 1 ), end );
+
+      QCOMPARE( extentResolution.text(), res.text() );
+
+      QDateTime firstClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 3 ), QTime( 16, 0, 0 ), Qt::UTC ) );
+      QDateTime firstExpected = QDateTime( QDate( 2020, 1, 3 ), QTime( 0, 0, 0 ), Qt::UTC );
+
+      QCOMPARE( firstClosest, firstExpected );
+
+      QDateTime secondClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 3 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QDateTime secondExpected = QDateTime( QDate( 2020, 1, 3 ), QTime( 0, 0, 0 ), Qt::UTC );
+
+      QCOMPARE( secondClosest, secondExpected );
+
+      QgsWmstDimensionExtent secondExtent = settings.parseTemporalExtent( QStringLiteral( "2020-01-02T00:00:00.000Z/2020-01-04T00:00:00.000Z/PT4H" ) );
+      settings.setTimeDimensionExtent( secondExtent );
+
+      QDateTime thirdClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 2 ), QTime( 5, 0, 0 ), Qt::UTC ) );
+      QDateTime thirdExpected = QDateTime( QDate( 2020, 1, 2 ), QTime( 4, 0, 0 ), Qt::UTC );
+
+      QCOMPARE( thirdClosest, thirdExpected );
+
+      QDateTime fourthClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 2 ), QTime( 3, 0, 0 ), Qt::UTC ) );
+      QDateTime fourthExpected = QDateTime( QDate( 2020, 1, 2 ), QTime( 0, 0, 0 ), Qt::UTC );
+
+      QCOMPARE( fourthClosest, fourthExpected );
+
+      QDateTime fifthClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 4 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QDateTime fifthExpected = QDateTime( QDate( 2020, 1, 4 ), QTime( 0, 0, 0 ), Qt::UTC );
+
+      QCOMPARE( fifthClosest, fifthExpected );
+
+      QDateTime outOfBoundsClosest = settings.findLeastClosestDateTime( QDateTime( QDate( 2020, 1, 5 ), QTime( 0, 0, 0 ), Qt::UTC ) );
+      QDateTime outofBoundsExpected = QDateTime( QDate( 2020, 1, 5 ), QTime( 0, 0, 0 ), Qt::UTC );
+
+      QCOMPARE( outOfBoundsClosest, outofBoundsExpected );
     }
 
 };


### PR DESCRIPTION
Removed creation of list of datetimes from temporal ranges extents in the WMS provider for temporal layers during layer loading, this creation can take a while to finish if the layer's temporal range extent  contains many datetimes.

Due to the removal of the datetimes, I have updated the matching mode logic for WMS-T layers, now not using the pre-calculated datetimes ( they are not available anymore ) and instead designed a different approach that can calculate/find the closest datetimes using only the temporal range extent and its resolution time/period .