### PR TITLE
Fix travis, broken due to some failure to convert struct QVariant property

### DIFF
--- a/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
+++ b/python/core/auto_generated/metadata/qgslayermetadatavalidator.sip.in
@@ -24,19 +24,47 @@ Abstract base class for metadata validators.
 %End
   public:
 
-    struct ValidationResult
-    {
+    class ValidationResult
+{
+%Docstring
+Contains the parameters describing a metadata validation failure.
 
-      ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() );
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgslayermetadatavalidator.h"
+%End
+      public:
+
+        ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() );
 %Docstring
 Constructor for ValidationResult.
 %End
 
-      QString section;
+        QString section;
 
-      QVariant identifier;
 
-      QString note;
+%Property( name = identifier, get = _identifier, set = _setIdentifier )
+
+        QVariant _identifier() const;
+%Docstring
+Returns the optional identifier for the failed metadata item.
+For instance, in list type metadata elements this
+will be set to the list index of the failed metadata
+item.
+%End
+
+        void _setIdentifier( QVariant identifier );
+%Docstring
+Sets the optional ``identifier`` for the failed metadata item.
+For instance, in list type metadata elements this
+will be set to the list index of the failed metadata
+item.
+%End
+
+        QString note;
+
     };
 
     virtual ~QgsAbstractMetadataBaseValidator();

--- a/src/core/metadata/qgslayermetadatavalidator.h
+++ b/src/core/metadata/qgslayermetadatavalidator.h
@@ -39,34 +39,55 @@ class CORE_EXPORT QgsAbstractMetadataBaseValidator
   public:
 
     /**
-     * Contains the parameters describing a metadata validation
-     * failure.
+     * \ingroup core
+     * \brief Contains the parameters describing a metadata validation failure.
+     * \since QGIS 3.0
      */
-    struct ValidationResult
+    class ValidationResult
     {
 
-      /**
-       * Constructor for ValidationResult.
-       */
-      ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() )
-        : section( section )
-        , identifier( identifier )
-        , note( note )
-      {}
+      public:
 
-      //! Metadata section which failed the validation
-      QString section;
+        /**
+         * Constructor for ValidationResult.
+         */
+        ValidationResult( const QString &section, const QString &note, const QVariant &identifier = QVariant() )
+          : section( section )
+          , note( note )
+          , mIdentifier( identifier )
+        {}
 
-      /**
-       * Optional identifier for the failed metadata item.
-       * For instance, in list type metadata elements this
-       * will be set to the list index of the failed metadata
-       * item.
-       */
-      QVariant identifier;
+        //! Metadata section which failed the validation
+        QString section;
 
-      //! The reason behind the validation failure.
-      QString note;
+        // TODO QGIS 4.0 - fix this
+
+#ifdef SIP_RUN
+        SIP_PROPERTY( name = identifier, get = _identifier, set = _setIdentifier )
+#endif
+
+        /**
+         * Returns the optional identifier for the failed metadata item.
+         * For instance, in list type metadata elements this
+         * will be set to the list index of the failed metadata
+         * item.
+         */
+        QVariant _identifier() const { return mIdentifier; }
+
+        /**
+         * Sets the optional \a identifier for the failed metadata item.
+         * For instance, in list type metadata elements this
+         * will be set to the list index of the failed metadata
+         * item.
+         */
+        void _setIdentifier( QVariant identifier ) { mIdentifier = identifier; }
+
+        //! The reason behind the validation failure.
+        QString note;
+
+      private:
+
+        QVariant mIdentifier;
     };
 
     virtual ~QgsAbstractMetadataBaseValidator() = default;

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -797,9 +797,9 @@ bool QgsMetadataWidget::checkMetadata()
     for ( const QgsAbstractMetadataBaseValidator::ValidationResult &result : qgis::as_const( validationResults ) )
     {
       errors += QLatin1String( "<b>" ) % result.section;
-      if ( ! result.identifier.isNull() )
+      if ( ! result._identifier().isNull() )
       {
-        errors += QLatin1String( " " ) % QVariant( result.identifier.toInt() + 1 ).toString();
+        errors += QLatin1String( " " ) % QVariant( result._identifier().toInt() + 1 ).toString();
       }
       errors += QLatin1String( "</b>: " ) % result.note % QLatin1String( "<br />" );
     }


### PR DESCRIPTION
## Description

This PR fixes broken state of travis. I have *no* idea why the python conversion of the struct ValidationResult's QVariant identifier variable, but well, it fails now.

It also happens to fail on my machine locally.

@nyalldawson , since you pretty much walked me through this, care to review? :) 