### PR TITLE
Defer model validation

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -182,6 +182,19 @@ algorithm with the specified ``childId`` depends upon.
 .. seealso:: :py:func:`dependentChildAlgorithms`
 %End
 
+    bool validateChildAlgorithm( const QString &childId, QStringList &issues /Out/ ) const;
+%Docstring
+Validates the child algorithm with matching ID, returning ``True`` if
+all mandatory inputs to the algorithm have valid values.
+
+:param childId: ID for child to validate
+
+:return: - ``True`` if the child is valid
+         - issues: will be set to a list of issues encountered during the validation
+
+.. versionadded:: 3.14
+%End
+
     void addModelParameter( QgsProcessingParameterDefinition *definition /Transfer/, const QgsProcessingModelParameter &component );
 %Docstring
 Adds a new parameter to the model, with the specified ``definition`` and graphical ``component``.

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -73,6 +73,17 @@ Sets the model ``group``.
 .. seealso:: :py:func:`group`
 %End
 
+    bool validate( QStringList &issues /Out/ ) const;
+%Docstring
+Validates the model, returning ``True`` if all child algorithms in the model are valid.
+
+
+:return: - ``True`` if the child is valid
+         - issues: will be set to a list of issues encountered during the validation
+
+.. versionadded:: 3.14
+%End
+
     QMap<QString, QgsProcessingModelChildAlgorithm> childAlgorithms() const;
 %Docstring
 Returns the map of child algorithms contained in the model. The keys

--- a/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
+++ b/python/gui/auto_generated/processing/models/qgsmodelgraphicsscene.sip.in
@@ -134,6 +134,25 @@ Sets the results for child algorithms for the last model execution.
 Sets the inputs for child algorithms for the last model execution.
 %End
 
+    QgsMessageBar *messageBar() const;
+%Docstring
+Returns the message bar associated with the scene.
+
+.. seealso:: :py:func:`setMessageBar`
+%End
+
+    void setMessageBar( QgsMessageBar *bar );
+%Docstring
+Sets the message ``bar`` associated with the scene.
+
+.. seealso:: :py:func:`messageBar`
+%End
+
+    void showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level = Qgis::Warning );
+%Docstring
+Shows a warning message, allowing users to click a button to see the full details (``longMessage``).
+%End
+
   signals:
 
     void rebuildRequired();

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -317,9 +317,16 @@ class ModelerDialog(QgsModelDesignerDialog):
                 output_offset_y += 1.5 * alg.modelOutput(out).size().height()
 
             self.beginUndoCommand(self.tr('Add Algorithm'))
-            self.model().addChildAlgorithm(alg)
+            id = self.model().addChildAlgorithm(alg)
             self.repaintModel()
             self.endUndoCommand()
+
+            res, errors = self.model().validateChildAlgorithm(id)
+            if not res:
+                self.view().scene().showWarning(self.tr('Algorithm “{}” is invalid').format(alg.description()), self.tr('Algorithm is Invalid'), self.tr(
+                    "<p>The “{}” algorithm is invalid, because:</p><ul><li>{}</li></ul>").format(alg.description(), '</li><li>'.join(errors)), level=Qgis.Warning)
+            else:
+                self.view().scene().messageBar().clearWidgets()
 
     def getPositionForAlgorithmItem(self):
         MARGIN = 20

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -23,6 +23,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 
 import sys
 import os
+import re
 
 from qgis.PyQt.QtCore import (
     QCoreApplication,
@@ -114,11 +115,23 @@ class ModelerDialog(QgsModelDesignerDialog):
             self.endUndoCommand()
 
     def runModel(self):
-        if len(self.model().childAlgorithms()) == 0:
-            self.messageBar().pushMessage("", self.tr(
-                "Model doesn't contain any algorithm and/or parameter and can't be executed"), level=Qgis.Warning,
-                duration=5)
-            return
+        valid, errors = self.model().validate()
+        if not valid:
+            message_box = QMessageBox()
+            message_box.setWindowTitle(self.tr('Model is Invalid'))
+            message_box.setIcon(QMessageBox.Warning)
+            message_box.setText(self.tr('This model is not valid and contains one or more issues. Are you sure you want to run it in this state?'))
+            message_box.setStandardButtons(QMessageBox.Yes | QMessageBox.Cancel)
+            message_box.setDefaultButton(QMessageBox.Cancel)
+
+            error_string = ''
+            for e in errors:
+                e = re.sub(r'<[^>]*>', '', e)
+                error_string += '• {}\n'.format(e)
+
+            message_box.setDetailedText(error_string)
+            if message_box.exec_() == QMessageBox.Cancel:
+                return
 
         def on_finished(successful, results):
             self.setLastRunChildAlgorithmResults(dlg.results().get('CHILD_RESULTS', {}))

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -22,7 +22,8 @@ __date__ = 'August 2012'
 __copyright__ = '(C) 2012, Victor Olaya'
 
 from qgis.core import (QgsProcessingParameterDefinition,
-                       QgsProject)
+                       QgsProject,
+                       Qgis)
 from qgis.gui import (
     QgsProcessingParameterDefinitionDialog,
     QgsProcessingParameterWidgetContext,
@@ -142,6 +143,13 @@ class ModelerChildAlgorithmGraphicItem(QgsModelChildAlgorithmGraphicItem):
             self.model().setChildAlgorithm(alg)
             self.requestModelRepaint.emit()
             self.changed.emit()
+
+            res, errors = self.model().validateChildAlgorithm(alg.childId())
+            if not res:
+                self.scene().showWarning(self.tr('Algorithm “{}” is invalid').format(alg.description()), self.tr('Algorithm is Invalid'), self.tr(
+                    "<p>The “{}” algorithm is invalid, because:</p><ul><li>{}</li></ul>").format(alg.description(), '</li><li>'.join(errors)), level=Qgis.Warning)
+            else:
+                self.scene().messageBar().clearWidgets()
 
     def editComponent(self):
         self.edit()

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -460,26 +460,25 @@ class ModelerParametersPanelWidget(QgsPanelWidget):
                 else:
                     val = wrapper.parameterValue()
             except InvalidParameterValue:
-                self.bar.pushMessage(self.tr("Error"),
-                                     self.tr("Wrong or missing value for parameter '{}'").format(param.description()),
-                                     level=Qgis.Warning)
-                return None
+                val = None
 
             if isinstance(val, QgsProcessingModelChildParameterSource):
                 val = [val]
             elif not (isinstance(val, list) and all(
                     [isinstance(subval, QgsProcessingModelChildParameterSource) for subval in val])):
                 val = [QgsProcessingModelChildParameterSource.fromStaticValue(val)]
+
+            valid = True
             for subval in val:
                 if (isinstance(subval, QgsProcessingModelChildParameterSource) and
                         subval.source() == QgsProcessingModelChildParameterSource.StaticValue and
                         not param.checkValueIsAcceptable(subval.staticValue())) \
                         or (subval is None and not param.flags() & QgsProcessingParameterDefinition.FlagOptional):
-                    self.bar.pushMessage(self.tr("Error"), self.tr("Wrong or missing value for parameter '{}'").format(
-                        param.description()),
-                        level=Qgis.Warning)
-                    return None
-            alg.addParameterSources(param.name(), val)
+                    valid = False
+                    break
+
+            if valid:
+                alg.addParameterSources(param.name(), val)
 
         outputs = {}
         for output in self._alg.destinationParameterDefinitions():

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1130,6 +1130,30 @@ void QgsProcessingModelAlgorithm::setGroup( const QString &group )
   mModelGroup = group;
 }
 
+bool QgsProcessingModelAlgorithm::validate( QStringList &issues ) const
+{
+  issues.clear();
+  bool res = true;
+
+  if ( mChildAlgorithms.empty() )
+  {
+    res = false;
+    issues << QObject::tr( "Model does not contain any algorithms" );
+  }
+
+  for ( auto it = mChildAlgorithms.constBegin(); it != mChildAlgorithms.constEnd(); ++it )
+  {
+    QStringList childIssues;
+    res = validateChildAlgorithm( it->childId(), childIssues ) && res;
+
+    for ( const QString &issue : qgis::as_const( childIssues ) )
+    {
+      issues << QStringLiteral( "<b>%1</b>: %2" ).arg( it->description(), issue );
+    }
+  }
+  return res;
+}
+
 QMap<QString, QgsProcessingModelChildAlgorithm> QgsProcessingModelAlgorithm::childAlgorithms() const
 {
   return mChildAlgorithms;

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -1632,6 +1632,87 @@ QSet< QString > QgsProcessingModelAlgorithm::dependsOnChildAlgorithms( const QSt
   return algs;
 }
 
+bool QgsProcessingModelAlgorithm::validateChildAlgorithm( const QString &childId, QStringList &issues ) const
+{
+  issues.clear();
+  QMap< QString, QgsProcessingModelChildAlgorithm >::const_iterator childIt = mChildAlgorithms.constFind( childId );
+  if ( childIt != mChildAlgorithms.constEnd() )
+  {
+    if ( !childIt->algorithm() )
+    {
+      issues << QObject::tr( "Algorithm is not available: <i>%1</i>" ).arg( childIt->algorithmId() );
+      return false;
+    }
+    bool res = true;
+
+    // loop through child algorithm parameters and check that they are all valid
+    const QgsProcessingParameterDefinitions defs = childIt->algorithm()->parameterDefinitions();
+    for ( const QgsProcessingParameterDefinition *def : defs )
+    {
+      if ( childIt->parameterSources().contains( def->name() ) )
+      {
+        // is the value acceptable?
+        const QList< QgsProcessingModelChildParameterSource > sources = childIt->parameterSources().value( def->name() );
+        for ( const QgsProcessingModelChildParameterSource &source : sources )
+        {
+          switch ( source.source() )
+          {
+            case QgsProcessingModelChildParameterSource::StaticValue:
+              if ( !def->checkValueIsAcceptable( source.staticValue() ) )
+              {
+                res = false;
+                issues <<  QObject::tr( "Value for <i>%1</i> is not acceptable for this parameter" ).arg( def->name() );
+              }
+              break;
+
+            case QgsProcessingModelChildParameterSource::ModelParameter:
+              if ( !parameterComponents().contains( source.parameterName() ) )
+              {
+                res = false;
+                issues <<  QObject::tr( "Model input <i>%1</i> used for parameter <i>%2</i> does not exist" ).arg( source.parameterName(), def->name() );
+              }
+              break;
+
+            case QgsProcessingModelChildParameterSource::ChildOutput:
+              if ( !childAlgorithms().contains( source.outputChildId() ) )
+              {
+                res = false;
+                issues <<  QObject::tr( "Child algorithm <i>%1</i> used for parameter <i>%2</i> does not exist" ).arg( source.outputChildId(), def->name() );
+              }
+              break;
+
+            case QgsProcessingModelChildParameterSource::Expression:
+            case QgsProcessingModelChildParameterSource::ExpressionText:
+            case QgsProcessingModelChildParameterSource::ModelOutput:
+              break;
+          }
+        }
+      }
+      else
+      {
+        // not specified. Is it optional?
+
+        // ignore destination parameters -- they shouldn't ever be mandatory
+        if ( def->isDestination() )
+          continue;
+
+        if ( !( def->flags() & QgsProcessingParameterDefinition::FlagOptional ) )
+        {
+          res = false;
+          issues <<  QObject::tr( "Parameter <i>%1</i> is mandatory" ).arg( def->name() );
+        }
+      }
+    }
+
+    return res;
+  }
+  else
+  {
+    issues << QObject::tr( "Invalid child ID: <i>%1</i>" ).arg( childId );
+    return false;
+  }
+}
+
 bool QgsProcessingModelAlgorithm::canExecute( QString *errorMessage ) const
 {
   reattachAlgorithms();

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -73,6 +73,15 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     void setGroup( const QString &group );
 
     /**
+     * Validates the model, returning TRUE if all child algorithms in the model are valid.
+     *
+     * \param issues will be set to a list of issues encountered during the validation
+     * \returns TRUE if the child is valid
+     * \since QGIS 3.14
+     */
+    bool validate( QStringList &issues SIP_OUT ) const;
+
+    /**
      * Returns the map of child algorithms contained in the model. The keys
      * are the child algorithm ids (see QgsProcessingModelAlgorithm::ChildAlgorithm::childId()).
      * \see childAlgorithm()

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -161,6 +161,17 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QSet< QString > dependsOnChildAlgorithms( const QString &childId ) const;
 
     /**
+     * Validates the child algorithm with matching ID, returning TRUE if
+     * all mandatory inputs to the algorithm have valid values.
+     *
+     * \param childId ID for child to validate
+     * \param issues will be set to a list of issues encountered during the validation
+     * \returns TRUE if the child is valid
+     * \since QGIS 3.14
+     */
+    bool validateChildAlgorithm( const QString &childId, QStringList &issues SIP_OUT ) const;
+
+    /**
      * Adds a new parameter to the model, with the specified \a definition and graphical \a component.
      * Ownership of \a definition is transferred to the model.
      * \see updateModelParameter()

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.cpp
@@ -861,6 +861,9 @@ QgsModelChildAlgorithmGraphicItem::QgsModelChildAlgorithmGraphicItem( QgsProcess
   }
 
   setLabel( child->description() );
+
+  QStringList issues;
+  mIsValid = model->validateChildAlgorithm( child->childId(), issues );
 }
 
 void QgsModelChildAlgorithmGraphicItem::contextMenuEvent( QGraphicsSceneContextMenuEvent *event )
@@ -893,7 +896,13 @@ void QgsModelChildAlgorithmGraphicItem::contextMenuEvent( QGraphicsSceneContextM
 
 QColor QgsModelChildAlgorithmGraphicItem::fillColor( QgsModelComponentGraphicItem::State state ) const
 {
-  QColor c( 255, 255, 255 );
+  QColor c;
+
+  if ( mIsValid )
+    c = QColor( 255, 255, 255 );
+  else
+    c = QColor( 208, 0, 0 );
+
   switch ( state )
   {
     case Selected:
@@ -914,17 +923,17 @@ QColor QgsModelChildAlgorithmGraphicItem::strokeColor( QgsModelComponentGraphicI
   switch ( state )
   {
     case Selected:
-      return QColor( 50, 50, 50 );
+      return mIsValid ? QColor( 50, 50, 50 ) : QColor( 80, 0, 0 );
     case Hover:
     case Normal:
-      return Qt::gray;
+      return mIsValid ? Qt::gray : QColor( 134, 0, 0 );
   }
   return QColor();
 }
 
 QColor QgsModelChildAlgorithmGraphicItem::textColor( QgsModelComponentGraphicItem::State ) const
 {
-  return dynamic_cast< const QgsProcessingModelChildAlgorithm * >( component() )->isActive() ? Qt::black : Qt::gray;
+  return mIsValid ? ( dynamic_cast< const QgsProcessingModelChildAlgorithm * >( component() )->isActive() ? Qt::black : Qt::gray ) : QColor( 255, 255, 255 );
 }
 
 QPixmap QgsModelChildAlgorithmGraphicItem::iconPixmap() const

--- a/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
+++ b/src/gui/processing/models/qgsmodelcomponentgraphicitem.h
@@ -493,6 +493,7 @@ class GUI_EXPORT QgsModelChildAlgorithmGraphicItem : public QgsModelComponentGra
     QPixmap mPixmap;
     QVariantMap mResults;
     QVariantMap mInputs;
+    bool mIsValid = true;
 };
 
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -418,7 +418,9 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
   mScene->setParent( this );
   mScene->setChildAlgorithmResults( mChildResults );
   mScene->setModel( mModel.get() );
+  mScene->setMessageBar( mMessageBar );
 
+  const QPointF center = mView->mapToScene( mView->viewport()->rect().center() );
   mView->setModelScene( mScene );
 
   mSelectTool->resetCache();
@@ -433,6 +435,8 @@ void QgsModelDesignerDialog::setModelScene( QgsModelGraphicsScene *scene )
   } );
   connect( mScene, &QgsModelGraphicsScene::componentAboutToChange, this, [ = ]( const QString & description, int id ) { beginUndoCommand( description, id ); } );
   connect( mScene, &QgsModelGraphicsScene::componentChanged, this, [ = ] { endUndoCommand(); } );
+
+  mView->centerOn( center );
 
   if ( oldScene )
     oldScene->deleteLater();

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -143,6 +143,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void updateWindowTitle();
     void deleteSelected();
     void populateZoomToMenu();
+    void validate();
 
   private:
 

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -451,13 +451,14 @@ void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QStr
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, detailsButton, [ = ]
   {
-    QgsMessageViewer dialog( mMessageBar, QgsGuiUtils::ModalDialogFlags, false );
+    QgsMessageViewer dialog( detailsButton, QgsGuiUtils::ModalDialogFlags, false );
     dialog.setTitle( title );
     dialog.setMessage( longMessage, QgsMessageOutput::MessageHtml );
     dialog.showMessage();
   } );
   messageWidget->layout()->addWidget( detailsButton );
-  mMessageBar->pushWidget( messageWidget, level, 0 );
+  mMessageBar->clearWidgets();
+  mMessageBar->pushWidget( messageWidget, level, 5 );
 }
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -19,7 +19,11 @@
 #include "qgsmodelcomponentgraphicitem.h"
 #include "qgsmodelarrowitem.h"
 #include "qgsprocessingmodelgroupbox.h"
+#include "qgsmessagebar.h"
+#include "qgsmessagebaritem.h"
+#include "qgsmessageviewer.h"
 #include <QGraphicsSceneMouseEvent>
+#include <QPushButton>
 
 ///@cond NOT_STABLE
 
@@ -429,6 +433,31 @@ void QgsModelGraphicsScene::addCommentItemForComponent( QgsProcessingModelAlgori
   std::unique_ptr< QgsModelArrowItem > arrow = qgis::make_unique< QgsModelArrowItem >( parentItem, commentItem );
   arrow->setPenStyle( Qt::DotLine );
   addItem( arrow.release() );
+}
+
+QgsMessageBar *QgsModelGraphicsScene::messageBar() const
+{
+  return mMessageBar;
+}
+
+void QgsModelGraphicsScene::setMessageBar( QgsMessageBar *messageBar )
+{
+  mMessageBar = messageBar;
+}
+
+void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level )
+{
+  QgsMessageBarItem *messageWidget = mMessageBar->createMessage( QString(), shortMessage );
+  QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
+  connect( detailsButton, &QPushButton::clicked, detailsButton, [ = ]
+  {
+    QgsMessageViewer dialog( mMessageBar, QgsGuiUtils::ModalDialogFlags, false );
+    dialog.setTitle( title );
+    dialog.setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dialog.showMessage();
+  } );
+  messageWidget->layout()->addWidget( detailsButton );
+  mMessageBar->pushWidget( messageWidget, level, 0 );
 }
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodelgraphicsscene.cpp
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.cpp
@@ -451,14 +451,14 @@ void QgsModelGraphicsScene::showWarning( const QString &shortMessage, const QStr
   QPushButton *detailsButton = new QPushButton( tr( "Details" ) );
   connect( detailsButton, &QPushButton::clicked, detailsButton, [ = ]
   {
-    QgsMessageViewer dialog( detailsButton, QgsGuiUtils::ModalDialogFlags, false );
-    dialog.setTitle( title );
-    dialog.setMessage( longMessage, QgsMessageOutput::MessageHtml );
-    dialog.showMessage();
+    QgsMessageViewer *dialog = new QgsMessageViewer( detailsButton );
+    dialog->setTitle( title );
+    dialog->setMessage( longMessage, QgsMessageOutput::MessageHtml );
+    dialog->showMessage();
   } );
   messageWidget->layout()->addWidget( detailsButton );
   mMessageBar->clearWidgets();
-  mMessageBar->pushWidget( messageWidget, level, 5 );
+  mMessageBar->pushWidget( messageWidget, level, 0 );
 }
 
 ///@endcond

--- a/src/gui/processing/models/qgsmodelgraphicsscene.h
+++ b/src/gui/processing/models/qgsmodelgraphicsscene.h
@@ -30,6 +30,7 @@ class QgsProcessingModelComponent;
 class QgsProcessingModelComment;
 class QgsModelChildAlgorithmGraphicItem;
 class QgsProcessingModelGroupBox;
+class QgsMessageBar;
 
 ///@cond NOT_STABLE
 
@@ -146,6 +147,25 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
      */
     void setChildAlgorithmInputs( const QVariantMap &inputs );
 
+    /**
+     * Returns the message bar associated with the scene.
+     *
+     * \see setMessageBar()
+     */
+    QgsMessageBar *messageBar() const;
+
+    /**
+     * Sets the message \a bar associated with the scene.
+     *
+     * \see messageBar()
+     */
+    void setMessageBar( QgsMessageBar *bar );
+
+    /**
+     * Shows a warning message, allowing users to click a button to see the full details (\a longMessage).
+     */
+    void showWarning( const QString &shortMessage, const QString &title, const QString &longMessage, Qgis::MessageLevel level = Qgis::Warning );
+
   signals:
 
     /**
@@ -222,6 +242,8 @@ class GUI_EXPORT QgsModelGraphicsScene : public QGraphicsScene
     QMap< QString, QgsModelComponentGraphicItem * > mGroupBoxItems;
     QVariantMap mChildResults;
     QVariantMap mChildInputs;
+
+    QgsMessageBar *mMessageBar = nullptr;
 
 };
 

--- a/src/gui/qgsmessageviewer.cpp
+++ b/src/gui/qgsmessageviewer.cpp
@@ -66,9 +66,8 @@ void QgsMessageViewer::showMessage( bool blocking )
 {
   if ( blocking )
   {
-    QApplication::setOverrideCursor( Qt::ArrowCursor );
+    QgsTemporaryCursorRestoreOverride override;
     exec();
-    QApplication::restoreOverrideCursor();
   }
   else
   {

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -58,6 +58,7 @@
      <addaction name="separator"/>
      <addaction name="mActionExportPython"/>
     </widget>
+    <addaction name="mActionValidate"/>
     <addaction name="mActionRun"/>
     <addaction name="separator"/>
     <addaction name="mActionOpen"/>
@@ -645,6 +646,15 @@
   <action name="mActionAddGroupBox">
    <property name="text">
     <string>Add Group Box</string>
+   </property>
+  </action>
+  <action name="mActionValidate">
+   <property name="icon">
+    <iconset resource="../../../images/images.qrc">
+     <normaloff>:/images/themes/default/mIconSuccess.svg</normaloff>:/images/themes/default/mIconSuccess.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Validate Model</string>
    </property>
   </action>
  </widget>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -9899,18 +9899,28 @@ void TestQgsProcessing::modelAcceptableValues()
 void TestQgsProcessing::modelValidate()
 {
   QgsProcessingModelAlgorithm m;
+  QStringList errors;
+  QVERIFY( !m.validate( errors ) );
+  QCOMPARE( errors.size(), 1 );
+  QCOMPARE( errors.at( 0 ), QStringLiteral( "Model does not contain any algorithms" ) );
+
   QgsProcessingModelParameter stringParam1( "string" );
   m.addModelParameter( new QgsProcessingParameterString( "string" ), stringParam1 );
   QgsProcessingModelChildAlgorithm alg2c1;
   alg2c1.setChildId( "cx1" );
   alg2c1.setAlgorithmId( "native:centroids" );
+  alg2c1.setDescription( QStringLiteral( "centroids" ) );
   m.addChildAlgorithm( alg2c1 );
 
-  QStringList errors;
   QVERIFY( !m.validateChildAlgorithm( QStringLiteral( "cx1" ), errors ) );
   QCOMPARE( errors.size(), 2 );
   QCOMPARE( errors.at( 0 ), QStringLiteral( "Parameter <i>INPUT</i> is mandatory" ) );
   QCOMPARE( errors.at( 1 ), QStringLiteral( "Parameter <i>ALL_PARTS</i> is mandatory" ) );
+
+  QVERIFY( !m.validate( errors ) );
+  QCOMPARE( errors.size(), 2 );
+  QCOMPARE( errors.at( 0 ), QStringLiteral( "<b>centroids</b>: Parameter <i>INPUT</i> is mandatory" ) );
+  QCOMPARE( errors.at( 1 ), QStringLiteral( "<b>centroids</b>: Parameter <i>ALL_PARTS</i> is mandatory" ) );
 
   QgsProcessingModelChildParameterSource badSource;
   badSource.setSource( QgsProcessingModelChildParameterSource::StaticValue );
@@ -9951,6 +9961,9 @@ void TestQgsProcessing::modelValidate()
   m.childAlgorithm( QStringLiteral( "cx1" ) ).addParameterSources( QStringLiteral( "INPUT" ), QList< QgsProcessingModelChildParameterSource >() << goodSource );
 
   QVERIFY( m.validateChildAlgorithm( QStringLiteral( "cx1" ), errors ) );
+  QCOMPARE( errors.size(), 0 );
+
+  QVERIFY( m.validate( errors ) );
   QCOMPARE( errors.size(), 0 );
 }
 


### PR DESCRIPTION
Instead of forcing all child algorithms to be immediately valid and have all parameters correctly filled, this PR defers model validation until run time or when a new "Validate model" action is triggered.

A common frustration with the QGIS model designer is that it constantly forces models to be valid, even work-in-progress models. This means it’s impossible to add a component to a model and only partially populate its settings — you have to fill in everything upfront. If you realise mid way through this that you need to make a change somewhere else in your model, it’s impossible to do without canceling and losing all the settings you’ve already configured.

This change sees the model validation deferred until run time. Models can be temporarily invalid (e.g. having algorithm components which are only partially configured). The missing required values can now be filled at a later stage, without losing any existing settings. If a non-valid model is run, the user gets a descriptive warning informing them of the changes they need to make in order to finish configuration of the model.