### PR TITLE
Allow reordering model inputs

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -300,6 +300,27 @@ this name a new component will be added to the model and returned.
 .. seealso:: :py:func:`setParameterComponent`
 %End
 
+    QList< QgsProcessingModelParameter > orderedParameters() const;
+%Docstring
+Returns an ordered list of parameters for the model.
+
+.. seealso:: :py:func:`setParameterOrder`
+
+.. versionadded:: 3.14
+%End
+
+    void setParameterOrder( const QStringList &order );
+%Docstring
+Sets the ``order`` for showing parameters for the model.
+
+The ``order`` list should consist of parameter names corresponding to existing
+model parameterComponents().
+
+.. seealso:: :py:func:`orderedParameters`
+
+.. versionadded:: 3.14
+%End
+
     void updateDestinationParameters();
 %Docstring
 Updates the model's parameter definitions to include all relevant destination

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -256,6 +256,25 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QgsProcessingModelParameter &parameterComponent( const QString &name );
 
     /**
+     * Returns an ordered list of parameters for the model.
+     *
+     * \see setParameterOrder()
+     * \since QGIS 3.14
+     */
+    QList< QgsProcessingModelParameter > orderedParameters() const;
+
+    /**
+     * Sets the \a order for showing parameters for the model.
+     *
+     * The \a order list should consist of parameter names corresponding to existing
+     * model parameterComponents().
+     *
+     * \see orderedParameters()
+     * \since QGIS 3.14
+     */
+    void setParameterOrder( const QStringList &order );
+
+    /**
      * Updates the model's parameter definitions to include all relevant destination
      * parameters as required by child algorithm ModelOutputs.
      * Must be called whenever child algorithm ModelOutputs are altered.
@@ -501,6 +520,8 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     QVariantMap mDesignerParameterValues;
 
     QMap< QString, QgsProcessingModelGroupBox > mGroupBoxes;
+
+    QStringList mParameterOrder;
 
     void dependsOnChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;
     void dependentChildAlgorithmsRecursive( const QString &childId, QSet<QString> &depends ) const;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -293,6 +293,7 @@ SET(QGIS_GUI_SRCS
   processing/models/qgsmodelgraphicsscene.cpp
   processing/models/qgsmodelgraphicsview.cpp
   processing/models/qgsmodelgroupboxdefinitionwidget.cpp
+  processing/models/qgsmodelinputreorderwidget.cpp
   processing/models/qgsmodelsnapper.cpp
   processing/models/qgsmodelundocommand.cpp
   processing/models/qgsmodelviewmouseevent.cpp
@@ -999,6 +1000,7 @@ SET(QGIS_GUI_HDRS
   processing/models/qgsmodelgraphicsscene.h
   processing/models/qgsmodelgraphicsview.h
   processing/models/qgsmodelgroupboxdefinitionwidget.h
+  processing/models/qgsmodelinputreorderwidget.h
   processing/models/qgsmodelsnapper.h
   processing/models/qgsmodelundocommand.h
   processing/models/qgsmodelviewmouseevent.h

--- a/src/gui/processing/models/qgsmodeldesignerdialog.cpp
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.cpp
@@ -28,6 +28,7 @@
 #include "qgsmodelgraphicsscene.h"
 #include "qgsmodelcomponentgraphicitem.h"
 #include "processing/models/qgsprocessingmodelgroupbox.h"
+#include "processing/models/qgsmodelinputreorderwidget.h"
 #include "qgsmessageviewer.h"
 #include "qgsmessagebaritem.h"
 
@@ -138,6 +139,8 @@ QgsModelDesignerDialog::QgsModelDesignerDialog( QWidget *parent, Qt::WindowFlags
   connect( mActionDeleteComponents, &QAction::triggered, this, &QgsModelDesignerDialog::deleteSelected );
   connect( mActionSnapSelected, &QAction::triggered, mView, &QgsModelGraphicsView::snapSelected );
   connect( mActionValidate, &QAction::triggered, this, &QgsModelDesignerDialog::validate );
+  connect( mActionReorderInputs, &QAction::triggered, this, &QgsModelDesignerDialog::reorderInputs );
+  connect( mReorderInputsButton, &QPushButton::clicked, this, &QgsModelDesignerDialog::reorderInputs );
 
   mActionSnappingEnabled->setChecked( settings.value( QStringLiteral( "/Processing/Modeler/enableSnapToGrid" ), false ).toBool() );
   connect( mActionSnappingEnabled, &QAction::toggled, this, [ = ]( bool enabled )
@@ -810,6 +813,19 @@ void QgsModelDesignerDialog::validate()
     messageWidget->layout()->addWidget( detailsButton );
     mMessageBar->clearWidgets();
     mMessageBar->pushWidget( messageWidget, Qgis::Warning, 0 );
+  }
+}
+
+void QgsModelDesignerDialog::reorderInputs()
+{
+  QgsModelInputReorderDialog dlg( this );
+  dlg.setInputs( mModel->orderedParameters() );
+  if ( dlg.exec() )
+  {
+    const QStringList inputOrder = dlg.inputOrder();
+    beginUndoCommand( tr( "Reorder Inputs" ) );
+    mModel->setParameterOrder( inputOrder );
+    endUndoCommand();
   }
 }
 

--- a/src/gui/processing/models/qgsmodeldesignerdialog.h
+++ b/src/gui/processing/models/qgsmodeldesignerdialog.h
@@ -144,6 +144,7 @@ class GUI_EXPORT QgsModelDesignerDialog : public QMainWindow, public Ui::QgsMode
     void deleteSelected();
     void populateZoomToMenu();
     void validate();
+    void reorderInputs();
 
   private:
 

--- a/src/gui/processing/models/qgsmodelinputreorderwidget.cpp
+++ b/src/gui/processing/models/qgsmodelinputreorderwidget.cpp
@@ -1,0 +1,101 @@
+/***************************************************************************
+                             qgsmodelinputreorderwidget.cpp
+                             ------------------------------------
+    Date                 : April 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmodelinputreorderwidget.h"
+#include "qgsgui.h"
+#include <QDialogButtonBox>
+#include <QStringListModel>
+///@cond NOT_STABLE
+
+QgsModelInputReorderWidget::QgsModelInputReorderWidget( QWidget *parent )
+  : QWidget( parent )
+{
+  setupUi( this );
+
+  mModel = new QStringListModel( this );
+  mInputsList->setModel( mModel );
+
+  connect( mButtonUp, &QPushButton::clicked, this, [ = ]
+  {
+    int currentRow = mInputsList->currentIndex().row() - 1;
+    if ( currentRow == -1 )
+      return;
+
+    mModel->moveRow( QModelIndex(), currentRow, QModelIndex(), currentRow + 2 );
+  } );
+
+  connect( mButtonDown, &QPushButton::clicked, this, [ = ]
+  {
+    int currentRow = mInputsList->currentIndex().row();
+    if ( currentRow == mModel->rowCount() - 1 )
+      return;
+
+    mModel->moveRow( QModelIndex(), currentRow, QModelIndex(), currentRow + 2 );
+  } );
+
+}
+
+void QgsModelInputReorderWidget::setInputs( const QList<QgsProcessingModelParameter> &inputs )
+{
+  mParameters = inputs;
+  QStringList res;
+  for ( const QgsProcessingModelParameter &param : inputs )
+    res << param.description();
+  mModel->setStringList( res );
+}
+
+QStringList QgsModelInputReorderWidget::inputOrder() const
+{
+  const QStringList order = mModel->stringList();
+  QStringList res;
+  for ( const QString &description : order )
+  {
+    for ( auto it = mParameters.constBegin(); it != mParameters.constEnd(); ++it )
+    {
+      if ( it->description() == description )
+      {
+        res << it->parameterName();
+      }
+    }
+  }
+  return res;
+}
+
+
+QgsModelInputReorderDialog::QgsModelInputReorderDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setWindowTitle( tr( "Reorder Model Inputs" ) );
+  mWidget = new QgsModelInputReorderWidget();
+  QVBoxLayout *vl = new QVBoxLayout();
+  vl->addWidget( mWidget, 1 );
+  QDialogButtonBox *buttonBox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel );
+  connect( buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+  vl->addWidget( buttonBox );
+  setLayout( vl );
+}
+
+void QgsModelInputReorderDialog::setInputs( const QList<QgsProcessingModelParameter> &inputs )
+{
+  mWidget->setInputs( inputs );
+}
+
+QStringList QgsModelInputReorderDialog::inputOrder() const
+{
+  return mWidget->inputOrder();
+}
+
+///@endcond

--- a/src/gui/processing/models/qgsmodelinputreorderwidget.h
+++ b/src/gui/processing/models/qgsmodelinputreorderwidget.h
@@ -1,0 +1,98 @@
+/***************************************************************************
+                             qgsmodelinputreorderwidget.h
+                             ----------------------------------
+    Date                 : April 2020
+    Copyright            : (C) 2020 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMODELINPUTREORDERWIDGET_H
+#define QGSMODELINPUTREORDERWIDGET_H
+
+#define SIP_NO_FILE
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "ui_qgsmodelinputreorderwidgetbase.h"
+#include "processing/models/qgsprocessingmodelparameter.h"
+#include <QDialog>
+
+class QStringListModel;
+
+///@cond PRIVATE
+
+/**
+ * A widget for reordering inputs for Processing models.
+ * \ingroup gui
+ * \note Not stable API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelInputReorderWidget : public QWidget, private Ui::QgsModelInputReorderWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsModelInputReorderWidget.
+     */
+    QgsModelInputReorderWidget( QWidget *parent = nullptr );
+
+    /**
+     * Sets the list of \a inputs to show, in their initial order.
+     */
+    void setInputs( const QList< QgsProcessingModelParameter > &inputs );
+
+    /**
+     * Returns the ordered list of inputs (by name).
+     */
+    QStringList inputOrder() const;
+
+  private:
+
+    QList< QgsProcessingModelParameter > mParameters;
+    QStringListModel *mModel = nullptr;
+};
+
+
+/**
+ * A dialog for reordering inputs for Processing models.
+ * \ingroup gui
+ * \note Not stable API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsModelInputReorderDialog : public QDialog
+{
+
+  public:
+
+    /**
+     * Constructor for QgsModelInputReorderDialog.
+     */
+    QgsModelInputReorderDialog( QWidget *parent = nullptr );
+
+    /**
+     * Sets the list of \a inputs to show, in their initial order.
+     */
+    void setInputs( const QList< QgsProcessingModelParameter > &inputs );
+
+    /**
+     * Returns the ordered list of inputs (by name).
+     */
+    QStringList inputOrder() const;
+
+  private:
+
+    QgsModelInputReorderWidget *mWidget = nullptr;
+};
+
+///@endcond
+
+#endif // QGSMODELINPUTREORDERWIDGET_H

--- a/src/ui/processing/qgsmodeldesignerdialogbase.ui
+++ b/src/ui/processing/qgsmodeldesignerdialogbase.ui
@@ -60,6 +60,7 @@
     </widget>
     <addaction name="mActionValidate"/>
     <addaction name="mActionRun"/>
+    <addaction name="mActionReorderInputs"/>
     <addaction name="separator"/>
     <addaction name="mActionOpen"/>
     <addaction name="mActionSave"/>
@@ -165,7 +166,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>98</height>
+          <height>90</height>
          </rect>
         </property>
         <layout class="QGridLayout" name="gridLayout">
@@ -255,7 +256,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>152</height>
+          <height>173</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -279,6 +280,39 @@
             </property>
            </column>
           </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <property name="leftMargin">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
+           <item>
+            <widget class="QPushButton" name="mReorderInputsButton">
+             <property name="text">
+              <string>Reorder Model Inputs…</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>
@@ -325,7 +359,7 @@
           <x>0</x>
           <y>0</y>
           <width>256</width>
-          <height>180</height>
+          <height>167</height>
          </rect>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -655,6 +689,11 @@
    </property>
    <property name="text">
     <string>Validate Model</string>
+   </property>
+  </action>
+  <action name="mActionReorderInputs">
+   <property name="text">
+    <string>Reorder Model Inputs…</string>
    </property>
   </action>
  </widget>

--- a/src/ui/processing/qgsmodelinputreorderwidgetbase.ui
+++ b/src/ui/processing/qgsmodelinputreorderwidgetbase.ui
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsModelInputReorderWidgetBase</class>
+ <widget class="QWidget" name="QgsModelInputReorderWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>356</width>
+    <height>253</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QListView" name="mInputsList">
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="pushBtnBox_2">
+       <property name="spacing">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="mButtonUp">
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Move up</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../images/images.qrc">
+           <normaloff>:/images/themes/default/mActionArrowUp.svg</normaloff>:/images/themes/default/mActionArrowUp.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="mButtonDown">
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Move down</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../images/images.qrc">
+           <normaloff>:/images/themes/default/mActionArrowDown.svg</normaloff>:/images/themes/default/mActionArrowDown.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -589,6 +589,7 @@ class TestQgsProcessing: public QObject
     void modelVectorOutputIsCompatibleType();
     void modelAcceptableValues();
     void modelValidate();
+    void modelInputs();
     void tempUtils();
     void convertCompatible();
     void create();
@@ -9965,6 +9966,35 @@ void TestQgsProcessing::modelValidate()
 
   QVERIFY( m.validate( errors ) );
   QCOMPARE( errors.size(), 0 );
+}
+
+void TestQgsProcessing::modelInputs()
+{
+  QgsProcessingModelAlgorithm m;
+
+  // add a bunch of inputs
+  QgsProcessingModelParameter stringParam1( "string" );
+  m.addModelParameter( new QgsProcessingParameterString( "string" ), stringParam1 );
+
+  QgsProcessingModelParameter stringParam2( "a string" );
+  m.addModelParameter( new QgsProcessingParameterString( "a string" ), stringParam2 );
+
+  QgsProcessingModelParameter stringParam3( "cc string" );
+  m.addModelParameter( new QgsProcessingParameterString( "cc string" ), stringParam3 );
+
+  // set specific input order for parameters
+  m.setParameterOrder( QStringList() << "cc string" << "a string" );
+
+  QgsProcessingModelAlgorithm m2;
+  m2.loadVariant( m.toVariant() );
+  QCOMPARE( m2.orderedParameters().count(), 3 );
+  QCOMPARE( m2.orderedParameters().at( 0 ).parameterName(), QStringLiteral( "cc string" ) );
+  QCOMPARE( m2.orderedParameters().at( 1 ).parameterName(), QStringLiteral( "a string" ) );
+  QCOMPARE( m2.orderedParameters().at( 2 ).parameterName(), QStringLiteral( "string" ) );
+
+  QCOMPARE( m2.parameterDefinitions().at( 0 )->name(), QStringLiteral( "cc string" ) );
+  QCOMPARE( m2.parameterDefinitions().at( 1 )->name(), QStringLiteral( "a string" ) );
+  QCOMPARE( m2.parameterDefinitions().at( 2 )->name(), QStringLiteral( "string" ) );
 }
 
 void TestQgsProcessing::tempUtils()


### PR DESCRIPTION
Instead of forcing a quasi-random ordering of inputs for models, this commit exposes a new "Reorder Model Inputs" option in the model designer which allows users control over the exact order of inputs to show users for their model.

No more illogical ordering like showing a field choice before the layer choice it's based on!

Sponsored by NaturalGIS
