### PR TITLE
Fix csv import sort order

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -179,6 +179,7 @@ void QgsValueMapConfigDlg::updateMap( const QList<QPair<QString, QVariant>> &lis
       setRow( row, pair.first, QString() );
     else
       setRow( row, pair.first, pair.second.toString() );
+    ++row;
   }
 }
 

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -321,8 +321,6 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
 
   QList<QPair<QString, QVariant>> map;
 
-  s.readLine();
-
   while ( !s.atEnd() )
   {
     QString l = s.readLine().trimmed();

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -295,7 +295,7 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
 {
   QgsSettings settings;
 
-  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Select a File" ), QDir::homePath() );
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Value Map from File" ), QDir::homePath() );
   if ( fileName.isNull() )
     return;
 


### PR DESCRIPTION
Fixes

- do not inverse the order of csv values in the value map widget configuration
- do not skip first line of the first line in csv imports
- improves the title of the csv import dialog

Fixes https://github.com/qgis/QGIS/issues/32250
