### PR TITLE
Scale dependent snapping bugfix

### DIFF
--- a/python/core/auto_generated/qgssnappingconfig.sip.in
+++ b/python/core/auto_generated/qgssnappingconfig.sip.in
@@ -285,7 +285,7 @@ Sets the tolerance
 
     double minimumScale() const;
 %Docstring
-Returns the min scale
+Returns the min scale (i.e. most \"zoomed out\" scale)
 
 .. versionadded:: 3.14
 %End
@@ -299,7 +299,7 @@ Sets the min scale on which snapping is enabled, 0.0 disable scale limit
 
     double maximumScale() const;
 %Docstring
-Returns the max scale
+Returns the max scale (i.e. most \"zoomed in\" scale)
 
 .. versionadded:: 3.14
 %End

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -104,14 +104,14 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
   if ( index.column() == QgsSnappingLayerTreeModel::MinScaleColumn )
   {
     QgsScaleWidget *minLimitSp = new QgsScaleWidget( parent );
-    minLimitSp->setToolTip( tr( "Min Scale" ) );
+    minLimitSp->setToolTip( tr( "Minimum scale from which snapping is enabled (i.e. most \"zoomed out\" scale)" ) );
     return minLimitSp;
   }
 
   if ( index.column() == QgsSnappingLayerTreeModel::MaxScaleColumn )
   {
     QgsScaleWidget *maxLimitSp = new QgsScaleWidget( parent );
-    maxLimitSp->setToolTip( tr( "Max Scale" ) );
+    maxLimitSp->setToolTip( tr( "Maximum scale up to which snapping is enabled (i.e. most \"zoomed in\" scale)" ) );
     return maxLimitSp;
   }
 

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -238,7 +238,6 @@ QgsSnappingLayerTreeModel::QgsSnappingLayerTreeModel( QgsProject *project, QgsMa
   , mProject( project )
   , mCanvas( canvas )
   , mIndividualLayerSettings( project->snappingConfig().individualLayerSettings() )
-  , mEnableMinMaxColumn( project->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::PerLayer )
 
 {
   connect( project, &QgsProject::snappingConfigChanged, this, &QgsSnappingLayerTreeModel::onSnappingSettingsChanged );
@@ -281,7 +280,7 @@ Qt::ItemFlags QgsSnappingLayerTreeModel::flags( const QModelIndex &idx ) const
       }
       else if ( idx.column() == MaxScaleColumn || idx.column() == MinScaleColumn )
       {
-        if ( mEnableMinMaxColumn )
+        if ( mProject->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::PerLayer )
         {
           return Qt::ItemIsEnabled | Qt::ItemIsEditable;
         }
@@ -345,7 +344,6 @@ void QgsSnappingLayerTreeModel::setFilterText( const QString &filterText )
 void QgsSnappingLayerTreeModel::onSnappingSettingsChanged()
 {
   const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> oldSettings = mIndividualLayerSettings;
-  bool wasMinMaxEnabled = mEnableMinMaxColumn;
 
   for ( auto it = oldSettings.constBegin(); it != oldSettings.constEnd(); ++it )
   {
@@ -369,18 +367,17 @@ void QgsSnappingLayerTreeModel::onSnappingSettingsChanged()
     }
   }
 
-  mEnableMinMaxColumn = ( mProject->snappingConfig().scaleDependencyMode() == QgsSnappingConfig::PerLayer );
-  hasRowchanged( mLayerTreeModel->rootGroup(), oldSettings, wasMinMaxEnabled != mEnableMinMaxColumn );
+  hasRowchanged( mLayerTreeModel->rootGroup(), oldSettings );
 }
 
-void QgsSnappingLayerTreeModel::hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings, bool forceRefresh )
+void QgsSnappingLayerTreeModel::hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings )
 {
   if ( node->nodeType() == QgsLayerTreeNode::NodeGroup )
   {
     const auto constChildren = node->children();
     for ( QgsLayerTreeNode *child : constChildren )
     {
-      hasRowchanged( child, oldSettings, forceRefresh );
+      hasRowchanged( child, oldSettings );
     }
   }
   else
@@ -391,7 +388,7 @@ void QgsSnappingLayerTreeModel::hasRowchanged( QgsLayerTreeNode *node, const QHa
     {
       emit dataChanged( QModelIndex(), idx );
     }
-    if ( oldSettings.value( vl ) != mProject->snappingConfig().individualLayerSettings().value( vl ) || forceRefresh )
+    if ( oldSettings.value( vl ) != mProject->snappingConfig().individualLayerSettings().value( vl ) )
     {
       mIndividualLayerSettings.insert( vl, mProject->snappingConfig().individualLayerSettings().value( vl ) );
       emit dataChanged( idx, index( idx.row(), columnCount( idx ) - 1 ) );

--- a/src/app/qgssnappinglayertreemodel.h
+++ b/src/app/qgssnappinglayertreemodel.h
@@ -95,9 +95,8 @@ class APP_EXPORT QgsSnappingLayerTreeModel : public QSortFilterProxyModel
     QString mFilterText;
     QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> mIndividualLayerSettings;
     QgsLayerTreeModel *mLayerTreeModel = nullptr;
-    bool mEnableMinMaxColumn = true;
 
-    void hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings, bool forceRefresh );
+    void hasRowchanged( QgsLayerTreeNode *node, const QHash<QgsVectorLayer *, QgsSnappingConfig::IndividualLayerSettings> &oldSettings );
 };
 
 #endif // QGSSNAPPINGLAYERTREEVIEW_H

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -195,12 +195,12 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   connect( mToleranceSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSnappingWidget::changeTolerance );
 
   mMinScaleWidget = new QgsScaleWidget();
-  mMinScaleWidget->setToolTip( tr( "Minimum scale from which snapping is enabled" ) );
+  mMinScaleWidget->setToolTip( tr( "Minimum scale from which snapping is enabled (i.e. most \"zoomed out\" scale)" ) );
   mMinScaleWidget->setObjectName( QStringLiteral( "SnappingMinScaleSpinBox" ) );
   connect( mMinScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsSnappingWidget::changeMinScale );
 
   mMaxScaleWidget = new QgsScaleWidget();
-  mMaxScaleWidget->setToolTip( tr( "Maximum scale up to which snapping is enabled" ) );
+  mMaxScaleWidget->setToolTip( tr( "Maximum scale up to which snapping is enabled (i.e. most \"zoomed in\" scale)" ) );
   mMaxScaleWidget->setObjectName( QStringLiteral( "SnappingMaxScaleSpinBox" ) );
   connect( mMaxScaleWidget, &QgsScaleWidget::scaleChanged, this, &QgsSnappingWidget::changeMaxScale );
 

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -707,6 +707,8 @@ void QgsSnappingWidget::snappingScaleModeTriggered( QAction *action )
   mMaxScaleWidget->setEnabled( mode == QgsSnappingConfig::Global );
   mConfig.setScaleDependencyMode( mode );
   mProject->setSnappingConfig( mConfig );
+
+  mLayerTreeView->reset();
 }
 
 void QgsSnappingWidget::updateToleranceDecimals()

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -288,7 +288,7 @@ class CORE_EXPORT QgsSnappingConfig
     void setTolerance( double tolerance );
 
     /**
-     * Returns the min scale
+     * Returns the min scale (i.e. most \"zoomed out\" scale)
      * \since QGIS 3.14
      */
     double minimumScale() const;
@@ -300,7 +300,7 @@ class CORE_EXPORT QgsSnappingConfig
     void setMinimumScale( double minScale );
 
     /**
-     * Returns the max scale
+     * Returns the max scale (i.e. most \"zoomed in\" scale)
      * \since QGIS 3.14
      */
     double maximumScale() const;

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -294,15 +294,18 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPointXY &pointMap, 
     QList<LayerAndAreaOfInterest> layers;
     QList<LayerConfig> filteredConfigs;
 
-    bool inRangeGlobal = ( mSnappingConfig.minimumScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.minimumScale() )
-                         && ( mSnappingConfig.maximumScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.maximumScale() );
+    //maximum scale is the one with smallest denominator
+    //minimum scale is the one with highest denominator
+    //So : maxscale < range on which snapping is enabled < minscale
+    bool inRangeGlobal = ( mSnappingConfig.minimumScale() <= 0.0 || mMapSettings.scale() <= mSnappingConfig.minimumScale() )
+                         && ( mSnappingConfig.maximumScale() <= 0.0 || mMapSettings.scale() >= mSnappingConfig.maximumScale() );
 
     for ( const LayerConfig &layerConfig : qgis::as_const( mLayers ) )
     {
       QgsSnappingConfig::IndividualLayerSettings layerSettings = mSnappingConfig.individualLayerSettings( layerConfig.layer );
 
-      bool inRangeLayer = ( layerSettings.minimumScale() <= 0.0 || mMapSettings.scale() >= layerSettings.minimumScale() )
-                          && ( layerSettings.maximumScale() <= 0.0 || mMapSettings.scale() <= layerSettings.maximumScale() );
+      bool inRangeLayer = ( layerSettings.minimumScale() <= 0.0 || mMapSettings.scale() <= layerSettings.minimumScale() )
+                          && ( layerSettings.maximumScale() <= 0.0 || mMapSettings.scale() >= layerSettings.maximumScale() );
 
       //If limit to scale is disabled, snapping activated on all layer
       //If no per layer config is set use the global one, otherwise use the layer config

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -492,8 +492,8 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m1.hasVertex() );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
-      snappingConfig.setMinimumScale( 1000.0 );
-      snappingConfig.setMaximumScale( 10000.0 );
+      snappingConfig.setMinimumScale( 10000.0 );// 1/10000 scale
+      snappingConfig.setMaximumScale( 1000.0 );// 1/1000 scale
       u.setConfig( snappingConfig );
 
       //Global settings for scale limit, but scale outside min max range -> no snapping
@@ -502,8 +502,8 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m2.hasVertex() == false );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::Global );
-      snappingConfig.setMinimumScale( 1000.0 );
-      snappingConfig.setMaximumScale( 100000.0 );
+      snappingConfig.setMinimumScale( 100000.0 );
+      snappingConfig.setMaximumScale( 1000.0 );
       u.setConfig( snappingConfig );
 
       //Global settings for scale limit, scale inside min max range -> snapping enabled
@@ -512,7 +512,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m3.hasVertex() );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::PerLayer );
-      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 1000.0, 10000.0 ) );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 10000.0, 1000.0 ) );
       u.setConfig( snappingConfig );
 
       //Per layer settings, but scale outside min max range of layer -> no snapping
@@ -521,7 +521,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( m4.hasVertex() == false );
 
       snappingConfig.setScaleDependencyMode( QgsSnappingConfig::PerLayer );
-      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 1000.0, 100000.0 ) );
+      snappingConfig.setIndividualLayerSettings( mVL, QgsSnappingConfig::IndividualLayerSettings( true, QgsSnappingConfig::VertexFlag, 10, QgsTolerance::Pixels, 100000.0, 1000.0 ) );
       u.setConfig( snappingConfig );
 
       //Per layer settings, scale inside min max range of layer -> snapping enabled


### PR DESCRIPTION
Should fix issues #35786 and #35789.

For the first issue I adapted the behavior of min and max scale parameters to match what is done in other places in qgis : min scale is the most zoomed out scale, max scale the most zoomed in. The tool tip have also been improved.

The second bug was an issue with the way the tree view for the snapping config per layer is refreshed when the snapping scale mode is changed. I now call reset on the tree view when the mode is changed, the strange combo box behavior disappeared.