### PR TITLE
display plugin name when an error occured in qgis_process

### DIFF
--- a/src/process/qgsprocess.cpp
+++ b/src/process/qgsprocess.cpp
@@ -262,11 +262,11 @@ void QgsProcessingExec::loadPlugins()
     {
       if ( !mPythonUtils->loadPlugin( plugin ) )
       {
-        std::cerr << "error loading plugin\n\n";
+        std::cerr << "error loading plugin: " << plugin.toLocal8Bit().constData() << "\n\n";
       }
       else if ( !mPythonUtils->startProcessingPlugin( plugin ) )
       {
-        std::cerr << "error starting plugin\n\n";
+        std::cerr << "error starting plugin: " << plugin.toLocal8Bit().constData() << "\n\n";
       }
     }
   }


### PR DESCRIPTION
One plugin was faulty, so better to have it's name displayed

Thanks @nyalldawson for the tool, it's nice!