### PR TITLE
Try to fix crash on GEOS 3.8.1 when empty coordinate sequence is returned for a point geometry (3.12)

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -1095,7 +1095,9 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
     case GEOS_POINT:                 // a point
     {
       const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, geos );
-      return std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
+      unsigned int nPoints = 0;
+      GEOSCoordSeq_getSize_r( geosinit()->ctxt, cs, &nPoints );
+      return nPoints > 0 ? std::unique_ptr<QgsAbstractGeometry>( coordSeqPoint( cs, 0, hasZ, hasM ).clone() ) : nullptr;
     }
     case GEOS_LINESTRING:
     {
@@ -1115,7 +1117,10 @@ std::unique_ptr<QgsAbstractGeometry> QgsGeos::fromGeos( const GEOSGeometry *geos
         const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq_r( geosinit()->ctxt, GEOSGetGeometryN_r( geosinit()->ctxt, geos, i ) );
         if ( cs )
         {
-          multiPoint->addGeometry( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
+          unsigned int nPoints = 0;
+          GEOSCoordSeq_getSize_r( geosinit()->ctxt, cs, &nPoints );
+          if ( nPoints > 0 )
+            multiPoint->addGeometry( coordSeqPoint( cs, 0, hasZ, hasM ).clone() );
         }
       }
       return std::move( multiPoint );

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -404,6 +404,10 @@ std::unique_ptr<LabelPosition> FeaturePart::createCandidatePointOnSurface( Point
     {
       const GEOSCoordSequence *coordSeq = GEOSGeom_getCoordSeq_r( geosctxt, pointGeom.get() );
 #if GEOS_VERSION_MAJOR>3 || GEOS_VERSION_MINOR>=8
+      unsigned int nPoints = 0;
+      GEOSCoordSeq_getSize_r( geosctxt, coordSeq, &nPoints );
+      if ( nPoints == 0 )
+        return nullptr;
       GEOSCoordSeq_getXY_r( geosctxt, coordSeq, 0, &px, &py );
 #else
       GEOSCoordSeq_getX_r( geosctxt, coordSeq, 0, &px );

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -819,6 +819,11 @@ double PointSet::minDistanceToPoint( double px, double py, double *rx, double *r
     double nx;
     double ny;
 #if GEOS_VERSION_MAJOR>3 || GEOS_VERSION_MINOR>=8
+    unsigned int nPoints = 0;
+    GEOSCoordSeq_getSize_r( geosctxt, nearestCoord.get(), &nPoints );
+    if ( nPoints == 0 )
+      return 0;
+
     ( void )GEOSCoordSeq_getXY_r( geosctxt, nearestCoord.get(), 0, &nx, &ny );
 #else
     ( void )GEOSCoordSeq_getX_r( geosctxt, nearestCoord.get(), 0, &nx );
@@ -855,6 +860,10 @@ void PointSet::getCentroid( double &px, double &py, bool forceInside ) const
     {
       const GEOSCoordSequence *coordSeq = GEOSGeom_getCoordSeq_r( geosctxt, centroidGeom.get() );
 #if GEOS_VERSION_MAJOR>3 || GEOS_VERSION_MINOR>=8
+      unsigned int nPoints = 0;
+      GEOSCoordSeq_getSize_r( geosctxt, coordSeq, &nPoints );
+      if ( nPoints == 0 )
+        return;
       GEOSCoordSeq_getXY_r( geosctxt, coordSeq, 0, &px, &py );
 #else
       GEOSCoordSeq_getX_r( geosctxt, coordSeq, 0, &px );
@@ -871,6 +880,11 @@ void PointSet::getCentroid( double &px, double &py, bool forceInside ) const
       {
         const GEOSCoordSequence *coordSeq = GEOSGeom_getCoordSeq_r( geosctxt, pointGeom.get() );
 #if GEOS_VERSION_MAJOR>3 || GEOS_VERSION_MINOR>=8
+        unsigned int nPoints = 0;
+        GEOSCoordSeq_getSize_r( geosctxt, coordSeq, &nPoints );
+        if ( nPoints == 0 )
+          return;
+
         GEOSCoordSeq_getXY_r( geosctxt, coordSeq, 0, &px, &py );
 #else
         GEOSCoordSeq_getX_r( geosctxt, coordSeq, 0, &px );

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -5304,6 +5304,10 @@ class TestQgsGeometry(unittest.TestCase):
         line = QgsLineString.fromQPolygonF(QPolygonF([QPointF(1.5, 2.5), QPointF(3, 4), QPointF(3, 6.5), QPointF(1.5, 2.5)]))
         self.assertEqual(line.asWkt(1), 'LineString (1.5 2.5, 3 4, 3 6.5, 1.5 2.5)')
 
+    def testGeosCrash(self):
+        # test we don't crash when geos returns a point geometry with no points
+        QgsGeometry.fromWkt('Polygon ((0 0, 1 1, 1 0, 0 0))').intersection(QgsGeometry.fromWkt('Point (42 0)')).isNull()
+
     def renderGeometry(self, geom, use_pen, as_polygon=False, as_painter_path=False):
         image = QImage(200, 200, QImage.Format_RGB32)
         image.fill(QColor(0, 0, 0))


### PR DESCRIPTION
for a point geometry

Fixes #35719, fixes #35526
