### PR TITLE
[TEMPORAL] allow temporal layout item map

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -9,7 +9,7 @@
 
 
 
-class QgsLayoutItemMap : QgsLayoutItem
+class QgsLayoutItemMap : QgsLayoutItem, QgsTemporalRangeObject
 {
 %Docstring
 Layout graphical items for displaying a map.

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -136,6 +136,9 @@ void QgsLayoutItem3DMap::draw( QgsLayoutItemRenderContext &context )
   QSize sizePixelsInt = QSize( static_cast<int>( std::ceil( sizePixels.width() ) ),
                                static_cast<int>( std::ceil( sizePixels.height() ) ) );
 
+  if ( isTemporal() )
+    mSettings->setTemporalRange( temporalRange() );
+
   if ( !mEngine )
   {
     mEngine.reset( new QgsOffscreen3DEngine );

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -209,7 +209,7 @@ bool QgsLayoutItem3DMap::writePropertiesToElement( QDomElement &element, QDomDoc
 
   //temporal settings
   QDomElement elemTemporal = document.createElement( QStringLiteral( "temporal-settings" ) );
-  elemTemporal.setAttribute( QStringLiteral( "isTemporal" ), isTemporal() ? 0 : 1 );
+  elemTemporal.setAttribute( QStringLiteral( "isTemporal" ), isTemporal() ? 1 : 0 );
   if ( isTemporal() )
   {
     elemTemporal.setAttribute( QStringLiteral( "temporalRangeBegin" ), temporalRange().begin().toString( Qt::ISODate ) );

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -207,6 +207,16 @@ bool QgsLayoutItem3DMap::writePropertiesToElement( QDomElement &element, QDomDoc
   QDomElement elemCameraPose = mCameraPose.writeXml( document );
   element.appendChild( elemCameraPose );
 
+  //temporal settings
+  QDomElement elemTemporal = document.createElement( QStringLiteral( "temporal-settings" ) );
+  elemTemporal.setAttribute( QStringLiteral( "isTemporal" ), isTemporal() ? 0 : 1 );
+  if ( isTemporal() )
+  {
+    elemTemporal.setAttribute( QStringLiteral( "temporalRangeBegin" ), temporalRange().begin().toString( Qt::ISODate ) );
+    elemTemporal.setAttribute( QStringLiteral( "temporalRangeEnd" ), temporalRange().end().toString( Qt::ISODate ) );
+  }
+  element.appendChild( elemTemporal );
+
   return true;
 }
 
@@ -231,6 +241,16 @@ bool QgsLayoutItem3DMap::readPropertiesFromElement( const QDomElement &element, 
   QDomElement elemCameraPose = element.firstChildElement( QStringLiteral( "camera-pose" ) );
   if ( !elemCameraPose.isNull() )
     mCameraPose.readXml( elemCameraPose );
+
+  //temporal settings
+  QDomElement elemTemporal = element.firstChildElement( QStringLiteral( "temporal-settings" ) );
+  setIsTemporal( elemTemporal.attribute( QStringLiteral( "isTemporal" ) ).toInt() );
+  if ( isTemporal() )
+  {
+    QDateTime begin = QDateTime::fromString( elemTemporal.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
+    QDateTime end = QDateTime::fromString( elemTemporal.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
+    setTemporalRange( QgsDateTimeRange( begin, end ) );
+  }
 
   return true;
 }

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -19,7 +19,7 @@
 #include "qgis_3d.h"
 
 #include "qgslayoutitem.h"
-
+#include "qgstemporalrangeobject.h"
 #include "qgscamerapose.h"
 
 
@@ -34,7 +34,7 @@ class QgsOffscreen3DEngine;
  *
  * \since QGIS 3.4
  */
-class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
+class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem, public QgsTemporalRangeObject
 {
     Q_OBJECT
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -650,7 +650,7 @@ bool QgsLayoutItemMap::writePropertiesToElement( QDomElement &mapElem, QDomDocum
   mapElem.appendChild( labelBlockingItemsElem );
 
   //temporal settings
-  mapElem.setAttribute( QStringLiteral( "isTemporal" ), isTemporal() ? 0 : 1 );
+  mapElem.setAttribute( QStringLiteral( "isTemporal" ), isTemporal() ? 1 : 0 );
   if ( isTemporal() )
   {
     mapElem.setAttribute( QStringLiteral( "temporalRangeBegin" ), temporalRange().begin().toString( Qt::ISODate ) );

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1455,6 +1455,9 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
     jobMapSettings.addRenderedFeatureHandler( handler );
   }
 
+  if ( isTemporal() )
+    jobMapSettings.setTemporalRange( temporalRange() );
+
   return jobMapSettings;
 }
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -649,6 +649,14 @@ bool QgsLayoutItemMap::writePropertiesToElement( QDomElement &mapElem, QDomDocum
   }
   mapElem.appendChild( labelBlockingItemsElem );
 
+  //temporal settings
+  mapElem.setAttribute( QStringLiteral( "isTemporal" ), isTemporal() ? 0 : 1 );
+  if ( isTemporal() )
+  {
+    mapElem.setAttribute( QStringLiteral( "temporalRangeBegin" ), temporalRange().begin().toString( Qt::ISODate ) );
+    mapElem.setAttribute( QStringLiteral( "temporalRangeEnd" ), temporalRange().end().toString( Qt::ISODate ) );
+  }
+
   return true;
 }
 
@@ -804,6 +812,15 @@ bool QgsLayoutItemMap::readPropertiesFromElement( const QDomElement &itemElem, c
   }
 
   updateBoundingRect();
+
+  //temporal settings
+  setIsTemporal( itemElem.attribute( QStringLiteral( "isTemporal" ) ).toInt() );
+  if ( isTemporal() )
+  {
+    QDateTime begin = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
+    QDateTime end = QDateTime::fromString( itemElem.attribute( QStringLiteral( "temporalRangeBegin" ) ), Qt::ISODate );
+    setTemporalRange( QgsDateTimeRange( begin, end ) );
+  }
 
   mUpdatesEnabled = true;
   return true;

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -25,6 +25,7 @@
 #include "qgslayoutitemmapgrid.h"
 #include "qgslayoutitemmapoverview.h"
 #include "qgsmaprendererstagedrenderjob.h"
+#include "qgstemporalrangeobject.h"
 
 class QgsAnnotation;
 class QgsRenderedFeatureHandlerInterface;
@@ -35,7 +36,7 @@ class QgsRenderedFeatureHandlerInterface;
  * \brief Layout graphical items for displaying a map.
  * \since QGIS 3.0
  */
-class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
+class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem, public QgsTemporalRangeObject
 {
 
     Q_OBJECT

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -204,7 +204,8 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setRenderingStopped( false );
   ctx.mCustomRenderingFlags = mapSettings.customRenderingFlags();
   ctx.setIsTemporal( mapSettings.isTemporal() );
-  ctx.setTemporalRange( mapSettings.temporalRange() );
+  if ( ctx.isTemporal() )
+    ctx.setTemporalRange( mapSettings.temporalRange() );
 
   return ctx;
 }

--- a/tests/src/3d/testqgslayout3dmap.cpp
+++ b/tests/src/3d/testqgslayout3dmap.cpp
@@ -124,7 +124,20 @@ void TestQgsLayout3DMap::testBasic()
   checker.setControlPathPrefix( QStringLiteral( "composer_3d" ) );
   bool result = checker.testLayout( mReport, 0, 100 );
   QVERIFY( result );
+
+  QVERIFY( !map->isTemporal() );
+
+  QDateTime begin( QDate( 2020, 01, 01 ), QTime( 10, 0, 0, Qt::UTC ) );
+  QDateTime end = begin.addSecs( 3600 );
+  map3dItem->setTemporalRange( QgsDateTimeRange( begin, end ) );
+
+  map3dItem->refresh();
+  checker.testLayout( mReport, 0, 100 );
+
+  QVERIFY( map->isTemporal() );
+  QCOMPARE( map->temporalRange(), QgsDateTimeRange( begin, end ) );
 }
+
 
 
 QGSTEST_MAIN( TestQgsLayout3DMap )

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -68,6 +68,7 @@ class TestQgsLayoutMap : public QObject
     void testRenderedFeatureHandler();
     void testLayeredExport();
     void testLayeredExportLabelsByLayer();
+    void testTemporal();
 
   private:
     QgsRasterLayer *mRasterLayer = nullptr;
@@ -1829,6 +1830,27 @@ void TestQgsLayoutMap::testLayeredExportLabelsByLayer()
   QVERIFY( map->shouldDrawPart( QgsLayoutItemMap::Frame ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Background ) );
   QVERIFY( !map->shouldDrawPart( QgsLayoutItemMap::Layer ) );
+}
+
+void TestQgsLayoutMap::testTemporal()
+{
+  QgsLayout l( QgsProject::instance( ) );
+  QgsLayoutItemMap *map = new QgsLayoutItemMap( &l );
+  QDateTime begin( QDate( 2020, 01, 01 ), QTime( 10, 0, 0, Qt::UTC ) );
+  QDateTime end = begin.addSecs( 3600 );
+
+  QgsMapSettings settings = map->mapSettings( map->extent(), QSize( 512, 512 ), 72, false );
+  QgsRenderContext renderContext = QgsRenderContext::fromMapSettings( settings );
+
+  QVERIFY( !renderContext.isTemporal() );
+
+  map->setTemporalRange( QgsDateTimeRange( begin, end ) );
+  map->refresh();
+
+  settings = map->mapSettings( map->extent(), QSize( 512, 512 ), 72, false );
+  renderContext = QgsRenderContext::fromMapSettings( settings );
+  QVERIFY( renderContext.isTemporal() );
+  QCOMPARE( renderContext.temporalRange(), QgsDateTimeRange( begin, end ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutMap )


### PR DESCRIPTION
This PR allows the possibility, in the API (only for now), to set temporal the layout map item (2D and 3D).
If the layout map is temporal, then temporal layer can be rendered depending on the time range.
For now, this can be done with python but in the future, this maybe could be done through layout map widget settings or other GUI way.