### PR TITLE
Add a super-basic way to pick legend patch shapes

### DIFF
--- a/src/gui/layout/qgslayoutlegendwidget.cpp
+++ b/src/gui/layout/qgslayoutlegendwidget.cpp
@@ -46,6 +46,8 @@
 #include <QMessageBox>
 #include <QInputDialog>
 
+///@cond PRIVATE
+
 Q_GUI_EXPORT extern int qt_defaultDpiX();
 
 static int _unfilteredLegendNodeIndex( QgsLayerTreeModelLegendNode *legendNode )
@@ -1491,3 +1493,5 @@ void QgsLayoutLegendNodeWidget::patchChanged( int )
   mLegend->updateFilterByMap();
   mLegend->endCommand();
 }
+
+///@endcond

--- a/src/gui/layout/qgslayoutlegendwidget.h
+++ b/src/gui/layout/qgslayoutlegendwidget.h
@@ -28,6 +28,8 @@
 #include <QWidget>
 #include <QItemDelegate>
 
+///@cond PRIVATE
+
 /**
  * \ingroup gui
  * A widget for setting properties relating to a layout legend.
@@ -195,6 +197,8 @@ class GUI_EXPORT QgsLayoutLegendNodeWidget: public QgsPanelWidget, private Ui::Q
     int mOriginalLegendNodeIndex = -1;
 
 };
+
+///@endcond
 
 #endif //QGSLAYOUTLEGENDWIDGET_H
 

--- a/src/gui/layout/qgslayoutlegendwidget.h
+++ b/src/gui/layout/qgslayoutlegendwidget.h
@@ -184,6 +184,7 @@ class GUI_EXPORT QgsLayoutLegendNodeWidget: public QgsPanelWidget, private Ui::Q
   private slots:
 
     void labelChanged( const QString &label );
+    void patchChanged( int index );
 
   private:
 

--- a/src/gui/layout/qgslayoutlegendwidget.h
+++ b/src/gui/layout/qgslayoutlegendwidget.h
@@ -85,7 +85,7 @@ class GUI_EXPORT QgsLayoutLegendWidget: public QgsLayoutItemBaseWidget, private 
     void mBoxSpaceSpinBox_valueChanged( double d );
     void mColumnSpaceSpinBox_valueChanged( double d );
     void mLineSpacingSpinBox_valueChanged( double d );
-    void mCheckBoxAutoUpdate_stateChanged( int state );
+    void mCheckBoxAutoUpdate_stateChanged( int state, bool userTriggered = true );
     void composerMapChanged( QgsLayoutItem *item );
     void mCheckboxResizeContents_toggled( bool checked );
 
@@ -164,6 +164,36 @@ class GUI_EXPORT QgsLayoutLegendMenuProvider : public QgsLayerTreeViewMenuProvid
     QgsLayoutLegendWidget *mWidget = nullptr;
 };
 
+#include "ui_qgslayoutlegendnodewidgetbase.h"
+
+/**
+ * \ingroup gui
+ * A widget for properties relating to a node in a layout legend.
+ *
+ * \note This class is not a part of public API
+ * \since QGIS 3.14
+ */
+class GUI_EXPORT QgsLayoutLegendNodeWidget: public QgsPanelWidget, private Ui::QgsLayoutLegendNodeWidgetBase
+{
+    Q_OBJECT
+
+  public:
+
+    QgsLayoutLegendNodeWidget( QgsLayoutItemLegend *legend, QgsLayerTreeNode *node, QgsLayerTreeModelLegendNode *legendNode, int originalLegendNodeIndex, QWidget *parent = nullptr );
+
+  private slots:
+
+    void labelChanged( const QString &label );
+
+  private:
+
+    QgsLayoutItemLegend *mLegend = nullptr;
+    QgsLayerTreeNode *mNode = nullptr;
+    QgsLayerTreeLayer *mLayer = nullptr;
+    QgsLayerTreeModelLegendNode *mLegendNode = nullptr;
+    int mOriginalLegendNodeIndex = -1;
+
+};
 
 #endif //QGSLAYOUTLEGENDWIDGET_H
 

--- a/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsLayoutLegendNodeWidgetBase</class>
+ <widget class="QgsPanelWidget" name="QgsLayoutLegendNodeWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mLabelEdit"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
+++ b/src/ui/layout/qgslayoutlegendnodewidgetbase.ui
@@ -26,6 +26,19 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item row="2" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -33,15 +46,18 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="1">
     <widget class="QLineEdit" name="mLabelEdit"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mPatchShapeLabel">
+     <property name="text">
+      <string>Patch shape</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="mPatchShapeCombo"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
And make legend node properties (such as renaming legend nodes) in layouts open in an inline panel.

This provides us with a place to insert more useful per-node properties for greater legend customisation power. For now, I've added a super-basic choice of legend patch shapes (With the only choices so far being the default or oval for fills, and default or "zig zag" for lines)