### PR TITLE
[TEMPORAL][MESH] Update temporal extent when mesh layer becomes temporal for first time

### DIFF
--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -34,6 +34,7 @@
 #include "qgsprojectionselectiondialog.h"
 #include "qgsrenderermeshpropertieswidget.h"
 #include "qgssettings.h"
+#include "qgsprojecttimesettings.h"
 #include "qgsproviderregistry.h"
 #ifdef HAVE_3D
 #include "qgsmeshlayer3drendererwidget.h"
@@ -229,11 +230,27 @@ void QgsMeshLayerProperties::addDataset()
   settings.setValue( QStringLiteral( "lastMeshDatasetDir" ), openFileInfo.absolutePath(), QgsSettings::App );
   QFile datasetFile( openFileString );
 
+  bool isTemporalBefore = mMeshLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities();
   bool ok = mMeshLayer->dataProvider()->addDataset( openFileString );
   if ( ok )
   {
+    if ( !isTemporalBefore && mMeshLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() )
+    {
+      mMeshLayer->temporalProperties()->setDefaultsFromDataProviderTemporalCapabilities(
+        mMeshLayer->dataProvider()->temporalCapabilities() );
+
+      if ( ! mMeshLayer->temporalProperties()->referenceTime().isValid() )
+      {
+        QDateTime referenceTime = QgsProject::instance()->timeSettings()->temporalRange().begin();
+        if ( !referenceTime.isValid() ) // If project reference time is invalid, use current date
+          referenceTime = QDateTime( QDate::currentDate(), QTime( 0, 0, 0, Qt::UTC ) );
+        mMeshLayer->temporalProperties()->setReferenceTime( referenceTime, mMeshLayer->dataProvider()->temporalCapabilities() );
+      }
+    }
+
     syncToLayer();
     QMessageBox::information( this, tr( "Load mesh datasets" ), tr( "Datasets successfully added to the mesh layer" ) );
+    emit mMeshLayer->dataSourceChanged();
   }
   else
   {

--- a/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
+++ b/src/app/mesh/qgsmeshstaticdatasetwidget.cpp
@@ -100,13 +100,18 @@ int QgsMeshDatasetListModel::rowCount( const QModelIndex &parent ) const
 
 QVariant QgsMeshDatasetListModel::data( const QModelIndex &index, int role ) const
 {
-  if ( !index.isValid() || !mLayer || !mLayer->dataProvider() || mDatasetGroup < 0 )
+  if ( !index.isValid() )
     return QVariant();
 
   if ( role == Qt::DisplayRole )
   {
-    if ( index.row() == 0 )
+    if ( !mLayer || !mLayer->dataProvider() || mDatasetGroup < 0 || index.row() == 0 )
       return tr( "none" );
+
+    else if ( index.row() == 1 && mLayer->dataProvider()->datasetCount( mDatasetGroup ) == 1 )
+    {
+      return tr( "Display dataset" );
+    }
     else
     {
       qint64 time = mLayer->dataProvider()->temporalCapabilities()->datasetTime( QgsMeshDatasetIndex( mDatasetGroup, index.row() - 1 ) );

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -70,7 +70,7 @@ void QgsMeshLayer::setDefaultRendererSettings()
   QgsMeshRendererMeshSettings meshSettings;
   if ( mDataProvider && mDataProvider->datasetGroupCount() > 0 )
   {
-    // show data from the first dataset group
+    // Show data from the first dataset group
     mRendererSettings.setActiveScalarDatasetGroup( 0 );
     // If the first dataset group has nan min/max, display the mesh to avoid nothing displayed
     QgsMeshDatasetGroupMetadata meta = mDataProvider->datasetGroupMetadata( 0 );
@@ -78,7 +78,7 @@ void QgsMeshLayer::setDefaultRendererSettings()
          meta.minimum() == std::numeric_limits<double>::quiet_NaN() )
       meshSettings.setEnabled( true );
 
-    //if the mesh is non temporal, set the static scalar dataset
+    // If the mesh is non temporal, set the static scalar dataset
     if ( !mDataProvider->temporalCapabilities()->hasTemporalCapabilities() )
       setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
   }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -72,12 +72,15 @@ void QgsMeshLayer::setDefaultRendererSettings()
   {
     // show data from the first dataset group
     mRendererSettings.setActiveScalarDatasetGroup( 0 );
-    // If the first dataset group is temporal or have nan min/max, display the mesh to avoid nothing displayed
+    // If the first dataset group has nan min/max, display the mesh to avoid nothing displayed
     QgsMeshDatasetGroupMetadata meta = mDataProvider->datasetGroupMetadata( 0 );
-    if ( ( meta.maximum() == std::numeric_limits<double>::quiet_NaN() &&
-           meta.minimum() == std::numeric_limits<double>::quiet_NaN() ) ||
-         meta.isTemporal() )
+    if ( meta.maximum() == std::numeric_limits<double>::quiet_NaN() &&
+         meta.minimum() == std::numeric_limits<double>::quiet_NaN() )
       meshSettings.setEnabled( true );
+
+    //if the mesh is non temporal, set the static scalar dataset
+    if ( !mDataProvider->temporalCapabilities()->hasTemporalCapabilities() )
+      setStaticScalarDatasetIndex( QgsMeshDatasetIndex( 0, 0 ) );
   }
   else
   {

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -165,7 +165,6 @@ void QgsTemporalControllerWidget::onLayersAdded()
 
         if ( !mHasTemporalLayersLoaded )
         {
-          //inspired by  QgsLayerTreeMapCanvasBridge::layersAdded
           connect( layer, &QgsMapLayer::dataSourceChanged, this, [ this, layer ]
           {
             if ( layer->isValid() && layer->temporalProperties()->isActive() && !mHasTemporalLayersLoaded )

--- a/src/gui/qgstemporalcontrollerwidget.cpp
+++ b/src/gui/qgstemporalcontrollerwidget.cpp
@@ -160,7 +160,23 @@ void QgsTemporalControllerWidget::onLayersAdded()
     for ( QgsMapLayer *layer : layers )
     {
       if ( layer->temporalProperties() )
+      {
         mHasTemporalLayersLoaded |= layer->temporalProperties()->isActive();
+
+        if ( !mHasTemporalLayersLoaded )
+        {
+          //inspired by  QgsLayerTreeMapCanvasBridge::layersAdded
+          connect( layer, &QgsMapLayer::dataSourceChanged, this, [ this, layer ]
+          {
+            if ( layer->isValid() && layer->temporalProperties()->isActive() && !mHasTemporalLayersLoaded )
+            {
+              mHasTemporalLayersLoaded = true;
+              // if we are moving from zero temporal layers to non-zero temporal layers, let's set temporal extent
+              this->setDatesToProjectTime();
+            }
+          } );
+        }
+      }
     }
 
     if ( mHasTemporalLayersLoaded )

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -346,8 +346,6 @@ void QgsMdalProvider::addGroupToTemporalCapabilities( int indexGroup )
   if ( !mMeshH )
     return;
   QgsMeshDataProviderTemporalCapabilities *tempCap = temporalCapabilities();
-  tempCap->setHasTemporalCapabilities( true );
-  tempCap->setHasTemporalCapabilities( true );
   QgsMeshDatasetGroupMetadata dsgMetadata = datasetGroupMetadata( indexGroup );
   QDateTime refTime = dsgMetadata.referenceTime();
   refTime.setTimeSpec( Qt::UTC ); //For now provider don't support time zone and return always in local time, force UTC
@@ -356,6 +354,7 @@ void QgsMdalProvider::addGroupToTemporalCapabilities( int indexGroup )
 
   if ( dsgMetadata.isTemporal() )
   {
+    tempCap->setHasTemporalCapabilities( true );
     for ( int dsi = 0; dsi < dsCount; ++dsi )
     {
       QgsMeshDatasetMetadata dsMeta = datasetMetadata( QgsMeshDatasetIndex( indexGroup, dsi ) );

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -124,10 +124,11 @@ void TestQgsMeshLayer::initTestCase()
   QString uri( mDataDir + "/quad_and_triangle.2dm" );
   mMdalLayer = new QgsMeshLayer( uri, "Triangle and Quad MDAL", "mdal" );
   QCOMPARE( mMdalLayer->dataProvider()->datasetGroupCount(), 1 ); //bed elevation is already in the 2dm
-  QVERIFY( mMdalLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
+  QVERIFY( !mMdalLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
   mMdalLayer->dataProvider()->addDataset( mDataDir + "/quad_and_triangle_vertex_scalar.dat" );
   mMdalLayer->dataProvider()->addDataset( mDataDir + "/quad_and_triangle_vertex_vector.dat" );
   QCOMPARE( mMdalLayer->dataProvider()->extraDatasets().count(), 2 );
+  QVERIFY( mMdalLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
 
   //The face dataset is recognized by "_els_" in the filename for this format
   mMdalLayer->dataProvider()->addDataset( mDataDir + "/quad_and_triangle_els_face_scalar.dat" );
@@ -161,13 +162,13 @@ void TestQgsMeshLayer::initTestCase()
   uri = QString( mDataDir + "/lines.2dm" );
   mMdal1DLayer = new QgsMeshLayer( uri, "Lines MDAL", "mdal" );
   QCOMPARE( mMdal1DLayer->dataProvider()->datasetGroupCount(), 1 ); //bed elevation is already in the 2dm
-  QVERIFY( mMemory1DLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
-  QVERIFY( mMemory1DLayer->temporalProperties()->isActive() );
+  QVERIFY( !mMdal1DLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
+  QVERIFY( !mMdal1DLayer->temporalProperties()->isActive() );
   mMdal1DLayer->dataProvider()->addDataset( mDataDir + "/lines_vertex_scalar.dat" );
   mMdal1DLayer->dataProvider()->addDataset( mDataDir + "/lines_vertex_vector.dat" );
   QCOMPARE( mMdal1DLayer->dataProvider()->extraDatasets().count(), 2 );
-  QVERIFY( mMemory1DLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
-  QVERIFY( mMemory1DLayer->temporalProperties()->isActive() );
+  QVERIFY( mMdal1DLayer->dataProvider()->temporalCapabilities()->hasTemporalCapabilities() );
+  QVERIFY( mMdal1DLayer->temporalProperties()->isActive() );
 
 
   //The face dataset is recognized by "_els_" in the filename for this format


### PR DESCRIPTION
Before this PR, when a non temporal mesh layer was loaded, the temporal extent was logically unchanged. But, after, when a temporal dataset was loaded, the layer stay non temporal and the temporal extent was not updated, event if it was the first temporal datasets.
With this PR, the temporal extent is updated when the first temporal dataset is loaded (if the mesh layer is non temporal before dataset loading).

