### PR TITLE
Qgisserveroutput

### DIFF
--- a/src/server/qgis_mapserver.cpp
+++ b/src/server/qgis_mapserver.cpp
@@ -205,12 +205,6 @@ int main( int argc, char *argv[] )
   else
   {
     const int port { tcpServer.serverPort() };
-    std::cout << QObject::tr( "QGIS Development Server listening on http://%1:%2" )
-              .arg( ipAddress ).arg( port ).toStdString() << std::endl;
-
-#ifndef Q_OS_WIN
-    std::cout << QObject::tr( "CTRL+C to exit" ).toStdString() << std::endl;
-#endif
 
     QAtomicInt connCounter { 0 };
 
@@ -237,6 +231,12 @@ int main( int argc, char *argv[] )
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     server.initPython();
+#endif
+
+    std::cout << QObject::tr( "QGIS Development Server listening on http://%1:%2" )
+              .arg( ipAddress ).arg( port ).toStdString() << std::endl;
+#ifndef Q_OS_WIN
+    std::cout << QObject::tr( "CTRL+C to exit" ).toStdString() << std::endl;
 #endif
 
     // Starts HTTP loop with a poor man's HTTP parser

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -397,7 +397,7 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         // Project is mandatory for OWS at this point
         if ( ! project )
         {
-          throw QgsServerException( QStringLiteral( "Project file error" ) );
+          throw QgsServerException( QStringLiteral( "Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file" ) );
         }
 
         if ( ! params.fileName().isEmpty() )

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -415,7 +415,7 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         else
         {
           throw QgsOgcServiceException( QStringLiteral( "Service configuration error" ),
-                                        QStringLiteral( "Service unknown or unsupported" ) );
+                                        QStringLiteral( "Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint" ) );
         }
       }
     }

--- a/src/server/services/wcs/qgswcs.cpp
+++ b/src/server/services/wcs/qgswcs.cpp
@@ -74,7 +74,7 @@ namespace QgsWcs
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
+                                     QStringLiteral( "Please add or check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )

--- a/src/server/services/wfs/qgswfs.cpp
+++ b/src/server/services/wfs/qgswfs.cpp
@@ -78,7 +78,7 @@ namespace QgsWfs
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
+                                     QStringLiteral( "Please add or check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -91,7 +91,7 @@ namespace QgsWms
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QgsServiceException::OGC_OperationNotSupported,
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
+                                     QStringLiteral( "Please add or check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( ( mVersion.compare( QLatin1String( "1.1.1" ) ) == 0 \

--- a/src/server/services/wmts/qgswmts.cpp
+++ b/src/server/services/wmts/qgswmts.cpp
@@ -72,7 +72,7 @@ namespace QgsWmts
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
-                                     QStringLiteral( "Please check the value of the REQUEST parameter" ), 501 );
+                                     QStringLiteral( "Please add or check the value of the REQUEST parameter" ), 501 );
         }
 
         if ( QSTR_COMPARE( req, "GetCapabilities" ) )

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -330,8 +330,8 @@ class TestQgsServer(QgsServerTestBase):
         request = QgsBufferServerRequest('http://somesite.com/somepath', QgsServerRequest.GetMethod, headers)
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response)
-        self.assertEqual(bytes(response.body()), b'<ServerException>Project file error</ServerException>\n')
-        self.assertEqual(response.headers(), {'Content-Length': '54', 'Content-Type': 'text/xml; charset=utf-8'})
+        self.assertEqual(bytes(response.body()), b'<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n')
+        self.assertEqual(response.headers(), {'Content-Length': '156', 'Content-Type': 'text/xml; charset=utf-8'})
         self.assertEqual(response.statusCode(), 500)
 
     def test_requestHandlerProject(self):
@@ -340,8 +340,8 @@ class TestQgsServer(QgsServerTestBase):
         request = QgsBufferServerRequest('http://somesite.com/somepath', QgsServerRequest.GetMethod, headers)
         response = QgsBufferServerResponse()
         self.server.handleRequest(request, response, None)
-        self.assertEqual(bytes(response.body()), b'<ServerException>Project file error</ServerException>\n')
-        self.assertEqual(response.headers(), {'Content-Length': '54', 'Content-Type': 'text/xml; charset=utf-8'})
+        self.assertEqual(bytes(response.body()), b'<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n')
+        self.assertEqual(response.headers(), {'Content-Length': '156', 'Content-Type': 'text/xml; charset=utf-8'})
         self.assertEqual(response.statusCode(), 500)
 
     def test_api(self):
@@ -350,9 +350,9 @@ class TestQgsServer(QgsServerTestBase):
         # Test as a whole
         header, body = self._execute_request("")
         response = self.strip_version_xmlns(header + body)
-        expected = self.strip_version_xmlns(b'Content-Length: 54\nContent-Type: text/xml; charset=utf-8\n\n<ServerException>Project file error</ServerException>\n')
+        expected = self.strip_version_xmlns(b'Content-Length: 156\nContent-Type: text/xml; charset=utf-8\n\n<ServerException>Project file error. For OWS services: please provide a SERVICE and a MAP parameter pointing to a valid QGIS project file</ServerException>\n')
         self.assertEqual(response, expected)
-        expected = b'Content-Length: 54\nContent-Type: text/xml; charset=utf-8\n\n'
+        expected = b'Content-Length: 156\nContent-Type: text/xml; charset=utf-8\n\n'
         self.assertEqual(header, expected)
 
         # Test response when project is specified but without service
@@ -360,13 +360,13 @@ class TestQgsServer(QgsServerTestBase):
         qs = '?MAP=%s' % (urllib.parse.quote(project))
         header, body = self._execute_request(qs)
         response = self.strip_version_xmlns(header + body)
-        expected = self.strip_version_xmlns(b'Content-Length: 206\nContent-Type: text/xml; charset=utf-8\n\n<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">\n <ServiceException code="Service configuration error">Service unknown or unsupported</ServiceException>\n</ServiceExceptionReport>\n')
+        expected = self.strip_version_xmlns(b'Content-Length: 326\nContent-Type: text/xml; charset=utf-8\n\n<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
         self.assertEqual(response, expected)
-        expected = b'Content-Length: 206\nContent-Type: text/xml; charset=utf-8\n\n'
+        expected = b'Content-Length: 326\nContent-Type: text/xml; charset=utf-8\n\n'
         self.assertEqual(header, expected)
 
         # Test body
-        expected = self.strip_version_xmlns(b'<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc">\n <ServiceException code="Service configuration error">Service unknown or unsupported</ServiceException>\n</ServiceExceptionReport>\n')
+        expected = self.strip_version_xmlns(b'<ServiceExceptionReport  >\n <ServiceException code="Service configuration error">Service unknown or unsupported. Current supported services (case-sensitive): WMS WFS WCS WMTS SampleService, or use a WFS3 (OGC API Features) endpoint</ServiceException>\n</ServiceExceptionReport>\n')
         self.assertEqual(self.strip_version_xmlns(body), expected)
 
     # WCS tests


### PR DESCRIPTION
As promised the first request is to make it for (ignorant) users like me more obvious which port qgis_mapserver is running.

Then I thought to add some more info in the server responses. In my (and some people I know) experience trying to setup qgisserver for the first time is sometimes harder that it should be.
Because QGIS itself (I know in the logs it often is) does not tell you if there was just one layer wrong, or if there was an reading issue with a project file (one of the things I often hit on Windows servers) etc

So I added some more commits, though I can also imagine that it was a deliberate choice to NOT tell users what was wrong with configuration of a server... 
But... if you ask me: we should tell the (early adopting) users...
An alternative would be to run the server in some kind of development or production mode?