### PR TITLE
Fix raster provider connection with statusChanged signal

### DIFF
--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -224,6 +224,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
 
   // copy the whole raster pipe!
   mPipe = new QgsRasterPipe( *layer->pipe() );
+  QObject::connect( mPipe->provider(), &QgsRasterDataProvider::statusChanged, layer, &QgsRasterLayer::statusChanged );
   QgsRasterRenderer *rasterRenderer = mPipe->renderer();
   if ( rasterRenderer && !( rendererContext.flags() & QgsRenderContext::RenderPreviewJob ) )
     layer->refreshRendererIfNeeded( rasterRenderer, rendererContext.extent() );


### PR DESCRIPTION
## Description

 As indicated in the `statusChanged` signal documentation in `QgsRasterDataProvider` class:

```
Emit a message to be displayed on status bar, usually used by network providers (WMS,WCS)
```

However, the underlying provider is cloned in `QgsRasterPipe` and the connect don't follow. Meaning that messages coming from the WMS provider (for example) are not displayed in the status bar and can't be caught through the Python API.