### PR TITLE
various fixes to connections dialogs in Datasource Manager

### DIFF
--- a/src/gui/ogr/qgsnewogrconnection.cpp
+++ b/src/gui/ogr/qgsnewogrconnection.cpp
@@ -41,6 +41,12 @@ QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString &connTy
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsNewOgrConnection::showHelp );
   Q_NOWARN_DEPRECATED_POP
 
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( txtName, &QLineEdit::textChanged, this, &QgsNewOgrConnection::updateOkButtonState );
+  connect( txtHost, &QLineEdit::textChanged, this, &QgsNewOgrConnection::updateOkButtonState );
+  connect( txtDatabase, &QLineEdit::textChanged, this, &QgsNewOgrConnection::updateOkButtonState );
+  connect( txtPort, &QLineEdit::textChanged, this, &QgsNewOgrConnection::updateOkButtonState );
+
   QgsSettings settings;
 
   //add database drivers
@@ -114,6 +120,13 @@ void QgsNewOgrConnection::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#creating-a-stored-connection" ) );
 }
+
+void QgsNewOgrConnection::updateOkButtonState()
+{
+  bool enabled = !txtName->text().isEmpty() && !txtHost->text().isEmpty() && !txtDatabase->text().isEmpty() && !txtPort->text().isEmpty();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
+}
+
 
 //! Autoconnected SLOTS *
 void QgsNewOgrConnection::accept()

--- a/src/gui/ogr/qgsnewogrconnection.h
+++ b/src/gui/ogr/qgsnewogrconnection.h
@@ -52,6 +52,7 @@ class GUI_EXPORT QgsNewOgrConnection : public QDialog, private Ui::QgsNewOgrConn
 
   public slots:
     void accept() override;
+    //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
 
   private slots:

--- a/src/gui/ogr/qgsnewogrconnection.h
+++ b/src/gui/ogr/qgsnewogrconnection.h
@@ -52,11 +52,11 @@ class GUI_EXPORT QgsNewOgrConnection : public QDialog, private Ui::QgsNewOgrConn
 
   public slots:
     void accept() override;
-    //! Updates state of the OK button depending of the filled fields
-    void updateOkButtonState();
 
   private slots:
     void btnConnect_clicked();
+    //! Updates state of the OK button depending of the filled fields
+    void updateOkButtonState();
 
   private:
     QString mOriginalConnName;

--- a/src/gui/ogr/qgsnewogrconnection.h
+++ b/src/gui/ogr/qgsnewogrconnection.h
@@ -52,6 +52,7 @@ class GUI_EXPORT QgsNewOgrConnection : public QDialog, private Ui::QgsNewOgrConn
 
   public slots:
     void accept() override;
+    void updateOkButtonState();
 
   private slots:
     void btnConnect_clicked();

--- a/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrdbsourceselect.cpp
@@ -193,7 +193,6 @@ void QgsOgrDbSourceSelect::mSearchModeComboBox_currentIndexChanged( const QStrin
   mSearchTableEdit_textChanged( mSearchTableEdit->text() );
 }
 
-
 void QgsOgrDbSourceSelect::populateConnectionList()
 {
   cmbConnections->clear();
@@ -203,12 +202,14 @@ void QgsOgrDbSourceSelect::populateConnectionList()
     QString text = name + tr( "@" ) + QgsOgrDbConnection( name, ogrDriverName( ) ).path();
     cmbConnections->addItem( text );
   }
-  setConnectionListPosition();
 
   btnConnect->setDisabled( cmbConnections->count() == 0 );
+  btnEdit->setDisabled( cmbConnections->count() == 0 );
   btnDelete->setDisabled( cmbConnections->count() == 0 );
-
+  btnSave->setDisabled( cmbConnections->count() == 0 );
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
 }
 
 void QgsOgrDbSourceSelect::btnNew_clicked()

--- a/src/gui/providers/ogr/qgsogrsourceselect.cpp
+++ b/src/gui/providers/ogr/qgsogrsourceselect.cpp
@@ -215,6 +215,11 @@ void QgsOgrSourceSelect::populateConnectionList()
     ++it;
   }
   settings.endGroup();
+
+  btnEdit->setDisabled( cmbConnections->count() == 0 );
+  btnDelete->setDisabled( cmbConnections->count() == 0 );
+  cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
   setConnectionListPosition();
 }
 

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -718,6 +718,7 @@ QDomDocument QgsManageConnectionsDialog::saveXyzTilesConnections( const QStringL
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password" ).toString() );
     el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer" ).toString() );
+    el.setAttribute( QStringLiteral( "tilePixelRatio" ), settings.value( path + "/tilePixelRatio", 0 ).toDouble() );
 
     root.appendChild( el );
   }
@@ -1460,6 +1461,7 @@ void QgsManageConnectionsDialog::loadXyzTilesConnections( const QDomDocument &do
     settings.setValue( QStringLiteral( "username" ), child.attribute( QStringLiteral( "username" ) ) );
     settings.setValue( QStringLiteral( "password" ), child.attribute( QStringLiteral( "password" ) ) );
     settings.setValue( QStringLiteral( "referer" ), child.attribute( QStringLiteral( "referer" ) ) );
+    settings.setValue( QStringLiteral( "tilePixelRatio" ), child.attribute( QStringLiteral( "tilePixelRatio" ) ) );
     settings.endGroup();
 
     child = child.nextSiblingElement();

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -129,14 +129,8 @@ QgsNewHttpConnection::QgsNewHttpConnection( QWidget *parent, ConnectionTypes typ
       mGroupBox->layout()->removeWidget( cmbDpiMode );
       lblDpiMode->setVisible( false );
       mGroupBox->layout()->removeWidget( lblDpiMode );
-
-      txtReferer->setVisible( false );
-      mGroupBox->layout()->removeWidget( txtReferer );
-      lblReferer->setVisible( false );
-      mGroupBox->layout()->removeWidget( lblReferer );
     }
   }
-
 
   if ( !( flags & FlagShowTestConnection ) )
   {
@@ -328,7 +322,7 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   // Enable/disable these items per WFS versions
   wfsVersionCurrentIndexChanged( versionIdx );
 
-  txtReferer->setText( settings.value( wmsKey + "/referer" ).toString() );
+  mRefererLineEdit->setText( settings.value( wmsKey + "/referer" ).toString() );
   txtMaxNumFeatures->setText( settings.value( wfsKey + "/maxnumfeatures" ).toString() );
 
   // Only default to paging enabled if WFS 2.0.0 or higher
@@ -336,8 +330,6 @@ void QgsNewHttpConnection::updateServiceSpecificSettings()
   txtPageSize->setText( settings.value( wfsKey + "/pagesize" ).toString() );
   cbxWfsFeaturePaging->setChecked( pagingEnabled );
 }
-
-
 
 // Mega ewwww. all this is taken from Qt's QUrl::setEncodedPath compatibility helper.
 // (I can't see any way to port the below code to NOT require this).
@@ -503,7 +495,7 @@ void QgsNewHttpConnection::accept()
 
     settings.setValue( wmsKey + "/dpiMode", dpiMode );
 
-    settings.setValue( wmsKey + "/referer", txtReferer->text() );
+    settings.setValue( wmsKey + "/referer", mRefererLineEdit->text() );
   }
   if ( mTypes & ConnectionWms )
   {

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.cpp
@@ -16,7 +16,9 @@
 #include "qgsvectortileconnectiondialog.h"
 #include "qgsvectortileconnection.h"
 #include "qgsgui.h"
+
 #include <QMessageBox>
+#include <QPushButton>
 
 ///@cond PRIVATE
 
@@ -29,6 +31,10 @@ QgsVectorTileConnectionDialog::QgsVectorTileConnectionDialog( QWidget *parent )
   // Behavior for min and max zoom checkbox
   connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
+
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( mEditName, &QLineEdit::textChanged, this, &QgsVectorTileConnectionDialog::updateOkButtonState );
+  connect( mEditUrl, &QLineEdit::textChanged, this, &QgsVectorTileConnectionDialog::updateOkButtonState );
 }
 
 void QgsVectorTileConnectionDialog::setConnection( const QString &name, const QString &uri )
@@ -57,6 +63,12 @@ QString QgsVectorTileConnectionDialog::connectionUri() const
 QString QgsVectorTileConnectionDialog::connectionName() const
 {
   return mEditName->text();
+}
+
+void QgsVectorTileConnectionDialog::updateOkButtonState()
+{
+  bool enabled = !mEditName->text().isEmpty() && !mEditUrl->text().isEmpty();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }
 
 void QgsVectorTileConnectionDialog::accept()

--- a/src/gui/vectortile/qgsvectortileconnectiondialog.h
+++ b/src/gui/vectortile/qgsvectortileconnectiondialog.h
@@ -37,8 +37,10 @@ class QgsVectorTileConnectionDialog : public QDialog, public Ui::QgsVectorTileCo
 
     void accept() override;
 
-  private:
+  private slots:
+    void updateOkButtonState();
 
+  private:
     QString mBaseKey;
     QString mCredentialsBaseKey;
 };

--- a/src/gui/vectortile/qgsvectortileproviderguimetadata.cpp
+++ b/src/gui/vectortile/qgsvectortileproviderguimetadata.cpp
@@ -27,7 +27,7 @@ class QgsVectorTileSourceSelectProvider : public QgsSourceSelectProvider
 
     QString providerKey() const override { return QStringLiteral( "vectortile" ); }
     QString text() const override { return QStringLiteral( "Vector Tile" ); } // untranslatable string as acronym for this particular case. Use QObject::tr() otherwise
-    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 12; }
+    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 50; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVectorTileLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
     {

--- a/src/gui/vectortile/qgsvectortilesourceselect.cpp
+++ b/src/gui/vectortile/qgsvectortilesourceselect.cpp
@@ -122,11 +122,12 @@ void QgsVectorTileSourceSelect::populateConnectionList()
   cmbConnections->addItems( QgsVectorTileProviderConnection::connectionList() );
   cmbConnections->blockSignals( false );
 
-  setConnectionListPosition();
-
   btnEdit->setDisabled( cmbConnections->count() == 0 );
   btnDelete->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
 }
 
 void QgsVectorTileSourceSelect::setConnectionListPosition()
@@ -142,6 +143,7 @@ void QgsVectorTileSourceSelect::setConnectionListPosition()
     else
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
   }
+
   emit enableButtons( !cmbConnections->currentText().isEmpty() );
 }
 

--- a/src/providers/db2/qgsdb2newconnection.cpp
+++ b/src/providers/db2/qgsdb2newconnection.cpp
@@ -38,6 +38,14 @@ QgsDb2NewConnection::QgsDb2NewConnection( QWidget *parent, const QString &connNa
   connect( btnConnect, &QPushButton::clicked, this, &QgsDb2NewConnection::btnConnect_clicked );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDb2NewConnection::showHelp );
 
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( txtName, &QLineEdit::textChanged, this, &QgsDb2NewConnection::updateOkButtonState );
+  connect( txtService, &QLineEdit::textChanged, this, &QgsDb2NewConnection::updateOkButtonState );
+  connect( txtDriver, &QLineEdit::textChanged, this, &QgsDb2NewConnection::updateOkButtonState );
+  connect( txtHost, &QLineEdit::textChanged, this, &QgsDb2NewConnection::updateOkButtonState );
+  connect( txtPort, &QLineEdit::textChanged, this, &QgsDb2NewConnection::updateOkButtonState );
+  connect( txtDatabase, &QLineEdit::textChanged, this, &QgsDb2NewConnection::updateOkButtonState );
+
   mAuthSettings->setDataprovider( QStringLiteral( "db2" ) );
   mAuthSettings->showStoreCheckboxes( true );
 
@@ -199,4 +207,12 @@ void QgsDb2NewConnection::listDatabases()
 void QgsDb2NewConnection::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#connecting-to-db2-spatial" ) );
+}
+
+void QgsDb2NewConnection::updateOkButtonState()
+{
+  bool enabled = !txtName->text().isEmpty() && (
+                   ( !txtService->text().isEmpty() && !txtDatabase->text().isEmpty() ) ||
+                   ( !txtDriver->text().isEmpty() && !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty() ) );
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/providers/db2/qgsdb2newconnection.h
+++ b/src/providers/db2/qgsdb2newconnection.h
@@ -45,6 +45,8 @@ class QgsDb2NewConnection : public QDialog, private Ui::QgsDb2NewConnectionBase
     void btnListDatabase_clicked();
     void btnConnect_clicked();
     void on_cb_trustedConnection_clicked();
+  private slots:
+    void updateOkButtonState();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();

--- a/src/providers/db2/qgsdb2newconnection.h
+++ b/src/providers/db2/qgsdb2newconnection.h
@@ -46,6 +46,7 @@ class QgsDb2NewConnection : public QDialog, private Ui::QgsDb2NewConnectionBase
     void btnConnect_clicked();
     void on_cb_trustedConnection_clicked();
   private slots:
+    //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename

--- a/src/providers/db2/qgsdb2sourceselect.cpp
+++ b/src/providers/db2/qgsdb2sourceselect.cpp
@@ -416,12 +416,13 @@ void QgsDb2SourceSelect::populateConnectionList()
     ++it;
   }
 
-  setConnectionListPosition();
-
+  btnConnect->setDisabled( cmbConnections->count() == 0 );
   btnEdit->setDisabled( cmbConnections->count() == 0 );
   btnDelete->setDisabled( cmbConnections->count() == 0 );
-  btnConnect->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
 }
 
 // Slot for performing action when the Add button is clicked

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -39,6 +39,12 @@ QgsMssqlNewConnection::QgsMssqlNewConnection( QWidget *parent, const QString &co
   connect( cb_trustedConnection, &QCheckBox::clicked, this, &QgsMssqlNewConnection::cb_trustedConnection_clicked );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsMssqlNewConnection::showHelp );
 
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( txtName, &QLineEdit::textChanged, this, &QgsMssqlNewConnection::updateOkButtonState );
+  connect( txtService, &QLineEdit::textChanged, this, &QgsMssqlNewConnection::updateOkButtonState );
+  connect( txtHost, &QLineEdit::textChanged, this, &QgsMssqlNewConnection::updateOkButtonState );
+  connect( listDatabase, &QListWidget::currentItemChanged, this, &QgsMssqlNewConnection::updateOkButtonState );
+
   lblWarning->hide();
 
   if ( !connName.isEmpty() )
@@ -242,4 +248,11 @@ void QgsMssqlNewConnection::listDatabases()
 void QgsMssqlNewConnection::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#connecting-to-mssql-spatial" ) );
+}
+
+void QgsMssqlNewConnection::updateOkButtonState()
+{
+  QListWidgetItem *item = listDatabase->currentItem();
+  bool enabled = !txtName->text().isEmpty() && !txtService->text().isEmpty() && !txtHost->text().isEmpty() && item;
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -45,6 +45,9 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     void btnListDatabase_clicked();
     void btnConnect_clicked();
     void cb_trustedConnection_clicked();
+
+  private slots:
+    void updateOkButtonState();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -47,6 +47,7 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     void cb_trustedConnection_clicked();
 
   private slots:
+    //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -415,12 +415,13 @@ void QgsMssqlSourceSelect::populateConnectionList()
     ++it;
   }
 
-  setConnectionListPosition();
-
+  btnConnect->setDisabled( cmbConnections->count() == 0 );
   btnEdit->setDisabled( cmbConnections->count() == 0 );
   btnDelete->setDisabled( cmbConnections->count() == 0 );
-  btnConnect->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
 }
 
 // Slot for performing action when the Add button is clicked

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -36,6 +36,12 @@ QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString &
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsOracleNewConnection::showHelp );
   connect( btnConnect, &QPushButton::clicked, this, &QgsOracleNewConnection::testConnection );
 
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( txtName, &QLineEdit::textChanged, this, &QgsOracleNewConnection::updateOkButtonState );
+  connect( txtDatabase, &QLineEdit::textChanged, this, &QgsOracleNewConnection::updateOkButtonState );
+  connect( txtHost, &QLineEdit::textChanged, this, &QgsOracleNewConnection::updateOkButtonState );
+  connect( txtPort, &QLineEdit::textChanged, this, &QgsOracleNewConnection::updateOkButtonState );
+
   mAuthSettings->setDataprovider( QStringLiteral( "oracle" ) );
   mAuthSettings->showStoreCheckboxes( true );
 
@@ -185,4 +191,10 @@ void QgsOracleNewConnection::testConnection()
 void QgsOracleNewConnection::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#connecting-to-oracle-spatial" ) );
+}
+
+void QgsOracleNewConnection::updateOkButtonState()
+{
+  bool enabled = !txtName->text().isEmpty() && !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/providers/oracle/qgsoraclenewconnection.h
+++ b/src/providers/oracle/qgsoraclenewconnection.h
@@ -40,6 +40,7 @@ class QgsOracleNewConnection : public QDialog, private Ui::QgsOracleNewConnectio
 
   private slots:
     void testConnection();
+    //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
 
   private:

--- a/src/providers/oracle/qgsoraclenewconnection.h
+++ b/src/providers/oracle/qgsoraclenewconnection.h
@@ -40,6 +40,7 @@ class QgsOracleNewConnection : public QDialog, private Ui::QgsOracleNewConnectio
 
   private slots:
     void testConnection();
+    void updateOkButtonState();
 
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -38,6 +38,13 @@ QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString &connName
   connect( cb_geometryColumnsOnly, &QCheckBox::clicked, this, &QgsPgNewConnection::cb_geometryColumnsOnly_clicked );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPgNewConnection::showHelp );
 
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( txtName, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
+  connect( txtService, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
+  connect( txtHost, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
+  connect( txtPort, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
+  connect( txtDatabase, &QLineEdit::textChanged, this, &QgsPgNewConnection::updateOkButtonState );
+
   cbxSSLmode->addItem( tr( "disable" ), QgsDataSourceUri::SslDisable );
   cbxSSLmode->addItem( tr( "allow" ), QgsDataSourceUri::SslAllow );
   cbxSSLmode->addItem( tr( "prefer" ), QgsDataSourceUri::SslPrefer );
@@ -237,4 +244,12 @@ void QgsPgNewConnection::testConnection()
 void QgsPgNewConnection::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "managing_data_source/opening_data.html#creating-a-stored-connection" ) );
+}
+
+void QgsPgNewConnection::updateOkButtonState()
+{
+  bool enabled = !txtName->text().isEmpty() && (
+                   ( !txtService->text().isEmpty() && !txtDatabase->text().isEmpty() ) ||
+                   ( !txtHost->text().isEmpty() && !txtPort->text().isEmpty() && !txtDatabase->text().isEmpty() ) );
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }

--- a/src/providers/postgres/qgspgnewconnection.h
+++ b/src/providers/postgres/qgspgnewconnection.h
@@ -39,6 +39,7 @@ class QgsPgNewConnection : public QDialog, private Ui::QgsPgNewConnectionBase
     void btnConnect_clicked();
     void cb_geometryColumnsOnly_clicked();
   private slots:
+    //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename

--- a/src/providers/postgres/qgspgnewconnection.h
+++ b/src/providers/postgres/qgspgnewconnection.h
@@ -38,6 +38,8 @@ class QgsPgNewConnection : public QDialog, private Ui::QgsPgNewConnectionBase
     void accept() override;
     void btnConnect_clicked();
     void cb_geometryColumnsOnly_clicked();
+  private slots:
+    void updateOkButtonState();
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -482,12 +482,13 @@ void QgsPgSourceSelect::populateConnectionList()
   cmbConnections->addItems( QgsPostgresConn::connectionList() );
   cmbConnections->blockSignals( false );
 
-  setConnectionListPosition();
-
+  btnConnect->setDisabled( cmbConnections->count() == 0 );
   btnEdit->setDisabled( cmbConnections->count() == 0 );
   btnDelete->setDisabled( cmbConnections->count() == 0 );
-  btnConnect->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
 }
 
 // Slot for performing action when the Add button is clicked

--- a/src/providers/wcs/qgswcsprovidergui.cpp
+++ b/src/providers/wcs/qgswcsprovidergui.cpp
@@ -28,7 +28,7 @@ class QgsWcsSourceSelectProvider : public QgsSourceSelectProvider
 
     QString providerKey() const override { return QStringLiteral( "wcs" ); }
     QString text() const override { return QObject::tr( "WCS" ); }
-    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 20; }
+    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 30; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddWcsLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
     {

--- a/src/providers/wfs/qgswfsprovidergui.cpp
+++ b/src/providers/wfs/qgswfsprovidergui.cpp
@@ -27,7 +27,7 @@ class QgsWfsSourceSelectProvider : public QgsSourceSelectProvider
 
     QString providerKey() const override { return QgsWFSProvider::WFS_PROVIDER_KEY; }
     QString text() const override { return QObject::tr( "WFS / OGC API - Features" ); }
-    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 40; }
+    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 20; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddWfsLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
     {

--- a/src/providers/wms/qgswmsprovidergui.cpp
+++ b/src/providers/wms/qgswmsprovidergui.cpp
@@ -44,7 +44,7 @@ class QgsXyzSourceSelectProvider : public QgsSourceSelectProvider
 
     QString providerKey() const override { return QStringLiteral( "xyz" ); }
     QString text() const override { return QStringLiteral( "XYZ" ); } // untranslatable string as acronym for this particular case. Use QObject::tr() otherwise
-    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 11; }
+    int ordering() const override { return QgsSourceSelectProvider::OrderRemoteProvider + 40; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddXyzLayer.svg" ) ); }
     QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
     {

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -70,7 +70,6 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
   connect( btnChangeSpatialRefSys, &QPushButton::clicked, this, &QgsWMSSourceSelect::btnChangeSpatialRefSys_clicked );
   connect( lstLayers, &QTreeWidget::itemSelectionChanged, this, &QgsWMSSourceSelect::lstLayers_itemSelectionChanged );
   connect( cmbConnections, static_cast<void ( QComboBox::* )( int )>( &QComboBox::activated ), this, &QgsWMSSourceSelect::cmbConnections_activated );
-  connect( btnAddDefault, &QPushButton::clicked, this, &QgsWMSSourceSelect::btnAddDefault_clicked );
   connect( btnSearch, &QPushButton::clicked, this, &QgsWMSSourceSelect::btnSearch_clicked );
   connect( btnAddWMS, &QPushButton::clicked, this, &QgsWMSSourceSelect::btnAddWMS_clicked );
   connect( tableWidgetWMSList, &QTableWidget::itemSelectionChanged, this, &QgsWMSSourceSelect::tableWidgetWMSList_itemSelectionChanged );
@@ -1123,11 +1122,6 @@ void QgsWMSSourceSelect::cmbConnections_activated( int )
   QgsWMSConnection::setSelectedConnection( cmbConnections->currentText() );
 }
 
-void QgsWMSSourceSelect::btnAddDefault_clicked()
-{
-  addDefaultServers();
-}
-
 QString QgsWMSSourceSelect::descriptionForAuthId( const QString &authId )
 {
   if ( mCrsNames.contains( authId ) )
@@ -1136,35 +1130,6 @@ QString QgsWMSSourceSelect::descriptionForAuthId( const QString &authId )
   QgsCoordinateReferenceSystem qgisSrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( authId );
   mCrsNames.insert( authId, qgisSrs.userFriendlyIdentifier() );
   return qgisSrs.userFriendlyIdentifier();
-}
-
-void QgsWMSSourceSelect::addDefaultServers()
-{
-  QMap<QString, QString> exampleServers;
-  exampleServers[QStringLiteral( "QGIS Server Demo - Alaska" )] = QStringLiteral( "http://demo.qgis.org/cgi-bin/qgis_mapserv.fcgi?map=/web/demos/alaska/alaska_map.qgs" );
-  exampleServers[QStringLiteral( "Geoserver Demo" )] = QStringLiteral( "https://demo.geo-solutions.it/geoserver/wms/" );
-  exampleServers[QStringLiteral( "Mapserver Demo" )] = QStringLiteral( "http://demo.mapserver.org/cgi-bin/wms" );
-
-  QgsSettings settings;
-  settings.beginGroup( QStringLiteral( "qgis/connections-wms" ) );
-  QMap<QString, QString>::const_iterator i = exampleServers.constBegin();
-  for ( ; i != exampleServers.constEnd(); ++i )
-  {
-    // Only do a server if it's name doesn't already exist.
-    QStringList keys = settings.childGroups();
-    if ( !keys.contains( i.key() ) )
-    {
-      QString path = i.key();
-      settings.setValue( path + "/url", i.value() );
-    }
-  }
-  settings.endGroup();
-  populateConnectionList();
-
-  QMessageBox::information( this, tr( "WMS proxies" ), "<p>" + tr( "Several WMS servers have "
-                            "been added to the server list. Note that if "
-                            "you access the internet via a web proxy, you will "
-                            "need to set the proxy settings in the QGIS options dialog." ) + "</p>" );
 }
 
 void QgsWMSSourceSelect::addWMSListRow( const QDomElement &item, int row )

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -256,6 +256,7 @@ QgsTreeWidgetItem *QgsWMSSourceSelect::createItem(
   item->setText( 0, QString::number( ++layerAndStyleCount ) );
   item->setText( 1, names[0].simplified() );
   item->setText( 2, names[1].simplified() );
+  item->setToolTip( 2, "<font color=black>" + names[1].simplified()  + "</font>" );
   item->setText( 3, names[2].simplified() );
   item->setToolTip( 3, "<font color=black>" + names[2].simplified()  + "</font>" );
 

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -163,6 +163,12 @@ void QgsWMSSourceSelect::populateConnectionList()
   cmbConnections->clear();
   cmbConnections->addItems( QgsWMSConnection::connectionList() );
 
+  btnConnect->setDisabled( cmbConnections->count() == 0 );
+  btnEdit->setDisabled( cmbConnections->count() == 0 );
+  btnDelete->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
+  cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
   setConnectionListPosition();
 }
 
@@ -1083,23 +1089,6 @@ void QgsWMSSourceSelect::setConnectionListPosition()
       cmbConnections->setCurrentIndex( 0 );
     else
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
-  }
-
-  if ( cmbConnections->count() == 0 )
-  {
-    // No connections - disable various buttons
-    btnConnect->setEnabled( false );
-    btnEdit->setEnabled( false );
-    btnDelete->setEnabled( false );
-    btnSave->setEnabled( false );
-  }
-  else
-  {
-    // Connections - enable various buttons
-    btnConnect->setEnabled( true );
-    btnEdit->setEnabled( true );
-    btnDelete->setEnabled( true );
-    btnSave->setEnabled( true );
   }
 }
 

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -173,7 +173,8 @@ void QgsWMSSourceSelect::populateConnectionList()
 
 void QgsWMSSourceSelect::btnNew_clicked()
 {
-  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this );
+  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, QgsNewHttpConnection::ConnectionWms, QStringLiteral( "qgis/connections-wms/" ), QString(), QgsNewHttpConnection::FlagShowHttpSettings );
+
 
   if ( nc->exec() )
   {
@@ -186,7 +187,7 @@ void QgsWMSSourceSelect::btnNew_clicked()
 
 void QgsWMSSourceSelect::btnEdit_clicked()
 {
-  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, QgsNewHttpConnection::ConnectionWms, QStringLiteral( "qgis/connections-wms/" ), cmbConnections->currentText() );
+  QgsNewHttpConnection *nc = new QgsNewHttpConnection( this, QgsNewHttpConnection::ConnectionWms, QStringLiteral( "qgis/connections-wms/" ), cmbConnections->currentText(), QgsNewHttpConnection::FlagShowHttpSettings );
 
   if ( nc->exec() )
   {

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -95,9 +95,6 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
     //! Stores the selected datasource whenerver it is changed
     void cmbConnections_activated( int );
 
-    //! Add some default wms servers to the list
-    void btnAddDefault_clicked();
-
   private:
     //! Populate the connection list combo box
     void populateConnectionList();
@@ -107,9 +104,6 @@ class QgsWMSSourceSelect : public QgsAbstractDataSourceWidget, private Ui::QgsWM
 
     //! Sets the server connection combo box to that stored in the config file.
     void setConnectionListPosition();
-
-    //! Add a few example servers to the list.
-    void addDefaultServers();
 
     //! Selected CRS
     QString mCRS;

--- a/src/providers/wms/qgsxyzconnectiondialog.cpp
+++ b/src/providers/wms/qgsxyzconnectiondialog.cpp
@@ -16,6 +16,7 @@
 #include "qgsxyzconnectiondialog.h"
 #include "qgsxyzconnection.h"
 #include "qgsgui.h"
+
 #include <QMessageBox>
 
 QgsXyzConnectionDialog::QgsXyzConnectionDialog( QWidget *parent )
@@ -27,6 +28,10 @@ QgsXyzConnectionDialog::QgsXyzConnectionDialog( QWidget *parent )
   // Behavior for min and max zoom checkbox
   connect( mCheckBoxZMin, &QCheckBox::toggled, mSpinZMin, &QSpinBox::setEnabled );
   connect( mCheckBoxZMax, &QCheckBox::toggled, mSpinZMax, &QSpinBox::setEnabled );
+
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  connect( mEditName, &QLineEdit::textChanged, this, &QgsXyzConnectionDialog::updateOkButtonState );
+  connect( mEditUrl, &QLineEdit::textChanged, this, &QgsXyzConnectionDialog::updateOkButtonState );
 }
 
 void QgsXyzConnectionDialog::setConnection( const QgsXyzConnection &conn )
@@ -69,6 +74,12 @@ QgsXyzConnection QgsXyzConnectionDialog::connection() const
     conn.tilePixelRatio = 0;  // unknown
   conn.authCfg = mAuthSettings->configId( );
   return conn;
+}
+
+void QgsXyzConnectionDialog::updateOkButtonState()
+{
+  bool enabled = !mEditName->text().isEmpty() && !mEditUrl->text().isEmpty();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( enabled );
 }
 
 void QgsXyzConnectionDialog::accept()

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -37,6 +37,7 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
     void accept() override;
 
   private slots:
+    //! Updates state of the OK button depending of the filled fields
     void updateOkButtonState();
 
   private:

--- a/src/providers/wms/qgsxyzconnectiondialog.h
+++ b/src/providers/wms/qgsxyzconnectiondialog.h
@@ -36,8 +36,10 @@ class QgsXyzConnectionDialog : public QDialog, public Ui::QgsXyzConnectionDialog
 
     void accept() override;
 
-  private:
+  private slots:
+    void updateOkButtonState();
 
+  private:
     QString mBaseKey;
     QString mCredentialsBaseKey;
 };

--- a/src/providers/wms/qgsxyzsourceselect.cpp
+++ b/src/providers/wms/qgsxyzsourceselect.cpp
@@ -114,11 +114,12 @@ void QgsXyzSourceSelect::populateConnectionList()
   cmbConnections->addItems( QgsXyzConnectionUtils::connectionList() );
   cmbConnections->blockSignals( false );
 
-  setConnectionListPosition();
-
   btnEdit->setDisabled( cmbConnections->count() == 0 );
   btnDelete->setDisabled( cmbConnections->count() == 0 );
+  btnSave->setDisabled( cmbConnections->count() == 0 );
   cmbConnections->setDisabled( cmbConnections->count() == 0 );
+
+  setConnectionListPosition();
 }
 
 void QgsXyzSourceSelect::setConnectionListPosition()
@@ -134,6 +135,7 @@ void QgsXyzSourceSelect::setConnectionListPosition()
     else
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
   }
+
   emit enableButtons( !cmbConnections->currentText().isEmpty() );
 }
 

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>828</height>
+    <height>761</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -103,41 +103,44 @@
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="3" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
-           <property name="text">
-            <string>Ignore GetFeatureInfo URI reported in capabilities</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
-           <property name="text">
-            <string>Ignore GetMap/GetTile URI reported in capabilities</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxWmsIgnoreAxisOrientation">
            <property name="text">
             <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
            </property>
           </widget>
          </item>
-         <item row="10" column="0" colspan="2">
+         <item row="2" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
+           <property name="text">
+            <string>Ignore GetFeatureInfo URI reported in capabilities</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
+           <property name="text">
+            <string>Ignore GetMap/GetTile URI reported in capabilities</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
            <property name="text">
             <string>Smooth pixmap transform</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0" colspan="2">
+         <item row="5" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxWmsInvertAxisOrientation">
            <property name="text">
             <string>Invert axis orientation</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbDpiMode"/>
+         </item>
+         <item row="0" column="0">
           <widget class="QLabel" name="lblDpiMode">
            <property name="text">
             <string>DPI-&amp;Mode</string>
@@ -147,23 +150,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="txtReferer"/>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblReferer">
-           <property name="text">
-            <string>&amp;Referer</string>
-           </property>
-           <property name="buddy">
-            <cstring>txtReferer</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QComboBox" name="cmbDpiMode"/>
-         </item>
-         <item row="5" column="0" colspan="2">
+         <item row="4" column="0" colspan="2">
           <widget class="QCheckBox" name="cbxWmsIgnoreReportedLayerExtents">
            <property name="text">
             <string>Ignore reported layer extents</string>
@@ -173,36 +160,26 @@
         </layout>
        </widget>
       </item>
-      <item row="6" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="3" column="0" colspan="2">
        <widget class="QGroupBox" name="mWfsOptionsGroupBox">
         <property name="title">
          <string>WFS Options</string>
         </property>
-        <layout class="QGridLayout" name="gridLayout1">
-         <item row="4" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWfsIgnoreAxisOrientation">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblVersion">
            <property name="text">
-            <string>Ignore axis orientation (WFS 1.1/WFS 2.0)</string>
+            <string>Version</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="0" colspan="2">
-          <widget class="QCheckBox" name="cbxWfsInvertAxisOrientation">
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cmbVersion"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="mWfsVersionDetectButton">
            <property name="text">
-            <string>Invert axis orientation</string>
+            <string>Detect</string>
            </property>
           </widget>
          </item>
@@ -213,41 +190,10 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblVersion">
-           <property name="text">
-            <string>Version</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
+         <item row="1" column="1" colspan="2">
           <widget class="QLineEdit" name="txtMaxNumFeatures">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a number to limit the maximum number of features retrieved per feature request. If let to empty, no limit is set.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <layout class="QHBoxLayout" name="layoutWfsVersion">
-           <item>
-            <widget class="QComboBox" name="cmbVersion"/>
-           </item>
-           <item>
-            <widget class="QPushButton" name="mWfsVersionDetectButton">
-             <property name="text">
-              <string>Detect</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="cbxWfsFeaturePaging">
-           <property name="text">
-            <string>Enable feature paging</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -258,10 +204,34 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="3" column="1" colspan="2">
           <widget class="QLineEdit" name="txtPageSize">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a number to limit the maximum number of features retrieved in a single GetFeature request when paging is enabled. If let to empty, server default will apply.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" colspan="3">
+          <widget class="QCheckBox" name="cbxWfsIgnoreAxisOrientation">
+           <property name="text">
+            <string>Ignore axis orientation (WFS 1.1/WFS 2.0)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="3">
+          <widget class="QCheckBox" name="cbxWfsFeaturePaging">
+           <property name="text">
+            <string>Enable feature paging</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="3">
+          <widget class="QCheckBox" name="cbxWfsInvertAxisOrientation">
+           <property name="text">
+            <string>Invert axis orientation</string>
            </property>
           </widget>
          </item>
@@ -325,6 +295,19 @@
         </layout>
        </widget>
       </item>
+      <item row="6" column="0" colspan="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
@@ -362,7 +345,6 @@
   <tabstop>txtPageSize</tabstop>
   <tabstop>cbxWfsIgnoreAxisOrientation</tabstop>
   <tabstop>cbxWfsInvertAxisOrientation</tabstop>
-  <tabstop>txtReferer</tabstop>
   <tabstop>cmbDpiMode</tabstop>
   <tabstop>cbxIgnoreGetMapURI</tabstop>
   <tabstop>cbxIgnoreGetFeatureInfoURI</tabstop>

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>773</width>
+    <width>744</width>
     <height>544</height>
    </rect>
   </property>
@@ -124,19 +124,6 @@
           </size>
          </property>
         </spacer>
-       </item>
-       <item row="1" column="11">
-        <widget class="QPushButton" name="btnAddDefault">
-         <property name="statusTip">
-          <string>Adds a few example WMS servers</string>
-         </property>
-         <property name="whatsThis">
-          <string comment="Adds several example WMS servers to the list"/>
-         </property>
-         <property name="text">
-          <string>Add Default Servers</string>
-         </property>
-        </widget>
        </item>
        <item row="2" column="0" colspan="12">
         <widget class="QTreeWidget" name="lstLayers">
@@ -507,7 +494,6 @@
   <tabstop>btnDelete</tabstop>
   <tabstop>btnLoad</tabstop>
   <tabstop>btnSave</tabstop>
-  <tabstop>btnAddDefault</tabstop>
   <tabstop>lstLayers</tabstop>
   <tabstop>mTileWidth</tabstop>
   <tabstop>mTileHeight</tabstop>

--- a/src/ui/qgsxyzconnectiondialog.ui
+++ b/src/ui/qgsxyzconnectiondialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>636</width>
-    <height>624</height>
+    <height>331</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
## Description

- take into account configured pixel ratio for XYZ connections when performing connections import/export. Previously this setting was ignored and configured value lost.
- Ok button in new connection dialog for OGR, PostGIS, Oracle, MSSQL, DB2, XYZ and Vector tile providers enabled only if all required fields are not empty preventing loosing data. Fixes #26038.
- disable editing and export buttons in the datasource select dialogs if no connections are available, having these buttons enabled makes no sense in such case.
- remove "Add default servers" button from the WMS page in the Datasource Manager. Most of the default servers are not working, the rest have very limited usage during last discussion in the mailing list couple of people suggested to remove it. Fixes #29873.
- use already available "Referer" field from the base widget in the new WMS connection dialog instead of custom field.
- add tooltip to the WMS layer title to allow displaying long titles (refs #28861)