### PR TITLE
More minor speed boost to identify highlight

### DIFF
--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -362,10 +362,12 @@ void QgsHighlight::paint( QPainter *p )
       // coefficient to subtract alpha using green (temporary fill)
       double k = ( 255. - mBrush.color().alpha() ) / 255.;
       QRgb *line = nullptr;
-      for ( int r = 0; r < image.height(); r++ )
+      const int height = image.height();
+      const int width = image.width();
+      for ( int r = 0; r < height; r++ )
       {
         line = reinterpret_cast<QRgb *>( image.scanLine( r ) );
-        for ( int c = 0; c < image.width(); c++ )
+        for ( int c = 0; c < width; c++ )
         {
           int alpha = qAlpha( line[c] );
           if ( alpha > 0 )


### PR DESCRIPTION
## Description
I was about to issue a bug report after noticing a big performance drop when a lot of features are highlighted on the map. Then I saw #6274 from git blame, so since it's a known issue, until QgsHighlight is completely reworked, we could benefit from some optimization and skip calling `image.width()` a gazillion times!


<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
