### PR TITLE
[browser] React when a custom data item provider is added/removed

### DIFF
--- a/python/core/auto_generated/qgsbrowsermodel.sip.in
+++ b/python/core/auto_generated/qgsbrowsermodel.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsBrowserModel : QAbstractItemModel
 {
 %Docstring

--- a/python/core/auto_generated/qgsdataitemproviderregistry.sip.in
+++ b/python/core/auto_generated/qgsdataitemproviderregistry.sip.in
@@ -11,7 +11,7 @@
 
 
 
-class QgsDataItemProviderRegistry
+class QgsDataItemProviderRegistry : QObject
 {
 %Docstring
 This class keeps a list of data item providers that may add items to the browser tree.
@@ -62,6 +62,22 @@ The provider object is automatically deleted.
 Returns the (possibly blank) data provider key for a given data item provider name.
 
 :param dataItemProviderName: name of the data item provider
+
+.. versionadded:: 3.14
+%End
+
+  signals:
+
+    void providerAdded( QgsDataItemProvider *provider );
+%Docstring
+Emitted when a new data item provider has been added.
+
+.. versionadded:: 3.14
+%End
+
+    void providerWillBeRemoved( QgsDataItemProvider *provider );
+%Docstring
+Emitted when a data item provider is about to be removed
 
 .. versionadded:: 3.14
 %End

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -49,6 +49,10 @@ QgsBrowserModel::QgsBrowserModel( QObject *parent )
   : QAbstractItemModel( parent )
 
 {
+  connect( QgsApplication::dataItemProviderRegistry(), &QgsDataItemProviderRegistry::providerAdded,
+           this, &QgsBrowserModel::dataItemProviderAdded );
+  connect( QgsApplication::dataItemProviderRegistry(), &QgsDataItemProviderRegistry::providerWillBeRemoved,
+           this, &QgsBrowserModel::dataItemProviderWillBeRemoved );
 }
 
 QgsBrowserModel::~QgsBrowserModel()
@@ -132,23 +136,9 @@ void QgsBrowserModel::addRootItems()
   const auto constProviders = QgsApplication::dataItemProviderRegistry()->providers();
   for ( QgsDataItemProvider *pr : constProviders )
   {
-    int capabilities = pr->capabilities();
-    if ( capabilities == QgsDataProvider::NoDataCapabilities )
+    if ( QgsDataItem *item = addProviderRootItem( pr ) )
     {
-      QgsDebugMsgLevel( pr->name() + " does not have any dataCapabilities", 4 );
-      continue;
-    }
-
-    QgsDataItem *item = pr->createDataItem( QString(), nullptr );  // empty path -> top level
-    if ( item )
-    {
-      // make sure the top level key is set always
-      item->setProviderKey( pr->name() );
-      // Forward the signal from the root items to the model (and then to the app)
-      connect( item, &QgsDataItem::connectionsChanged, this, &QgsBrowserModel::connectionsChanged );
-      QgsDebugMsgLevel( "Add new top level item : " + item->name(), 4 );
-      setupItemConnections( item );
-      providerMap.insertMulti( capabilities, item );
+      providerMap.insertMulti( pr->capabilities(), item );
     }
   }
 
@@ -180,6 +170,32 @@ void QgsBrowserModel::removeRootItems()
 
   mRootItems.clear();
   mDriveItems.clear();
+}
+
+void QgsBrowserModel::dataItemProviderAdded( QgsDataItemProvider *provider )
+{
+  if ( !mInitialized )
+    return;
+
+  if ( QgsDataItem *item = addProviderRootItem( provider ) )
+  {
+    beginInsertRows( QModelIndex(), rowCount(), rowCount() );
+    mRootItems << item;
+    endInsertRows();
+  }
+}
+
+void QgsBrowserModel::dataItemProviderWillBeRemoved( QgsDataItemProvider *provider )
+{
+  const auto constMRootItems = mRootItems;
+  for ( QgsDataItem *item : constMRootItems )
+  {
+    if ( item->providerKey() == provider->name() )
+    {
+      removeRootItem( item );
+      break;  // assuming there is max. 1 root item per provider
+    }
+  }
 }
 
 QMap<QString, QgsDirectoryItem *> QgsBrowserModel::driveItems() const
@@ -733,3 +749,24 @@ void QgsBrowserModel::removeRootItem( QgsDataItem *item )
   endRemoveRows();
 }
 
+QgsDataItem *QgsBrowserModel::addProviderRootItem( QgsDataItemProvider *pr )
+{
+  int capabilities = pr->capabilities();
+  if ( capabilities == QgsDataProvider::NoDataCapabilities )
+  {
+    QgsDebugMsgLevel( pr->name() + " does not have any dataCapabilities", 4 );
+    return nullptr;
+  }
+
+  QgsDataItem *item = pr->createDataItem( QString(), nullptr );  // empty path -> top level
+  if ( item )
+  {
+    // make sure the top level key is set always
+    item->setProviderKey( pr->name() );
+    // Forward the signal from the root items to the model (and then to the app)
+    connect( item, &QgsDataItem::connectionsChanged, this, &QgsBrowserModel::connectionsChanged );
+    QgsDebugMsgLevel( "Add new top level item : " + item->name(), 4 );
+    setupItemConnections( item );
+  }
+  return item;
+}

--- a/src/core/qgsbrowsermodel.h
+++ b/src/core/qgsbrowsermodel.h
@@ -25,6 +25,8 @@
 
 #include "qgsdataitem.h"
 
+class QgsDataItemProvider;
+
 /**
  * \ingroup core
  * \class QgsBrowserWatcher
@@ -252,6 +254,10 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
     QgsFavoritesItem *mFavorites = nullptr;
     QgsDirectoryItem *mProjectHome = nullptr;
 
+  private slots:
+    void dataItemProviderAdded( QgsDataItemProvider *provider );
+    void dataItemProviderWillBeRemoved( QgsDataItemProvider *provider );
+
   private:
     bool mInitialized = false;
     QMap< QString, QgsDirectoryItem * > mDriveItems;
@@ -259,6 +265,8 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
     void setupItemConnections( QgsDataItem *item );
 
     void removeRootItem( QgsDataItem *item );
+
+    QgsDataItem *addProviderRootItem( QgsDataItemProvider *provider );
 
     friend class TestQgsBrowserModel;
     friend class TestQgsBrowserProxyModel;

--- a/src/core/qgsdataitemproviderregistry.cpp
+++ b/src/core/qgsdataitemproviderregistry.cpp
@@ -66,13 +66,17 @@ void QgsDataItemProviderRegistry::addProvider( QgsDataItemProvider *provider )
     mDataItemProviderOrigin[ provider->name() ] = provider->dataProviderKey();
   }
   mProviders.append( provider );
+  emit providerAdded( provider );
 }
 
 void QgsDataItemProviderRegistry::removeProvider( QgsDataItemProvider *provider )
 {
   int index = mProviders.indexOf( provider );
   if ( index >= 0 )
+  {
+    emit providerWillBeRemoved( provider );
     delete mProviders.takeAt( index );
+  }
 }
 
 QString QgsDataItemProviderRegistry::dataProviderKey( const QString &dataItemProviderName )

--- a/src/core/qgsdataitemproviderregistry.h
+++ b/src/core/qgsdataitemproviderregistry.h
@@ -18,6 +18,7 @@
 
 #include <QList>
 #include <QMap>
+#include <QObject>
 
 #include "qgis_sip.h"
 
@@ -35,8 +36,9 @@ class QgsDataItemProvider;
  *
  * \since QGIS 2.10
  */
-class CORE_EXPORT QgsDataItemProviderRegistry
+class CORE_EXPORT QgsDataItemProviderRegistry : public QObject
 {
+    Q_OBJECT
   public:
 
     QgsDataItemProviderRegistry();
@@ -78,6 +80,20 @@ class CORE_EXPORT QgsDataItemProviderRegistry
      * \since QGIS 3.14
      */
     QString dataProviderKey( const QString &dataItemProviderName );
+
+  signals:
+
+    /**
+     * Emitted when a new data item provider has been added.
+     * \since QGIS 3.14
+     */
+    void providerAdded( QgsDataItemProvider *provider );
+
+    /**
+     * Emitted when a data item provider is about to be removed
+     * \since QGIS 3.14
+     */
+    void providerWillBeRemoved( QgsDataItemProvider *provider );
 
   private:
 #ifdef SIP_RUN


### PR DESCRIPTION
Until now, if a newly activated plugin had a custom data item provider that added a root item to the browser model, the new root data item would not get added and a restart of QGIS was necessary.
