### PR TITLE
Added field name autocomplete to the query builder

### DIFF
--- a/python/gui/auto_generated/qgscodeeditorsql.sip.in
+++ b/python/gui/auto_generated/qgscodeeditorsql.sip.in
@@ -31,6 +31,13 @@ code autocompletion.
 Constructor for QgsCodeEditorSQL
 %End
 
+    void setFields( const QgsFields &fields );
+%Docstring
+Set field names to be added to the lexer API.
+
+.. versionadded:: 3.14
+%End
+
 };
 
 

--- a/src/gui/qgscodeeditorsql.cpp
+++ b/src/gui/qgscodeeditorsql.cpp
@@ -33,11 +33,11 @@ QgsCodeEditorSQL::QgsCodeEditorSQL( QWidget *parent )
   setMarginVisible( false );
   setFoldingVisible( true );
   setAutoCompletionCaseSensitivity( false );
-  setSciLexerSQL();
+  initializeLexer();
 }
 
 
-void QgsCodeEditorSQL::setSciLexerSQL()
+void QgsCodeEditorSQL::initializeLexer()
 {
   QHash< QString, QColor > colors;
   if ( QgsApplication::instance()->themeName() != QStringLiteral( "default" ) )
@@ -56,25 +56,50 @@ void QgsCodeEditorSQL::setSciLexerSQL()
 #endif
   QColor defaultColor = colors.value( QStringLiteral( "sql/defaultFontColor" ), Qt::black );
 
-  QsciLexerSQL *sqlLexer = new QgsCaseInsensitiveLexerSQL( this );
-  sqlLexer->setDefaultFont( font );
-  sqlLexer->setDefaultColor( defaultColor );
-  sqlLexer->setDefaultPaper( colors.value( QStringLiteral( "sql/paperBackgroundColor" ), Qt::white ) );
-  sqlLexer->setFont( font, -1 );
+  mSqlLexer = new QgsCaseInsensitiveLexerSQL( this );
+  mSqlLexer->setDefaultFont( font );
+  mSqlLexer->setDefaultColor( defaultColor );
+  mSqlLexer->setDefaultPaper( colors.value( QStringLiteral( "sql/paperBackgroundColor" ), Qt::white ) );
+  mSqlLexer->setFont( font, -1 );
   font.setBold( true );
-  sqlLexer->setFont( font, QsciLexerSQL::Keyword );
+  mSqlLexer->setFont( font, QsciLexerSQL::Keyword );
 
-  sqlLexer->setColor( defaultColor, QsciLexerSQL::Default );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/commentFontColor" ), QColor( 142, 144, 140 ) ), QsciLexerSQL::Comment );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/commentLineFontColor" ), QColor( 142, 144, 140 ) ), QsciLexerSQL::CommentLine );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/numberFontColor" ), QColor( 200, 40, 41 ) ), QsciLexerSQL::Number );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/keywordFontColor" ), QColor( 137, 89, 168 ) ), QsciLexerSQL::Keyword );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/singleQuoteFontColor" ), QColor( 113, 140, 0 ) ), QsciLexerSQL::SingleQuotedString );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/doubleQuoteFontColor" ), QColor( 234, 183, 0 ) ), QsciLexerSQL::DoubleQuotedString );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/operatorFontColor" ), QColor( 66, 113, 174 ) ), QsciLexerSQL::Operator );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/identifierFontColor" ), QColor( 62, 153, 159 ) ), QsciLexerSQL::Identifier );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/QuotedIdentifierFontColor" ), Qt::black ), QsciLexerSQL::QuotedIdentifier );
-  sqlLexer->setColor( colors.value( QStringLiteral( "sql/QuotedOperatorFontColor" ), Qt::black ), QsciLexerSQL::QuotedOperator );
+  mSqlLexer->setColor( defaultColor, QsciLexerSQL::Default );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/commentFontColor" ), QColor( 142, 144, 140 ) ), QsciLexerSQL::Comment );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/commentLineFontColor" ), QColor( 142, 144, 140 ) ), QsciLexerSQL::CommentLine );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/numberFontColor" ), QColor( 200, 40, 41 ) ), QsciLexerSQL::Number );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/keywordFontColor" ), QColor( 137, 89, 168 ) ), QsciLexerSQL::Keyword );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/singleQuoteFontColor" ), QColor( 113, 140, 0 ) ), QsciLexerSQL::SingleQuotedString );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/doubleQuoteFontColor" ), QColor( 234, 183, 0 ) ), QsciLexerSQL::DoubleQuotedString );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/operatorFontColor" ), QColor( 66, 113, 174 ) ), QsciLexerSQL::Operator );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/identifierFontColor" ), QColor( 62, 153, 159 ) ), QsciLexerSQL::Identifier );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/QuotedIdentifierFontColor" ), Qt::black ), QsciLexerSQL::QuotedIdentifier );
+  mSqlLexer->setColor( colors.value( QStringLiteral( "sql/QuotedOperatorFontColor" ), Qt::black ), QsciLexerSQL::QuotedOperator );
 
-  setLexer( sqlLexer );
+  setLexer( mSqlLexer );
+}
+
+void QgsCodeEditorSQL::setFields( const QgsFields &fields )
+{
+  mFieldNames.clear();
+
+  for ( const QgsField &field : fields )
+  {
+    mFieldNames << field.name();
+  }
+
+  updateApis();
+}
+
+void QgsCodeEditorSQL::updateApis()
+{
+  mApis = new QsciAPIs( mSqlLexer );
+
+  for ( const QString &fieldName : qgis::as_const( mFieldNames ) )
+  {
+    mApis->add( fieldName );
+  }
+
+  mApis->prepare();
+  mSqlLexer->setAPIs( mApis );
 }

--- a/src/gui/qgscodeeditorsql.h
+++ b/src/gui/qgscodeeditorsql.h
@@ -19,6 +19,7 @@
 #include "qgscodeeditor.h"
 #include "qgis_sip.h"
 #include "qgis_gui.h"
+#include "qgsfeature.h"
 #include <Qsci/qscilexersql.h>
 
 SIP_IF_MODULE( HAVE_QSCI_SIP )
@@ -38,10 +39,23 @@ class GUI_EXPORT QgsCodeEditorSQL : public QgsCodeEditor
     //! Constructor for QgsCodeEditorSQL
     QgsCodeEditorSQL( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
+    /**
+     * Set field names to be added to the lexer API.
+     *
+     * \since QGIS 3.14
+     */
+    void setFields( const QgsFields &fields );
+
   private:
     //QgsCodeEditor *mSciWidget;
     //QWidget *mWidget;
     void setSciLexerSQL();
+    void initializeLexer();
+    void updateApis();
+    QsciAPIs *mApis = nullptr;
+    QsciLexerSQL *mSqlLexer;
+
+    QStringList mFieldNames;
 };
 
 #ifndef SIP_RUN

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -91,6 +91,7 @@ void QgsQueryBuilder::showEvent( QShowEvent *event )
 void QgsQueryBuilder::populateFields()
 {
   const QgsFields &fields = mLayer->fields();
+  txtSQL->setFields( fields );
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     if ( fields.fieldOrigin( idx ) != QgsFields::OriginProvider )


### PR DESCRIPTION
## Description
Added autocomplete for field names in `QgsCodeEditorSQL` used in the query builder.

`QgsCodeEditorSQL` and `QgsCodeEditorExpression` could be refactored to avoid duplicate code.

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare-commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle-all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
